### PR TITLE
Fix bug with multiple collections

### DIFF
--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -70,16 +70,17 @@ class Hnswlib(Index):
     _index: hnswlib.Index
     _index_metadata: IndexMetadata
     _params: HnswParams
-
-    # Mapping of IDs to HNSW integer labels
-    _id_to_label = {}
-    _label_to_id = {}
+    _id_to_label: dict[str, int]
+    _label_to_id: dict[int, str]
 
     def __init__(self, id, settings, metadata):
         self._save_folder = settings.persist_directory + "/index"
         self._params = HnswParams(metadata)
         self._id = id
         self._index = None
+        # Mapping of IDs to HNSW integer labels
+        self._id_to_label = {}
+        self._label_to_id = {}
 
         self._load()
 


### PR DESCRIPTION
## Description of changes

A recent refactoring contained an error where certain index information was cached on a per-class basis, rather than a per-instance basis. 

This will result in inconsistent embedding IDs being returned when using multiple collections in the same process.

This change also ensures that our unit tests properly cover persistence(and demonstrate the bug fixed in #265.)

## Test plan
Added a new unit test demonstrating the failure, watched it fail, fixed the problem, watched it pass.

## Documentation Changes
Bugfix, no doc change required.
