### PR TITLE
Rebuild hnswlib on Docker launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ COPY ./requirements.txt requirements.txt
 
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
+COPY ./bin/docker_entrypoint.sh /docker_entrypoint.sh
 COPY ./ /chroma
 
 EXPOSE 8000
 
-CMD ["uvicorn", "chromadb.app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1", "--proxy-headers"]
+CMD ["/docker_entrypoint.sh"]

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Rebuilding hnsw to ensure architecture compatibility"
+pip install --force-reinstall --no-cache-dir hnswlib
+uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -2,4 +2,4 @@
 
 echo "Rebuilding hnsw to ensure architecture compatibility"
 pip install --force-reinstall --no-cache-dir hnswlib
-uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000
+uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers


### PR DESCRIPTION
## Description of changes

This PR changes the default Docker launch script to rebuild hnswlib before starting uvicorn.

This is required to ensure that instruction set used by the hnswlib native build matches the actual running hardware. Previous to this fix, the process could fail with a SIGILL, because the Docker image is originally built on a system with AVX2 available, but some target systems on AWS EC2 do not support AVX2.

This change makes a tradeoff: the docker image now takes longer to start, but it guarantees not only that there won't be invalid instructions, but that hnsw will be compiled in a way that is optimal for the hardware the user is actually using.

## Test plan

Integration tests will indicate that this did not cause any regressions

## Documentation Changes

No documentation changes necessary for this change: documentation will be provided for the upcoming "one click deploy" feature.