### PR TITLE
Add get_or_create

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -58,7 +58,23 @@ class API(ABC):
         Args:
             name (str): The name of the collection to create. The name must be unique.
             metadata (Optional[Dict], optional): A dictionary of metadata to associate with the collection. Defaults to None.
+        Returns:
+            dict: the created collection
 
+        """
+        pass
+    
+    @abstractmethod
+    def get_or_create_collection(
+        self,
+        name: str,
+        metadata: Optional[Dict] = None,
+    ) -> Collection:
+        """Creates a new collection in the database, or returns it if an identical one exists
+
+        Args:
+            name (str): The name of the collection to create. The name must be unique.
+            metadata (Optional[Dict], optional): A dictionary of metadata to associate with the collection. Defaults to None.
         Returns:
             dict: the created collection
 

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -52,6 +52,7 @@ class API(ABC):
         self,
         name: str,
         metadata: Optional[Dict] = None,
+        get_or_create: bool = False,
     ) -> Collection:
         """Creates a new collection in the database
 
@@ -63,14 +64,14 @@ class API(ABC):
 
         """
         pass
-    
+
     @abstractmethod
     def get_or_create_collection(
         self,
         name: str,
-        metadata: Optional[Dict] = None,
+        metadata: Optional[Dict] = None
     ) -> Collection:
-        """Creates a new collection in the database, or returns it if an identical one exists
+        """Calls create_collection with get_or_create=True
 
         Args:
             name (str): The name of the collection to create. The name must be unique.
