### PR TITLE
Add document string $contains, $or, $and

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -12,6 +12,7 @@ from chromadb.api.types import (
     Where,
     QueryResult,
     GetResult,
+    WhereDocument,
 )
 import json
 
@@ -159,6 +160,7 @@ class API(ABC):
         offset: Optional[int] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
+        where_document: Optional[WhereDocument] = {},
     ) -> GetResult:
 
         """Gets embeddings from the database. Supports filtering, sorting, and pagination.
@@ -179,7 +181,7 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def _delete(self, collection_name: str, ids: Optional[IDs], where: Optional[Where] = {}):
+    def _delete(self, collection_name: str, ids: Optional[IDs], where: Optional[Where] = {}, where_document: Optional[WhereDocument] = {}):
         """Deletes embeddings from the database
         ⚠️ This method should not be used directly.
 
@@ -195,6 +197,7 @@ class API(ABC):
         query_embeddings: Embeddings,
         n_results: int = 10,
         where: Where = {},
+        where_document: WhereDocument = {},
     ) -> QueryResult:
         """Gets the nearest neighbors of a single embedding
         ⚠️ This method should not be used directly.

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -94,6 +94,7 @@ class FastAPI(API):
         offset=None,
         page=None,
         page_size=None,
+        where_document={},
     ):
         """Gets embeddings from the database"""
         if page and page_size:
@@ -103,19 +104,19 @@ class FastAPI(API):
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/get",
             data=json.dumps(
-                {"ids": ids, "where": where, "sort": sort, "limit": limit, "offset": offset}
+                {"ids": ids, "where": where, "sort": sort, "limit": limit, "offset": offset, "where_document": where_document}
             ),
         )
 
         resp.raise_for_status()
         return resp.json()
 
-    def _delete(self, collection_name, ids=None, where={}):
+    def _delete(self, collection_name, ids=None, where={}, where_document={}):
         """Deletes embeddings from the database"""
 
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/delete",
-            data=json.dumps({"where": where, "ids": ids}),
+            data=json.dumps({"where": where, "ids": ids, "where_document": where_document}),
         )
 
         resp.raise_for_status()
@@ -180,13 +181,13 @@ class FastAPI(API):
         resp.raise_for_status
         return True
 
-    def _query(self, collection_name, query_embeddings, n_results=10, where={}):
+    def _query(self, collection_name, query_embeddings, n_results=10, where={}, where_document={}):
         """Gets the nearest neighbors of a single embedding"""
 
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/query",
             data=json.dumps(
-                {"query_embeddings": query_embeddings, "n_results": n_results, "where": where}
+                {"query_embeddings": query_embeddings, "n_results": n_results, "where": where, "where_document": where_document}
             ),
         )
 

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -152,10 +152,14 @@ class LocalAPI(API):
         offset=None,
         page=None,
         page_size=None,
+        where_document=None
     ):
 
         if where is None:
             where = {}
+        
+        if where_document is None:
+            where_document = {}
 
         if page and page_size:
             offset = (page - 1) * page_size
@@ -169,15 +173,16 @@ class LocalAPI(API):
                 sort=sort,
                 limit=limit,
                 offset=offset,
+                where_document=where_document,
             )
         )
 
-    def _delete(self, collection_name, ids=None, where=None):
+    def _delete(self, collection_name, ids=None, where=None, where_document=None):
 
         if where is None:
             where = {}
 
-        deleted_uuids = self._db.delete(collection_name=collection_name, where=where, ids=ids)
+        deleted_uuids = self._db.delete(collection_name=collection_name, where=where, ids=ids, where_document=where_document)
         return deleted_uuids
 
     def _count(self, collection_name):
@@ -188,10 +193,11 @@ class LocalAPI(API):
         self._db.reset()
         return True
 
-    def _query(self, collection_name, query_embeddings, n_results=10, where={}):
+    def _query(self, collection_name, query_embeddings, n_results=10, where={}, where_document={}):
         uuids, distances = self._db.get_nearest_neighbors(
             collection_name=collection_name,
             where=where,
+            where_document=where_document,
             embeddings=query_embeddings,
             n_results=n_results,
         )

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -16,12 +16,18 @@ Parameter = TypeVar("Parameter", Embedding, Document, Metadata, ID)
 T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
-WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
-WhereDocumentOperator = Literal["$contains"]
-OperatorExpression = Dict[WhereOperator, Union[str, int, float]]
 
-Where = Dict[str,  Union[str, int, float, OperatorExpression]]
-WhereDocument = Dict[WhereDocumentOperator, str]
+# Grammar for where expressions
+LiteralValue = Union[str, int, float]
+LogicalOperator = Literal["$and", "$or"]
+WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
+OperatorExpression = Dict[Union[WhereOperator, LogicalOperator], LiteralValue]
+
+Where = Dict[Union[str, LogicalOperator], Union[LiteralValue, OperatorExpression, List["Where"]]]
+
+WhereDocumentOperator = Literal["$contains", LogicalOperator]
+WhereDocument = Dict[WhereDocumentOperator, Union[str, List["WhereDocument"]]]
+
 
 class GetResult(TypedDict):
     ids: List[ID]
@@ -61,6 +67,7 @@ def maybe_cast_one_to_many(
     # Already a sequence
     return target  # type: ignore
 
+
 def validate_metadata(metadata: Metadata) -> Metadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, or floats"""
     if not isinstance(metadata, dict):
