### PR TITLE
Add upsert on Collection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,23 +1,25 @@
 {
-    "git.ignoreLimitWarning": true,
-    "editor.rulers": [
-        120
-    ],
-    "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
-    "files.exclude": {
-        "**/__pycache__": true,
-        "**/.ipynb_checkpoints": true,
-        "**/.pytest_cache": true,
-        "**/chroma.egg-info": true
-    },
-    "python.analysis.typeCheckingMode": "basic",
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
-    "python.linting.flake8Args": [
-        "--extend-ignore=E203",
-        "--extend-ignore=E501",
-        "--extend-ignore=E503",
-        "--max-line-length=88",
-    ],
+  "git.ignoreLimitWarning": true,
+  "editor.rulers": [120],
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.ipynb_checkpoints": true,
+    "**/.pytest_cache": true,
+    "**/chroma.egg-info": true
+  },
+  "python.analysis.typeCheckingMode": "basic",
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.linting.flake8Args": [
+    "--extend-ignore=E203",
+    "--extend-ignore=E501",
+    "--extend-ignore=E503",
+    "--max-line-length=88"
+  ],
+
+  "python.testing.pytestArgs": ["chromadb"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -168,6 +168,30 @@ class API(ABC):
         pass
 
     @abstractmethod
+    def _upsert(
+        self,
+        collection_name: str,
+        ids: IDs,
+        embeddings: Optional[Embeddings] = None,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        increment_index: bool = True,
+    ):
+        """Add or update entries in the embedding store. 
+        If an entry with the same id already exists, it will be updated, otherwise it will be added.
+        ⚠️ This operation is slower than add because it needs to check if the entry already exists.
+
+        Args:
+            collection_name (str): The model space to add the embeddings to
+            ids (Optional[Union[str, Sequence[str]]], optional): The ids to associate with the embeddings. Defaults to None.
+            embeddings (Sequence[Sequence[float]]): The sequence of embeddings to add
+            metadatas (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
+            documents (Optional[Union[str, Sequence[str]]], optional): The documents to associate with the embeddings. Defaults to None.
+            increment_index (bool, optional): If True, will incrementally add to the ANN index of the collection. Defaults to True.
+        """
+        pass
+
+    @abstractmethod
     def _count(self, collection_name: str) -> int:
         """Returns the number of embeddings in the database
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -180,10 +180,10 @@ class FastAPI(API):
             self._api_url + "/collections/" + collection_name + "/add",
             data=json.dumps(
                 {
+                    "ids": ids,
                     "embeddings": embeddings,
                     "metadatas": metadatas,
                     "documents": documents,
-                    "ids": ids,
                     "increment_index": increment_index,
                 }
             ),
@@ -217,6 +217,36 @@ class FastAPI(API):
                     "embeddings": embeddings,
                     "metadatas": metadatas,
                     "documents": documents,
+                }
+            ),
+        )
+
+        resp.raise_for_status()
+        return True
+
+    def _upsert(
+        self,
+        collection_name: str,
+        ids: IDs,
+        embeddings: Embeddings,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        increment_index: bool = True,
+    ):
+        """
+        Updates a batch of embeddings in the database
+        - pass in column oriented data lists
+        """
+
+        resp = requests.post(
+            self._api_url + "/collections/" + collection_name + "/upsert",
+            data=json.dumps(
+                {
+                    "ids": ids,
+                    "embeddings": embeddings,
+                    "metadatas": metadatas,
+                    "documents": documents,
+                    "increment_index": increment_index,
                 }
             ),
         )

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -167,9 +167,9 @@ class LocalAPI(API):
         # Determine which ids need to be added and which need to be updated based on the ids already in the collection
         existing_ids = set(self._get(collection_name, ids=ids, include=[])['ids'])
 
-        ids_to_add = list(set(ids) - existing_ids)
-        ids_to_update = list(set(ids) & existing_ids)
-        
+
+        ids_to_add = []
+        ids_to_update = []        
         embeddings_to_add: Embeddings = []
         embeddings_to_update: Embeddings = []
         metadatas_to_add: Optional[Metadatas] = [] if metadatas else None
@@ -178,22 +178,24 @@ class LocalAPI(API):
         documents_to_update: Optional[Documents] = [] if documents else None
 
         for i, id in enumerate(ids):
-            if id in ids_to_add:
-                if embeddings is not None:
-                    embeddings_to_add.append(embeddings[i])
-                if metadatas is not None:
-                    metadatas_to_add.append(metadatas[i])
-                if documents is not None:
-                    documents_to_add.append(documents[i])
-            elif id in ids_to_update:
+            if id in existing_ids:
+                ids_to_update.append(id)
                 if embeddings is not None:
                     embeddings_to_update.append(embeddings[i])
                 if metadatas is not None:
                     metadatas_to_update.append(metadatas[i])
                 if documents is not None:
                     documents_to_update.append(documents[i])
+            else:
+                ids_to_add.append(id)
+                if embeddings is not None:
+                    embeddings_to_add.append(embeddings[i])
+                if metadatas is not None:
+                    metadatas_to_add.append(metadatas[i])
+                if documents is not None:
+                    documents_to_add.append(documents[i])
         
-        if ids_to_add:
+        if len(ids_to_add) > 0:
             self._add(
                 ids_to_add,
                 collection_name,
@@ -203,7 +205,7 @@ class LocalAPI(API):
                 increment_index=increment_index,
             )
 
-        if ids_to_update:
+        if len(ids_to_update) > 0:
             self._update(
                 collection_name,
                 ids_to_update,

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -318,7 +318,14 @@ class Collection(BaseModel):
                 raise ValueError("You must provide embeddings or a function to compute them")
             embeddings = self._embedding_function(documents)
 
-        self._client._upsert(collection_name=self.name, ids=ids, embeddings=embeddings, metadatas=metadatas, documents=documents, increment_index=increment_index)
+        self._client._upsert(
+            collection_name=self.name,
+            ids=ids,
+            embeddings=embeddings,
+            metadatas=metadatas,
+            documents=documents,
+            increment_index=increment_index,
+        )
 
     def delete(
         self,

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -86,6 +86,9 @@ class FastAPI(chromadb.server.Server):
             "/api/v1/collections/{collection_name}/update", self.update, methods=["POST"]
         )
         self.router.add_api_route(
+            "/api/v1/collections/{collection_name}/upsert", self.upsert, methods=["POST"]
+        )
+        self.router.add_api_route(
             "/api/v1/collections/{collection_name}/get", self.get, methods=["POST"]
         )
         self.router.add_api_route(
@@ -174,6 +177,16 @@ class FastAPI(chromadb.server.Server):
             embeddings=add.embeddings,
             documents=add.documents,
             metadatas=add.metadatas,
+        )
+
+    def upsert(self, collection_name: str, upsert: AddEmbedding):        
+        return self._api._upsert(
+            collection_name=collection_name,
+            ids=upsert.ids,
+            embeddings=upsert.embeddings,
+            documents=upsert.documents,
+            metadatas=upsert.metadatas,
+            increment_index=upsert.increment_index,
         )
 
     def get(self, collection_name, get: GetEmbedding):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1430,10 +1430,7 @@ def test_upsert(api_fixture, request):
     assert get_result['metadatas'][0] == new_records['metadatas'][0]
     assert get_result['documents'][0] == new_records['documents'][0]
 
-    print(get_result)
-
     query_result = collection.query(query_embeddings=get_result['embeddings'], n_results=1, include=['embeddings', 'metadatas', 'documents'])
-    print(query_result)
     assert query_result['embeddings'][0][0] == new_records['embeddings'][0]
     assert query_result['metadatas'][0][0] == new_records['metadatas'][0]
     assert query_result['documents'][0][0] == new_records['documents'][0]

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1397,3 +1397,19 @@ def test_update_query(api_fixture, request):
     assert results["documents"][0][0] == updated_records["documents"][0]
     assert results["metadatas"][0][0]["foo"] == "bar"
     assert results["embeddings"][0][0] == updated_records["embeddings"][0]
+    
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_add_with_redunant_ids(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+    api.reset()
+    collection = api.create_collection("test")
+    # Add an item with a given ID
+    collection.add(ids=["id1", "id2", "id3"], documents=["hello", "world", "foo"])
+
+    # Add an item with the same ID - here add plays the role of 'upsert' 
+    collection.add(ids=["id1", "id4"], documents=["bar", "baz"])
+
+    # We should expect there to be only one item, the "world" one
+    items = collection.get(ids="id1")
+    assert len(items["ids"]) == 1
+    assert items["documents"][0] == "bar"

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1403,14 +1403,14 @@ def test_add_with_redunant_ids(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
     api.reset()
     collection = api.create_collection("test")
-    # Add an item with a given ID
+    # Add some items
     collection.add(ids=["id1", "id2", "id3"], documents=["hello", "world", "foo"])
 
     # Add an item with the same ID - here add plays the role of 'upsert' 
     # If we have a separate upsert method, 'add' should fail and complain here. 
     collection.add(ids=["id1", "id4"], documents=["bar", "baz"])
 
-    # We should expect there to be only one item, the "world" one
+    # We should expect there to be only one item, the "bar" one
     items = collection.get(ids="id1")
     assert len(items["ids"]) == 1
     assert items["documents"][0] == "bar"

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1399,16 +1399,17 @@ def test_update_query(api_fixture, request):
     assert results["embeddings"][0][0] == updated_records["embeddings"][0]
     
 @pytest.mark.parametrize("api_fixture", test_apis)
-def test_add_with_redunant_ids(api_fixture, request):
+def test_upsert(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
     api.reset()
     collection = api.create_collection("test")
-    # Add some items
-    collection.add(ids=["id1", "id2", "id3"], documents=["hello", "world", "foo"])
+    
+    # Add some items via upsert
+    collection.upsert(ids=["id1", "id2", "id3"], documents=["hello", "world", "foo"])
+    assert collection.count() == 3
 
-    # Add an item with the same ID - here add plays the role of 'upsert' 
-    # If we have a separate upsert method, 'add' should fail and complain here. 
-    collection.add(ids=["id1", "id4"], documents=["bar", "baz"])
+    # Add an item with the same ID 
+    collection.upsert(ids=["id1", "id4"], documents=["bar", "baz"])
 
     # We should expect there to be only one item, the "bar" one
     items = collection.get(ids="id1")

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1407,6 +1407,7 @@ def test_add_with_redunant_ids(api_fixture, request):
     collection.add(ids=["id1", "id2", "id3"], documents=["hello", "world", "foo"])
 
     # Add an item with the same ID - here add plays the role of 'upsert' 
+    # If we have a separate upsert method, 'add' should fail and complain here. 
     collection.add(ids=["id1", "id4"], documents=["bar", "baz"])
 
     # We should expect there to be only one item, the "world" one


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.* 
Adds `upsert` as a method on `Collection`. Upsert updates entries in the embeddings store if their ids already exist, otherwise it adds them. 

I thought a bit about where to add this and decided that the API level is the right place. I didn't want to couple the use-facing method on `Collection`, nor did I want to implement `upsert` operations separately for the database implementations. This seemed like the right place to put it. 

## Test plan
Added a new test, `test_upsert` to `test_api.py`

## Documentation Changes
https://github.com/chroma-core/docs/pull/27