### PR TITLE
js 1.5.2

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Bump JS to 1.5.2 to pick up the types changes to unblock langchainjs. 

This has already been released to npm. 