### PR TITLE
superfluous extension loading makes DuckDB raise IOException

### DIFF
--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -50,7 +50,6 @@ class DuckDB(Clickhouse):
         self._settings = settings
 
         # https://duckdb.org/docs/extensions/overview
-        self._conn.execute("INSTALL 'json';")
         self._conn.execute("LOAD 'json';")
 
     def _create_table_collections(self):


### PR DESCRIPTION
## Description of changes

An Exception was raised upon instanciating a `chromadb.db.duckdb.DuckDB` class, as the constructor tries to install the `json` extension. This installation step is superfluous, as the `json` extension is already loaded into the python client. Removing the attempted installation solves the issue.

For further details, see: https://github.com/duckdb/duckdb/issues/6931

 - Improvements & Bug fixes
	 - No `IOException` error when connecting to DuckDB
 - New functionality
	 - None

## Testing

Tested manually.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

No changes in the documentation required.
