### PR TITLE
Run Chroma using the docker-compose without mounting the entire project in a directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ COPY ./requirements.txt requirements.txt
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
 COPY ./bin/docker_entrypoint.sh /docker_entrypoint.sh
-COPY ./ /chroma
+COPY ./chromadb/ chromadb 
+COPY ./log_config.yml log_config.yml
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./:/chroma
       - index_data:/index_data
     command: uvicorn chromadb.app:app --reload --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml
     environment:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - Right now the `Dockerfile` copies everything under the root directory to the `/chroma` directory. I have changed it to only copy `chromadb` and `log_config.yml`.
	 - The `docker-compose.yml` mounts the entire root directory so that `chromadb` directory and `log_config.yml` can be found. This makes it difficult to start the project by simply copying the `docker-compose.yml` file and using `image` clause instead of `build` clause.
	 
	Now, anyone can simply grab the `docker-compose.yml` file and make the following changes to start the chroma server locally

```
  server:
    #build:
    #  context: .
    #  dockerfile: Dockerfile
    image: chroma_server # or any upstream Chroma image
```


## Documentation Changes
N/A