@@ -80,7 +81,7 @@ class API(ABC):
 
         """
         pass
-
+    
     @abstractmethod
     def get_collection(
         self,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -46,10 +46,11 @@ class FastAPI(API):
         name: str,
         metadata: Optional[Dict] = None,
         embedding_function: Optional[Callable] = None,
+        get_or_create: bool = False,
     ) -> Collection:
         """Creates a collection"""
         resp = requests.post(
-            self._api_url + "/collections", data=json.dumps({"name": name, "metadata": metadata})
+            self._api_url + "/collections", data=json.dumps({"name": name, "metadata": metadata, "get_or_create": get_or_create})
         )
         resp.raise_for_status()
         return Collection(client=self, name=name, embedding_function=embedding_function)
@@ -67,11 +68,8 @@ class FastAPI(API):
         embedding_function: Optional[Callable] = None,
     ) -> Collection:
         """Get a collection, or return it if it exists"""
-        resp = requests.post(
-            self._api_url + "/collections", data=json.dumps({"get_or_create": True, "name": name, "metadata": metadata})
-        )
-        resp.raise_for_status()
-        return Collection(client=self, name=name, embedding_function=embedding_function)
+        
+        return self.create_collection(name, metadata, embedding_function, get_or_create=True)
 
     def modify(self, current_name, new_name: str, new_metadata: Optional[Dict] = None) -> int:
         """Updates a collection"""

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -60,6 +60,19 @@ class FastAPI(API):
         resp.raise_for_status()
         return Collection(client=self, name=name)
 
+    def get_or_create_collection(
+        self,
+        name: str,
+        metadata: Optional[Dict] = None,
+        embedding_function: Optional[Callable] = None,
+    ) -> Collection:
+        """Get a collection, or return it if it exists"""
+        resp = requests.post(
+            self._api_url + "/collections", data=json.dumps({"get_or_create": True, "name": name, "metadata": metadata})
+        )
+        resp.raise_for_status()
+        return Collection(client=self, name=name, embedding_function=embedding_function)
+
     def modify(self, current_name, new_name: str, new_metadata: Optional[Dict] = None) -> int:
         """Updates a collection"""
         resp = requests.put(

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -43,6 +43,23 @@ class LocalAPI(API):
         self._db.create_collection(name, metadata)
         return Collection(client=self, name=name, embedding_function=embedding_function)
 
+    def get_or_create_collection(
+        self,
+        name: str,
+        metadata: Optional[Dict] = None,
+        embedding_function: Optional[Callable] = None,
+    ) -> Collection:
+        if not is_valid_index_name(name):
+            raise ValueError("Invalid index name: %s" % name)  # NIT: tell the user why
+
+        if metadata is None:
+            metadata = {}
+            
+        metadata['get_or_create'] = True
+
+        self._db.create_collection(name, metadata)
+        return Collection(client=self, name=name, embedding_function=embedding_function)
+
     def get_collection(
         self,
         name: str,

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -41,7 +41,7 @@ class LocalAPI(API):
         if not is_valid_index_name(name):
             raise ValueError("Invalid index name: %s" % name)  # NIT: tell the user why
 
-        self._db.create_collection(name, metadata, get_or_create=get_or_create)
+        self._db.create_collection(name, metadata, get_or_create)
         return Collection(client=self, name=name, embedding_function=embedding_function)
 
     def get_or_create_collection(
@@ -50,6 +50,7 @@ class LocalAPI(API):
         metadata: Optional[Dict] = None,
         embedding_function: Optional[Callable] = None,
     ) -> Collection:
+        print("Calling it from here!")
         return self.create_collection(name, metadata, embedding_function, get_or_create=True)
 
     def get_collection(

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -36,11 +36,12 @@ class LocalAPI(API):
         name: str,
         metadata: Optional[Dict] = None,
         embedding_function: Optional[Callable] = None,
+        get_or_create: bool = False
     ) -> Collection:
         if not is_valid_index_name(name):
             raise ValueError("Invalid index name: %s" % name)  # NIT: tell the user why
 
-        self._db.create_collection(name, metadata)
+        self._db.create_collection(name, metadata, get_or_create=get_or_create)
         return Collection(client=self, name=name, embedding_function=embedding_function)
 
     def get_or_create_collection(
@@ -49,16 +50,7 @@ class LocalAPI(API):
         metadata: Optional[Dict] = None,
         embedding_function: Optional[Callable] = None,
     ) -> Collection:
-        if not is_valid_index_name(name):
-            raise ValueError("Invalid index name: %s" % name)  # NIT: tell the user why
-
-        if metadata is None:
-            metadata = {}
-            
-        metadata['get_or_create'] = True
-
-        self._db.create_collection(name, metadata)
-        return Collection(client=self, name=name, embedding_function=embedding_function)
+        return self.create_collection(name, metadata, embedding_function, get_or_create=True)
 
     def get_collection(
         self,

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -50,7 +50,6 @@ class LocalAPI(API):
         metadata: Optional[Dict] = None,
         embedding_function: Optional[Callable] = None,
     ) -> Collection:
-        print("Calling it from here!")
         return self.create_collection(name, metadata, embedding_function, get_or_create=True)
 
     def get_collection(

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -11,6 +11,9 @@ class DB(ABC):
     def create_collection(self, name, metadata=None):
         pass
 
+    def get_or_create_collection(self, name, metadata=None):
+        pass
+
     @abstractmethod
     def get_collection(self, collection_uuid):
         pass

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -8,7 +8,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def create_collection(self, name, metadata=None):
+    def create_collection(self, name, metadata=None, get_or_create=False):
         pass
 
     def get_or_create_collection(self, name, metadata=None):

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -125,7 +125,10 @@ class Clickhouse(DB):
         ).result_rows
 
         if len(checkname) > 0:
-            raise Exception("Collection already exists with that name")
+            if metadata['get_or_create'] == False:
+                raise Exception(f"collection with name {name} already exists")
+            else:
+                return self.get_collection(name)
 
         collection_uuid = uuid.uuid4()
         data_to_insert = []

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -126,6 +126,7 @@ class Clickhouse(DB):
 
         if len(checkname) > 0:
             if get_or_create:
+                print(f"collection with name {name} already exists, returning existing collection")
                 return self.get_collection(name)
             else:
                 raise Exception(f"collection with name {name} already exists")

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -129,7 +129,7 @@ class Clickhouse(DB):
                 print(f"collection with name {name} already exists, returning existing collection")
                 return self.get_collection(name)
             else:
-                raise Exception(f"collection with name {name} already exists")
+                raise ValueError(f"collection with name {name} already exists")
 
         collection_uuid = uuid.uuid4()
         data_to_insert = []

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -113,7 +113,7 @@ class Clickhouse(DB):
     #
     #  COLLECTION METHODS
     #
-    def create_collection(self, name, metadata=None):
+    def create_collection(self, name, metadata=None, get_or_create=False):
         if metadata is None:
             metadata = {}
 
@@ -125,10 +125,10 @@ class Clickhouse(DB):
         ).result_rows
 
         if len(checkname) > 0:
-            if metadata['get_or_create'] == False:
-                raise Exception(f"collection with name {name} already exists")
-            else:
+            if get_or_create:
                 return self.get_collection(name)
+            else:
+                raise Exception(f"collection with name {name} already exists")
 
         collection_uuid = uuid.uuid4()
         data_to_insert = []

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -86,8 +86,6 @@ class DuckDB(Clickhouse):
         # poor man's unique constraint
         dupe_check = self.get_collection(name)
         if not dupe_check.empty:
-            print("Current value is:")
-            print(get_or_create)
             if get_or_create == True:
                 print(f"collection with name {name} already exists, returning existing collection")
                 return dupe_check

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -86,7 +86,9 @@ class DuckDB(Clickhouse):
         # poor man's unique constraint
         dupe_check = self.get_collection(name)
         if not dupe_check.empty:
-            if get_or_create:
+            print("Current value is:")
+            print(get_or_create)
+            if get_or_create == True:
                 print(f"collection with name {name} already exists, returning existing collection")
                 return dupe_check
             else:

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -87,6 +87,7 @@ class DuckDB(Clickhouse):
         dupe_check = self.get_collection(name)
         if not dupe_check.empty:
             if get_or_create:
+                print(f"collection with name {name} already exists, returning existing collection")
                 return dupe_check
             else:
                 raise Exception(f"collection with name {name} already exists")

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -84,8 +84,13 @@ class DuckDB(Clickhouse):
             metadata = {}
 
         # poor man's unique constraint
-        if not self.get_collection(name).empty:
-            raise Exception(f"collection with name {name} already exists")
+        dupe_check = self.get_collection(name)
+        if not dupe_check.empty:
+            if metadata['get_or_create'] == False:
+                raise Exception(f"collection with name {name} already exists")
+            else:
+                return dupe_check
+            
 
         return self._conn.execute(
             f"""INSERT INTO collections (uuid, name, metadata) VALUES (?, ?, ?)""",

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -79,17 +79,17 @@ class DuckDB(Clickhouse):
     #
     #  COLLECTION METHODS
     #
-    def create_collection(self, name, metadata=None):
+    def create_collection(self, name, metadata=None, get_or_create=False):
         if metadata is None:
             metadata = {}
 
         # poor man's unique constraint
         dupe_check = self.get_collection(name)
         if not dupe_check.empty:
-            if metadata['get_or_create'] == False:
-                raise Exception(f"collection with name {name} already exists")
-            else:
+            if get_or_create:
                 return dupe_check
+            else:
+                raise Exception(f"collection with name {name} already exists")
             
 
         return self._conn.execute(

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -87,7 +87,7 @@ class FastAPI(chromadb.server.Server):
         return self._api.list_collections()
 
     def create_collection(self, collection: CreateCollection):
-        return self._api.create_collection(name=collection.name, metadata=collection.metadata)
+        return self._api.create_collection(name=collection.name, metadata=collection.metadata, get_or_create=collection.get_or_create)
 
     def get_collection(self, collection_name: str):
         return self._api.get_collection(collection_name)

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -58,6 +58,7 @@ class DeleteEmbedding(BaseModel):
 class CreateCollection(BaseModel):
     name: str
     metadata: dict = None
+    get_or_create: bool = False
 
 
 class UpdateCollection(BaseModel):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -140,6 +140,24 @@ def test_add(api_fixture, request):
 
     assert collection.count() == 2
 
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_get_or_create(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+
+    collection = api.create_collection("testspace")
+
+    collection.add(**batch_records)
+
+    assert collection.count() == 2
+
+    with pytest.raises(Exception):
+        collection = api.create_collection("testspace")
+
+    collection = api.get_or_create_collection("testspace")
+
+    assert collection.count() == 2
 
 minimal_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],


### PR DESCRIPTION
### Current issue: 

if I'm using `create_collection` in a notebook cell (or in another Python function), the code will fail on the second run as the collection already exists. This forces users to change their code from `create` to `get` collection, or to use an `or` statement like this:

```
repos = chroma_client.get_collection(name="my_repos") or chroma_client.create_collection(name="my_repos")
```

### Proposed solution

Inspired by Rails ActiveRecord's `find_or_create_by`, Chroma could support a `get_or_create` function that creates the collection OR returns it if it already exists. 

If the collection exist, Chroma prints a notice. This will help avoid issues in which users are writing into someone else's collection, or write data in a collection thinking it's brand new but it already has data in it.  