### PR TITLE
Add support for multiple spaces

### DIFF
--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -5,7 +5,11 @@ from typing import Dict
 from chromadb.api.types import IndexMetadata
 import hnswlib
 from chromadb.db.index import Index
-from chromadb.errors import NoIndexException, InvalidDimensionException, NotEnoughElementsException
+from chromadb.errors import (
+    NoIndexException,
+    InvalidDimensionException,
+    NotEnoughElementsException,
+)
 import logging
 import re
 from uuid import UUID
@@ -24,7 +28,6 @@ valid_params = {
 
 
 class HnswParams:
-
     space: str
     construction_ef: int
     search_ef: int
@@ -33,7 +36,6 @@ class HnswParams:
     resize_factor: float
 
     def __init__(self, metadata):
-
         metadata = metadata or {}
 
         # Convert all values to strings for future compatibility.
@@ -44,7 +46,9 @@ class HnswParams:
                 if param not in valid_params:
                     raise ValueError(f"Unknown HNSW parameter: {param}")
                 if not re.match(valid_params[param], value):
-                    raise ValueError(f"Invalid value for HNSW parameter: {param} = {value}")
+                    raise ValueError(
+                        f"Invalid value for HNSW parameter: {param} = {value}"
+                    )
 
         self.space = metadata.get("hnsw:space", "l2")
         self.construction_ef = int(metadata.get("hnsw:construction_ef", 100))
@@ -128,7 +132,7 @@ class Hnswlib(Index):
 
         labels = []
         for id in ids:
-            if id in self._id_to_label:
+            if hexid(id) in self._id_to_label:
                 if update:
                     labels.append(self._id_to_label[hexid(id)])
                 else:
@@ -141,7 +145,9 @@ class Hnswlib(Index):
                 labels.append(next_label)
 
         if self._index_metadata["elements"] > self._index.get_max_elements():
-            new_size = max(self._index_metadata["elements"] * self._params.resize_factor, 1000)
+            new_size = max(
+                self._index_metadata["elements"] * self._params.resize_factor, 1000
+            )
             self._index.resize_index(int(new_size))
 
         self._index.add_items(embeddings, labels)
@@ -196,7 +202,6 @@ class Hnswlib(Index):
         return
 
     def _load(self):
-
         if not os.path.exists(f"{self._save_folder}/index_{self._id}.bin"):
             return
 
@@ -208,7 +213,9 @@ class Hnswlib(Index):
         with open(f"{self._save_folder}/index_metadata_{self._id}.pkl", "rb") as f:
             self._index_metadata = pickle.load(f)
 
-        p = hnswlib.Index(space=self._params.space, dim=self._index_metadata["dimensionality"])
+        p = hnswlib.Index(
+            space=self._params.space, dim=self._index_metadata["dimensionality"]
+        )
         self._index = p
         self._index.load_index(
             f"{self._save_folder}/index_{self._id}.bin",
@@ -218,9 +225,10 @@ class Hnswlib(Index):
         self._index.set_num_threads(self._params.num_threads)
 
     def get_nearest_neighbors(self, query, k, ids=None):
-
         if self._index is None:
-            raise NoIndexException("Index not found, please create an instance before querying")
+            raise NoIndexException(
+                "Index not found, please create an instance before querying"
+            )
 
         # Check dimensionality
         self._check_dimensionality(query)
@@ -245,8 +253,12 @@ class Hnswlib(Index):
         logger.debug(f"time to pre process our knn query: {time.time() - s2}")
 
         s3 = time.time()
-        database_labels, distances = self._index.knn_query(query, k=k, filter=filter_function)
+        database_labels, distances = self._index.knn_query(
+            query, k=k, filter=filter_function
+        )
         logger.debug(f"time to run knn query: {time.time() - s3}")
 
-        ids = [[self._label_to_id[label] for label in labels] for labels in database_labels]
+        ids = [
+            [self._label_to_id[label] for label in labels] for labels in database_labels
+        ]
         return ids, distances

--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -75,7 +75,7 @@ class Hnswlib(Index):
     _index_metadata: IndexMetadata
     _params: HnswParams
     _id_to_label: Dict[str, int]
-    _label_to_id: Dict[int, str]
+    _label_to_id: Dict[int, UUID]
 
     def __init__(self, id, settings, metadata):
         self._save_folder = settings.persist_directory + "/index"

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -112,6 +112,7 @@ def no_duplicates(collection: Collection):
     assert len(ids) == len(set(ids))
 
 
+# These match what the spec of hnswlib is
 distance_functions = {
     "l2": lambda x, y: np.linalg.norm(x - y) ** 2,
     "cosine": lambda x, y: 1 - np.dot(x, y) / (np.linalg.norm(x) * np.linalg.norm(y)),
@@ -194,6 +195,7 @@ def ann_accuracy(
             if id not in expected_ids:
                 continue
             index = id_to_index[id]
+            # TODO: IP distance is resulting in more noise than expected so atol=1e-5
             assert np.allclose(
                 distances_i[index], query_results["distances"][i][j], atol=1e-5
             )

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -146,8 +146,9 @@ def collections(draw, add_filterable_data=False, with_hnsw_params=False):
         if metadata is None:
             metadata = {}
         metadata.update(test_hnsw_config)
-        # Select a space at random
-        metadata["hnsw:space"] = draw(st.sampled_from(["cosine", "l2", "ip"]))
+        # Sometimes, select a space at random
+        if draw(st.booleans()):
+            metadata["hnsw:space"] = draw(st.sampled_from(["cosine", "l2", "ip"]))
 
     known_metadata_keys = {}
     if add_filterable_data:

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -146,6 +146,8 @@ def collections(draw, add_filterable_data=False, with_hnsw_params=False):
         if metadata is None:
             metadata = {}
         metadata.update(test_hnsw_config)
+        # Select a space at random
+        metadata["hnsw:space"] = draw(st.sampled_from(["cosine", "l2", "ip"]))
 
     known_metadata_keys = {}
     if add_filterable_data:

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -148,6 +148,8 @@ def collections(draw, add_filterable_data=False, with_hnsw_params=False):
         metadata.update(test_hnsw_config)
         # Sometimes, select a space at random
         if draw(st.booleans()):
+            # TODO: pull the distance functions from a source of truth that lives not
+            # in tests once https://github.com/chroma-core/issues/issues/61 lands
             metadata["hnsw:space"] = draw(st.sampled_from(["cosine", "l2", "ip"]))
 
     known_metadata_keys = {}

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -25,31 +25,37 @@ COLLECTION_NAME_LOWERCASE_VERSION = "0.3.21"
 version_re = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
 
-def _patch_uppercase_coll_name(collection: strategies.Collection,
-                               embeddings: strategies.RecordSet):
+def _patch_uppercase_coll_name(
+    collection: strategies.Collection, embeddings: strategies.RecordSet
+):
     """Old versions didn't handle uppercase characters in collection names"""
     collection.name = collection.name.lower()
 
 
-def _patch_empty_dict_metadata(collection: strategies.Collection,
-                               embeddings: strategies.RecordSet):
+def _patch_empty_dict_metadata(
+    collection: strategies.Collection, embeddings: strategies.RecordSet
+):
     """Old versions do the wrong thing when metadata is a single empty dict"""
     if embeddings["metadatas"] == {}:
         embeddings["metadatas"] = None
 
 
-version_patches = [("0.3.21", _patch_uppercase_coll_name),
-                   ("0.3.21", _patch_empty_dict_metadata)]
+version_patches = [
+    ("0.3.21", _patch_uppercase_coll_name),
+    ("0.3.21", _patch_empty_dict_metadata),
+]
 
 
-def patch_for_version(version,
-                      collection: strategies.Collection,
-                      embeddings: strategies.RecordSet):
+def patch_for_version(
+    version, collection: strategies.Collection, embeddings: strategies.RecordSet
+):
     """Override aspects of the collection and embeddings, before testing, to account for
     breaking changes in old versions."""
 
     for patch_version, patch in version_patches:
-        if packaging_version.Version(version) <= packaging_version.Version(patch_version):
+        if packaging_version.Version(version) <= packaging_version.Version(
+            patch_version
+        ):
             patch(collection, embeddings)
 
 
@@ -84,9 +90,7 @@ base_install_dir = tempfile.gettempdir() + "/persistence_test_chromadb_versions"
 
 # This fixture is not shared with the rest of the tests because it is unique in how it
 # installs the versions of chromadb
-@pytest.fixture(
-    scope="module", params=configurations(test_old_versions)
-)
+@pytest.fixture(scope="module", params=configurations(test_old_versions))
 def version_settings(request) -> Generator[Tuple[str, Settings], None, None]:
     configuration = request.param
     version = configuration[0]
@@ -172,7 +176,7 @@ def persist_generated_data_with_old_version(
     coll = api.create_collection(
         name=collection_strategy.name,
         metadata=collection_strategy.metadata,
-        embedding_function=collection_strategy.embedding_function,
+        embedding_function=lambda x: None,
     )
     coll.add(**embeddings_strategy)
     # We can't use the invariants module here because it uses the current version


### PR DESCRIPTION
## Description of changes
Add support for multiple distance metrics in tests.

1. We coin-flip and sometimes add a space when using hnsw_params
2. Added the distance functions to the invariant and use them when needed.

In the process of writing this test I discovered a bug with our implementation of update that was revealed by the inner product space. Since the inner product is not a true metric, a point may not be a neighbor to itself. Our update code was strictly appending to the index due to the a bug with how we manage string UUID vs UUID objects. In l2 and cosine spaces, this usually was fine in the eyes of tests since the results returned were correct with the updated data. But IP exacerbated the issue by making the results not always be the same point. 

## Test plan
These are tests!

## Documentation Changes
None required!