### PR TITLE
bump JS version and update release process

### DIFF
--- a/clients/js/DEVELOP.md
+++ b/clients/js/DEVELOP.md
@@ -22,7 +22,7 @@ This readme is helpful for local dev.
 
 The goal of the design is that this will be added to our github action releases so that the JS API is always up to date and pinned against the python backend API.
 
-`npm publish` pushes the `package.json` defined packaged to the package manager for authenticated users.
+`yarn release` pushes the `package.json` defined packaged to the package manager for authenticated users. It will build, test, and then publish the new version.
 
 ### Useful links
 

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",
@@ -37,6 +37,7 @@
     "build:main": "tsc -p tsconfig.json",
     "build:module": "tsc -p tsconfig.module.json",
     "genapi": "./genapi.sh",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "release": "run-s build test:run && npm publish"
   }
 }


### PR DESCRIPTION
Update our release process for JS to avoid missing a fresh build. 