### PR TITLE
Persistence example notebook

### DIFF
--- a/examples/local_persistence.ipynb
+++ b/examples/local_persistence.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import chromadb\n",
+    "from chromadb.config import Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running Chroma using direct local API.\n",
+      "No existing DB found in db, skipping load\n",
+      "No existing DB found in db, skipping load\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/antontroynikov/miniforge3/envs/chroma/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a new Chroma client with persistence enabled. \n",
+    "persist_directory = \"db\"\n",
+    "\n",
+    "client = chromadb.Client(\n",
+    "    Settings(\n",
+    "        persist_directory=persist_directory,\n",
+    "        chroma_db_impl=\"duckdb+parquet\",\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Srart from scratch\n",
+    "client.reset()\n",
+    "\n",
+    "# Create a new chroma collection\n",
+    "collection_name = \"peristed_collection\"\n",
+    "collection = client.create_collection(name=collection_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add some data to the collection\n",
+    "collection.add(\n",
+    "    embeddings=[\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "    ],\n",
+    "    metadatas=[\n",
+    "        {\"uri\": \"img1.png\", \"style\": \"style1\"},\n",
+    "        {\"uri\": \"img2.png\", \"style\": \"style2\"},\n",
+    "        {\"uri\": \"img3.png\", \"style\": \"style1\"},\n",
+    "        {\"uri\": \"img4.png\", \"style\": \"style1\"},\n",
+    "        {\"uri\": \"img5.png\", \"style\": \"style1\"},\n",
+    "        {\"uri\": \"img6.png\", \"style\": \"style1\"},\n",
+    "        {\"uri\": \"img7.png\", \"style\": \"style1\"},\n",
+    "        {\"uri\": \"img8.png\", \"style\": \"style1\"},\n",
+    "    ],\n",
+    "    documents=[\"doc1\", \"doc2\", \"doc3\", \"doc4\", \"doc5\", \"doc6\", \"doc7\", \"doc8\"],\n",
+    "    ids=[\"id1\", \"id2\", \"id3\", \"id4\", \"id5\", \"id6\", \"id7\", \"id8\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Persisting DB to disk, putting it in the save folder db\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Persist the DB. This also happens automatically when the client is garbage collected.\n",
+    "# In a notebook, prefer to call persist explicitly.\n",
+    "client.persist()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running Chroma using direct local API.\n",
+      "loaded in 8 embeddings\n",
+      "loaded in 1 collections\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a new client with the same settings\n",
+    "client = chromadb.Client(\n",
+    "    Settings(\n",
+    "        persist_directory=persist_directory,\n",
+    "        chroma_db_impl=\"duckdb+parquet\",\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Load the collection\n",
+    "collection = client.get_collection(collection_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'embeddings': [[[1.1, 2.3, 3.2]]], 'documents': [['doc5']], 'ids': [['id5']], 'metadatas': [[{'uri': 'img5.png', 'style': 'style1'}]], 'distances': [[0.0]]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Query the collection\n",
+    "results = collection.query(\n",
+    "    query_embeddings=[[1.1, 2.3, 3.2]],\n",
+    "    n_results=1\n",
+    ")\n",
+    "\n",
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Persisting DB to disk, putting it in the save folder db\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Clean up\n",
+    "client.reset()\n",
+    "client.persist()\n",
+    "\n",
+    "# You can also just delete the persist directory\n",
+    "!rm -rf db/"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "chroma",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "88f09714c9334832bac29166716f9f6a879ee2a4ed4822c1d4120cb2393b58dd"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/local_persistence.ipynb
+++ b/examples/local_persistence.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Local Peristence Demo\n",
+    "This notebook demonstrates how to persist the in-memory version of Chroma to disk, then load it back in. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
## Description of changes
This PR adds a simple example notebook demonstrating how to persist the local / in-memory Chroma database to disk, and load it again. 

## Test plan
Simply run the notebook. 

## Documentation Changes
None, this is documentation.