### PR TITLE
Use strings everywhere, not UUID + add more types

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -103,7 +103,7 @@ class LocalAPI(API):
     #
     def _add(
         self,
-        ids,
+        ids: List[str],
         collection_name: str,
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -1,4 +1,5 @@
 from pydantic import BaseSettings, Field
+from typing import Optional
 
 
 class Settings(BaseSettings):
@@ -7,14 +8,14 @@ class Settings(BaseSettings):
     chroma_db_impl: str = "duckdb"
     chroma_api_impl: str = "local"
 
-    clickhouse_host: str = None
-    clickhouse_port: str = None
+    clickhouse_host: Optional[str] = None
+    clickhouse_port: Optional[str] = None
 
     persist_directory: str = ".chroma"
 
-    chroma_server_host: str = None
-    chroma_server_http_port: str = None
-    chroma_server_grpc_port: str = None
+    chroma_server_host: Optional[str] = None
+    chroma_server_http_port: Optional[str] = None
+    chroma_server_grpc_port: Optional[str] = None
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Sequence, Optional, Tuple
-from uuid import UUID
 import numpy.typing as npt
 from chromadb.api.types import Embeddings, Documents, IDs, Metadatas, Where, WhereDocument
 
@@ -48,12 +47,12 @@ class DB(ABC):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas],
         documents: Optional[Documents],
-        ids: List[UUID],
-    ) -> List[UUID]:
+        ids: List[str],
+    ) -> List[str]:
         pass
 
     @abstractmethod
-    def add_incremental(self, collection_uuid: str, ids: List[UUID], embeddings: Embeddings):
+    def add_incremental(self, collection_uuid: str, ids: List[str], embeddings: Embeddings):
         pass
 
     @abstractmethod
@@ -104,11 +103,11 @@ class DB(ABC):
     @abstractmethod
     def get_nearest_neighbors(
         self, collection_name, where, embeddings, n_results, where_document
-    ) -> Tuple[List[List[UUID]], npt.NDArray]:
+    ) -> Tuple[List[List[str]], npt.NDArray]:
         pass
 
     @abstractmethod
-    def get_by_ids(self, uuids, columns=None) -> Sequence:
+    def get_by_ids(self, uuids: List[str], columns: Optional[List[str]] = None) -> Sequence:
         pass
 
     @abstractmethod
@@ -120,7 +119,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def has_index(self, collection_name):
+    def has_index(self, collection_name: str):
         pass
 
     @abstractmethod

--- a/chromadb/db/index/__init__.py
+++ b/chromadb/db/index/__init__.py
@@ -1,17 +1,19 @@
 from abc import ABC, abstractmethod
+from chromadb.config import Settings
+from typing import List
 
 
 class Index(ABC):
     @abstractmethod
-    def __init__(self, settings):
+    def __init__(self, settings: Settings):
         pass
 
     @abstractmethod
-    def delete(self, collection_name):
+    def delete(self, collection_name: str):
         pass
 
     @abstractmethod
-    def delete_from_index(self, collection_name, uuids):
+    def delete_from_index(self, collection_name: str, uuids: List[str]):
         pass
 
     @abstractmethod
@@ -19,13 +21,15 @@ class Index(ABC):
         pass
 
     @abstractmethod
-    def run(self, collection_name, uuids, embeddings):
+    def run(self, collection_name: str, uuids: List[str], embeddings):
         pass
 
     @abstractmethod
-    def has_index(self, collection_name):
+    def has_index(self, collection_name: str):
         pass
 
     @abstractmethod
-    def get_nearest_neighbors(self, collection_name, embedding, n_results, ids):
+    def get_nearest_neighbors(
+        self, collection_name: str, embedding, n_results: int, ids: List[str]
+    ):
         pass


### PR DESCRIPTION
## Description of changes
Adds a bunch of types which (i think) are correct ~ pls lmk if not. Also this _should_ fix #126 by using Strings everywhere, even in Clickhouse where they have a uuid type. Think this makes sense since string uuids are more universally compatible with other possible future backends.

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - Adds a bunch of typing
	 - Removes use of UUID type and uses raw strings
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*
Current tests

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
Potentially 
