### PR TITLE
types bump

### DIFF
--- a/chroma/api/__init__.py
+++ b/chroma/api/__init__.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Union, Sequence, Optional, TypedDict
+from typing import Union, Sequence, Optional, TypedDict, List, Dict
 from uuid import UUID
 import pandas as pd
+
 
 class API(ABC):
 
@@ -38,7 +39,7 @@ class API(ABC):
 
     @abstractmethod
     def fetch(self,
-              where: Optional[dict[str, str]]={},
+              where: Optional[Dict[str, str]]={},
               sort: Optional[str]=None,
               limit: Optional[int]=None,
               offset: Optional[int]=None,
@@ -49,7 +50,7 @@ class API(ABC):
 
 
     @abstractmethod
-    def delete(self, where: Optional[dict[str, str]]={}) -> Sequence[UUID]:
+    def delete(self, where: Optional[Dict[str, str]]={}) -> Sequence[UUID]:
         '''Deletes embeddings from the database'''
         pass
 
@@ -63,7 +64,7 @@ class API(ABC):
     def get_nearest_neighbors(self,
                               embedding: Sequence[float],
                               n_results: int=10,
-                              where: dict[str, str]={}) -> NearestNeighborsResult:
+                              where: Dict[str, str]={}) -> NearestNeighborsResult:
         '''Gets the nearest neighbors of a single embedding'''
         pass
 


### PR DESCRIPTION
This lets us run inside Google Colab's default python which is `Python 3.8.15`. Otherwise we would have to force users to upgrade to `3.9`, which I don't think is necessary?