### PR TITLE
Add a thin client

### DIFF
--- a/.github/workflows/chroma-client-integration-test.yml
+++ b/.github/workflows/chroma-client-integration-test.yml
@@ -1,0 +1,29 @@
+name: Chroma Client Inegration Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    timeout-minutes: 90
+    strategy:
+      matrix:
+        python: ['3.7', '3.8', '3.9', '3.10']
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install test dependencies
+      run: python -m pip install -r requirements.txt && python -m pip install -r requirements_dev.txt
+    - name: Test
+      run: clients/python/integration-test

--- a/.github/workflows/chroma-client-integration-test.yml
+++ b/.github/workflows/chroma-client-integration-test.yml
@@ -1,4 +1,4 @@
-name: Chroma Client Inegration Tests
+name: Chroma Client Integration Tests
 
 on:
   push:
@@ -26,4 +26,4 @@ jobs:
     - name: Install test dependencies
       run: python -m pip install -r requirements.txt && python -m pip install -r requirements_dev.txt
     - name: Test
-      run: clients/python/integration-test
+      run: clients/python/integration-test.sh

--- a/.github/workflows/chroma-integration-test.yml
+++ b/.github/workflows/chroma-integration-test.yml
@@ -35,3 +35,5 @@ jobs:
       run: python -m pip install -r requirements.txt && python -m pip install -r requirements_dev.txt
     - name: Integration Test
       run: bin/integration-test ${{ matrix.testfile }}
+    - name: Client Integration Test
+      run: clients/python/integration-test

--- a/.github/workflows/chroma-integration-test.yml
+++ b/.github/workflows/chroma-integration-test.yml
@@ -35,5 +35,3 @@ jobs:
       run: python -m pip install -r requirements.txt && python -m pip install -r requirements_dev.txt
     - name: Integration Test
       run: bin/integration-test ${{ matrix.testfile }}
-    - name: Client Integration Test
-      run: clients/python/integration-test

--- a/.github/workflows/chroma-release-python-client.yml
+++ b/.github/workflows/chroma-release-python-client.yml
@@ -1,0 +1,40 @@
+name: Chroma Release Python Client
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+      - hammad/thin_client
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install Client Dev Dependencies
+      run: python -m pip install -r requirements_dev.txt
+    - name: Build Client
+      run: ./clients/python/build_python_thin_client.sh
+    - name: Install setuptools_scm
+      run: python -m pip install setuptools_scm
+    - name: Get Release Version
+      id: version
+      run: echo "version=$(python -m setuptools_scm)" >> $GITHUB_OUTPUT
+    - name: Get current date
+      id: builddate
+      run: echo "builddate=$(date +'%Y-%m-%dT%H:%M')" >> $GITHUB_OUTPUT
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/chroma-release-python-client.yml
+++ b/.github/workflows/chroma-release-python-client.yml
@@ -36,5 +36,5 @@ jobs:
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/chroma-release-python-client.yml
+++ b/.github/workflows/chroma-release-python-client.yml
@@ -38,3 +38,8 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
         repository_url: https://test.pypi.org/legacy/
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_PYTHON_CLIENT_PUBLISH_KEY }}

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -16,7 +16,7 @@ from chromadb.api.types import (
     GetResult,
     WhereDocument,
 )
-
+import chromadb.utils.embedding_functions as ef
 from chromadb.telemetry import Telemetry
 
 
@@ -56,7 +56,7 @@ class API(ABC):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
         get_or_create: bool = False,
     ) -> Collection:
         """Creates a new collection in the database
@@ -90,7 +90,7 @@ class API(ABC):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
     ) -> Collection:
         """Calls create_collection with get_or_create=True.
            If the collection exists, but with different metadata, the metadata will be replaced.
