### PR TITLE
Python docstings and types for docs

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -315,7 +315,7 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def create_index(self, collection_name: Optional[str] = None) -> bool:
+    def create_index(self, collection_name: str) -> bool:
         """Creates an index for the given collection
         ⚠️ This method should not be used directly.
 

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Optional
+from typing import Sequence, Optional
 import pandas as pd
 from uuid import UUID
 from chromadb.api.models.Collection import Collection
@@ -56,17 +56,17 @@ class API(ABC):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        get_or_create: bool = False,
         embedding_function: Optional[EmbeddingFunction] = None,
+        get_or_create: bool = False,
     ) -> Collection:
         """Creates a new collection in the database
 
         Args:
             name  The name of the collection to create. The name must be unique.
             metadata: A dictionary of metadata to associate with the collection. Defaults to None.
+            embedding_function: A function that takes documents and returns an embedding. Defaults to None.
             get_or_create: If True, will return the collection if it already exists,
                 and update the metadata (if applicable). Defaults to False.
-            embedding_function: A function that takes documents and returns an embedding. Defaults to None.
 
         Returns:
             dict: the created collection
@@ -108,7 +108,7 @@ class API(ABC):
     @abstractmethod
     def get_collection(
         self,
-        name: Optional[str] = None,
+        name: str,
         embedding_function: Optional[EmbeddingFunction] = None,
     ) -> Collection:
         """Gets a collection from the database by either name or uuid
@@ -143,11 +143,11 @@ class API(ABC):
         self,
         ids: IDs,
         collection_id: UUID,
-        embeddings: Optional[Embeddings],
+        embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
         increment_index: bool = True,
-    ) -> None:
+    ) -> bool:
         """Add embeddings to the data store. This is the most general way to add embeddings to the database.
         ⚠️ It is recommended to use the more specific methods below when possible.
 
@@ -168,7 +168,7 @@ class API(ABC):
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-    ) -> None:
+    ) -> bool:
         """Add embeddings to the data store. This is the most general way to add embeddings to the database.
         ⚠️ It is recommended to use the more specific methods below when possible.
 
@@ -183,11 +183,11 @@ class API(ABC):
         self,
         collection_id: UUID,
         ids: IDs,
-        embeddings: Optional[Embeddings] = None,
+        embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
         increment_index: bool = True,
-    ) -> None:
+    ) -> bool:
         """Add or update entries in the embedding store.
         If an entry with the same id already exists, it will be updated, otherwise it will be added.
 
@@ -257,7 +257,7 @@ class API(ABC):
         ids: Optional[IDs],
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> List[UUID]:
+    ) -> IDs:
         """Deletes embeddings from the database
         ⚠️ This method should not be used directly.
 
@@ -315,21 +315,7 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def create_index(self, collection_name: Optional[str] = None) -> bool:
-        """Creates an index for the given collection
-        ⚠️ This method should not be used directly.
-
-        Args:
-            collection_name: The collection to create the index for. Uses the client's collection if None. Defaults to None.
-
-        Returns:
-            bool: True if the index was created successfully
-
-        """
-        pass
-
-    @abstractmethod
-    def persist(self) -> None:
+    def persist(self) -> bool:
         """Persist the database to disk"""
         pass
 

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -315,6 +315,20 @@ class API(ABC):
         pass
 
     @abstractmethod
+    def create_index(self, collection_name: Optional[str] = None) -> bool:
+        """Creates an index for the given collection
+        ⚠️ This method should not be used directly.
+
+        Args:
+            collection_name: The collection to create the index for. Uses the client's collection if None. Defaults to None.
+
+        Returns:
+            bool: True if the index was created successfully
+
+        """
+        pass
+
+    @abstractmethod
     def persist(self) -> bool:
         """Persist the database to disk"""
         pass

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -1,6 +1,5 @@
 import json
 import time
-import pd
 from uuid import UUID
 from typing import List, Optional, Sequence, Callable, cast
 from chromadb import __version__
@@ -494,7 +493,7 @@ class LocalAPI(API):
 
         return query_result
 
-    def raw_sql(self, raw_sql: str) -> pd.DataFrame:
+    def raw_sql(self, raw_sql: str):  # type: ignore
         return self._db.raw_sql(raw_sql)  # type: ignore
 
     def create_index(self, collection_name: str) -> bool:

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -56,7 +56,12 @@ class LocalAPI(API):
         self._telemetry_client = telemetry_client
 
     def heartbeat(self) -> int:
-        """Ping the database to ensure it is alive"""
+        """Ping the database to ensure it is alive
+
+        Returns:
+            The current time in milliseconds
+
+        """
         return int(1000 * time.time_ns())
 
     #
@@ -84,11 +89,13 @@ class LocalAPI(API):
             ValueError: If the collection name is invalid
 
         Examples:
-            >>> client.create_collection("my_collection")
-            collection(name="my_collection", metadata={})
+            ```python
+            client.create_collection("my_collection")
+            # collection(name="my_collection", metadata={})
 
-            >>> client.create_collection("my_collection", metadata={"foo": "bar"})
-            collection(name="my_collection", metadata={"foo": "bar"})
+            client.create_collection("my_collection", metadata={"foo": "bar"})
+            # collection(name="my_collection", metadata={"foo": "bar"})
+            ```
         """
         check_index_name(name)
 
