### PR TITLE
Log embedding function

### DIFF
--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -42,6 +42,9 @@ class Collection(BaseModel):
         else:
             import chromadb.utils.embedding_functions as ef
 
+            print(
+                "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction"
+            )
             self._embedding_function = ef.SentenceTransformerEmbeddingFunction()
 
         super().__init__(name=name)


### PR DESCRIPTION
## Description of changes
Addresses #171 
*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - Our handling of embedding functions is a bit odd since we require it whenever we get/create/get_or_create an embedding_function. In order to make the behavior clear to users we should log when we use the default.
 - New functionality
	 - None

## Test plan
Not testing as its just a logging change.

## Documentation Changes
None needed. The docs address this behavior. Although it being a source of confusion is perhaps a flag to address it in a cleaner way.
