### PR TITLE
Support ints/floats in metadata and for where clauses

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -110,23 +110,6 @@ class LocalAPI(API):
             else:
                 documents = None
 
-        # convert all metadatas values to strings : TODO: handle this better
-        # this is currently here because clickhouse-driver does not support json
-        if isinstance(embeddings[0], list):
-            for m in metadatas:
-                for k, v in m.items():
-                    m[k] = str(v)
-        else:
-            for k, v in metadatas.items():
-                metadatas[k] = str(v)
-
-        # convert to array for downstream processing
-        if not isinstance(embeddings[0], list):
-            embeddings = [embeddings]
-            metadatas = [metadatas]
-            documents = [documents]
-            ids = [ids]
-
         collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
         added_uuids = self._db.add(
             collection_uuid, embedding=embeddings, metadata=metadatas, documents=documents, ids=ids
@@ -156,7 +139,7 @@ class LocalAPI(API):
             query_result["embeddings"].append(entry[2])
             query_result["documents"].append(entry[3])
             query_result["ids"].append(entry[4])
-            query_result["metadatas"].append(json.loads(entry[5]))
+            query_result["metadatas"].append(entry[5])
         return query_result
 
     def _get(

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -109,7 +109,7 @@ class Collection(BaseModel):
 
         Args:
             ids: The ids of the embeddings to get. Optional.
-            where: A dict of key, value string pairs to filter results by. E.g. {"color" : "red"}. Optional.
+            where: A dict of key, value string:string/int/float pairs to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
             limit: The number of documents to return. Optional.
             offset: The offset to start returning results from. Useful for paging results with limit. Optional.
         """
@@ -138,7 +138,7 @@ class Collection(BaseModel):
             query_embeddings: The embeddings to get the closes neighbors of. Optional.
             query_texts: The document texts to get the closes neighbors of. Optional.
             n_results: The number of neighbots to return for each query_embedding or query_text. Optional.
-            where: A dict of key, value string pairs to filter results by. E.g. {"color" : "red"}. Optional.
+            where: A dict of key, value string:string/int/float pairs to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
         """
         where = validate_where(where) if where else None
         query_embeddings = maybe_cast_one_to_many(query_embeddings) if query_embeddings else None
@@ -236,7 +236,7 @@ class Collection(BaseModel):
 
         Args:
             ids: The ids of the embeddings to delete
-            where: A dict of key, value string pairs to filter deletions by. E.g. {"color" : "red"}. Optional.
+            where:  A dict of key, value string:string/int/float pairs to filter deletions by. E.g. {"color" : "red", "price": 4.20}. Optional.
         """
         where = validate_where(where) if where else None
         return self._client._delete(self.name, ids, where)

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -13,6 +13,8 @@ from chromadb.api.types import (
     ID,
     OneOrMany,
     maybe_cast_one_to_many,
+    validate_metadatas,
+    validate_where,
 )
 
 if TYPE_CHECKING:
@@ -66,7 +68,7 @@ class Collection(BaseModel):
 
         ids = maybe_cast_one_to_many(ids)
         embeddings = maybe_cast_one_to_many(embeddings) if embeddings else None
-        metadatas = maybe_cast_one_to_many(metadatas) if metadatas else None
+        metadatas = validate_metadatas(maybe_cast_one_to_many(metadatas)) if metadatas else None
         documents = maybe_cast_one_to_many(documents) if documents else None
 
         # Check that one of embeddings or documents is provided
@@ -111,6 +113,7 @@ class Collection(BaseModel):
             limit: The number of documents to return. Optional.
             offset: The offset to start returning results from. Useful for paging results with limit. Optional.
         """
+        where = validate_where(where) if where else None
         ids = maybe_cast_one_to_many(ids) if ids else None
         return self._client._get(self.name, ids, where, None, limit, offset)
 
@@ -137,7 +140,7 @@ class Collection(BaseModel):
             n_results: The number of neighbots to return for each query_embedding or query_text. Optional.
             where: A dict of key, value string pairs to filter results by. E.g. {"color" : "red"}. Optional.
         """
-
+        where = validate_where(where) if where else None
         query_embeddings = maybe_cast_one_to_many(query_embeddings) if query_embeddings else None
         query_texts = maybe_cast_one_to_many(query_texts) if query_texts else None
 
@@ -195,7 +198,7 @@ class Collection(BaseModel):
 
         ids = maybe_cast_one_to_many(ids)
         embeddings = maybe_cast_one_to_many(embeddings) if embeddings else None
-        metadatas = maybe_cast_one_to_many(metadatas) if metadatas else None
+        metadatas = validate_metadatas(maybe_cast_one_to_many(metadatas)) if metadatas else None
         documents = maybe_cast_one_to_many(documents) if documents else None
 
         # Must update one of embeddings, metadatas, or documents
@@ -235,6 +238,7 @@ class Collection(BaseModel):
             ids: The ids of the embeddings to delete
             where: A dict of key, value string pairs to filter deletions by. E.g. {"color" : "red"}. Optional.
         """
+        where = validate_where(where) if where else None
         return self._client._delete(self.name, ids, where)
 
     def create_index(self):

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -6,7 +6,7 @@ IDs = List[ID]
 Embedding = List[float]
 Embeddings = List[Embedding]
 
-Metadata = Dict[str, str]
+Metadata = Dict[str, str | int | float]
 Metadatas = List[Metadata]
 
 Document = str
@@ -16,7 +16,7 @@ Parameter = TypeVar("Parameter", Embedding, Document, Metadata, ID)
 T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
-Where = Dict[str, str]
+Where = Dict[str, str | int | float]
 
 
 class GetResult(TypedDict):
@@ -56,3 +56,33 @@ def maybe_cast_one_to_many(
         return [target]
     # Already a sequence
     return target  # type: ignore
+
+def validate_metadata(metadata: Metadata) -> Metadata:
+    """Validates metadata to ensure it is a dictionary of strings to strings, ints, or floats"""
+    if not isinstance(metadata, dict):
+        raise ValueError("Metadata must be a dictionary")
+    for key, value in metadata.items():
+        if not isinstance(key, str):
+            raise ValueError(f"Metadata key {key} must be a string")
+        if not isinstance(value, (str, int, float)):
+            raise ValueError(f"Metadata value {value} must be a string, int, or float")
+    return metadata
+
+def validate_metadatas(metadatas: Metadatas) -> Metadatas:
+    """Validates metadatas to ensure it is a list of dictionaries of strings to strings, ints, or floats"""
+    if not isinstance(metadatas, list):
+        raise ValueError("Metadatas must be a list")
+    for metadata in metadatas:
+        validate_metadata(metadata)
+    return metadatas
+    
+def validate_where(where: Where) -> Where:
+    """Validates where to ensure it is a dictionary of strings to strings, ints, or floats"""
+    if not isinstance(where, dict):
+        raise ValueError("Where must be a dictionary")
+    for key, value in where.items():
+        if not isinstance(key, str):
+            raise ValueError(f"Where key {key} must be a string")
+        if not isinstance(value, (str, int, float)):
+            raise ValueError(f"Where value {value} must be a string, int, or float")
+    return where

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -85,11 +85,6 @@ class Clickhouse(DB):
         return res.result_rows[0][0]
 
     def _create_where_clause(self, collection_uuid, ids=None, where={}):
-        # ensure where only contains strings, as we only support string equality for now
-        for key in where:
-            if not isinstance(where[key], str):
-                raise Exception("Invalid metadata: " + str(where))
-
         where = " AND ".join([self._filter_metadata(key, value) for key, value in where.items()])
 
         if ids is not None:
@@ -181,14 +176,12 @@ class Clickhouse(DB):
     #
     #  ITEM METHODS
     #
-    def add(self, collection_uuid, embedding, metadata=None, documents=None, ids=None):
-
-        metadata = [json.dumps(x) if not isinstance(x, str) else x for x in metadata]
+    def add(self, collection_uuid, embedding, metadata, documents, ids):
 
         data_to_insert = []
         for i in range(len(embedding)):
             data_to_insert.append(
-                [collection_uuid, uuid.uuid4(), embedding[i], metadata[i], documents[i], ids[i]]
+                [collection_uuid, uuid.uuid4(), embedding[i], json.dumps(metadata[i]), documents[i], ids[i]]
             )
 
         column_names = ["collection_uuid", "uuid", "embedding", "metadata", "document", "id"]
@@ -215,7 +208,7 @@ class Clickhouse(DB):
                 parameters[f"e{i}"] = embeddings[i]
             if metadatas is not None:
                 update_fields.append(f"metadata = {{m{i}:String}}")
-                parameters[f"m{i}"] = metadatas[i]
+                parameters[f"m{i}"] = json.dumps(metadatas[i])
             if documents is not None:
                 update_fields.append(f"document = {{d{i}:String}}")
                 parameters[f"d{i}"] = documents[i]
@@ -256,12 +249,19 @@ class Clickhouse(DB):
             self._idx.add_incremental(collection_uuid, update_uuids, embeddings)
 
     def _get(self, where={}):
-        return self._conn.query(
+        res = self._conn.query(
             f"""SELECT {db_schema_to_keys()} FROM embeddings {where}"""
         ).result_rows
+        # json.load the metadata
+        return [[*x[:5], json.loads(x[5])] for x in res]
 
     def _filter_metadata(self, key, value):
-        return f" JSONExtractString(metadata,'{key}') = '{value}'"
+        if type(value) == str:
+            return f" JSONExtractString(metadata,'{key}') = '{value}'"
+        elif type(value) == int:
+            return f" JSONExtractInt(metadata,'{key}') = {value}"
+        elif type(value) == float:
+            return f" JSONExtractFloat(metadata,'{key}') = {value}"
 
     def get(
         self,

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -157,9 +157,9 @@ class DuckDB(Clickhouse):
         if type(value) == str:
             return f" json_extract_string(metadata,'$.{key}') = '{value}'"
         if type(value) == int:
-            return f" CAST(json_extract_string(metadata,'$.{key}') AS INT) = {value}"
+            return f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}"
         if type(value) == float:
-            return f" CAST(json_extract_string(metadata,'$.{key}') AS DOUBLE) = {value}"
+            return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}"
 
     def _get(self, where):
         val = self._conn.execute(

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -154,12 +154,34 @@ class DuckDB(Clickhouse):
         return self._count(collection_uuid=collection_uuid).fetchall()[0][0]
 
     def _filter_metadata(self, key, value):
+        # Shortcut for $eq
         if type(value) == str:
             return f" json_extract_string(metadata,'$.{key}') = '{value}'"
         if type(value) == int:
             return f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}"
         if type(value) == float:
             return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}"
+        # Operator expression
+        elif type(value) == dict:
+            operator, operand = list(value.items())[0]
+            if operator == "$gt":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}"
+            elif operator == "$lt":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) < {operand}"
+            elif operator == "$gte":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) >= {operand}"
+            elif operator == "$lte":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) <= {operand}"
+            elif operator == "$ne":
+                if type(operand) == str:
+                    return f" json_extract_string(metadata,'$.{key}') != '{operand}'"
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
+            elif operator == "$eq":
+                if type(operand) == str:
+                    return f" json_extract_string(metadata,'$.{key}') = '{operand}'"
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {operand}"
+            else:
+                raise ValueError(f"Operator {operator} not supported")
 
     def _get(self, where):
         val = self._conn.execute(

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -31,8 +31,6 @@ def clickhouse_to_duckdb_schema(table_schema):
             item[list(item.keys())[0]] = "STRING"
         if "FLOAT64" in item[list(item.keys())[0]]:
             item[list(item.keys())[0]] = "DOUBLE"
-        # NIT: here we need to turn metadata into JSON for duckdb
-
     return table_schema
 
 
@@ -122,9 +120,7 @@ class DuckDB(Clickhouse):
     #  ITEM METHODS
     #
     # the execute many syntax is different than clickhouse, the (?,?) syntax is different than clickhouse
-    def add(self, collection_uuid, embedding, metadata=None, documents=None, ids=None):
-
-        metadata = [json.dumps(x) if not isinstance(x, str) else x for x in metadata]
+    def add(self, collection_uuid, embedding, metadata, documents, ids):
 
         data_to_insert = []
         for i in range(len(embedding)):
@@ -133,7 +129,7 @@ class DuckDB(Clickhouse):
                     collection_uuid,
                     str(uuid.uuid4()),
                     embedding[i],
-                    metadata[i],
+                    json.dumps(metadata[i]),
                     documents[i],
                     ids[i],
                 ]
