### PR TITLE
Disable telemetry in CI

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,6 +17,7 @@ services:
       - CHROMA_DB_IMPL=clickhouse
       - CLICKHOUSE_HOST=test_clickhouse
       - CLICKHOUSE_PORT=8123
+      - ANONYMIZED_TELEMETRY=False
     ports:
       - ${CHROMA_PORT}:8000
     depends_on:


### PR DESCRIPTION
## Description of changes

Disable telemetry when running integration tests in CI.

## Test plan

Ran and verified that previously we were seeing the log message about enabled telemetry, and not after this change.

## Documentation Changes
 
N/A