@@ -109,7 +109,7 @@ class API(ABC):
     def get_collection(
         self,
         name: str,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
     ) -> Collection:
         """Gets a collection from the database by either name or uuid
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -7,7 +7,6 @@ from chromadb.api.types import (
     EmbeddingFunction,
     IDs,
     Include,
-    Metadata,
     Metadatas,
     Where,
     WhereDocument,
@@ -15,6 +14,7 @@ from chromadb.api.types import (
     QueryResult,
     CollectionMetadata,
 )
+import chromadb.utils.embedding_functions as ef
 import pandas as pd
 import requests
 import json
@@ -53,7 +53,7 @@ class FastAPI(API):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
         get_or_create: bool = False,
     ) -> Collection:
         """Creates a collection"""
@@ -76,7 +76,7 @@ class FastAPI(API):
     def get_collection(
         self,
         name: str,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
     ) -> Collection:
         """Returns a collection"""
         resp = requests.get(self._api_url + "/collections/" + name)
@@ -94,7 +94,7 @@ class FastAPI(API):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
     ) -> Collection:
         """Get a collection, or return it if it exists"""
 

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -1,13 +1,14 @@
 import json
 import time
 from uuid import UUID
-from typing import List, Optional, Sequence, Callable, cast
+from typing import List, Optional, Sequence, cast
 from chromadb import __version__
 import chromadb.errors as errors
 from chromadb.api import API
 from chromadb.db import DB
 from chromadb.api.types import (
     Documents,
+    EmbeddingFunction,
     Embeddings,
     GetResult,
     IDs,
@@ -21,7 +22,7 @@ from chromadb.api.types import (
 )
 from chromadb.api.models.Collection import Collection
 from chromadb.config import System
-
+import chromadb.utils.embedding_functions as ef
 import re
 
 from chromadb.telemetry import Telemetry
@@ -73,7 +74,7 @@ class LocalAPI(API):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[Callable] = None,  # type: ignore
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
         get_or_create: bool = False,
     ) -> Collection:
         """Create a new collection with the given name and metadata.
@@ -114,7 +115,7 @@ class LocalAPI(API):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[Callable] = None,  # type: ignore
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
     ) -> Collection:
         """Get or create a collection with the given name and metadata.
         Args:
@@ -138,7 +139,7 @@ class LocalAPI(API):
     def get_collection(
         self,
         name: str,
-        embedding_function: Optional[Callable] = None,  # type: ignore
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
     ) -> Collection:
         """Get a collection with the given name.
         Args:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Optional, Tuple, cast, List
 from pydantic import BaseModel, PrivateAttr
 from uuid import UUID
+import chromadb.utils.embedding_functions as ef
 
 from chromadb.api.types import (
     CollectionMetadata,
@@ -45,19 +46,11 @@ class Collection(BaseModel):
         client: "API",
         name: str,
         id: UUID,
-        embedding_function: Optional[EmbeddingFunction] = None,
+        embedding_function: Optional[EmbeddingFunction] = ef.DefaultEmbeddingFunction(),
         metadata: Optional[CollectionMetadata] = None,
     ):
         self._client = client
-        if embedding_function is not None:
-            self._embedding_function = embedding_function
-        else:
-            import chromadb.utils.embedding_functions as ef
-
-            logger.warning(
-                "No embedding_function provided, using default embedding function: DefaultEmbeddingFunction https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2"
-            )
-            self._embedding_function = ef.DefaultEmbeddingFunction()
+        self._embedding_function = embedding_function
         super().__init__(name=name, metadata=metadata, id=id)
 
     def __repr__(self) -> str:

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -97,8 +97,10 @@ class System:
     def get_db(self) -> chromadb.db.DB:
         if is_thin_client:
             raise RuntimeError(
-                "Chroma is running in thin client mode, and cannot access the database."
+                "Chroma is running in thin client mode, and cannot directly access the database. \
+                See https://docs.trychroma.com/usage-guide?lang=py#using-the-python-http-only-client for more information."
             )
+
         if self.db is None:
             self.db = self._instantiate("chroma_db_impl")
         return self.db
@@ -110,8 +112,10 @@ class System:
         ):
             # TODO: show example and link to docs
             raise RuntimeError(
-                "Chroma is running in thin client mode, and can only be run with chromadb.api.fastapi.FastAPI as the chroma_api_impl."
+                "Chroma is running in thin client mode, and can only be run with 'chromadb.api.fastapi.FastAPI' or 'rest' as the chroma_api_impl. \
+                see https://docs.trychroma.com/usage-guide?lang=py#using-the-python-http-only-client for more information."
             )
+
         if self.api is None:
             self.api = self._instantiate("chroma_api_impl")
         return self.api

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -97,7 +97,7 @@ class System:
     def get_db(self) -> chromadb.db.DB:
         if is_thin_client:
             raise RuntimeError(
-                "Chroma is running in thin client mode, and cannot directly access the database. \
+                "Chroma is running in http-only client mode, and cannot directly access the database. \
                 See https://docs.trychroma.com/usage-guide?lang=py#using-the-python-http-only-client for more information."
             )
 
