### PR TITLE
Generalized ANN Tests

### DIFF
--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -105,6 +105,7 @@ def ann_accuracy(
     if len(embeddings["ids"]) == 0:
         return  # nothing to test here
 
+    # TODO Remove once we support querying by documents in tests
     if embeddings["embeddings"] is None:
         # If we don't have embeddings, we can't do an ANN search
         return

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 import chromadb
 from chromadb.api import API
 from chromadb.test.configurations import configurations
@@ -14,6 +14,7 @@ def api(request):
 
 
 @given(collection=strategies.collections(), embeddings=strategies.embedding_set())
+@settings(deadline=None)
 def test_add(
     api: API, collection: strategies.Collection, embeddings: strategies.EmbeddingSet
 ):

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -28,7 +28,7 @@ def test_add(
         coll.name,
         len(embeddings["ids"]),
     )
-    invariants.ann_accuracy(coll, embeddings)
+    invariants.ann_accuracy(coll, embeddings, n_results=len(embeddings["ids"]))
 
 
 # TODO: This test fails right now because the ids are not sorted by the input order

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -161,11 +161,17 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
             if id in self.embeddings["ids"]:
                 target_idx = self.embeddings["ids"].index(id)
                 if "embeddings" in embeddings and embeddings["embeddings"] is not None:
-                    self.embeddings["embeddings"][target_idx] = embeddings["embeddings"][idx]
+                    self.embeddings["embeddings"][target_idx] = embeddings[
+                        "embeddings"
+                    ][idx]
                 if "metadatas" in embeddings and embeddings["metadatas"] is not None:
-                    self.embeddings["metadatas"][target_idx] = embeddings["metadatas"][idx]
+                    self.embeddings["metadatas"][target_idx] = embeddings["metadatas"][
+                        idx
+                    ]
                 if "documents" in embeddings and embeddings["documents"] is not None:
-                    self.embeddings["documents"][target_idx] = embeddings["documents"][idx]
+                    self.embeddings["documents"][target_idx] = embeddings["documents"][
+                        idx
+                    ]
             else:
                 self.embeddings["ids"].append(id)
                 if "embeddings" in embeddings and embeddings["embeddings"] is not None:
@@ -190,6 +196,7 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
             del self.embeddings["embeddings"][i]
             del self.embeddings["metadatas"][i]
             del self.embeddings["documents"][i]
+
 
 def test_embeddings_state(caplog, api):
     caplog.set_level(logging.ERROR)
@@ -234,4 +241,3 @@ def test_escape_chars_in_ids(api: API):
     assert coll.count() == 1
     coll.delete(ids=[id])
     assert coll.count() == 0
-


### PR DESCRIPTION
## Description of changes

This PR further generalizes the ANN test to more than the 1st neighbor. We can now test for any number of neighbors. 

For now we use the embeddings in the EmbeddingSet as the query, but this could be generalized still further by adding (random) query vectors not in the collection / embedding set.

## Test plan
These are the tests 

## Documentation Changes
N/A