### PR TITLE
Add bookkeep on delete

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -60,7 +60,7 @@ class IndexMetadata(TypedDict):
     # The auto-incrementing ID of the last inserted element, never decreases so
     # can be used as a count of total historical size. Should increase by 1 every add.
     # Assume cannot overflow
-    curr_id: int
+    total_elements_added: int
     time_created: float
 
 

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -55,8 +55,12 @@ class QueryResult(TypedDict):
 
 class IndexMetadata(TypedDict):
     dimensionality: int
-    elements: int  # The capacity of the index, never shrinks since that works poorly with hnswlib
-    curr_elements: int  # The current number of elements in the index
+    # The current number of elements in the index (total = additions - deletes)
+    curr_elements: int
+    # The auto-incrementing ID of the last inserted element, never decreases so
+    # can be used as a count of total historical size. Should increase by 1 every add.
+    # Assume cannot overflow
+    curr_id: int
     time_created: float
 
 

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -55,7 +55,8 @@ class QueryResult(TypedDict):
 
 class IndexMetadata(TypedDict):
     dimensionality: int
-    elements: int
+    elements: int  # The capacity of the index, never shrinks since that works poorly with hnswlib
+    curr_elements: int  # The current number of elements in the index
     time_created: float
 
 
@@ -243,5 +244,7 @@ def validate_embeddings(embeddings: Embeddings) -> Embeddings:
     for embedding in embeddings:
         for value in embedding:
             if not isinstance(value, (int, float)):
-                raise ValueError(f"Expected embeddings to be a int, float, got {embeddings}")
+                raise ValueError(
+                    f"Expected embeddings to be a int, float, got {embeddings}"
+                )
     return embeddings

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -95,7 +95,12 @@ class Clickhouse(DB):
         if collection_id not in self.index_cache:
             coll = self.get_collection_by_id(collection_id)
             collection_metadata = coll[2]
-            index = Hnswlib(collection_id, self._settings, collection_metadata)
+            index = Hnswlib(
+                collection_id,
+                self._settings,
+                collection_metadata,
+                self.count(collection_id),
+            )
             self.index_cache[collection_id] = index
 
         return self.index_cache[collection_id]

--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -184,6 +184,7 @@ class Hnswlib(Index):
                 self._index.mark_deleted(label)
                 del self._label_to_id[label]
                 del self._id_to_label[hexid(id)]
+                self._index_metadata["elements"] -= 1
 
         self._save()
 

--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -112,8 +112,8 @@ class Hnswlib(Index):
         self._index = index
         self._index_metadata = {
             "dimensionality": dimensionality,
-            "elements": 0,
             "curr_elements": 0,
+            "curr_id": 0,
             "time_created": time.time(),
         }
         self._save()
@@ -150,22 +150,21 @@ class Hnswlib(Index):
                 else:
                     raise ValueError(f"ID {id} already exists in index")
             else:
-                self._index_metadata["elements"] += 1
+                self._index_metadata["curr_id"] += 1
                 self._index_metadata["curr_elements"] += 1
-                next_label = self._index_metadata["elements"]
+                next_label = self._index_metadata["curr_id"]
                 self._id_to_label[hexid(id)] = next_label
                 self._label_to_id[next_label] = id
                 labels.append(next_label)
 
-        if self._index_metadata["elements"] > self._index.get_max_elements():
+        if self._index_metadata["curr_id"] > self._index.get_max_elements():
             new_size = int(
                 max(
-                    self._index_metadata["elements"] * self._params.resize_factor,
+                    self._index_metadata["curr_id"] * self._params.resize_factor,
                     DEFAULT_CAPACITY,
                 )
             )
             self._index.resize_index(new_size)
-            self._index_metadata["elements"] = new_size
 
         self._index.add_items(embeddings, labels)
         self._save()
@@ -231,9 +230,11 @@ class Hnswlib(Index):
         with open(f"{self._save_folder}/index_metadata_{self._id}.pkl", "rb") as f:
             self._index_metadata = pickle.load(f)
 
-        # Backwards compatability with versions that don't have curr_elements
+        # Backwards compatability with versions that don't have curr_elements or curr_id
         if "curr_elements" not in self._index_metadata:
             self._index_metadata["curr_elements"] = self._index_metadata["elements"]
+        if "curr_id" not in self._index_metadata:
+            self._index_metadata["curr_id"] = self._index_metadata["elements"]
 
         p = hnswlib.Index(
             space=self._params.space, dim=self._index_metadata["dimensionality"]
@@ -241,7 +242,10 @@ class Hnswlib(Index):
         self._index = p
         self._index.load_index(
             f"{self._save_folder}/index_{self._id}.bin",
-            max_elements=self._index_metadata["elements"],
+            max_elements=max(
+                int(self._index_metadata["curr_id"] * self._params.resize_factor),
+                DEFAULT_CAPACITY,
+            ),
         )
         self._index.set_ef(self._params.search_ef)
         self._index.set_num_threads(self._params.num_threads)
@@ -259,7 +263,7 @@ class Hnswlib(Index):
 
         if k > self._index_metadata["curr_elements"]:
             raise NotEnoughElementsException(
-                f"Number of requested results {k} cannot be greater than number of elements in index {self._index_metadata['elements']}"
+                f"Number of requested results {k} cannot be greater than number of elements in index {self._index_metadata['curr_elements']}"
             )
 
         s2 = time.time()

--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -89,7 +89,7 @@ class Hnswlib(Index):
         id: str,
         settings: Settings,
         metadata: Dict[str, str],
-        number_elements: int = DEFAULT_CAPACITY,
+        number_elements: int,
     ):
         self._save_folder = settings.persist_directory + "/index"
         self._params = HnswParams(metadata)
