### PR TITLE
Add support for query "include"

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -8,6 +8,7 @@ from chromadb.api.types import (
     Documents,
     Embeddings,
     IDs,
+    Include,
     Metadatas,
     Where,
     QueryResult,
@@ -204,10 +205,7 @@ class API(ABC):
         n_results: int = 10,
         where: Where = {},
         where_document: WhereDocument = {},
-        include_embeddings: bool = True,
-        include_documents: bool = True,
-        include_metadatas: bool = True,
-        include_distances: bool = True,
+        include: Optional[Include] = ["embeddings", "metadatas", "documents", "distances"],
     ) -> QueryResult:
         """Gets the nearest neighbors of a single embedding
         ⚠️ This method should not be used directly.

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -181,7 +181,13 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def _delete(self, collection_name: str, ids: Optional[IDs], where: Optional[Where] = {}, where_document: Optional[WhereDocument] = {}):
+    def _delete(
+        self,
+        collection_name: str,
+        ids: Optional[IDs],
+        where: Optional[Where] = {},
+        where_document: Optional[WhereDocument] = {},
+    ):
         """Deletes embeddings from the database
         ⚠️ This method should not be used directly.
 
@@ -198,6 +204,10 @@ class API(ABC):
         n_results: int = 10,
         where: Where = {},
         where_document: WhereDocument = {},
