### PR TITLE
Add comparator support: gt, lt, gte, lte, ne

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -16,7 +16,7 @@ Parameter = TypeVar("Parameter", Embedding, Document, Metadata, ID)
 T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
-WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne"]
+WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
 OperatorExpression = Dict[WhereOperator, Union[str, int, float]]
 Where = Dict[str, str | int | float | OperatorExpression]
 
@@ -99,8 +99,8 @@ def validate_where(where: Where) -> Where:
                     if not isinstance(operand, (int, float)):
                         raise ValueError(f"Where operand value {operand} must be an int or float for operator {operator}")
 
-                if operator not in ["$gt", "$gte", "$lt", "$lte", "$ne"]:
-                    raise ValueError(f"Where operator must be one of $gt, $gte, $lt, $lte, $ne")
+                if operator not in ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]:
+                    raise ValueError(f"Where operator must be one of $gt, $gte, $lt, $lte, $ne", "$eq")
 
                 if not isinstance(operand, (str, int, float)):
                     raise ValueError(f"Where operand value {operand} must be a string, int, or float")

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1,4 +1,4 @@
-from typing import Union, Dict, Sequence, TypedDict, Protocol, TypeVar, List
+from typing import Literal, Union, Dict, Sequence, TypedDict, Protocol, TypeVar, List
 
 ID = str
 IDs = List[ID]
@@ -16,7 +16,9 @@ Parameter = TypeVar("Parameter", Embedding, Document, Metadata, ID)
 T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
-Where = Dict[str, str | int | float]
+WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne"]
+OperatorExpression = Dict[WhereOperator, Union[str, int, float]]
+Where = Dict[str, str | int | float | OperatorExpression]
 
 
 class GetResult(TypedDict):
@@ -77,12 +79,29 @@ def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     return metadatas
     
 def validate_where(where: Where) -> Where:
-    """Validates where to ensure it is a dictionary of strings to strings, ints, or floats"""
+    """Validates where to ensure it is a dictionary of strings to strings, ints, floats or operator expressions"""
     if not isinstance(where, dict):
         raise ValueError("Where must be a dictionary")
     for key, value in where.items():
         if not isinstance(key, str):
             raise ValueError(f"Where key {key} must be a string")
-        if not isinstance(value, (str, int, float)):
-            raise ValueError(f"Where value {value} must be a string, int, or float")
+        if not isinstance(value, (str, int, float, dict)):
+            raise ValueError(f"Where value {value} must be a string, int, or float, or operator expression")
+        # Value is a operator expression
+        if isinstance(value, dict):
+            # Ensure there is only one operator
+            if len(value) != 1:
+                raise ValueError(f"Where operator expression {value} must have exactly one operator")
+            
+            for operator, operand in value.items():
+                # Only numbers can be compared with gt, gte, lt, lte
+                if operator in ["$gt", "$gte", "$lt", "$lte"]:
+                    if not isinstance(operand, (int, float)):
+                        raise ValueError(f"Where operand value {operand} must be an int or float for operator {operator}")
+
+                if operator not in ["$gt", "$gte", "$lt", "$lte", "$ne"]:
+                    raise ValueError(f"Where operator must be one of $gt, $gte, $lt, $lte, $ne")
+
+                if not isinstance(operand, (str, int, float)):
+                    raise ValueError(f"Where operand value {operand} must be a string, int, or float")
     return where

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -256,14 +256,15 @@ class Clickhouse(DB):
         return [[*x[:5], json.loads(x[5])] for x in res]
 
     def _filter_metadata(self, key, value):
+        # Shortcut for $eq
         if type(value) == str:
             return f" JSONExtractString(metadata,'{key}') = '{value}'"
         elif type(value) == int:
             return f" JSONExtractInt(metadata,'{key}') = {value}"
         elif type(value) == float:
             return f" JSONExtractFloat(metadata,'{key}') = {value}"
+        # Operator expression
         elif type(value) == dict:
-            # Operator expression
             operator, operand = list(value.items())[0]
             if operator == "$gt":
                 return f" JSONExtractFloat(metadata,'{key}') > {operand}"
@@ -277,6 +278,10 @@ class Clickhouse(DB):
                 if type(operand) == str:
                     return f" JSONExtractString(metadata,'{key}') != '{operand}'"
                 return f" JSONExtractFloat(metadata,'{key}') != {operand}"
+            elif operator == "$eq":
+                if type(operand) == str:
+                    return f" JSONExtractString(metadata,'{key}') = '{operand}'"
+                return f" JSONExtractFloat(metadata,'{key}') = {operand}"
             else:
                 raise ValueError(f"Operator {operator} not supported")
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -262,6 +262,23 @@ class Clickhouse(DB):
             return f" JSONExtractInt(metadata,'{key}') = {value}"
         elif type(value) == float:
             return f" JSONExtractFloat(metadata,'{key}') = {value}"
