### PR TITLE
Run integration tests in docker-compose cluster

### DIFF
--- a/.github/workflows/chroma-release.yml
+++ b/.github/workflows/chroma-release.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         context: chroma-server
         push: true
+        target: chroma_server
         tags: ${{ steps.tag.outputs.tag_name}}
     - name: Get Release Version
       id: version

--- a/.github/workflows/chroma-server-test.yml
+++ b/.github/workflows/chroma-server-test.yml
@@ -17,19 +17,10 @@ jobs:
     strategy:
       matrix:
         python: ['3.10']
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install test dependencies
-      run: |
-        cd chroma-server && python -m pip install -r requirements.txt -r requirements_dev.txt
-    - name: Install chroma_client
-      run: cd chroma-client && pip install .
     - name: Test
-      run: cd chroma-server && python -m pytest
+      run: bin/test

--- a/chroma-server/Dockerfile
+++ b/chroma-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.10
+FROM --platform=linux/amd64 python:3.10 AS chroma_server
 
 #RUN apt-get update -qq
 #RUN apt-get install python3.10 python3-pip -y --no-install-recommends && rm -rf /var/lib/apt/lists_/*
@@ -14,4 +14,14 @@ COPY ./chroma_server /chroma-server/chroma_server
 EXPOSE 8000
 
 CMD ["uvicorn", "chroma_server:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]
+
+# Use a multi-stage build to layer in test dependencies without bloating server image
+# https://docs.docker.com/build/building/multi-stage/
+# Note: requires passing --target to docker-build.
+FROM chroma_server AS chroma_server_test
+
+COPY ./requirements_dev.txt requirements_dev.txt
+RUN pip install --no-cache-dir --upgrade -r requirements_dev.txt
+
+CMD ["python", "-m", "pytest"]
 

--- a/chroma-server/README.md
+++ b/chroma-server/README.md
@@ -12,7 +12,8 @@ pip install -r requirements.txt
 pip install -r requirements_dev.txt
 ```
 
-To run tests, run `pytest`.
+To run tests, run `bin/test`. This will run the test suite inside a
+docker compose cluster, with the database available, and clean up when complete.
 
 To run the server locally, in development mode, run `uvicorn chroma_server:app --reload`
 

--- a/chroma-server/bin/build
+++ b/chroma-server/bin/build
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build . -t ghcr.io/chroma-core/chroma-server:`bin/version`
+docker build . --target chroma_server -t ghcr.io/chroma-core/chroma-server:`bin/version`

--- a/chroma-server/bin/test
+++ b/chroma-server/bin/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash -e
+
+function cleanup {
+  docker-compose -f docker-compose.test.yml down
+}
+
+trap cleanup EXIT
+
+docker-compose -f docker-compose.test.yml run --rm server_test echo hi

--- a/chroma-server/docker-compose.test.yml
+++ b/chroma-server/docker-compose.test.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+
+networks:
+  my-network:
+    driver: bridge
+
+services:
+  server_test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: chroma_server_test
+    depends_on:
+      - clickhouse
+    networks:
+      - my-network
+
+  clickhouse:
+    image: docker.io/bitnami/clickhouse:22.9
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    networks:
+      - my-network

--- a/chroma-server/requirements_dev.txt
+++ b/chroma-server/requirements_dev.txt
@@ -1,8 +1,3 @@
 httpx
 pytest
 setuptools_scm
-duckdb
-hnswlib @ git+https://oauth2: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@github.com/chroma-core/hnswlib.git
-pandas
-numpy
-pyarrow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     build:
       context: ./chroma-server
       dockerfile: Dockerfile
+      target: chroma_server
     volumes:
       - ./chroma-server/:/chroma-server/
     command: uvicorn chroma_server:app --reload --workers 1 --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This ensures that a Clickhouse instance is available when running tests. Tests must now be launched using `bin/test` rather than running pytest directly.

Note that this also means these are now effectively "integration" tests vs unit tests.