### PR TITLE
Prevent duplicate collection names

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -212,6 +212,10 @@ class Clickhouse(DB):
         new_metadata: Optional[Dict] = None,
     ):
         if new_name is not None:
+            dupe_check = self.get_collection(new_name)
+            if len(dupe_check) > 0:
+                raise ValueError(f"Collection with name {new_name} already exists")
+
             self._get_conn().command(
                 "ALTER TABLE collections UPDATE name = %(new_name)s WHERE uuid = %(uuid)s",
                 parameters={"new_name": new_name, "uuid": id},

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -213,7 +213,7 @@ class Clickhouse(DB):
     ):
         if new_name is not None:
             dupe_check = self.get_collection(new_name)
-            if len(dupe_check) > 0:
+            if len(dupe_check) > 0 and dupe_check[0][0] != id:
                 raise ValueError(f"Collection with name {new_name} already exists")
 
             self._get_conn().command(

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -1,3 +1,4 @@
+# type: ignore
 from chromadb.api.types import Documents, Embeddings, IDs, Metadatas
 from chromadb.db.clickhouse import (
     Clickhouse,
@@ -132,6 +133,10 @@ class DuckDB(Clickhouse):
         self, id: uuid.UUID, new_name: str, new_metadata: Optional[Dict] = None
     ):
         if new_name is not None:
+            dupe_check = self.get_collection(new_name)
+            if len(dupe_check) > 0:
+                raise ValueError(f"Collection with name {new_name} already exists")
+
             self._conn.execute(
                 """UPDATE collections SET name = ? WHERE uuid = ?""",
                 [new_name, id],

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -134,7 +134,7 @@ class DuckDB(Clickhouse):
     ):
         if new_name is not None:
             dupe_check = self.get_collection(new_name)
-            if len(dupe_check) > 0:
+            if len(dupe_check) > 0 and dupe_check[0][0] != id:
                 raise ValueError(f"Collection with name {new_name} already exists")
 
             self._conn.execute(

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -134,7 +134,7 @@ class DuckDB(Clickhouse):
     ):
         if new_name is not None:
             dupe_check = self.get_collection(new_name)
-            if len(dupe_check) > 0 and dupe_check[0][0] != id:
+            if len(dupe_check) > 0 and dupe_check[0][0] != str(id):
                 raise ValueError(f"Collection with name {new_name} already exists")
 
             self._conn.execute(

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -106,7 +106,7 @@ class CollectionStateMachine(RuleBasedStateMachine):  # type: ignore
         c = self.api.get_or_create_collection(
             name=coll.name,
             metadata=new_metadata,
-            embedding_function=coll.embedding_function,
+            embedding_function=coll.embedding_function,  # type: ignore
         )
         assert c.name == coll.name
         assert c.metadata == coll.metadata
@@ -136,6 +136,11 @@ class CollectionStateMachine(RuleBasedStateMachine):  # type: ignore
             coll.metadata = new_metadata
 
         if new_name is not None:
+            if new_name in self.existing:
+                with pytest.raises(Exception):
+                    c.modify(metadata=new_metadata, name=new_name)
+                return multiple()
+
             self.existing.remove(coll.name)
             self.existing.add(new_name)
             coll.name = new_name

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -136,7 +136,7 @@ class CollectionStateMachine(RuleBasedStateMachine):  # type: ignore
             coll.metadata = new_metadata
 
         if new_name is not None:
-            if new_name in self.existing:
+            if new_name in self.existing and new_name != coll.name:
                 with pytest.raises(Exception):
                     c.modify(metadata=new_metadata, name=new_name)
                 return multiple()

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1,3 +1,4 @@
+# type: ignore
 import chromadb
 from chromadb.api.types import QueryResult
 from chromadb.config import Settings
@@ -284,6 +285,16 @@ def test_modify(api):
 
     # collection name is modify
     assert collection.name == "testspace2"
+
+
+def test_modify_error_on_existing_name(api):
+    api.reset()
+
+    api.create_collection("testspace")
+    c2 = api.create_collection("testspace2")
+
+    with pytest.raises(Exception):
+        c2.modify(name="testspace")
 
 
 def test_metadata_cru(api):


### PR DESCRIPTION
## Description of changes

Previously, it was possible to create two collections with the same name using `Collection.modify` to modify a collection to have the same name as an existing one.

## Test plan

Hypothesis tests updated to expect this case.

## Documentation Changes

N/A