### PR TITLE
Return 0 results Instead of raising NoDatapointException on an empty filter

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -457,10 +457,10 @@ class LocalAPI(API):
             distances=[] if include_distances else None,
         )
         for i in range(len(uuids)):
-            embeddings = []
-            documents = []
-            ids = []
-            metadatas = []
+            embeddings: Embeddings = []
+            documents: Documents = []
+            ids: IDs = []
+            metadatas: List[Optional[Metadata]] = []
             # Remove plural from include since db columns are singular
             db_columns = [
                 column[:-1] for column in include if column != "distances"
@@ -484,13 +484,15 @@ class LocalAPI(API):
                 ids.append(entry[column_index["id"]])
 
             if include_embeddings:
-                cast(List, query_result["embeddings"]).append(embeddings)  # type: ignore
+                cast(List[Embeddings], query_result["embeddings"]).append(embeddings)
             if include_documents:
-                cast(List, query_result["documents"]).append(documents)  # type: ignore
+                cast(List[Documents], query_result["documents"]).append(documents)
             if include_metadatas:
-                cast(List, query_result["metadatas"]).append(metadatas)  # type: ignore
+                cast(List[List[Optional[Metadata]]], query_result["metadatas"]).append(
+                    metadatas
+                )
             if include_distances:
-                cast(List, query_result["distances"]).append(distances[i].tolist())  # type: ignore
+                cast(List[float], query_result["distances"]).append(distances[i])
             query_result["ids"].append(ids)
 
         return query_result

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -9,9 +9,6 @@ from chromadb.api.types import (
 )
 from chromadb.db import DB
 from chromadb.db.index.hnswlib import Hnswlib, delete_all_indexes
-from chromadb.errors import (
-    NoDatapointsException,
-)
 import uuid
 import numpy.typing as npt
 import json
@@ -579,9 +576,10 @@ class Clickhouse(DB):
             if len(results) > 0:
                 ids = [x[1] for x in results]
             else:
-                raise NoDatapointsException(
-                    f"No datapoints found for the supplied filter {json.dumps(where)}"
-                )
+                # No results found, return empty lists
+                return [[] for _ in range(len(embeddings))], [
+                    [] for _ in range(len(embeddings))
+                ]
         else:
             ids = None
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -10,7 +10,6 @@ from chromadb.api.types import (
 from chromadb.db import DB
 from chromadb.db.index.hnswlib import Hnswlib, delete_all_indexes
 import uuid
-import numpy.typing as npt
 import json
 from typing import Dict, Optional, Sequence, List, Tuple, cast
 import clickhouse_connect
@@ -561,7 +560,7 @@ class Clickhouse(DB):
         where_document: WhereDocument,
         embeddings: Embeddings,
         n_results: int,
-    ) -> Tuple[List[List[uuid.UUID]], npt.NDArray]:
+    ) -> Tuple[List[List[uuid.UUID]], List[List[float]]]:
         # Either the collection name or the collection uuid must be provided
         if collection_uuid is None:
             raise TypeError("Argument collection_uuid cannot be None")

--- a/chromadb/db/index/hnswlib.py
+++ b/chromadb/db/index/hnswlib.py
@@ -267,6 +267,7 @@ class Hnswlib(Index):
         database_labels, distances = self._index.knn_query(
             query, k=k, filter=filter_function
         )
+        distances = distances.tolist()
         distances = cast(List[List[float]], distances)
         logger.debug(f"time to run knn query: {time.time() - s3}")
 

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -18,13 +18,6 @@ class ChromaError(Exception, EnforceOverrides):
         pass
 
 
-class NoDatapointsException(ChromaError):
-    @classmethod
-    @overrides
-    def name(cls) -> str:
-        return "NoDatapoints"
-
-
 class NoIndexException(ChromaError):
     @classmethod
     @overrides
@@ -72,7 +65,6 @@ class InvalidUUIDError(ChromaError):
 
 
 error_types: Dict[str, Type[ChromaError]] = {
-    "NoDatapoints": NoDatapointsException,
     "NoIndex": NoIndexException,
     "InvalidDimension": InvalidDimensionException,
     "NotEnoughElements": NotEnoughElementsException,

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -243,21 +243,6 @@ def test_get_nearest_neighbors(api):
         assert len(nn[key]) == 2
 
 
-def test_get_nearest_neighbors_filter(api, request):
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records)
-
-    # assert api.create_index(collection_name="testspace") # default is auto now
-
-    with pytest.raises(Exception) as e:
-        collection.query(
-            query_embeddings=[[1.1, 2.3, 3.2]], n_results=1, where={"distance": "false"}
-        )
-
-    assert str(e.value).__contains__("found")
-
-
 def test_delete(api):
     api.reset()
     collection = api.create_collection("testspace")
@@ -1308,7 +1293,7 @@ def test_invalid_embeddings(api):
 
     # Add with string embeddings
     invalid_records = {
-        "embeddings": [['0', '0', '0'], ['1.2', '2.24', '3.2']],
+        "embeddings": [["0", "0", "0"], ["1.2", "2.24", "3.2"]],
         "ids": ["id1", "id2"],
     }
     with pytest.raises(ValueError) as e:
@@ -1318,7 +1303,7 @@ def test_invalid_embeddings(api):
     # Query with invalid embeddings
     with pytest.raises(ValueError) as e:
         collection.query(
-            query_embeddings=[['1.1', '2.3', '3.2']],
+            query_embeddings=[["1.1", "2.3", "3.2"]],
             n_results=1,
         )
     assert "embeddings" in str(e.value)


### PR DESCRIPTION
## Description of changes
Return 0 results Instead of raising NoDatapointException on an empty filter result. This will be a breaking change for anyone depending on the existing error.

Addresses #435

## Test plan
Modified existing state machine test for this case, added a new test solely for this case.

## Documentation Changes
We don't currently document the behavior so not required.