+        include_embeddings: bool = True,
+        include_documents: bool = True,
+        include_metadatas: bool = True,
+        include_distances: bool = True,
     ) -> QueryResult:
         """Gets the nearest neighbors of a single embedding
         ⚠️ This method should not be used directly.

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -104,7 +104,14 @@ class FastAPI(API):
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/get",
             data=json.dumps(
-                {"ids": ids, "where": where, "sort": sort, "limit": limit, "offset": offset, "where_document": where_document}
+                {
+                    "ids": ids,
+                    "where": where,
+                    "sort": sort,
+                    "limit": limit,
+                    "offset": offset,
+                    "where_document": where_document,
+                }
             ),
         )
 
@@ -181,13 +188,33 @@ class FastAPI(API):
         resp.raise_for_status
         return True
 
-    def _query(self, collection_name, query_embeddings, n_results=10, where={}, where_document={}):
+    def _query(
+        self,
+        collection_name,
+        query_embeddings,
+        n_results=10,
+        where={},
+        where_document={},
+        include_embeddings: bool = True,
+        include_documents: bool = True,
+        include_metadatas: bool = True,
+        include_distances: bool = True,
+    ):
         """Gets the nearest neighbors of a single embedding"""
 
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/query",
             data=json.dumps(
-                {"query_embeddings": query_embeddings, "n_results": n_results, "where": where, "where_document": where_document}
+                {
+                    "query_embeddings": query_embeddings,
+                    "n_results": n_results,
+                    "where": where,
+                    "where_document": where_document,
+                    "include_embeddings": include_embeddings,
+                    "include_documents": include_documents,
+                    "include_metadatas": include_metadatas,
+                    "include_distances": include_distances,
+                }
             ),
         )
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -4,6 +4,7 @@ from chromadb.api.types import (
     Documents,
     Embeddings,
     IDs,
+    Include,
     Metadatas,
 )
 from chromadb.errors import NoDatapointsException
@@ -156,8 +157,8 @@ class FastAPI(API):
         try:
             resp.raise_for_status()
         except requests.HTTPError as e:
-            raise(Exception(resp.text))
-                       
+            raise (Exception(resp.text))
+
         return True
 
     def _update(
@@ -195,10 +196,7 @@ class FastAPI(API):
         n_results=10,
         where={},
         where_document={},
-        include_embeddings: bool = True,
-        include_documents: bool = True,
-        include_metadatas: bool = True,
-        include_distances: bool = True,
+        include: Include = ["embeddings", "metadatas", "documents", "distances"],
     ):
         """Gets the nearest neighbors of a single embedding"""
 
@@ -210,10 +208,7 @@ class FastAPI(API):
                     "n_results": n_results,
                     "where": where,
                     "where_document": where_document,
-                    "include_embeddings": include_embeddings,
-                    "include_documents": include_documents,
-                    "include_metadatas": include_metadatas,
-                    "include_distances": include_distances,
+                    "include": include,
                 }
             ),
         )
@@ -221,8 +216,8 @@ class FastAPI(API):
         try:
             resp.raise_for_status()
         except requests.HTTPError as e:
-            raise(Exception(resp.text))
-        
+            raise (Exception(resp.text))
+
         body = resp.json()
         return body
 
@@ -250,5 +245,5 @@ class FastAPI(API):
         try:
             resp.raise_for_status()
         except requests.HTTPError as e:
-            raise(Exception(resp.text))
+            raise (Exception(resp.text))
         return resp.json()

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -3,7 +3,7 @@ import time
 from typing import Dict, List, Optional, Sequence, Callable, Type, cast
 from chromadb.api import API
 from chromadb.db import DB
-from chromadb.api.types import Embedding, GetResult, IDs, QueryResult
+from chromadb.api.types import Embedding, GetResult, IDs, Include, QueryResult
 from chromadb.api.models.Collection import Collection
 
 import re
@@ -188,10 +188,7 @@ class LocalAPI(API):
         n_results=10,
         where={},
         where_document={},
-        include_embeddings: bool = True,
-        include_documents: bool = True,
-        include_metadatas: bool = True,
-        include_distances: bool = True,
+        include: Include = ["embeddings", "documents", "metadatas", "distances"],
     ):
         uuids, distances = self._db.get_nearest_neighbors(
             collection_name=collection_name,
@@ -200,6 +197,11 @@ class LocalAPI(API):
             embeddings=query_embeddings,
             n_results=n_results,
         )
+
+        include_embeddings = "embeddings" in include
+        include_documents = "documents" in include
+        include_metadatas = "metadatas" in include
+        include_distances = "distances" in include
 
         columns = []
         column_index = {}

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -1,9 +1,9 @@
 import json
 import time
-from typing import Dict, Optional, Sequence, Callable
+from typing import Dict, List, Optional, Sequence, Callable, Type, cast
 from chromadb.api import API
 from chromadb.db import DB
-from chromadb.api.types import GetResult, IDs, QueryResult
+from chromadb.api.types import Embedding, GetResult, IDs, QueryResult
 from chromadb.api.models.Collection import Collection
 
 import re
@@ -198,7 +198,18 @@ class LocalAPI(API):
         self._db.reset()
         return True
 
-    def _query(self, collection_name, query_embeddings, n_results=10, where={}, where_document={}):
+    def _query(
+        self,
+        collection_name,
+        query_embeddings,
+        n_results=10,
+        where={},
+        where_document={},
+        include_embeddings: bool = True,
+        include_documents: bool = True,
+        include_metadatas: bool = True,
+        include_distances: bool = True,
+    ):
         uuids, distances = self._db.get_nearest_neighbors(
             collection_name=collection_name,
             where=where,
@@ -207,25 +218,56 @@ class LocalAPI(API):
             n_results=n_results,
         )
 
-        query_result = QueryResult(embeddings=[], documents=[], ids=[], metadatas=[], distances=[])
+        columns = []
+        column_index = {}
+        i = 0
+        if include_embeddings:
+            columns.append("embedding")
+            column_index["embedding"] = i
+            i += 1
+        if include_documents:
+            columns.append("document")
+            column_index["document"] = i
+            i += 1
+        if include_metadatas:
+            columns.append("metadata")
+            column_index["metadata"] = i
+            i += 1
+        columns.append("id")
+        column_index["id"] = i
+
+        query_result = QueryResult(
+            ids=[],
+            embeddings=[] if include_embeddings else None,
+            documents=[] if include_documents else None,
+            metadatas=[] if include_metadatas else None,
+            distances=[] if include_distances else None,
+        )
         for i in range(len(uuids)):
             embeddings = []
             documents = []
             ids = []
             metadatas = []
-            db_result = self._db.get_by_ids(uuids[i])
+            db_result = self._db.get_by_ids(uuids[i], columns=columns)
 
             for entry in db_result:
-                embeddings.append(entry[2])
-                documents.append(entry[3])
-                ids.append(entry[4])
-                metadatas.append(json.loads(entry[5]))
+                if include_embeddings:
+                    embeddings.append(entry[column_index["embedding"]])
+                if include_documents:
+                    documents.append(entry[column_index["document"]])
+                if include_metadatas:
+                    metadatas.append(json.loads(entry[column_index["metadata"]]))
+                ids.append(entry[column_index["id"]])
 
-            query_result["embeddings"].append(embeddings)
-            query_result["documents"].append(documents)
+            if include_embeddings:
+                cast(List, query_result["embeddings"]).append(embeddings)
+            if include_documents:
+                cast(List, query_result["documents"]).append(documents)
+            if include_metadatas:
+                cast(List, query_result["metadatas"]).append(metadatas)
+            if include_distances:
+                cast(List, query_result["distances"]).append(distances[i].tolist())
             query_result["ids"].append(ids)
-            query_result["metadatas"].append(metadatas)
-            query_result["distances"].append(distances[i].tolist())
 
         return query_result
 

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, PrivateAttr
 
 from chromadb.api.types import (
     Embedding,
+    Include,
     Metadata,
     Document,
     Where,
@@ -139,10 +140,7 @@ class Collection(BaseModel):
         n_results: int = 10,
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
-        include_embeddings: bool = True,
-        include_documents: bool = True,
-        include_metadatas: bool = True,
-        include_distances: bool = True,
+        include: Optional[Include] = ["embeddings", "metadatas", "documents", "distances"],
     ) -> QueryResult:
         """Get the n_results nearest neighbor embeddings for provided query_embeddings or query_texts.
 