@@ -106,13 +106,12 @@ class System:
         return self.db
 
     def get_api(self) -> chromadb.api.API:
-        if (
-            is_thin_client
-            and self.settings["chroma_api_impl"] != "chromadb.api.fastapi.FastAPI"
+        if is_thin_client and (
+            self.settings["chroma_api_impl"] != "chromadb.api.fastapi.FastAPI"
         ):
-            # TODO: show example and link to docs
+            print(self.settings["chroma_api_impl"])
             raise RuntimeError(
-                "Chroma is running in thin client mode, and can only be run with 'chromadb.api.fastapi.FastAPI' or 'rest' as the chroma_api_impl. \
+                "Chroma is running in http-only client mode, and can only be run with 'chromadb.api.fastapi.FastAPI' or 'rest' as the chroma_api_impl. \
                 see https://docs.trychroma.com/usage-guide?lang=py#using-the-python-http-only-client for more information."
             )
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -7,8 +7,9 @@ import chromadb.api
 import chromadb.telemetry
 
 # The thin client will have a flag to control which implementations to use
+is_thin_client = False
 try:
-    from chromadb.is_thin_client import is_thin_client
+    from chromadb.is_thin_client import is_thin_client  # type: ignore
 except ImportError:
     is_thin_client = False
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -8,7 +8,6 @@ import tempfile
 import numpy as np
 from chromadb.utils.embedding_functions import (
     DefaultEmbeddingFunction,
-    ONNXMiniLM_L6_V2,
 )
 
 
@@ -1158,10 +1157,6 @@ def test_default_embedding():
     docs = ["this is a test" for _ in range(64)]
     embeddings = embedding_function(docs)
     assert len(embeddings) == 64
-
-
-def test_default_ef_is_onnx_mini_l6_v2():
-    assert DefaultEmbeddingFunction == ONNXMiniLM_L6_V2
 
 
 def test_multiple_collections(api):

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -8,7 +8,11 @@ import numpy as np
 import numpy.typing as npt
 import importlib
 from typing import Optional
-from chromadb.config import is_thin_client
+
+try:
+    from chromadb.is_thin_client import is_thin_client
+except ImportError:
+    is_thin_client = False
 
 
 class SentenceTransformerEmbeddingFunction(EmbeddingFunction):

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.typing as npt
 import importlib
 from typing import Optional
+from chromadb.config import is_thin_client
 
 
 class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
@@ -299,7 +300,11 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction):
                 tar.extractall(self.DOWNLOAD_PATH)
 
 
-DefaultEmbeddingFunction = ONNXMiniLM_L6_V2
+def DefaultEmbeddingFunction() -> Optional[EmbeddingFunction]:
+    if is_thin_client:
+        return None
+    else:
+        return ONNXMiniLM_L6_V2()
 
 
 class GooglePalmEmbeddingFunction(EmbeddingFunction):

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,41 @@
+<p align="center">
+  <a href="https://trychroma.com"><img src="https://user-images.githubusercontent.com/891664/227103090-6624bf7d-9524-4e05-9d2c-c28d5d451481.png" alt="Chroma logo"></a>
+</p>
+
+<p align="center">
+    <b>Chroma - the open-source embedding database</b>. <br />
+    This package is for the the Python HTTP client-only library for Chroma. This client connects to the Chroma Server. If that it not what you are looking for, you might want to check out the <a href="https://github.com/chroma-core/chroma ">full library</a>.
+</p>
+
+
+```bash
+pip install chromadb-client # python http-client only library
+```
+
+To connect to your server and perform operations using the client only library, you can do the following:
+
+```python
+import chromadb
+from chromadb.config import Settings
+# Example setup of the client to connect to your chroma server
+client = chromadb.Client(Settings(chroma_api_impl="rest", chroma_server_host="localhost", chroma_server_port=8000))
+
+collection = client.create_collection("all-my-documents")
+
+collection.add(
+    documents=["This is document1", "This is document2"],
+    metadatas=[{"source": "notion"}, {"source": "google-docs"}], # filter on these!
+    ids=["doc1", "doc2"], # unique for each doc
+    embeddings = [[1.2, 2.1, ...], [1.2, 2.1, ...]]
+)
+
+results = collection.query(
+    query_texts=["This is a query document"],
+    n_results=2,
+    # where={"metadata_field": "is_equal_to_this"}, # optional filter
+    # where_document={"$contains":"search_string"}  # optional filter
+)
+```
+## License
+
+[Apache 2.0](./LICENSE)

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -18,7 +18,9 @@ To connect to your server and perform operations using the client only library, 
 import chromadb
 from chromadb.config import Settings
 # Example setup of the client to connect to your chroma server
