### PR TITLE
updated n_results parameter in example query

### DIFF
--- a/examples/where_filtering.ipynb
+++ b/examples/where_filtering.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,15 +20,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Running Chroma using direct local API.\n",
-      "Using DuckDB in-memory for database. Data will be transient.\n"
+      "Using embedded DuckDB without persistence: data will be transient\n"
      ]
     }
    ],
@@ -38,9 +37,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n"
+     ]
+    }
+   ],
    "source": [
     "# Create a new chroma collection\n",
     "collection_name = \"filter_example_collection\"\n",
@@ -49,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,19 +89,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'ids': ['id7'],\n",
-       " 'embeddings': [[1.1, 2.3, 3.2]],\n",
+       " 'embeddings': None,\n",
        " 'documents': ['A document that discusses international affairs'],\n",
        " 'metadatas': [{'status': 'read'}]}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -106,20 +113,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'ids': ['id8', 'id1'],\n",
-       " 'embeddings': [[4.5, 6.9, 4.4], [1.1, 2.3, 3.2]],\n",
+       " 'embeddings': None,\n",
        " 'documents': ['A document that discusses global affairs',\n",
        "  'A document that discusses domestic policy'],\n",
        " 'metadatas': [{'status': 'unread'}, {'status': 'read'}]}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -131,14 +138,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'ids': [['id7', 'id2', 'id8']],\n",
-       " 'embeddings': [[[1.1, 2.3, 3.2], [4.5, 6.9, 4.4], [4.5, 6.9, 4.4]]],\n",
+       " 'embeddings': None,\n",
        " 'documents': [['A document that discusses international affairs',\n",
        "   'A document that discusses international affairs',\n",
        "   'A document that discusses global affairs']],\n",
@@ -148,22 +155,16 @@
        " 'distances': [[16.740001678466797, 87.22000122070312, 87.22000122070312]]}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Get the closest vectors to [0, 0, 0] that are about affairs\n",
-    "collection.query(query_embeddings=[[0, 0, 0]], where_document={\"$contains\": \"affairs\"})"
+    "# Get 5 closest vectors to [0, 0, 0] that are about affairs\n",
+    "# Outputs 3 docs because collection only has 3 docs about affairs\n",
+    "collection.query(query_embeddings=[[0, 0, 0]], where_document={\"$contains\": \"affairs\"}, n_results=5)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description of changes

 Added n_results parameter for query in `examples/where_filtering.ipynb` as mentioned in #315 

## Test plan
*How are these changes tested?*

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
