### PR TITLE
Update typing for older python versions

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -6,7 +6,7 @@ IDs = List[ID]
 Embedding = List[float]
 Embeddings = List[Embedding]
 
-Metadata = Dict[str, str | int | float]
+Metadata = Dict[str, Union[str, int, float]]
 Metadatas = List[Metadata]
 
 Document = str
@@ -18,7 +18,7 @@ OneOrMany = Union[T, List[T]]
 
 WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
 OperatorExpression = Dict[WhereOperator, Union[str, int, float]]
-Where = Dict[str, str | int | float | OperatorExpression]
+Where = Dict[str,  Union[str, int, float, OperatorExpression]]
 
 
 class GetResult(TypedDict):


### PR DESCRIPTION
Older versions of python don't support Union as |. Use Union instead.