### PR TITLE
Local in-memory HNSWlib segment implementation

### DIFF
--- a/chromadb/segment/__init__.py
+++ b/chromadb/segment/__init__.py
@@ -50,16 +50,16 @@ class VectorReader(SegmentImplementation):
     def get_vectors(
         self, ids: Optional[Sequence[str]] = None
     ) -> Sequence[VectorEmbeddingRecord]:
-        """Get embeddings from the segment. If no IDs are provided,
-        all embeddings are returned."""
+        """Get embeddings from the segment. If no IDs are provided, all embeddings are
+        returned."""
         pass
 
     @abstractmethod
     def query_vectors(
-        self, queries: Sequence[VectorQuery]
+        self, query: VectorQuery
     ) -> Sequence[Sequence[VectorQueryResult]]:
-        """Given a list of vector queries, return the top-k nearest
-        neighbors for each query."""
+        """Given a vector query, return the top-k nearest neighbors for vector in the
+        query."""
         pass
 
 

--- a/chromadb/segment/__init__.py
+++ b/chromadb/segment/__init__.py
@@ -16,7 +16,15 @@ from uuid import UUID
 
 
 class SegmentImplementation(ABC, EnforceOverrides):
-    pass
+    @abstractmethod
+    def count(self) -> int:
+        """Get the number of embeddings in this segment"""
+        pass
+
+    @abstractmethod
+    def max_seqid(self) -> SeqId:
+        """Get the maximum SeqID currently indexed by this segment"""
+        pass
 
 
 class MetadataReader(SegmentImplementation):
@@ -34,23 +42,13 @@ class MetadataReader(SegmentImplementation):
         """Query for embedding metadata."""
         pass
 
-    @abstractmethod
-    def count_metadata(self) -> int:
-        """Get the number of embeddings in this segment."""
-        pass
-
-    @abstractmethod
-    def max_seqid(self) -> SeqId:
-        """Get the maximum SeqID currently indexed by this segment"""
-        pass
-
 
 class VectorReader(SegmentImplementation):
     """Embedding Vector segment interface"""
 
     @abstractmethod
     def get_vectors(
-        self, ids: Optional[Sequence[str]]
+        self, ids: Optional[Sequence[str]] = None
     ) -> Sequence[VectorEmbeddingRecord]:
         """Get embeddings from the segment. If no IDs are provided,
         all embeddings are returned."""
@@ -62,11 +60,6 @@ class VectorReader(SegmentImplementation):
     ) -> Sequence[Sequence[VectorQueryResult]]:
         """Given a list of vector queries, return the top-k nearest
         neighbors for each query."""
-        pass
-
-    @abstractmethod
-    def max_seqid(self) -> SeqId:
-        """Get the maximum SeqID currently indexed by this segment"""
         pass
 
 

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -81,7 +81,7 @@ class SqliteMetadataSegment(Component, MetadataReader):
                 return _decode_seq_id(result[0])
 
     @override
