### PR TITLE
[WIP] Rename inference_dataset_name to unlabeled_dataset_name to match local API implementation

### DIFF
--- a/bin/getting-started.py
+++ b/bin/getting-started.py
@@ -18,9 +18,9 @@ chroma_api.add_production(
 print(chroma_api.count(model_space="sample_space"))
 
 
-# chroma_api.process(training_dataset_name="training", inference_dataset_name="production", model_space="default_scope")
+# chroma_api.process(training_dataset_name="training", unlabeled_dataset_name="production", model_space="default_scope")
 # chroma_api.get_results()
-# chroma_api.process(training_dataset_name="training", inference_dataset_name="production", model_space="sample_space")
+# chroma_api.process(training_dataset_name="training", unlabeled_dataset_name="production", model_space="sample_space")
 # results = chroma_api.get_results(dataset_name="production", n_results=2)
 print(chroma_api.count(model_space="sample_space"))
 

--- a/chroma/api/fastapi.py
+++ b/chroma/api/fastapi.py
@@ -104,13 +104,13 @@ class FastAPI(API):
 
         return val
 
-    def process(self, model_space=None, training_dataset_name="training", inference_dataset_name="inference"):
+    def process(self, model_space=None, training_dataset_name="training", unlabeled_dataset_name="unlabeled"):
         '''
         Processes embeddings in the database
         '''
         payload = {"model_space": model_space or self._model_space,
                    "training_dataset_name": training_dataset_name,
-                   "inference_dataset_name": inference_dataset_name}
+                   "unlabeled_dataset_name": unlabeled_dataset_name}
         resp = requests.post(self._api_url + "/process", data = json.dumps(payload))
         resp.raise_for_status()
         return resp.json()
@@ -127,7 +127,7 @@ class FastAPI(API):
         resp.raise_for_status()
         return pd.DataFrame.from_dict(resp.json())
 
-    def get_results(self, model_space=None, n_results = 100, dataset_name="inference"):
+    def get_results(self, model_space=None, n_results = 100, dataset_name="unlabeled"):
         '''Gets the results for the given space key'''
         resp = requests.post(self._api_url + "/get_results",
                              data = json.dumps({"model_space": model_space or self._model_space, "n_results": n_results, "dataset_name": dataset_name}))

--- a/chroma/api/local.py
+++ b/chroma/api/local.py
@@ -79,8 +79,11 @@ class LocalAPI(API):
         return self._db.raw_sql(raw_sql)
 
     def create_index(self, model_space=None, dataset_name=None):
+
+        model_space = model_space or self.get_model_space()
+
         self._db.create_index(
-            model_space=model_space or self._model_space, dataset_name=dataset_name
+            model_space=model_space, dataset_name=dataset_name
         )
         return True
 

--- a/chroma/api/local.py
+++ b/chroma/api/local.py
@@ -69,7 +69,7 @@ class LocalAPI(API):
         self._db.reset()
         return True
 
-    def get_nearest_neighbors(self, embedding, n_results, where={}):
+    def get_nearest_neighbors(self, embedding, n_results=10, where={}):
 
         where = self.where_with_model_space(where)
         return self._db.get_nearest_neighbors(where, embedding, n_results)

--- a/chroma/server/fastapi/__init__.py
+++ b/chroma/server/fastapi/__init__.py
@@ -96,7 +96,8 @@ class FastAPI(chroma.server.Server):
 
 
     def process(self, process: ProcessEmbedding):
-        self._api.process(process.model_space, process.training_dataset_name, process.inference_dataset_name)
+        print(process)
+        self._api.process(process.model_space, process.training_dataset_name, process.unlabeled_dataset_name)
         return True
 
 

--- a/chroma/server/fastapi/__init__.py
+++ b/chroma/server/fastapi/__init__.py
@@ -96,7 +96,6 @@ class FastAPI(chroma.server.Server):
 
 
     def process(self, process: ProcessEmbedding):
-        print(process)
         self._api.process(process.model_space, process.training_dataset_name, process.unlabeled_dataset_name)
         return True
 

--- a/chroma/server/fastapi/types.py
+++ b/chroma/server/fastapi/types.py
@@ -18,7 +18,7 @@ class QueryEmbedding(BaseModel):
 class ProcessEmbedding(BaseModel):
     model_space: str = None
     training_dataset_name: str = None
-    inference_dataset_name: str = None
+    unlabeled_dataset_name: str = None
 
 class FetchEmbedding(BaseModel):
     where: dict = {}


### PR DESCRIPTION
The local api implementation uses ```unlabeled_dataset_name``` however the fastapi version is outdated - using ``` inference_dataset_name```.  This breaks calls like process() since they have the wrong dataset name.