### PR TITLE
switch to named params for JS client

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -13,7 +13,8 @@ import {
   PositiveInteger,
   CollectionType,
   GetResponse,
-  QueryResponse
+  QueryResponse,
+  AddResponse
 } from "./types";
 import { Configuration, ApiApi as DefaultApi, Api } from "./generated";
 import Count200Response = Api.Count200Response;
@@ -298,7 +299,7 @@ export class Collection {
    * @param {Embedding | Embeddings} [params.embeddings] - Optional embeddings of the items to add.
    * @param {Metadata | Metadatas} [params.metadatas] - Optional metadata of the items to add.
    * @param {Document | Documents} [params.documents] - Optional documents of the items to add.
-   * @returns {Promise<boolean>} - The response from the API. True if successful.
+   * @returns {Promise<AddResponse>} - The response from the API. True if successful.
    *
    * @example
    * ```typescript
@@ -320,7 +321,7 @@ export class Collection {
     embeddings?: Embedding | Embeddings,
     metadatas?: Metadata | Metadatas,
     documents?: Document | Documents,
-  }): Promise<boolean> {
+  }): Promise<AddResponse> {
 
     const [idsArray, embeddingsArray, metadatasArray, documentsArray] = await this.validate(
       true,

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -160,10 +160,25 @@ type CallableFunction = {
 };
 
 export class Collection {
+  /**
+   * @ignore
+   */
   public name: string;
+  /**
+   * @ignore
+   */
   public id: string;
+  /**
+   * @ignore
+   */
   public metadata: Metadata | undefined;
+  /**
+   * @ignore
+   */
   private api: DefaultApi;
+  /**
+   * @ignore
+   */
   public embeddingFunction: CallableFunction | undefined;
 
   /**
@@ -270,6 +285,25 @@ export class Collection {
     return [idsArray, embeddingsArray, metadatasArray, documentsArray]
   }
 
+  /**
+   * Add items to the collection
+   * @param {Object} params - The parameters for the query.
+   * @param {ID | IDs} [params.ids] - IDs of the items to add.
+   * @param {Embedding | Embeddings} [params.embeddings] - Optional embeddings of the items to add.
+   * @param {Metadata | Metadatas} [params.metadatas] - Optional metadata of the items to add.
+   * @param {Document | Documents} [params.documents] - Optional documents of the items to add.
+   * @returns {Promise<AddResponse>} - The response from the API.
+   *
+   * @example
+   * ```typescript
+   * const response = await collection.add({
+   *   ids: ["id1", "id2"],
+   *   embeddings: [[1, 2, 3], [4, 5, 6]],
+   *   metadatas: [{ "key": "value" }, { "key": "value" }],
+   *   documents: ["document1", "document2"]
+   * });
+   * ```
+   */
   public async add({
     ids,
     embeddings,
@@ -305,6 +339,25 @@ export class Collection {
     return response
   }
 
+  /**
+   * Upsert items to the collection
+   * @param {Object} params - The parameters for the query.
+   * @param {ID | IDs} [params.ids] - IDs of the items to add.
+   * @param {Embedding | Embeddings} [params.embeddings] - Optional embeddings of the items to add.
+   * @param {Metadata | Metadatas} [params.metadatas] - Optional metadata of the items to add.
+   * @param {Document | Documents} [params.documents] - Optional documents of the items to add.
+   * @returns {Promise<UpsertResponse>} - The response from the API.
+   *
+   * @example
+   * ```typescript
+   * const response = await collection.upsert({
+   *   ids: ["id1", "id2"],
+   *   embeddings: [[1, 2, 3], [4, 5, 6]],
+   *   metadatas: [{ "key": "value" }, { "key": "value" }],
+   *   documents: ["document1", "document2"],
+   * });
+   * ```
+   */
   public async upsert({
     ids,
     embeddings,
@@ -341,11 +394,35 @@ export class Collection {
 
   }
 
+  /**
+   * Count the number of items in the collection
+   * @returns {Promise<CountResponse>} - The response from the API.
+   *
+   * @example
+   * ```typescript
+   * const response = await collection.count();
+   * ```
+   */
   public async count() {
     const response = await this.api.count(this.id);
     return handleSuccess(response);
   }
 
+  /**
+   * Modify the collection name or metadata
+   * @param {Object} params - The parameters for the query.
+   * @param {string} [params.name] - Optional new name for the collection.
+   * @param {Metadata} [params.metadata] - Optional new metadata for the collection.
+   * @returns {Promise<ModifyResponse>} - The response from the API.
+   *
+   * @example
+   * ```typescript
+   * const response = await collection.modify({
+   *   name: "new name",
+   *   metadata: { "key": "value" },
+   * });
+   * ```
+   */
   public async modify({
     name,
     metadata
@@ -371,12 +448,36 @@ export class Collection {
 
   }
 
+  /**
+   * Get items from the collection
+   * @param {Object} params - The parameters for the query.
+   * @param {ID | IDs} [params.ids] - Optional IDs of the items to get.
+   * @param {Where} [params.where] - Optional where clause to filter items by.
+   * @param {PositiveInteger} [params.limit] - Optional limit on the number of items to get.
+   * @param {PositiveInteger} [params.offset] - Optional offset on the items to get.
+   * @param {IncludeEnum[]} [params.include] - Optional list of items to include in the response.
+   * @param {WhereDocument} [params.where_document] - Optional where clause to filter items by.
+   * @returns {Promise<GetResponse>} - The response from the server.
+   *
+   * @example
+   * ```typescript
+   * const response = await collection.get({
+   *   ids: ["id1", "id2"],
+   *   where: { "key": "value" },
+   *   limit: 10,
+   *   offset: 0,
+   *   include: ["embeddings", "metadatas", "documents"],
+   *   where_document: { $contains: "value" },
+   * });
+   * ```
+   */
   public async get({
     ids,
     where,
     limit,
     offset,
     include,
+    where_document,
   }: {
     ids?: ID | IDs,
     where?: Where,
@@ -395,11 +496,31 @@ export class Collection {
         limit,
         offset,
         include,
+        where_document,
       })
       .then(handleSuccess)
       .catch(handleError);
   }
 
+  /**
+   * Update the embeddings, documents, and/or metadatas of existing items
+   * @param {Object} params - The parameters for the query.
+   * @param {ID | IDs} [params.ids] - The IDs of the items to update.
+   * @param {Embedding | Embeddings} [params.embeddings] - Optional embeddings to update.
+   * @param {Metadata | Metadatas} [params.metadatas] - Optional metadatas to update.
+   * @param {Document | Documents} [params.documents] - Optional documents to update.
+   * @returns {Promise<APIResponse>} - The API Response.
+   *
+   * @example
+   * ```typescript
+   * const response = await collection.update({
+   *   ids: ["id1", "id2"],
+   *   embeddings: [[1, 2, 3], [4, 5, 6]],
+   *   metadatas: [{ "key": "value" }, { "key": "value" }],
+   *   documents: ["new document 1", "new document 2"],
+   * });
+   * ```
+   */
   public async update({
     ids,
     embeddings,
@@ -526,6 +647,20 @@ export class Collection {
       .catch(handleError);
   }
 
+  /**
+   * Peek inside the collection
+   * @param {Object} params - The parameters for the query.
+   * @param {PositiveInteger} [params.limit] - Optional number of results to return (default is 10).
+   * @returns {Promise<any>} A promise that resolves to the query results.
+   * @throws {Error} If there is an issue executing the query.
+   *
+   * @example
+   * ```typescript
+   * const results = await collection.peek({
+   *   limit: 10
+   * });
+   * ```
+   */
   public async peek({ limit }: { limit?: PositiveInteger } = {}) {
     if (limit === undefined) limit = 10;
     const response = await this.api.aGet(this.id, {
@@ -534,10 +669,24 @@ export class Collection {
     return handleSuccess(response);
   }
 
-  public async createIndex() {
-    return await this.api.createIndex(this.name);
-  }
-
+  /**
+   * Deletes items from the collection.
+   * @param {Object} params - The parameters for deleting items from the collection.
+   * @param {ID | IDs} [params.ids] - Optional ID or array of IDs of items to delete.
+   * @param {Where} [params.where] - Optional query condition to filter items to delete based on metadata values.
+   * @param {WhereDocument} [params.where_document] - Optional query condition to filter items to delete based on document content.
+   * @returns {Promise<any>} A promise that resolves to the deletion results.
+   * @throws {Error} If there is an issue deleting items from the collection.
+   *
+   * @example
+   * ```typescript
+   * const results = await collection.delete({
+   *   ids: "some_id",
+   *   where: {"name": {"$eq": "John Doe"}},
+   *   where_document: {"$contains":"search_string"}
+   * });
+   * ```
+   */
   public async delete({
     ids,
     where,
@@ -557,8 +706,24 @@ export class Collection {
 }
 
 export class ChromaClient {
+  /**
+   * @ignore
+   */
   private api: DefaultApi;
 
+  /**
+   * Creates a new ChromaClient instance.
+   * @param {Object} params - The parameters for creating a new client
+   * @param {string} [params.path] - The base path for the Chroma API.
+   * @returns {ChromaClient} A new ChromaClient instance.
+   *
+   * @example
+   * ```typescript
+   * const client = new ChromaClient({
+   *   path: "http://localhost:8000"
+   * });
+   * ```
+   */
   constructor({ path }: { path?: string } = {}) {
     if (path === undefined) path = "http://localhost:8000";
     const apiConfig: Configuration = new Configuration({
@@ -572,16 +737,39 @@ export class ChromaClient {
    *
    * @returns {Promise<void>} A promise that resolves when the reset operation is complete.
    * @throws {Error} If there is an issue resetting the state.
+   *
+   * @example
+   * ```typescript
+   * await client.reset();
+   * ```
    */
   public async reset() {
     return await this.api.reset();
   }
 
+  /**
+   * Returns the version of the Chroma API.
+   * @returns {Promise<string>} A promise that resolves to the version of the Chroma API.
+   *
+   * @example
+   * ```typescript
+   * const version = await client.version();
+   * ```
+   */
   public async version(): Promise<string> {
     const response = await this.api.version();
     return await handleSuccess(response);
   }
 
+  /**
+   * Returns a heartbeat from the Chroma API.
+   * @returns {Promise<number>} A promise that resolves to the heartbeat from the Chroma API.
+   *
+   * @example
+   * ```typescript
+   * const heartbeat = await client.heartbeat();
+   * ```
+   */
   public async heartbeat(): Promise<number> {
     const response = await this.api.heartbeat();
     let ret = await handleSuccess(response);
@@ -602,6 +790,16 @@ export class ChromaClient {
    *
    * @returns {Promise<Collection>} A promise that resolves to the created collection.
    * @throws {Error} If there is an issue creating the collection.
+   *
+   * @example
+   * ```typescript
+   * const collection = await client.createCollection({
+   *   name: "my_collection",
+   *   metadata: {
+   *     "description": "My first collection"
+   *   }
+   * });
+   * ```
    */
   public async createCollection({
     name,
@@ -627,6 +825,27 @@ export class ChromaClient {
     return new Collection(name, newCollection.id, this.api, metadata, embeddingFunction);
   }
 
+  /**
+   * Gets or creates a collection with the specified properties.
+   *
+   * @param {Object} params - The parameters for creating a new collection.
+   * @param {string} params.name - The name of the collection.
+   * @param {Metadata} [params.metadata] - Optional metadata associated with the collection.
+   * @param {CallableFunction} [params.embeddingFunction] - Optional custom embedding function for the collection.
+   *
+   * @returns {Promise<Collection>} A promise that resolves to the got or created collection.
+   * @throws {Error} If there is an issue getting or creating the collection.
+   *
+   * @example
+   * ```typescript
+   * const collection = await client.getOrCreateCollection({
+   *   name: "my_collection",
+   *   metadata: {
+   *     "description": "My first collection"
+   *   }
+   * });
+   * ```
+   */
   public async getOrCreateCollection({
     name,
     metadata,
@@ -658,11 +877,37 @@ export class ChromaClient {
     );
   }
 
+  /**
+   * Lists all collections.
+   *
+   * @returns {Promise<string[]>} A promise that resolves to a list of collection names.
+   * @throws {Error} If there is an issue listing the collections.
+   *
+   * @example
+   * ```typescript
+   * const collections = await client.listCollections();
+   * ```
+   */
   public async listCollections() {
     const response = await this.api.listCollections();
     return handleSuccess(response);
   }
 
+  /**
+   * Gets a collection with the specified name.
+   * @param {Object} params - The parameters for getting a collection.
+   * @param {string} params.name - The name of the collection.
+   * @param {CallableFunction} [params.embeddingFunction] - Optional custom embedding function for the collection.
+   * @returns {Promise<Collection>} A promise that resolves to the collection.
+   * @throws {Error} If there is an issue getting the collection.
+   *
+   * @example
+   * ```typescript
+   * const collection = await client.getCollection({
+   *   name: "my_collection"
+   * });
+   * ```
+   */
   public async getCollection({
     name,
     embeddingFunction
@@ -684,6 +929,20 @@ export class ChromaClient {
     );
   }
 
+  /**
+   * Deletes a collection with the specified name.
+   * @param {Object} params - The parameters for deleting a collection.
+   * @param {string} params.name - The name of the collection.
+   * @returns {Promise<void>} A promise that resolves when the collection is deleted.
+   * @throws {Error} If there is an issue deleting the collection.
+   *
+   * @example
+   * ```typescript
+   * await client.deleteCollection({
+   *  name: "my_collection"
+   * });
+   * ```
+   */
   public async deleteCollection({
     name
   }: {

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -166,6 +166,9 @@ export class Collection {
   private api: DefaultApi;
   public embeddingFunction: CallableFunction | undefined;
 
+  /**
+   * @ignore
+   */
   constructor(
     name: string,
     id: string,
@@ -181,13 +184,22 @@ export class Collection {
       this.embeddingFunction = embeddingFunction;
   }
 
+  /**
+   * @ignore
+   */
   private setName(name: string): void {
     this.name = name;
   }
+  /**
+   * @ignore
+   */
   private setMetadata(metadata: Metadata | undefined): void {
     this.metadata = metadata;
   }
 
+  /**
+   * @ignore
+   */
   private async validate(
     require_embeddings_or_documents: boolean, // set to false in the case of Update
     ids: string | string[],
@@ -434,6 +446,39 @@ export class Collection {
     return resp;
   }
 
+  /**
+   * Performs a query on the collection using the specified parameters.
+   *
+   * @param {Object} params - The parameters for the query.
+   * @param {Embedding | Embeddings} [params.query_embeddings] - Optional query embeddings to use for the search.
+   * @param {PositiveInteger} [params.n_results] - Optional number of results to return (default is 10).
+   * @param {Where} [params.where] - Optional query condition to filter results based on metadata values.
+   * @param {string | string[]} [params.query_text] - Optional query text(s) to search for in the collection (renamed to 'query_texts' in the future).
+   * @param {WhereDocument} [params.where_document] - Optional query condition to filter results based on document content.
+   * @param {IncludeEnum[]} [params.include] - Optional array of fields to include in the result, such as "metadata" and "document".
+   *
+   * @returns {Promise<any>} A promise that resolves to the query results.
+   * @throws {Error} If there is an issue executing the query.
+   * @example
+   * // Query the collection using embeddings
+   * const results = await collection.query({
+   *   query_embeddings: [[0.1, 0.2, ...], ...],
+   *   n_results: 10,
+   *   where: {"name": {"$eq": "John Doe"}},
+   *   include: ["metadata", "document"]
+   * });
+   * @example
+   * ```js
+   * // Query the collection using query text
+   * const results = await collection.query({
+   *   query_text: "some text",
+   *   n_results: 10,
+   *   where: {"name": {"$eq": "John Doe"}},
+   *   include: ["metadata", "document"]
+   * });
+   * ```
+   *
+   */
   public async query({
     query_embeddings,
     n_results,
@@ -522,6 +567,12 @@ export class ChromaClient {
     this.api = new DefaultApi(apiConfig);
   }
 
+  /**
+   * Resets the state of the object by making an API call to the reset endpoint.
+   *
+   * @returns {Promise<void>} A promise that resolves when the reset operation is complete.
+   * @throws {Error} If there is an issue resetting the state.
+   */
   public async reset() {
     return await this.api.reset();
   }
@@ -541,6 +592,17 @@ export class ChromaClient {
     throw new Error("Not implemented in JS client");
   }
 
+  /**
+   * Creates a new collection with the specified properties.
+   *
+   * @param {Object} params - The parameters for creating a new collection.
+   * @param {string} params.name - The name of the collection.
+   * @param {Metadata} [params.metadata] - Optional metadata associated with the collection.
+   * @param {CallableFunction} [params.embeddingFunction] - Optional custom embedding function for the collection.
+   *
+   * @returns {Promise<Collection>} A promise that resolves to the created collection.
+   * @throws {Error} If there is an issue creating the collection.
+   */
   public async createCollection({
     name,
     metadata,

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -14,7 +14,8 @@ import {
   CollectionType,
   GetResponse,
   QueryResponse,
-  AddResponse
+  AddResponse,
+  CollectionMetadata
 } from "./types";
 import { Configuration, ApiApi as DefaultApi, Api } from "./generated";
 import Count200Response = Api.Count200Response;
@@ -169,7 +170,7 @@ type CallableFunction = {
 export class Collection {
   public name: string;
   public id: string;
-  public metadata: Metadata | undefined;
+  public metadata: CollectionMetadata | undefined;
   /**
    * @ignore
    */
@@ -186,7 +187,7 @@ export class Collection {
     name: string,
     id: string,
     api: DefaultApi,
-    metadata?: Metadata,
+    metadata?: CollectionMetadata,
     embeddingFunction?: CallableFunction
   ) {
     this.name = name;
@@ -206,7 +207,7 @@ export class Collection {
   /**
    * @ignore
    */
-  private setMetadata(metadata: Metadata | undefined): void {
+  private setMetadata(metadata: CollectionMetadata | undefined): void {
     this.metadata = metadata;
   }
 
@@ -419,7 +420,7 @@ export class Collection {
    * Modify the collection name or metadata
    * @param {Object} params - The parameters for the query.
    * @param {string} [params.name] - Optional new name for the collection.
-   * @param {Metadata} [params.metadata] - Optional new metadata for the collection.
+   * @param {CollectionMetadata} [params.metadata] - Optional new metadata for the collection.
    * @returns {Promise<void>} - The response from the API.
    *
    * @example
@@ -435,7 +436,7 @@ export class Collection {
     metadata
   }: {
     name?: string,
-    metadata?: Metadata
+    metadata?: CollectionMetadata
   } = {}): Promise<void> {
     const response = await this.api
       .updateCollection(
@@ -799,7 +800,7 @@ export class ChromaClient {
    *
    * @param {Object} params - The parameters for creating a new collection.
    * @param {string} params.name - The name of the collection.
-   * @param {Metadata} [params.metadata] - Optional metadata associated with the collection.
+   * @param {CollectionMetadata} [params.metadata] - Optional metadata associated with the collection.
    * @param {CallableFunction} [params.embeddingFunction] - Optional custom embedding function for the collection.
    *
    * @returns {Promise<Collection>} A promise that resolves to the created collection.
@@ -821,7 +822,7 @@ export class ChromaClient {
     embeddingFunction
   }: {
     name: string,
-    metadata?: Metadata,
+    metadata?: CollectionMetadata,
     embeddingFunction?: CallableFunction
   }): Promise<Collection> {
     const newCollection = await this.api
@@ -844,7 +845,7 @@ export class ChromaClient {
    *
    * @param {Object} params - The parameters for creating a new collection.
    * @param {string} params.name - The name of the collection.
-   * @param {Metadata} [params.metadata] - Optional metadata associated with the collection.
+   * @param {CollectionMetadata} [params.metadata] - Optional metadata associated with the collection.
    * @param {CallableFunction} [params.embeddingFunction] - Optional custom embedding function for the collection.
    *
    * @returns {Promise<Collection>} A promise that resolves to the got or created collection.
@@ -866,7 +867,7 @@ export class ChromaClient {
     embeddingFunction
   }: {
     name: string,
-    metadata?: Metadata,
+    metadata?: CollectionMetadata,
     embeddingFunction?: CallableFunction
   }): Promise<Collection> {
     const newCollection = await this.api

--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -68,5 +68,7 @@ export type QueryResponse = {
 }
 
 export type AddResponse = {
-    error: string;
+  error: string;
 }
+
+export type CollectionMetadata = Record<string, unknown>;

--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -4,3 +4,43 @@ export enum IncludeEnum {
   Metadatas = 'metadatas',
   Distances = 'distances'
 }
+
+type Number = number;
+export type Embedding = Array<Number>;
+export type Embeddings = Array<Embedding>;
+
+export type Metadata = Record<string, string | number | boolean>;
+export type Metadatas = Array<Metadata>;
+
+export type Document = string;
+export type Documents = Array<Document>;
+
+export type ID = string;
+export type IDs = ID[];
+
+export type PositiveInteger = number;
+
+type LiteralValue = string | number;
+type LiteralNumber = number;
+type LogicalOperator = "$and" | "$or";
+type WhereOperator = "$gt" | "$gte" | "$lt" | "$lte" | "$ne" | "$eq";
+
+type OperatorExpression = {
+  [key in WhereOperator | LogicalOperator]?: LiteralValue | LiteralNumber;
+};
+
+type BaseWhere = {
+  [key: string]: LiteralValue | OperatorExpression;
+};
+
+type LogicalWhere = {
+  [key in LogicalOperator]?: Where[];
+};
+
+export type Where = BaseWhere & LogicalWhere;
+
+type WhereDocumentOperator = "$contains" | LogicalOperator;
+
+export type WhereDocument = {
+  [key in WhereDocumentOperator]?: LiteralValue | LiteralNumber | WhereDocument[];
+};

--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -56,12 +56,17 @@ export type GetResponse = {
   embeddings: null | Embeddings;
   documents: (null | Document)[];
   metadatas: (null | Metadata)[];
+  error: null | string;
 };
 
 export type QueryResponse = {
-  ids: IDs;
-  embeddings: null | Embeddings;
-  documents: (null | Document)[];
-  metadatas: (null | Metadata)[];
-  distances: null | number[][];
+  ids: IDs[];
+  embeddings: null | Embeddings[][];
+  documents: (null | Document)[][];
+  metadatas: (null | Metadata)[][];
+  distances: null | number[][][];
+}
+
+export type AddResponse = {
+    error: string;
 }

--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -44,3 +44,24 @@ type WhereDocumentOperator = "$contains" | LogicalOperator;
 export type WhereDocument = {
   [key in WhereDocumentOperator]?: LiteralValue | LiteralNumber | WhereDocument[];
 };
+
+export type CollectionType = {
+  name: string;
+  id: string;
+  metadata: Metadata | null;
+};
+
+export type GetResponse = {
+  ids: IDs;
+  embeddings: null | Embeddings;
+  documents: (null | Document)[];
+  metadatas: (null | Metadata)[];
+};
+
+export type QueryResponse = {
+  ids: IDs;
+  embeddings: null | Embeddings;
+  documents: (null | Document)[];
+  metadatas: (null | Metadata)[];
+  distances: null | number[][];
+}

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -18,7 +18,7 @@ test("it should add single embeddings to a collection", async () => {
       IncludeEnum.Embeddings,
     ]
   });
-  expect(res.embeddings[0]).toEqual(embeddings);
+  expect(res.embeddings![0]).toEqual(embeddings);
 });
 
 test("it should add batch embeddings to a collection", async () => {
@@ -38,7 +38,8 @@ test("it should add batch embeddings to a collection", async () => {
 test("add documents", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
-  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, documents: DOCUMENTS });
+  let resp = await collection.add({ ids: IDS, embeddings: EMBEDDINGS, documents: DOCUMENTS });
+  expect(resp).toBe(true)
   const results = await collection.get({ ids: ["test1"] });
   expect(results.documents[0]).toBe("This is a test");
 });

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -6,56 +6,60 @@ import { IncludeEnum } from "../src/types";
 
 test("it should add single embeddings to a collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  const id = "test1";
-  const embedding = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  const metadata = { test: "test" };
-  await collection.add(id, embedding, metadata);
+  const collection = await chroma.createCollection({ name: "test" });
+  const ids = "test1";
+  const embeddings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const metadatas = { test: "test" };
+  await collection.add({ ids, embeddings, metadatas });
   const count = await collection.count();
   expect(count).toBe(1);
-  var res = await collection.get([id], undefined, undefined, undefined, [
-    IncludeEnum.Embeddings,
-  ]);
-  expect(res.embeddings[0]).toEqual(embedding);
+  var res = await collection.get({
+    ids: [ids], include: [
+      IncludeEnum.Embeddings,
+    ]
+  });
+  expect(res.embeddings[0]).toEqual(embeddings);
 });
 
 test("it should add batch embeddings to a collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
   const count = await collection.count();
   expect(count).toBe(3);
-  var res = await collection.get(IDS, undefined, undefined, undefined, [
-    IncludeEnum.Embeddings,
-  ]);
+  var res = await collection.get({
+    ids: IDS, include: [
+      IncludeEnum.Embeddings,
+    ]
+  });
   expect(res.embeddings).toEqual(EMBEDDINGS); // reverse because of the order of the ids
 });
 
 test("add documents", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, undefined, DOCUMENTS);
-  const results = await collection.get(["test1"]);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, documents: DOCUMENTS });
+  const results = await collection.get({ ids: ["test1"] });
   expect(results.documents[0]).toBe("This is a test");
 });
 
 test('it should return an error when inserting an ID that alreay exists in the Collection', async () => {
   await chroma.reset()
-  const collection = await chroma.createCollection('test')
-  await collection.add(IDS, EMBEDDINGS, METADATAS)
-  const results = await collection.add(IDS, EMBEDDINGS, METADATAS);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS })
+  const results = await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS });
   expect(results.error).toBeDefined()
   expect(results.error).toContain("IDAlreadyExists")
 })
 
 test('It should return an error when inserting duplicate IDs in the same batch', async () => {
   await chroma.reset()
-  const collection = await chroma.createCollection('test')
+  const collection = await chroma.createCollection({ name: "test" });
   const ids = IDS.concat(["test1"])
   const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
   const metadatas = METADATAS.concat([{ test: 'test1', 'float_value': 0.1 }])
   try {
-    await collection.add(ids, embeddings, metadatas);
+    await collection.add({ ids, embeddings, metadatas });
   } catch (e: any) {
     expect(e.message).toMatch('duplicates')
   }

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -26,7 +26,7 @@ test("it should reset the database", async () => {
     expect(collections).toBeInstanceOf(Array);
     expect(collections.length).toBe(0);
 
-    const collection = await chroma.createCollection("test");
+    const collection = await chroma.createCollection({ name: "test" });
     const collections2 = await chroma.listCollections();
     expect(collections2).toBeDefined();
     expect(collections2).toBeInstanceOf(Array);
@@ -45,15 +45,15 @@ test('it should list collections', async () => {
     expect(collections).toBeDefined()
     expect(collections).toBeInstanceOf(Array)
     expect(collections.length).toBe(0)
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     collections = await chroma.listCollections()
     expect(collections.length).toBe(1)
 })
 
 test('it should get a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
-    const collection2 = await chroma.getCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
+    const collection2 = await chroma.getCollection({ name: "test" });
     expect(collection).toBeDefined()
     expect(collection2).toBeDefined()
     expect(collection).toHaveProperty('name')
@@ -66,50 +66,50 @@ test('it should get a collection', async () => {
 
 test('it should delete a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     let collections = await chroma.listCollections()
     expect(collections.length).toBe(1)
-    var resp = await chroma.deleteCollection('test')
+    var resp = await chroma.deleteCollection({ name: "test" });
     collections = await chroma.listCollections()
     expect(collections.length).toBe(0)
 })
 
 test('it should add single embeddings to a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
-    const id = 'test1'
-    const embedding = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    const metadata = { test: 'test' }
-    await collection.add(id, embedding, metadata)
+    const collection = await chroma.createCollection({ name: "test" });
+    const ids = 'test1'
+    const embeddings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const metadatas = { test: 'test' }
+    await collection.add({ ids, embeddings, metadatas })
     const count = await collection.count()
     expect(count).toBe(1)
 })
 
 test('it should add batch embeddings to a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2', 'test3']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
-    await collection.add(ids, embeddings)
+    await collection.add({ ids, embeddings })
     const count = await collection.count()
     expect(count).toBe(3)
 })
 
 test('it should query a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2', 'test3']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
-    await collection.add(ids, embeddings)
-    const results = await collection.query([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2)
+    await collection.add({ ids, embeddings })
+    const results = await collection.query({ query_embeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n_results: 2 })
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
     // expect(results.embeddings[0].length).toBe(2)
@@ -119,15 +119,15 @@ test('it should query a collection', async () => {
 
 test('it should peek a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2', 'test3']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
-    await collection.add(ids, embeddings)
-    const results = await collection.peek(2)
+    await collection.add({ ids, embeddings })
+    const results = await collection.peek({ limit: 2 })
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
     expect(results.ids.length).toBe(2)
@@ -136,7 +136,7 @@ test('it should peek a collection', async () => {
 
 test('it should get a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2', 'test3']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -144,15 +144,15 @@ test('it should get a collection', async () => {
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
     const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
-    await collection.add(ids, embeddings, metadatas)
-    const results = await collection.get(['test1'])
+    await collection.add({ ids, embeddings, metadatas })
+    const results = await collection.get({ ids: ['test1'] })
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
     expect(results.ids.length).toBe(1)
     expect(['test1']).toEqual(expect.arrayContaining(results.ids));
     expect(['test2']).not.toEqual(expect.arrayContaining(results.ids));
 
-    const results2 = await collection.get(undefined, { 'test': 'test1' })
+    const results2 = await collection.get({ where: { 'test': 'test1' } })
     expect(results2).toBeDefined()
     expect(results2).toBeInstanceOf(Object)
     expect(results2.ids.length).toBe(1)
@@ -160,7 +160,7 @@ test('it should get a collection', async () => {
 
 test('it should delete a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2', 'test3']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -168,17 +168,17 @@ test('it should delete a collection', async () => {
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
     const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
-    await collection.add(ids, embeddings, metadatas)
+    await collection.add({ ids, embeddings, metadatas })
     let count = await collection.count()
     expect(count).toBe(3)
-    var resp = await collection.delete(undefined, { 'test': 'test1' })
+    var resp = await collection.delete({ where: { 'test': 'test1' } })
     count = await collection.count()
     expect(count).toBe(2)
 })
 
 test('wrong code returns an error', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2', 'test3']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -186,8 +186,8 @@ test('wrong code returns an error', async () => {
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
     const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
-    await collection.add(ids, embeddings, metadatas)
-    const results = await collection.get(undefined, { "test": { "$contains": "hello" } });
+    await collection.add({ ids, embeddings, metadatas })
+    const results = await collection.get({ where: { "test": { "$contains": "hello" } } });
     expect(results.error).toBeDefined()
     expect(results.error).toBe("ValueError('Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got $contains')")
 })

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -187,6 +187,7 @@ test('wrong code returns an error', async () => {
     ]
     const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
     await collection.add({ ids, embeddings, metadatas })
+    // @ts-ignore - supposed to fail
     const results = await collection.get({ where: { "test": { "$contains": "hello" } } });
     expect(results.error).toBeDefined()
     expect(results.error).toBe("ValueError('Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got $contains')")

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -113,7 +113,8 @@ test('it should query a collection', async () => {
     expect(results).toBeDefined()
     expect(results).toBeInstanceOf(Object)
     // expect(results.embeddings[0].length).toBe(2)
-    expect(['test1', 'test2']).toEqual(expect.arrayContaining(results.ids[0]));
+    const result: string[]= ['test1', 'test2']
+    expect(result).toEqual(expect.arrayContaining(results.ids[0]));
     expect(['test3']).not.toEqual(expect.arrayContaining(results.ids[0]));
 })
 

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -10,13 +10,13 @@ test("it should list collections", async () => {
   expect(collections).toBeDefined();
   expect(collections).toBeInstanceOf(Array);
   expect(collections.length).toBe(0);
-  const collection = await chroma.createCollection("test");
+  const collection = await chroma.createCollection({ name: "test" });
   collections = await chroma.listCollections();
   expect(collections.length).toBe(1);
 });
 
 test("it should create a collection", async () => {
-  const collection = await chroma.createCollection("test");
+  const collection = await chroma.createCollection({ name: "test" });
   expect(collection).toBeDefined();
   expect(collection).toHaveProperty("name");
   expect(collection).toHaveProperty('id')
@@ -30,7 +30,7 @@ test("it should create a collection", async () => {
   );
 
   await chroma.reset();
-  const collection2 = await chroma.createCollection("test2", { test: "test" });
+  const collection2 = await chroma.createCollection({ name: "test2", metadata: { test: "test" } });
   expect(collection2).toBeDefined();
   expect(collection2).toHaveProperty("name");
   expect(collection2).toHaveProperty('id')
@@ -45,8 +45,8 @@ test("it should create a collection", async () => {
 });
 
 test("it should get a collection", async () => {
-  const collection = await chroma.createCollection("test");
-  const collection2 = await chroma.getCollection("test");
+  const collection = await chroma.createCollection({ name: "test" });
+  const collection2 = await chroma.getCollection({ name: "test" });
   expect(collection).toBeDefined();
   expect(collection2).toBeDefined();
   expect(collection).toHaveProperty("name");
@@ -69,10 +69,10 @@ test("it should get a collection", async () => {
 // });
 
 test("it should delete a collection", async () => {
-  const collection = await chroma.createCollection("test");
+  const collection = await chroma.createCollection({ name: "test" });
   let collections = await chroma.listCollections();
   expect(collections.length).toBe(1);
-  await chroma.deleteCollection("test");
+  await chroma.deleteCollection({ name: "test" });
   collections = await chroma.listCollections();
   expect(collections.length).toBe(0);
 });

--- a/clients/js/test/collection.test.ts
+++ b/clients/js/test/collection.test.ts
@@ -3,15 +3,15 @@ import chroma from "./initClient";
 
 test("it should modify collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
+  const collection = await chroma.createCollection({ name: "test" });
   expect(collection.name).toBe("test");
   expect(collection.metadata).toBeUndefined();
 
-  await collection.modify("test2");
+  await collection.modify({ name: "test2" });
   expect(collection.name).toBe("test2");
   expect(collection.metadata).toBeUndefined();
 
-  const collection2 = await chroma.getCollection("test2");
+  const collection2 = await chroma.getCollection({ name: "test2" });
   expect(collection2.name).toBe("test2");
   expect(collection2.metadata).toBeNull();
 
@@ -22,48 +22,48 @@ test("it should modify collection", async () => {
   const original_metadata = { test: "test" };
   const new_metadata = { test: "test2" };
 
-  const collection3 = await chroma.createCollection(
-    original_name,
-    original_metadata
-  );
+  const collection3 = await chroma.createCollection({
+    name: original_name,
+    metadata: original_metadata
+  });
   expect(collection3.name).toBe(original_name);
   expect(collection3.metadata).toEqual(original_metadata);
 
-  await collection3.modify(new_name);
+  await collection3.modify({ name: new_name });
   expect(collection3.name).toBe(new_name);
   expect(collection3.metadata).toEqual(original_metadata);
 
-  const collection4 = await chroma.getCollection(new_name);
+  const collection4 = await chroma.getCollection({ name: new_name });
   expect(collection4.name).toBe(new_name);
   expect(collection4.metadata).toEqual(original_metadata);
 
-  await collection3.modify(undefined, new_metadata);
+  await collection3.modify({ metadata: new_metadata });
   expect(collection3.name).toBe(new_name);
   expect(collection3.metadata).toEqual(new_metadata);
 
-  const collection5 = await chroma.getCollection(new_name);
+  const collection5 = await chroma.getCollection({ name: new_name });
   expect(collection5.name).toBe(new_name);
   expect(collection5.metadata).toEqual(new_metadata);
 });
 
 test("it should store metadata", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test", { test: "test" });
+  const collection = await chroma.createCollection({ name: "test", metadata: { test: "test" } });
   expect(collection.metadata).toEqual({ test: "test" });
 
   // get the collection
-  const collection2 = await chroma.getCollection("test");
+  const collection2 = await chroma.getCollection({ name: "test" });
   expect(collection2.metadata).toEqual({ test: "test" });
 
   // get or create the collection
-  const collection3 = await chroma.getOrCreateCollection("test");
+  const collection3 = await chroma.getOrCreateCollection({ name: "test" });
   expect(collection3.metadata).toEqual({ test: "test" });
 
   // modify
-  await collection3.modify(undefined, { test: "test2" });
+  await collection3.modify({ metadata: { test: "test2" } });
   expect(collection3.metadata).toEqual({ test: "test2" });
 
   // get it again
-  const collection4 = await chroma.getCollection("test");
+  const collection4 = await chroma.getCollection({ name: "test" });
   expect(collection4.metadata).toEqual({ test: "test2" });
 });

--- a/clients/js/test/delete.collection.test.ts
+++ b/clients/js/test/delete.collection.test.ts
@@ -4,11 +4,11 @@ import { EMBEDDINGS, IDS, METADATAS } from "./data";
 
 test("it should delete a collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, METADATAS);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS });
   let count = await collection.count();
   expect(count).toBe(3);
-  var resp = await collection.delete(undefined, { test: "test1" });
+  var resp = await collection.delete({ where: { test: "test1" } });
   count = await collection.count();
   expect(count).toBe(2);
 

--- a/clients/js/test/get.collection.test.ts
+++ b/clients/js/test/get.collection.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@jest/globals";
 import chroma from "./initClient";
-import { EMBEDDINGS, IDS, METADATAS } from "./data";
+import { DOCUMENTS, EMBEDDINGS, IDS, METADATAS } from "./data";
 
 test("it should get a collection", async () => {
   await chroma.reset();
@@ -32,6 +32,17 @@ test("wrong code returns an error", async () => {
   });
   expect(results.error).toBeDefined();
   expect(results.error).toContain("ValueError");
+});
+
+test("it should get embedding with matching documents", async () => {
+  await chroma.reset();
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS, documents: DOCUMENTS });
+  const results2 = await collection.get({ where_document: { $contains: "This is a test" } });
+  expect(results2).toBeDefined();
+  expect(results2).toBeInstanceOf(Object);
+  expect(results2.ids.length).toBe(1);
+  expect(["test1"]).toEqual(expect.arrayContaining(results2.ids));
 });
 
 test("test gt, lt, in a simple small way", async () => {

--- a/clients/js/test/get.collection.test.ts
+++ b/clients/js/test/get.collection.test.ts
@@ -4,16 +4,16 @@ import { EMBEDDINGS, IDS, METADATAS } from "./data";
 
 test("it should get a collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, METADATAS);
-  const results = await collection.get(["test1"]);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS });
+  const results = await collection.get({ ids: ["test1"] });
   expect(results).toBeDefined();
   expect(results).toBeInstanceOf(Object);
   expect(results.ids.length).toBe(1);
   expect(["test1"]).toEqual(expect.arrayContaining(results.ids));
   expect(["test2"]).not.toEqual(expect.arrayContaining(results.ids));
 
-  const results2 = await collection.get(undefined, { test: "test1" });
+  const results2 = await collection.get({ where: { test: "test1" } });
   expect(results2).toBeDefined();
   expect(results2).toBeInstanceOf(Object);
   expect(results2.ids.length).toBe(1);
@@ -22,10 +22,12 @@ test("it should get a collection", async () => {
 
 test("wrong code returns an error", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, METADATAS);
-  const results = await collection.get(undefined, {
-    test: { $contains: "hello" },
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS });
+  const results = await collection.get({
+    where: {
+      test: { $contains: "hello" },
+    }
   });
   expect(results.error).toBeDefined();
   expect(results.error).toContain("ValueError");
@@ -33,9 +35,9 @@ test("wrong code returns an error", async () => {
 
 test("test gt, lt, in a simple small way", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, METADATAS);
-  const items = await collection.get(undefined, { float_value: { $gt: -1.4 } });
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS });
+  const items = await collection.get({ where: { float_value: { $gt: -1.4 } } });
   expect(items.ids.length).toBe(2);
   expect(["test2", "test3"]).toEqual(expect.arrayContaining(items.ids));
 });

--- a/clients/js/test/get.collection.test.ts
+++ b/clients/js/test/get.collection.test.ts
@@ -26,6 +26,7 @@ test("wrong code returns an error", async () => {
   await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS });
   const results = await collection.get({
     where: {
+      //@ts-ignore supposed to fail
       test: { $contains: "hello" },
     }
   });

--- a/clients/js/test/initClient.ts
+++ b/clients/js/test/initClient.ts
@@ -2,6 +2,6 @@ import { ChromaClient } from "../src/index";
 
 const PORT = process.env.PORT || "8000";
 const URL = "http://localhost:" + PORT;
-const chroma = new ChromaClient(URL);
+const chroma = new ChromaClient({ path: URL });
 
 export default chroma;

--- a/clients/js/test/peek.collection.test.ts
+++ b/clients/js/test/peek.collection.test.ts
@@ -4,9 +4,9 @@ import { IDS, EMBEDDINGS } from "./data";
 
 test("it should peek a collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS);
-  const results = await collection.peek(2);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
+  const results = await collection.peek({ limit: 2 });
   expect(results).toBeDefined();
   expect(results).toBeInstanceOf(Object);
   expect(results.ids.length).toBe(2);

--- a/clients/js/test/query.collection.test.ts
+++ b/clients/js/test/query.collection.test.ts
@@ -44,6 +44,6 @@ test("it should get embedding with matching documents", async () => {
   });
 
   // expect(results2.embeddings[0][0]).toBeInstanceOf(Array);
-  expect(results2.embeddings[0].length).toBe(1);
-  expect(results2.embeddings[0][0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  expect(results2.embeddings![0].length).toBe(1);
+  expect(results2.embeddings![0][0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 });

--- a/clients/js/test/query.collection.test.ts
+++ b/clients/js/test/query.collection.test.ts
@@ -5,9 +5,9 @@ import { EMBEDDINGS, IDS, METADATAS, DOCUMENTS } from "./data";
 
 test("it should query a collection", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS);
-  const results = await collection.query([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
+  const results = await collection.query({ query_embeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], n_results: 2 });
   expect(results).toBeDefined();
   expect(results).toBeInstanceOf(Object);
   expect(["test1", "test2"]).toEqual(expect.arrayContaining(results.ids[0]));
@@ -17,16 +17,14 @@ test("it should query a collection", async () => {
 // test where_document
 test("it should get embedding with matching documents", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, METADATAS, DOCUMENTS);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS, documents: DOCUMENTS });
 
-  const results = await collection.query(
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    3,
-    undefined,
-    undefined,
-    { $contains: "This is a test" }
-  );
+  const results = await collection.query({
+    query_embeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    n_results: 3,
+    where_document: { $contains: "This is a test" }
+  });
 
   // it should only return doc1
   expect(results).toBeDefined();
@@ -38,14 +36,12 @@ test("it should get embedding with matching documents", async () => {
     expect.arrayContaining(results.documents[0])
   );
 
-  const results2 = await collection.query(
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    3,
-    undefined,
-    undefined,
-    { $contains: "This is a test" },
-    [IncludeEnum.Embeddings]
-  );
+  const results2 = await collection.query({
+    query_embeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    n_results: 3,
+    where_document: { $contains: "This is a test" },
+    include: [IncludeEnum.Embeddings]
+  });
 
   // expect(results2.embeddings[0][0]).toBeInstanceOf(Array);
   expect(results2.embeddings[0].length).toBe(1);

--- a/clients/js/test/update.collection.test.ts
+++ b/clients/js/test/update.collection.test.ts
@@ -18,7 +18,7 @@ test("it should get embedding with matching documents", async () => {
   });
   expect(results).toBeDefined();
   expect(results).toBeInstanceOf(Object);
-  expect(results.embeddings[0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  expect(results.embeddings![0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
   await collection.update({
     ids: ["test1"],
@@ -37,7 +37,7 @@ test("it should get embedding with matching documents", async () => {
   });
   expect(results2).toBeDefined();
   expect(results2).toBeInstanceOf(Object);
-  expect(results2.embeddings[0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 11]);
+  expect(results2.embeddings![0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 11]);
   expect(results2.metadatas[0]).toEqual({ test: "test1new" });
   expect(results2.documents[0]).toEqual("doc1new");
 });

--- a/clients/js/test/update.collection.test.ts
+++ b/clients/js/test/update.collection.test.ts
@@ -41,3 +41,27 @@ test("it should get embedding with matching documents", async () => {
   expect(results2.metadatas[0]).toEqual({ test: "test1new" });
   expect(results2.documents[0]).toEqual("doc1new");
 });
+
+// this currently fails
+// test("it should update metadata or documents to array of Nones", async () => {
+//   await chroma.reset();
+//   const collection = await chroma.createCollection({ name: "test" });
+//   await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS, documents: DOCUMENTS });
+
+//   await collection.update({
+//     ids: ["test1"],
+//     metadatas: [undefined],
+//   });
+
+//   const results3 = await collection.get({
+//     ids: ["test1"],
+//     include: [
+//       IncludeEnum.Embeddings,
+//       IncludeEnum.Metadatas,
+//       IncludeEnum.Documents,
+//     ]
+//   });
+//   expect(results3).toBeDefined();
+//   expect(results3).toBeInstanceOf(Object);
+//   expect(results3.metadatas[0]).toEqual({});
+// });

--- a/clients/js/test/update.collection.test.ts
+++ b/clients/js/test/update.collection.test.ts
@@ -5,42 +5,36 @@ import { IDS, DOCUMENTS, EMBEDDINGS, METADATAS } from "./data";
 
 test("it should get embedding with matching documents", async () => {
   await chroma.reset();
-  const collection = await chroma.createCollection("test");
-  await collection.add(IDS, EMBEDDINGS, METADATAS, DOCUMENTS);
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS, documents: DOCUMENTS });
 
-  const results = await collection.get(
-    ["test1"],
-    undefined,
-    undefined,
-    undefined,
-    [
+  const results = await collection.get({
+    ids: ["test1"],
+    include: [
       IncludeEnum.Embeddings,
       IncludeEnum.Metadatas,
       IncludeEnum.Documents,
     ]
-  );
+  });
   expect(results).toBeDefined();
   expect(results).toBeInstanceOf(Object);
   expect(results.embeddings[0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
-  await collection.update(
-    ["test1"],
-    [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
-    [{ test: "test1new" }],
-    ["doc1new"]
-  );
+  await collection.update({
+    ids: ["test1"],
+    embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
+    metadatas: [{ test: "test1new" }],
+    documents: ["doc1new"]
+  });
 
-  const results2 = await collection.get(
-    ["test1"],
-    undefined,
-    undefined,
-    undefined,
-    [
+  const results2 = await collection.get({
+    ids: ["test1"],
+    include: [
       IncludeEnum.Embeddings,
       IncludeEnum.Metadatas,
       IncludeEnum.Documents,
     ]
-  );
+  });
   expect(results2).toBeDefined();
   expect(results2).toBeInstanceOf(Object);
   expect(results2.embeddings[0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 11]);

--- a/clients/js/test/upsert.collections.test.ts
+++ b/clients/js/test/upsert.collections.test.ts
@@ -6,13 +6,13 @@ import { METADATAS } from './data';
 
 test('it should upsert embeddings to a collection', async () => {
     await chroma.reset()
-    const collection = await chroma.createCollection('test')
+    const collection = await chroma.createCollection({ name: "test" });
     const ids = ['test1', 'test2']
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ]
-    await collection.add(ids, embeddings)
+    await collection.add({ ids, embeddings })
     const count = await collection.count()
     expect(count).toBe(2)
 
@@ -22,7 +22,7 @@ test('it should upsert embeddings to a collection', async () => {
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     ]
 
-    await collection.upsert(ids2, embeddings2)
+    await collection.upsert({ ids: ids2, embeddings: embeddings2 })
 
     const count2 = await collection.count()
     expect(count2).toBe(3)

--- a/clients/js/tsconfig.json
+++ b/clients/js/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
@@ -7,12 +9,9 @@
     "outDir": "dist/main",
     "sourceMap": true,
     "target": "ES2017",
-
     "strict": true,
-
     "esModuleInterop": true,
     "moduleResolution": "Node",
-
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true
   }


### PR DESCRIPTION
In this PR
- docstrings! 
- types!
- named params! 

This is a breaking change to the JS Client - it switches from positional to named arguments originally brought up by @transitive-bullshit in https://github.com/chroma-core/chroma/issues/254

Example: 

```
// before
const collection = await chroma.createCollection("test");

//after
const collection = await chroma.createCollection({ name: "test" });
```

This is especially nice when you are only using a few params. 

This PR does not bump the `npm` version number - we will cut a new release on Monday. 

We will need to land an update to our docs at that time as well. TBD