### PR TITLE
docker-compose data persistence fix and docker compose up without build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ results = collection.query(
 - __Free & Open Source__: Apache 2.0 Licensed
 
 ## Chroma DB Server Deployment with Persistance Storage
-This method doesnt need cloning the entire codebase and rebuilding process. Docker container used in this process are using docker volumes to store data. As long as volumes are not retained restarting the containers will persist data in chromadb.
+This method doesnt need cloning of the entire codebase and rebuilding process. 
+Docker container used in this process are using docker volumes to store data. As long as volumes are retained during the restarting containers the data will persist in the chromadb.
 1. Download docker-compose.server.example.yml file from the root and rename it to docker-compose.yml
 2. Install docker on your local machine. [`Docker Engine`](https://docs.docker.com/engine/install/) or [`Docker Desktop`](https://docs.docker.com/desktop/install/)
 3. Install docker compose [`Docker Compose`](https://docs.docker.com/compose/install/)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@
 ```bash
 pip install chromadb # python client
 # for javascript, npm install chromadb!
-# for client-server mode, docker-compose up -d --build
 ```
 
 The core API is only 4 functions (run our [💡 Google Colab](https://colab.research.google.com/drive/1QEzFyqnoFxq7LUGyP1vzR4iLt9PpCDXv?usp=sharing) or [Replit template](https://replit.com/@swyx/BasicChromaStarter?v=1)):
@@ -70,6 +69,34 @@ results = collection.query(
 - __Dev, Test, Prod__: the same API that runs in your python notebook, scales to your cluster
 - __Feature-rich__: Queries, filtering, density estimation and more
 - __Free & Open Source__: Apache 2.0 Licensed
+
+## Chroma DB Server Deployment with Persistance Storage
+This method doesnt need cloning the entire codebase and rebuilding process. Docker container used in this process are using docker volumes to store data. As long as volumes are not retained restarting the containers will persist data in chromadb.
+1. Download docker-compose.server.example.yml file from the root and rename it to docker-compose.yml
+2. Install docker on your local machine. [`Docker Engine`](https://docs.docker.com/engine/install/) or [`Docker Desktop`](https://docs.docker.com/desktop/install/)
+3. Install docker compose [`Docker Compose`](https://docs.docker.com/compose/install/)
+4. run following commands from the directory where earlier downloaded docker compose file is saved.
+
+- __Command to Start Containers__
+``` bash
+docker compose up -d
+or 
+docker-compose up -d
+```
+
+- __Command to Stop Containers__
+``` bash
+docker compose down
+or 
+docker-compose down
+```
+- __Command to Stop Containers and delete volumes__
+This is distructive command. With this command volumes created earlier will be deleted along with data stored.
+``` bash
+docker compose down -v
+or 
+docker-compose down -v
+```
 
 ## Use case: ChatGPT for ______
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 ```bash
 pip install chromadb # python client
 # for javascript, npm install chromadb!
+# for client-server mode, docker-compose up -d --build
 ```
 
 The core API is only 4 functions (run our [💡 Google Colab](https://colab.research.google.com/drive/1QEzFyqnoFxq7LUGyP1vzR4iLt9PpCDXv?usp=sharing) or [Replit template](https://replit.com/@swyx/BasicChromaStarter?v=1)):
@@ -69,35 +70,6 @@ results = collection.query(
 - __Dev, Test, Prod__: the same API that runs in your python notebook, scales to your cluster
 - __Feature-rich__: Queries, filtering, density estimation and more
 - __Free & Open Source__: Apache 2.0 Licensed
-
-## Chroma DB Server Deployment with Persistance Storage
-This method doesnt need cloning of the entire codebase and rebuilding process. 
-Docker container used in this process are using docker volumes to store data. As long as volumes are retained during the restarting containers the data will persist in the chromadb.
-1. Download docker-compose.server.example.yml file from the root and rename it to docker-compose.yml
-2. Install docker on your local machine. [`Docker Engine`](https://docs.docker.com/engine/install/) or [`Docker Desktop`](https://docs.docker.com/desktop/install/)
-3. Install docker compose [`Docker Compose`](https://docs.docker.com/compose/install/)
-4. run following commands from the directory where earlier downloaded docker compose file is saved.
-
-- __Command to Start Containers__
-``` bash
-docker compose up -d
-or 
-docker-compose up -d
-```
-
-- __Command to Stop Containers__
-``` bash
-docker compose down
-or 
-docker-compose down
-```
-- __Command to Stop Containers and delete volumes__
-This is distructive command. With this command volumes created earlier will be deleted along with data stored.
-``` bash
-docker compose down -v
-or 
-docker-compose down -v
-```
 
 ## Use case: ChatGPT for ______
 

--- a/docker-compose.server.example.yml
+++ b/docker-compose.server.example.yml
@@ -1,0 +1,46 @@
+version: '3.9'
+
+networks:
+  net:
+    driver: bridge
+services:
+  server:
+    image: ghcr.io/chroma-core/chroma:latest
+    volumes:
+      - index_data:/chroma/.chroma/index
+    environment:
+      - CHROMA_DB_IMPL=clickhouse
+      - CLICKHOUSE_HOST=clickhouse
+      - CLICKHOUSE_PORT=8123
+    ports:
+      - 8000:8000
+    depends_on:
+      - clickhouse
+    networks:
+      - net
+  clickhouse:
+    image: clickhouse/clickhouse-server:22.9-alpine
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - CLICKHOUSE_TCP_PORT=9000
+      - CLICKHOUSE_HTTP_PORT=8123
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - clickhouse_logs:/var/log/clickhouse-server
+      - backups:/backups
+      - ./clickhouse/config/backup_disk.xml:/etc/clickhouse-server/config.d/backup_disk.xml
+      - ./clickhouse/config/chroma_users.xml:/etc/clickhouse-server/users.d/chroma.xml
+    networks:
+      - net
+volumes:
+  clickhouse_data:
+    driver: local
+  clickhouse_logs:
+    driver: local
+  index_data:
+    driver: local
+  backups:
+    driver: local

--- a/docker-compose.server.example.yml
+++ b/docker-compose.server.example.yml
@@ -31,8 +31,8 @@ services:
       - clickhouse_data:/var/lib/clickhouse
       - clickhouse_logs:/var/log/clickhouse-server
       - backups:/backups
-      - ./clickhouse/config/backup_disk.xml:/etc/clickhouse-server/config.d/backup_disk.xml
-      - ./clickhouse/config/chroma_users.xml:/etc/clickhouse-server/users.d/chroma.xml
+      - ./config/backup_disk.xml:/etc/clickhouse-server/config.d/backup_disk.xml
+      - ./config/chroma_users.xml:/etc/clickhouse-server/users.d/chroma.xml
     networks:
       - net
 volumes:


### PR DESCRIPTION

## Description of changes
Update docker-compose.yml to fix the persistence volume issue and run the docker-compose up -d command without building a local image.

1. index_data mount fixed - It was mounted to the root of the server container, but it should be mounted to /chroma/.chroma/index location, that's where indexes are generated.
2. clickhouse mount fixed - Added mount location where actual database is stored.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 [- (https://github.com/chroma-core/chroma/issues/527) ] 
        1. docker compose up -d
        2. create collection
        3. add documents
        4. query documents
        5. docker compose down
        6. docker compose up -d
        7. query documents - Output will be httpError, data is lost when step 5 was performed

 - New functionality
	 - Users can directly run the following command, no need to clone repo and build local image

            > 	docker-compose up -d


## Test plan
*How are these changes tested?*
1. docker-compose up -d
2. create collection
3. add documents
4. query documents
5. docker compose down
6. docker compose up -d
7. query documents
8. compare result of 4 & 7 - changes does match and preserve data.

## Added NOTE:
This PR may conflict with the following PR. I think the docker-compose command should be usable without a manual build process locally, hence creating this PR.

https://github.com/chroma-core/chroma/pull/456


## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

Yes, main readme
