### PR TITLE
bump JS to 1.5.0

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Since our release process is manual - this does not need to land before release. 