### PR TITLE
fixes: slow listing of collections, pass an optional embedding_function

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -141,7 +141,8 @@ class LocalAPI(API):
             client=self, name=name, embedding_function=embedding_function, metadata=res[0][2]
         )
 
-    def list_collections(self) -> Sequence[Collection]:
+    def list_collections(self,
+                         embedding_function: Optional[Callable] = None) -> Sequence[Collection]:
         """List all collections.
         Returns:
             A list of collections
@@ -154,7 +155,9 @@ class LocalAPI(API):
         db_collections = self._db.list_collections()
         for db_collection in db_collections:
             collections.append(
-                Collection(client=self, name=db_collection[1], metadata=db_collection[2])
+                Collection(client=self, name=db_collection[1],
+                           metadata=db_collection[2],
+                           embedding_function=embedding_function)
             )
         return collections
 


### PR DESCRIPTION
- avoids unecessary fallback to the default embedding function

## Description of changes

*Summarize the changes made by this PR.* 
 - Improvements & Bug fixes
	 -  pass an optional `embedding_function` to `list_collections` to avoid the slow fallback to default embeddings.


## Test plan
- Before this fix, listing collections is slow even when using other embedding functions like OpenAI's one.
- With this fix, if the embedding function is passed, listing collections is instant. 

