### PR TITLE
$and + $or support

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -165,6 +165,9 @@ def validate_where_document(where_document: WhereDocument) -> WhereDocument:
                 )
             for where_document_expression in operand:
                 validate_where_document(where_document_expression)
+        # Value is a $contains operator
         elif not isinstance(operand, str):
-            raise ValueError(f"Where document operand value {operand} must be a string")
+            raise ValueError(
+                f"Where document operand value {operand} must be a string for operator $contains"
+            )
     return where_document

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -16,12 +16,18 @@ Parameter = TypeVar("Parameter", Embedding, Document, Metadata, ID)
 T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
-WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
-WhereDocumentOperator = Literal["$contains"]
-OperatorExpression = Dict[WhereOperator, Union[str, int, float]]
 
-Where = Dict[str,  Union[str, int, float, OperatorExpression]]
-WhereDocument = Dict[WhereDocumentOperator, str]
+# Grammar for where expressions
+LiteralValue = Union[str, int, float]
+LogicalOperator = Literal["$and", "$or"]
+WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
+OperatorExpression = Dict[Union[WhereOperator, LogicalOperator], LiteralValue]
+
+Where = Dict[Union[str, LogicalOperator], Union[LiteralValue, OperatorExpression, List["Where"]]]
+
+WhereDocumentOperator = Literal["$contains", LogicalOperator]
+WhereDocument = Dict[WhereDocumentOperator, Union[str, List["WhereDocument"]]]
+
 
 class GetResult(TypedDict):
     ids: List[ID]
