### PR TITLE
Apply Hypothesis tests as integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
 venv
 .git
 examples
+clients
+.hypothesis
+__pycache__
+.vscode
+*.egg-info
+.pytest_cache

--- a/bin/clickhouse-run
+++ b/bin/clickhouse-run
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+#function cleanup {
+#  docker compose -f docker-compose.test.yml down --rmi local --volumes
+#}
+
+#trap cleanup EXIT
+
+#docker compose -f docker-compose.test.yml up --build -d
+
+
+#export CHROMA_API_IMPL=rest
+#export CHROMA_SERVER_HOST=localhost
+#export CHROMA_SERVER_HTTP_PORT=8000
+
+export CHROMA_INTEGRATION_TEST_ONLY=1
+
+export CHROMA_DB_IMPL=clickhouse
+export CLICKHOUSE_HOST=0.0.0.0
+export CLICKHOUSE_PORT=8123
+
+python -m pytest

--- a/bin/integration-test
+++ b/bin/integration-test
@@ -10,10 +10,9 @@ trap cleanup EXIT
 
 docker compose -f docker-compose.test.yml up --build -d
 
-export CHROMA_INTEGRATION_TEST=1
+export CHROMA_INTEGRATION_TEST_ONLY=1
 export CHROMA_API_IMPL=rest
 export CHROMA_SERVER_HOST=localhost
 export CHROMA_SERVER_HTTP_PORT=8000
 
 python -m pytest
-

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -15,6 +15,7 @@ import json
 from typing import Sequence
 from chromadb.api.models.Collection import Collection
 from chromadb.telemetry import Telemetry
+import chromadb.errors as errors
 
 
 class FastAPI(API):
@@ -26,13 +27,13 @@ class FastAPI(API):
     def heartbeat(self):
         """Returns the current server time in nanoseconds to check if the server is alive"""
         resp = requests.get(self._api_url)
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return int(resp.json()["nanosecond heartbeat"])
 
     def list_collections(self) -> Sequence[Collection]:
         """Returns a list of all collections"""
         resp = requests.get(self._api_url + "/collections")
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         json_collections = resp.json()
         collections = []
         for json_collection in json_collections:
@@ -52,7 +53,7 @@ class FastAPI(API):
             self._api_url + "/collections",
             data=json.dumps({"name": name, "metadata": metadata, "get_or_create": get_or_create}),
         )
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         resp_json = resp.json()
         return Collection(
             client=self,
@@ -68,7 +69,7 @@ class FastAPI(API):
     ) -> Collection:
         """Returns a collection"""
         resp = requests.get(self._api_url + "/collections/" + name)
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         resp_json = resp.json()
         return Collection(
             client=self,
@@ -93,18 +94,18 @@ class FastAPI(API):
             self._api_url + "/collections/" + current_name,
             data=json.dumps({"new_metadata": new_metadata, "new_name": new_name}),
         )
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json()
 
     def delete_collection(self, name: str):
         """Deletes a collection"""
         resp = requests.delete(self._api_url + "/collections/" + name)
-        resp.raise_for_status()
+        raise_chroma_error(resp)
 
     def _count(self, collection_name: str):
         """Returns the number of embeddings in the database"""
         resp = requests.get(self._api_url + "/collections/" + collection_name + "/count")
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json()
 
     def _peek(self, collection_name, limit=10):
@@ -147,7 +148,7 @@ class FastAPI(API):
             ),
         )
 
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json()
 
     def _delete(self, collection_name, ids=None, where={}, where_document={}):
@@ -158,7 +159,7 @@ class FastAPI(API):
             data=json.dumps({"where": where, "ids": ids, "where_document": where_document}),
         )
 
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json()
 
     def _add(
@@ -189,11 +190,7 @@ class FastAPI(API):
             ),
         )
 
-        try:
-            resp.raise_for_status()
-        except requests.HTTPError:
-            raise (Exception(resp.text))
-
+        raise_chroma_error(resp)
         return True
 
     def _update(
@@ -248,43 +245,60 @@ class FastAPI(API):
             ),
         )
 
