### PR TITLE
Add organization_id to openai embeddings

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -39,7 +39,8 @@ class Text2VecEmbeddingFunction(EmbeddingFunction):
 
 class OpenAIEmbeddingFunction(EmbeddingFunction):
     def __init__(
-        self, api_key: Optional[str] = None, model_name: str = "text-embedding-ada-002"
+            self, api_key: Optional[str] = None, model_name: str = "text-embedding-ada-002",
+            organization_id: Optional[str] = None
     ):
         try:
             import openai
@@ -55,6 +56,9 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
             raise ValueError(
                 "Please provide an OpenAI API key. You can get one at https://platform.openai.com/account/api-keys"
             )
+
+        if organization_id is not None:
+            openai.organization = organization_id
 
         self._client = openai.Embedding
         self._model_name = model_name


### PR DESCRIPTION
## Description of changes
This related to #547 issue.
 - New functionality added:
	 - add optional organization_id parameter to OpenAIEmbeddingFunction.

## Test plan
- Create the class object without organization_id and no errors expected.
- Create the class object with organization_id.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
- The class optional parameters are not mentioned explicitly.
