### PR TITLE
remove increment_index from API

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -139,7 +139,6 @@ class API(ABC):
         embedding: Optional[Embeddings],
         metadata: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ):
         """Add embeddings to the data store. This is the most general way to add embeddings to the database.
         ⚠️ It is recommended to use the more specific methods below when possible.
@@ -179,7 +178,6 @@ class API(ABC):
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ):
         """Add or update entries in the embedding store.
         If an entry with the same id already exists, it will be updated, otherwise it will be added.
@@ -190,7 +188,6 @@ class API(ABC):
             embeddings (Sequence[Sequence[float]]): The sequence of embeddings to add
             metadatas (Optional[Union[Dict, Sequence[Dict]]], optional): The metadata to associate with the embeddings. Defaults to None.
             documents (Optional[Union[str, Sequence[str]]], optional): The documents to associate with the embeddings. Defaults to None.
-            increment_index (bool, optional): If True, will incrementally add to the ANN index of the collection. Defaults to True.
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -51,7 +51,9 @@ class FastAPI(API):
         """Creates a collection"""
         resp = requests.post(
             self._api_url + "/collections",
-            data=json.dumps({"name": name, "metadata": metadata, "get_or_create": get_or_create}),
+            data=json.dumps(
+                {"name": name, "metadata": metadata, "get_or_create": get_or_create}
+            ),
         )
         raise_chroma_error(resp)
         resp_json = resp.json()
@@ -86,9 +88,13 @@ class FastAPI(API):
     ) -> Collection:
         """Get a collection, or return it if it exists"""
 
-        return self.create_collection(name, metadata, embedding_function, get_or_create=True)
+        return self.create_collection(
+            name, metadata, embedding_function, get_or_create=True
+        )
 
-    def _modify(self, current_name: str, new_name: str, new_metadata: Optional[Dict] = None):
+    def _modify(
+        self, current_name: str, new_name: str, new_metadata: Optional[Dict] = None
+    ):
         """Updates a collection"""
         resp = requests.put(
             self._api_url + "/collections/" + current_name,
@@ -104,7 +110,9 @@ class FastAPI(API):
 
     def _count(self, collection_name: str):
         """Returns the number of embeddings in the database"""
-        resp = requests.get(self._api_url + "/collections/" + collection_name + "/count")
+        resp = requests.get(
+            self._api_url + "/collections/" + collection_name + "/count"
+        )
         raise_chroma_error(resp)
         return resp.json()
 
@@ -156,7 +164,9 @@ class FastAPI(API):
 
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/delete",
-            data=json.dumps({"where": where, "ids": ids, "where_document": where_document}),
+            data=json.dumps(
+                {"where": where, "ids": ids, "where_document": where_document}
+            ),
         )
 
         raise_chroma_error(resp)
@@ -169,13 +179,10 @@ class FastAPI(API):
         embeddings,
         metadatas=None,
         documents=None,
-        increment_index=True,
     ):
         """
         Adds a batch of embeddings to the database
         - pass in column oriented data lists
-        - by default, the index is progressively built up as you add more data. If for ingestion performance reasons you want to disable this, set increment_index to False
-        -     and then manually create the index yourself with collection.create_index()
         """
         resp = requests.post(
             self._api_url + "/collections/" + collection_name + "/add",
@@ -185,7 +192,6 @@ class FastAPI(API):
                     "embeddings": embeddings,
                     "metadatas": metadatas,
                     "documents": documents,
-                    "increment_index": increment_index,
                 }
             ),
         )
@@ -228,7 +234,6 @@ class FastAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ):
         """
         Updates a batch of embeddings in the database
@@ -243,7 +248,6 @@ class FastAPI(API):
                     "embeddings": embeddings,
                     "metadatas": metadatas,
                     "documents": documents,
-                    "increment_index": increment_index,
                 }
             ),
         )
@@ -293,13 +297,17 @@ class FastAPI(API):
 
     def raw_sql(self, sql):
         """Runs a raw SQL query against the database"""
-        resp = requests.post(self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql}))
+        resp = requests.post(
+            self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql})
+        )
         raise_chroma_error(resp)
         return pd.DataFrame.from_dict(resp.json())
 
     def create_index(self, collection_name: str):
         """Creates an index for the given space key"""
-        resp = requests.post(self._api_url + "/collections/" + collection_name + "/create_index")
+        resp = requests.post(
+            self._api_url + "/collections/" + collection_name + "/create_index"
+        )
         raise_chroma_error(resp)
         return resp.json()
 

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -202,7 +202,6 @@ class LocalAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ):
         existing_ids = self._get(collection_name, ids=ids, include=[])["ids"]
         if len(existing_ids) > 0:
@@ -219,8 +218,7 @@ class LocalAPI(API):
             ids=ids,
         )
 
-        if increment_index:
-            self._db.add_incremental(collection_uuid, added_uuids, embeddings)
+        self._db.add_incremental(collection_uuid, added_uuids, embeddings)
 
         self._telemetry_client.capture(CollectionAddEvent(collection_uuid, len(ids)))
         return True  # NIT: should this return the ids of the succesfully added items?
@@ -244,7 +242,6 @@ class LocalAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ):
         # Determine which ids need to be added and which need to be updated based on the ids already in the collection
         existing_ids = set(self._get(collection_name, ids=ids, include=[])["ids"])
@@ -283,7 +280,6 @@ class LocalAPI(API):
                 embeddings_to_add,
                 metadatas_to_add,
                 documents_to_add,
-                increment_index=increment_index,
             )
 
         if len(ids_to_update) > 0:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -72,7 +72,6 @@ class Collection(BaseModel):
         embeddings: Optional[OneOrMany[Embedding]] = None,
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
-        increment_index: bool = True,
     ):
         """Add embeddings to the data store.
         Args:
@@ -98,9 +97,7 @@ class Collection(BaseModel):
             ids, embeddings, metadatas, documents
         )
 
-        self._client._add(
-            ids, self.name, embeddings, metadatas, documents, increment_index
-        )
+        self._client._add(ids, self.name, embeddings, metadatas, documents)
 
     def get(
         self,
@@ -274,7 +271,6 @@ class Collection(BaseModel):
         embeddings: Optional[OneOrMany[Embedding]] = None,
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
-        increment_index: bool = True,
     ):
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist.
 
@@ -295,7 +291,6 @@ class Collection(BaseModel):
             embeddings=embeddings,
             metadatas=metadatas,
             documents=documents,
-            increment_index=increment_index,
         )
 
     def delete(

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -1,7 +1,11 @@
 from pydantic import BaseSettings
 from typing import List
 
-TELEMETRY_WHITELISTED_SETTINGS = ["chroma_db_impl", "chroma_api_impl", "chroma_server_ssl_enabled"]
+TELEMETRY_WHITELISTED_SETTINGS = [
+    "chroma_db_impl",
+    "chroma_api_impl",
+    "chroma_server_ssl_enabled",
+]
 
 
 class Settings(BaseSettings):

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -2,7 +2,14 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Sequence, Optional, Tuple
 from uuid import UUID
 import numpy.typing as npt
-from chromadb.api.types import Embeddings, Documents, IDs, Metadatas, Where, WhereDocument
+from chromadb.api.types import (
+    Embeddings,
+    Documents,
+    IDs,
+    Metadatas,
+    Where,
+    WhereDocument,
+)
 
 
 class DB(ABC):
@@ -26,7 +33,10 @@ class DB(ABC):
 
     @abstractmethod
     def update_collection(
-        self, current_name: str, new_name: Optional[str] = None, new_metadata: Optional[Dict] = None
+        self,
+        current_name: str,
+        new_name: Optional[str] = None,
+        new_metadata: Optional[Dict] = None,
     ):
         pass
 
@@ -50,7 +60,9 @@ class DB(ABC):
         pass
 
     @abstractmethod
-    def add_incremental(self, collection_uuid: str, ids: List[UUID], embeddings: Embeddings):
+    def add_incremental(
+        self, collection_uuid: str, ids: List[UUID], embeddings: Embeddings
+    ):
         pass
 
     @abstractmethod

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -47,9 +47,9 @@ async def catch_exceptions_middleware(request: Request, call_next):
     try:
         return await call_next(request)
     except ChromaError as e:
-        return JSONResponse(content={"error": e.name(),
-                                     "message": e.message()},
-                            status_code=e.code())
+        return JSONResponse(
+            content={"error": e.name(), "message": e.message()}, status_code=e.code()
+        )
     except Exception as e:
         logger.exception(e)
         return JSONResponse(content={"error": repr(e)}, status_code=500)
@@ -79,8 +79,12 @@ class FastAPI(chromadb.server.Server):
         self.router.add_api_route("/api/v1/persist", self.persist, methods=["POST"])
         self.router.add_api_route("/api/v1/raw_sql", self.raw_sql, methods=["POST"])
 
-        self.router.add_api_route("/api/v1/collections", self.list_collections, methods=["GET"])
-        self.router.add_api_route("/api/v1/collections", self.create_collection, methods=["POST"])
+        self.router.add_api_route(
+            "/api/v1/collections", self.list_collections, methods=["GET"]
+        )
+        self.router.add_api_route(
+            "/api/v1/collections", self.create_collection, methods=["POST"]
+        )
 
         self.router.add_api_route(
             "/api/v1/collections/{collection_name}/add",
@@ -89,16 +93,22 @@ class FastAPI(chromadb.server.Server):
             status_code=status.HTTP_201_CREATED,
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/update", self.update, methods=["POST"]
+            "/api/v1/collections/{collection_name}/update",
+            self.update,
+            methods=["POST"],
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/upsert", self.upsert, methods=["POST"]
+            "/api/v1/collections/{collection_name}/upsert",
+            self.upsert,
+            methods=["POST"],
         )
         self.router.add_api_route(
             "/api/v1/collections/{collection_name}/get", self.get, methods=["POST"]
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/delete", self.delete, methods=["POST"]
+            "/api/v1/collections/{collection_name}/delete",
+            self.delete,
+            methods=["POST"],
         )
         self.router.add_api_route(
             "/api/v1/collections/{collection_name}/count", self.count, methods=["GET"]
@@ -114,13 +124,19 @@ class FastAPI(chromadb.server.Server):
             methods=["POST"],
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}", self.get_collection, methods=["GET"]
+            "/api/v1/collections/{collection_name}",
+            self.get_collection,
+            methods=["GET"],
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}", self.update_collection, methods=["PUT"]
+            "/api/v1/collections/{collection_name}",
+            self.update_collection,
+            methods=["PUT"],
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}", self.delete_collection, methods=["DELETE"]
+            "/api/v1/collections/{collection_name}",
+            self.delete_collection,
+            methods=["DELETE"],
         )
 
         self._app.include_router(self.router)
