### PR TITLE
line up distances with documents for queries

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import time
 from typing import Dict, List, Optional, Sequence, Callable, Type, cast
 from chromadb.api import API
@@ -239,9 +240,16 @@ class LocalAPI(API):
             ids = []
             metadatas = []
             # Remove plural from include since db columns are singular
-            db_columns = [column[:-1] for column in include if column != "distances"] + ["id"]
+            db_columns = (
+                [column[:-1] for column in include if column != "distances"] + ["id"] + ["uuid"]
+            )
             column_index = {column_name: index for index, column_name in enumerate(db_columns)}
             db_result = self._db.get_by_ids(uuids[i], columns=db_columns)
+
+            # sort db results by the order of the uuids
+            db_result = sorted(
+                db_result, key=lambda obj: uuids[i].index(uuid.UUID(obj[column_index["uuid"]]))
+            )
 
             for entry in db_result:
                 if include_embeddings:

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -240,16 +240,9 @@ class LocalAPI(API):
             ids = []
             metadatas = []
             # Remove plural from include since db columns are singular
-            db_columns = (
-                [column[:-1] for column in include if column != "distances"] + ["id"] + ["uuid"]
-            )
+            db_columns = [column[:-1] for column in include if column != "distances"] + ["id"]
             column_index = {column_name: index for index, column_name in enumerate(db_columns)}
             db_result = self._db.get_by_ids(uuids[i], columns=db_columns)
-
-            # sort db results by the order of the uuids
-            db_result = sorted(
-                db_result, key=lambda obj: uuids[i].index(uuid.UUID(obj[column_index["uuid"]]))
-            )
 
             for entry in db_result:
                 if include_embeddings:

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -429,8 +429,9 @@ class Clickhouse(DB):
         return deleted_uuids
 
     def get_by_ids(self, ids: list, columns: Optional[List] = None):
+        columns = columns + ["uuid"] if columns else ["uuid"]
         select_columns = db_schema_to_keys() if columns is None else columns
-        return (
+        response = (
             self._get_conn()
             .query(
                 f"""
@@ -439,6 +440,11 @@ class Clickhouse(DB):
             )
             .result_rows
         )
+
+        # sort db results by the order of the uuids
+        response = sorted(response, key=lambda obj: ids.index(obj[len(columns) - 1]))
+
+        return response
 
     def get_nearest_neighbors(
         self,

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1118,3 +1118,4 @@ def test_query_order(api_fixture, request):
     )
 
     assert items["documents"][0][0] == "this document is second"
+    assert items["documents"][0][1] == "this document is first"

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1100,3 +1100,21 @@ def test_get_include(api_fixture, request):
     with pytest.raises(ValueError) as e:
         items = collection.get(include=None)
     assert "Include" in str(e.value)
+
+
+# make sure query results are returned in the right order
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_query_order(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_query_order")
+    collection.add(**records)
+
+    items = collection.query(
+        query_embeddings=[1.2, 2.24, 3.2],
+        include=["metadatas", "documents", "distances"],
+        n_results=2,
+    )
+
+    assert items["documents"][0][0] == "this document is second"


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.* 
There was a bug where distances did not line up with returned documents/metadata/etc because of the db resorting things. This fixes that.

## Test plan
There is a test

## Documentation Changes
None