@@ -72,6 +79,7 @@ def validate_metadata(metadata: Metadata) -> Metadata:
             raise ValueError(f"Metadata value {value} must be a string, int, or float")
     return metadata
 
+
 def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     """Validates metadatas to ensure it is a list of dictionaries of strings to strings, ints, or floats"""
     if not isinstance(metadatas, list):
@@ -79,44 +87,87 @@ def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     for metadata in metadatas:
         validate_metadata(metadata)
     return metadatas
-    
+
+
 def validate_where(where: Where) -> Where:
-    """Validates where to ensure it is a dictionary of strings to strings, ints, floats or operator expressions"""
+    """
+    Validates where to ensure it is a dictionary of strings to strings, ints, floats or operator expressions,
+    or in the case of $and and $or, a list of where expressions
+    """
     if not isinstance(where, dict):
         raise ValueError("Where must be a dictionary")
     for key, value in where.items():
         if not isinstance(key, str):
             raise ValueError(f"Where key {key} must be a string")
-        if not isinstance(value, (str, int, float, dict)):
-            raise ValueError(f"Where value {value} must be a string, int, or float, or operator expression")
+        if key != "$and" and key != "$or" and not isinstance(value, (str, int, float, dict)):
+            raise ValueError(
+                f"Where value {value} must be a string, int, or float, or operator expression"
+            )
+        if key == "$and" or key == "$or":
+            if not isinstance(value, list):
+                raise ValueError(
+                    f"Where value {value} for $and or $or must be a list of where expressions"
+                )
+            if len(value) <= 1:
+                raise ValueError(
+                    f"Where value {value} for $and or $or must have at least two where expressions"
+                )
+            for where_expression in value:
+                validate_where(where_expression)
         # Value is a operator expression
         if isinstance(value, dict):
             # Ensure there is only one operator
             if len(value) != 1:
-                raise ValueError(f"Where operator expression {value} must have exactly one operator")
-            
+                raise ValueError(
+                    f"Where operator expression {value} must have exactly one operator"
+                )
+
             for operator, operand in value.items():
                 # Only numbers can be compared with gt, gte, lt, lte
                 if operator in ["$gt", "$gte", "$lt", "$lte"]:
                     if not isinstance(operand, (int, float)):
-                        raise ValueError(f"Where operand value {operand} must be an int or float for operator {operator}")
+                        raise ValueError(
+                            f"Where operand value {operand} must be an int or float for operator {operator}"
+                        )
 
                 if operator not in ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]:
-                    raise ValueError(f"Where operator must be one of $gt, $gte, $lt, $lte, $ne", "$eq")
+                    raise ValueError(
+                        f"Where operator must be one of $gt, $gte, $lt, $lte, $ne", "$eq"
+                    )
 
                 if not isinstance(operand, (str, int, float)):
-                    raise ValueError(f"Where operand value {operand} must be a string, int, or float")
+                    raise ValueError(
+                        f"Where operand value {operand} must be a string, int, or float"
+                    )
     return where
 
+
 def validate_where_document(where_document: WhereDocument) -> WhereDocument:
-    """Validates where_document to ensure it is a dictionary of WhereDocumentOperator to strings"""
+    """
+    Validates where_document to ensure it is a dictionary of WhereDocumentOperator to strings, or in the case of $and and $or,
+    a list of where_document expressions
+    """
     if not isinstance(where_document, dict):
         raise ValueError("Where document must be a dictionary")
     if len(where_document) != 1:
         raise ValueError("Where document must have exactly one operator")
     for operator, operand in where_document.items():
-        if operator not in ["$contains"]:
-            raise ValueError(f"Where document operator must be $contains")
-        if not isinstance(operand, str):
-            raise ValueError(f"Where document operand value {operand} must be a string")
+        if operator not in ["$contains", "$and", "$or"]:
+            raise ValueError(f"Where document operator must be $contains, $and, or $or")
+        if operator == "$and" or operator == "$or":
+            if not isinstance(operand, list):
+                raise ValueError(
+                    f"Where document value {operand} for $and or $or must be a list of where document expressions"
+                )
+            if len(operand) <= 1:
+                raise ValueError(
+                    f"Where document value {operand} for $and or $or must have at least two where document expressions"
+                )
+            for where_document_expression in operand:
+                validate_where_document(where_document_expression)
+        # Value is a $contains operator
+        elif not isinstance(operand, str):
+            raise ValueError(
+                f"Where document operand value {operand} must be a string for operator $contains"
+            )
     return where_document

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -17,9 +17,11 @@ T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
 WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
+WhereDocumentOperator = Literal["$contains"]
 OperatorExpression = Dict[WhereOperator, Union[str, int, float]]
-Where = Dict[str,  Union[str, int, float, OperatorExpression]]
 
+Where = Dict[str,  Union[str, int, float, OperatorExpression]]
+WhereDocument = Dict[WhereDocumentOperator, str]
 
 class GetResult(TypedDict):
     ids: List[ID]
@@ -105,3 +107,16 @@ def validate_where(where: Where) -> Where:
                 if not isinstance(operand, (str, int, float)):
                     raise ValueError(f"Where operand value {operand} must be a string, int, or float")
     return where
+
+def validate_where_document(where_document: WhereDocument) -> WhereDocument:
+    """Validates where_document to ensure it is a dictionary of WhereDocumentOperator to strings"""
+    if not isinstance(where_document, dict):
+        raise ValueError("Where document must be a dictionary")
+    if len(where_document) != 1:
+        raise ValueError("Where document must have exactly one operator")
+    for operator, operand in where_document.items():
+        if operator not in ["$contains"]:
+            raise ValueError(f"Where document operator must be $contains")
+        if not isinstance(operand, str):
+            raise ValueError(f"Where document operand value {operand} must be a string")
+    return where_document

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -53,6 +53,7 @@ class DB(ABC):
         sort=None,
         limit=None,
         offset=None,
+        where_document={},
     ):
         pass
 

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -153,40 +153,71 @@ class DuckDB(Clickhouse):
         collection_uuid = self.get_collection_uuid_from_name(collection_name)
         return self._count(collection_uuid=collection_uuid).fetchall()[0][0]
 