@@ -117,8 +124,10 @@ class LocalAPI(API):
             The collection
 
         Examples:
-            >>> client.get_or_create_collection("my_collection")
-            collection(name="my_collection", metadata={})
+            ```python
+            client.get_or_create_collection("my_collection")
+            # collection(name="my_collection", metadata={})
+            ```
         """
         return self.create_collection(
             name, metadata, embedding_function, get_or_create=True
@@ -141,8 +150,10 @@ class LocalAPI(API):
             ValueError: If the collection does not exist
 
         Examples:
-            >>> client.get_collection("my_collection")
-            collection(name="my_collection", metadata={})
+            ```python
+            client.get_collection("my_collection")
+            # collection(name="my_collection", metadata={})
+            ```
         """
         res = self._db.get_collection(name)
         if len(res) == 0:
@@ -161,8 +172,10 @@ class LocalAPI(API):
             A list of collections
 
         Examples:
-            >>> client.list_collections()
-            [collection(name="my_collection", metadata={})]
+            ```python
+            client.list_collections()
+            # [collection(name="my_collection", metadata={})]
+            ```
         """
         collections = []
         db_collections = self._db.list_collections()
@@ -197,7 +210,9 @@ class LocalAPI(API):
             ValueError: If the collection does not exist
 
         Examples:
-            >>> client.delete_collection("my_collection")
+            ```python
+            client.delete_collection("my_collection")
+            ```
         """
         self._db.delete_collection(name)
 

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -1,5 +1,6 @@
 import json
 import time
+import pd
 from uuid import UUID
 from typing import List, Optional, Sequence, Callable, cast
 from chromadb import __version__
@@ -492,6 +493,14 @@ class LocalAPI(API):
             query_result["ids"].append(ids)
 
         return query_result
+
+    def raw_sql(self, raw_sql: str) -> pd.DataFrame:
+        return self._db.raw_sql(raw_sql)  # type: ignore
+
+    def create_index(self, collection_name: str) -> bool:
+        collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
+        self._db.create_index(collection_uuid=collection_uuid)
+        return True
 
     def _peek(self, collection_id: UUID, n: int = 10) -> GetResult:
         return self._get(

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, cast, List, Dict, Tuple
+from typing import TYPE_CHECKING, Optional, cast, List, Tuple
 from pydantic import BaseModel, PrivateAttr
 from uuid import UUID
 
@@ -31,10 +31,10 @@ if TYPE_CHECKING:
     from chromadb.api import API
 
 
-class Collection(BaseModel):
+class Collection(BaseModel):  # type: ignore
     name: str
     id: UUID
-    metadata: Optional[Dict] = None
+    metadata: Optional[Metadata] = None
     _client: "API" = PrivateAttr()
     _embedding_function: Optional[EmbeddingFunction] = PrivateAttr()
 
@@ -44,7 +44,7 @@ class Collection(BaseModel):
         name: str,
         id: UUID,
         embedding_function: Optional[EmbeddingFunction] = None,
-        metadata: Optional[Dict] = None,
+        metadata: Optional[Metadata] = None,
     ):
         self._client = client
         if embedding_function is not None:
@@ -58,7 +58,7 @@ class Collection(BaseModel):
             self._embedding_function = ef.SentenceTransformerEmbeddingFunction()
         super().__init__(name=name, metadata=metadata, id=id)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Collection(name={self.name})"
 
     def count(self) -> int:
@@ -77,7 +77,7 @@ class Collection(BaseModel):
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
         increment_index: bool = True,
-    ):
+    ) -> None:
         """Add embeddings to the data store.
         Args:
             ids: The ids of the embeddings you wish to add
@@ -120,11 +120,11 @@ class Collection(BaseModel):
 
         Args:
             ids: The ids of the embeddings to get. Optional.
-            where: A Where type dict used to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
+            where: A Where type dict used to filter results by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
             limit: The number of documents to return. Optional.
             offset: The offset to start returning results from. Useful for paging results with limit. Optional.
-            where_document: A WhereDocument type dict used to filter by the documents. E.g. {$contains: {"text": "hello"}}. Optional.
-            include: A list of what to include in the results. Can contain "embeddings", "metadatas", "documents". Ids are always included. Defaults to ["metadatas", "documents"]. Optional.
+            where_document: A WhereDocument type dict used to filter by the documents. E.g. `{$contains: {"text": "hello"}}`. Optional.
+            include: A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`. Ids are always included. Defaults to `["metadatas", "documents"]`. Optional.
 
         Returns:
             GetResult: A GetResult object containing the results.
@@ -173,9 +173,9 @@ class Collection(BaseModel):
             query_embeddings: The embeddings to get the closes neighbors of. Optional.
             query_texts: The document texts to get the closes neighbors of. Optional.
             n_results: The number of neighbors to return for each query_embedding or query_text. Optional.
-            where: A Where type dict used to filter results by. E.g. {"color" : "red", "price": 4.20}. Optional.
-            where_document: A WhereDocument type dict used to filter by the documents. E.g. {$contains: {"text": "hello"}}. Optional.
-            include: A list of what to include in the results. Can contain "embeddings", "metadatas", "documents", "distances". Ids are always included. Defaults to ["metadatas", "documents", "distances"]. Optional.
+            where: A Where type dict used to filter results by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
+            where_document: A WhereDocument type dict used to filter by the documents. E.g. `{$contains: {"text": "hello"}}`. Optional.
+            include: A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`, `"distances"`. Ids are always included. Defaults to `["metadatas", "documents", "distances"]`. Optional.
 
         Returns:
             QueryResult: A QueryResult object containing the results.
@@ -233,7 +233,9 @@ class Collection(BaseModel):
             include=include,
         )
 
-    def modify(self, name: Optional[str] = None, metadata=None):
+    def modify(
+        self, name: Optional[str] = None, metadata: Optional[Metadata] = None
+    ) -> None:
         """Modify the collection name or metadata
 
         Args:
@@ -255,7 +257,7 @@ class Collection(BaseModel):
         embeddings: Optional[OneOrMany[Embedding]] = None,
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
-    ):
+    ) -> None:
         """Update the embeddings, metadatas or documents for provided ids.
 
         Args:
@@ -281,7 +283,7 @@ class Collection(BaseModel):
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
         increment_index: bool = True,
-    ):
+    ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist.
 
         Args:
@@ -309,13 +311,13 @@ class Collection(BaseModel):
         ids: Optional[IDs] = None,
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
-    ):
+    ) -> List[str]:
         """Delete the embeddings based on ids and/or a where filter
 
         Args:
             ids: The ids of the embeddings to delete
-            where: A Where type dict used to filter the delection by. E.g. {"color" : "red", "price": 4.20}. Optional.
-            where_document: A WhereDocument type dict used to filter the deletion by the document content. E.g. {$contains: {"text": "hello"}}. Optional.
+            where: A Where type dict used to filter the delection by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
+            where_document: A WhereDocument type dict used to filter the deletion by the document content. E.g. `{$contains: {"text": "hello"}}`. Optional.
 
         Returns:
             None