-        try:
-            resp.raise_for_status()
-        except requests.HTTPError:
-            raise (Exception(resp.text))
-
+        raise_chroma_error(resp)
         body = resp.json()
         return body
 
     def reset(self):
         """Resets the database"""
         resp = requests.post(self._api_url + "/reset")
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json
 
     def persist(self):
         """Persists the database"""
         resp = requests.post(self._api_url + "/persist")
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json
 
     def raw_sql(self, sql):
         """Runs a raw SQL query against the database"""
         resp = requests.post(self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql}))
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return pd.DataFrame.from_dict(resp.json())
 
     def create_index(self, collection_name: str):
         """Creates an index for the given space key"""
         resp = requests.post(self._api_url + "/collections/" + collection_name + "/create_index")
-        try:
-            resp.raise_for_status()
-        except requests.HTTPError:
-            raise (Exception(resp.text))
+        raise_chroma_error(resp)
         return resp.json()
 
     def get_version(self):
         """Returns the version of the server"""
         resp = requests.get(self._api_url + "/version")
-        resp.raise_for_status()
+        raise_chroma_error(resp)
         return resp.json()
+
+
+def raise_chroma_error(resp):
+    """Raises an error if the response is not ok, using a ChromaError if possible"""
+    if resp.ok:
+        return
+
+    chroma_error = None
+    try:
+        body = resp.json()
+        if "error" in body:
+            if body["error"] in errors.error_types:
+                chroma_error = errors.error_types[body["error"]](body["message"])
+
+    except BaseException:
+        pass
+
+    if chroma_error:
+        raise chroma_error
+
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError:
+        raise (Exception(resp.text))

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -205,11 +205,11 @@ class Clickhouse(DB):
          ALTER TABLE
             collections
          UPDATE
-            metadata = '{json.dumps(new_metadata)}',
-            name = '{new_name}'
+            metadata = %s,
+            name = %s
          WHERE
-            name = '{current_name}'
-         """
+            name = %s
+         """, [json.dumps(new_metadata), new_name, current_name]
         )
 
     def delete_collection(self, name: str):
@@ -263,20 +263,20 @@ class Clickhouse(DB):
             update_fields = []
             parameters[f"i{i}"] = ids[i]
             if embeddings is not None:
-                update_fields.append(f"embedding = {{e{i}:Array(Float64)}}")
+                update_fields.append(f"embedding = %(e{i})s")
                 parameters[f"e{i}"] = embeddings[i]
             if metadatas is not None:
-                update_fields.append(f"metadata = {{m{i}:String}}")
+                update_fields.append(f"metadata = %(m{i})s")
                 parameters[f"m{i}"] = json.dumps(metadatas[i])
             if documents is not None:
-                update_fields.append(f"document = {{d{i}:String}}")
+                update_fields.append(f"document = %(d{i})s")
                 parameters[f"d{i}"] = documents[i]
 
             update_statement = f"""
             UPDATE
                 {",".join(update_fields)}
             WHERE
-                id = {{i{i}:String}} AND
+                id = %(i{i})s AND
                 collection_uuid = '{collection_uuid}'{"" if i == len(ids) - 1 else ","}
             """
             updates.append(update_statement)

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -1,22 +1,66 @@
-class NoDatapointsException(Exception):
-    pass
+from abc import ABCMeta, abstractmethod
 
 
-class NoIndexException(Exception):
-    pass
+class ChromaError(Exception):
+
+    def code(self):
+        """Return an appropriate HTTP response code for this error"""
+        return 400 # Bad Request
+
+    def message(self):
+        return ", ".join(self.args)
+
+    @classmethod
+    @abstractmethod
+    def name(self):
+        """Return the error name"""
+        pass
 
 
-class InvalidDimensionException(Exception):
-    pass
+class NoDatapointsException(ChromaError):
+    @classmethod
+    def name(cls):
+        return "NoDatapoints"
 
 
-class NotEnoughElementsException(Exception):
-    pass
+class NoIndexException(ChromaError):
+    @classmethod
+    def name(cls):
+        return "NoIndex"
 
 
-class IDAlreadyExistsError(ValueError):
-    pass
+class InvalidDimensionException(ChromaError):
+    @classmethod
+    def name(cls):
+        return "InvalidDimension"
 
 
-class DuplicateIDError(ValueError):
-    pass
+class NotEnoughElementsException(ChromaError):
+    @classmethod
+    def name(cls):
+        return "NotEnoughElements"
+
+
+class IDAlreadyExistsError(ChromaError):
+
+    def code(self):
+        return 409 # Conflict
+
+    @classmethod
+    def name(cls):
+        return "IDAlreadyExists"
+
+
+class DuplicateIDError(ChromaError):
+    @classmethod
+    def name(cls):
+        return "DuplicateID"
+
+error_types = {
+    "NoDatapoints": NoDatapointsException,
+    "NoIndex": NoIndexException,
+    "InvalidDimension": InvalidDimensionException,
+    "NotEnoughElements": NotEnoughElementsException,
+    "IDAlreadyExists": IDAlreadyExistsError,
+    "DuplicateID": DuplicateIDError,
+}

