### PR TITLE
Add embedding support for Transformers.js

### DIFF
--- a/clients/js/src/embeddings/TransformersEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/TransformersEmbeddingFunction.ts
@@ -4,50 +4,59 @@ import { IEmbeddingFunction } from "./IEmbeddingFunction";
 let TransformersApi: Promise<any>;
 
 export class TransformersEmbeddingFunction implements IEmbeddingFunction {
+  private pipelinePromise: Promise<any> | null;
 
-    private pipelinePromise: Promise<any> | null;
-
-    /**
-     * TransformersEmbeddingFunction constructor.
-     * @param options The configuration options.
-     * @param options.model The model to use to calculate embeddings. Defaults to 'Xenova/all-MiniLM-L6-v2', which is an ONNX port of `sentence-transformers/all-MiniLM-L6-v2`.
-     * @param options.revision The specific model version to use (can be a branch, tag name, or commit id). Defaults to 'main'.
-     * @param options.quantized Whether to load the 8-bit quantized version of the model. Defaults to `false`.
-     * @param options.progress_callback If specified, this function will be called during model construction, to provide the user with progress updates.
-     */
-    constructor({
-        model = 'Xenova/all-MiniLM-L6-v2',
-        revision = 'main',
-        quantized = false,
-        progress_callback = null,
-    }: { model?: string; revision?: string; quantized?: boolean; progress_callback?: Function | null; } = {}) {
-        try {
-            // Since Transformers.js is an ESM package, we use the dynamic `import` syntax instead of `require`.
-            // Also, since we use `"module": "commonjs"` in tsconfig.json, we use the following workaround to ensure
-            // the dynamic import is not transpiled to a `require` statement.
-            // For more information, see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-1008361973
-            TransformersApi = Function('return import("@xenova/transformers")')();
-
-        } catch (e) {
-            throw new Error(
-                "Please install the @xenova/transformers package to use the TransformersEmbeddingFunction, `npm install -S @xenova/transformers`."
-            );
-        }
-
-        // Store a promise that resolves to the pipeline
-        this.pipelinePromise = new Promise(async (resolve, reject) => {
-            try {
-                const { pipeline } = await TransformersApi;
-                resolve(await pipeline('feature-extraction', model, { quantized, revision, progress_callback }));
-            } catch (e) {
-                reject(e);
-            }
-        });
+  /**
+   * TransformersEmbeddingFunction constructor.
+   * @param options The configuration options.
+   * @param options.model The model to use to calculate embeddings. Defaults to 'Xenova/all-MiniLM-L6-v2', which is an ONNX port of `sentence-transformers/all-MiniLM-L6-v2`.
+   * @param options.revision The specific model version to use (can be a branch, tag name, or commit id). Defaults to 'main'.
+   * @param options.quantized Whether to load the 8-bit quantized version of the model. Defaults to `false`.
+   * @param options.progress_callback If specified, this function will be called during model construction, to provide the user with progress updates.
+   */
+  constructor({
+    model = "Xenova/all-MiniLM-L6-v2",
+    revision = "main",
+    quantized = false,
+    progress_callback = null,
+  }: {
+    model?: string;
+    revision?: string;
+    quantized?: boolean;
+    progress_callback?: Function | null;
+  } = {}) {
+    try {
+      // Since Transformers.js is an ESM package, we use the dynamic `import` syntax instead of `require`.
+      // Also, since we use `"module": "commonjs"` in tsconfig.json, we use the following workaround to ensure
+      // the dynamic import is not transpiled to a `require` statement.
+      // For more information, see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-1008361973
+      TransformersApi = Function('return import("@xenova/transformers")')();
+    } catch (e) {
+      throw new Error(
+        "Please install the @xenova/transformers package to use the TransformersEmbeddingFunction, `npm install -S @xenova/transformers`."
+      );
     }
 
-    public async generate(texts: string[]): Promise<number[][]> {
-        let pipe = await this.pipelinePromise;
-        let output = await pipe(texts, { pooling: 'mean', normalize: true });
-        return output.tolist();
-    }
+    // Store a promise that resolves to the pipeline
+    this.pipelinePromise = new Promise(async (resolve, reject) => {
+      try {
+        const { pipeline } = await TransformersApi;
+        resolve(
+          await pipeline("feature-extraction", model, {
+            quantized,
+            revision,
+            progress_callback,
+          })
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  public async generate(texts: string[]): Promise<number[][]> {
+    let pipe = await this.pipelinePromise;
+    let output = await pipe(texts, { pooling: "mean", normalize: true });
+    return output.tolist();
+  }
 }

--- a/clients/js/src/embeddings/TransformersEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/TransformersEmbeddingFunction.ts
@@ -1,0 +1,53 @@
+import { IEmbeddingFunction } from "./IEmbeddingFunction";
+
+// Dynamically import module
+let TransformersApi: Promise<any>;
+
+export class TransformersEmbeddingFunction implements IEmbeddingFunction {
+
+    private pipelinePromise: Promise<any> | null;
+
+    /**
+     * TransformersEmbeddingFunction constructor.
+     * @param options The configuration options.
+     * @param options.model The model to use to calculate embeddings. Defaults to 'Xenova/all-MiniLM-L6-v2', which is an ONNX port of `sentence-transformers/all-MiniLM-L6-v2`.
+     * @param options.revision The specific model version to use (can be a branch, tag name, or commit id). Defaults to 'main'.
+     * @param options.quantized Whether to load the 8-bit quantized version of the model. Defaults to `false`.
+     * @param options.progress_callback If specified, this function will be called during model construction, to provide the user with progress updates.
+     */
+    constructor({
+        model = 'Xenova/all-MiniLM-L6-v2',
+        revision = 'main',
+        quantized = false,
+        progress_callback = null,
+    }: { model?: string; revision?: string; quantized?: boolean; progress_callback?: Function | null; } = {}) {
+        try {
+            // Since Transformers.js is an ESM package, we use the dynamic `import` syntax instead of `require`.
+            // Also, since we use `"module": "commonjs"` in tsconfig.json, we use the following workaround to ensure
+            // the dynamic import is not transpiled to a `require` statement.
+            // For more information, see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-1008361973
+            TransformersApi = Function('return import("@xenova/transformers")')();
+
+        } catch (e) {
+            throw new Error(
+                "Please install the @xenova/transformers package to use the TransformersEmbeddingFunction, `npm install -S @xenova/transformers`."
+            );
+        }
+
+        // Store a promise that resolves to the pipeline
+        this.pipelinePromise = new Promise(async (resolve, reject) => {
+            try {
+                const { pipeline } = await TransformersApi;
+                resolve(await pipeline('feature-extraction', model, { quantized, revision, progress_callback }));
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
+    public async generate(texts: string[]): Promise<number[][]> {
+        let pipe = await this.pipelinePromise;
+        let output = await pipe(texts, { pooling: 'mean', normalize: true });
+        return output.tolist();
+    }
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -3,3 +3,5 @@ export { Collection } from './Collection';
 export { IEmbeddingFunction } from './embeddings/IEmbeddingFunction';
 export { OpenAIEmbeddingFunction } from './embeddings/OpenAIEmbeddingFunction';
 export { CohereEmbeddingFunction } from './embeddings/CohereEmbeddingFunction';
+export { WebAIEmbeddingFunction } from './embeddings/WebAIEmbeddingFunction';
+export { TransformersEmbeddingFunction } from './embeddings/TransformersEmbeddingFunction';


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Add support for [Transformers.js](https://github.com/xenova/transformers.js). This allows users to run Hugging Face transformers directly from their JS applications. For more information, see https://huggingface.co/docs/transformers.js.

## Test plan
*How are these changes tested?*
I followed the [JS "Getting started" guide](https://docs.trychroma.com/getting-started?lang=js) to ensure it works as intended. Here's the script, and its output:
```js
const {ChromaClient, TransformersEmbeddingFunction} = require('chromadb');
const client = new ChromaClient();

// Create the embedder. In this case, I just use the defaults, but you can change the model,
// quantization, revision, or add a progress callback, if desired.
const embedder = new TransformersEmbeddingFunction({ /* Configuration goes here */ });

const main = async () => {
    // Empties and completely resets the database.
    await client.reset()

    // Create the collection
    const collection = await client.createCollection({name: "my_collection", embeddingFunction: embedder})

    // Add some data to the collection
    await collection.add({
        ids: ["id1", "id2", "id3"],
        metadatas: [{"source": "my_source"}, {"source": "my_source"},  {"source": "my_source"}],
        documents: ["I love walking my dog", "This is another document", "This is a legal document"],
    }) 
    
    // Query the collection
    const results = await collection.query({
        nResults: 2, 
        queryTexts: ["This is a query document"]
    }) 
    console.log(results)
    // {
    //     ids: [ [ 'id2', 'id3' ] ],
    //     embeddings: null,
    //     documents: [ [ 'This is another document', 'This is a legal document' ] ],
    //     metadatas: [ [ [Object], [Object] ] ],
    //     distances: [ [ 1.0109775066375732, 1.0756263732910156 ] ]
    // }
}

main();

```


## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
I just added some type annotations for the constructor.