@@ -173,7 +189,6 @@ class FastAPI(chromadb.server.Server):
                 metadatas=add.metadatas,
                 documents=add.documents,
                 ids=add.ids,
-                increment_index=add.increment_index,
             )
         except InvalidDimensionException as e:
             raise HTTPException(status_code=500, detail=str(e))
@@ -188,14 +203,13 @@ class FastAPI(chromadb.server.Server):
             metadatas=add.metadatas,
         )
 
-    def upsert(self, collection_name: str, upsert: AddEmbedding):        
+    def upsert(self, collection_name: str, upsert: AddEmbedding):
         return self._api._upsert(
             collection_name=collection_name,
             ids=upsert.ids,
             embeddings=upsert.embeddings,
             documents=upsert.documents,
             metadatas=upsert.metadatas,
-            increment_index=upsert.increment_index,
         )
 
     def get(self, collection_name, get: GetEmbedding):

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -9,7 +9,6 @@ class AddEmbedding(BaseModel):
     metadatas: Union[List, dict] = None
     documents: Union[str, List] = None
     ids: Union[str, List] = None
-    increment_index: bool = True
 
 
 class UpdateEmbedding(BaseModel):
@@ -17,7 +16,6 @@ class UpdateEmbedding(BaseModel):
     metadatas: Union[List, dict] = None
     documents: Union[str, List] = None
     ids: Union[str, List] = None
-    increment_index: bool = True
 
 
 class QueryEmbedding(BaseModel):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -23,6 +23,7 @@ def local_persist_api():
         )
     )
 
+
 # https://docs.pytest.org/en/6.2.x/fixture.html#fixtures-can-be-requested-more-than-once-per-test-return-values-are-cached
 @pytest.fixture
 def local_persist_api_cache_bust():
@@ -85,14 +86,18 @@ def test_persist_index_get_or_create_embedding_function(api_fixture, request):
     embedding_function = lambda x: [[1, 2, 3] for _ in range(len(x))]
     api = request.getfixturevalue("local_persist_api")
     api.reset()
-    collection = api.get_or_create_collection("test", embedding_function=embedding_function)
+    collection = api.get_or_create_collection(
+        "test", embedding_function=embedding_function
+    )
     collection.add(ids="id1", documents="hello")
 
     api.persist()
     del api
 
     api2 = request.getfixturevalue("local_persist_api_cache_bust")
