### PR TITLE
Only push cf template to /latest for release versions

### DIFF
--- a/bin/generate_cloudformation.py
+++ b/bin/generate_cloudformation.py
@@ -2,7 +2,7 @@ import boto3
 import json
 import subprocess
 import os
-
+import re
 
 def b64text(txt):
     """Generate Base 64 encoded CF json for a multiline string, subbing in values where appropriate"""
@@ -159,6 +159,13 @@ s3 = boto3.client("s3", region_name="us-east-1")
 s3.upload_file(
     "/tmp/chroma.cf.json", "public.trychroma.com", f"cloudformation/{version}/chroma.cf.json"
 )
-s3.upload_file(
-    "/tmp/chroma.cf.json", "public.trychroma.com", f"cloudformation/latest/chroma.cf.json"
-)
+
+# Upload to s3 under /latest version only if this is a release
+pattern = re.compile(r"^\d+\.\d+\.\d+$")
+if pattern.match(version):
+    s3.upload_file(
+        "/tmp/chroma.cf.json", "public.trychroma.com", "cloudformation/latest/chroma.cf.json"
+    )
+else:
+    print(f"Version {version} is not a 3-part semver, not uploading to /latest")
+


### PR DESCRIPTION
## Description of changes

Previously, it was easy to accidentally release the CF template to the /latest path in S3 when building locally.

## Test plan

Tested the negative case locally, only possible to test the positive case by actually running it on CI.

## Documentation Changes

Not a user-facing change.