### PR TITLE
Fixes #341 (querying an empty collection)

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -423,7 +423,7 @@ class LocalAPI(API):
             distances=[] if include_distances else None,
         )
 
-        if self._db.count(collection_name=collection_name) == 0 :
+        if self._db.count(collection_id) == 0 :
             return query_result
 
         uuids, distances = self._db.get_nearest_neighbors(

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -409,13 +409,6 @@ class LocalAPI(API):
         where_document={},
         include: Include = ["documents", "metadatas", "distances"],
     ):
-        uuids, distances = self._db.get_nearest_neighbors(
-            collection_uuid=collection_id,
-            where=where,
-            where_document=where_document,
-            embeddings=query_embeddings,
-            n_results=n_results,
-        )
 
         include_embeddings = "embeddings" in include
         include_documents = "documents" in include
@@ -429,6 +422,18 @@ class LocalAPI(API):
             metadatas=[] if include_metadatas else None,
             distances=[] if include_distances else None,
         )
+
+        if self._db.count(collection_name=collection_name) == 0 :
+            return query_result
+
+        uuids, distances = self._db.get_nearest_neighbors(
+            collection_uuid=collection_id,
+            where=where,
+            where_document=where_document,
+            embeddings=query_embeddings,
+            n_results=n_results,
+        )
+
         for i in range(len(uuids)):
             embeddings = []
             documents = []

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1216,7 +1216,7 @@ def test_update_query(api):
     assert results["embeddings"][0][0] == updated_records["embeddings"][0]
 
 
-@pytest.mark.parametrize("api_fixture", test_apis)
+@pytest.mark.parametrize("api_fixture", [local_persist_api])
 def test_empty_collection(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
     api.reset()

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -5,7 +5,6 @@ import chromadb.server.fastapi
 import pytest
 import tempfile
 import os
-import inspect
 from multiprocessing import Process
 import uvicorn
 from requests.exceptions import ConnectionError
@@ -1222,8 +1221,7 @@ def test_empty_collection(api_fixture, request):
     api = request.getfixturevalue(api_fixture.__name__)
     api.reset()
     collection = api.create_collection("test_empty_collection")
-    cnt = collection.count()
-    assert cnt == 0, "collection should be empty"
+    assert collection.count() == 0, "collection should be empty"
 
     # check that query does not crash
     try:
@@ -1231,7 +1229,6 @@ def test_empty_collection(api_fixture, request):
             query_embeddings=[[1.1, 2.3, 3.3], [5.1, 4.3, 2.2]],
             n_results=1
         )
-        print(f"results are {type(results)} with members {inspect.getmembers(results)}")
         assert not results.get("ids"), "expecting empty QueryResult object"
         assert not results.get("embeddings"), "expecting empty embeddings QueryResult object"
     except Exception as e:


### PR DESCRIPTION
## Description of changes
 * Check if a collection has any elements before querying the index
 * Add a test to verify that querying empty collection does not fail

## Test plan
1. I wrote the test first and verified that it fails with the same error that  @sw-yx reported in https://github.com/chroma-core/chroma/issues/341
2. With the change in `local.py` the test passes
3.  Ran `pytest` to make sure I didn't break anything else