-    collection = api2.get_or_create_collection("test", embedding_function=embedding_function)
+    collection = api2.get_or_create_collection(
+        "test", embedding_function=embedding_function
+    )
 
     nn = collection.query(
         query_texts="hello",
@@ -131,7 +136,6 @@ def test_persist(api_fixture, request):
 
 
 def test_heartbeat(api):
-
     assert isinstance(api.heartbeat(), int)
 
 
@@ -142,7 +146,6 @@ batch_records = {
 
 
 def test_add(api):
-
     api.reset()
 
     collection = api.create_collection("testspace")
@@ -153,7 +156,6 @@ def test_add(api):
 
 
 def test_get_or_create(api):
-
     api.reset()
 
     collection = api.create_collection("testspace")
@@ -187,7 +189,6 @@ def test_add_minimal(api):
 
 
 def test_get_from_db(api):
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
@@ -197,7 +198,6 @@ def test_get_from_db(api):
 
 
 def test_reset_db(api):
-
     api.reset()
 
     collection = api.create_collection("testspace")
@@ -209,7 +209,6 @@ def test_reset_db(api):
 
 
 def test_get_nearest_neighbors(api):
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
@@ -259,7 +258,6 @@ def test_get_nearest_neighbors_filter(api, request):
 
 
 def test_delete(api):
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
@@ -270,7 +268,6 @@ def test_delete(api):
 
 
 def test_delete_with_index(api):
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
@@ -279,7 +276,6 @@ def test_delete_with_index(api):
 
 
 def test_count(api):
-
     api.reset()
     collection = api.create_collection("testspace")
     assert collection.count() == 0
@@ -288,7 +284,6 @@ def test_count(api):
 
 
 def test_modify(api):
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.modify(name="testspace2")
@@ -298,7 +293,6 @@ def test_modify(api):
 
 
 def test_metadata_cru(api):
-
     api.reset()
     metadata_a = {"a": 1, "b": 2}
     # Test create metatdata
@@ -347,10 +341,7 @@ def test_metadata_cru(api):
             assert collection.metadata is None
 
 
-
 def test_increment_index_on(api):
-
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
@@ -367,45 +358,7 @@ def test_increment_index_on(api):
         assert len(nn[key]) == 1
 
 
-
-def test_increment_index_off(api):
-
-
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records, increment_index=False)
-    assert collection.count() == 2
-
-    # incremental index
-    collection.create_index()
-    nn = collection.query(
-        query_embeddings=[[1.1, 2.3, 3.2]],
-        n_results=1,
-        include=["embeddings", "documents", "metadatas", "distances"],
-    )
-    for key in nn.keys():
-        assert len(nn[key]) == 1
-
-
-
-def skipping_indexing_will_fail(api):
-
-
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records, increment_index=False)
-    assert collection.count() == 2
-
-    # incremental index
-    with pytest.raises(Exception) as e:
-        collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
-    assert str(e.value).__contains__("index not found")
-
-
-
 def test_add_a_collection(api):
-
-
     api.reset()
     api.create_collection("testspace")
 
@@ -418,10 +371,7 @@ def test_add_a_collection(api):
         collection = api.get_collection("testspace2")
 
 
-
 def test_list_collections(api):
-
-
     api.reset()
     api.create_collection("testspace")
     api.create_collection("testspace2")
@@ -431,10 +381,7 @@ def test_list_collections(api):
     assert len(collections) == 2
 
 
-
 def test_reset(api):
-
-
     api.reset()
     api.create_collection("testspace")
     api.create_collection("testspace2")
@@ -448,10 +395,7 @@ def test_reset(api):
     assert len(collections) == 0
 
 
-
 def test_peek(api):
-
-
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
@@ -469,14 +413,14 @@ def test_peek(api):
 metadata_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}],
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2},
+    ],
 }
 
 
-
 def test_metadata_add_get_int_float(api):
-
-
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
@@ -489,15 +433,14 @@ def test_metadata_add_get_int_float(api):
     assert type(items["metadatas"][0]["float_value"]) == float
 
 
-
 def test_metadata_add_query_int_float(api):
-
-
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
 
-    items: QueryResult = collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
+    items: QueryResult = collection.query(
+        query_embeddings=[[1.1, 2.3, 3.2]], n_results=1
+    )
     assert items["metadatas"] is not None
     assert items["metadatas"][0][0]["int_value"] == 1
     assert items["metadatas"][0][0]["float_value"] == 1.001
@@ -505,10 +448,7 @@ def test_metadata_add_query_int_float(api):
     assert type(items["metadatas"][0][0]["float_value"]) == float
 
 
-
 def test_metadata_get_where_string(api):
-
-
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
@@ -518,10 +458,7 @@ def test_metadata_get_where_string(api):
     assert items["metadatas"][0]["string_value"] == "one"
 
 
-
 def test_metadata_get_where_int(api):
-
-
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
@@ -531,10 +468,7 @@ def test_metadata_get_where_int(api):
     assert items["metadatas"][0]["string_value"] == "one"
 
 
-
 def test_metadata_get_where_float(api):
-
-
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
@@ -545,16 +479,14 @@ def test_metadata_get_where_float(api):
     assert items["metadatas"][0]["float_value"] == 1.001
 
 
-
 def test_metadata_update_get_int_float(api):
