### PR TITLE
Increase hnswlib num_threads to match cpu_count

### DIFF
--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -14,6 +14,7 @@ from chromadb.errors import (
 import logging
 import re
 from uuid import UUID
+import multiprocessing
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,9 @@ class HnswParams:
         self.construction_ef = int(metadata.get("hnsw:construction_ef", 100))
         self.search_ef = int(metadata.get("hnsw:search_ef", 10))
         self.M = int(metadata.get("hnsw:M", 16))
-        self.num_threads = int(metadata.get("hnsw:num_threads", 4))
+        self.num_threads = int(
+            metadata.get("hnsw:num_threads", multiprocessing.cpu_count())
+        )
         self.resize_factor = float(metadata.get("hnsw:resize_factor", 1.2))
 
 


### PR DESCRIPTION
## Description of changes
Addresses #337 by using multiprocessing.cpu_count() instead of 4 as the default. This cpu_count could over-report the true number of physical cores on processors supporting hyperthreading. However so does the underlying hnswlib std::hardware_concurrency that is used by default that we were overriding. Unfortunately, there isn't a good platform-independent, dependency-free, or reliable way to get a more accurate count (that I can find) so this is our best stdlib based approach for now.

## Test plan
Existing tests should capture this change as hnswlib is trivially parallel under the FFI.

## Documentation Changes
None required. 
