### PR TITLE
Fix Collection UUID bug on DuckDB

### DIFF
--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -93,11 +93,12 @@ class DuckDB(Clickhouse):
             else:
                 raise ValueError(f"Collection with name {name} already exists")
 
+        collection_uuid = uuid.uuid4()
         self._conn.execute(
             f"""INSERT INTO collections (uuid, name, metadata) VALUES (?, ?, ?)""",
-            [str(uuid.uuid4()), name, json.dumps(metadata)],
+            [str(collection_uuid), name, json.dumps(metadata)],
         )
-        return [[str(uuid.uuid4()), name, metadata]]
+        return [[str(collection_uuid), name, metadata]]
 
     def get_collection(self, name: str) -> Sequence:
         res = self._conn.execute(f"""SELECT * FROM collections WHERE name = ?""", [name]).fetchall()


### PR DESCRIPTION
## Description of changes
The collection uuid returned by `create_collection` method on `DuckDB` is different from the one inserted into the db.

The following files were created with the wrong uuid:
- id_to_uuid_{collection_uuid}.pkl
- index_{collection_uuid}.pkl
- index_metadata_{collection_uuid}.pkl
- uuid_to_id_{collection_uuid}.pkl

## Documentation Changes
No need.
