### PR TITLE
Allow embedding_function to be passed to get_collection

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Union, Sequence, Optional, TypedDict, List, Dict
+from typing import Callable, Union, Sequence, Optional, TypedDict, List, Dict
 from uuid import UUID
 import pandas as pd
 from chromadb.api.models.Collection import Collection
@@ -52,14 +52,15 @@ class API(ABC):
     @abstractmethod
     def create_collection(
         self,
-        name: str,
         metadata: Optional[Dict] = None,
+        embedding_function: Optional[Callable] = None,
     ) -> Collection:
         """Creates a new collection in the database
 
         Args:
             name (str): The name of the collection to create. The name must be unique.
             metadata (Optional[Dict], optional): A dictionary of metadata to associate with the collection. Defaults to None.
+            embedding_function (Optional[Callable], optional): A function that takes documents and returns an embedding. Defaults to None.
 
         Returns:
             dict: the created collection
@@ -71,13 +72,13 @@ class API(ABC):
     def get_collection(
         self,
         name: Optional[str] = None,
-        uuid: Optional[UUID] = None,
+        embedding_function: Optional[Callable] = None,
     ) -> Collection:
         """Gets a collection from the database by either name or uuid
 
         Args:
             name (Optional[str]): The name of the collection to get. Defaults to None.
-            the uuid (Optional[UUID]): The uuid of the collection to get. Defaults to None.
+            embedding_function (Optional[Callable], optional): A function that takes documents and returns an embedding. Should be the same as the one used to create the collection. Defaults to None.
 
         Returns:
             dict: the requested collection

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -51,11 +51,15 @@ class FastAPI(API):
         resp.raise_for_status()
         return Collection(client=self, name=name, embedding_function=embedding_function)
 
-    def get_collection(self, name: str) -> Collection:
+    def get_collection(
+        self,
+        name: str,
+        embedding_function: Optional[Callable] = None,
+    ) -> Collection:
         """Returns a collection"""
         resp = requests.get(self._api_url + "/collections/" + name)
         resp.raise_for_status()
-        return Collection(client=self, name=name)
+        return Collection(client=self, name=name, embedding_function=embedding_function)
 
     def modify(self, current_name, new_name: str, new_metadata: Optional[Dict] = None) -> int:
         """Updates a collection"""

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -47,9 +47,10 @@ class LocalAPI(API):
     def get_collection(
         self,
         name: str,
+        embedding_function: Optional[Callable] = None,
     ) -> Collection:
         self._db.get_collection(name)
-        return Collection(client=self, name=name)
+        return Collection(client=self, name=name, embedding_function=embedding_function)
 
     def _get_collection_db(self, name: str) -> int:
         return self._db.get_collection(name)

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -128,6 +128,25 @@ def test_persist_index_loading(api_fixture, request):
 
 
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
+def test_persist_index_loading_embedding_function(api_fixture, request):
+    embedding_function = lambda x: [[1, 2, 3] for _ in range(len(x))]
+    api = request.getfixturevalue("local_persist_api")
+    api.reset()
+    collection = api.create_collection("test", embedding_function=embedding_function)
+    collection.add(ids="id1", documents="hello")
+
+    api.persist()
+    del api
+
+    api2 = request.getfixturevalue("local_persist_api_cache_bust")
+    collection = api2.get_collection("test", embedding_function=embedding_function)
+
+    nn = collection.query(query_texts="hello", n_results=1)
+    for key in nn.keys():
+        assert len(nn[key]) == 1
+
+
+@pytest.mark.parametrize("api_fixture", [local_persist_api])
 def test_persist(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
 


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
	 - Fix a bug where persistence and `embedding_function`s are fundamentally incompatible. We do not allow a user to get_collection and supply an embedding function. Previously, if they were to `create_collection` with an `embedding_function` and then create a new client, `get_collection `would not be aware of the `embedding_function`, leading to it use the default. This change allows get'ing a collection and allowing for an `embedding_function `to be passed.

Thanks to @wpnbos for finding this bug!

## Test plan
A test was added for the bug-fixed case.

## Documentation Changes
All docstrings are now up to date.  Documentation PR is here https://github.com/chroma-core/docs/pull/4