-    def _format_where(self, key, value):
-        # Shortcut for $eq
-        if type(value) == str:
-            return f" json_extract_string(metadata,'$.{key}') = '{value}'"
-        if type(value) == int:
-            return f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}"
-        if type(value) == float:
-            return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}"
-        # Operator expression
-        elif type(value) == dict:
-            operator, operand = list(value.items())[0]
-            if operator == "$gt":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}"
-            elif operator == "$lt":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) < {operand}"
-            elif operator == "$gte":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) >= {operand}"
-            elif operator == "$lte":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) <= {operand}"
-            elif operator == "$ne":
-                if type(operand) == str:
-                    return f" json_extract_string(metadata,'$.{key}') != '{operand}'"
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
-            elif operator == "$eq":
-                if type(operand) == str:
-                    return f" json_extract_string(metadata,'$.{key}') = '{operand}'"
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {operand}"
-            else:
-                raise ValueError(f"Operator {operator} not supported")
-    
-    def _format_where_document(self, where_document):
+    def _format_where(self, where, result):
+        for key, value in where.items():
+            # Shortcut for $eq
+            if type(value) == str:
+                result.append(f" json_extract_string(metadata,'$.{key}') = '{value}'")
+            if type(value) == int:
+                result.append(f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}")
+            if type(value) == float:
+                result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}")
+            # Operator expression
+            elif type(value) == dict:
+                operator, operand = list(value.items())[0]
+                if operator == "$gt":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}")
+                elif operator == "$lt":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) < {operand}")
+                elif operator == "$gte":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) >= {operand}")
+                elif operator == "$lte":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) <= {operand}")
+                elif operator == "$ne":
+                    if type(operand) == str:
+                        return result.append(
+                            f" json_extract_string(metadata,'$.{key}') != '{operand}'"
+                        )
+                    return result.append(
+                        f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
+                    )
+                elif operator == "$eq":
+                    if type(operand) == str:
+                        return result.append(
+                            f" json_extract_string(metadata,'$.{key}') = '{operand}'"
+                        )
+                    return result.append(
+                        f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {operand}"
+                    )
+                else:
+                    raise ValueError(f"Operator {operator} not supported")
+            elif type(value) == list:
+                all_subresults = []
+                for subwhere in value:
+                    subresults = []
+                    self._format_where(subwhere, subresults)
+                    all_subresults.append(subresults[0])
+                if key == "$or":
+                    result.append(f"({' OR '.join(all_subresults)})")
+                elif key == "$and":
+                    result.append(f"({' AND '.join(all_subresults)})")
+                else:
+                    raise ValueError(f"Operator {key} not supported with a list of where clauses")
+
+    def _format_where_document(self, where_document, results):
         operator = list(where_document.keys())[0]
         if operator == "$contains":
-            return f"position('{where_document[operator]}' in document) > 0"
+            results.append(f"position('{where_document[operator]}' in document) > 0")
+        elif operator == "$and" or operator == "$or":
+            all_subresults = []
+            for subwhere in where_document[operator]:
+                subresults = []
+                self._format_where_document(subwhere, subresults)
+                all_subresults.append(subresults[0])
+            if operator == "$or":
+                results.append(f"({' OR '.join(all_subresults)})")
+            if operator == "$and":
+                results.append(f"({' AND '.join(all_subresults)})")
         else:
             raise ValueError(f"Operator {operator} not supported")
 
@@ -294,7 +325,9 @@ class DuckDB(Clickhouse):
         self._idx.reset()
 
     def persist(self):
-        raise NotImplementedError("chroma_db_impl='duckdb+parquet' to get persistence functionality")
+        raise NotImplementedError(
+            "chroma_db_impl='duckdb+parquet' to get persistence functionality"
+        )
 
 
 class PersistentDuckDB(DuckDB):
@@ -336,9 +369,11 @@ class PersistentDuckDB(DuckDB):
                 (SELECT * FROM embeddings)
             TO '{self._save_folder}/chroma-embeddings.parquet'
                 (FORMAT PARQUET);
-        """)
+        """
+        )
 
-        self._conn.execute(f"""
+        self._conn.execute(
+            f"""
             COPY
                 (SELECT * FROM collections)
             TO '{self._save_folder}/chroma-collections.parquet'

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -127,6 +127,7 @@ class FastAPI(chromadb.server.Server):
             collection_name=collection_name,
             ids=get.ids,
             where=get.where,
+            where_document=get.where_document,
             sort=get.sort,
             limit=get.limit,
             offset=get.offset,
@@ -134,7 +135,7 @@ class FastAPI(chromadb.server.Server):
 
     def delete(self, collection_name: str, delete: DeleteEmbedding):
         return self._api._delete(
-            where=delete.where, ids=delete.ids, collection_name=collection_name
+            where=delete.where, ids=delete.ids, collection_name=collection_name, where_document=delete.where_document,
         )
 
     def count(self, collection_name: str):
@@ -148,6 +149,7 @@ class FastAPI(chromadb.server.Server):
             nnresult = self._api._query(
                 collection_name=collection_name,
                 where=query.where,
+                where_document=query.where_document,
                 query_embeddings=query.query_embeddings,
                 n_results=query.n_results,
             )

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -20,6 +20,7 @@ class UpdateEmbedding(BaseModel):
 
 class QueryEmbedding(BaseModel):
     where: dict = {}
+    where_document: dict = {}
     query_embeddings: list
     n_results: int = 10
 
@@ -33,6 +34,7 @@ class ProcessEmbedding(BaseModel):
 class GetEmbedding(BaseModel):
     ids: list = None
     where: dict = None
+    where_document: dict = None
     sort: str = None
     limit: int = None
     offset: int = None
@@ -53,6 +55,7 @@ class SpaceKeyInput(BaseModel):
 class DeleteEmbedding(BaseModel):
     ids: list = None
     where: dict = None
+    where_document: dict = None
 
 
 class CreateCollection(BaseModel):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -24,6 +24,7 @@ def local_api():
         )
     )
 
