### PR TITLE
Add embedding wrapper for http request to hugging faces embedding api

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -58,3 +58,19 @@ class CohereEmbeddingFunction(EmbeddingFunction):
         return [
             embeddings for embeddings in self._client.embed(texts=texts, model=self._model_name)
         ]
+
+class HuggingFaceEmbeddingFunction(EmbeddingFunction):
+    def __init__(self, api_key: str, model_name: str = "sentence-transformers/all-MiniLM-L6-v2"):
+        try:
+            import requests
+        except ImportError:
+            raise ValueError(
+                "The requests python package is not installed. Please install it with `pip install requests`"
+            )
+        self.api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_id}"
+        self._headers = {"Authorization": f"Bearer {hf_token}"}
+        self._model_name = model_name
+
+    def __call__(self, texts: Documents) -> Embeddings:
+        # Call HuggingFace Embedding API for each document.
+        return requests.post(api_url, headers=headers, json={"inputs": texts, "options":{"wait_for_model":True}}).json()

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -62,14 +62,15 @@ class CohereEmbeddingFunction(EmbeddingFunction):
 class HuggingFaceEmbeddingFunction(EmbeddingFunction):
     def __init__(self, api_key: str, model_name: str = "sentence-transformers/all-MiniLM-L6-v2"):
         try:
-            import requests
+            import requests 
         except ImportError:
             raise ValueError(
                 "The requests python package is not installed. Please install it with `pip install requests`"
             )
-        self.api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_id}"
-        self._headers = {"Authorization": f"Bearer {hf_token}"}
+        self._api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_name}" 
+        self._session = requests.Session()
+        self._session.headers.update({"Authorization": f"Bearer {api_key}"})
 
     def __call__(self, texts: Documents) -> Embeddings:
-        # Call HuggingFace Embedding API for each document.
-        return requests.post(self._api_url, headers=self._headers, json={"inputs": texts, "options":{"wait_for_model":True}}).json()
+        # Call HuggingFace Embedding API for each document
+        return self._session.post(self._api_url, json={"inputs": texts, "options":{"wait_for_model":True}}).json()

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -69,8 +69,7 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction):
             )
         self.api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_id}"
         self._headers = {"Authorization": f"Bearer {hf_token}"}
-        self._model_name = model_name
 
     def __call__(self, texts: Documents) -> Embeddings:
         # Call HuggingFace Embedding API for each document.
-        return requests.post(api_url, headers=headers, json={"inputs": texts, "options":{"wait_for_model":True}}).json()
+        return requests.post(self._api_url, headers=self._headers, json={"inputs": texts, "options":{"wait_for_model":True}}).json()


### PR DESCRIPTION
## Description of changes
Add embedding wrapper for http request to hugging faces embedding api

 - New functionality
	 - allows user to supply their hf token and use hf models for embeddings

## Test plan
Locally tested the code as I cannot provide an API key for automated testing

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
Yeah, worth mentioning this is available