@@ -327,19 +329,16 @@ class Collection(BaseModel):
         )
         return self._client._delete(self.id, ids, where, where_document)
 
-    def create_index(self):
-        self._client.create_index(self.name)
-
     def _validate_embedding_set(
         self,
-        ids,
-        embeddings,
-        metadatas,
-        documents,
-        require_embeddings_or_documents=True,
+        ids: OneOrMany[ID],
+        embeddings: Optional[OneOrMany[Embedding]],
+        metadatas: Optional[OneOrMany[Metadata]],
+        documents: Optional[OneOrMany[Document]],
+        require_embeddings_or_documents: bool = True,
     ) -> Tuple[
         IDs,
-        Optional[List[Embedding]],
+        List[Embedding],
         Optional[List[Metadata]],
         Optional[List[Document]],
     ]:
@@ -384,5 +383,10 @@ class Collection(BaseModel):
                     "You must provide embeddings or a function to compute them"
                 )
             embeddings = self._embedding_function(documents)
+
+        if embeddings is None:
+            raise ValueError(
+                "Something went wrong. Embeddings should be computed at this point"
+            )
 
         return ids, embeddings, metadatas, documents

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,5 +1,5 @@
-from typing import TYPE_CHECKING, Optional, cast, List, Tuple
-from pydantic import BaseModel, PrivateAttr
+from typing import TYPE_CHECKING, Optional, cast, List, Tuple, Dict, Union
+from pydantic import BaseModel, PrivateAttr, StrictStr, StrictInt, StrictFloat
 from uuid import UUID
 
 from chromadb.api.types import (
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 class Collection(BaseModel):  # type: ignore
     name: str
     id: UUID
-    metadata: Optional[Metadata] = None
+    metadata: Optional[Dict[str, Union[StrictStr, StrictInt, StrictFloat]]] = None
     _client: "API" = PrivateAttr()
     _embedding_function: Optional[EmbeddingFunction] = PrivateAttr()
 

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -384,9 +384,9 @@ class Collection(BaseModel):  # type: ignore
                 )
             embeddings = self._embedding_function(documents)
 
-        if embeddings is None:
-            raise ValueError(
-                "Something went wrong. Embeddings should be computed at this point"
-            )
+        # if embeddings is None:
+        #     raise ValueError(
+        #         "Something went wrong. Embeddings should be computed at this point"
+        #     )
 
-        return ids, embeddings, metadatas, documents
+        return ids, embeddings, metadatas, documents  # type: ignore

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -329,6 +329,9 @@ class Collection(BaseModel):  # type: ignore
         )
         return self._client._delete(self.id, ids, where, where_document)
 
+    def create_index(self):  # type: ignore
+        self._client.create_index(self.name)
+
     def _validate_embedding_set(
         self,
         ids: OneOrMany[ID],

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Sequence, Optional, Tuple
+from typing import List, Sequence, Optional, Tuple
 from uuid import UUID
 import numpy.typing as npt
 from chromadb.api.types import (
@@ -7,6 +7,7 @@ from chromadb.api.types import (
     Documents,
     IDs,
     Metadatas,
+    Metadata,
     Where,
     WhereDocument,
 )
@@ -14,12 +15,15 @@ from chromadb.api.types import (
 
 class DB(ABC):
     @abstractmethod
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     @abstractmethod
     def create_collection(
-        self, name: str, metadata: Optional[Dict] = None, get_or_create: bool = False
+        self,
+        name: str,
+        metadata: Optional[Metadata] = None,
+        get_or_create: bool = False,
     ) -> Sequence:
         pass
 
@@ -36,12 +40,12 @@ class DB(ABC):
         self,
         id: UUID,
         new_name: Optional[str] = None,
-        new_metadata: Optional[Dict] = None,
-    ):
+        new_metadata: Optional[Metadata] = None,
+    ) -> None:
         pass
 
     @abstractmethod
-    def delete_collection(self, name: str):
+    def delete_collection(self, name: str) -> None:
         pass
 
     @abstractmethod
@@ -55,14 +59,14 @@ class DB(ABC):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas],
         documents: Optional[Documents],
