### PR TITLE
Remove create_index from API

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -315,20 +315,6 @@ class API(ABC):
         pass
 
     @abstractmethod
-    def create_index(self, collection_name: str) -> bool:
-        """Creates an index for the given collection
-        ⚠️ This method should not be used directly.
-
-        Args:
-            collection_name: The collection to create the index for. Uses the client's collection if None. Defaults to None.
-
-        Returns:
-            bool: True if the index was created successfully
-
-        """
-        pass
-
-    @abstractmethod
     def persist(self) -> bool:
         """Persist the database to disk"""
         pass

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -7,7 +7,6 @@ from chromadb.api.types import (
     EmbeddingFunction,
     IDs,
     Include,
-    Metadata,
     Metadatas,
     Where,
     WhereDocument,
@@ -339,14 +338,6 @@ class FastAPI(API):
         )
         raise_chroma_error(resp)
         return pd.DataFrame.from_dict(resp.json())
-
-    def create_index(self, collection_name: str) -> bool:
-        """Creates an index for the given space key"""
-        resp = requests.post(
-            self._api_url + "/collections/" + collection_name + "/create_index"
-        )
-        raise_chroma_error(resp)
-        return cast(bool, resp.json())
 
     def get_version(self) -> str:
         """Returns the version of the server"""

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -500,11 +500,6 @@ class LocalAPI(API):
     def raw_sql(self, raw_sql: str):  # type: ignore
         return self._db.raw_sql(raw_sql)  # type: ignore
 
-    def create_index(self, collection_name: str) -> bool:
-        collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
-        self._db.create_index(collection_uuid=collection_uuid)
-        return True
-
     def _peek(self, collection_id: UUID, n: int = 10) -> GetResult:
         return self._get(
             collection_id=collection_id,

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -335,9 +335,6 @@ class Collection(BaseModel):
         )
         self._client._delete(self.id, ids, where, where_document)
 
-    def create_index(self) -> None:
-        self._client.create_index(self.name)
-
     def _validate_embedding_set(
         self,
         ids: OneOrMany[ID],

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Optional, Tuple
+from typing import List, Sequence, Optional, Tuple, Any
 from uuid import UUID
 import numpy.typing as npt
 from chromadb.api.types import (
@@ -24,15 +24,15 @@ class DB(ABC):
         name: str,
         metadata: Optional[Metadata] = None,
         get_or_create: bool = False,
-    ) -> Sequence:
+    ) -> Sequence[Sequence[Any]]:
         pass
 
     @abstractmethod
-    def get_collection(self, name: str) -> Sequence:
+    def get_collection(self, name: str) -> Sequence[Sequence[Any]]:
         pass
 
     @abstractmethod
-    def list_collections(self) -> Sequence:
+    def list_collections(self) -> Sequence[Sequence[Any]]:
         pass
 
     @abstractmethod
@@ -81,7 +81,7 @@ class DB(ABC):
         offset: Optional[int] = None,
         where_document: WhereDocument = {},
         columns: Optional[List[str]] = None,
-    ) -> Sequence:
+    ) -> Sequence[Any]:
         pass
 
     @abstractmethod
@@ -127,15 +127,11 @@ class DB(ABC):
     @abstractmethod
     def get_by_ids(
         self, uuids: List[UUID], columns: Optional[List[str]] = None
-    ) -> Sequence:
+    ) -> Sequence[Any]:
         pass
 
     @abstractmethod
-    def raw_sql(self, raw_sql):
-        pass
-
-    @abstractmethod
-    def create_index(self, collection_uuid: UUID):
+    def raw_sql(self, raw_sql):  # type: ignore
         pass
 
     @abstractmethod

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -592,22 +592,6 @@ class Clickhouse(DB):
 
         return uuids, distances
 
-    def create_index(self, collection_uuid: str):
-        """Create an index for a collection_uuid and optionally scoped to a dataset.
-        Args:
-            collection_uuid (str): The collection_uuid to create an index for
-            dataset (str, optional): The dataset to scope the index to. Defaults to None.
-        Returns:
-            None
-        """
-        get = self.get(collection_uuid=collection_uuid)
-
-        uuids = [x[1] for x in get]
-        embeddings = [x[2] for x in get]
-
-        index = self._index(collection_uuid)
-        index.add(uuids, embeddings)
-
     def add_incremental(self, collection_uuid, uuids, embeddings):
         index = self._index(collection_uuid)
         index.add(uuids, embeddings)

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -217,7 +217,6 @@ def test_get_nearest_neighbors(api):
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
-    # assert api.create_index(collection_name="testspace") # default is auto now
 
     nn = collection.query(
         query_embeddings=[1.1, 2.3, 3.2],
@@ -348,7 +347,6 @@ def test_increment_index_on(api):
     assert collection.count() == 2
 
     # increment index
-    # collection.create_index(index_type="hnsw", index_params={"M": 16, "efConstruction": 200})
     nn = collection.query(
         query_embeddings=[[1.1, 2.3, 3.2]],
         n_results=1,

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -356,23 +356,6 @@ def test_increment_index_on(api):
         assert len(nn[key]) == 1
 
 
-def test_increment_index_off(api):
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records, increment_index=False)
-    assert collection.count() == 2
-
-    # incremental index
-    collection.create_index()
-    nn = collection.query(
-        query_embeddings=[[1.1, 2.3, 3.2]],
-        n_results=1,
-        include=["embeddings", "documents", "metadatas", "distances"],
-    )
-    for key in nn.keys():
-        assert len(nn[key]) == 1
-
-
 def skipping_indexing_will_fail(api):
     api.reset()
     collection = api.create_collection("testspace")


### PR DESCRIPTION
## Description of changes

Requires #595 
Closes: #593 

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Removed `create_index` from API
	 - Address formatting/typing errors flagged by Linter

## Test plan


## Documentation Changes
Need to remove references to `create_index` from docs (https://docs.trychroma.com/api-reference#methods-on-client)