-
-
     api.reset()
     collection = api.create_collection("test_int")
     collection.add(**metadata_records)
 
     collection.update(
-        ids=["id1"], metadatas=[{"int_value": 2, "string_value": "two", "float_value": 2.002}]
+        ids=["id1"],
+        metadatas=[{"int_value": 2, "string_value": "two", "float_value": 2.002}],
     )
     items = collection.get(ids=["id1"])
     assert items["metadatas"][0]["int_value"] == 2
@@ -569,20 +501,14 @@ bad_metadata_records = {
 }
 
 
-
 def test_metadata_validation_add(api):
-
-
     api.reset()
     collection = api.create_collection("test_metadata_validation")
     with pytest.raises(ValueError, match="metadata"):
         collection.add(**bad_metadata_records)
 
 
-
 def test_metadata_validation_update(api):
-
-
     api.reset()
     collection = api.create_collection("test_metadata_validation")
     collection.add(**metadata_records)
@@ -590,20 +516,14 @@ def test_metadata_validation_update(api):
         collection.update(ids=["id1"], metadatas={"value": {"nested": "5"}})
 
 
-
 def test_where_validation_get(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_validation")
     with pytest.raises(ValueError, match="where"):
         collection.get(where={"value": {"nested": "5"}})
 
 
-
 def test_where_validation_query(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_validation")
     with pytest.raises(ValueError, match="where"):
@@ -620,10 +540,7 @@ operator_records = {
 }
 
 
-
 def test_where_lt(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_lt")
     collection.add(**operator_records)
@@ -631,10 +548,7 @@ def test_where_lt(api):
     assert len(items["metadatas"]) == 1
 
 
-
 def test_where_lte(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_lte")
     collection.add(**operator_records)
@@ -642,10 +556,7 @@ def test_where_lte(api):
     assert len(items["metadatas"]) == 2
 
 
-
 def test_where_gt(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_lte")
     collection.add(**operator_records)
@@ -653,10 +564,7 @@ def test_where_gt(api):
     assert len(items["metadatas"]) == 2
 
 
-
 def test_where_gte(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_lte")
     collection.add(**operator_records)
@@ -664,10 +572,7 @@ def test_where_gte(api):
     assert len(items["metadatas"]) == 1
 
 
-
 def test_where_ne_string(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_lte")
     collection.add(**operator_records)
@@ -675,10 +580,7 @@ def test_where_ne_string(api):
     assert len(items["metadatas"]) == 1
 
 
-
 def test_where_ne_eq_number(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_lte")
     collection.add(**operator_records)
@@ -688,10 +590,7 @@ def test_where_ne_eq_number(api):
     assert len(items["metadatas"]) == 1
 
 
-
 def test_where_valid_operators(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_valid_operators")
     collection.add(**operator_records)
@@ -709,10 +608,14 @@ def test_where_valid_operators(api):
         collection.get(where={"$and": {"int_value": {"$lt": 2}}})
 
     with pytest.raises(ValueError):
-        collection.get(where={"int_value": {"$lt": 2}, "$or": {"int_value": {"$gt": 1}}})
+        collection.get(
+            where={"int_value": {"$lt": 2}, "$or": {"int_value": {"$gt": 1}}}
+        )
 
     with pytest.raises(ValueError):
-        collection.get(where={"$gt": [{"int_value": {"$lt": 2}}, {"int_value": {"$gt": 1}}]})
+        collection.get(
+            where={"$gt": [{"int_value": {"$lt": 2}}, {"int_value": {"$gt": 1}}]}
+        )
 
     with pytest.raises(ValueError):
         collection.get(where={"$or": [{"int_value": {"$lt": 2}}]})
@@ -750,10 +653,7 @@ bad_number_of_results_query = {
 }
 
 
-
 def test_dimensionality_validation_add(api):
-
-
     api.reset()
     collection = api.create_collection("test_dimensionality_validation")
     collection.add(**minimal_records)
@@ -763,10 +663,7 @@ def test_dimensionality_validation_add(api):
     assert "dimensionality" in str(e.value)
 
 
-
 def test_dimensionality_validation_query(api):
-
-
     api.reset()
     collection = api.create_collection("test_dimensionality_validation_query")
     collection.add(**minimal_records)
@@ -776,10 +673,7 @@ def test_dimensionality_validation_query(api):
     assert "dimensionality" in str(e.value)
 
 
-
 def test_number_of_elements_validation_query(api):
-
-
     api.reset()
     collection = api.create_collection("test_number_of_elements_validation")
     collection.add(**minimal_records)
@@ -789,10 +683,7 @@ def test_number_of_elements_validation_query(api):
     assert "number of elements" in str(e.value)
 
 
-
 def test_query_document_valid_operators(api):
-
-
     api.reset()
     collection = api.create_collection("test_where_valid_operators")
     collection.add(**operator_records)
@@ -810,7 +701,9 @@ def test_query_document_valid_operators(api):
         collection.get(where_document={"$and": {"$unsupported": "doc"}})
 
     with pytest.raises(ValueError):
-        collection.get(where_document={"$or": [{"$unsupported": "doc"}, {"$unsupported": "doc"}]})
+        collection.get(
+            where_document={"$or": [{"$unsupported": "doc"}, {"$unsupported": "doc"}]}
+        )
 
     with pytest.raises(ValueError):
         collection.get(where_document={"$or": [{"$contains": "doc"}]})
@@ -820,7 +713,9 @@ def test_query_document_valid_operators(api):
 
     with pytest.raises(ValueError):
         collection.get(
-            where_document={"$or": [{"$and": [{"$contains": "doc"}]}, {"$contains": "doc"}]}
+            where_document={
+                "$or": [{"$and": [{"$contains": "doc"}]}, {"$contains": "doc"}]
+            }
         )
 
 
@@ -835,10 +730,7 @@ contains_records = {
 }
 
 
-
 def test_get_where_document(api):
-
-
     api.reset()
     collection = api.create_collection("test_get_where_document")
     collection.add(**contains_records)
@@ -853,10 +745,7 @@ def test_get_where_document(api):
     assert len(items["metadatas"]) == 0
 
 
-
 def test_query_where_document(api):
-
-
     api.reset()
     collection = api.create_collection("test_query_where_document")
     collection.add(**contains_records)
@@ -878,10 +767,7 @@ def test_query_where_document(api):
         assert "datapoints" in str(e.value)
 
 
-
 def test_delete_where_document(api):
-
-
     api.reset()
     collection = api.create_collection("test_delete_where_document")
     collection.add(**contains_records)
@@ -897,7 +783,12 @@ def test_delete_where_document(api):
 
 
 logical_operator_records = {
-    "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2], [1.3, 2.25, 3.2], [1.4, 2.26, 3.2]],
+    "embeddings": [
+        [1.1, 2.3, 3.2],
+        [1.2, 2.24, 3.2],
+        [1.3, 2.25, 3.2],
+        [1.4, 2.26, 3.2],
+    ],
     "ids": ["id1", "id2", "id3", "id4"],
     "metadatas": [
         {"int_value": 1, "string_value": "one", "float_value": 1.001, "is": "doc"},
@@ -914,10 +805,7 @@ logical_operator_records = {
 }
 
 
-
 def test_where_logical_operators(api):
-
-
     api.reset()
     collection = api.create_collection("test_logical_operators")
     collection.add(**logical_operator_records)
@@ -935,8 +823,18 @@ def test_where_logical_operators(api):
     items = collection.get(
         where={
             "$or": [
-                {"$and": [{"int_value": {"$eq": 3}}, {"string_value": {"$eq": "three"}}]},
-                {"$and": [{"int_value": {"$eq": 4}}, {"string_value": {"$eq": "four"}}]},
+                {
+                    "$and": [
+                        {"int_value": {"$eq": 3}},
+                        {"string_value": {"$eq": "three"}},
+                    ]
+                },
+                {
+                    "$and": [
+                        {"int_value": {"$eq": 4}},
+                        {"string_value": {"$eq": "four"}},
+                    ]
+                },
             ]
         }
     )
@@ -945,8 +843,18 @@ def test_where_logical_operators(api):
     items = collection.get(
         where={
             "$or": [
-                {"$and": [{"int_value": {"$eq": 3}}, {"string_value": {"$eq": "three"}}]},
-                {"$and": [{"int_value": {"$eq": 4}}, {"string_value": {"$eq": "four"}}]},
+                {
+                    "$and": [
+                        {"int_value": {"$eq": 3}},
+                        {"string_value": {"$eq": "three"}},
+                    ]
+                },
+                {
+                    "$and": [
+                        {"int_value": {"$eq": 4}},
+                        {"string_value": {"$eq": "four"}},
+                    ]
+                },
             ],
             "$and": [{"is": "doc"}, {"string_value": "four"}],
         }
@@ -954,10 +862,7 @@ def test_where_logical_operators(api):
     assert len(items["metadatas"]) == 1
 
 
-
 def test_where_document_logical_operators(api):
-
-
     api.reset()
     collection = api.create_collection("test_document_logical_operators")
     collection.add(**logical_operator_records)
@@ -1001,28 +906,32 @@ def test_where_document_logical_operators(api):
 records = {
     "embeddings": [[0, 0, 0], [1.2, 2.24, 3.2]],
     "ids": ["id1", "id2"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}],
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2},
+    ],
     "documents": ["this document is first", "this document is second"],
 }
 
 
-
 def test_query_include(api):
-
-
     api.reset()
     collection = api.create_collection("test_query_include")
     collection.add(**records)
 
     items = collection.query(
-        query_embeddings=[0, 0, 0], include=["metadatas", "documents", "distances"], n_results=1
+        query_embeddings=[0, 0, 0],
+        include=["metadatas", "documents", "distances"],
+        n_results=1,
     )
     assert items["embeddings"] is None
     assert items["ids"][0][0] == "id1"
     assert items["metadatas"][0][0]["int_value"] == 1
 
     items = collection.query(
-        query_embeddings=[0, 0, 0], include=["embeddings", "documents", "distances"], n_results=1
+        query_embeddings=[0, 0, 0],
+        include=["embeddings", "documents", "distances"],
+        n_results=1,
     )
     assert items["metadatas"] is None
     assert items["ids"][0][0] == "id1"
@@ -1040,10 +949,7 @@ def test_query_include(api):
     assert items["ids"][0][1] == "id2"
 
 
-
 def test_get_include(api):
-
-
     api.reset()
     collection = api.create_collection("test_get_include")
     collection.add(**records)
@@ -1074,9 +980,8 @@ def test_get_include(api):
 
 # make sure query results are returned in the right order
 
+
 def test_query_order(api):
-
-
     api.reset()
     collection = api.create_collection("test_query_order")
     collection.add(**records)
@@ -1093,9 +998,8 @@ def test_query_order(api):
 
 # test to make sure add, get, delete error on invalid id input
 
+
 def test_invalid_id(api):
-
-
     api.reset()
     collection = api.create_collection("test_invalid_id")
     # Add with non-string id
@@ -1114,10 +1018,7 @@ def test_invalid_id(api):
     assert "ID" in str(e.value)
 
 
-
 def test_index_params(api):
-
-
     # first standard add
     api.reset()
     collection = api.create_collection(name="test_index_params")
@@ -1144,7 +1045,9 @@ def test_index_params(api):
 
     # ip
     api.reset()
-    collection = api.create_collection(name="test_index_params", metadata={"hnsw:space": "ip"})
+    collection = api.create_collection(
+        name="test_index_params", metadata={"hnsw:space": "ip"}
+    )
     collection.add(**records)
     items = collection.query(
         query_embeddings=[0.6, 1.12, 1.6],
@@ -1153,10 +1056,7 @@ def test_index_params(api):
     assert items["distances"][0][0] < -5
 
 
-
 def test_invalid_index_params(api):
-
-
     api.reset()
 
     with pytest.raises(Exception):
@@ -1195,10 +1095,7 @@ def test_persist_index_loading_params(api, request):
         assert len(nn[key]) == 1
 
 
-
 def test_add_large(api):
-
-
     api.reset()
 
     collection = api.create_collection("testspace")
@@ -1216,8 +1113,8 @@ def test_add_large(api):
 
 # test get_version
 
-def test_get_version(api):
 
+def test_get_version(api):
     api.reset()
     version = api.get_version()
 
@@ -1229,8 +1126,8 @@ def test_get_version(api):
 
 # test delete_collection
 
-def test_delete_collection(api):
 
+def test_delete_collection(api):
     api.reset()
     collection = api.create_collection("test_delete_collection")
     collection.add(**records)
@@ -1240,14 +1137,11 @@ def test_delete_collection(api):
     assert len(api.list_collections()) == 0
 
 
-
 def test_multiple_collections(api):
-
     embeddings1 = np.random.rand(10, 512).astype(np.float32).tolist()
     embeddings2 = np.random.rand(10, 512).astype(np.float32).tolist()
     ids1 = [f"http://example.com/1/{i}" for i in range(len(embeddings1))]
     ids2 = [f"http://example.com/2/{i}" for i in range(len(embeddings2))]
-
 
     api.reset()
     coll1 = api.create_collection("coll1")
@@ -1267,10 +1161,7 @@ def test_multiple_collections(api):
     assert results2["ids"][0][0] == ids2[0]
 
 
-
 def test_update_query(api):
-
-
     api.reset()
     collection = api.create_collection("test_update_query")
     collection.add(**records)
@@ -1300,16 +1191,31 @@ def test_update_query(api):
 initial_records = {
     "embeddings": [[0, 0, 0], [1.2, 2.24, 3.2], [2.2, 3.24, 4.2]],
     "ids": ["id1", "id2", "id3"],
-    "metadatas": [{"int_value": 1, "string_value": "one", "float_value": 1.001}, {"int_value": 2}, {"string_value": "three"}],
-    "documents": ["this document is first", "this document is second", "this document is third"],
+    "metadatas": [
+        {"int_value": 1, "string_value": "one", "float_value": 1.001},
+        {"int_value": 2},
+        {"string_value": "three"},
+    ],
+    "documents": [
+        "this document is first",
+        "this document is second",
+        "this document is third",
+    ],
 }
 
 new_records = {
     "embeddings": [[3.0, 3.0, 1.1], [3.2, 4.24, 5.2]],
     "ids": ["id1", "id4"],
-    "metadatas": [{"int_value": 1, "string_value": "one_of_one", "float_value": 1.001}, {"int_value": 4}],
-    "documents": ["this document is even more first", "this document is new and fourth"],
+    "metadatas": [
+        {"int_value": 1, "string_value": "one_of_one", "float_value": 1.001},
+        {"int_value": 4},
+    ],
+    "documents": [
+        "this document is even more first",
+        "this document is new and fourth",
+    ],
 }
+
 
 def test_upsert(api):
     api.reset()
@@ -1321,21 +1227,33 @@ def test_upsert(api):
     collection.upsert(**new_records)
     assert collection.count() == 4
 
-    get_result = collection.get(include=['embeddings', 'metadatas', 'documents'], ids=new_records['ids'][0])
-    assert get_result['embeddings'][0] == new_records['embeddings'][0]
-    assert get_result['metadatas'][0] == new_records['metadatas'][0]
-    assert get_result['documents'][0] == new_records['documents'][0]
+    get_result = collection.get(
+        include=["embeddings", "metadatas", "documents"], ids=new_records["ids"][0]
+    )
+    assert get_result["embeddings"][0] == new_records["embeddings"][0]
+    assert get_result["metadatas"][0] == new_records["metadatas"][0]
+    assert get_result["documents"][0] == new_records["documents"][0]
 
-    query_result = collection.query(query_embeddings=get_result['embeddings'], n_results=1, include=['embeddings', 'metadatas', 'documents'])
-    assert query_result['embeddings'][0][0] == new_records['embeddings'][0]
-    assert query_result['metadatas'][0][0] == new_records['metadatas'][0]
-    assert query_result['documents'][0][0] == new_records['documents'][0]
+    query_result = collection.query(
+        query_embeddings=get_result["embeddings"],
+        n_results=1,
+        include=["embeddings", "metadatas", "documents"],
+    )
+    assert query_result["embeddings"][0][0] == new_records["embeddings"][0]
+    assert query_result["metadatas"][0][0] == new_records["metadatas"][0]
+    assert query_result["documents"][0][0] == new_records["documents"][0]
 
-    collection.delete(ids=initial_records['ids'][2])
-    collection.upsert(ids=initial_records['ids'][2], embeddings=[[1.1, 0.99, 2.21]], metadatas=[{"string_value": "a new string value"}])
+    collection.delete(ids=initial_records["ids"][2])
+    collection.upsert(
+        ids=initial_records["ids"][2],
+        embeddings=[[1.1, 0.99, 2.21]],
+        metadatas=[{"string_value": "a new string value"}],
+    )
     assert collection.count() == 4
 
-    get_result = collection.get(include=['embeddings', 'metadatas', 'documents'], ids=['id3'])
-    assert get_result['embeddings'][0] == [1.1, 0.99, 2.21]
-    assert get_result['metadatas'][0] == {"string_value": "a new string value"}
-    assert get_result['documents'][0] == None
+    get_result = collection.get(
+        include=["embeddings", "metadatas", "documents"], ids=["id3"]
+    )
+    assert get_result["embeddings"][0] == [1.1, 0.99, 2.21]
+    assert get_result["metadatas"][0] == {"string_value": "a new string value"}
+    assert get_result["documents"][0] == None

--- a/chromadb/test/test_chroma.py
+++ b/chromadb/test/test_chroma.py
@@ -15,7 +15,9 @@ class GetDBTest(unittest.TestCase):
     @patch("chromadb.db.duckdb.PersistentDuckDB", autospec=True)
     def test_persistent_duckdb(self, mock):
         chromadb.get_db(
-            chromadb.config.Settings(chroma_db_impl="duckdb+parquet", persist_directory="./foo")
+            chromadb.config.Settings(
+                chroma_db_impl="duckdb+parquet", persist_directory="./foo"
+            )
         )
         assert mock.called
 


### PR DESCRIPTION
## Description of changes
- This removes `increment_index` from the API since we are going to deprecate it and this makes the API simpler
- This also adds a lot of formatting changes 
- closes https://github.com/chroma-core/chroma/issues/296

## Test plan
Same tests

## Documentation Changes
We need to update the not-yet-landed python API docs, otherwise no.