### PR TITLE
Validate len(array) > 0 - address #437

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -87,6 +87,8 @@ def validate_ids(ids: IDs) -> IDs:
     """Validates ids to ensure it is a list of strings"""
     if not isinstance(ids, list):
         raise ValueError(f"Expected IDs to be a list, got {ids}")
+    if len(ids) == 0:
+        raise ValueError(f"Expected IDs to be a non-empty list, got {ids}")
     for id in ids:
         if not isinstance(id, str):
             raise ValueError(f"Expected ID to be a str, got {id}")
@@ -238,10 +240,16 @@ def validate_embeddings(embeddings: Embeddings) -> Embeddings:
     """Validates embeddings to ensure it is a list of list of ints, or floats"""
     if not isinstance(embeddings, list):
         raise ValueError(f"Expected embeddings to be a list, got {embeddings}")
+    if len(embeddings) == 0:
+        raise ValueError(
+            f"Expected embeddings to be a list with at least one item, got {embeddings}"
+        )
     if not isinstance(embeddings[0], list):
         raise ValueError(f"Expected embeddings to be a list, got {embeddings}")
     for embedding in embeddings:
         for value in embedding:
             if not isinstance(value, (int, float)):
-                raise ValueError(f"Expected embeddings to be a int, float, got {embeddings}")
+                raise ValueError(
+                    f"Expected embeddings to be a int, float, got {embeddings}"
+                )
     return embeddings

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -244,12 +244,13 @@ def validate_embeddings(embeddings: Embeddings) -> Embeddings:
         raise ValueError(
             f"Expected embeddings to be a list with at least one item, got {embeddings}"
         )
-    if not isinstance(embeddings[0], list):
-        raise ValueError(f"Expected embeddings to be a list, got {embeddings}")
+    if not all([isinstance(e, list) for e in embeddings]):
+        raise ValueError(
+            f"Expected each embedding in the embeddings to be a list, got {embeddings}"
+        )
     for embedding in embeddings:
-        for value in embedding:
-            if not isinstance(value, (int, float)):
-                raise ValueError(
-                    f"Expected embeddings to be a int, float, got {embeddings}"
-                )
+        if not all([isinstance(value, (int, float)) for value in embedding]):
+            raise ValueError(
+                f"Expected each value in the embedding to be a int or float, got {embeddings}"
+            )
     return embeddings

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1308,20 +1308,20 @@ def test_invalid_embeddings(api):
 
     # Add with string embeddings
     invalid_records = {
-        "embeddings": [['0', '0', '0'], ['1.2', '2.24', '3.2']],
+        "embeddings": [["0", "0", "0"], ["1.2", "2.24", "3.2"]],
         "ids": ["id1", "id2"],
     }
     with pytest.raises(ValueError) as e:
         collection.add(**invalid_records)
-    assert "embeddings" in str(e.value)
+    assert "embedding" in str(e.value)
 
     # Query with invalid embeddings
     with pytest.raises(ValueError) as e:
         collection.query(
-            query_embeddings=[['1.1', '2.3', '3.2']],
+            query_embeddings=[["1.1", "2.3", "3.2"]],
             n_results=1,
         )
-    assert "embeddings" in str(e.value)
+    assert "embedding" in str(e.value)
 
     # Update with invalid embeddings
     invalid_records = {
@@ -1330,7 +1330,7 @@ def test_invalid_embeddings(api):
     }
     with pytest.raises(ValueError) as e:
         collection.update(**invalid_records)
-    assert "embeddings" in str(e.value)
+    assert "embedding" in str(e.value)
 
     # Upsert with invalid embeddings
     invalid_records = {
@@ -1339,4 +1339,4 @@ def test_invalid_embeddings(api):
     }
     with pytest.raises(ValueError) as e:
         collection.upsert(**invalid_records)
-    assert "embeddings" in str(e.value)
+    assert "embedding" in str(e.value)


### PR DESCRIPTION
## Description of changes
Validate len(array) > 0 - address #437

## Test plan
They are not tested in a new way. These cases previously error'ed in the validation code since all validation for lists checks the datatype of the first element. Now we ensure the list has length > 0.

## Documentation Changes
None required.