--- a/chromadb/test/fixtures.py
+++ b/chromadb/test/fixtures.py
@@ -1,4 +1,5 @@
 from chromadb.config import Settings
+from chromadb import Client
 import hypothesis
 import tempfile
 import os
@@ -10,29 +11,35 @@ hypothesis.settings.register_profile(
 hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))
 
 
-def configurations():
-    """Based on the environment, return a list of API configurations to test."""
-    return [
-        Settings(
+def duckdb():
+    yield Client(
+       Settings(
             chroma_api_impl="local",
             chroma_db_impl="duckdb",
             persist_directory=tempfile.gettempdir(),
-        ),
+        )
+    )
+
+
+def duckdb_parquet():
+    yield Client(
         Settings(
             chroma_api_impl="local",
             chroma_db_impl="duckdb+parquet",
             persist_directory=tempfile.gettempdir() + "/tests",
-        ),
-    ]
+        )
+    )
+
+
+def fixtures():
+    return [duckdb, duckdb_parquet]
 
 
 def persist_configurations():
-    """Only returns configurations that persist to disk."""
     return [
         Settings(
             chroma_api_impl="local",
             chroma_db_impl="duckdb+parquet",
             persist_directory=tempfile.gettempdir() + "/tests",
-        ),
+        )
     ]
-

--- a/chromadb/test/fixtures.py
+++ b/chromadb/test/fixtures.py
@@ -1,9 +1,13 @@
 from chromadb.config import Settings
 from chromadb import Client
+import chromadb.server.fastapi
+from requests.exceptions import ConnectionError
 import hypothesis
 import tempfile
 import os
-
+import uvicorn
+import time
+from multiprocessing import Process
 
 hypothesis.settings.register_profile(
     "dev", deadline=10000, suppress_health_check=[hypothesis.HealthCheck.data_too_large]
@@ -11,7 +15,45 @@ hypothesis.settings.register_profile(
 hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))
 
 
+def _run_server():
+    """Run a Chroma server locally"""
+    settings = Settings(
+        chroma_api_impl="local",
+        chroma_db_impl="duckdb",
+        persist_directory=tempfile.gettempdir() + "/test_server",
+    )
+    server = chromadb.server.fastapi.FastAPI(settings)
+    uvicorn.run(server.app(), host="0.0.0.0", port=6666, log_level="error")
+
+
+def _await_server(api, attempts=0):
+    try:
+        api.heartbeat()
+    except ConnectionError as e:
+        if attempts > 10:
+            raise e
+        else:
+            time.sleep(2)
+            _await_server(api, attempts + 1)
+
+
+def fastapi():
+    """Fixture generator that launches a server in a separate process, and yields a
+    fastapi client connect to it"""
+    proc = Process(target=_run_server, args=(), daemon=True)
+    proc.start()
+    api = chromadb.Client(
+        Settings(
+            chroma_api_impl="rest", chroma_server_host="localhost", chroma_server_http_port="6666"
+        )
+    )
+    _await_server(api)
+    yield api
+    proc.kill()
+
+
 def duckdb():