@@ -152,10 +150,7 @@ class Collection(BaseModel):
             n_results: The number of neighbots to return for each query_embedding or query_text. Optional.
             where: A Where type dict used to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
             where_document: A WhereDocument type dict used to filter by the documents. E.g. {$contains: {"text": "hello"}}. Optional.
-            include_embeddings: Whether to include the embeddings in the results. Sets embeddings to None if True. Optional.
-            include_documents: Whether to include the documents in the results. Sets documents to None if True. Optional.
-            include_metadatas: Whether to include the metadatas in the results. Sets metadata to None if True. Optional.
-            include_distances: Whether to include the distances in the results. Sets distances to None if True. Optional.
+            include: A list of what to include in the results. Can contain "embeddings", "metadatas", "documents", "distances". Defaults to all. Optional.
         """
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None
@@ -189,10 +184,7 @@ class Collection(BaseModel):
             n_results=n_results,
             where=where,
             where_document=where_document,
-            include_embeddings=include_embeddings,
-            include_documents=include_documents,
-            include_metadatas=include_metadatas,
-            include_distances=include_distances,
+            include=include,
         )
 
     def modify(self, name: Optional[str] = None, metadata=None):

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -119,7 +119,9 @@ class Collection(BaseModel):
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None
         ids = maybe_cast_one_to_many(ids) if ids else None
-        return self._client._get(self.name, ids, where, None, limit, offset, where_document=where_document)
+        return self._client._get(
+            self.name, ids, where, None, limit, offset, where_document=where_document
+        )
 
     def peek(self, limit: int = 10) -> GetResult:
         """Get the first few results in the database up to limit
@@ -136,6 +138,10 @@ class Collection(BaseModel):
         n_results: int = 10,
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
+        include_embeddings: bool = True,
+        include_documents: bool = True,
+        include_metadatas: bool = True,
+        include_distances: bool = True,
     ) -> QueryResult:
         """Get the n_results nearest neighbor embeddings for provided query_embeddings or query_texts.
 
@@ -167,7 +173,7 @@ class Collection(BaseModel):
 
         if where is None:
             where = {}
-        
+
         if where_document is None:
             where_document = {}
 
@@ -177,6 +183,10 @@ class Collection(BaseModel):
             n_results=n_results,
             where=where,
             where_document=where_document,
+            include_embeddings=include_embeddings,
+            include_documents=include_documents,
+            include_metadatas=include_metadatas,
+            include_distances=include_distances,
         )
 
     def modify(self, name: Optional[str] = None, metadata=None):
@@ -241,7 +251,12 @@ class Collection(BaseModel):
 
         self._client._update(self.name, ids, embeddings, metadatas, documents)
 
-    def delete(self, ids: Optional[IDs] = None, where: Optional[Where] = None, where_document: Optional[WhereDocument] = None):
+    def delete(
+        self,
+        ids: Optional[IDs] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ):
         """Delete the embeddings based on ids and/or a where filter
 
         Args:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -112,9 +112,10 @@ class Collection(BaseModel):
 
         Args:
             ids: The ids of the embeddings to get. Optional.
-            where: A dict of key, value string:string/int/float pairs to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where: A Where type dict used to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
             limit: The number of documents to return. Optional.
             offset: The offset to start returning results from. Useful for paging results with limit. Optional.
