### PR TITLE
Catch and throw error in ChromaClient.getCollection

### DIFF
--- a/clients/js/src/ChromaClient.ts
+++ b/clients/js/src/ChromaClient.ts
@@ -223,6 +223,10 @@ export class ChromaClient {
             .then(handleSuccess)
             .catch(handleError);
 
+        if (response.error) {
+            throw new Error(response.error);
+        }
+
         return new Collection(
             response.name,
             response.id,

--- a/clients/js/test/get.collection.test.ts
+++ b/clients/js/test/get.collection.test.ts
@@ -20,6 +20,8 @@ test("it should get a collection", async () => {
   expect(["test1"]).toEqual(expect.arrayContaining(results2.ids));
 });
 
+
+
 test("wrong code returns an error", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
@@ -52,4 +54,13 @@ test("test gt, lt, in a simple small way", async () => {
   const items = await collection.get({ where: { float_value: { $gt: -1.4 } } });
   expect(items.ids.length).toBe(2);
   expect(["test2", "test3"]).toEqual(expect.arrayContaining(items.ids));
+});
+
+
+test("it should throw an error if the collection does not exist", async () => {
+  await chroma.reset();
+
+  await expect(
+    async () => await chroma.getCollection({ name: "test" })
+  ).rejects.toThrow(Error);
 });


### PR DESCRIPTION
## Description of changes
When fetching a collection that does not exist, the JS client would fail silently, returning a collection with `undefined` for all its attributes.

 - Improvements & Bug fixes
	 -  `ChromaClient.getCollection` will throw an error if there is an error in the API response
	 - closes: #634 

## Test plan
Passed tests with `$ yarn test`

## Documentation Changes
None