+
 @pytest.fixture
 def local_persist_api():
     return chromadb.Client(
@@ -91,6 +92,7 @@ if "CHROMA_INTEGRATION_TEST" in os.environ:
     print("Including integration tests")
     test_apis.append(fastapi_integration_api)
 
+
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
 def test_persist(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -116,6 +118,7 @@ def test_persist(api_fixture, request):
 
     api = request.getfixturevalue(api_fixture.__name__)
     assert api.list_collections() == []
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_heartbeat(api_fixture, request):
@@ -186,6 +189,7 @@ def test_reset_db(api_fixture, request):
 
     assert api.reset()
     assert len(api.list_collections()) == 0
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_nearest_neighbors(api_fixture, request):
@@ -383,15 +387,15 @@ def test_peek(api_fixture, request):
         assert len(peek[key]) == 2
 
 
-
 #### TEST METADATA AND METADATA FILTERING ####
 # region
- 
+
 metadata_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}]
+    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_add_get_int_float(api_fixture, request):
@@ -400,13 +404,14 @@ def test_metadata_add_get_int_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items = collection.get(ids=["id1", "id2"])
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["float_value"] == 1.001
     assert items["metadatas"][1]["int_value"] == 2
     assert type(items["metadatas"][0]["int_value"]) == int
     assert type(items["metadatas"][0]["float_value"]) == float
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_add_query_int_float(api_fixture, request):
@@ -415,12 +420,13 @@ def test_metadata_add_query_int_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items: QueryResult = collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
     assert items["metadatas"][0][0]["int_value"] == 1
     assert items["metadatas"][0][0]["float_value"] == 1.001
     assert type(items["metadatas"][0][0]["int_value"]) == int
     assert type(items["metadatas"][0][0]["float_value"]) == float
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_get_where_string(api_fixture, request):
@@ -429,10 +435,11 @@ def test_metadata_get_where_string(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
-    items = collection.get(where={"string_value": "one"}) 
+
+    items = collection.get(where={"string_value": "one"})
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["string_value"] == "one"
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_get_where_int(api_fixture, request):
@@ -441,10 +448,11 @@ def test_metadata_get_where_int(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items = collection.get(where={"int_value": 1})
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["string_value"] == "one"
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_get_where_float(api_fixture, request):
@@ -453,11 +461,12 @@ def test_metadata_get_where_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items = collection.get(where={"float_value": 1.001})
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["string_value"] == "one"
     assert items["metadatas"][0]["float_value"] == 1.001
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_update_get_int_float(api_fixture, request):
@@ -466,18 +475,22 @@ def test_metadata_update_get_int_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
-    collection.update(ids=["id1"], metadatas=[{"int_value": 2, "string_value": "two", "float_value": 2.002}])
+
+    collection.update(
+        ids=["id1"], metadatas=[{"int_value": 2, "string_value": "two", "float_value": 2.002}]
+    )
     items = collection.get(ids=["id1"])
     assert items["metadatas"][0]["int_value"] == 2
     assert items["metadatas"][0]["string_value"] == "two"
     assert items["metadatas"][0]["float_value"] == 2.002
 
+
 bad_metadata_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"value": {"nested": "5"}}, {"value": [1,2,3]}]
