### PR TITLE
Allow clickhouse to create session_id per request

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -13,6 +13,7 @@ import json
 from typing import Dict, Optional, Sequence, List, Tuple, cast
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
+from clickhouse_connect import common
 
 COLLECTION_TABLE_SCHEMA = [{"uuid": "UUID"}, {"name": "String"}, {"metadata": "String"}]
 
@@ -51,6 +52,7 @@ class Clickhouse(DB):
         self._settings = settings
 
     def _init_conn(self):
+        common.set_setting("autogenerate_session_id", False)
         self._conn = clickhouse_connect.get_client(
             host=self._settings.clickhouse_host, port=int(self._settings.clickhouse_port)
         )
@@ -315,7 +317,9 @@ class Clickhouse(DB):
                         return result.append(f" JSONExtractString(metadata,'{key}') = '{operand}'")
                     return result.append(f" JSONExtractFloat(metadata,'{key}') = {operand}")
                 else:
-                    raise ValueError(f"Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got {operator}")
+                    raise ValueError(
+                        f"Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got {operator}"
+                    )
             elif type(value) == list:
                 all_subresults = []
                 for subwhere in value:


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
	 - As per https://clickhouse.com/docs/en/integrations/language-clients/python/options/ - clickhouse-connect autogenerates session_ids per client by default. However clickhouse by default creates a unique session_id internally per query, which is the behavior we want. This disables clickhouse-connects autogeneration of a persistent session_id across queries. This was previously breaking concurrent requests from succeeding on occasion
 - New functionality
	 - None

## Test plan
Existing tests capture the changes

## Documentation Changes
None required