-        ids: List[UUID],
+        ids: List[str],
     ) -> List[UUID]:
         pass
 
     @abstractmethod
     def add_incremental(
         self, collection_uuid: UUID, ids: List[UUID], embeddings: Embeddings
-    ):
+    ) -> None:
         pass
 
     @abstractmethod
@@ -88,11 +92,11 @@ class DB(ABC):
         embeddings: Optional[Embeddings] = None,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-    ):
+    ) -> bool:
         pass
 
     @abstractmethod
-    def count(self, collection_id: UUID):
+    def count(self, collection_id: UUID) -> int:
         pass
 
     @abstractmethod
@@ -102,36 +106,30 @@ class DB(ABC):
         collection_uuid: Optional[UUID] = None,
         ids: Optional[IDs] = None,
         where_document: WhereDocument = {},
-    ) -> List:
+    ) -> List[str]:
         pass
 
     @abstractmethod
-    def reset(self):
+    def reset(self) -> None:
         pass
 
     @abstractmethod
     def get_nearest_neighbors(
         self,
         collection_uuid: UUID,
-        where,
-        embeddings,
-        n_results,
-        where_document,
+        where: Where = {},
+        embeddings: Optional[Embeddings] = None,
+        n_results: int = 10,
+        where_document: WhereDocument = {},
     ) -> Tuple[List[List[UUID]], npt.NDArray]:
         pass
 
     @abstractmethod
-    def get_by_ids(self, uuids, columns=None) -> Sequence:
+    def get_by_ids(
+        self, uuids: List[UUID], columns: Optional[List[str]] = None
+    ) -> Sequence:
         pass
 
     @abstractmethod
-    def raw_sql(self, raw_sql):
-        pass
-
-    @abstractmethod
-    def create_index(self, collection_uuid: UUID):
-        pass
-
-    @abstractmethod
-    def persist(self):
+    def persist(self) -> None:
         pass

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -131,5 +131,13 @@ class DB(ABC):
         pass
 
     @abstractmethod
+    def raw_sql(self, raw_sql):
+        pass
+
+    @abstractmethod
+    def create_index(self, collection_uuid: UUID):
+        pass
+
+    @abstractmethod
     def persist(self) -> None:
         pass

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -490,7 +490,7 @@ class Clickhouse(DB):
 
         return val
 
-    def count(self, collection_uuid: UUID):
+    def count(self, collection_uuid: UUID) -> int:
         where_string = f"WHERE collection_uuid = '{collection_uuid}'"
         return (
             self._get_conn()

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -370,6 +370,9 @@ class DuckDB(Clickhouse):
 
         return response
 
+    def raw_sql(self, sql):
+        return self._conn.execute(sql).df()
+
     # TODO: This method should share logic with clickhouse impl
     def reset(self):
         self._conn.execute("DROP TABLE collections")

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -175,7 +175,7 @@ class DuckDB(Clickhouse):
 
         return [uuid.UUID(x[1]) for x in data_to_insert]  # return uuids
 
-    def count(self, collection_uuid):
+    def count(self, collection_uuid) -> int:
         where_string = f"WHERE collection_uuid = '{collection_uuid}'"
         return self._conn.query(
             f"SELECT COUNT() FROM embeddings {where_string}"
@@ -370,9 +370,6 @@ class DuckDB(Clickhouse):
 
         return response
 
-    def raw_sql(self, sql):
-        return self._conn.execute(sql).df()
-
     # TODO: This method should share logic with clickhouse impl
     def reset(self):
         self._conn.execute("DROP TABLE collections")
@@ -386,7 +383,7 @@ class DuckDB(Clickhouse):
         logger.info("Exiting: Cleaning up .chroma directory")
         self.reset_indexes()
 
-    def persist(self):
+    def persist(self) -> None:
         raise NotImplementedError(
             "Set chroma_db_impl='duckdb+parquet' to get persistence functionality"
         )


### PR DESCRIPTION
This PR adds a bunch of types and improved docstrings for the python docs 

https://github.com/chroma-core/docs/pull/28

there are some `#type: ignore`s used. in some cases its because we are going to remove the functionality soon anyway, in other cases the `Sequence` return types were not legible to me. 