### PR TITLE
changed default value of persist_directory in settings

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     clickhouse_host: str = None
     clickhouse_port: str = None
 
-    persist_directory: str = ".chroma"
+    persist_directory: str = "./chroma"
 
     chroma_server_host: str = None
     chroma_server_http_port: str = None


### PR DESCRIPTION
## Description of changes

This pull request addresses an issue with the default value of persist_directory in the Settings class. Previously, the default value was set to ".chroma", which is not a valid path. This PR updates the default value to "./chroma", ensuring the path is valid and the directory is created correctly.

Currently, if you create a client with these settings: 

```
from chromadb.config import Settings
client = chromadb.Client(Settings(
    chroma_db_impl="duckdb+parquet",
))
```

the program will fail

**Disclaimer:**
I am new to open source! This is my first PR so if I made any mistakes or skipped any steps of this process please let me know! I'd love to learn and contribute more in the future. Thanks.