+            where_document: A WhereDocument type dict used to filter by the documents. E.g. {$contains: {"text": "hello"}}. Optional.
         """
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None
@@ -149,7 +150,12 @@ class Collection(BaseModel):
             query_embeddings: The embeddings to get the closes neighbors of. Optional.
             query_texts: The document texts to get the closes neighbors of. Optional.
             n_results: The number of neighbots to return for each query_embedding or query_text. Optional.
-            where: A dict of key, value string:string/int/float pairs to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where: A Where type dict used to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where_document: A WhereDocument type dict used to filter by the documents. E.g. {$contains: {"text": "hello"}}. Optional.
+            include_embeddings: Whether to include the embeddings in the results. Sets embeddings to None if True. Optional.
+            include_documents: Whether to include the documents in the results. Sets documents to None if True. Optional.
+            include_metadatas: Whether to include the metadatas in the results. Sets metadata to None if True. Optional.
+            include_distances: Whether to include the distances in the results. Sets distances to None if True. Optional.
         """
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None
@@ -261,7 +267,9 @@ class Collection(BaseModel):
 
         Args:
             ids: The ids of the embeddings to delete
-            where:  A dict of key, value string:string/int/float pairs to filter deletions by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where: Where type. A dict of string:string/int/float pairs to filter deletions by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where: A Where type dict used to filter the delection by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where_document: A WhereDocument type dict used to filter the deletion by the document content. E.g. {$contains: {"text": "hello"}}. Optional.
         """
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -259,7 +259,6 @@ class Collection(BaseModel):
 
         Args:
             ids: The ids of the embeddings to delete
-            where: Where type. A dict of string:string/int/float pairs to filter deletions by. E.g. {"color" : "red", "price": 4.20}. Optional.
             where: A Where type dict used to filter the delection by. E.g. {"color" : "red", "price": 4.20}. Optional.
             where_document: A WhereDocument type dict used to filter the deletion by the document content. E.g. {$contains: {"text": "hello"}}. Optional.
         """

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -18,7 +18,7 @@ Parameter = TypeVar("Parameter", Embedding, Document, Metadata, ID)
 T = TypeVar("T")
 OneOrMany = Union[T, List[T]]
 
-Includes = List[Literal["documents", "embeddings", "metadatas", "distances"]]
+Include = List[Literal["documents", "embeddings", "metadatas", "distances"]]
 
 # Grammar for where expressions
 LiteralValue = Union[str, int, float]

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union, Dict, Sequence, TypedDict, Protocol, TypeVar, List
+from typing import Literal, Optional, Union, Dict, Sequence, TypedDict, Protocol, TypeVar, List
 
 ID = str
 IDs = List[ID]
@@ -38,10 +38,10 @@ class GetResult(TypedDict):
 
 class QueryResult(TypedDict):
     ids: List[IDs]
-    embeddings: List[List[Embedding]]
-    documents: List[List[Document]]
-    metadatas: List[List[Metadata]]
-    distances: List[List[float]]
+    embeddings: Optional[List[List[Embedding]]]
+    documents: Optional[List[List[Document]]]
+    metadatas: Optional[List[List[Metadata]]]
+    distances: Optional[List[List[float]]]
 
 
 class EmbeddingFunction(Protocol):

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from chromadb.api.types import Embeddings, Documents, IDs, Metadatas
 
+
 class DB(ABC):
     @abstractmethod
     def __init__(self):