@@ -253,7 +253,9 @@ class Hnswlib(Index):
         self._index = p
         self._index.load_index(
             f"{self._save_folder}/index_{self._id}.bin",
-            max_elements=int(curr_elements * self._params.resize_factor),
+            max_elements=int(
+                max(curr_elements * self._params.resize_factor, DEFAULT_CAPACITY)
+            ),
         )
         self._index.set_ef(self._params.search_ef)
         self._index.set_num_threads(self._params.num_threads)

--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -231,6 +231,10 @@ class Hnswlib(Index):
         with open(f"{self._save_folder}/index_metadata_{self._id}.pkl", "rb") as f:
             self._index_metadata = pickle.load(f)
 
+        # Backwards compatability with versions that don't have curr_elements
+        if "curr_elements" not in self._index_metadata:
+            self._index_metadata["curr_elements"] = self._index_metadata["elements"]
+
         p = hnswlib.Index(
             space=self._params.space, dim=self._index_metadata["dimensionality"]
         )

--- a/chromadb/test/hnswlib/test_hnswlib.py
+++ b/chromadb/test/hnswlib/test_hnswlib.py
@@ -1,0 +1,23 @@
+from chromadb.db.index.hnswlib import Hnswlib
+from chromadb.config import Settings
+import uuid
+import numpy as np
+
+
+def test_count_tracking() -> None:
+    hnswlib = Hnswlib("test", Settings(), {})
+    hnswlib._init_index(2)
+    assert hnswlib._index_metadata["elements"] == 0
+    idA, idB = uuid.uuid4(), uuid.uuid4()
+
+    embeddingA = np.random.rand(1, 2)
+    hnswlib.add([idA], embeddingA.tolist())
+    assert hnswlib._index_metadata["elements"] == 1
+
+    embeddingB = np.random.rand(1, 2)
+    hnswlib.add([idB], embeddingB.tolist())
+    assert hnswlib._index_metadata["elements"] == 2
+    hnswlib.delete_from_index(ids=[idA])
+    assert hnswlib._index_metadata["elements"] == 1
+    hnswlib.delete_from_index(ids=[idB])
+    assert hnswlib._index_metadata["elements"] == 0

--- a/chromadb/test/hnswlib/test_hnswlib.py
+++ b/chromadb/test/hnswlib/test_hnswlib.py
@@ -14,6 +14,7 @@ import numpy as np
 def settings() -> Generator[Settings, None, None]:
     save_path = tempfile.gettempdir() + "/tests/hnswlib/"
     yield Settings(persist_directory=save_path)
+    print("after yield")
     if os.path.exists(save_path):
         shutil.rmtree(save_path)
 
@@ -22,16 +23,46 @@ def test_count_tracking(settings: Settings) -> None:
     hnswlib = Hnswlib("test", settings, {})
     hnswlib._init_index(2)
     assert hnswlib._index_metadata["curr_elements"] == 0
+    assert hnswlib._index_metadata["total_elements_added"] == 0
     idA, idB = uuid.uuid4(), uuid.uuid4()
 
     embeddingA = np.random.rand(1, 2)
     hnswlib.add([idA], embeddingA.tolist())
-    assert hnswlib._index_metadata["curr_elements"] == 1
-
+    assert (
+        hnswlib._index_metadata["curr_elements"]
+        == hnswlib._index_metadata["total_elements_added"]
+        == 1
+    )
     embeddingB = np.random.rand(1, 2)
     hnswlib.add([idB], embeddingB.tolist())
-    assert hnswlib._index_metadata["curr_elements"] == 2
+    assert (
+        hnswlib._index_metadata["curr_elements"]
+        == hnswlib._index_metadata["total_elements_added"]
+        == 2
+    )
     hnswlib.delete_from_index(ids=[idA])
     assert hnswlib._index_metadata["curr_elements"] == 1
+    assert hnswlib._index_metadata["total_elements_added"] == 2
     hnswlib.delete_from_index(ids=[idB])
     assert hnswlib._index_metadata["curr_elements"] == 0