-    def count_metadata(self) -> int:
+    def count(self) -> int:
         embeddings_t = Table("embeddings")
         q = (
             self._db.querybuilder()
@@ -213,7 +213,7 @@ class SqliteMetadataSegment(Component, MetadataReader):
             if upsert:
                 return self._update_record(cur, record)
             else:
-                raise
+                logger.warning(f"Insert of existing embedding ID: {record['id']}")
 
         if record["metadata"]:
             self._update_metadata(cur, id, record["metadata"])

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -1,0 +1,270 @@
+from overrides import override
+from typing import Optional, Sequence, Dict, Callable, Union, cast
+from uuid import UUID
+from chromadb.segment import VectorReader
+from chromadb.ingest import Consumer
+from chromadb.config import Component, System, Settings
+from chromadb.types import (
+    EmbeddingRecord,
+    VectorEmbeddingRecord,
+    VectorQuery,
+    VectorQueryResult,
+    SeqId,
+    Segment,
+    Metadata,
+    Operation,
+    Vector,
+)
+from chromadb.errors import InvalidDimensionException
+import re
+import multiprocessing
+import hnswlib
+from threading import Lock
+import logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CAPACITY = 1000
+
+Validator = Callable[[Union[str, int, float]], bool]
+
+param_validators: Dict[str, Validator] = {
+    "hnsw:space": lambda p: bool(re.match(r"^(l2|cosine|ip)$", str(p))),
+    "hnsw:construction_ef": lambda p: isinstance(p, int),
+    "hnsw:search_ef": lambda p: isinstance(p, int),
+    "hnsw:M": lambda p: isinstance(p, int),
+    "hnsw:num_threads": lambda p: isinstance(p, int),
+    "hnsw:resize_factor": lambda p: isinstance(p, (int, float)),
+}
+
+
+class HnswParams:
+    space: str
+    construction_ef: int
+    search_ef: int
+    M: int
+    num_threads: int
+    resize_factor: float
+
+    def __init__(self, metadata: Metadata):
+        metadata = metadata or {}
+
+        for param, value in metadata.items():
+            if param.startswith("hnsw:"):
+                if param not in param_validators:
+                    raise ValueError(f"Unknown HNSW parameter: {param}")
+                if not param_validators[param](value):
+                    raise ValueError(
+                        f"Invalid value for HNSW parameter: {param} = {value}"
+                    )
+
+        self.space = str(metadata.get("hnsw:space", "l2"))
+        self.construction_ef = int(metadata.get("hnsw:construction_ef", 100))
+        self.search_ef = int(metadata.get("hnsw:search_ef", 10))
+        self.M = int(metadata.get("hnsw:M", 16))
+        self.num_threads = int(
+            metadata.get("hnsw:num_threads", multiprocessing.cpu_count())
+        )
+        self.resize_factor = float(metadata.get("hnsw:resize_factor", 1.2))
+
+
+class LocalHnswSegment(Component, VectorReader):
+    _id: UUID
+    _consumer: Consumer
+    _topic: Optional[str]
+    _subscription: UUID
+    _settings: Settings
+    _params: HnswParams
+
+    _index: Optional[hnswlib.Index]
+    _dimensionality: Optional[int]
+    _elements: int
+    _max_seq_id: SeqId
+
+    _lock: Lock
+
+    _id_to_label: Dict[str, int]
+    _label_to_id: Dict[int, str]
+    _id_to_seq_id: Dict[str, SeqId]
+
+    def __init__(self, system: System, segment: Segment):
+        self._consumer = system.instance(Consumer)
+        self._id = segment["id"]
+        self._topic = segment["topic"]
+        self._settings = system.settings
+        self._params = HnswParams(segment["metadata"] or {})
+
+        self._index = None
+        self._dimensionality = None
+        self._total_elements_added = 0
+        self._max_seq_id = self._consumer.min_seqid()
+
+        self._id_to_seq_id = {}
+        self._id_to_label = {}
+        self._label_to_id = {}
+
+        self._lock = Lock()
+        super().__init__(system)
+
+    @override
+    def start(self) -> None:
+        super().start()
+        if self._topic:
+            seq_id = self.max_seqid()
+            self._subscription = self._consumer.subscribe(
+                self._topic, self._write_records, start=seq_id
+            )
+
+    @override
+    def stop(self) -> None:
+        super().stop()
+        if self._subscription:
+            self._consumer.unsubscribe(self._subscription)
+
+    @override
+    def get_vectors(
+        self, ids: Optional[Sequence[str]] = None
+    ) -> Sequence[VectorEmbeddingRecord]:
+        if ids is None:
+            labels = list(self._label_to_id.keys())
+        else:
+            labels = [self._id_to_label[id] for id in ids]
+
+        results = []
+        if self._index is not None:
+            vectors = cast(Sequence[Vector], self._index.get_items(labels))
+
+            for label, vector in zip(labels, vectors):
+                id = self._label_to_id[label]
+                seq_id = self._id_to_seq_id[id]
+                results.append(
+                    VectorEmbeddingRecord(id=id, seq_id=seq_id, embedding=vector)
+                )
+
+        return results
+
+    @override
+    def query_vectors(
+        self, queries: Sequence[VectorQuery]
+    ) -> Sequence[Sequence[VectorQueryResult]]:
+        """Given a list of vector queries, return the top-k nearest
+        neighbors for each query."""
+        raise NotImplementedError()
+
+    @override
+    def max_seqid(self) -> SeqId:
+        return self._max_seq_id
+
+    @override
+    def count(self) -> int:
+        return len(self._id_to_label)
+
+    def _init_index(self, dimensionality: int) -> None:
+        # more comments available at the source: https://github.com/nmslib/hnswlib
+
+        index = hnswlib.Index(
+            space=self._params.space, dim=dimensionality
+        )  # possible options are l2, cosine or ip
+        index.init_index(
+            max_elements=DEFAULT_CAPACITY,
+            ef_construction=self._params.construction_ef,
+            M=self._params.M,
+        )
+        index.set_ef(self._params.search_ef)
+        index.set_num_threads(self._params.num_threads)
+
+        self._index = index
+        self._dimensionality = dimensionality
+
+    def _check_dimensionality(self, data: Vector) -> None:
+        """Assert that the given data matches the index dimensionality"""
+        if len(data) != self._dimensionality:
+            raise InvalidDimensionException(
+                f"Dimensionality of ({len(data)}) does not match index"
+                + f"dimensionality ({self._dimensionality})"
+            )
+
+    def _resize_index(self) -> None:
+        """Resize the index (if necessary)"""
+        index = cast(hnswlib.Index, self._index)
+
+        if self._total_elements_added > index.get_max_elements():
+            new_size = int(self._total_elements_added * self._params.resize_factor)
+            index.resize_index(max(new_size, DEFAULT_CAPACITY))
+
+    def _delete_vector_from_index(self, id: str) -> None:
+        """Delete a vector from the index"""
+        index = cast(hnswlib.Index, self._index)
+
+        label = self._id_to_label[id]
+        index.delete_items([label])
+        del self._id_to_label[id]
+        del self._label_to_id[label]
+        del self._id_to_seq_id[id]
+
+    def _add_vector_to_index(self, id: str, seq_id: SeqId, embedding: Vector) -> None:
+        """Add a vector to the index"""
+        if not self._index:
+            self._init_index(len(embedding))
+
+        index = cast(hnswlib.Index, self._index)
+
+        self._check_dimensionality(embedding)
+
+        if id in self._id_to_label:
+            label = self._id_to_label[id]
+        else:
+            self._total_elements_added += 1
+            label = self._total_elements_added
+            self._id_to_label[id] = label
+            self._label_to_id[label] = id
+            self._id_to_seq_id[id] = seq_id
+
+        self._resize_index()
+        index.add_items([embedding], [label])
+
+    def _write_record(self, record: EmbeddingRecord) -> None:
+        """Add a single embedding to the index"""
+
+        # let's be safe, just in case
+        with self._lock:
+            self._max_seq_id = max(self._max_seq_id, record["seq_id"])
+
+            if record["operation"] == Operation.DELETE:
+                if record["id"] in self._id_to_label:
+                    return self._delete_vector_from_index(record["id"])
+                else:
+                    logger.warning(
+                        f"Delete of nonexisting embedding ID: {record['id']}"
+                    )
+                    return
+
+            if record["id"] in self._id_to_label:
+                if record["operation"] == Operation.ADD:
+                    logger.warning(f"Insert of existing embedding ID: {record['id']}")
+                    return
+            else:
+                if record["operation"] == Operation.UPDATE:
+                    logger.warning(
+                        f"Update of nonexisting embedding ID: {record['id']}"
+                    )
+                    return
+
+            # Might be false for updates
+            if record["embedding"]:
+                self._add_vector_to_index(
+                    record["id"], record["seq_id"], record["embedding"]
+                )
+
+    def _write_records(self, records: Sequence[EmbeddingRecord]) -> None:
+        """Add a batch of embeddings to the index"""
+        if not self._running:
+            raise RuntimeError("Cannot add embeddings to stopped component")
+
+        for record in records:
+            self._write_record(record)
+
+
+# TODO: Implement this
+class PersistentLocalHnswSegment(LocalHnswSegment):
+    pass

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -128,7 +128,10 @@ class LocalHnswSegment(Component, VectorReader):
         if ids is None:
             labels = list(self._label_to_id.keys())
         else:
-            labels = [self._id_to_label[id] for id in ids]
+            labels = []
+            for id in ids:
+                if id in self._id_to_label:
+                    labels.append(self._id_to_label[id])
 
         results = []
         if self._index is not None:
@@ -237,7 +240,7 @@ class LocalHnswSegment(Component, VectorReader):
         index = cast(hnswlib.Index, self._index)
 
         label = self._id_to_label[id]
-        index.delete_items([label])
+        index.mark_deleted(label)
         del self._id_to_label[id]
         del self._label_to_id[label]
         del self._id_to_seq_id[id]

--- a/chromadb/test/segment/test_metadata.py
+++ b/chromadb/test/segment/test_metadata.py
@@ -120,14 +120,14 @@ def test_insert_and_count(
 
     sync(segment, max_id)
 
-    assert segment.count_metadata() == 3
+    assert segment.count() == 3
 
     for i in range(3):
         max_id = producer.submit_embedding(topic, next(sample_embeddings))
 
     sync(segment, max_id)
 
-    assert segment.count_metadata() == 6
+    assert segment.count() == 6
 
 
 def assert_equiv_records(
@@ -320,7 +320,7 @@ def test_delete(
 
     sync(segment, max_id)
 
-    assert segment.count_metadata() == 10
+    assert segment.count() == 10
     results = segment.get_metadata(ids=["embedding_0"])
     assert_equiv_records(embeddings[:1], results)
 
@@ -338,7 +338,7 @@ def test_delete(
 
     sync(segment, max_id)
 
-    assert segment.count_metadata() == 9
+    assert segment.count() == 9
     assert segment.get_metadata(ids=["embedding_0"]) == []
 
     # Delete is idempotent
@@ -354,13 +354,13 @@ def test_delete(
     )
 
     sync(segment, max_id)
-    assert segment.count_metadata() == 9
+    assert segment.count() == 9
     assert segment.get_metadata(ids=["embedding_0"]) == []
 
     # re-add
     max_id = producer.submit_embedding(topic, embeddings[0])
     sync(segment, max_id)
-    assert segment.count_metadata() == 10
+    assert segment.count() == 10
     results = segment.get_metadata(ids=["embedding_0"])
 
 
@@ -389,7 +389,7 @@ def test_update(
     sync(segment, max_id)
     results = segment.get_metadata(ids=["no_such_id"])
     assert len(results) == 0
-    assert segment.count_metadata() == 3
+    assert segment.count() == 3
 
 
 def test_upsert(

--- a/chromadb/test/segment/test_vector.py
+++ b/chromadb/test/segment/test_vector.py
@@ -1,0 +1,138 @@
+import pytest
+from typing import Generator, List, Callable, Iterator
+from chromadb.config import System, Settings
+from chromadb.types import (
+    SubmitEmbeddingRecord,
+    Operation,
+    ScalarEncoding,
+    Segment,
+    SegmentScope,
+    SeqId,
+)
+from chromadb.ingest import Producer
+from chromadb.segment import VectorReader
+import uuid
+import time
+
+from chromadb.segment.impl.vector.local_hnsw import LocalHnswSegment
+
+from pytest import FixtureRequest
+from itertools import count
+
+
+def sqlite() -> Generator[System, None, None]:
+    """Fixture generator for sqlite DB"""
+    settings = Settings(sqlite_database=":memory:", allow_reset=True)
+    system = System(settings)
+    system.start()
+    yield system
+    system.stop()
+
+
+def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
+    return [sqlite]
+
+
+@pytest.fixture(scope="module", params=system_fixtures())
+def system(request: FixtureRequest) -> Generator[System, None, None]:
+    yield next(request.param())
+
+
+@pytest.fixture(scope="function")
+def sample_embeddings() -> Iterator[SubmitEmbeddingRecord]:
+    def create_record(i: int) -> SubmitEmbeddingRecord:
+        vector = [i + i * 0.5, i + i * 0.5]
+        record = SubmitEmbeddingRecord(
+            id=f"embedding_{i}",
+            embedding=vector,
+            encoding=ScalarEncoding.FLOAT32,
+            metadata=None,
+            operation=Operation.ADD,
+        )
+        return record
+
+    return (create_record(i) for i in count())
+
+
+segment_definition = Segment(
+    id=uuid.uuid4(),
+    type="test_type",
+    scope=SegmentScope.VECTOR,
+    topic="persistent://test/test/test_topic_1",
+    collection=None,
+    metadata=None,
+)
+
+
+def sync(segment: VectorReader, seq_id: SeqId) -> None:
+    # Try for up to 5 seconds, then throw a TimeoutError
+    start = time.time()
+    while time.time() - start < 5:
+        if segment.max_seqid() >= seq_id:
+            return
+        time.sleep(0.25)
+    raise TimeoutError(f"Timed out waiting for seq_id {seq_id}")
+
+
+def test_insert_and_count(
+    system: System, sample_embeddings: Iterator[SubmitEmbeddingRecord]
+) -> None:
+    system.reset()
+    producer = system.instance(Producer)
+
+    topic = str(segment_definition["topic"])
+
+    max_id = 0
+    for i in range(3):
+        max_id = producer.submit_embedding(topic, next(sample_embeddings))
+
+    segment = LocalHnswSegment(system, segment_definition)
+    segment.start()
+
+    sync(segment, max_id)
+
+    assert segment.count() == 3
+    for i in range(3):
+        max_id = producer.submit_embedding(topic, next(sample_embeddings))
+
+    sync(segment, max_id)
+    assert segment.count() == 6
+
+
+def test_get_vectors(
+    system: System, sample_embeddings: Iterator[SubmitEmbeddingRecord]
+) -> None:
+    system.reset()
+    producer = system.instance(Producer)
+
+    topic = str(segment_definition["topic"])
+
+    segment = LocalHnswSegment(system, segment_definition)
+    segment.start()
+
+    embeddings = [next(sample_embeddings) for i in range(10)]
+
+    seq_ids: List[SeqId] = []
+    for e in embeddings:
+        seq_ids.append(producer.submit_embedding(topic, e))
+
+    sync(segment, seq_ids[-1])
+
+    # Get all items
+    vectors = segment.get_vectors()
+    assert len(vectors) == len(embeddings)
+    vectors = sorted(vectors, key=lambda v: v["id"])
+    for actual, expected, seq_id in zip(vectors, embeddings, seq_ids):
+        assert actual["id"] == expected["id"]
+        assert actual["embedding"] == expected["embedding"]
+        assert actual["seq_id"] == seq_id
+
+    # Get selected IDs
+    ids = [e["id"] for e in embeddings[5:]]
+    vectors = segment.get_vectors(ids=ids)
+    assert len(vectors) == 5
+    vectors = sorted(vectors, key=lambda v: v["id"])
+    for actual, expected, seq_id in zip(vectors, embeddings[5:], seq_ids[5:]):
+        assert actual["id"] == expected["id"]
+        assert actual["embedding"] == expected["embedding"]
+        assert actual["seq_id"] == seq_id

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -66,7 +66,6 @@ class VectorEmbeddingRecord(TypedDict):
     id: str
     seq_id: SeqId
     embedding: Vector
-    encoding: ScalarEncoding
 
 
 class MetadataEmbeddingRecord(TypedDict):

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -94,15 +94,17 @@ class SubmitEmbeddingRecord(TypedDict):
 class VectorQuery(TypedDict):
     """A KNN/ANN query"""
 
-    vector: Vector
+    vectors: Sequence[Vector]
     k: int
     allowed_ids: Optional[Sequence[str]]
     options: Optional[dict[str, Union[str, int, float]]]
 
 
-class VectorQueryResult(VectorEmbeddingRecord):
+class VectorQueryResult(TypedDict):
     """A KNN/ANN query result"""
 
+    id: str
+    seq_id: SeqId
     distance: float
 
 


### PR DESCRIPTION
## Description of changes

Adds a `VectorReader` segment implementation using HNSWlib.

This PR's implementation only runs in memory. In this scenario, because the data is already persisted to the embedding queue, persisting the index itself is purely a performance improvement and can be implemented in a separate PR.

## Test plan

Unit tests included and will be exercised by property tests once the new architecture is extended to the `API` interface.

## Documentation Changes

N/A
