### PR TITLE
Client/Server example

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -71,7 +71,7 @@ def Client(settings=__settings):
         assert settings[key], f"Setting '{key}' is required when chroma_api_impl={setting}"
 
     def require_installed(key):
-        assert importlib.util.find_spec(key), f"Package '{key}' is required when chroma_api_impl='local'. Switch to 'rest' or install chroma[server]."
+        assert importlib.util.find_spec(key), f"Package '{key}' is required when chroma_api_impl='local' (default). Switch to 'rest' or install chromadb[server]."
 
     if setting == "rest":
         require("chroma_server_host")
@@ -81,7 +81,7 @@ def Client(settings=__settings):
 
         return chromadb.api.fastapi.FastAPI(settings, telemetry_client)
     elif setting == "local":
-        required_dependencies = ['pandas', 'duckdb'] # TODO: add other server requirements
+        required_dependencies = ['duckdb'] # TODO: add other server requirements
         for dep in required_dependencies:
             require_installed(dep)
         logger.info("Running Chroma using direct local API.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
   'fastapi >= 0.85.1',
+  'posthog >= 2.4.0',
 ]
 
 [project.optional-dependencies]
@@ -30,7 +31,6 @@ server = [
   'fastapi >= 0.85.1',
   'uvicorn[standard] >= 0.18.3',
   'numpy >= 1.21.6',
-  'posthog >= 2.4.0'
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ classifiers = [
 ]
 dependencies = [
   'fastapi >= 0.85.1',
+  'pandas >= 1.3',
   'posthog >= 2.4.0',
 ]
 
 [project.optional-dependencies]
 server = [
-  'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
   'hnswlib >= 0.7',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+  'fastapi >= 0.85.1',
+]
+
+[project.optional-dependencies]
+server = [
   'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic >= 1.9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   'fastapi >= 0.85.1',
   'pandas >= 1.3',
   'posthog >= 2.4.0',
+  'sentence-transformers >= 2.2.2',
 ]
 
 [project.optional-dependencies]
@@ -26,7 +27,6 @@ server = [
   'pydantic >= 1.9',
   'hnswlib >= 0.7',
   'clickhouse_connect >= 0.5.7',
-  'sentence-transformers >= 2.2.2',
   'duckdb >= 0.7.1',
   'fastapi >= 0.85.1',
   'uvicorn[standard] >= 0.18.3',


### PR DESCRIPTION
## Description of changes

**Not backwards-compatible PR**

This PR is inspired by https://github.com/chroma-core/chroma/issues/289 and updates the pip package to *by default* have minimal dependencies, only those needed to run as a client. This is because the install of all dependencies could take 30+ minutes, which makes chromaDB not ideal to deploy in a prod environment where such long build times are not acceptable.

With this change, it's possible to either install all ChromaDB dependencies as `pip install chromadb[server]`, and just the client with `pip install chromadb`. Installing the client would require running another container with this repo as the server, and using the client in `chroma_api_impl="rest"` mode.

By splitting out the long-running dependency installs into their own container, we can ensure that apps running the client can have fast build times, and only require the long build times when there are actual updates to the server code.

*This PR is meant as a suggestion and working example, but is not backwards compatible and a big ask, so I'm very open to other implementations of the same idea.*

## How to use
In requirements.txt (of app installing client):
```
# chromadb==0.3.20 # old way
chromadb @ git+https://github.com/thefedoration/chroma@client-server-dependencies # client-only mode
```

In docker-compose (to run chromadb server as a separate container):
```
# this will run chromadb as a service found at localhost:8001 or at chromadb:8000 on local network
services:
  chromadb:
    build: https://github.com/chroma-core/chroma.git#0.3.21
    ports:
      - "8001:8000"
    expose:
      - "8001"
```

Using chroma client in application
```
import os
import chromadb
from chromadb.config import Settings

# host defaults to chromadb for docker-compose example above, but for prod deployment set the CHROMADB_HOST env var
client = chromadb.Client(Settings(
        chroma_api_impl='rest',
        chroma_server_host=os.environ.get('CHROMADB_HOST', 'chromadb'),
        chroma_server_http_port="8000",
))
```

Usage with langchain
```
import os
from chromadb.config import Settings
from langchain.vectorstores import Chroma
from langchain.text_splitter import RecursiveCharacterTextSplitter

chroma_settings = Settings(
      chroma_api_impl="rest",
      chroma_server_host=os.environ.get('CHROMADB_HOST', 'chromadb'),
      chroma_server_http_port="8000",
)

all_texts = ["text1", "text2"]
text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0)
documents = text_splitter.create_documents(texts=all_texts)
embeddings = OpenAIEmbeddings()
vectordb = Chroma.from_documents(documents, embeddings, client_settings=chroma_settings)
```

## Notes
* This PR assumes the following dependencies are required to run the client only: fastapi, pandas, posthog, sentence-transformers. It's possible there are others depending on other methods you might be calling.
* `sentence-transformers` and `pandas` is also a big install. Would be nice to be able to extract that from the client install as well, and keep it on the server

## Test plan
* Test that `pip install chromadb` doesn't install huge dependencies like `duckdb` and all `chromadb.Client` functionality still works as expected.
* Test that `pip install chromadb[server]` installs all dependencies needed to run chroma in local mode

## Documentation Changes
*Would add something like the above "How to use" section to the [deployment docs](https://docs.trychroma.com/deployment)
