### PR TITLE
run tests while the app running

### DIFF
--- a/chroma-server/chroma_server/db/clickhouse.py
+++ b/chroma-server/chroma_server/db/clickhouse.py
@@ -1,6 +1,7 @@
 from chroma_server.db.abstract import Database
 import uuid
 import time
+import os
 
 from clickhouse_driver import connect, Client
 
@@ -56,7 +57,7 @@ class Clickhouse(Database):
         ) ENGINE = MergeTree() ORDER BY space_key''')
 
     def __init__(self):
-        client = Client(host='clickhouse', port='9007')
+        client = Client(host='clickhouse', port=os.getenv('CLICKHOUSE_TCP_PORT', '9000'))
         self._conn = client
         self._create_table_embeddings()
         self._create_table_results()

--- a/chroma-server/docker-compose.test.yml
+++ b/chroma-server/docker-compose.test.yml
@@ -14,19 +14,21 @@ services:
       - ./:/chroma-server/
       - index_data:/index_data
     depends_on:
-      - clickhouse_test
+      - clickhouse
     networks:
       - chroma-net
+    environment:
+      - CLICKHOUSE_TCP_PORT=9001
 
-  clickhouse_test:
+  clickhouse:
     image: docker.io/bitnami/clickhouse:22.9
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-      - CLICKHOUSE_TCP_PORT=9008
+      - CLICKHOUSE_TCP_PORT=9001
       - CLICKHOUSE_HTTP_PORT=8124
     ports:
       - '8124:8124'
-      - '9008:9008'
+      - '9001:9001'
     networks:
       - chroma-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - CLICKHOUSE_TCP_PORT=9000
     ports:
       - 8000:8000
     depends_on:
@@ -46,11 +47,11 @@ services:
     image: docker.io/bitnami/clickhouse:22.9
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-      - CLICKHOUSE_TCP_PORT=9007
+      - CLICKHOUSE_TCP_PORT=9000
       - CLICKHOUSE_HTTP_PORT=8123
     ports:
       - '8123:8123'
-      - '9007:9007'
+      - '9000:9000'
     volumes:
       - clickhouse_data:/bitnami/clickhouse
     networks:


### PR DESCRIPTION
Update, got this working! 

***

I want to be able to run tests with `bin/test` while the normal backend is also running. However the clickhouse ports are fighting. I am trying to make it so that 

We are currently using this docker image for clickhouse - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse. 

This is not working yet.

Current behavior.. I can set the port to `9008` and it works. I can load data into the db and read it out. However when i set the port to `9007` and run the tests I get this error

```
Successfully built 8f385a0d115e
Successfully tagged chroma-server_server_test:latest
WARNING: Image for service server_test was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating chroma-server_clickhouse_test_1 ... done
Creating chroma-server_server_test_run   ... done
======================================================================= test session starts =======================================================================
platform linux -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
rootdir: /chroma-server
plugins: anyio-3.6.2, celery-4.4.7
collected 0 items / 1 error

============================================================================= ERRORS ==============================================================================
_________________________________________________________ ERROR collecting chroma_server/test/test_api.py _________________________________________________________
chroma_server/test/test_api.py:4: in <module>
    from ..api import app
chroma_server/api.py:30: in <module>
    app._db = db()
chroma_server/db/clickhouse.py:61: in __init__
    self._create_table_embeddings()
chroma_server/db/clickhouse.py:47: in _create_table_embeddings
    self._conn.execute(f'''CREATE TABLE IF NOT EXISTS embeddings (
/usr/local/lib/python3.10/site-packages/clickhouse_driver/client.py:292: in execute
    with self.disconnect_on_error(query, settings):
/usr/local/lib/python3.10/contextlib.py:135: in __enter__
    return next(self.gen)
/usr/local/lib/python3.10/site-packages/clickhouse_driver/client.py:235: in disconnect_on_error
    self.connection.force_connect()
/usr/local/lib/python3.10/site-packages/clickhouse_driver/connection.py:219: in force_connect
    self.connect()
/usr/local/lib/python3.10/site-packages/clickhouse_driver/connection.py:346: in connect
    raise err
E   clickhouse_driver.errors.NetworkError: Code: 210. Connection refused (clickhouse:9008)
===================================================================== short test summary info =====================================================================
ERROR chroma_server/test/test_api.py - clickhouse_driver.errors.NetworkError: Code: 210. Connection refused (clickhouse:9008)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================================== 1 error in 3.69s =========================================================================
ERROR: 2
Stopping chroma-server_clickhouse_test_1 ... done
Removing chroma-server_clickhouse_test_1 ... done
```