### PR TITLE
Return metadata as part of collection

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -52,6 +52,7 @@ class API(ABC):
     @abstractmethod
     def create_collection(
         self,
+        name: str,
         metadata: Optional[Dict] = None,
         get_or_create: bool = False,
         embedding_function: Optional[Callable] = None,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -53,7 +53,13 @@ class FastAPI(API):
             data=json.dumps({"name": name, "metadata": metadata, "get_or_create": get_or_create}),
         )
         resp.raise_for_status()
-        return Collection(client=self, name=name, embedding_function=embedding_function)
+        resp_json = resp.json()
+        return Collection(
+            client=self,
+            name=resp_json["name"],
+            embedding_function=embedding_function,
+            metadata=resp_json["metadata"],
+        )
 
     def get_collection(
         self,
@@ -63,7 +69,13 @@ class FastAPI(API):
         """Returns a collection"""
         resp = requests.get(self._api_url + "/collections/" + name)
         resp.raise_for_status()
-        return Collection(client=self, name=name, embedding_function=embedding_function)
+        resp_json = resp.json()
+        return Collection(
+            client=self,
+            name=resp_json["name"],
+            embedding_function=embedding_function,
+            metadata=resp_json["metadata"],
+        )
 
     def get_or_create_collection(
         self,
@@ -79,7 +91,7 @@ class FastAPI(API):
         """Updates a collection"""
         resp = requests.put(
             self._api_url + "/collections/" + current_name,
-            data=json.dumps({"metadata": new_metadata, "name": new_name}),
+            data=json.dumps({"new_metadata": new_metadata, "new_name": new_name}),
         )
         resp.raise_for_status()
         return resp.json()

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -54,8 +54,10 @@ class LocalAPI(API):
         if not is_valid_index_name(name):
             raise ValueError("Invalid index name: %s" % name)  # NIT: tell the user why
 
-        self._db.create_collection(name, metadata, get_or_create)
-        return Collection(client=self, name=name, embedding_function=embedding_function)
+        res = self._db.create_collection(name, metadata, get_or_create)
+        return Collection(
+            client=self, name=name, embedding_function=embedding_function, metadata=res[0][2]
+        )
 
     def get_or_create_collection(
         self,
@@ -73,13 +75,17 @@ class LocalAPI(API):
         res = self._db.get_collection(name)
         if len(res) == 0:
             raise ValueError("Collection not found: %s" % name)
-        return Collection(client=self, name=name, embedding_function=embedding_function)
+        return Collection(
+            client=self, name=name, embedding_function=embedding_function, metadata=res[0][2]
+        )
 
     def list_collections(self) -> Sequence[Collection]:
         collections = []
         db_collections = self._db.list_collections()
         for db_collection in db_collections:
-            collections.append(Collection(client=self, name=db_collection[1]))
+            collections.append(
+                Collection(client=self, name=db_collection[1], metadata=db_collection[2])
+            )
         return collections
 
     def _modify(

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, cast, List
+from typing import TYPE_CHECKING, Optional, cast, List, Dict
 from pydantic import BaseModel, PrivateAttr
 
 from chromadb.api.types import (
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 class Collection(BaseModel):
     name: str
+    metadata: Optional[Dict] = None
     _client: "API" = PrivateAttr()
     _embedding_function: Optional[EmbeddingFunction] = PrivateAttr()
 
@@ -35,7 +36,9 @@ class Collection(BaseModel):
         client: "API",
         name: str,
         embedding_function: Optional[EmbeddingFunction] = None,
+        metadata: Optional[Dict] = None,
     ):
+
         self._client = client
         if embedding_function is not None:
             self._embedding_function = embedding_function
@@ -46,8 +49,7 @@ class Collection(BaseModel):
                 "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction"
             )
             self._embedding_function = ef.SentenceTransformerEmbeddingFunction()
-
-        super().__init__(name=name)
+        super().__init__(name=name, metadata=metadata)
 
     def __repr__(self):
         return f"Collection(name={self.name})"
@@ -212,6 +214,8 @@ class Collection(BaseModel):
         self._client._modify(current_name=self.name, new_name=name, new_metadata=metadata)
         if name:
             self.name = name
+        if metadata:
+            self.metadata = metadata
 
     def update(
         self,

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -13,10 +13,7 @@ class DB(ABC):
     @abstractmethod
     def create_collection(
         self, name: str, metadata: Optional[Dict] = None, get_or_create: bool = False
-    ):
-        pass
-
-    def get_or_create_collection(self, name, metadata=None):
+    ) -> Sequence:
         pass
 
     @abstractmethod
@@ -24,7 +21,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def list_collections(self) -> Sequence[Sequence[str]]:
+    def list_collections(self) -> Sequence:
         pass
 
     @abstractmethod

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -121,10 +121,7 @@ class Clickhouse(DB):
     #
     def create_collection(
         self, name: str, metadata: Optional[Dict] = None, get_or_create: bool = False
-    ):
-        if metadata is None:
-            metadata = {}
-
+    ) -> Sequence:
         # poor man's unique constraint
         dupe_check = self.get_collection(name)
 
@@ -136,16 +133,15 @@ class Clickhouse(DB):
                 raise Exception(f"collection with name {name} already exists")
 
         collection_uuid = uuid.uuid4()
-        data_to_insert = []
-        data_to_insert.append([collection_uuid, name, json.dumps(metadata)])
+        data_to_insert = [[collection_uuid, name, json.dumps(metadata)]]
 
         self._get_conn().insert(
             "collections", data_to_insert, column_names=["uuid", "name", "metadata"]
         )
-        return collection_uuid
+        return [[collection_uuid, name, metadata]]
 
     def get_collection(self, name: str):
-        return (
+        res = (
             self._get_conn()
             .query(
                 f"""
@@ -154,9 +150,12 @@ class Clickhouse(DB):
             )
             .result_rows
         )
+        # json.loads the metadata
+        return [[x[0], x[1], json.loads(x[2])] for x in res]
 
-    def list_collections(self) -> Sequence[Sequence[str]]:
-        return self._get_conn().query(f"""SELECT * FROM collections""").result_rows
+    def list_collections(self) -> Sequence:
+        res = self._get_conn().query(f"""SELECT * FROM collections""").result_rows
+        return [[x[0], x[1], json.loads(x[2])] for x in res]
 
     def update_collection(
         self, current_name: str, new_name: Optional[str] = None, new_metadata: Optional[Dict] = None

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -78,10 +78,7 @@ class DuckDB(Clickhouse):
     #
     def create_collection(
         self, name: str, metadata: Optional[Dict] = None, get_or_create: bool = False
-    ):
-        if metadata is None:
-            metadata = {}
-
+    ) -> Sequence:
         # poor man's unique constraint
         dupe_check = self.get_collection(name)
         if len(dupe_check) > 0:
@@ -91,18 +88,20 @@ class DuckDB(Clickhouse):
             else:
                 raise Exception(f"collection with name {name} already exists")
 
-        return self._conn.execute(
+        self._conn.execute(
             f"""INSERT INTO collections (uuid, name, metadata) VALUES (?, ?, ?)""",
             [str(uuid.uuid4()), name, json.dumps(metadata)],
         )
+        return [[str(uuid.uuid4()), name, metadata]]
 
     def get_collection(self, name: str) -> Sequence:
-        return self._conn.execute(
-            f"""SELECT * FROM collections WHERE name = ?""", [name]
-        ).fetchall()
+        res = self._conn.execute(f"""SELECT * FROM collections WHERE name = ?""", [name]).fetchall()
+        # json.loads the metadata
+        return [[x[0], x[1], json.loads(x[2])] for x in res]
 
-    def list_collections(self) -> Sequence[Sequence[str]]:
-        return self._conn.execute(f"""SELECT * FROM collections""").fetchall()
+    def list_collections(self) -> Sequence:
+        res = self._conn.execute(f"""SELECT * FROM collections""").fetchall()
+        return [[x[0], x[1], json.loads(x[2])] for x in res]
 
     def delete_collection(self, name: str):
         collection_uuid = self.get_collection_uuid_from_name(name)

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -45,6 +45,7 @@ async def catch_exceptions_middleware(request: Request, call_next):
     try:
         return await call_next(request)
     except Exception as e:
+        print("ERROR: ", e)
         return JSONResponse(content={"error": repr(e)}, status_code=500)
 
 


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
	 - This PR properly returns metadata as a part of collection. This functionality was previously a bit broken as if you added metadata to a collection you could never access it. This makes progress towards #183 
 - New functionality
	 - None

## Test plan
Tests were added for creating, retrieving, modifying and listing collections with metadata

## Documentation Changes
None required
