### PR TITLE
Explicit persist

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -207,6 +207,12 @@ class FastAPI(API):
         resp.raise_for_status()
         return resp.json
 
+    def persist(self):
+        """Persists the database"""
+        resp = requests.post(self._api_url + "/persist")
+        resp.raise_for_status()
+        return resp.json
+
     def raw_sql(self, sql):
         """Runs a raw SQL query against the database"""
         resp = requests.post(self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql}))

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -247,3 +247,7 @@ class LocalAPI(API):
 
     def _peek(self, collection_name, n=10):
         return self._get(collection_name=collection_name, limit=n)
+
+    def persist(self):
+        self._db.persist()
+        return True

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -76,6 +76,9 @@ class Clickhouse(DB):
     #
     #  UTILITY METHODS
     #
+    def persist(self):
+        raise NotImplementedError("Clickhouse is a persistent database, this method is not needed")
+
     def get_collection_uuid_from_name(self, name):
         res = self._conn.query(
             f"""

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -261,6 +261,9 @@ class DuckDB(Clickhouse):
         print("Exiting: Cleaning up .chroma directory")
         self._idx.reset()
 
+    def persist(self):
+        raise NotImplementedError("chroma_db_impl='duckdb+parquet' to get persistence functionality")
+
 
 class PersistentDuckDB(DuckDB):
 

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -28,6 +28,7 @@ class FastAPI(chromadb.server.Server):
         self.router = fastapi.APIRouter()
         self.router.add_api_route("/api/v1", self.root, methods=["GET"])
         self.router.add_api_route("/api/v1/reset", self.reset, methods=["POST"])
+        self.router.add_api_route("/api/v1/persist", self.persist, methods=["POST"])
         self.router.add_api_route("/api/v1/raw_sql", self.raw_sql, methods=["POST"])
 
         self.router.add_api_route("/api/v1/collections", self.list_collections, methods=["GET"])
@@ -78,6 +79,9 @@ class FastAPI(chromadb.server.Server):
 
     def root(self):
         return {"nanosecond heartbeat": self._api.heartbeat()}
+
+    def persist(self):
+        self._api.persist()
 
     def list_collections(self):
         return self._api.list_collections()


### PR DESCRIPTION
@atroyn please review to assure this does what you expect. 

Context: if a user deleted the client mid-script, the `__del__` would not get run via garbage collection until after the program exited. In rare cases (like in tests) - you want to be able to explicitly call `.persist`. This pipes that through. 