@@ -61,6 +67,7 @@ def maybe_cast_one_to_many(
     # Already a sequence
     return target  # type: ignore
 
+
 def validate_metadata(metadata: Metadata) -> Metadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, or floats"""
     if not isinstance(metadata, dict):
@@ -72,6 +79,7 @@ def validate_metadata(metadata: Metadata) -> Metadata:
             raise ValueError(f"Metadata value {value} must be a string, int, or float")
     return metadata
 
+
 def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     """Validates metadatas to ensure it is a list of dictionaries of strings to strings, ints, or floats"""
     if not isinstance(metadatas, list):
@@ -79,44 +87,84 @@ def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     for metadata in metadatas:
         validate_metadata(metadata)
     return metadatas
-    
+
+
 def validate_where(where: Where) -> Where:
-    """Validates where to ensure it is a dictionary of strings to strings, ints, floats or operator expressions"""
+    """
+    Validates where to ensure it is a dictionary of strings to strings, ints, floats or operator expressions,
+    or in the case of $and and $or, a list of where expressions
+    """
     if not isinstance(where, dict):
         raise ValueError("Where must be a dictionary")
     for key, value in where.items():
         if not isinstance(key, str):
             raise ValueError(f"Where key {key} must be a string")
-        if not isinstance(value, (str, int, float, dict)):
-            raise ValueError(f"Where value {value} must be a string, int, or float, or operator expression")
+        if key != "$and" and key != "$or" and not isinstance(value, (str, int, float, dict)):
+            raise ValueError(
+                f"Where value {value} must be a string, int, or float, or operator expression"
+            )
+        if key == "$and" or key == "$or":
+            if not isinstance(value, list):
+                raise ValueError(
+                    f"Where value {value} for $and or $or must be a list of where expressions"
+                )
+            if len(value) <= 1:
+                raise ValueError(
+                    f"Where value {value} for $and or $or must have at least two where expressions"
+                )
+            for where_expression in value:
+                validate_where(where_expression)
         # Value is a operator expression
         if isinstance(value, dict):
             # Ensure there is only one operator
             if len(value) != 1:
-                raise ValueError(f"Where operator expression {value} must have exactly one operator")
-            
+                raise ValueError(
+                    f"Where operator expression {value} must have exactly one operator"
+                )
+
             for operator, operand in value.items():
                 # Only numbers can be compared with gt, gte, lt, lte
                 if operator in ["$gt", "$gte", "$lt", "$lte"]:
                     if not isinstance(operand, (int, float)):
-                        raise ValueError(f"Where operand value {operand} must be an int or float for operator {operator}")
+                        raise ValueError(
+                            f"Where operand value {operand} must be an int or float for operator {operator}"
+                        )
 
                 if operator not in ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]:
-                    raise ValueError(f"Where operator must be one of $gt, $gte, $lt, $lte, $ne", "$eq")
+                    raise ValueError(
+                        f"Where operator must be one of $gt, $gte, $lt, $lte, $ne", "$eq"
+                    )
 
                 if not isinstance(operand, (str, int, float)):
-                    raise ValueError(f"Where operand value {operand} must be a string, int, or float")
+                    raise ValueError(
+                        f"Where operand value {operand} must be a string, int, or float"
+                    )
     return where
 
+
 def validate_where_document(where_document: WhereDocument) -> WhereDocument:
-    """Validates where_document to ensure it is a dictionary of WhereDocumentOperator to strings"""
+    """
+    Validates where_document to ensure it is a dictionary of WhereDocumentOperator to strings, or in the case of $and and $or,
+    a list of where_document expressions
+    """
     if not isinstance(where_document, dict):
         raise ValueError("Where document must be a dictionary")
     if len(where_document) != 1:
         raise ValueError("Where document must have exactly one operator")
     for operator, operand in where_document.items():
-        if operator not in ["$contains"]:
-            raise ValueError(f"Where document operator must be $contains")
-        if not isinstance(operand, str):
+        if operator not in ["$contains", "$and", "$or"]:
+            raise ValueError(f"Where document operator must be $contains, $and, or $or")
+        if operator == "$and" or operator == "$or":
+            if not isinstance(operand, list):
+                raise ValueError(
+                    f"Where document value {operand} for $and or $or must be a list of where document expressions"
+                )
+            if len(operand) <= 1:
+                raise ValueError(
+                    f"Where document value {operand} for $and or $or must have at least two where document expressions"
+                )
+            for where_document_expression in operand:
+                validate_where_document(where_document_expression)
+        elif not isinstance(operand, str):
             raise ValueError(f"Where document operand value {operand} must be a string")
     return where_document

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -109,7 +109,6 @@ class Clickhouse(DB):
         # We know that where_clauses is not empty, so force typechecker
         where = " AND ".join(cast(list[str], where_clauses))
         where = f"WHERE {where}"
-        print(where)
         return where
 
     #

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -21,6 +21,7 @@ EMBEDDING_TABLE_SCHEMA = [
     {"metadata": "String"},
 ]
 
+
 def db_array_schema_to_clickhouse_schema(table_schema):
     return_str = ""
     for element in table_schema:
@@ -69,7 +70,8 @@ class Clickhouse(DB):
         conn.command(
             f"""CREATE TABLE IF NOT EXISTS collections (
             {db_array_schema_to_clickhouse_schema(COLLECTION_TABLE_SCHEMA)}
-        ) ENGINE = MergeTree() ORDER BY uuid""")
+        ) ENGINE = MergeTree() ORDER BY uuid"""
+        )
 
     def _create_table_embeddings(self, conn):
         conn.command(
@@ -93,10 +95,13 @@ class Clickhouse(DB):
         return res.result_rows[0][0]
 
     def _create_where_clause(self, collection_uuid, ids=None, where={}, where_document={}):
-        where_clauses= [self._format_where(key, value) for key, value in where.items()]
+        where_clauses = []
+        self._format_where(where, where_clauses)
         if len(where_document) > 0:
-            where_clauses.append(self._format_where_document(where_document))
-        
+            where_document_clauses = []
+            self._format_where_document(where_document, where_document_clauses)
+            where_clauses.extend(where_document_clauses)
+
         if ids is not None:
             where_clauses.append(f" id IN {tuple(ids)}")
 
@@ -104,6 +109,7 @@ class Clickhouse(DB):
         # We know that where_clauses is not empty, so force typechecker
         where = " AND ".join(cast(list[str], where_clauses))
         where = f"WHERE {where}"
+        print(where)
         return where
 
     #
@@ -114,11 +120,15 @@ class Clickhouse(DB):
             metadata = {}
 
         # poor man's unique constraint
-        checkname = self._get_conn().query(
-            f"""
+        checkname = (
+            self._get_conn()
+            .query(
+                f"""
             SELECT * FROM collections WHERE name = '{name}'
         """
-        ).result_rows
+            )
+            .result_rows
+        )
 
         if len(checkname) > 0:
             raise Exception("Collection already exists with that name")
@@ -127,15 +137,21 @@ class Clickhouse(DB):
         data_to_insert = []
         data_to_insert.append([collection_uuid, name, json.dumps(metadata)])
 
-        self._get_conn().insert("collections", data_to_insert, column_names=["uuid", "name", "metadata"])
+        self._get_conn().insert(
+            "collections", data_to_insert, column_names=["uuid", "name", "metadata"]
+        )
         return collection_uuid
 
     def get_collection(self, name):
-        return self._get_conn().query(
-            f"""
+        return (
+            self._get_conn()
+            .query(
+                f"""
          SELECT * FROM collections WHERE name = '{name}'
          """
-        ).result_rows
+            )
+            .result_rows
+        )
 
     def list_collections(self) -> Sequence[Sequence[str]]:
         return self._get_conn().query(f"""SELECT * FROM collections""").result_rows
@@ -185,7 +201,14 @@ class Clickhouse(DB):
         data_to_insert = []
         for i in range(len(embedding)):
             data_to_insert.append(
-                [collection_uuid, uuid.uuid4(), embedding[i], json.dumps(metadata[i]), documents[i], ids[i]]
+                [
+                    collection_uuid,
+                    uuid.uuid4(),
+                    embedding[i],
+                    json.dumps(metadata[i]),
+                    documents[i],
+                    ids[i],
+                ]
             )
 
         column_names = ["collection_uuid", "uuid", "embedding", "metadata", "document", "id"]
@@ -253,46 +276,71 @@ class Clickhouse(DB):
             self._idx.add_incremental(collection_uuid, update_uuids, embeddings)
 
     def _get(self, where={}):
-        res = self._get_conn().query(
-            f"""SELECT {db_schema_to_keys()} FROM embeddings {where}"""
-        ).result_rows
+        res = (
+            self._get_conn()
+            .query(f"""SELECT {db_schema_to_keys()} FROM embeddings {where}""")
+            .result_rows
+        )
         # json.load the metadata
         return [[*x[:5], json.loads(x[5])] for x in res]
 
-    def _format_where(self, key, value):
-        # Shortcut for $eq
-        if type(value) == str:
-            return f" JSONExtractString(metadata,'{key}') = '{value}'"
-        elif type(value) == int:
-            return f" JSONExtractInt(metadata,'{key}') = {value}"
-        elif type(value) == float:
-            return f" JSONExtractFloat(metadata,'{key}') = {value}"
-        # Operator expression
-        elif type(value) == dict:
-            operator, operand = list(value.items())[0]
-            if operator == "$gt":
-                return f" JSONExtractFloat(metadata,'{key}') > {operand}"
-            elif operator == "$lt":
-                return f" JSONExtractFloat(metadata,'{key}') < {operand}"
-            elif operator == "$gte":
-                return f" JSONExtractFloat(metadata,'{key}') >= {operand}"
-            elif operator == "$lte":
-                return f" JSONExtractFloat(metadata,'{key}') <= {operand}"
-            elif operator == "$ne":
-                if type(operand) == str:
-                    return f" JSONExtractString(metadata,'{key}') != '{operand}'"
-                return f" JSONExtractFloat(metadata,'{key}') != {operand}"
-            elif operator == "$eq":
-                if type(operand) == str:
-                    return f" JSONExtractString(metadata,'{key}') = '{operand}'"
-                return f" JSONExtractFloat(metadata,'{key}') = {operand}"
-            else:
-                raise ValueError(f"Operator {operator} not supported")
-    
-    def _format_where_document(self, where_document):
+    def _format_where(self, where, result):
+        for key, value in where.items():
+            # Shortcut for $eq
+            if type(value) == str:
+                result.append(f" JSONExtractString(metadata,'{key}') = '{value}'")
+            elif type(value) == int:
+                result.append(f" JSONExtractInt(metadata,'{key}') = {value}")
+            elif type(value) == float:
+                result.append(f" JSONExtractFloat(metadata,'{key}') = {value}")
+            # Operator expression
+            elif type(value) == dict:
+                operator, operand = list(value.items())[0]
+                if operator == "$gt":
+                    return result.append(f" JSONExtractFloat(metadata,'{key}') > {operand}")
+                elif operator == "$lt":
+                    return result.append(f" JSONExtractFloat(metadata,'{key}') < {operand}")
+                elif operator == "$gte":
+                    return result.append(f" JSONExtractFloat(metadata,'{key}') >= {operand}")
+                elif operator == "$lte":
+                    return result.append(f" JSONExtractFloat(metadata,'{key}') <= {operand}")
+                elif operator == "$ne":
+                    if type(operand) == str:
+                        return result.append(f" JSONExtractString(metadata,'{key}') != '{operand}'")
+                    return result.append(f" JSONExtractFloat(metadata,'{key}') != {operand}")
+                elif operator == "$eq":
+                    if type(operand) == str:
+                        return result.append(f" JSONExtractString(metadata,'{key}') = '{operand}'")
+                    return result.append(f" JSONExtractFloat(metadata,'{key}') = {operand}")
+                else:
+                    raise ValueError(f"Operator {operator} not supported")
+            elif type(value) == list:
+                all_subresults = []
+                for subwhere in value:
+                    subresults = []
+                    self._format_where(subwhere, subresults)
+                    all_subresults.append(subresults[0])
+                if key == "$or":
+                    result.append(f"({' OR '.join(all_subresults)})")
+                elif key == "$and":
+                    result.append(f"({' AND '.join(all_subresults)})")
+                else:
+                    raise ValueError(f"Operator {key} not supported with a list of where clauses")
+
+    def _format_where_document(self, where_document, results):
         operator = list(where_document.keys())[0]
         if operator == "$contains":
-            return f"position(document, '{where_document[operator]}') > 0"
+            results.append(f"position(document, '{where_document[operator]}') > 0")
+        elif operator == "$and" or operator == "$or":
+            all_subresults = []
+            for subwhere in where_document[operator]:
+                subresults = []
+                self._format_where_document(subwhere, subresults)
+                all_subresults.append(subresults[0])
+            if operator == "$or":
+                results.append(f"({' OR '.join(all_subresults)})")
+            if operator == "$and":
+                results.append(f"({' AND '.join(all_subresults)})")
         else:
             raise ValueError(f"Operator {operator} not supported")
 
@@ -315,7 +363,9 @@ class Clickhouse(DB):
 
         s3 = time.time()
 
-        where = self._create_where_clause(collection_uuid, ids=ids, where=where, where_document=where_document)
+        where = self._create_where_clause(
+            collection_uuid, ids=ids, where=where, where_document=where_document
+        )
 
         if sort is not None:
             where += f" ORDER BY {sort}"
@@ -343,7 +393,9 @@ class Clickhouse(DB):
         return self._count(collection_uuid=collection_uuid)[0][0]
 
     def _delete(self, where_str=None):
-        deleted_uuids = self._get_conn().query(f"""SELECT uuid FROM embeddings {where_str}""").result_rows
+        deleted_uuids = (
+            self._get_conn().query(f"""SELECT uuid FROM embeddings {where_str}""").result_rows
+        )
         self._get_conn().command(
             f"""
             DELETE FROM
@@ -353,7 +405,9 @@ class Clickhouse(DB):
         )
         return [res[0] for res in deleted_uuids] if len(deleted_uuids) > 0 else []
 
-    def delete(self, where={}, collection_name=None, collection_uuid=None, ids=None, where_document={}):
+    def delete(
+        self, where={}, collection_name=None, collection_uuid=None, ids=None, where_document={}
+    ):
         if collection_name == None and collection_uuid == None:
             raise TypeError("Arguments collection_name and collection_uuid cannot both be None")
 
@@ -361,7 +415,9 @@ class Clickhouse(DB):
             collection_uuid = self.get_collection_uuid_from_name(collection_name)
 
         s3 = time.time()
-        where_str = self._create_where_clause(collection_uuid, ids=ids, where=where, where_document=where_document)
+        where_str = self._create_where_clause(
+            collection_uuid, ids=ids, where=where, where_document=where_document
+        )
 
         deleted_uuids = self._delete(where_str)
 
@@ -372,27 +428,33 @@ class Clickhouse(DB):
         return deleted_uuids
 
     def get_by_ids(self, ids: list):
-        return self._get_conn().query(
-            f"""
+        return (
+            self._get_conn()
+            .query(
+                f"""
         SELECT {db_schema_to_keys()} FROM embeddings WHERE uuid IN ({[id.hex for id in ids]})
         """
-        ).result_rows
+            )
+            .result_rows
+        )
 
     def get_nearest_neighbors(
-        self, 
-        where: Where, 
+        self,
+        where: Where,
         where_document: WhereDocument,
         embeddings: Embeddings,
         n_results: int,
-        collection_name=None, 
-        collection_uuid=None
+        collection_name=None,
+        collection_uuid=None,
     ) -> Tuple[List[List[uuid.UUID]], List[List[float]]]:
 
         if collection_name is not None:
             collection_uuid = self.get_collection_uuid_from_name(collection_name)
 
         if len(where) != 0 or len(where_document) != 0:
-            results = self.get(collection_uuid=collection_uuid, where=where, where_document=where_document)
+            results = self.get(
+                collection_uuid=collection_uuid, where=where, where_document=where_document
+            )
 
             if len(results) > 0:
                 ids = [x[1] for x in results]

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -153,40 +153,71 @@ class DuckDB(Clickhouse):
         collection_uuid = self.get_collection_uuid_from_name(collection_name)
         return self._count(collection_uuid=collection_uuid).fetchall()[0][0]
 
-    def _format_where(self, key, value):
-        # Shortcut for $eq
-        if type(value) == str:
-            return f" json_extract_string(metadata,'$.{key}') = '{value}'"
-        if type(value) == int:
-            return f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}"
-        if type(value) == float:
-            return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}"
-        # Operator expression
-        elif type(value) == dict:
-            operator, operand = list(value.items())[0]
-            if operator == "$gt":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}"
-            elif operator == "$lt":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) < {operand}"
-            elif operator == "$gte":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) >= {operand}"
-            elif operator == "$lte":
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) <= {operand}"
-            elif operator == "$ne":
-                if type(operand) == str:
-                    return f" json_extract_string(metadata,'$.{key}') != '{operand}'"
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
-            elif operator == "$eq":
-                if type(operand) == str:
-                    return f" json_extract_string(metadata,'$.{key}') = '{operand}'"
-                return f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {operand}"
-            else:
-                raise ValueError(f"Operator {operator} not supported")
-    
-    def _format_where_document(self, where_document):
+    def _format_where(self, where, result):
+        for key, value in where.items():
+            # Shortcut for $eq
+            if type(value) == str:
+                result.append(f" json_extract_string(metadata,'$.{key}') = '{value}'")
+            if type(value) == int:
+                result.append(f" CAST(json_extract(metadata,'$.{key}') AS INT) = {value}")
+            if type(value) == float:
+                result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {value}")
+            # Operator expression
+            elif type(value) == dict:
+                operator, operand = list(value.items())[0]
+                if operator == "$gt":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) > {operand}")
+                elif operator == "$lt":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) < {operand}")
+                elif operator == "$gte":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) >= {operand}")
+                elif operator == "$lte":
+                    result.append(f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) <= {operand}")
+                elif operator == "$ne":
+                    if type(operand) == str:
+                        return result.append(
+                            f" json_extract_string(metadata,'$.{key}') != '{operand}'"
+                        )
+                    return result.append(
+                        f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) != {operand}"
+                    )
+                elif operator == "$eq":
+                    if type(operand) == str:
+                        return result.append(
+                            f" json_extract_string(metadata,'$.{key}') = '{operand}'"
+                        )
+                    return result.append(
+                        f" CAST(json_extract(metadata,'$.{key}') AS DOUBLE) = {operand}"
+                    )
+                else:
+                    raise ValueError(f"Operator {operator} not supported")
+            elif type(value) == list:
+                all_subresults = []
+                for subwhere in value:
+                    subresults = []
+                    self._format_where(subwhere, subresults)
+                    all_subresults.append(subresults[0])
+                if key == "$or":
+                    result.append(f"({' OR '.join(all_subresults)})")
+                elif key == "$and":
+                    result.append(f"({' AND '.join(all_subresults)})")
+                else:
+                    raise ValueError(f"Operator {key} not supported with a list of where clauses")
+
+    def _format_where_document(self, where_document, results):
         operator = list(where_document.keys())[0]
         if operator == "$contains":