-client = chromadb.Client(Settings(chroma_api_impl="rest", chroma_server_host="localhost", chroma_server_port=8000))
+client = chromadb.Client(Settings(chroma_api_impl="rest",
+                                  chroma_server_host="localhost",
+                                  chroma_server_port=8000))
 
 collection = client.create_collection("all-my-documents")
 

--- a/clients/python/build_python_thin_client.sh
+++ b/clients/python/build_python_thin_client.sh
@@ -25,5 +25,3 @@ rm "$existing_toml"
 mv "$staged_toml" "$existing_toml"
 
 rm "$is_thin_client_target"
-
-echo "Teardown completed."

--- a/clients/python/build_python_thin_client.sh
+++ b/clients/python/build_python_thin_client.sh
@@ -20,6 +20,20 @@ mv "$existing_toml" "$staged_toml"
 staged_readme="staged_README.md"
 mv "$existing_readme" "$staged_readme"
 
+function cleanup {
+  # Teardown: Remove the new toml file and put the old one back
+  rm "$existing_toml"
+  mv "$staged_toml" "$existing_toml"
+
+  rm "$is_thin_client_target"
+
+  # Teardown: Remove the new readme file and put the old one back
+  rm "$existing_readme"
+  mv "$staged_readme" "$existing_readme"
+}
+
+trap cleanup EXIT
+
 # Copy the new toml file in place
 cp "$thin_client_toml" "$existing_toml"
 
@@ -30,13 +44,3 @@ cp "$is_thin_client_py" "$is_thin_client_target"
 cp "$thin_client_readme" "$existing_readme"
 
 python -m build
-
-# Teardown: Remove the new toml file and put the old one back
-rm "$existing_toml"
-mv "$staged_toml" "$existing_toml"
-
-rm "$is_thin_client_target"
-
-# Teardown: Remove the new readme file and put the old one back
-rm "$existing_readme"
-mv "$staged_readme" "$existing_readme"

--- a/clients/python/build_python_thin_client.sh
+++ b/clients/python/build_python_thin_client.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Define the paths to the existing and new toml files
+existing_toml="pyproject.toml"
+thin_client_toml="clients/python/pyproject.toml"
+
+# Define the path to the thin client flag script
+is_thin_client_py="clients/python/is_thin_client.py"
+is_thin_client_target="chromadb/is_thin_client.py"
+
+# Stage the existing toml file
+staged_toml="staged_pyproject.toml"
+mv "$existing_toml" "$staged_toml"
+
+# Copy the new toml file in place
+cp "$thin_client_toml" "$existing_toml"
+
+# Copy the thin client flag script in place
+cp "$is_thin_client_py" "$is_thin_client_target"
+
+# Perform the work that could potentially error
+# Add your commands here
+python -m build
+
+# Teardown: Remove the new toml file and put the old one back
+rm "$existing_toml"
+mv "$staged_toml" "$existing_toml"
+
+rm "$is_thin_client_target"
+
+echo "Teardown completed."

--- a/clients/python/build_python_thin_client.sh
+++ b/clients/python/build_python_thin_client.sh
@@ -18,8 +18,6 @@ cp "$thin_client_toml" "$existing_toml"
 # Copy the thin client flag script in place
 cp "$is_thin_client_py" "$is_thin_client_target"
 
-# Perform the work that could potentially error
-# Add your commands here
 python -m build
 
 # Teardown: Remove the new toml file and put the old one back

--- a/clients/python/build_python_thin_client.sh
+++ b/clients/python/build_python_thin_client.sh
@@ -8,15 +8,26 @@ thin_client_toml="clients/python/pyproject.toml"
 is_thin_client_py="clients/python/is_thin_client.py"
 is_thin_client_target="chromadb/is_thin_client.py"
 