+    "metadatas": [{"value": {"nested": "5"}}, {"value": [1, 2, 3]}],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_validation_add(api_fixture, request):
@@ -488,6 +501,7 @@ def test_metadata_validation_add(api_fixture, request):
     with pytest.raises(ValueError) as e:
         collection.add(**bad_metadata_records)
     assert "Metadata" in str(e.value)
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_validation_update(api_fixture, request):
@@ -500,6 +514,7 @@ def test_metadata_validation_update(api_fixture, request):
         collection.update(ids=["id1"], metadatas={"value": {"nested": "5"}})
     assert "Metadata" in str(e.value)
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_validation_get(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -510,6 +525,7 @@ def test_where_validation_get(api_fixture, request):
         collection.get(where={"value": {"nested": "5"}})
     assert "Where" in str(e.value)
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_validation_query(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -517,15 +533,19 @@ def test_where_validation_query(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_where_validation")
     with pytest.raises(ValueError) as e:
-        collection.query(query_embeddings=[0,0,0], where={"value": {"nested": "5"}})
+        collection.query(query_embeddings=[0, 0, 0], where={"value": {"nested": "5"}})
     assert "Where" in str(e.value)
 
 
 operator_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2, "float_value": 2.002, "string_value": "two"}]
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2, "float_value": 2.002, "string_value": "two"},
+    ],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_lt(api_fixture, request):
@@ -537,6 +557,7 @@ def test_where_lt(api_fixture, request):
     items = collection.get(where={"int_value": {"$lt": 2}})
     assert len(items["metadatas"]) == 1
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_lte(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -546,6 +567,7 @@ def test_where_lte(api_fixture, request):
     collection.add(**operator_records)
     items = collection.get(where={"int_value": {"$lte": 2.0}})
     assert len(items["metadatas"]) == 2
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_gt(api_fixture, request):
@@ -557,6 +579,7 @@ def test_where_gt(api_fixture, request):
     items = collection.get(where={"float_value": {"$gt": -1.4}})
     assert len(items["metadatas"]) == 2
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_gte(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -567,6 +590,7 @@ def test_where_gte(api_fixture, request):
     items = collection.get(where={"float_value": {"$gte": 2.002}})
     assert len(items["metadatas"]) == 1
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_ne_string(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -576,6 +600,7 @@ def test_where_ne_string(api_fixture, request):
     collection.add(**operator_records)
     items = collection.get(where={"string_value": {"$ne": "two"}})
     assert len(items["metadatas"]) == 1
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_ne_eq_number(api_fixture, request):
@@ -589,6 +614,7 @@ def test_where_ne_eq_number(api_fixture, request):
     items = collection.get(where={"float_value": {"$eq": 2.002}})
     assert len(items["metadatas"]) == 1
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_valid_operators(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -601,9 +627,39 @@ def test_where_valid_operators(api_fixture, request):
 
     with pytest.raises(ValueError) as e:
         collection.get(where={"int_value": {"$lt": "2"}})
-    
+
     with pytest.raises(ValueError) as e:
         collection.get(where={"int_value": {"$lt": 2, "$gt": 1}})
+
+    # Test invalid $and, $or
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$and": {"int_value": {"$lt": 2}}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$lt": 2}, "$or": {"int_value": {"$gt": 1}}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$gt": [{"int_value": {"$lt": 2}}, {"int_value": {"$gt": 1}}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$or": [{"int_value": {"$lt": 2}}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$or": []})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"a": {"$contains": "test"}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(
+            where={
+                "$or": [
+                    {"a": {"$contains": "first"}},  # invalid
+                    {"$contains": "second"},  # valid
+                ]
+            }
+        )
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_query_document_valid_operators(api_fixture, request):
@@ -617,19 +673,42 @@ def test_query_document_valid_operators(api_fixture, request):
     assert "Where document" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        collection.query(query_embeddings=[0,0,0], where_document={"$contains": 2})
+        collection.query(query_embeddings=[0, 0, 0], where_document={"$contains": 2})
     assert "Where document" in str(e.value)
-    
+
     with pytest.raises(ValueError) as e:
         collection.get(where_document={"$contains": []})
     assert "Where document" in str(e.value)
+
+    # Test invalid $and, $or
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$and": {"$unsupported": "doc"}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$or": [{"$unsupported": "doc"}, {"$unsupported": "doc"}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$or": [{"$contains": "doc"}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$or": []})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(
+            where_document={"$or": [{"$and": [{"$contains": "doc"}]}, {"$contains": "doc"}]}
+        )
+
 
 contains_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "documents": ["this is doc1 and it's great!", "doc2 is also great!"],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2, "float_value": 2.002, "string_value": "two"}]
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2, "float_value": 2.002, "string_value": "two"},
+    ],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_where_document(api_fixture, request):
@@ -657,14 +736,21 @@ def test_query_where_document(api_fixture, request):
     collection = api.create_collection("test_query_where_document")
     collection.add(**contains_records)
 
