### PR TITLE
Fix query bug

### DIFF
--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -2,7 +2,6 @@ from pydantic import BaseModel
 from typing import Any, Dict, List, Optional
 from chromadb.api.types import (
     CollectionMetadata,
-    IDs,
     Include,
 )
 
@@ -14,7 +13,7 @@ class AddEmbedding(BaseModel):  # type: ignore
     embeddings: Optional[List[Any]] = None
     metadatas: Optional[List[Dict[Any, Any]]] = None
     documents: Optional[List[str]] = None
-    ids: IDs
+    ids: List[str]
     increment_index: bool = True
 
 
@@ -22,7 +21,7 @@ class UpdateEmbedding(BaseModel):  # type: ignore
     embeddings: Optional[List[Any]] = None
     metadatas: Optional[List[Dict[Any, Any]]] = None
     documents: Optional[List[str]] = None
-    ids: IDs
+    ids: List[str]
     increment_index: bool = True
 
 
@@ -30,15 +29,15 @@ class QueryEmbedding(BaseModel):  # type: ignore
     # TODO: Pydantic doesn't bode well with recursive types so we use generic Dicts
     # for Where and WhereDocument. This is not ideal, but it works for now since
     # there is a lot of downstream validation.
-    where: Optional[Dict[Any, Any]] = None
-    where_document: Optional[Dict[Any, Any]] = None
+    where: Optional[Dict[Any, Any]] = {}
+    where_document: Optional[Dict[Any, Any]] = {}
     query_embeddings: List[Any]
     n_results: int = 10
     include: Include = ["metadatas", "documents", "distances"]
 
 
 class GetEmbedding(BaseModel):  # type: ignore
-    ids: Optional[IDs] = None
+    ids: Optional[List[str]] = None
     where: Optional[Dict[Any, Any]] = None
     where_document: Optional[Dict[Any, Any]] = None
     sort: Optional[str] = None
@@ -52,7 +51,7 @@ class RawSql(BaseModel):  # type: ignore
 
 
 class DeleteEmbedding(BaseModel):  # type: ignore
-    ids: Optional[IDs] = None
+    ids: Optional[List[str]] = None
     where: Optional[Dict[Any, Any]] = None
     where_document: Optional[Dict[Any, Any]] = None
 


### PR DESCRIPTION
## Description of changes

#524 Introduced a bug in the js client which depends on the default value of the empty dict {} for where and where document. It got merged because not all of our test matrix was marked as required. That is now fixed. Since that PR is supposed to just be type changes, we revert back to that default for now instead of fixing the upstream client.

## Test plan
Existing tests.

## Documentation Changes
None