+# Define the path to the existing readme and new readme for packaging
+existing_readme="README.md"
+thin_client_readme="clients/python/README.md"
+
 # Stage the existing toml file
 staged_toml="staged_pyproject.toml"
 mv "$existing_toml" "$staged_toml"
+
+# Stage the existing readme file
+staged_readme="staged_README.md"
+mv "$existing_readme" "$staged_readme"
 
 # Copy the new toml file in place
 cp "$thin_client_toml" "$existing_toml"
 
 # Copy the thin client flag script in place
 cp "$is_thin_client_py" "$is_thin_client_target"
+
+# Copy the new readme file in place
+cp "$thin_client_readme" "$existing_readme"
 
 python -m build
 
@@ -25,3 +36,7 @@ rm "$existing_toml"
 mv "$staged_toml" "$existing_toml"
 
 rm "$is_thin_client_target"
+
+# Teardown: Remove the new readme file and put the old one back
+rm "$existing_readme"
+mv "$staged_readme" "$existing_readme"

--- a/clients/python/integration-test.sh
+++ b/clients/python/integration-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+export CHROMA_PORT=8000
+
+# Define the path to the thin client flag script
+is_thin_client_py="clients/python/is_thin_client.py"
+is_thin_client_target="chromadb/is_thin_client.py"
+
+function cleanup {
+  rm "$is_thin_client_target"
+  docker compose -f docker-compose.test.yml down --rmi local --volumes
+}
+
+trap cleanup EXIT
+
+docker compose -f docker-compose.test.yml up --build -d
+
+export CHROMA_INTEGRATION_TEST_ONLY=1
+export CHROMA_API_IMPL=rest
+export CHROMA_SERVER_HOST=localhost
+export CHROMA_SERVER_HTTP_PORT=8000
+
+echo testing: python -m pytest "$@"
+
+# Copy the thin client flag script in place, uvicorn takes a while to startup inside docker
+sleep 5
+cp "$is_thin_client_py" "$is_thin_client_target"
+python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py'

--- a/clients/python/is_thin_client.py
+++ b/clients/python/is_thin_client.py
@@ -1,0 +1,1 @@
+is_thin_client = True

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "chromadb-thin-client"
+dynamic = ["version"]
+
+authors = [
+  { name="Jeff Huber", email="jeff@trychroma.com" },
+  { name="Anton Troynikov", email="anton@trychroma.com" }
+]
+description = "Chroma Client."
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+  'pandas >= 1.3',
+  'requests >= 2.28',
+  'pydantic >= 1.9',
+  'numpy >= 1.21.6',
+  'posthog >= 2.4.0',
+  'typing_extensions >= 4.5.0',
+  'overrides >= 7.3.1',
+]
+
+[tool.black]
+line-length = 88
+required-version = "23.3.0" # Black will refuse to run if it's not this version.
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
+[project.urls]
+"Homepage" = "https://github.com/chroma-core/chroma"
+"Bug Tracker" = "https://github.com/chroma-core/chroma/issues"
+
+[build-system]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme="no-local-version"
+
+[tool.setuptools]
+packages = ["chromadb"]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "chromadb-thin-client"
+name = "chromadb-client"
 dynamic = ["version"]
 
 authors = [

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./:/chroma
       - test_index_data:/index_data
-    command: uvicorn chromadb.app:app --reload --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml
+    command: uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml
     environment:
       - CHROMA_DB_IMPL=clickhouse
       - CLICKHOUSE_HOST=test_clickhouse


### PR DESCRIPTION
## Description of changes
*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Typing cleanup
	 - Changes embedding function defaults to work through the default params as opposed to via None so that None now means - NO embedding function as opposed to use the default. This is technically a breaking change. 
 - New functionality
	 - Adds a thin client that restricts what you can create to the REST api client and builds it separately so it can be published to its own pypi package. The thin client restricts the default embedding function to be None always - forcing manual specification of the embedding function while using the thin client. 
	 - The thin client is built with its own pyproject.toml with a limited set of dependencies and a is_thin_client.py file that acts as a compile flag. The build script stages the toml, places the two files in the right place, performs the build and then tears down the changes. 
	 
Addresses #289 

## Test plan
The existing tests should cover this configuration. We can add CI for the thin-client in the future.

## Documentation Changes
We will add a section on the docs that explains the thin client and its limitations. 