@@ -158,7 +154,12 @@ class DuckDB(Clickhouse):
         return self._count(collection_uuid=collection_uuid).fetchall()[0][0]
 
     def _filter_metadata(self, key, value):
-        return f" json_extract_string(metadata,'$.{key}') = '{value}'"
+        if type(value) == str:
+            return f" json_extract_string(metadata,'$.{key}') = '{value}'"
+        if type(value) == int:
+            return f" CAST(json_extract_string(metadata,'$.{key}') AS INT) = {value}"
+        if type(value) == float:
+            return f" CAST(json_extract_string(metadata,'$.{key}') AS DOUBLE) = {value}"
 
     def _get(self, where):
         val = self._conn.execute(
@@ -168,6 +169,8 @@ class DuckDB(Clickhouse):
             val[i] = list(val[i])
             val[i][0] = uuid.UUID(val[i][0])
             val[i][1] = uuid.UUID(val[i][1])
+            # json.loads metadata
+            val[i][5] = json.loads(val[i][5])
 
         return val
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -486,6 +486,91 @@ def test_where_validation_query(api_fixture, request):
     assert "Where" in str(e.value)
 
 
+operator_records = {
+    "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
+    "ids": ["id1", "id2"],
+    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2, "float_value": 2.002, "string_value": "two"}]
+}
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_lt(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lt")
+    collection.add(**operator_records)
+    items = collection.get(where={"int_value": {"$lt": 2}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_lte(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"int_value": {"$lte": 2.0}})
+    assert len(items["metadatas"]) == 2
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_gt(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"float_value": {"$gt": -1.4}})
+    assert len(items["metadatas"]) == 2
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_gte(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"float_value": {"$gte": 2.002}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_ne_string(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"string_value": {"$ne": "two"}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_ne_eq_number(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"int_value": {"$ne": 1}})
+    assert len(items["metadatas"]) == 1
+    items = collection.get(where={"float_value": {"$eq": 2.002}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_valid_operators(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_valid_operators")
+    collection.add(**operator_records)
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$invalid": 2}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$lt": "2"}})
+    
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$lt": 2, "$gt": 1}})
+
 # endregion 
+
 
 


### PR DESCRIPTION
This PR enables users to add int/float metadata and to filter on it as part of where clauses.

**All changes**

1. Add int and float support in metadata 
2. Add metadata validation
3. Add int and float support in where clauses
4. Add where validation
5. Add handling in duckdb and clickhouse for int/float filtering
6. Add extensive tests for added functionality 
7. Remove unnecessary validation and one_to_many logic (cleanup)
8. Adds comparator support from stacked pr #122 
