### PR TITLE
Add new `overrides` lib to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   'uvicorn[standard] >= 0.18.3',
   'numpy >= 1.21.6',
   'posthog >= 2.4.0',
-  'typing_extensions >= 4.5.0'
+  'typing_extensions >= 4.5.0',
+  'overrides >= 7.3.1'
 ]
 
 [tool.black]


### PR DESCRIPTION
## Description of changes

The `overrides` library was added in #480, however, we missed adding it to `pyproject.toml`.

`requirements.txt` and `pyproject.toml` are required to match but we have no automated mechanism for ensuring that this is the case aside from the "release" CI job, which doesn't run on PRs, only on `main`.

As a separate task, we should configure CI for PRs to exercise this functionality so we don't run into this issue again.

## Test plan

None, there is currently no way to test the "release" job aside from letting it run in CI on main.

## Documentation Changes

N/A