+    """Fixture generator for duckdb"""
     yield Client(
        Settings(
             chroma_api_impl="local",
@@ -22,6 +64,7 @@ def duckdb():
 
 
 def duckdb_parquet():
+    """Fixture generator for duckdb+parquet"""
     yield Client(
         Settings(
             chroma_api_impl="local",

--- a/chromadb/test/fixtures.py
+++ b/chromadb/test/fixtures.py
@@ -74,9 +74,20 @@ def duckdb_parquet():
     )
 
 
-def fixtures():
-    return [duckdb, duckdb_parquet]
+def integration_api():
+    """Fixture generator for returning a client configured via environmenet
+    variables, intended for externally configured integration tests
+    """
+    yield chromadb.Client()
 
+
+def fixtures():
+    api_fixtures = [duckdb, duckdb_parquet, fastapi]
+    if "CHROMA_INTEGRATION_TEST" in os.environ:
+        api_fixtures.append(integration_api)
+    if "CHROMA_INTEGRATION_TEST_ONLY" in os.environ:
+        api_fixtures = [integration_api]
+    return api_fixtures
 
 def persist_configurations():
     return [

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -2,15 +2,14 @@ import pytest
 from hypothesis import given
 import chromadb
 from chromadb.api import API
-from chromadb.test.configurations import configurations
+from chromadb.test.fixtures import fixtures
 import chromadb.test.property.strategies as strategies
 import chromadb.test.property.invariants as invariants
 
 
-@pytest.fixture(scope="module", params=configurations())
+@pytest.fixture(scope="module", params=fixtures())
 def api(request):
-    configuration = request.param
-    return chromadb.Client(configuration)
+    yield next(request.param())
 
 
 @given(collection=strategies.collections(), embeddings=strategies.embedding_set())

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -6,7 +6,7 @@ from typing import List
 import chromadb
 from chromadb.api import API
 from chromadb.api.models.Collection import Collection
-from chromadb.test.configurations import configurations
+from chromadb.test.fixtures import fixtures
 import chromadb.test.property.strategies as strategies
 from hypothesis.stateful import (
     Bundle,
@@ -20,10 +20,9 @@ from hypothesis.stateful import (
 )
 
 
-@pytest.fixture(scope="module", params=configurations())
+@pytest.fixture(scope="module", params=fixtures())
 def api(request):
-    configuration = request.param
-    return chromadb.Client(configuration)
+    yield next(request.param())
 
 
 class CollectionStateMachine(RuleBasedStateMachine):

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -6,7 +6,7 @@ import chromadb
 import chromadb.errors as errors
 from chromadb.api import API
 from chromadb.api.models.Collection import Collection
-from chromadb.test.configurations import configurations
+from chromadb.test.fixtures import fixtures
 import chromadb.test.property.strategies as strategies
 from hypothesis.stateful import (
     Bundle,
@@ -37,10 +37,9 @@ def print_traces():
         print(f"{key}: {value}")
 
 
-@pytest.fixture(scope="module", params=configurations())
+@pytest.fixture(scope="module", params=fixtures())
 def api(request):
-    configuration = request.param
-    return chromadb.Client(configuration)
+    yield next(request.param())
 
 
 dtype_shared_st = st.shared(st.sampled_from(strategies.float_types), key="dtype")

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -5,7 +5,7 @@ import chromadb
 from chromadb.api import API
 import chromadb.test.property.strategies as strategies
 import chromadb.test.property.invariants as invariants
-from chromadb.test.configurations import persist_configurations
+from chromadb.test.fixtures import persist_configurations
 
 
 CreatePersistAPI = Callable[[], API]


### PR DESCRIPTION
## Description of changes

- Add fixtures required to run Hypothesis tests as integration tests
- Includes both local FastAPI server test and Dockerized integration tests

Includes two code fixes:
- Correctly propagate Python error types over the REST API.
- Use more robust SQL parametrization to handle escape characters in documents and metadata.

## Test plan

These are the tests.

## Documentation Changes

N/A
