### PR TITLE
update duckdb to fix type stubs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.85.1
 uvicorn[standard]==0.18.3
 requests==2.28.1
 pandas==1.3.5
-duckdb==0.5.1
+duckdb~=0.7.1.dev # fixes fetchall type returning an object instead of a list see https://github.com/duckdb/duckdb/pull/5732
 hnswlib==0.7.0
 clickhouse-connect==0.5.7
 pydantic==1.9.0


### PR DESCRIPTION
## Description of changes
You probably don't want to merge this yet because the current version is a pre-release. But when an official release comes about, we should prob update to fix typing e.g. on `fetchall` (changes from being an object that doesn't allow [] access to a proper list type)
see https://github.com/duckdb/duckdb/pull/5732

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