+    assert hnswlib._index_metadata["total_elements_added"] == 2
+
+
+def test_add_delete_large_amount(settings: Settings) -> None:
+    # Test adding a large number of records
+    N = 2000
+    D = 512
+    large_records = np.random.rand(N, D).astype(np.float32).tolist()
+    ids = [uuid.uuid4() for _ in range(N)]
+    hnswlib = Hnswlib("test", settings, {})
+    hnswlib._init_index(D)
+    hnswlib.add(ids, large_records)
+    assert hnswlib._index_metadata["curr_elements"] == N
+    assert hnswlib._index_metadata["total_elements_added"] == N
+
+    # Test deleting a large number of records by getting a random subset of the ids
+    ids_to_delete = np.random.choice(np.array(ids), size=100, replace=False).tolist()
+    hnswlib.delete_from_index(ids_to_delete)
+
+    assert hnswlib._index_metadata["curr_elements"] == N - 100
+    assert hnswlib._index_metadata["total_elements_added"] == N

--- a/chromadb/test/hnswlib/test_hnswlib.py
+++ b/chromadb/test/hnswlib/test_hnswlib.py
@@ -20,7 +20,7 @@ def settings() -> Generator[Settings, None, None]:
 
 
 def test_count_tracking(settings: Settings) -> None:
-    hnswlib = Hnswlib("test", settings, {})
+    hnswlib = Hnswlib("test", settings, {}, 2)
     hnswlib._init_index(2)
     assert hnswlib._index_metadata["curr_elements"] == 0
     assert hnswlib._index_metadata["total_elements_added"] == 0
@@ -54,7 +54,7 @@ def test_add_delete_large_amount(settings: Settings) -> None:
     D = 512
     large_records = np.random.rand(N, D).astype(np.float32).tolist()
     ids = [uuid.uuid4() for _ in range(N)]
-    hnswlib = Hnswlib("test", settings, {})
+    hnswlib = Hnswlib("test", settings, {}, N)
     hnswlib._init_index(D)
     hnswlib.add(ids, large_records)
     assert hnswlib._index_metadata["curr_elements"] == N

--- a/chromadb/test/hnswlib/test_hnswlib.py
+++ b/chromadb/test/hnswlib/test_hnswlib.py
@@ -10,11 +10,10 @@ import uuid
 import numpy as np
 
 
-@pytest.fixture(scope="module")  # type: ignore
+@pytest.fixture(scope="module")
 def settings() -> Generator[Settings, None, None]:
     save_path = tempfile.gettempdir() + "/tests/hnswlib/"
     yield Settings(persist_directory=save_path)
-    print("after yield")
     if os.path.exists(save_path):
         shutil.rmtree(save_path)
 

--- a/chromadb/test/hnswlib/test_hnswlib.py
+++ b/chromadb/test/hnswlib/test_hnswlib.py
@@ -21,17 +21,17 @@ def settings() -> Generator[Settings, None, None]:
 def test_count_tracking(settings: Settings) -> None:
     hnswlib = Hnswlib("test", settings, {})
     hnswlib._init_index(2)
-    assert hnswlib._index_metadata["elements"] == 0
+    assert hnswlib._index_metadata["curr_elements"] == 0
     idA, idB = uuid.uuid4(), uuid.uuid4()
 
     embeddingA = np.random.rand(1, 2)
     hnswlib.add([idA], embeddingA.tolist())
-    assert hnswlib._index_metadata["elements"] == 1
+    assert hnswlib._index_metadata["curr_elements"] == 1
 
     embeddingB = np.random.rand(1, 2)
     hnswlib.add([idB], embeddingB.tolist())
-    assert hnswlib._index_metadata["elements"] == 2
+    assert hnswlib._index_metadata["curr_elements"] == 2
     hnswlib.delete_from_index(ids=[idA])
-    assert hnswlib._index_metadata["elements"] == 1
+    assert hnswlib._index_metadata["curr_elements"] == 1
     hnswlib.delete_from_index(ids=[idB])
-    assert hnswlib._index_metadata["elements"] == 0
+    assert hnswlib._index_metadata["curr_elements"] == 0

--- a/chromadb/test/hnswlib/test_hnswlib.py
+++ b/chromadb/test/hnswlib/test_hnswlib.py
@@ -1,11 +1,25 @@
+import os
+import shutil
+import tempfile
+from typing import Generator
+
+import pytest
 from chromadb.db.index.hnswlib import Hnswlib
 from chromadb.config import Settings
 import uuid
 import numpy as np
 
 
-def test_count_tracking() -> None:
-    hnswlib = Hnswlib("test", Settings(), {})
+@pytest.fixture(scope="module")  # type: ignore
+def settings() -> Generator[Settings, None, None]:
+    save_path = tempfile.gettempdir() + "/tests/hnswlib/"
+    yield Settings(persist_directory=save_path)
+    if os.path.exists(save_path):
+        shutil.rmtree(save_path)
+
+
+def test_count_tracking(settings: Settings) -> None:
+    hnswlib = Hnswlib("test", settings, {})
     hnswlib._init_index(2)
     assert hnswlib._index_metadata["elements"] == 0
     idA, idB = uuid.uuid4(), uuid.uuid4()


### PR DESCRIPTION
## Description of changes
@jeffchuber observed in #360 that hnswlib does not correctly bookkeep deletes. This PR adds the bookkeeping so that the index tracks its element count correctly.

## Test plan
We adds a simple unit test that reaches into the object to check its state keeping.

## Documentation Changes
None