-    items = collection.query(query_embeddings=[0,0,0], where_document={"$contains": "doc1"}, n_results=1)
+    items = collection.query(
+        query_embeddings=[0, 0, 0], where_document={"$contains": "doc1"}, n_results=1
+    )
     assert len(items["metadatas"][0]) == 1
 
-    items = collection.query(query_embeddings=[0,0,0], where_document={"$contains": "great"}, n_results=2)
+    items = collection.query(
+        query_embeddings=[0, 0, 0], where_document={"$contains": "great"}, n_results=2
+    )
     assert len(items["metadatas"][0]) == 2
 
     with pytest.raises(NoDatapointsException) as e:
-        items = collection.query(query_embeddings=[0,0,0], where_document={"$contains": "bad"}, n_results=1)
+        items = collection.query(
+            query_embeddings=[0, 0, 0], where_document={"$contains": "bad"}, n_results=1
+        )
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_delete_where_document(api_fixture, request):
@@ -683,7 +769,105 @@ def test_delete_where_document(api_fixture, request):
     collection.delete(where_document={"$contains": "great"})
     assert collection.count() == 0
 
-# endregion 
+
+logical_operator_records = {
+    "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2], [1.3, 2.25, 3.2], [1.4, 2.26, 3.2]],
+    "ids": ["id1", "id2", "id3", "id4"],
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001, "is": "doc"},
+        {"int_value": 2, "float_value": 2.002, "string_value": "two", "is": "doc"},
+        {"int_value": 3, "float_value": 3.003, "string_value": "three", "is": "doc"},
+        {"int_value": 4, "float_value": 4.004, "string_value": "four", "is": "doc"},
+    ],
+    "documents": [
+        "this document is first and great",
+        "this document is second and great",
+        "this document is third and great",
+        "this document is fourth and great",
+    ],
+}
 
 
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_logical_operators(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
 
+    api.reset()
+    collection = api.create_collection("test_logical_operators")
+    collection.add(**logical_operator_records)
+
+    items = collection.get(
+        where={
+            "$and": [
+                {"$or": [{"int_value": {"$gte": 3}}, {"float_value": {"$lt": 1.9}}]},
+                {"is": "doc"},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 3
+
+    items = collection.get(
+        where={
+            "$or": [
+                {"$and": [{"int_value": {"$eq": 3}}, {"string_value": {"$eq": "three"}}]},
+                {"$and": [{"int_value": {"$eq": 4}}, {"string_value": {"$eq": "four"}}]},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 2
+
+    items = collection.get(
+        where={
+            "$or": [
+                {"$and": [{"int_value": {"$eq": 3}}, {"string_value": {"$eq": "three"}}]},
+                {"$and": [{"int_value": {"$eq": 4}}, {"string_value": {"$eq": "four"}}]},
+            ],
+            "$and": [{"is": "doc"}, {"string_value": "four"}],
+        }
+    )
+    assert len(items["metadatas"]) == 1
+
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_document_logical_operators(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_document_logical_operators")
+    collection.add(**logical_operator_records)
+
+    items = collection.get(
+        where_document={
+            "$and": [
+                {"$contains": "first"},
+                {"$contains": "doc"},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 1
+
+    items = collection.get(
+        where_document={
+            "$or": [
+                {"$contains": "first"},
+                {"$contains": "second"},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 2
+
+    items = collection.get(
+        where_document={
+            "$or": [
+                {"$contains": "first"},
+                {"$contains": "second"},
+            ]
+        },
+        where={
+            "int_value": {"$ne": 2},
+        },
+    )
+    assert len(items["metadatas"]) == 1
+
+
+# endregion


### PR DESCRIPTION
This PR adds support for doing string $contains on the document provided (if any). It is a fairly naive solution for now, to get the API in place. We can add a more performant solution in the future!

All changes
- Add support for WhereDocument type
- Add validator to WhereDocument type
- Plumb WhereDocument validator and as a flag to query, get, delete
- Add support for string contains in clickhouse and duckdb
From stacked #133 
Add typing for logical operators $and + $or
Add validation and validation tests for logical operators
Add support in clickhouse and duckdb. The code is duplicative across dbs but we expect this to change soon so leaving for now since footprint is minimal.
