### PR TITLE
Fix bug with loading a saved index

### DIFF
--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -201,9 +201,9 @@ class Hnswlib(Index):
 
         # unpickle the mappers
         with open(f"{self._save_folder}/id_to_uuid_{self._id}.pkl", "rb") as f:
-            self._id_to_uuid = pickle.load(f)
+            self._label_to_id = pickle.load(f)
         with open(f"{self._save_folder}/uuid_to_id_{self._id}.pkl", "rb") as f:
-            self._uuid_to_id = pickle.load(f)
+            self._id_to_label = pickle.load(f)
         with open(f"{self._save_folder}/index_metadata_{self._id}.pkl", "rb") as f:
             self._index_metadata = pickle.load(f)
 


### PR DESCRIPTION
## Description of changes

This was a very stupid error, forgetting to rename one of the variables after refactoring the hnswlib implementation.

It should have been caught by an existing unit test: `test_persist_index_loading` exists precisely to validate this behavior. 

However, something in the implementation is cacheing the loaded index, so the unit test test does not catch the fact that the `hnswlib._load()` method was completely broken. This is why it took (relatively) long to debug, we thought the simple case was ruled out.

I'll keep working on figuring out the caching issue so we can get a proper unit test, we need to have test coverage of index save/load cycle. Meanwhile, this fixes the critical issue for our users.

## Test plan

Manually, by creating a persistent ChromaDB, persisting it, shutting down the entire python process, then loading it up again.

## Documentation Changes

Bug fix only, no documentation changes required.
