### PR TITLE
Fix updates by ensuring correct ID ordering

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -302,7 +302,8 @@ class Clickhouse(DB):
 
         # Update the index
         if embeddings is not None:
-            update_uuids = [x[1] for x in existing_items]
+            uuid_mapping = {r[4]: r[1] for r in existing_items}
+            update_uuids = [uuid_mapping[id] for id in ids]
             index = self._index(collection_uuid)
             index.add(update_uuids, embeddings, update=True)
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -302,6 +302,8 @@ class Clickhouse(DB):
 
         # Update the index
         if embeddings is not None:
+            # `get` current returns items in arbitrary order.
+            # TODO if we fix `get`, we can remove this explicit mapping.
             uuid_mapping = {r[4]: r[1] for r in existing_items}
             update_uuids = [uuid_mapping[id] for id in ids]
             index = self._index(collection_uuid)

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -104,6 +104,9 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
         self.collection.delete(ids=ids)
         self._remove_embeddings(set(indices_to_remove))
 
+    # Removing the precondition causes the tests to frequently fail as "unsatisfiable"
+    # Using a value < 5 causes retries and lowers the number of valid samples
+    @precondition(lambda self: len(self.embeddings["ids"]) >= 5)
     @rule(
         embedding_set=strategies.embedding_set(
             dtype_st=dtype_shared_st,
@@ -174,8 +177,6 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
                 self.embeddings["documents"][idx] = embeddings["documents"][i]
 
 
-# TODO: Investigate why update on HNSW index causes very low recall in certain cases
-@pytest.mark.xfail(reason="Unusual behavior when updating HNSW index")
 def test_embeddings_state(caplog, api):
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(lambda: EmbeddingStateMachine(api))

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -218,3 +218,4 @@ def test_escape_chars_in_ids(api):
     assert coll.count() == 1
     coll.delete(ids=[id])
     assert coll.count() == 0
+


### PR DESCRIPTION
## Description of changes

Fixes bug where when updating multiple records at the same time, the user-facing IDs and internal UUIDs were mismapped leading towards invalid HNSW indices.

## Test plan

Hypothesis state machine

## Documentation Changes

N/A