+        elif type(value) == dict:
+            # Operator expression
+            operator, operand = list(value.items())[0]
+            if operator == "$gt":
+                return f" JSONExtractFloat(metadata,'{key}') > {operand}"
+            elif operator == "$lt":
+                return f" JSONExtractFloat(metadata,'{key}') < {operand}"
+            elif operator == "$gte":
+                return f" JSONExtractFloat(metadata,'{key}') >= {operand}"
+            elif operator == "$lte":
+                return f" JSONExtractFloat(metadata,'{key}') <= {operand}"
+            elif operator == "$ne":
+                if type(operand) == str:
+                    return f" JSONExtractString(metadata,'{key}') != '{operand}'"
+                return f" JSONExtractFloat(metadata,'{key}') != {operand}"
+            else:
+                raise ValueError(f"Operator {operator} not supported")
 
     def get(
         self,

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -160,6 +160,23 @@ class DuckDB(Clickhouse):
             return f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}"
         if type(value) == float:
             return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}"
+        elif type(value) == dict:
+            # Operator expression
+            operator, operand = list(value.items())[0]
+            if operator == "$gt":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}"
+            elif operator == "$lt":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) < {operand}"
+            elif operator == "$gte":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) >= {operand}"
+            elif operator == "$lte":
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) <= {operand}"
+            elif operator == "$ne":
+                if type(operand) == str:
+                    return f" json_extract_string(metadata,'$.{key}') != '{operand}'"
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
+            else:
+                raise ValueError(f"Operator {operator} not supported")
 
     def _get(self, where):
         val = self._conn.execute(

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -154,14 +154,15 @@ class DuckDB(Clickhouse):
         return self._count(collection_uuid=collection_uuid).fetchall()[0][0]
 
     def _filter_metadata(self, key, value):
+        # Shortcut for $eq
         if type(value) == str:
             return f" json_extract_string(metadata,'$.{key}') = '{value}'"
         if type(value) == int:
             return f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}"
         if type(value) == float:
             return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}"
+        # Operator expression
         elif type(value) == dict:
-            # Operator expression
             operator, operand = list(value.items())[0]
             if operator == "$gt":
                 return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}"
@@ -175,6 +176,10 @@ class DuckDB(Clickhouse):
                 if type(operand) == str:
                     return f" json_extract_string(metadata,'$.{key}') != '{operand}'"
                 return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
+            elif operator == "$eq":
+                if type(operand) == str:
+                    return f" json_extract_string(metadata,'$.{key}') = '{operand}'"
+                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {operand}"
             else:
                 raise ValueError(f"Operator {operator} not supported")
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -543,13 +543,15 @@ def test_where_ne_string(api_fixture, request):
     assert len(items["metadatas"]) == 1
 
 @pytest.mark.parametrize("api_fixture", test_apis)
-def test_where_ne_number(api_fixture, request):
+def test_where_ne_eq_number(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
 
     api.reset()
     collection = api.create_collection("test_where_lte")
     collection.add(**operator_records)
     items = collection.get(where={"int_value": {"$ne": 1}})
+    assert len(items["metadatas"]) == 1
+    items = collection.get(where={"float_value": {"$eq": 2.002}})
     assert len(items["metadatas"]) == 1
 
 @pytest.mark.parametrize("api_fixture", test_apis)

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -486,6 +486,89 @@ def test_where_validation_query(api_fixture, request):
     assert "Where" in str(e.value)
 
 
+operator_records = {
+    "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
+    "ids": ["id1", "id2"],
+    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2, "float_value": 2.002, "string_value": "two"}]
+}
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_lt(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lt")
+    collection.add(**operator_records)
+    items = collection.get(where={"int_value": {"$lt": 2}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_lte(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"int_value": {"$lte": 2.0}})
+    assert len(items["metadatas"]) == 2
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_gt(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"float_value": {"$gt": -1.4}})
+    assert len(items["metadatas"]) == 2
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_gte(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"float_value": {"$gte": 2.002}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_ne_string(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"string_value": {"$ne": "two"}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_ne_number(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_lte")
+    collection.add(**operator_records)
+    items = collection.get(where={"int_value": {"$ne": 1}})
+    assert len(items["metadatas"]) == 1
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_valid_operators(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_where_valid_operators")
+    collection.add(**operator_records)
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$invalid": 2}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$lt": "2"}})
+    
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$lt": 2, "$gt": 1}})
+
 # endregion 
+
 
 


### PR DESCRIPTION
This PR adds support for comparators in where clauses. gt, lt, gte, lte are supported on numbers (ints, floats). ne is supported on (ints, floats, strings). This PR is stacked on #121, please see that before looking at this.

All changes

1. Add operator expression typing. 
2. Update where validation for operator expressions
3. Add support for operators in duckdb and clickhouse
4. Add tests for all functionality 