@@ -34,19 +35,20 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def add(self, 
-            collection_uuid: str, 
-            embeddings: Embeddings, 
-            metadatas: Optional[Metadatas], 
-            documents: Optional[Documents], 
-            ids: List[UUID]
+    def add(
+        self,
+        collection_uuid: str,
+        embeddings: Embeddings,
+        metadatas: Optional[Metadatas],
+        documents: Optional[Documents],
+        ids: List[UUID],
     ) -> List[UUID]:
         pass
 
     @abstractmethod
     def add_incremental(self, collection_uuid: str, ids: List[UUID], embeddings: Embeddings):
         pass
-    
+
     @abstractmethod
     def get(
         self,
@@ -74,7 +76,9 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def get_nearest_neighbors(self, collection_name, where, embeddings, n_results) -> Tuple[List[List[UUID]], List[List[float]]]:
+    def get_nearest_neighbors(
+        self, collection_name, where, embeddings, n_results, where_document
+    ) -> Tuple[List[List[UUID]], List[List[float]]]:
         pass
 
     @abstractmethod

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -74,7 +74,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def get_by_ids(self, uuids):
+    def get_by_ids(self, uuids, columns=None):
         pass
 
     @abstractmethod

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -426,12 +426,13 @@ class Clickhouse(DB):
 
         return deleted_uuids
 
-    def get_by_ids(self, ids: list):
+    def get_by_ids(self, ids: list, columns: Optional[list] = None):
+        select_columns = db_schema_to_keys() if columns is None else ",".join(columns)
         return (
             self._get_conn()
             .query(
                 f"""
-        SELECT {db_schema_to_keys()} FROM embeddings WHERE uuid IN ({[id.hex for id in ids]})
+        SELECT {select_columns} FROM embeddings WHERE uuid IN ({[id.hex for id in ids]})
         """
             )
             .result_rows

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -287,7 +287,7 @@ class DuckDB(Clickhouse):
         ).fetchall()[0]
         return [uuid.UUID(x[0]) for x in uuids_deleted]
 
-    def get_by_ids(self, ids=list):
+    def get_by_ids(self, ids: list, columns: Optional[list] = None):
         # select from duckdb table where ids are in the list
         if not isinstance(ids, list):
             raise Exception("ids must be a list")
@@ -296,10 +296,11 @@ class DuckDB(Clickhouse):
             # create an empty pandas dataframe
             return pd.DataFrame()
 
+        select_columns = db_schema_to_keys() if columns is None else ", ".join(columns)
         return self._conn.execute(
             f"""
             SELECT
-                {db_schema_to_keys()}
+                {select_columns}
             FROM
                 embeddings
             WHERE

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -3,7 +3,11 @@ from fastapi.responses import JSONResponse
 from fastapi import HTTPException, status
 import chromadb
 import chromadb.server
-from chromadb.errors import NoDatapointsException, InvalidDimensionException, NotEnoughElementsException
+from chromadb.errors import (
+    NoDatapointsException,
+    InvalidDimensionException,
+    NotEnoughElementsException,
+)
 from chromadb.server.fastapi.types import (
     AddEmbedding,
     CountEmbedding,
@@ -159,10 +163,7 @@ class FastAPI(chromadb.server.Server):
                 where_document=query.where_document,
                 query_embeddings=query.query_embeddings,
                 n_results=query.n_results,
-                include_embeddings=query.include_embeddings,
-                include_metadatas=query.include_metadatas,
-                include_documents=query.include_documents,
-                include_distances=query.include_distances,
+                include=query.include,
             )
             return nnresult
         except NoDatapointsException as e:

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -135,7 +135,10 @@ class FastAPI(chromadb.server.Server):
 
     def delete(self, collection_name: str, delete: DeleteEmbedding):
         return self._api._delete(
-            where=delete.where, ids=delete.ids, collection_name=collection_name, where_document=delete.where_document,
+            where=delete.where,
+            ids=delete.ids,
+            collection_name=collection_name,
+            where_document=delete.where_document,
         )
 
     def count(self, collection_name: str):
@@ -152,6 +155,10 @@ class FastAPI(chromadb.server.Server):
                 where_document=query.where_document,
                 query_embeddings=query.query_embeddings,
                 n_results=query.n_results,
+                include_embeddings=query.include_embeddings,
+                include_metadatas=query.include_metadatas,
+                include_documents=query.include_documents,
+                include_distances=query.include_distances,
             )
             return nnresult
         except NoDatapointsException:

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel
 from typing import Union, Any
 
+from chromadb.api.types import Include
+
 # type supports single and batch mode
 class AddEmbedding(BaseModel):
     embeddings: list
@@ -23,10 +25,7 @@ class QueryEmbedding(BaseModel):
     where_document: dict = {}
     query_embeddings: list
     n_results: int = 10
-    include_embeddings: bool = True
-    include_documents: bool = True
-    include_metadatas: bool = True
-    include_distances: bool = True
+    include: Include = ["embeddings", "metadatas", "documents", "distances"]
 
 
 class ProcessEmbedding(BaseModel):

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -23,6 +23,10 @@ class QueryEmbedding(BaseModel):
     where_document: dict = {}
     query_embeddings: list
     n_results: int = 10
+    include_embeddings: bool = True
+    include_documents: bool = True
+    include_metadatas: bool = True
+    include_distances: bool = True
 
 
 class ProcessEmbedding(BaseModel):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -868,3 +868,43 @@ def test_where_document_logical_operators(api_fixture, request):
 
 
 # endregion
+
+records = {
+    "embeddings": [[0, 0, 0], [1.2, 2.24, 3.2]],
+    "ids": ["id1", "id2"],
+    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}],
+    "documents": ["this document is first", "this document is second"],
+}
+
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_query_include(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_query_include")
+    collection.add(**records)
+
+    items = collection.query(query_embeddings=[0, 0, 0], include_embeddings=False, n_results=1)
+    assert items["embeddings"] == None
+    assert items["ids"][0][0] == "id1"
+    assert items["metadatas"][0][0]["int_value"] == 1
+
+    items = collection.query(query_embeddings=[0, 0, 0], include_metadatas=False, n_results=1)
+    assert items["metadatas"] == None
+    assert items["ids"][0][0] == "id1"
+
+    items = collection.query(
+        query_embeddings=[[0, 0, 0], [1, 2, 1.2]],
+        include_documents=False,
+        include_metadatas=False,
+        include_embeddings=False,
+        include_distances=False,
+        n_results=2,
+    )
+    assert items["documents"] == None
+    assert items["metadatas"] == None
+    assert items["embeddings"] == None
+    assert items["distances"] == None
+    assert items["ids"][0][0] == "id1"
+    assert items["ids"][0][1] == "id2"

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -667,20 +667,21 @@ def test_where_valid_operators(api_fixture, request):
         )
 
 
-# TODO: Define the dimensionality of these embeddingds in terms of the default record        
+# TODO: Define the dimensionality of these embeddingds in terms of the default record
 bad_dimensionality_records = {
-    "embeddings": [[1.1, 2.3, 3.2,4.5], [1.2, 2.24, 3.2, 4.5]],
+    "embeddings": [[1.1, 2.3, 3.2, 4.5], [1.2, 2.24, 3.2, 4.5]],
     "ids": ["id1", "id2"],
 }
 
 bad_dimensionality_query = {
-    "query_embeddings": [[1.1, 2.3, 3.2,4.5], [1.2, 2.24, 3.2, 4.5]],
+    "query_embeddings": [[1.1, 2.3, 3.2, 4.5], [1.2, 2.24, 3.2, 4.5]],
 }
 
 bad_number_of_results_query = {
     "query_embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
-    "n_results": 100
+    "n_results": 100,
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_dimensionality_validation_add(api_fixture, request):
@@ -694,6 +695,7 @@ def test_dimensionality_validation_add(api_fixture, request):
         collection.add(**bad_dimensionality_records)
     assert "dimensionality" in str(e.value)
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_dimensionality_validation_query(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -706,6 +708,7 @@ def test_dimensionality_validation_query(api_fixture, request):
         collection.query(**bad_dimensionality_query)
     assert "dimensionality" in str(e.value)
 
+
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_number_of_elements_validation_query(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
@@ -717,6 +720,7 @@ def test_number_of_elements_validation_query(api_fixture, request):
     with pytest.raises(Exception) as e:
         collection.query(**bad_number_of_results_query)
     assert "number of elements" in str(e.value)
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_query_document_valid_operators(api_fixture, request):
@@ -765,6 +769,7 @@ contains_records = {
         {"int_value": 2, "float_value": 2.002, "string_value": "two"},
     ],
 }
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_where_document(api_fixture, request):
@@ -945,21 +950,22 @@ def test_query_include(api_fixture, request):
     collection = api.create_collection("test_query_include")
     collection.add(**records)
 
-    items = collection.query(query_embeddings=[0, 0, 0], include_embeddings=False, n_results=1)
+    items = collection.query(
+        query_embeddings=[0, 0, 0], include=["metadatas", "documents", "distances"], n_results=1
+    )
     assert items["embeddings"] == None
     assert items["ids"][0][0] == "id1"
     assert items["metadatas"][0][0]["int_value"] == 1
 
-    items = collection.query(query_embeddings=[0, 0, 0], include_metadatas=False, n_results=1)
+    items = collection.query(
+        query_embeddings=[0, 0, 0], include=["embeddings", "documents", "distances"], n_results=1
+    )
     assert items["metadatas"] == None
     assert items["ids"][0][0] == "id1"
 
     items = collection.query(
         query_embeddings=[[0, 0, 0], [1, 2, 1.2]],
-        include_documents=False,
-        include_metadatas=False,
-        include_embeddings=False,
-        include_distances=False,
+        include=[],
         n_results=2,
     )
     assert items["documents"] == None


### PR DESCRIPTION
This PR adds support for includes fields while query()ing. These new parameters control if what data is returned (and queried in the db).

All changes:
- Add includes_[documents,embeddings,metadatas,distances] to query and pass it through to client.
- Add logic in db to support controlling which columns are selected
- Wire up client to support column selection
- Tests for includes fields