### PR TITLE
Lazily initialize default embedding function

### DIFF
--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -40,7 +40,7 @@ def test_persist_index_loading(api_fixture, request):
     api = request.getfixturevalue("local_persist_api")
     api.reset()
     collection = api.create_collection("test")
-    collection.add(ids="id1", documents="hello")
+    collection.add(ids="id1", embeddings=[1.1, 2.2, 3.3])
 
     api.persist()
     del api
@@ -49,7 +49,7 @@ def test_persist_index_loading(api_fixture, request):
     collection = api2.get_collection("test")
 
     nn = collection.query(
-        query_texts="hello",
+        query_embeddings=[1.1, 2.2, 3.3],
         n_results=1,
         include=["embeddings", "documents", "metadatas", "distances"],
     )

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1350,6 +1350,7 @@ def local_api():
         )
     )
 
+@patch('chromadb.utils.embedding_functions.SentenceTransformerEmbeddingFunction.models', {})
 def test_default_embedding_function(local_api):
     api = local_api
     api.reset()

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1176,7 +1176,7 @@ def test_persist_index_loading_params(api, request):
     api = request.getfixturevalue("local_persist_api")
     api.reset()
     collection = api.create_collection("test", metadata={"hnsw:space": "ip"})
-    collection.add(ids="id1", documents="hello")
+    collection.add(ids="id1", embeddings=[1.1, 2.2, 3.3])
 
     api.persist()
     del api
@@ -1187,7 +1187,7 @@ def test_persist_index_loading_params(api, request):
     assert collection.metadata["hnsw:space"] == "ip"
 
     nn = collection.query(
-        query_texts="hello",
+        query_embeddings=[1.1, 2.2, 3.3],
         n_results=1,
         include=["embeddings", "documents", "metadatas", "distances"],
     )


### PR DESCRIPTION
## Description of changes

Previously, the default embedding function was initialized immediately upon creating a collection without an explicit embedding function.

This PR modifies the behavior to avoid initializing the default embedding function until it is actually needed. The user-facing semantics are the same: they will still get a warning when creating a Collection without an embedding function, and they will still get SentenceTransformers by default. The only change is when the model is downloaded (when they add their first embedding vs when initializing the collection.)

*Rationale*:

Initializing an embedding function is a heavyweight activity: it requires downloading the Sentence Transformer model from HuggingFace. 

But, in the case where a user intends to supply their own embedding vectors (such as we do in our tests), this effort is wasted and we end up initializing a model needlessly. And, because this is a heavyweight external network call, it can fail; this change makes our tests more reliable.

## Test plan

Existing unit and integration tests continue to pass. New unit test added that mocks SentenceTransformers construction and verifies that it occurs when expected.

## Documentation Changes

None required, user-facing behavior is the same.