### PR TITLE
Fix OpenAIEmbeddingFunction in JS to use passed model name

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -51,7 +51,7 @@ export class OpenAIEmbeddingFunction {
     const openai = new OpenAIApi.OpenAIApi(configuration);
     const embeddings = [];
     const response = await openai.createEmbedding({
-      model: "text-embedding-ada-002",
+      model: this.model,
       input: texts,
     });
     const data = response.data['data'];


### PR DESCRIPTION
Class OpenAIEmbeddingFunction() is initiated with an optional parameter - model (string). But inside the generate() function of the class, the optional parameter is forgotten to be used when making API Call to OpenAI. Instead of the parameter, a string literal "text-embedding-ada-002" is used.

## Description of changes

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
