### PR TITLE
Add error on get_collection fail

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -49,7 +49,7 @@ class LocalAPI(API):
         name: str,
         metadata: Optional[Dict] = None,
         embedding_function: Optional[Callable] = None,
-        get_or_create: bool = False
+        get_or_create: bool = False,
     ) -> Collection:
         if not is_valid_index_name(name):
             raise ValueError("Invalid index name: %s" % name)  # NIT: tell the user why
@@ -70,7 +70,9 @@ class LocalAPI(API):
         name: str,
         embedding_function: Optional[Callable] = None,
     ) -> Collection:
-        self._db.get_collection(name)
+        res = self._db.get_collection(name)
+        if len(res) == 0:
+            raise ValueError("Collection not found: %s" % name)
         return Collection(client=self, name=name, embedding_function=embedding_function)
 
     def list_collections(self) -> Sequence[Collection]:

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -20,7 +20,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def get_collection(self, name: str):
+    def get_collection(self, name: str) -> Sequence:
         pass
 
     @abstractmethod

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -439,6 +439,10 @@ def test_add_a_collection(api_fixture, request):
     collection = api.get_collection("testspace")
     assert collection.name == "testspace"
 
+    # get collection should throw an error if collection does not exist
+    with pytest.raises(Exception) as e:
+        collection = api.get_collection("testspace2")
+
 
 @pytest.mark.parametrize("api_fixture", test_apis)
 def test_list_collections(api_fixture, request):


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - This addresses #170 by throwing an error if the collection does not exist on get_collection
 - New functionality
	 - None

## Test plan
Adds a test to check for errors. I did not add verification of the error contents, as the server version does not transmit errors back down to the client until #150 lands exception middleware.

## Documentation Changes
No changes needed.
