### PR TITLE
Fix Clickhouse port & integration tests

### DIFF
--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -148,8 +148,7 @@ def test_reset_db(api_fixture, request):
     assert collection.count() == 2
 
     assert api.reset()
-    # assert collection.count() == 0
-
+    assert len(api.list_collections()) == 0
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_nearest_neighbors(api_fixture, request):

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
     environment:
       - CHROMA_DB_IMPL=clickhouse
       - CLICKHOUSE_HOST=test_clickhouse
-      - CLICKHOUSE_PORT=9000
+      - CLICKHOUSE_PORT=8123
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
Integration tests had been broken earlier by a change to the Clickhouse client, disguising a different failure of the `chromadb.test_api.test_reset_db` test.
