### PR TITLE
Guard against missing collection in Collection hypothesis tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
     rev: 'v1.2.0'
     hooks:
     -   id: mypy
-        args: [--strict, --ignore-missing-imports, --follow-imports=skip]
+        args: [--strict, --ignore-missing-imports, --follow-imports=silent]
         additional_dependencies: ["types-requests"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ repos:
     rev: 'v1.2.0'
     hooks:
     -   id: mypy
-        args: [--strict, --ignore-missing-imports, --follow-imports=silent]
+        args: [--strict, --ignore-missing-imports, --follow-imports=skip]
         additional_dependencies: ["types-requests"]

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -1,3 +1,4 @@
+# type: ignore
 from chromadb.api.types import (
     Documents,
     Embeddings,
@@ -70,7 +71,7 @@ class Clickhouse(DB):
     def _get_conn(self) -> Client:
         if self._conn is None:
             self._init_conn()
-        return self._conn  # type: ignore because we know it's not None
+        return self._conn
 
     def _create_table_collections(self, conn):
         conn.command(

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -92,9 +92,10 @@ class CollectionStateMachine(RuleBasedStateMachine):  # type: ignore
         coll=st.one_of(consumes(collections), strategies.collections()),
     )  # type: ignore
     def get_or_create_coll(
-        self, coll: strategies.Collection
+        self,
+        coll: strategies.Collection,
+        new_metadata: Optional[types.Metadata],
     ) -> MultipleResults[strategies.Collection]:
-
         # In our current system, you can create with None but not update with None
         # An update with none is a no-op for the update of that field
         if coll.name not in self.existing:

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -2,6 +2,8 @@ import pytest
 import logging
 import hypothesis.strategies as st
 import chromadb.test.property.strategies as strategies
+from chromadb.api import API
+import chromadb.api.types as types
 from hypothesis.stateful import (
     Bundle,
     RuleBasedStateMachine,
@@ -10,25 +12,31 @@ from hypothesis.stateful import (
     multiple,
     consumes,
     run_state_machine_as_test,
+    MultipleResults,
 )
+from typing import Optional
 
 
-class CollectionStateMachine(RuleBasedStateMachine):
-    def __init__(self, api):
-        super().__init__()
-        self.existing = set()
-        self.model = {}
-        self.api = api
+class CollectionStateMachine(RuleBasedStateMachine):  # type: ignore
+    collections: Bundle
+    existing: set[str]
 
     collections = Bundle("collections")
 
-    @initialize()
-    def initialize(self):
+    def __init__(self, api: API):
+        super().__init__()
+        self.existing = set()
+        self.api = api
+
+    @initialize()  # type: ignore
+    def initialize(self) -> None:
         self.api.reset()
         self.existing = set()
 
-    @rule(target=collections, coll=strategies.collections())
-    def create_coll(self, coll):
+    @rule(target=collections, coll=strategies.collections())  # type: ignore
+    def create_coll(
+        self, coll: strategies.Collection
+    ) -> MultipleResults[strategies.Collection]:
         if coll.name in self.existing:
             with pytest.raises(Exception):
                 c = self.api.create_collection(
@@ -47,10 +55,10 @@ class CollectionStateMachine(RuleBasedStateMachine):
 
         assert c.name == coll.name
         assert c.metadata == coll.metadata
-        return coll
+        return multiple(coll)
 
-    @rule(coll=collections)
-    def get_coll(self, coll):
+    @rule(coll=collections)  # type: ignore
+    def get_coll(self, coll: strategies.Collection) -> None:
         if coll.name in self.existing:
             c = self.api.get_collection(name=coll.name)
             assert c.name == coll.name
@@ -59,8 +67,8 @@ class CollectionStateMachine(RuleBasedStateMachine):
             with pytest.raises(Exception):
                 self.api.get_collection(name=coll.name)
 
-    @rule(coll=consumes(collections))
-    def delete_coll(self, coll):
+    @rule(coll=consumes(collections))  # type: ignore
+    def delete_coll(self, coll: strategies.Collection) -> None:
         if coll.name in self.existing:
             self.api.delete_collection(name=coll.name)
             self.existing.remove(coll.name)
@@ -71,8 +79,8 @@ class CollectionStateMachine(RuleBasedStateMachine):
         with pytest.raises(Exception):
             self.api.get_collection(name=coll.name)
 
-    @rule()
-    def list_collections(self):
+    @rule()  # type: ignore
+    def list_collections(self) -> None:
         colls = self.api.list_collections()
         assert len(colls) == len(self.existing)
         for c in colls:
@@ -81,8 +89,10 @@ class CollectionStateMachine(RuleBasedStateMachine):
     @rule(
         target=collections,
         coll=st.one_of(consumes(collections), strategies.collections()),
-    )
-    def get_or_create_coll(self, coll):
+    )  # type: ignore
+    def get_or_create_coll(
+        self, coll: strategies.Collection
+    ) -> MultipleResults[strategies.Collection]:
         c = self.api.get_or_create_collection(
             name=coll.name,
             metadata=coll.metadata,
@@ -92,15 +102,25 @@ class CollectionStateMachine(RuleBasedStateMachine):
         if coll.metadata is not None:
             assert c.metadata == coll.metadata
         self.existing.add(coll.name)
-        return coll
+        return multiple(coll)
 
     @rule(
         target=collections,
         coll=consumes(collections),
         new_metadata=strategies.collection_metadata,
         new_name=st.one_of(st.none(), strategies.collection_name()),
-    )
-    def modify_coll(self, coll, new_metadata, new_name):
+    )  # type: ignore
+    def modify_coll(
+        self,
+        coll: strategies.Collection,
+        new_metadata: types.Metadata,
+        new_name: Optional[str],
+    ) -> MultipleResults[strategies.Collection]:
+        if coll.name not in self.existing:
+            with pytest.raises(Exception):
+                c = self.api.get_collection(name=coll.name)
+            return multiple()
+
         c = self.api.get_collection(name=coll.name)
 
         if new_metadata is not None:
@@ -116,9 +136,9 @@ class CollectionStateMachine(RuleBasedStateMachine):
 
         assert c.name == coll.name
         assert c.metadata == coll.metadata
-        return coll
+        return multiple(coll)
 
 
-def test_collections(caplog, api):
+def test_collections(caplog: pytest.LogCaptureFixture, api: API) -> None:
     caplog.set_level(logging.ERROR)
     run_state_machine_as_test(lambda: CollectionStateMachine(api))

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -14,12 +14,12 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
     MultipleResults,
 )
-from typing import Optional
+from typing import Optional, Set
 
 
 class CollectionStateMachine(RuleBasedStateMachine):  # type: ignore
     collections: Bundle
-    existing: set[str]
+    existing: Set[str]
 
     collections = Bundle("collections")
 


### PR DESCRIPTION
## Description of changes

Fix a error in the Hypothesis state machine that can cause a rare failure.

Also fixes types for `chromadb/test/property/test_collections.py`


The scenario this guards against is:

```python
   state = CollectionStateMachine(api)
   state.initialize()

   c1 = strategies.Collection(
       name="A00",
       metadata=None,
       dimension=2,
       dtype=np.float16,
       known_metadata_keys={},
       known_document_keywords=[],
       has_documents=False,
       has_embeddings=True,
       embedding_function=lambda x: [[0, 0]],
   )

   v1 = state.create_coll(coll=c1)

   c2 = strategies.Collection(
       name="A00",
       metadata=None,
       dimension=2,
       dtype=np.float16,
       known_metadata_keys={},
       known_document_keywords=[],
       has_documents=False,
       has_embeddings=True,
       embedding_function=lambda x: [[0, 0]],
   )

   v2 = state.get_or_create_coll(c2)
   state.delete_coll(coll=v2)
   state.modify_coll(coll=v1, new_metadata=None, new_name=None)
   state.teardown()
```

The root cause is that there are two copies of `A00` in the bundle, but only one "really" exists. The fix is to guard based on what we know exists via the `existing` set and expect an exception instead.

## Test plan

This is the test.

## Documentation Changes

N/A
