### PR TITLE
Fix occasional Hypothesis test failure when calling `get_or_create_collection`

### DIFF
--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -90,7 +90,8 @@ class CollectionStateMachine(RuleBasedStateMachine):
 
         c = self.api.get_or_create_collection(**coll)
         assert c.name == coll["name"]
-        assert c.metadata == coll["metadata"]
+        if coll["metadata"] is not None:
+            assert c.metadata == coll["metadata"]
         self.existing.add(coll["name"])
         return coll
 

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -132,3 +132,11 @@ def test_upsert_metadata_example(api):
     v1 = state.create_coll(coll={"name": "E40", "metadata": None})
     state.get_or_create_coll(coll={"name": "E40", "metadata": {"foo": "bar"}})
     state.teardown()
+
+
+def test_create_coll_with_none_metadata(api):
+    coll = {"name": "foo", "metadata": None}
+    api.reset()
+    c = api.get_or_create_collection(**coll)
+    assert c.name == coll["name"]
+    assert c.metadata == coll["metadata"]


### PR DESCRIPTION
## Description of changes

Hypothesis tests would occasionally fail when they stumbled on a scenario like the following:

```python
state = CollectionStateMachine(api)
state.initialize()
v1 = state.create_coll(coll={"name": "A11", "metadata": {"foo": "bar"}})
state.get_or_create_coll(coll={"name": "A11", "metadata": None})
state.teardown()
```

This PR allows the tests to pass by not making the assertion in the special case of `metadata=None`.

This cannot be fixed in code, because we have already designed passing `metadata=None` to mean "do not update the metadata." As such, there is no way to explicitly set the metadata to None without making user-facing API changes, and so the tests should not try to do so.

## Test plan

This fixes a failure in the existing tests.

## Documentation Changes

N/A