### PR TITLE
used 'List' instead of 'list' to ensure python <3.9 compatibilty

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -110,7 +110,7 @@ class Clickhouse(DB):
 
         where_clauses.append(f"collection_uuid = '{collection_uuid}'")
         # We know that where_clauses is not empty, so force typechecker
-        where = " AND ".join(cast(list[str], where_clauses))
+        where = " AND ".join(cast(List[str], where_clauses))
         where = f"WHERE {where}"
         return where
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - changed `list` to `List` in typing to ensure python <3.9 compatibility