### PR TITLE
Change the spelling of Srart to Start

### DIFF
--- a/examples/local_persistence.ipynb
+++ b/examples/local_persistence.ipynb
@@ -53,7 +53,7 @@
     "    )\n",
     ")\n",
     "\n",
-    "# Srart from scratch\n",
+    "# Start from scratch\n",
     "client.reset()\n",
     "\n",
     "# Create a new chroma collection\n",


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
	 - Change the spelling of Srart to Start

## Test plan
Running the chroma/examples/local_persistence.ipynb notebook.

## Documentation Changes
None