### PR TITLE
[bugfix] Ensure Openai batch embeddings are sorted by index

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -1,4 +1,3 @@
-import operator
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
 
 
@@ -39,12 +38,10 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         embeddings = self._client.create(input=texts, engine=self._model_name)["data"]
 
         # Sort resulting embeddings by index
-        sorted_embeddings = sorted(embeddings, key=operator.attrgetter('index'))
+        sorted_embeddings = sorted(embeddings, key=lambda e: e["index"])
 
         # Return just the embeddings
-        return [
-            result["embedding"] for result in sorted_embeddings
-        ]
+        return [result["embedding"] for result in sorted_embeddings]
 
 
 class CohereEmbeddingFunction(EmbeddingFunction):

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -1,3 +1,4 @@
+import operator
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
 
 
@@ -33,13 +34,16 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
     def __call__(self, texts: Documents) -> Embeddings:
         # replace newlines, which can negatively affect performance.
         texts = [t.replace("\n", " ") for t in texts]
-        # Call the OpenAI Embedding API in parallel for each document
+
+        # Call the OpenAI Embedding API
+        embeddings = self._client.create(input=texts, engine=self._model_name)["data"]
+
+        # Sort resulting embeddings by index
+        sorted_embeddings = sorted(embeddings, key=operator.attrgetter('index'))
+
+        # Return just the embeddings
         return [
-            result["embedding"]
-            for result in self._client.create(
-                input=texts,
-                engine=self._model_name,
-            )["data"]
+            result["embedding"] for result in sorted_embeddings
         ]
 
 


### PR DESCRIPTION
## Description of changes
The [OpenAI documentation](https://platform.openai.com/docs/guides/rate-limits/error-mitigation) warns that "the response object may not return completions in the order of the prompts, so always remember to match responses back to prompts using the index field."

This PR sorts the returned embeddings by index so that they are guaranteed to be in order.

## Test plan
I apologize but I was in a hurry and haven't tested this yet, so hopefully a kind maintainer will run a test for me. I wanted to get the PR in because this could be a silent but deadly bug.

## Documentation Changes
Bug fix, no user facing changes
