### PR TITLE
Use collection id instead of name

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -146,7 +146,7 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_ids: The collection to add the embeddings to
+            collection_id: The collection to add the embeddings to
             embedding: The sequence of embeddings to add
             metadata: The metadata to associate with the embeddings. Defaults to None.
             documents: The documents to associate with the embeddings. Defaults to None.

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Callable, Union, Sequence, Optional, Dict
 import pandas as pd
+from uuid import UUID
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
     Documents,
@@ -118,7 +119,7 @@ class API(ABC):
 
     def _modify(
         self,
-        current_name: str,
+        id: UUID,
         new_name: Optional[str] = None,
         new_metadata: Optional[Dict] = None,
     ):
@@ -135,9 +136,9 @@ class API(ABC):
     def _add(
         self,
         ids: IDs,
-        collection_name: Union[str, Sequence[str]],
-        embedding: Optional[Embeddings],
-        metadata: Optional[Metadatas] = None,
+        collection_id: UUID,
+        embeddings: Optional[Embeddings],
+        metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
         increment_index: bool = True,
     ):
@@ -145,7 +146,7 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_name (Union[str, Sequence[str]]): The collection(s) to add the embeddings to
+            collection_ids (Union[UUID, Sequence[UUID]]): The collection(s) to add the embeddings to
             embedding (Sequence[Sequence[float]]): The sequence of embeddings to add
             metadata (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
             documents (Optional[Union[str, Sequence[str]]], optional): The documents to associate with the embeddings. Defaults to None.
@@ -156,7 +157,7 @@ class API(ABC):
     @abstractmethod
     def _update(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: IDs,
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
@@ -166,15 +167,16 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_name (Union[str, Sequence[str]]): The collection(s) to add the embeddings to
+            collection_id (UUID): The collection(s) to add the embeddings to
             embedding (Sequence[Sequence[float]]): The sequence of embeddings to add
         """
         pass
 
     @abstractmethod
+
     def _upsert(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: IDs,
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
@@ -185,7 +187,7 @@ class API(ABC):
         If an entry with the same id already exists, it will be updated, otherwise it will be added.
 
         Args:
-            collection_name (str): The collection to add the embeddings to
+            collection_id (UUID): The collection to add the embeddings to
             ids (Optional[Union[str, Sequence[str]]], optional): The ids to associate with the embeddings. Defaults to None.
             embeddings (Sequence[Sequence[float]]): The sequence of embeddings to add
             metadatas (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
@@ -195,11 +197,12 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def _count(self, collection_name: str) -> int:
+    def _count(self, collection_id: UUID) -> int:
         """Returns the number of embeddings in the database
 
         Args:
-            collection_name (str): The collection to count the embeddings in.
+            collection_id (UUID): The collection to count the embeddings in.
+
 
         Returns:
             int: The number of embeddings in the collection
@@ -208,13 +211,13 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def _peek(self, collection_name: str, n: int = 10) -> GetResult:
+    def _peek(self, collection_id: UUID, n: int = 10) -> GetResult:
         pass
 
     @abstractmethod
     def _get(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: Optional[IDs] = None,
         where: Optional[Where] = {},
         sort: Optional[str] = None,
@@ -245,7 +248,7 @@ class API(ABC):
     @abstractmethod
     def _delete(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: Optional[IDs],
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
@@ -261,7 +264,7 @@ class API(ABC):
     @abstractmethod
     def _query(
         self,
-        collection_name: str,
+        collection_id: UUID,
         query_embeddings: Embeddings,
         n_results: int = 10,
         where: Where = {},

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -60,11 +60,11 @@ class API(ABC):
         """Creates a new collection in the database
 
         Args:
-            name (str): The name of the collection to create. The name must be unique.
-            metadata (Optional[Dict], optional): A dictionary of metadata to associate with the collection. Defaults to None.
-            get_or_create (bool, optional): If True, will return the collection if it already exists,
+            name  The name of the collection to create. The name must be unique.
+            metadata: A dictionary of metadata to associate with the collection. Defaults to None.
+            get_or_create: If True, will return the collection if it already exists,
                 and update the metadata (if applicable). Defaults to False.
-            embedding_function (Optional[Callable], optional): A function that takes documents and returns an embedding. Defaults to None.
+            embedding_function: A function that takes documents and returns an embedding. Defaults to None.
 
         Returns:
             dict: the created collection
@@ -80,7 +80,7 @@ class API(ABC):
         """Deletes a collection from the database
 
         Args:
-            name (str): The name of the collection to delete
+            name: The name of the collection to delete
         """
 
     @abstractmethod
@@ -91,10 +91,10 @@ class API(ABC):
            If the collection exists, but with different metadata, the metadata will be replaced.
 
         Args:
-            name (str): The name of the collection to create. The name must be unique.
-            metadata (Optional[Dict], optional): A dictionary of metadata to associate with the collection. Defaults to None.
+            name: The name of the collection to create. The name must be unique.
+            metadata: A dictionary of metadata to associate with the collection. Defaults to None.
         Returns:
-            dict: the created collection
+            the created collection
 
         """
         pass
@@ -108,8 +108,8 @@ class API(ABC):
         """Gets a collection from the database by either name or uuid
 
         Args:
-            name (Optional[str]): The name of the collection to get. Defaults to None.
-            embedding_function (Optional[Callable], optional): A function that takes documents and returns an embedding. Should be the same as the one used to create the collection. Defaults to None.
+            name: The name of the collection to get. Defaults to None.
+            embedding_function: A function that takes documents and returns an embedding. Should be the same as the one used to create the collection. Defaults to None.
 
         Returns:
             dict: the requested collection
@@ -126,9 +126,9 @@ class API(ABC):
         """Modify a collection in the database - can update the name and/or metadata
 
         Args:
-            current_name (str): The name of the collection to modify
-            new_name (Optional[str], optional): The new name of the collection. Defaults to None.
-            new_metadata (Optional[Dict], optional): The new metadata to associate with the collection. Defaults to None.
+            current_name: The name of the collection to modify
+            new_name: The new name of the collection. Defaults to None.
+            new_metadata: The new metadata to associate with the collection. Defaults to None.
         """
         pass
 
@@ -146,11 +146,11 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_ids (UUID): The collection to add the embeddings to
-            embedding (Sequence[Sequence[float]]): The sequence of embeddings to add
-            metadata (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
-            documents (Optional[Union[str, Sequence[str]]], optional): The documents to associate with the embeddings. Defaults to None.
-            ids (Optional[Union[str, Sequence[str]]], optional): The ids to associate with the embeddings. Defaults to None.
+            collection_ids: The collection to add the embeddings to
+            embedding: The sequence of embeddings to add
+            metadata: The metadata to associate with the embeddings. Defaults to None.
+            documents: The documents to associate with the embeddings. Defaults to None.
+            ids: The ids to associate with the embeddings. Defaults to None.
         """
         pass
 
@@ -167,8 +167,8 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_id (UUID): The collection to add the embeddings to
-            embedding (Sequence[Sequence[float]]): The sequence of embeddings to add
+            collection_id: The collection to add the embeddings to
+            embedding: The sequence of embeddings to add
         """
         pass
 
@@ -186,12 +186,12 @@ class API(ABC):
         If an entry with the same id already exists, it will be updated, otherwise it will be added.
 
         Args:
-            collection_id (UUID): The collection to add the embeddings to
-            ids (Optional[Union[str, Sequence[str]]], optional): The ids to associate with the embeddings. Defaults to None.
-            embeddings (Sequence[Sequence[float]]): The sequence of embeddings to add
-            metadatas (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
-            documents (Optional[Union[str, Sequence[str]]], optional): The documents to associate with the embeddings. Defaults to None.
-            increment_index (bool, optional): If True, will incrementally add to the ANN index of the collection. Defaults to True.
+            collection_id: The collection to add the embeddings to
+            ids: The ids to associate with the embeddings. Defaults to None.
+            embeddings: The sequence of embeddings to add
+            metadatas: The metadata to associate with the embeddings. Defaults to None.
+            documents: The documents to associate with the embeddings. Defaults to None.
+            increment_index: If True, will incrementally add to the ANN index of the collection. Defaults to True.
         """
         pass
 
@@ -200,7 +200,7 @@ class API(ABC):
         """Returns the number of embeddings in the database
 
         Args:
-            collection_id (UUID): The collection to count the embeddings in.
+            collection_id: The collection to count the embeddings in.
 
 
         Returns:
@@ -231,12 +231,12 @@ class API(ABC):
         ⚠️ This method should not be used directly.
 
         Args:
-            where (Optional[Dict[str, str]], optional): A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
-            sort (Optional[str], optional): The column to sort the embeddings by. Defaults to None.
-            limit (Optional[int], optional): The maximum number of embeddings to return. Defaults to None.
-            offset (Optional[int], optional): The number of embeddings to skip before returning. Defaults to None.
-            page (Optional[int], optional): The page number to return. Defaults to None.
-            page_size (Optional[int], optional): The number of embeddings to return per page. Defaults to None.
+            where: A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
+            sort: The column to sort the embeddings by. Defaults to None.
+            limit: The maximum number of embeddings to return. Defaults to None.
+            offset: The number of embeddings to skip before returning. Defaults to None.
+            page: The page number to return. Defaults to None.
+            page_size: The number of embeddings to return per page. Defaults to None.
 
         Returns:
             pd.DataFrame: A pandas dataframe containing the embeddings and metadata
@@ -256,7 +256,7 @@ class API(ABC):
         ⚠️ This method should not be used directly.
 
         Args:
-            where (Optional[Dict[str, str]], optional): A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
+            where: A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
         """
         pass
 
@@ -274,9 +274,9 @@ class API(ABC):
         ⚠️ This method should not be used directly.
 
         Args:
-            embedding (Sequence[float]): The embedding to find the nearest neighbors of
-            n_results (int, optional): The number of nearest neighbors to return. Defaults to 10.
-            where (Dict[str, str], optional): A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
+            embedding: The embedding to find the nearest neighbors of
+            n_results: The number of nearest neighbors to return. Defaults to 10.
+            where: A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
         """
         pass
 
@@ -288,7 +288,7 @@ class API(ABC):
             None
 
         Returns:
-            bool: True if the reset was successful
+            True if the reset was successful
         """
         pass
 
@@ -298,7 +298,7 @@ class API(ABC):
         ⚠️ This method should not be used directly.
 
         Args:
-            sql (str): The SQL query to run
+            sql: The SQL query to run
 
         Returns:
             pd.DataFrame: A pandas dataframe containing the results of the query
@@ -311,7 +311,7 @@ class API(ABC):
         ⚠️ This method should not be used directly.
 
         Args:
-            collection_name (Optional[str], optional): The collection to create the index for. Uses the client's collection if None. Defaults to None.
+            collection_name: The collection to create the index for. Uses the client's collection if None. Defaults to None.
 
         Returns:
             bool: True if the index was created successfully

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -146,7 +146,7 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_ids (Union[UUID, Sequence[UUID]]): The collection(s) to add the embeddings to
+            collection_ids (UUID): The collection to add the embeddings to
             embedding (Sequence[Sequence[float]]): The sequence of embeddings to add
             metadata (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
             documents (Optional[Union[str, Sequence[str]]], optional): The documents to associate with the embeddings. Defaults to None.
@@ -167,13 +167,12 @@ class API(ABC):
         ⚠️ It is recommended to use the more specific methods below when possible.
 
         Args:
-            collection_id (UUID): The collection(s) to add the embeddings to
+            collection_id (UUID): The collection to add the embeddings to
             embedding (Sequence[Sequence[float]]): The sequence of embeddings to add
         """
         pass
 
     @abstractmethod
-
     def _upsert(
         self,
         collection_id: UUID,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -16,6 +16,7 @@ from typing import Sequence
 from chromadb.api.models.Collection import Collection
 from chromadb.telemetry import Telemetry
 import chromadb.errors as errors
+from uuid import UUID
 
 
 class FastAPI(API):
@@ -57,6 +58,7 @@ class FastAPI(API):
         resp_json = resp.json()
         return Collection(
             client=self,
+            id=resp_json["id"],
             name=resp_json["name"],
             embedding_function=embedding_function,
             metadata=resp_json["metadata"],
@@ -74,6 +76,7 @@ class FastAPI(API):
         return Collection(
             client=self,
             name=resp_json["name"],
+            id=resp_json["id"],
             embedding_function=embedding_function,
             metadata=resp_json["metadata"],
         )
@@ -88,10 +91,10 @@ class FastAPI(API):
 
         return self.create_collection(name, metadata, embedding_function, get_or_create=True)
 
-    def _modify(self, current_name: str, new_name: str, new_metadata: Optional[Dict] = None):
+    def _modify(self, id: UUID, new_name: str, new_metadata: Optional[Dict] = None):
         """Updates a collection"""
         resp = requests.put(
-            self._api_url + "/collections/" + current_name,
+            self._api_url + "/collections/" + str(id),
             data=json.dumps({"new_metadata": new_metadata, "new_name": new_name}),
         )
         raise_chroma_error(resp)
@@ -102,22 +105,22 @@ class FastAPI(API):
         resp = requests.delete(self._api_url + "/collections/" + name)
         raise_chroma_error(resp)
 
-    def _count(self, collection_name: str):
+    def _count(self, collection_id: UUID):
         """Returns the number of embeddings in the database"""
-        resp = requests.get(self._api_url + "/collections/" + collection_name + "/count")
+        resp = requests.get(self._api_url + "/collections/" + str(collection_id) + "/count")
         raise_chroma_error(resp)
         return resp.json()
 
-    def _peek(self, collection_name, limit=10):
+    def _peek(self, collection_id, limit=10):
         return self._get(
-            collection_name,
+            collection_id,
             limit=limit,
             include=["embeddings", "documents", "metadatas"],
         )
 
     def _get(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: Optional[IDs] = None,
         where: Optional[Where] = {},
         sort: Optional[str] = None,
@@ -134,7 +137,7 @@ class FastAPI(API):
             limit = page_size
 
         resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/get",
+            self._api_url + "/collections/" + str(collection_id) + "/get",
             data=json.dumps(
                 {
                     "ids": ids,
@@ -151,11 +154,11 @@ class FastAPI(API):
         raise_chroma_error(resp)
         return resp.json()
 
-    def _delete(self, collection_name, ids=None, where={}, where_document={}):
+    def _delete(self, collection_id: UUID, ids=None, where={}, where_document={}):
         """Deletes embeddings from the database"""
 
         resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/delete",
+            self._api_url + "/collections/" + str(collection_id) + "/delete",
             data=json.dumps({"where": where, "ids": ids, "where_document": where_document}),
         )
 
@@ -165,7 +168,7 @@ class FastAPI(API):
     def _add(
         self,
         ids,
-        collection_name,
+        collection_id: UUID,
         embeddings,
         metadatas=None,
         documents=None,
@@ -178,7 +181,7 @@ class FastAPI(API):
         -     and then manually create the index yourself with collection.create_index()
         """
         resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/add",
+            self._api_url + "/collections/" + str(collection_id) + "/add",
             data=json.dumps(
                 {
                     "ids": ids,
@@ -195,7 +198,7 @@ class FastAPI(API):
 
     def _update(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: IDs,
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
@@ -207,7 +210,7 @@ class FastAPI(API):
         """
 
         resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/update",
+            self._api_url + "/collections/" + str(collection_id) + "/update",
             data=json.dumps(
                 {
                     "ids": ids,
@@ -223,7 +226,7 @@ class FastAPI(API):
 
     def _upsert(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: IDs,
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
@@ -236,7 +239,7 @@ class FastAPI(API):
         """
 
         resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/upsert",
+            self._api_url + "/collections/" + str(collection_id) + "/upsert",
             data=json.dumps(
                 {
                     "ids": ids,
@@ -253,7 +256,7 @@ class FastAPI(API):
 
     def _query(
         self,
-        collection_name,
+        collection_id: UUID,
         query_embeddings,
         n_results=10,
         where={},
@@ -263,7 +266,7 @@ class FastAPI(API):
         """Gets the nearest neighbors of a single embedding"""
 
         resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/query",
+            self._api_url + "/collections/" + str(collection_id) + "/query",
             data=json.dumps(
                 {
                     "query_embeddings": query_embeddings,

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -1,6 +1,6 @@
 import json
 import time
-
+from uuid import UUID
 from typing import Dict, List, Optional, Sequence, Callable, cast
 from chromadb import __version__
 import chromadb.errors as errors
@@ -93,6 +93,7 @@ class LocalAPI(API):
             client=self,
             name=name,
             embedding_function=embedding_function,
+            id=res[0][0],
             metadata=res[0][2],
         )
 
@@ -145,6 +146,7 @@ class LocalAPI(API):
         return Collection(
             client=self,
             name=name,
+            id=res[0][0],
             embedding_function=embedding_function,
             metadata=res[0][2],
         )
@@ -163,21 +165,24 @@ class LocalAPI(API):
         for db_collection in db_collections:
             collections.append(
                 Collection(
-                    client=self, name=db_collection[1], metadata=db_collection[2]
+                    client=self,
+                    id=db_collection[0],
+                    name=db_collection[1],
+                    metadata=db_collection[2],
                 )
             )
         return collections
 
     def _modify(
         self,
-        current_name: str,
+        id: UUID,
         new_name: Optional[str] = None,
         new_metadata: Optional[Dict] = None,
     ):
         if new_name is not None:
             check_index_name(new_name)
 
-        self._db.update_collection(current_name, new_name, new_metadata)
+        self._db.update_collection(id, new_name, new_metadata)
 
     def delete_collection(self, name: str):
         """Delete a collection with the given name.
@@ -198,21 +203,20 @@ class LocalAPI(API):
     def _add(
         self,
         ids,
-        collection_name: str,
+        collection_id: UUID,
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
         increment_index: bool = True,
     ):
-        existing_ids = self._get(collection_name, ids=ids, include=[])["ids"]
+        existing_ids = self._get(collection_id, ids=ids, include=[])["ids"]
         if len(existing_ids) > 0:
             raise errors.IDAlreadyExistsError(
-                f"IDs {existing_ids} already exist in collection {collection_name}"
+                f"IDs {existing_ids} already exist in collection {collection_id}"
             )
 
-        collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
         added_uuids = self._db.add(
-            collection_uuid,
+            collection_id,
             embeddings=embeddings,
             metadatas=metadatas,
             documents=documents,
@@ -220,26 +224,25 @@ class LocalAPI(API):
         )
 
         if increment_index:
-            self._db.add_incremental(collection_uuid, added_uuids, embeddings)
+            self._db.add_incremental(collection_id, added_uuids, embeddings)
 
-        self._telemetry_client.capture(CollectionAddEvent(collection_uuid, len(ids)))
+        self._telemetry_client.capture(CollectionAddEvent(str(collection_id), len(ids)))
         return True  # NIT: should this return the ids of the succesfully added items?
 
     def _update(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: IDs,
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
     ):
-        collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
-        self._db.update(collection_uuid, ids, embeddings, metadatas, documents)
+        self._db.update(collection_id, ids, embeddings, metadatas, documents)
         return True
 
     def _upsert(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: IDs,
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
@@ -247,7 +250,7 @@ class LocalAPI(API):
         increment_index: bool = True,
     ):
         # Determine which ids need to be added and which need to be updated based on the ids already in the collection
-        existing_ids = set(self._get(collection_name, ids=ids, include=[])["ids"])
+        existing_ids = set(self._get(collection_id, ids=ids, include=[])["ids"])
 
         ids_to_add = []
         ids_to_update = []
@@ -279,7 +282,7 @@ class LocalAPI(API):
         if len(ids_to_add) > 0:
             self._add(
                 ids_to_add,
-                collection_name,
+                collection_id,
                 embeddings_to_add,
                 metadatas_to_add,
                 documents_to_add,
@@ -288,18 +291,19 @@ class LocalAPI(API):
 
         if len(ids_to_update) > 0:
             self._update(
-                collection_name,
+                collection_id,
                 ids_to_update,
                 embeddings_to_update,
                 metadatas_to_update,
                 documents_to_update,
             )
+        self._db.update(collection_id, ids, embeddings, metadatas, documents)
 
         return True
 
     def _get(
         self,
-        collection_name: str,
+        collection_id: UUID,
         ids: Optional[IDs] = None,
         where: Optional[Where] = {},
         sort: Optional[str] = None,
@@ -331,7 +335,7 @@ class LocalAPI(API):
         }
 
         db_result = self._db.get(
-            collection_name=collection_name,
+            collection_uuid=collection_id,
             ids=ids,
             where=where,
             sort=sort,
@@ -364,27 +368,27 @@ class LocalAPI(API):
             get_result["ids"].append(entry[column_index["id"]])
         return get_result
 
-    def _delete(self, collection_name, ids=None, where=None, where_document=None):
+    def _delete(self, collection_id, ids=None, where=None, where_document=None):
         if where is None:
             where = {}
 
         if where_document is None:
             where_document = {}
 
-        collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
         deleted_uuids = self._db.delete(
-            collection_uuid=collection_uuid,
+            collection_uuid=collection_id,
             where=where,
             ids=ids,
             where_document=where_document,
         )
         self._telemetry_client.capture(
-            CollectionDeleteEvent(collection_uuid, len(deleted_uuids))
+            CollectionDeleteEvent(str(collection_id), len(deleted_uuids))
         )
+
         return deleted_uuids
 
-    def _count(self, collection_name):
-        return self._db.count(collection_name=collection_name)
+    def _count(self, collection_id):
+        return self._db.count(collection_id)
 
     def reset(self):
         """Reset the database. This will delete all collections and items.
@@ -398,7 +402,7 @@ class LocalAPI(API):
 
     def _query(
         self,
-        collection_name,
+        collection_id,
         query_embeddings,
         n_results=10,
         where={},
@@ -406,7 +410,7 @@ class LocalAPI(API):
         include: Include = ["documents", "metadatas", "distances"],
     ):
         uuids, distances = self._db.get_nearest_neighbors(
-            collection_name=collection_name,
+            collection_uuid=collection_id,
             where=where,
             where_document=where_document,
             embeddings=query_embeddings,
@@ -472,9 +476,9 @@ class LocalAPI(API):
         self._db.create_index(collection_uuid=collection_uuid)
         return True
 
-    def _peek(self, collection_name, n=10):
+    def _peek(self, collection_id: UUID, n=10):
         return self._get(
-            collection_name=collection_name,
+            collection_id=collection_id,
             limit=n,
             include=["embeddings", "documents", "metadatas"],
         )

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional, cast, List, Dict, Tuple
 from pydantic import BaseModel, PrivateAttr
+from uuid import UUID
 
 from chromadb.api.types import (
     Embedding,
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 
 class Collection(BaseModel):
     name: str
+    id: UUID
     metadata: Optional[Dict] = None
     _client: "API" = PrivateAttr()
     _embedding_function: Optional[EmbeddingFunction] = PrivateAttr()
@@ -39,6 +41,7 @@ class Collection(BaseModel):
         self,
         client: "API",
         name: str,
+        id: UUID,
         embedding_function: Optional[EmbeddingFunction] = None,
         metadata: Optional[Dict] = None,
     ):
@@ -52,7 +55,7 @@ class Collection(BaseModel):
                 "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction"
             )
             self._embedding_function = ef.SentenceTransformerEmbeddingFunction()
-        super().__init__(name=name, metadata=metadata)
+        super().__init__(name=name, metadata=metadata, id=id)
 
     def __repr__(self):
         return f"Collection(name={self.name})"
@@ -64,7 +67,7 @@ class Collection(BaseModel):
             int: The total number of embeddings added to the database
 
         """
-        return self._client._count(collection_name=self.name)
+        return self._client._count(collection_id=self.id)
 
     def add(
         self,
@@ -99,7 +102,7 @@ class Collection(BaseModel):
         )
 
         self._client._add(
-            ids, self.name, embeddings, metadatas, documents, increment_index
+            ids, self.id, embeddings, metadatas, documents, increment_index
         )
 
     def get(
@@ -133,7 +136,7 @@ class Collection(BaseModel):
         ids = validate_ids(maybe_cast_one_to_many(ids)) if ids else None
         include = validate_include(include, allow_distances=False)
         return self._client._get(
-            self.name,
+            self.id,
             ids,
             where,
             None,
@@ -152,7 +155,7 @@ class Collection(BaseModel):
         Returns:
             GetResult: A GetResult object containing the results.
         """
-        return self._client._peek(self.name, limit)
+        return self._client._peek(self.id, limit)
 
     def query(
         self,
@@ -217,7 +220,7 @@ class Collection(BaseModel):
             where_document = {}
 
         return self._client._query(
-            collection_name=self.name,
+            collection_id=self.id,
             query_embeddings=query_embeddings,
             n_results=n_results,
             where=where,
@@ -235,9 +238,7 @@ class Collection(BaseModel):
         Returns:
             None
         """
-        self._client._modify(
-            current_name=self.name, new_name=name, new_metadata=metadata
-        )
+        self._client._modify(id=self.id, new_name=name, new_metadata=metadata)
         if name:
             self.name = name
         if metadata:
@@ -266,7 +267,7 @@ class Collection(BaseModel):
             ids, embeddings, metadatas, documents, require_embeddings_or_documents=False
         )
 
-        self._client._update(self.name, ids, embeddings, metadatas, documents)
+        self._client._update(self.id, ids, embeddings, metadatas, documents)
 
     def upsert(
         self,
@@ -290,7 +291,7 @@ class Collection(BaseModel):
         )
 
         self._client._upsert(
-            collection_name=self.name,
+            collection_id=self.id,
             ids=ids,
             embeddings=embeddings,
             metadatas=metadatas,
@@ -319,7 +320,7 @@ class Collection(BaseModel):
         where_document = (
             validate_where_document(where_document) if where_document else None
         )
-        return self._client._delete(self.name, ids, where, where_document)
+        return self._client._delete(self.id, ids, where, where_document)
 
     def create_index(self):
         self._client.create_index(self.name)

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -26,7 +26,7 @@ class DB(ABC):
 
     @abstractmethod
     def update_collection(
-        self, current_name: str, new_name: Optional[str] = None, new_metadata: Optional[Dict] = None
+        self, id: UUID, new_name: Optional[str] = None, new_metadata: Optional[Dict] = None
     ):
         pass
 
@@ -35,13 +35,13 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def get_collection_uuid_from_name(self, collection_name: str) -> str:
+    def get_collection_uuid_from_name(self, collection_name: str) -> UUID:
         pass
 
     @abstractmethod
     def add(
         self,
-        collection_uuid: str,
+        collection_uuid: UUID,
         embeddings: Embeddings,
         metadatas: Optional[Metadatas],
         documents: Optional[Documents],
@@ -50,7 +50,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def add_incremental(self, collection_uuid: str, ids: List[UUID], embeddings: Embeddings):
+    def add_incremental(self, collection_uuid: UUID, ids: List[UUID], embeddings: Embeddings):
         pass
 
     @abstractmethod
@@ -58,7 +58,7 @@ class DB(ABC):
         self,
         where: Where = {},
         collection_name: Optional[str] = None,
-        collection_uuid: Optional[str] = None,
+        collection_uuid: Optional[UUID] = None,
         ids: Optional[IDs] = None,
         sort: Optional[str] = None,
         limit: Optional[int] = None,
@@ -71,7 +71,7 @@ class DB(ABC):
     @abstractmethod
     def update(
         self,
-        collection_uuid: str,
+        collection_uuid: UUID,
         ids: IDs,
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
@@ -80,14 +80,14 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def count(self, collection_name: str):
+    def count(self, collection_id: UUID):
         pass
 
     @abstractmethod
     def delete(
         self,
         where: Where = {},
-        collection_uuid: Optional[str] = None,
+        collection_uuid: Optional[UUID] = None,
         ids: Optional[IDs] = None,
         where_document: WhereDocument = {},
     ) -> List:
@@ -99,7 +99,13 @@ class DB(ABC):
 
     @abstractmethod
     def get_nearest_neighbors(
-        self, collection_name, where, embeddings, n_results, where_document
+        self,
+        where,
+        embeddings,
+        n_results,
+        where_document,
+        collection_name=None,
+        collection_uuid: Optional[UUID] = None,
     ) -> Tuple[List[List[UUID]], npt.NDArray]:
         pass
 
@@ -112,7 +118,7 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def create_index(self, collection_uuid: str):
+    def create_index(self, collection_uuid: UUID):
         pass
 
     @abstractmethod

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -100,12 +100,11 @@ class DB(ABC):
     @abstractmethod
     def get_nearest_neighbors(
         self,
+        collection_uuid: UUID,
         where,
         embeddings,
         n_results,
         where_document,
-        collection_name=None,
-        collection_uuid: Optional[UUID] = None,
     ) -> Tuple[List[List[UUID]], npt.NDArray]:
         pass
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -19,6 +19,7 @@ import clickhouse_connect
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect import common
 import logging
+from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
@@ -202,28 +203,17 @@ class Clickhouse(DB):
         return [[x[0], x[1], json.loads(x[2])] for x in res]
 
     def update_collection(
-        self,
-        current_name: str,
-        new_name: Optional[str] = None,
-        new_metadata: Optional[Dict] = None,
+        self, id: UUID, new_name: Optional[str] = None, new_metadata: Optional[Dict] = None
     ):
-        if new_name is None:
-            new_name = current_name
-        if new_metadata is None:
-            new_metadata = self.get_collection(current_name)[0][2]
+        if new_name is not None:
+            self._get_conn().command(
+                f"ALTER TABLE collections UPDATE name = '{new_name}' WHERE uuid = '{id}'",
+            )
 
-        return self._get_conn().command(
-            f"""
-
-         ALTER TABLE
-            collections
-         UPDATE
-            metadata = %s,
-            name = %s
-         WHERE
-            name = %s
-         """, [json.dumps(new_metadata), new_name, current_name]
-        )
+        if new_metadata is not None:
+            self._get_conn().command(
+                f"ALTER TABLE collections UPDATE metadata = '{json.dumps(new_metadata)}' WHERE uuid = '{id}'"
+            )
 
     def delete_collection(self, name: str):
         collection_uuid = self.get_collection_uuid_from_name(name)
@@ -478,17 +468,13 @@ class Clickhouse(DB):
 
         return val
 
-    def _count(self, collection_uuid: str):
+    def count(self, collection_uuid: str):
         where_string = f"WHERE collection_uuid = '{collection_uuid}'"
         return (
             self._get_conn()
             .query(f"SELECT COUNT() FROM embeddings {where_string}")
-            .result_rows
+            .result_rows[0][0]
         )
-
-    def count(self, collection_name: str):
-        collection_uuid = self.get_collection_uuid_from_name(collection_name)
-        return self._count(collection_uuid=collection_uuid)[0][0]
 
     def _delete(self, where_str: Optional[str] = None) -> List:
         deleted_uuids = (

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -207,12 +207,14 @@ class Clickhouse(DB):
     ):
         if new_name is not None:
             self._get_conn().command(
-                f"ALTER TABLE collections UPDATE name = '{new_name}' WHERE uuid = '{id}'",
+                f"ALTER TABLE collections UPDATE name = %(new_name)s WHERE uuid = %(uuid)s",
+                parameters={"new_name": new_name, "uuid": id},
             )
 
         if new_metadata is not None:
             self._get_conn().command(
-                f"ALTER TABLE collections UPDATE metadata = '{json.dumps(new_metadata)}' WHERE uuid = '{id}'"
+                f"ALTER TABLE collections UPDATE metadata = $(new_metadata)s WHERE uuid = $(uuid)s",
+                parameters={"new_metadata": json.dumps(new_metadata), "uuid": id},
             )
 
     def delete_collection(self, name: str):
@@ -468,7 +470,7 @@ class Clickhouse(DB):
 
         return val
 
-    def count(self, collection_uuid: str):
+    def count(self, collection_uuid: UUID):
         where_string = f"WHERE collection_uuid = '{collection_uuid}'"
         return (
             self._get_conn()
@@ -533,7 +535,7 @@ class Clickhouse(DB):
 
     def get_nearest_neighbors(
         self,
-        collection_uuid: uuid.UUID,
+        collection_uuid: UUID,
         where: Where,
         where_document: WhereDocument,
         embeddings: Embeddings,

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -213,7 +213,7 @@ class Clickhouse(DB):
 
         if new_metadata is not None:
             self._get_conn().command(
-                f"ALTER TABLE collections UPDATE metadata = $(new_metadata)s WHERE uuid = $(uuid)s",
+                f"ALTER TABLE collections UPDATE metadata = %(new_metadata)s WHERE uuid = %(uuid)s",
                 parameters={"new_metadata": json.dumps(new_metadata), "uuid": id},
             )
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -113,7 +113,7 @@ class Clickhouse(DB):
             "Clickhouse is a persistent database, this method is not needed"
         )
 
-    def get_collection_uuid_from_name(self, name: str) -> str:
+    def get_collection_uuid_from_name(self, name: str) -> UUID:
         res = self._get_conn().query(
             f"""
             SELECT uuid FROM collections WHERE name = '{name}'
@@ -429,7 +429,7 @@ class Clickhouse(DB):
         self,
         where: Where = {},
         collection_name: Optional[str] = None,
-        collection_uuid: Optional[str] = None,
+        collection_uuid: Optional[UUID] = None,
         ids: Optional[IDs] = None,
         sort: Optional[str] = None,
         limit: Optional[int] = None,
@@ -533,21 +533,17 @@ class Clickhouse(DB):
 
     def get_nearest_neighbors(
         self,
+        collection_uuid: uuid.UUID,
         where: Where,
         where_document: WhereDocument,
         embeddings: Embeddings,
         n_results: int,
-        collection_name=None,
-        collection_uuid=None,
     ) -> Tuple[List[List[uuid.UUID]], npt.NDArray]:
         # Either the collection name or the collection uuid must be provided
-        if collection_name is None and collection_uuid is None:
+        if collection_uuid is None:
             raise TypeError(
-                "Arguments collection_name and collection_uuid cannot both be None"
+                "Argument collection_uuid cannot be None"
             )
-
-        if collection_name is not None:
-            collection_uuid = self.get_collection_uuid_from_name(collection_name)
 
         if len(where) != 0 or len(where_document) != 0:
             results = self.get(

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -155,7 +155,7 @@ class Clickhouse(DB):
         if len(dupe_check) > 0:
             if get_or_create:
                 if dupe_check[0][2] != metadata:
-                    self.update_collection(name, new_name=name, new_metadata=metadata)
+                    self.update_collection(dupe_check[0][0], new_name=name, new_metadata=metadata)
                     dupe_check = self.get_collection(name)
                 logger.info(
                     f"collection with name {name} already exists, returning existing collection"

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -2,10 +2,9 @@ from abc import ABCMeta, abstractmethod
 
 
 class ChromaError(Exception):
-
     def code(self):
         """Return an appropriate HTTP response code for this error"""
-        return 400 # Bad Request
+        return 400  # Bad Request
 
     def message(self):
         return ", ".join(self.args)
@@ -42,9 +41,8 @@ class NotEnoughElementsException(ChromaError):
 
 
 class IDAlreadyExistsError(ChromaError):
-
     def code(self):
-        return 409 # Conflict
+        return 409  # Conflict
 
     @classmethod
     def name(cls):
@@ -56,6 +54,13 @@ class DuplicateIDError(ChromaError):
     def name(cls):
         return "DuplicateID"
 
+
+class InvalidUUIDError(ChromaError):
+    @classmethod
+    def name(cls):
+        return "InvalidUUID"
+
+
 error_types = {
     "NoDatapoints": NoDatapointsException,
     "NoIndex": NoIndexException,
@@ -63,4 +68,5 @@ error_types = {
     "NotEnoughElements": NotEnoughElementsException,
     "IDAlreadyExists": IDAlreadyExistsError,
     "DuplicateID": DuplicateIDError,
+    "InvalidUUID": InvalidUUIDError,
 }

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -157,7 +157,7 @@ class FastAPI(chromadb.server.Server):
     def get_collection(self, collection_name: str):
         return self._api.get_collection(collection_name)
 
-    def update_collection(self, collection_id, collection: UpdateCollection):
+    def update_collection(self, collection_id: str, collection: UpdateCollection):
         return self._api._modify(
             id=UUID(collection_id),
             new_name=collection.new_name,

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -5,9 +5,11 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
+from uuid import UUID
 
 import chromadb
 import chromadb.server
+import chromadb.api
 from chromadb.errors import (
     ChromaError,
     NoDatapointsException,
@@ -60,7 +62,7 @@ class FastAPI(chromadb.server.Server):
         super().__init__(settings)
         Telemetry.SERVER_CONTEXT = ServerContext.FASTAPI
         self._app = fastapi.FastAPI(debug=True)
-        self._api = chromadb.Client(settings)
+        self._api: chromadb.api.API = chromadb.Client(settings)
 
         self._app.middleware("http")(catch_exceptions_middleware)
         self._app.add_middleware(
@@ -83,28 +85,28 @@ class FastAPI(chromadb.server.Server):
         self.router.add_api_route("/api/v1/collections", self.create_collection, methods=["POST"])
 
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/add",
+            "/api/v1/collections/{collection_id}/add",
             self.add,
             methods=["POST"],
             status_code=status.HTTP_201_CREATED,
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/update", self.update, methods=["POST"]
+            "/api/v1/collections/{collection_id}/update", self.update, methods=["POST"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/upsert", self.upsert, methods=["POST"]
+            "/api/v1/collections/{collection_id}/upsert", self.upsert, methods=["POST"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/get", self.get, methods=["POST"]
+            "/api/v1/collections/{collection_id}/get", self.get, methods=["POST"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/delete", self.delete, methods=["POST"]
+            "/api/v1/collections/{collection_id}/delete", self.delete, methods=["POST"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/count", self.count, methods=["GET"]
+            "/api/v1/collections/{collection_id}/count", self.count, methods=["GET"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/query",
+            "/api/v1/collections/{collection_id}/query",
             self.get_nearest_neighbors,
             methods=["POST"],
         )
@@ -117,7 +119,7 @@ class FastAPI(chromadb.server.Server):
             "/api/v1/collections/{collection_name}", self.get_collection, methods=["GET"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}", self.update_collection, methods=["PUT"]
+            "/api/v1/collections/{collection_id}", self.update_collection, methods=["PUT"]
         )
         self.router.add_api_route(
             "/api/v1/collections/{collection_name}", self.delete_collection, methods=["DELETE"]
@@ -155,9 +157,9 @@ class FastAPI(chromadb.server.Server):
     def get_collection(self, collection_name: str):
         return self._api.get_collection(collection_name)
 
-    def update_collection(self, collection_name, collection: UpdateCollection):
+    def update_collection(self, collection_id, collection: UpdateCollection):
         return self._api._modify(
-            current_name=collection_name,
+            id=UUID(collection_id),
             new_name=collection.new_name,
             new_metadata=collection.new_metadata,
         )
@@ -165,10 +167,10 @@ class FastAPI(chromadb.server.Server):
     def delete_collection(self, collection_name: str):
         return self._api.delete_collection(collection_name)
 
-    def add(self, collection_name: str, add: AddEmbedding):
+    def add(self, collection_id: str, add: AddEmbedding):
         try:
             result = self._api._add(
-                collection_name=collection_name,
+                collection_id=UUID(collection_id),
                 embeddings=add.embeddings,
                 metadatas=add.metadatas,
                 documents=add.documents,
@@ -179,18 +181,18 @@ class FastAPI(chromadb.server.Server):
             raise HTTPException(status_code=500, detail=str(e))
         return result
 
-    def update(self, collection_name: str, add: UpdateEmbedding):
+    def update(self, collection_id: str, add: UpdateEmbedding):
         return self._api._update(
             ids=add.ids,
-            collection_name=collection_name,
+            collection_id=UUID(collection_id),
             embeddings=add.embeddings,
             documents=add.documents,
             metadatas=add.metadatas,
         )
 
-    def upsert(self, collection_name: str, upsert: AddEmbedding):        
+    def upsert(self, collection_id: str, upsert: AddEmbedding):
         return self._api._upsert(
-            collection_name=collection_name,
+            collection_id=UUID(collection_id),
             ids=upsert.ids,
             embeddings=upsert.embeddings,
             documents=upsert.documents,
@@ -198,9 +200,9 @@ class FastAPI(chromadb.server.Server):
             increment_index=upsert.increment_index,
         )
 
-    def get(self, collection_name, get: GetEmbedding):
+    def get(self, collection_id: str, get: GetEmbedding):
         return self._api._get(
-            collection_name=collection_name,
+            collection_id=UUID(collection_id),
             ids=get.ids,
             where=get.where,
             where_document=get.where_document,
@@ -210,23 +212,23 @@ class FastAPI(chromadb.server.Server):
             include=get.include,
         )
 
-    def delete(self, collection_name: str, delete: DeleteEmbedding):
+    def delete(self, collection_id: str, delete: DeleteEmbedding):
         return self._api._delete(
             where=delete.where,
             ids=delete.ids,
-            collection_name=collection_name,
+            collection_id=UUID(collection_id),
             where_document=delete.where_document,
         )
 
-    def count(self, collection_name: str):
-        return self._api._count(collection_name)
+    def count(self, collection_id: str):
+        return self._api._count(UUID(collection_id))
 
     def reset(self):
         return self._api.reset()
 
-    def get_nearest_neighbors(self, collection_name, query: QueryEmbedding):
+    def get_nearest_neighbors(self, collection_id: str, query: QueryEmbedding):
         nnresult = self._api._query(
-            collection_name=collection_name,
+            collection_id=UUID(collection_id),
             where=query.where,
             where_document=query.where_document,
             query_embeddings=query.query_embeddings,

--- a/clients/js/src/generated/api.ts
+++ b/clients/js/src/generated/api.ts
@@ -26,22 +26,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 	return {
 		/**
 		 * @summary Add
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.AddEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		add(collectionName: string, request: Api.AddEmbedding, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling add.');
+		add(collectionId: string, request: Api.AddEmbedding, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling add.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling add.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/add`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/add`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -69,22 +69,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Delete
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.DeleteEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		aDelete(collectionName: string, request: Api.DeleteEmbedding, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling aDelete.');
+		aDelete(collectionId: string, request: Api.DeleteEmbedding, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling aDelete.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling aDelete.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/delete`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/delete`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -112,22 +112,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Get
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.GetEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		aGet(collectionName: string, request: Api.GetEmbedding, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling aGet.');
+		aGet(collectionId: string, request: Api.GetEmbedding, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling aGet.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling aGet.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/get`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/get`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -155,17 +155,17 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Count
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		count(collectionName: string, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling count.');
+		count(collectionId: string, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling count.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/count`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/count`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'GET' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -320,22 +320,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Get Nearest Neighbors
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.QueryEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		getNearestNeighbors(collectionName: string, request: Api.QueryEmbedding, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling getNearestNeighbors.');
+		getNearestNeighbors(collectionId: string, request: Api.QueryEmbedding, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling getNearestNeighbors.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling getNearestNeighbors.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/query`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/query`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -530,22 +530,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Update
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.UpdateEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		update(collectionName: string, request: Api.UpdateEmbedding, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling update.');
+		update(collectionId: string, request: Api.UpdateEmbedding, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling update.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling update.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/update`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/update`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -573,22 +573,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Update Collection
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.UpdateCollection} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		updateCollection(collectionName: string, request: Api.UpdateCollection, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling updateCollection.');
+		updateCollection(collectionId: string, request: Api.UpdateCollection, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling updateCollection.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling updateCollection.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'PUT' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -616,22 +616,22 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 		},
 		/**
 		 * @summary Upsert
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.AddEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		upsert(collectionName: string, request: Api.AddEmbedding, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling upsert.');
+		upsert(collectionId: string, request: Api.AddEmbedding, options: RequestInit = {}): FetchArgs {
+			// verify required parameter 'collectionId' is not null or undefined
+			if (collectionId === null || collectionId === undefined) {
+				throw new RequiredError('collectionId', 'Required parameter collectionId was null or undefined when calling upsert.');
 			}
 			// verify required parameter 'request' is not null or undefined
 			if (request === null || request === undefined) {
 				throw new RequiredError('request', 'Required parameter request was null or undefined when calling upsert.');
 			}
-			let localVarPath = `/api/v1/collections/{collection_name}/upsert`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
+			let localVarPath = `/api/v1/collections/{collection_id}/upsert`
+				.replace('{collection_id}', encodeURIComponent(String(collectionId)));
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
@@ -694,13 +694,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 	return {
 		/**
 		 * @summary Add
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.AddEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		add(collectionName: string, request: Api.AddEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Add201Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).add(collectionName, request, options);
+		add(collectionId: string, request: Api.AddEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Add201Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).add(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -724,13 +724,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Delete
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.DeleteEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		aDelete(collectionName: string, request: Api.DeleteEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.ADelete200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).aDelete(collectionName, request, options);
+		aDelete(collectionId: string, request: Api.DeleteEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.ADelete200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).aDelete(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -754,13 +754,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Get
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.GetEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		aGet(collectionName: string, request: Api.GetEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.AGet200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).aGet(collectionName, request, options);
+		aGet(collectionId: string, request: Api.GetEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.AGet200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).aGet(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -784,12 +784,12 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Count
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		count(collectionName: string, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Count200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).count(collectionName, options);
+		count(collectionId: string, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Count200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).count(collectionId, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -929,13 +929,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Get Nearest Neighbors
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.QueryEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		getNearestNeighbors(collectionName: string, request: Api.QueryEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.GetNearestNeighbors200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).getNearestNeighbors(collectionName, request, options);
+		getNearestNeighbors(collectionId: string, request: Api.QueryEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.GetNearestNeighbors200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).getNearestNeighbors(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -1098,13 +1098,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Update
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.UpdateEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		update(collectionName: string, request: Api.UpdateEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Update200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).update(collectionName, request, options);
+		update(collectionId: string, request: Api.UpdateEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Update200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).update(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -1128,13 +1128,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Update Collection
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.UpdateCollection} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		updateCollection(collectionName: string, request: Api.UpdateCollection, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.UpdateCollection200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).updateCollection(collectionName, request, options);
+		updateCollection(collectionId: string, request: Api.UpdateCollection, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.UpdateCollection200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).updateCollection(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -1158,13 +1158,13 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		},
 		/**
 		 * @summary Upsert
-		 * @param {string} collectionName
+		 * @param {string} collectionId
 		 * @param {Api.AddEmbedding} request
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		upsert(collectionName: string, request: Api.AddEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Upsert200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).upsert(collectionName, request, options);
+		upsert(collectionId: string, request: Api.AddEmbedding, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Upsert200Response> {
+			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).upsert(collectionId, request, options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
 					const contentType = response.headers.get('Content-Type');
@@ -1228,45 +1228,45 @@ export const ApiApiFactory: FactoryFunction<ApiApi> = function (configuration?: 
 export class ApiApi extends BaseAPI {
 	/**
 	 * @summary Add
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.AddEmbedding} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public add(collectionName: string, request: Api.AddEmbedding, options?: RequestInit) {
-		return ApiApiFp(this.configuration).add(collectionName, request, options)(this.fetch, this.basePath);
+	public add(collectionId: string, request: Api.AddEmbedding, options?: RequestInit) {
+		return ApiApiFp(this.configuration).add(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**
 	 * @summary Delete
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.DeleteEmbedding} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public aDelete(collectionName: string, request: Api.DeleteEmbedding, options?: RequestInit) {
-		return ApiApiFp(this.configuration).aDelete(collectionName, request, options)(this.fetch, this.basePath);
+	public aDelete(collectionId: string, request: Api.DeleteEmbedding, options?: RequestInit) {
+		return ApiApiFp(this.configuration).aDelete(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**
 	 * @summary Get
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.GetEmbedding} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public aGet(collectionName: string, request: Api.GetEmbedding, options?: RequestInit) {
-		return ApiApiFp(this.configuration).aGet(collectionName, request, options)(this.fetch, this.basePath);
+	public aGet(collectionId: string, request: Api.GetEmbedding, options?: RequestInit) {
+		return ApiApiFp(this.configuration).aGet(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**
 	 * @summary Count
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public count(collectionName: string, options?: RequestInit) {
-		return ApiApiFp(this.configuration).count(collectionName, options)(this.fetch, this.basePath);
+	public count(collectionId: string, options?: RequestInit) {
+		return ApiApiFp(this.configuration).count(collectionId, options)(this.fetch, this.basePath);
 	}
 
 	/**
@@ -1311,13 +1311,13 @@ export class ApiApi extends BaseAPI {
 
 	/**
 	 * @summary Get Nearest Neighbors
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.QueryEmbedding} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public getNearestNeighbors(collectionName: string, request: Api.QueryEmbedding, options?: RequestInit) {
-		return ApiApiFp(this.configuration).getNearestNeighbors(collectionName, request, options)(this.fetch, this.basePath);
+	public getNearestNeighbors(collectionId: string, request: Api.QueryEmbedding, options?: RequestInit) {
+		return ApiApiFp(this.configuration).getNearestNeighbors(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**
@@ -1377,35 +1377,35 @@ export class ApiApi extends BaseAPI {
 
 	/**
 	 * @summary Update
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.UpdateEmbedding} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public update(collectionName: string, request: Api.UpdateEmbedding, options?: RequestInit) {
-		return ApiApiFp(this.configuration).update(collectionName, request, options)(this.fetch, this.basePath);
+	public update(collectionId: string, request: Api.UpdateEmbedding, options?: RequestInit) {
+		return ApiApiFp(this.configuration).update(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**
 	 * @summary Update Collection
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.UpdateCollection} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public updateCollection(collectionName: string, request: Api.UpdateCollection, options?: RequestInit) {
-		return ApiApiFp(this.configuration).updateCollection(collectionName, request, options)(this.fetch, this.basePath);
+	public updateCollection(collectionId: string, request: Api.UpdateCollection, options?: RequestInit) {
+		return ApiApiFp(this.configuration).updateCollection(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**
 	 * @summary Upsert
-	 * @param {string} collectionName
+	 * @param {string} collectionId
 	 * @param {Api.AddEmbedding} request
 	 * @param {RequestInit} [options] Override http request option.
 	 * @throws {RequiredError}
 	 */
-	public upsert(collectionName: string, request: Api.AddEmbedding, options?: RequestInit) {
-		return ApiApiFp(this.configuration).upsert(collectionName, request, options)(this.fetch, this.basePath);
+	public upsert(collectionId: string, request: Api.AddEmbedding, options?: RequestInit) {
+		return ApiApiFp(this.configuration).upsert(collectionId, request, options)(this.fetch, this.basePath);
 	}
 
 	/**

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -384,7 +384,7 @@ export class Collection {
 
     var resp = await this.api
       .update(
-        this.name,
+        this.id,
         {
           ids: toArray(ids),
           embeddings: embeddings ? toArrayOfArrays(embeddings) : undefined,

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -146,17 +146,20 @@ type CallableFunction = {
 
 export class Collection {
   public name: string;
+  public id: string;
   public metadata: object | undefined;
   private api: DefaultApi;
   public embeddingFunction: CallableFunction | undefined;
 
   constructor(
     name: string,
+    id: string,
     api: DefaultApi,
     metadata?: object,
     embeddingFunction?: CallableFunction
   ) {
     this.name = name;
+    this.id = id;
     this.metadata = metadata;
     this.api = api;
     if (embeddingFunction !== undefined)
@@ -256,7 +259,7 @@ export class Collection {
       documents
     )
 
-    const response = await this.api.add(this.name,
+    const response = await this.api.add(this.id,
       {
         // @ts-ignore
         ids: idsArray,
@@ -288,7 +291,7 @@ export class Collection {
       documents
     )
 
-    const response = await this.api.upsert(this.name,
+    const response = await this.api.upsert(this.id,
       {
         //@ts-ignore
         ids: idsArray,
@@ -308,7 +311,7 @@ export class Collection {
 
 
   public async count() {
-    const response = await this.api.count(this.name);
+    const response = await this.api.count(this.id);
     return handleSuccess(response);
   }
 
@@ -328,6 +331,7 @@ export class Collection {
     this.setMetadata(metadata || this.metadata);
 
     return response;
+
   }
 
   public async get(
@@ -342,7 +346,7 @@ export class Collection {
     if (ids !== undefined) idsArray = toArray(ids);
 
     return await this.api
-      .aGet(this.name, {
+      .aGet(this.id, {
         ids: idsArray,
         where,
         limit,
@@ -422,7 +426,7 @@ export class Collection {
     const query_embeddingsArray: number[][] = toArrayOfArrays(query_embeddings);
 
     return await this.api
-      .getNearestNeighbors(this.name, {
+      .getNearestNeighbors(this.id, {
         query_embeddings: query_embeddingsArray,
         where,
         n_results: n_results,
@@ -434,7 +438,7 @@ export class Collection {
   }
 
   public async peek(limit: number = 10) {
-    const response = await this.api.aGet(this.name, {
+    const response = await this.api.aGet(this.id, {
       limit: limit,
     });
     return handleSuccess(response);
@@ -446,7 +450,7 @@ export class Collection {
 
   public async delete(ids?: string[], where?: object, where_document?: object) {
     return await this.api
-      .aDelete(this.name, { ids: ids, where: where, where_document: where_document })
+      .aDelete(this.id, { ids: ids, where: where, where_document: where_document })
       .then(handleSuccess)
       .catch(handleError);
   }
@@ -499,7 +503,7 @@ export class ChromaClient {
       throw new Error(newCollection.error);
     }
 
-    return new Collection(name, this.api, metadata, embeddingFunction);
+    return new Collection(name, newCollection.id, this.api, metadata, embeddingFunction);
   }
 
   public async getOrCreateCollection(
@@ -522,6 +526,7 @@ export class ChromaClient {
 
     return new Collection(
       name,
+      newCollection.id,
       this.api,
       newCollection.metadata,
       embeddingFunction
@@ -544,6 +549,7 @@ export class ChromaClient {
 
     return new Collection(
       response.name,
+      response.id,
       this.api,
       response.metadata,
       embeddingFunction

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -318,7 +318,7 @@ export class Collection {
   public async modify(name?: string, metadata?: object) {
     const response = await this.api
       .updateCollection(
-        this.name,
+        this.id,
         {
           new_name: name,
           new_metadata: metadata,

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -59,6 +59,9 @@ test('it should get a collection', async () => {
     expect(collection).toHaveProperty('name')
     expect(collection2).toHaveProperty('name')
     expect(collection.name).toBe(collection2.name)
+    expect(collection).toHaveProperty('id')
+    expect(collection2).toHaveProperty('id')
+    expect(collection.id).toBe(collection2.id)
 })
 
 test('it should delete a collection', async () => {

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -15,21 +15,6 @@ test("it should list collections", async () => {
   expect(collections.length).toBe(1);
 });
 
-
-test('it should create a collection', async () => {
-  await chroma.reset()
-  const collection = await chroma.createCollection('test')
-  expect(collection).toBeDefined()
-  expect(collection).toHaveProperty('name')
-  let collections = await chroma.listCollections()
-  expect(collections).toHaveLength(1)
-  let resultColl = collections[0]
-  expect(resultColl).toHaveProperty('name')
-  expect(resultColl.name).toBe('test')
-  expect(resultColl).toHaveProperty('metadata')
-  expect(resultColl.metadata).toBeNull()
-})
-
 test("it should create a collection", async () => {
   const collection = await chroma.createCollection("test");
   expect(collection).toBeDefined();
@@ -37,7 +22,7 @@ test("it should create a collection", async () => {
   expect(collection).toHaveProperty('id')
   expect(collection.name).toBe("test");
   let collections = await chroma.listCollections();
-  expect([{ name: "test", metadata: null }]).toEqual(
+  expect([{ name: "test", metadata: null, id: collection.id }]).toEqual(
     expect.arrayContaining(collections)
   );
   expect([{ name: "test2", metadata: null }]).not.toEqual(
@@ -54,7 +39,7 @@ test("it should create a collection", async () => {
   expect(collection2.metadata).toHaveProperty("test");
   expect(collection2.metadata).toEqual({ test: "test" });
   let collections2 = await chroma.listCollections();
-  expect([{ name: "test2", metadata: { test: "test" } }]).toEqual(
+  expect([{ name: "test2", metadata: { test: "test" }, id: collection2.id }]).toEqual(
     expect.arrayContaining(collections2)
   );
 });

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -15,10 +15,26 @@ test("it should list collections", async () => {
   expect(collections.length).toBe(1);
 });
 
+
+test('it should create a collection', async () => {
+  await chroma.reset()
+  const collection = await chroma.createCollection('test')
+  expect(collection).toBeDefined()
+  expect(collection).toHaveProperty('name')
+  let collections = await chroma.listCollections()
+  expect(collections).toHaveLength(1)
+  let resultColl = collections[0]
+  expect(resultColl).toHaveProperty('name')
+  expect(resultColl.name).toBe('test')
+  expect(resultColl).toHaveProperty('metadata')
+  expect(resultColl.metadata).toBeNull()
+})
+
 test("it should create a collection", async () => {
   const collection = await chroma.createCollection("test");
   expect(collection).toBeDefined();
   expect(collection).toHaveProperty("name");
+  expect(collection).toHaveProperty('id')
   expect(collection.name).toBe("test");
   let collections = await chroma.listCollections();
   expect([{ name: "test", metadata: null }]).toEqual(
@@ -32,6 +48,7 @@ test("it should create a collection", async () => {
   const collection2 = await chroma.createCollection("test2", { test: "test" });
   expect(collection2).toBeDefined();
   expect(collection2).toHaveProperty("name");
+  expect(collection2).toHaveProperty('id')
   expect(collection2.name).toBe("test2");
   expect(collection2).toHaveProperty("metadata");
   expect(collection2.metadata).toHaveProperty("test");


### PR DESCRIPTION
## Description of changes

- Use Collection UUID everywhere we can instead of collection name
- Private methods only, does not affect user-facing APIs
- Prevents extra DB calls to look up the ID from the name (should improve perf)
- Forward-compatible with enterprise architecture refactor
- Fixes #138 

Tagged as a draft because this does change the REST API, so I will need to update the Node client in tandem. However, the Python code is ready for review and merge.

## Test plan

Unit and integration tests continue to pass without changes.

## Documentation Changes

No user facing changes, no docs required.
