### PR TITLE
Add delete tests back and where_document null handling

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -152,12 +152,12 @@ class LocalAPI(API):
         offset=None,
         page=None,
         page_size=None,
-        where_document=None
+        where_document=None,
     ):
 
         if where is None:
             where = {}
-        
+
         if where_document is None:
             where_document = {}
 
@@ -182,7 +182,12 @@ class LocalAPI(API):
         if where is None:
             where = {}
 
-        deleted_uuids = self._db.delete(collection_name=collection_name, where=where, ids=ids, where_document=where_document)
+        if where_document is None:
+            where_document = {}
+
+        deleted_uuids = self._db.delete(
+            collection_name=collection_name, where=where, ids=ids, where_document=where_document
+        )
         return deleted_uuids
 
     def _count(self, collection_name):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -233,11 +233,8 @@ def test_delete(api_fixture, request):
     collection.add(**batch_records)
     assert collection.count() == 2
 
-    # generic delete on collection not working yet
-    # assert collection.delete() == []
-    # assert collection.count() == 2
-    # assert collection.delete()
-    # assert collection.count() == 0
+    collection.delete()
+    assert collection.count() == 0
 
 
 @pytest.mark.parametrize("api_fixture", test_apis)


### PR DESCRIPTION
If where_document is None at the Collection call, delete should pass an empty dict down to the client. Add back tests to catch this case. They were commented out.