### PR TITLE
Add support for ids pre-filtering on query

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -240,6 +240,7 @@ class API(ABC):
         where: Where = {},
         where_document: WhereDocument = {},
         include: Include = ["embeddings", "metadatas", "documents", "distances"],
+        ids: Optional[IDs] = None,
     ) -> QueryResult:
         """Gets the nearest neighbors of a single embedding
         ⚠️ This method should not be used directly.
@@ -248,6 +249,9 @@ class API(ABC):
             embedding (Sequence[float]): The embedding to find the nearest neighbors of
             n_results (int, optional): The number of nearest neighbors to return. Defaults to 10.
             where (Dict[str, str], optional): A dictionary of key-value pairs to filter the embeddings by. Defaults to {}.
+            where_document (Dict[str, str], optional): A dictionary of key-value pairs to filter the documents by. Defaults to {}.
+            include (Include, optional): A list of fields to include in the results. Defaults to ["embeddings", "metadatas", "documents", "distances"].
+            ids (Optional[IDs], optional): A list of ids to filter the embeddings by. Defaults to None.
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -232,6 +232,7 @@ class FastAPI(API):
         where={},
         where_document={},
         include: Include = ["metadatas", "documents", "distances"],
+        ids=None,
     ):
         """Gets the nearest neighbors of a single embedding"""
 
@@ -244,6 +245,7 @@ class FastAPI(API):
                     "where": where,
                     "where_document": where_document,
                     "include": include,
+                    "ids": ids,
                 }
             ),
         )

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -243,6 +243,7 @@ class LocalAPI(API):
         where={},
         where_document={},
         include: Include = ["documents", "metadatas", "distances"],
+        ids: Optional[IDs] = None,
     ):
         uuids, distances = self._db.get_nearest_neighbors(
             collection_name=collection_name,
@@ -250,6 +251,7 @@ class LocalAPI(API):
             where_document=where_document,
             embeddings=query_embeddings,
             n_results=n_results,
+            ids=ids,
         )
 
         include_embeddings = "embeddings" in include

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -161,6 +161,7 @@ class Collection(BaseModel):
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
         include: Include = ["metadatas", "documents", "distances"],
+        ids: Optional[IDs] = None,
     ) -> QueryResult:
         """Get the n_results nearest neighbor embeddings for provided query_embeddings or query_texts.
 
@@ -171,6 +172,7 @@ class Collection(BaseModel):
             where: A Where type dict used to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
             where_document: A WhereDocument type dict used to filter by the documents. E.g. {$contains: {"text": "hello"}}. Optional.
             include: A list of what to include in the results. Can contain "embeddings", "metadatas", "documents", "distances". Ids are always included. Defaults to ["metadatas", "documents", "distances"]. Optional.
+            ids: The ids of the embeddings to pre-filter for query. Optional.
         """
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None
@@ -206,6 +208,7 @@ class Collection(BaseModel):
             where=where,
             where_document=where_document,
             include=include,
+            ids=ids,
         )
 
     def modify(self, name: Optional[str] = None, metadata=None):

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -174,6 +174,7 @@ class Collection(BaseModel):
             include: A list of what to include in the results. Can contain "embeddings", "metadatas", "documents", "distances". Ids are always included. Defaults to ["metadatas", "documents", "distances"]. Optional.
             ids: The ids of the embeddings to pre-filter for query. Optional.
         """
+        ids = validate_ids(maybe_cast_one_to_many(ids)) if ids else None
         where = validate_where(where) if where else None
         where_document = validate_where_document(where_document) if where_document else None
         query_embeddings = maybe_cast_one_to_many(query_embeddings) if query_embeddings else None

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -99,7 +99,7 @@ class DB(ABC):
 
     @abstractmethod
     def get_nearest_neighbors(
-        self, collection_name, where, embeddings, n_results, where_document
+        self, collection_name, where, embeddings, n_results, where_document, ids
     ) -> Tuple[List[List[UUID]], npt.NDArray]:
         pass
 

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -215,6 +215,7 @@ class FastAPI(chromadb.server.Server):
                 query_embeddings=query.query_embeddings,
                 n_results=query.n_results,
                 include=query.include,
+                ids=query.ids,
             )
             return nnresult
         except NoDatapointsException as e:

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -26,6 +26,7 @@ class QueryEmbedding(BaseModel):
     query_embeddings: List
     n_results: int = 10
     include: Include = ["metadatas", "documents", "distances"]
+    ids: Union[str, List] = None
 
 
 class ProcessEmbedding(BaseModel):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1142,6 +1142,28 @@ def test_query_include(api_fixture, request):
 
 
 @pytest.mark.parametrize("api_fixture", test_apis)
+def test_query_ids(api_fixture, request):
+    api = request.getfixturevalue(api_fixture.__name__)
+
+    api.reset()
+    collection = api.create_collection("test_query_ids")
+    collection.add(**records)
+
+    items = collection.query(query_embeddings=[0, 0, 0], n_results=2)
+    print(items)
+    assert items["ids"][0][0] == "id1"
+    assert items["ids"][0][1] == "id2"
+
+    items = collection.query(query_embeddings=[[0, 0, 0], [1, 2, 1.2]], n_results=1, ids=["id2"])
+    assert len(items["ids"]) == 2
+    print(items)
+    assert items["metadatas"][0][0]["int_value"] == 2
+    assert items["metadatas"][1][0]["int_value"] == 2
+    assert items["ids"][0][0] == "id2"
+    assert items["ids"][1][0] == "id2"
+
+
+@pytest.mark.parametrize("api_fixture", test_apis)
 def test_get_include(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
 


### PR DESCRIPTION
## Description of changes
Enables support for passing in a list of IDs that will pre-filter the embeddings set in the collection before performing kNN. Addresses request in https://github.com/chroma-core/chroma/issues/224.

## Test plan
Unit tests.

## Documentation Changes
Updated doc strings
