### PR TITLE
Fixes for collections property tests

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -61,7 +61,8 @@ class API(ABC):
         Args:
             name (str): The name of the collection to create. The name must be unique.
             metadata (Optional[Dict], optional): A dictionary of metadata to associate with the collection. Defaults to None.
-            get_or_create (bool, optional): If True, will return the collection if it already exists. Defaults to False.
+            get_or_create (bool, optional): If True, will return the collection if it already exists,
+                and update the metadata (if applicable). Defaults to False.
             embedding_function (Optional[Callable], optional): A function that takes documents and returns an embedding. Defaults to None.
 
         Returns:
@@ -83,7 +84,8 @@ class API(ABC):
 
     @abstractmethod
     def get_or_create_collection(self, name: str, metadata: Optional[Dict] = None) -> Collection:
-        """Calls create_collection with get_or_create=True
+        """Calls create_collection with get_or_create=True.
+           If the collection exists, but with different metadata, the metadata will be replaced.
 
         Args:
             name (str): The name of the collection to create. The name must be unique.

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -38,7 +38,7 @@ def check_index_name(index_name):
     )
     if len(index_name) < 3 or len(index_name) > 63:
         raise ValueError(msg)
-    if not re.match("^[a-z0-9][a-z0-9._-]*[a-z0-9]$", index_name):
+    if not re.match("^[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]$", index_name):
         raise ValueError(msg)
     if ".." in index_name:
         raise ValueError(msg)

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
     from chromadb.api import API
 
 
+default_embedding_function = None
+
+
 class Collection(BaseModel):
     name: str
     metadata: Optional[Dict] = None
@@ -47,12 +50,16 @@ class Collection(BaseModel):
         if embedding_function is not None:
             self._embedding_function = embedding_function
         else:
-            import chromadb.utils.embedding_functions as ef
+            global default_embedding_function
+            if default_embedding_function is None:
+                from chromadb.utils import embedding_functions as ef
+
+                default_embedding_function = ef.SentenceTransformerEmbeddingFunction()
 
             logger.warning(
                 "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction"
             )
-            self._embedding_function = ef.SentenceTransformerEmbeddingFunction()
+            self._embedding_function = default_embedding_function
         super().__init__(name=name, metadata=metadata)
 
     def __repr__(self):

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -29,9 +29,6 @@ if TYPE_CHECKING:
     from chromadb.api import API
 
 
-default_embedding_function = None
-
-
 class Collection(BaseModel):
     name: str
     metadata: Optional[Dict] = None
@@ -50,16 +47,12 @@ class Collection(BaseModel):
         if embedding_function is not None:
             self._embedding_function = embedding_function
         else:
-            global default_embedding_function
-            if default_embedding_function is None:
-                from chromadb.utils import embedding_functions as ef
-
-                default_embedding_function = ef.SentenceTransformerEmbeddingFunction()
+            import chromadb.utils.embedding_functions as ef
 
             logger.warning(
                 "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction"
             )
-            self._embedding_function = default_embedding_function
+            self._embedding_function = ef.SentenceTransformerEmbeddingFunction()
         super().__init__(name=name, metadata=metadata)
 
     def __repr__(self):

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -143,6 +143,9 @@ class Clickhouse(DB):
 
         if len(dupe_check) > 0:
             if get_or_create:
+                if dupe_check[0][2] != metadata:
+                    self.update_collection(name, new_name=name, new_metadata=metadata)
+                    dupe_check = self.get_collection(name)
                 logger.info(
                     f"collection with name {name} already exists, returning existing collection"
                 )

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -82,6 +82,10 @@ class DuckDB(Clickhouse):
         dupe_check = self.get_collection(name)
         if len(dupe_check) > 0:
             if get_or_create is True:
+                if dupe_check[0][2] != metadata:
+                    self.update_collection(name, new_name=name, new_metadata=metadata)
+                    dupe_check = self.get_collection(name)
+
                 logger.info(
                     f"collection with name {name} already exists, returning existing collection"
                 )

--- a/chromadb/test/configurations.py
+++ b/chromadb/test/configurations.py
@@ -16,9 +16,9 @@ def configurations():
             chroma_db_impl="duckdb",
             persist_directory=tempfile.gettempdir(),
         ),
-        # Settings(
-        #     chroma_api_impl="local",
-        #     chroma_db_impl="duckdb+parquet",
-        #     persist_directory=tempfile.gettempdir() + "/tests",
-        # ),
+        Settings(
+            chroma_api_impl="local",
+            chroma_db_impl="duckdb+parquet",
+            persist_directory=tempfile.gettempdir() + "/tests",
+        ),
     ]

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -119,6 +119,7 @@ class CollectionStateMachine(RuleBasedStateMachine):
         return coll
 
 
+# TODO: takes 7-8 minutes to run, figure out how to make faster. It shouldn't take that long, it's only 3-5000 database operations and DuckDB is faster than that
 def test_collections(caplog, api):
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(lambda: CollectionStateMachine(api))

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -119,7 +119,6 @@ class CollectionStateMachine(RuleBasedStateMachine):
         return coll
 
 
-# TODO: takes 7-8 minutes to run, figure out how to make faster. It shouldn't take that long, it's only 3-5000 database operations and DuckDB is faster than that
 def test_collections(caplog, api):
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(lambda: CollectionStateMachine(api))

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -36,7 +36,6 @@ class CollectionStateMachine(RuleBasedStateMachine):
 
     @initialize()
     def initialize(self):
-        print("initializing")
         self.api.reset()
         self.existing = set()
 

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -2,16 +2,21 @@ from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
 
 
 class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
+
+    models = {}
+
     # If you have a beefier machine, try "gtr-t5-large".
     # for a full list of options: https://huggingface.co/sentence-transformers, https://www.sbert.net/docs/pretrained_models.html
     def __init__(self, model_name: str = "all-MiniLM-L6-v2"):
-        try:
-            from sentence_transformers import SentenceTransformer
-        except ImportError:
-            raise ValueError(
-                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
-            )
-        self._model = SentenceTransformer(model_name)
+        if model_name not in self.models:
+            try:
+                from sentence_transformers import SentenceTransformer
+            except ImportError:
+                raise ValueError(
+                    "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+                )
+            self.models[model_name] = SentenceTransformer(model_name)
+        self._model = self.models[model_name]
 
     def __call__(self, texts: Documents) -> Embeddings:
         return self._model.encode(list(texts), convert_to_numpy=True).tolist()


### PR DESCRIPTION
## Description of changes

- Fix collection name validation
- Don't reinitialize the default function every time a Collection model object is constructed (1000x perf improvement, thanks @HammadB !)
- When doing an "upsert" on a collection (`get_or_create`), update the metadata if it's different from the previous value.

## Test plan

These changes are to satisfy the new property-based tests for Collections, which now pass.

## Documentation Changes

No user facing changes; documented behavior was not changed.