-            return f"position('{where_document[operator]}' in document) > 0"
+            results.append(f"position('{where_document[operator]}' in document) > 0")
+        elif operator == "$and" or operator == "$or":
+            all_subresults = []
+            for subwhere in where_document[operator]:
+                subresults = []
+                self._format_where_document(subwhere, subresults)
+                all_subresults.append(subresults[0])
+            if operator == "$or":
+                results.append(f"({' OR '.join(all_subresults)})")
+            if operator == "$and":
+                results.append(f"({' AND '.join(all_subresults)})")
         else:
             raise ValueError(f"Operator {operator} not supported")
 
@@ -294,7 +325,9 @@ class DuckDB(Clickhouse):
         self._idx.reset()
 
     def persist(self):
-        raise NotImplementedError("chroma_db_impl='duckdb+parquet' to get persistence functionality")
+        raise NotImplementedError(
+            "chroma_db_impl='duckdb+parquet' to get persistence functionality"
+        )
 
 
 class PersistentDuckDB(DuckDB):
@@ -336,9 +369,11 @@ class PersistentDuckDB(DuckDB):
                 (SELECT * FROM embeddings)
             TO '{self._save_folder}/chroma-embeddings.parquet'
                 (FORMAT PARQUET);
-        """)
+        """
+        )
 
