### PR TITLE
Removing pat due to public repo being clonable with no permissions

### DIFF
--- a/bin/setup_linux.sh
+++ b/bin/setup_linux.sh
@@ -26,7 +26,7 @@ pip3 install docker-compose
 
 
 # get the code 
-git clone https://oauth2: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@github.com/chroma-core/chroma.git
+git clone https://github.com/chroma-core/chroma.git
 
 #checkout the right branch
 cd chroma

--- a/bin/setup_mac.sh
+++ b/bin/setup_mac.sh
@@ -3,7 +3,7 @@
 # - pip
 
 # get the code 
-git clone https://oauth2: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@github.com/chroma-core/chroma.git
+git clone https://github.com/chroma-core/chroma.git
 
 #checkout the right branch
 cd chroma


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.* 
the github personal access token in install_linux and install_mac.sh were expired. 
Removed them due to being able to clone publicly without permissions. 

## Test plan
Ran on a fresh ubuntu 22.04 server box and I get errors due to docker version differences(docker compose vs docker-compose), however the change itself runs correctly in the script. 
I don't have a mac so I can't test the full use case of these changes

