### PR TITLE
Use current region instead of explicit param

### DIFF
--- a/bin/generate_cloudformation.py
+++ b/bin/generate_cloudformation.py
@@ -80,7 +80,6 @@ cf = {
             "Type": "String",
             "Default": "t3.small",
         },
-        "Region": {"Description": "AWS Region", "Type": "String", "Default": "us-east-1"},
         "ChromaVersion": {
             "Description": "Chroma version to install",
             "Type": "String",
@@ -94,7 +93,7 @@ cf = {
         "ChromaInstance": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
-                "ImageId": {"Fn::FindInMap": ["Region2AMI", {"Ref": "Region"}, "AMI"]},
+                "ImageId": {"Fn::FindInMap": ["Region2AMI", {"Ref": "AWS::Region"}, "AMI"]},
                 "InstanceType": {"Ref": "InstanceType"},
                 "UserData": b64text(userdata),
                 "SecurityGroupIds": [{"Ref": "ChromaInstanceSecurityGroup"}],
@@ -102,7 +101,7 @@ cf = {
                 "BlockDeviceMappings": [
                     {
                         "DeviceName": {
-                            "Fn::FindInMap": ["Region2AMI", {"Ref": "Region"}, "RootDeviceName"]
+                            "Fn::FindInMap": ["Region2AMI", {"Ref": "AWS::Region"}, "RootDeviceName"]
                         },
                         "Ebs": {"VolumeSize": 24},
                     }


### PR DESCRIPTION
## Description of changes

Remove "Region" parameter from generated CF template. It is not necessary since the AWS Region is already configured in the AWS CLI or console, 

## Test plan

Tested manually by generating a CF template locally and deploying to an arbitrary region.

## Documentation Changes

https://github.com/chroma-core/docs/pull/9
