### PR TITLE
add extra instructions for running docker and talking to it

### DIFF
--- a/chroma-server/README.md
+++ b/chroma-server/README.md
@@ -38,7 +38,7 @@ In brief, version numbers are generated as follows:
   version will be appended to the version number. For example,
   `0.0.2-dev5-dirty`.
 
-To run 
+To run use `docker images` to see what containers and tags you have available:
 ```
 docker run -p 8000:8000 ghcr.io/chroma-core/chroma-server:<tag name -- eg 0.0.2-dirty>>
 ```


### PR DESCRIPTION
Add some extra docs to help users run and connect to the `fastapi` app running inside the `docker` container. 