### PR TITLE
add: GH action to test python version compatibility

### DIFF
--- a/.github/workflows/python-compatibility.yaml
+++ b/.github/workflows/python-compatibility.yaml
@@ -1,0 +1,42 @@
+name: Testing chromadb compatibility with python versions
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  testing_chromadb_compatibility_with_python_versions:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies and test dependencies
+        run: |
+          pip install chromadb
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements_dev.txt
+
+      - name: Test
+        run: python -m pytest
+
+      - name: Integration Test
+        run: bin/integration-test
+
+      - name: Pipeline complete
+        run: echo "Compatibility pipeline completed successfully"
+


### PR DESCRIPTION
## Description of changes

Improves the documentation of discussed python-version-compability.

https://github.com/chroma-core/chroma/issues/308

It will also point to common issues and an improvement of structure in the roadmap could be gained.

**The pipeline will be triggered on every created release. Common Python versions (3.7, 3.8, 3.9, 3.10, 3.11) will be tested on (macos, ubuntu, windows)-latest**

## Documentation Changes

We could add a link to our pipeline for user to check the compatibility like here:
https://github.com/chroma-core/docs/pull/35

_In case anything needs changes or isn't clear, please let me know_