-        self._conn.execute(f"""
+        self._conn.execute(
+            f"""
             COPY
                 (SELECT * FROM collections)
             TO '{self._save_folder}/chroma-collections.parquet'

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -816,6 +816,17 @@ def test_where_logical_operators(api_fixture, request):
     )
     assert len(items["metadatas"]) == 2
 
+    items = collection.get(
+        where={
+            "$or": [
+                {"$and": [{"int_value": {"$eq": 3}}, {"string_value": {"$eq": "three"}}]},
+                {"$and": [{"int_value": {"$eq": 4}}, {"string_value": {"$eq": "four"}}]},
+            ],
+            "$and": [{"is": "doc"}, {"string_value": "four"}],
+        }
+    )
+    assert len(items["metadatas"]) == 1
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_document_logical_operators(api_fixture, request):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -845,5 +845,18 @@ def test_where_document_logical_operators(api_fixture, request):
     )
     assert len(items["metadatas"]) == 2
 
+    items = collection.get(
+        where_document={
+            "$or": [
+                {"$contains": "first"},
+                {"$contains": "second"},
+            ]
+        },
+        where={
+            "int_value": {"$ne": 2},
+        },
+    )
+    assert len(items["metadatas"]) == 1
+
 
 # endregion

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -24,6 +24,7 @@ def local_api():
         )
     )
 
