### PR TITLE
fix #622: duckdb boolean option for persist atexit handler

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -41,6 +41,8 @@ class Settings(BaseSettings):
 
     allow_reset: bool = False
 
+    persist_atexit: bool = True
+
     sqlite_database: Optional[str] = ":memory:"
     migrations: Literal["none", "validate", "apply"] = "apply"
 

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -409,7 +409,9 @@ class PersistentDuckDB(DuckDB):
         self._save_folder = system.settings.persist_directory
         self.load()
         # https://docs.python.org/3/library/atexit.html
-        atexit.register(self.persist)
+        persist_atexit = system.settings.require("persist_atexit")
+        if persist_atexit:
+            atexit.register(self.persist)
 
     def set_save_folder(self, path):
         self._save_folder = path


### PR DESCRIPTION
Adds a config setting to disable the `atexit` persistence handler. See #622  for context.