### PR TITLE
on delete_collection, if the collection does not exist, more clear error is shown

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -98,8 +98,11 @@ class FastAPI(API):
 
     def delete_collection(self, name: str):
         """Deletes a collection"""
-        resp = requests.delete(self._api_url + "/collections/" + name)
-        resp.raise_for_status()
+        try:
+            resp = requests.delete(self._api_url + "/collections/" + name)
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise ValueError(f"Collection with name {name} does not exist")
 
     def _count(self, collection_name: str):
         """Returns the number of embeddings in the database"""

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -106,12 +106,15 @@ class Clickhouse(DB):
         raise NotImplementedError("Clickhouse is a persistent database, this method is not needed")
 
     def get_collection_uuid_from_name(self, name: str) -> str:
-        res = self._get_conn().query(
-            f"""
-            SELECT uuid FROM collections WHERE name = '{name}'
-        """
-        )
-        return res.result_rows[0][0]
+        try:
+            res = self._get_conn().query(
+                f"""
+                SELECT uuid FROM collections WHERE name = '{name}'
+            """
+            )
+            return res.result_rows[0][0]
+        except IndexError:
+            raise ValueError(f"Collection with name {name} does not exist")
 
     def _create_where_clause(
         self,

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -72,9 +72,12 @@ class DuckDB(Clickhouse):
     #  UTILITY METHODS
     #
     def get_collection_uuid_from_name(self, name):
-        return self._conn.execute(
-            f"""SELECT uuid FROM collections WHERE name = ?""", [name]
-        ).fetchall()[0][0]
+        try:
+            return self._conn.execute(
+                f"""SELECT uuid FROM collections WHERE name = ?""", [name]
+            ).fetchall()[0][0]
+        except IndexError:
+            raise ValueError(f"Collection with name {name} does not exist")
 
     #
     #  COLLECTION METHODS

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -541,6 +541,28 @@ def test_list_collections(api_fixture, request):
 
 
 @pytest.mark.parametrize("api_fixture", test_apis)
+def test_delete_collection(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    api.create_collection("testspace")
+    api.create_collection("testspace2")
+
+    collections = api.list_collections()
+    assert len(collections) == 2
+
+    api.delete_collection("testspace")
+    collections = api.list_collections()
+    assert len(collections) == 1
+
+    # delete collection should throw an error if collection does not exist
+    with pytest.raises(ValueError) as e:
+        api.delete_collection("testspace")
+
+    assert "does not exist" in str(e.value)
+
+
+@pytest.mark.parametrize("api_fixture", test_apis)
 def test_reset(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
 


### PR DESCRIPTION
## Description of changes

 - Improvements & Bug fixes
	 - Clearer error thrown when trying to delete unexisting collection

## Test plan

```python

import chromadb

chroma_client = chromadb.Client()
chroma_client.delete_collection('test1')

>>> ...
>>> ValueError: Collection with name test1 does not exist
# Before: IndexError: list index out of range
```

## Documentation Changes

No documentation changes necessary.