+
 @pytest.fixture
 def local_persist_api():
     return chromadb.Client(
@@ -91,6 +92,7 @@ if "CHROMA_INTEGRATION_TEST" in os.environ:
     print("Including integration tests")
     test_apis.append(fastapi_integration_api)
 
+
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
 def test_persist(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -116,6 +118,7 @@ def test_persist(api_fixture, request):
 
     api = request.getfixturevalue(api_fixture.__name__)
     assert api.list_collections() == []
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_heartbeat(api_fixture, request):
@@ -186,6 +189,7 @@ def test_reset_db(api_fixture, request):
 
     assert api.reset()
     assert len(api.list_collections()) == 0
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_nearest_neighbors(api_fixture, request):
@@ -383,15 +387,15 @@ def test_peek(api_fixture, request):
         assert len(peek[key]) == 2
 
 
-
 #### TEST METADATA AND METADATA FILTERING ####
 # region
- 
+
 metadata_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}]
+    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_add_get_int_float(api_fixture, request):
@@ -400,13 +404,14 @@ def test_metadata_add_get_int_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items = collection.get(ids=["id1", "id2"])
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["float_value"] == 1.001
     assert items["metadatas"][1]["int_value"] == 2
     assert type(items["metadatas"][0]["int_value"]) == int
     assert type(items["metadatas"][0]["float_value"]) == float
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_add_query_int_float(api_fixture, request):
@@ -415,12 +420,13 @@ def test_metadata_add_query_int_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items: QueryResult = collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
     assert items["metadatas"][0][0]["int_value"] == 1
     assert items["metadatas"][0][0]["float_value"] == 1.001
     assert type(items["metadatas"][0][0]["int_value"]) == int
     assert type(items["metadatas"][0][0]["float_value"]) == float
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_get_where_string(api_fixture, request):
@@ -429,10 +435,11 @@ def test_metadata_get_where_string(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
-    items = collection.get(where={"string_value": "one"}) 
+
+    items = collection.get(where={"string_value": "one"})
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["string_value"] == "one"
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_get_where_int(api_fixture, request):
@@ -441,10 +448,11 @@ def test_metadata_get_where_int(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items = collection.get(where={"int_value": 1})
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["string_value"] == "one"
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_get_where_float(api_fixture, request):
@@ -453,11 +461,12 @@ def test_metadata_get_where_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
+
     items = collection.get(where={"float_value": 1.001})
     assert items["metadatas"][0]["int_value"] == 1
     assert items["metadatas"][0]["string_value"] == "one"
     assert items["metadatas"][0]["float_value"] == 1.001
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_update_get_int_float(api_fixture, request):
@@ -466,18 +475,22 @@ def test_metadata_update_get_int_float(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
-    
-    collection.update(ids=["id1"], metadatas=[{"int_value": 2, "string_value": "two", "float_value": 2.002}])
+
+    collection.update(
+        ids=["id1"], metadatas=[{"int_value": 2, "string_value": "two", "float_value": 2.002}]
+    )
     items = collection.get(ids=["id1"])
     assert items["metadatas"][0]["int_value"] == 2
     assert items["metadatas"][0]["string_value"] == "two"
     assert items["metadatas"][0]["float_value"] == 2.002
 
+
 bad_metadata_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"value": {"nested": "5"}}, {"value": [1,2,3]}]
+    "metadatas": [{"value": {"nested": "5"}}, {"value": [1, 2, 3]}],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_validation_add(api_fixture, request):
@@ -488,6 +501,7 @@ def test_metadata_validation_add(api_fixture, request):
     with pytest.raises(ValueError) as e:
         collection.add(**bad_metadata_records)
     assert "Metadata" in str(e.value)
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_metadata_validation_update(api_fixture, request):
@@ -500,6 +514,7 @@ def test_metadata_validation_update(api_fixture, request):
         collection.update(ids=["id1"], metadatas={"value": {"nested": "5"}})
     assert "Metadata" in str(e.value)
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_validation_get(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -510,6 +525,7 @@ def test_where_validation_get(api_fixture, request):
         collection.get(where={"value": {"nested": "5"}})
     assert "Where" in str(e.value)
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_validation_query(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -517,15 +533,19 @@ def test_where_validation_query(api_fixture, request):
     api.reset()
     collection = api.create_collection("test_where_validation")
     with pytest.raises(ValueError) as e:
-        collection.query(query_embeddings=[0,0,0], where={"value": {"nested": "5"}})
+        collection.query(query_embeddings=[0, 0, 0], where={"value": {"nested": "5"}})
     assert "Where" in str(e.value)
 
 
 operator_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2, "float_value": 2.002, "string_value": "two"}]
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2, "float_value": 2.002, "string_value": "two"},
+    ],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_lt(api_fixture, request):
@@ -537,6 +557,7 @@ def test_where_lt(api_fixture, request):
     items = collection.get(where={"int_value": {"$lt": 2}})
     assert len(items["metadatas"]) == 1
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_lte(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -546,6 +567,7 @@ def test_where_lte(api_fixture, request):
     collection.add(**operator_records)
     items = collection.get(where={"int_value": {"$lte": 2.0}})
     assert len(items["metadatas"]) == 2
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_gt(api_fixture, request):
@@ -557,6 +579,7 @@ def test_where_gt(api_fixture, request):
     items = collection.get(where={"float_value": {"$gt": -1.4}})
     assert len(items["metadatas"]) == 2
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_gte(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -567,6 +590,7 @@ def test_where_gte(api_fixture, request):
     items = collection.get(where={"float_value": {"$gte": 2.002}})
     assert len(items["metadatas"]) == 1
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_ne_string(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -576,6 +600,7 @@ def test_where_ne_string(api_fixture, request):
     collection.add(**operator_records)
     items = collection.get(where={"string_value": {"$ne": "two"}})
     assert len(items["metadatas"]) == 1
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_ne_eq_number(api_fixture, request):
@@ -589,6 +614,7 @@ def test_where_ne_eq_number(api_fixture, request):
     items = collection.get(where={"float_value": {"$eq": 2.002}})
     assert len(items["metadatas"]) == 1
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_where_valid_operators(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -601,9 +627,39 @@ def test_where_valid_operators(api_fixture, request):
 
     with pytest.raises(ValueError) as e:
         collection.get(where={"int_value": {"$lt": "2"}})
-    
+
     with pytest.raises(ValueError) as e:
         collection.get(where={"int_value": {"$lt": 2, "$gt": 1}})
+
+    # Test invalid $and, $or
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$and": {"int_value": {"$lt": 2}}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"int_value": {"$lt": 2}, "$or": {"int_value": {"$gt": 1}}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$gt": [{"int_value": {"$lt": 2}}, {"int_value": {"$gt": 1}}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$or": [{"int_value": {"$lt": 2}}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"$or": []})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where={"a": {"$contains": "test"}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(
+            where={
+                "$or": [
+                    {"a": {"$contains": "first"}},  # invalid
+                    {"$contains": "second"},  # valid
+                ]
+            }
+        )
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_query_document_valid_operators(api_fixture, request):
@@ -617,19 +673,42 @@ def test_query_document_valid_operators(api_fixture, request):
     assert "Where document" in str(e.value)
 
     with pytest.raises(ValueError) as e:
-        collection.query(query_embeddings=[0,0,0], where_document={"$contains": 2})
+        collection.query(query_embeddings=[0, 0, 0], where_document={"$contains": 2})
     assert "Where document" in str(e.value)
-    
+
     with pytest.raises(ValueError) as e:
         collection.get(where_document={"$contains": []})
     assert "Where document" in str(e.value)
+
+    # Test invalid $and, $or
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$and": {"$unsupported": "doc"}})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$or": [{"$unsupported": "doc"}, {"$unsupported": "doc"}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$or": [{"$contains": "doc"}]})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(where_document={"$or": []})
+
+    with pytest.raises(ValueError) as e:
+        collection.get(
+            where_document={"$or": [{"$and": [{"$contains": "doc"}]}, {"$contains": "doc"}]}
+        )
+
 
 contains_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "documents": ["this is doc1 and it's great!", "doc2 is also great!"],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2, "float_value": 2.002, "string_value": "two"}]
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2, "float_value": 2.002, "string_value": "two"},
+    ],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_where_document(api_fixture, request):
@@ -657,14 +736,21 @@ def test_query_where_document(api_fixture, request):
     collection = api.create_collection("test_query_where_document")
     collection.add(**contains_records)
 
-    items = collection.query(query_embeddings=[0,0,0], where_document={"$contains": "doc1"}, n_results=1)
+    items = collection.query(
+        query_embeddings=[0, 0, 0], where_document={"$contains": "doc1"}, n_results=1
+    )
     assert len(items["metadatas"][0]) == 1
 
-    items = collection.query(query_embeddings=[0,0,0], where_document={"$contains": "great"}, n_results=2)
+    items = collection.query(
+        query_embeddings=[0, 0, 0], where_document={"$contains": "great"}, n_results=2
+    )
     assert len(items["metadatas"][0]) == 2
 
     with pytest.raises(NoDatapointsException) as e:
-        items = collection.query(query_embeddings=[0,0,0], where_document={"$contains": "bad"}, n_results=1)
+        items = collection.query(
+            query_embeddings=[0, 0, 0], where_document={"$contains": "bad"}, n_results=1
+        )
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_delete_where_document(api_fixture, request):
@@ -683,7 +769,81 @@ def test_delete_where_document(api_fixture, request):
     collection.delete(where_document={"$contains": "great"})
     assert collection.count() == 0
 
-# endregion 
+
+logical_operator_records = {
+    "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2], [1.3, 2.25, 3.2], [1.4, 2.26, 3.2]],
+    "ids": ["id1", "id2", "id3", "id4"],
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001, "is": "doc"},
+        {"int_value": 2, "float_value": 2.002, "string_value": "two", "is": "doc"},
+        {"int_value": 3, "float_value": 3.003, "string_value": "three", "is": "doc"},
+        {"int_value": 4, "float_value": 4.004, "string_value": "four", "is": "doc"},
+    ],
+    "documents": [
+        "this document is first and great",
+        "this document is second and great",
+        "this document is third and great",
+        "this document is fourth and great",
+    ],
+}
 
 
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_logical_operators(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
 
+    api.reset()
+    collection = api.create_collection("test_logical_operators")
+    collection.add(**logical_operator_records)
+
+    items = collection.get(
+        where={
+            "$and": [
+                {"$or": [{"int_value": {"$gte": 3}}, {"float_value": {"$lt": 1.9}}]},
+                {"is": "doc"},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 3
+
+    items = collection.get(
+        where={
+            "$or": [
+                {"$and": [{"int_value": {"$eq": 3}}, {"string_value": {"$eq": "three"}}]},
+                {"$and": [{"int_value": {"$eq": 4}}, {"string_value": {"$eq": "four"}}]},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 2
+
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_where_document_logical_operators(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_document_logical_operators")
+    collection.add(**logical_operator_records)
+
+    items = collection.get(
+        where_document={
+            "$and": [
+                {"$contains": "first"},
+                {"$contains": "doc"},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 1
+
+    items = collection.get(
+        where_document={
+            "$or": [
+                {"$contains": "first"},
+                {"$contains": "second"},
+            ]
+        }
+    )
+    assert len(items["metadatas"]) == 2
+
+
+# endregion


### PR DESCRIPTION
This PR adds $and as well as $or support for where as well as where_document fields during get, query, and delete. This PR is stacked on #130 so please read that before this.

All changes
1. Add typing for logical operators $and + $or
2. Add validation and validation tests for logical operators
3. Add support in clickhouse and duckdb. The code is duplicative across dbs but we expect this to change soon so leaving for now since footprint is minimal.

You can use this functionality like so


```
  items = collection.get(
      where_document={
          "$or": [
              {"$contains": "first"},
              {"$contains": "second"},
          ]
      },
      where={
          "int_value": {"$ne": 2},
      },
  )

```