### PR TITLE
Fix types for metadata search filters

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -28,14 +28,14 @@ Include = List[Literal["documents", "embeddings", "metadatas", "distances"]]
 LiteralValue = Union[str, int, float]
 LogicalOperator = Literal["$and", "$or"]
 WhereOperator = Literal["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]
-OperatorExpression = Dict[Union[WhereOperator, LogicalOperator], LiteralValue]
 
-Where = Dict[
-    Union[str, LogicalOperator], Union[LiteralValue, OperatorExpression, List["Where"]]
-]
+LogicalExpression = Dict[LogicalOperator, List["Where"]]
+ConditionExpression = Dict[str, Union[LiteralValue, Dict[WhereOperator, LiteralValue]]]
+Where = Union[LogicalExpression, ConditionExpression]
 
-WhereDocumentOperator = Literal["$contains", LogicalOperator]
-WhereDocument = Dict[WhereDocumentOperator, Union[str, List["WhereDocument"]]]
+WhereDocumentConditionExpression = Dict[Literal["$contains"], str]
+WhereDocumentLogicalExpression = Dict[LogicalOperator, "WhereDocument"]
+WhereDocument = Union[WhereDocumentLogicalExpression, WhereDocumentConditionExpression]
 
 
 class GetResult(TypedDict):


### PR DESCRIPTION
## Description of changes

Change types for `Where` and `WhereDocument` to match the actual logic and expectations of the code.

This precludes certain invalid constructions that were previously valid. For example:

```
ex1a: Where = {"foo": []}
ex2a: Where = {"$or": [{"$gt": 1}, {"$lt": 2}]}
ex3a: Where = {"$or": 42}
ex4a: Where = {"foobar": {"$or": 1}}
ex5a: WhereDocument = {"$or": "hi"}
```

I am not sure if we should merge these changes or not. During my own testing, I discovered a bug in MyPy that it is possible for this to trigger (https://github.com/python/mypy/issues/15323).

On the other hand, the unit test suite passes, so it's unlikely to cause an issue for our users.

## Test plan

MyPy passes when applied to `test_api.py` unit tests.

## Documentation Changes

No documentation changes required, these types *better* reflect what's already documented.