### PR TITLE
Fix update bug

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -299,8 +299,9 @@ class Clickhouse(DB):
 
         # Update the index
         if embeddings is not None:
+            update_uuids = [x[1] for x in existing_items]
             index = self._index(collection_uuid)
-            index.add(ids, embeddings, update=True)
+            index.add(update_uuids, embeddings, update=True)
 
     def _get(self, where={}, columns: Optional[List] = None):
         select_columns = db_schema_to_keys() if columns is None else columns

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1367,3 +1367,25 @@ def test_multiple_collections(api_fixture, request):
 
     assert results1["ids"][0][0] == ids1[0]
     assert results2["ids"][0][0] == ids2[0]
+
+
+@pytest.mark.parametrize("api_fixture", test_apis)
+def test_update_query(api_fixture, request):
+
+    api = request.getfixturevalue(api_fixture.__name__)
+    api.reset()
+    collection = api.create_collection("test_update_query")
+    collection.add(**records)
+
+    updated_records = {
+        "ids": [records["ids"][0]],
+        "embeddings": [[0.1, 0.2, 0.3]],
+        "documents": ["updated document"],
+        "metadatas": [{"foo": "bar"}],
+    }
+
+    collection.update(**updated_records)
+
+    # test query
+    results = collection.query(query_embeddings=updated_records['embeddings'], n_results=1)
+    assert len(results["ids"][0]) == 1

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1387,5 +1387,13 @@ def test_update_query(api_fixture, request):
     collection.update(**updated_records)
 
     # test query
-    results = collection.query(query_embeddings=updated_records['embeddings'], n_results=1)
+    results = collection.query(
+        query_embeddings=updated_records["embeddings"],
+        n_results=1,
+        include=["embeddings", "documents", "metadatas"],
+    )
     assert len(results["ids"][0]) == 1
+    assert results["ids"][0][0] == updated_records["ids"][0]
+    assert results["documents"][0][0] == updated_records["documents"][0]
+    assert results["metadatas"][0][0]["foo"] == "bar"
+    assert results["embeddings"][0][0] == updated_records["embeddings"][0]


### PR DESCRIPTION
## Description of changes
A bug was introduced in #245. [Here](https://github.com/chroma-core/chroma/pull/245/files#diff-e9db4ed78af14ad050bb2ef1f4946b60f50f4eb3bf284c0b40745f683d49ac64L274) we changed from passing uuids into the index to ids, which leads to breakage. This is a bugfix that fixes the functionality by passing in uuids, along with a test. 

## Test plan
A new test was added that
- Adds a record
- Updates it
- Queries for it to check if it was valid

## Documentation Changes
None required
