### PR TITLE
Migrate to lower bounds for pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'pandas ~= 1.3',
-  'requests ~= 2.28',
-  'pydantic ~= 1.9',
-  'hnswlib ~= 0.7',
-  'clickhouse_connect ~= 0.5.7',
-  'sentence-transformers ~= 2.2.2',
-  'duckdb ~= 0.5.1',
-  'fastapi ~=0.85.1',
-  'uvicorn[standard] ~= 0.18.3',
-  'numpy ~= 1.21.6',
+  'pandas >= 1.3',
+  'requests >= 2.28',
+  'pydantic >= 1.9',
+  'hnswlib >= 0.7',
+  'clickhouse_connect >= 0.5.7',
+  'sentence-transformers >= 2.2.2',
+  'duckdb >= 0.5.1',
+  'fastapi >= 0.85.1',
+  'uvicorn[standard] >= 0.18.3',
+  'numpy >= 1.21.6',
 ]
 
 [tool.black]


### PR DESCRIPTION
## Description of changes
This addresses #147 by relaxing the requirements to known-good lower bounds. We could perhaps go lower than these bounds but without spending too much time this unblocks users trying to use newer versions of python that have transitive dependencies that are pinned to a non-compatible version.

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - Change package dependencies to only require lower bounds
 - New functionality
	 - None

## Test plan
By Integration and Release CI pipelines.

## Documentation Changes
None required.
