### PR TITLE
fix js tests, fix bug with index deletion

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -220,13 +220,13 @@ class Clickhouse(DB):
         """
         )
 
+        self._delete_index(collection_uuid)
+
         self._get_conn().command(
             f"""
          DELETE FROM collections WHERE name = '{name}'
          """
         )
-
-        self._delete_index(collection_uuid)
 
     #
     #  ITEM METHODS

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1319,3 +1319,16 @@ def test_get_version(api_fixture, request):
     import re
 
     assert re.match(r"\d+\.\d+\.\d+", version)
+
+
+# test delete_collection
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_delete_collection(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+    api.reset()
+    collection = api.create_collection("test_delete_collection")
+    collection.add(**records)
+
+    assert len(api.list_collections()) == 1
+    api.delete_collection("test_delete_collection")
+    assert len(api.list_collections()) == 0

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -136,7 +136,6 @@ test('it should peek a collection', async () => {
     const results = await collection.peek(2)
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
-    console.log('results', results)
     expect(results.ids.length).toBe(2)
     expect(['test1', 'test2']).toEqual(expect.arrayContaining(results.ids));
 })

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -44,8 +44,8 @@ test('it should create a collection', async () => {
     expect(collection).toBeDefined()
     expect(collection).toHaveProperty('name')
     let collections = await chroma.listCollections()
-    expect([{ name: 'test' }]).toEqual(expect.arrayContaining(collections));
-    expect([{ name: 'test2' }]).not.toEqual(expect.arrayContaining(collections));
+    expect([{ name: 'test', metadata: null }]).toEqual(expect.arrayContaining(collections));
+    expect([{ name: 'test2', metadata: null }]).not.toEqual(expect.arrayContaining(collections));
 })
 
 test('it should list collections', async () => {
@@ -118,7 +118,7 @@ test('it should query a collection', async () => {
     const results = await collection.query([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2)
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
-    expect(results.embeddings[0].length).toBe(2)
+    // expect(results.embeddings[0].length).toBe(2)
     expect(['test1', 'test2']).toEqual(expect.arrayContaining(results.ids[0]));
     expect(['test3']).not.toEqual(expect.arrayContaining(results.ids[0]));
 })
@@ -136,7 +136,8 @@ test('it should peek a collection', async () => {
     const results = await collection.peek(2)
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
-    expect(results.embeddings.length).toBe(2)
+    console.log('results', results)
+    expect(results.ids.length).toBe(2)
     expect(['test1', 'test2']).toEqual(expect.arrayContaining(results.ids));
 })
 
@@ -154,14 +155,14 @@ test('it should get a collection', async () => {
     const results = await collection.get(['test1'])
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
-    expect(results.embeddings.length).toBe(1)
+    expect(results.ids.length).toBe(1)
     expect(['test1']).toEqual(expect.arrayContaining(results.ids));
     expect(['test2']).not.toEqual(expect.arrayContaining(results.ids));
 
     const results2 = await collection.get(undefined, { 'test': 'test1' })
     expect(results2).toBeDefined()
     expect(results2).toBeInstanceOf(Object)
-    expect(results2.embeddings.length).toBe(1)
+    expect(results2.ids.length).toBe(1)
 })
 
 test('it should delete a collection', async () => {
@@ -194,7 +195,6 @@ test('wrong code returns an error', async () => {
     const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
     await collection.add(ids, embeddings, metadatas)
     const results = await collection.get(undefined, { "test": { "$contains": "hello" } });
-    // error includes 'Operator $contains not supported'
     expect(results.error).toBeDefined()
-    expect(results.error).toBe("ValueError('Operator $contains not supported')")
+    expect(results.error).toBe("ValueError('Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got $contains')")
 })


### PR DESCRIPTION
This PR
- fixes our JS tests - they had grown out of date. And we do need to add them to CI! (not addressed in this PR)
- fixes a bug where `_delete_index` relied on the collection still existing but it was deleted before `_delete_index` ran. This flips the order. 
