### PR TITLE
Implement JS client persist function

### DIFF
--- a/clients/js/.prettierrc.json
+++ b/clients/js/.prettierrc.json
@@ -1,1 +1,4 @@
-{}
+{
+    "tabWidth": 4,
+    "useTabs": false
+}

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -19,6 +19,13 @@ test("it should get the heartbeat", async () => {
     expect(heartbeat).toBeGreaterThan(0);
 });
 
+test("it should get exception when calling persist", async () => {
+    await chroma.reset();
+    await expect(async () => {
+        await chroma.persist();
+    }).rejects.toThrow(Error);
+});
+
 test("it should reset the database", async () => {
     await chroma.reset();
     const collections = await chroma.listCollections();
@@ -39,157 +46,164 @@ test("it should reset the database", async () => {
     expect(collections3.length).toBe(0);
 });
 
-test('it should list collections', async () => {
-    await chroma.reset()
-    let collections = await chroma.listCollections()
-    expect(collections).toBeDefined()
-    expect(collections).toBeInstanceOf(Array)
-    expect(collections.length).toBe(0)
+test("it should list collections", async () => {
+    await chroma.reset();
+    let collections = await chroma.listCollections();
+    expect(collections).toBeDefined();
+    expect(collections).toBeInstanceOf(Array);
+    expect(collections.length).toBe(0);
     const collection = await chroma.createCollection({ name: "test" });
-    collections = await chroma.listCollections()
-    expect(collections.length).toBe(1)
-})
+    collections = await chroma.listCollections();
+    expect(collections.length).toBe(1);
+});
 
-test('it should get a collection', async () => {
-    await chroma.reset()
+test("it should get a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
     const collection2 = await chroma.getCollection({ name: "test" });
-    expect(collection).toBeDefined()
-    expect(collection2).toBeDefined()
-    expect(collection).toHaveProperty('name')
-    expect(collection2).toHaveProperty('name')
-    expect(collection.name).toBe(collection2.name)
-    expect(collection).toHaveProperty('id')
-    expect(collection2).toHaveProperty('id')
-    expect(collection.id).toBe(collection2.id)
-})
+    expect(collection).toBeDefined();
+    expect(collection2).toBeDefined();
+    expect(collection).toHaveProperty("name");
+    expect(collection2).toHaveProperty("name");
+    expect(collection.name).toBe(collection2.name);
+    expect(collection).toHaveProperty("id");
+    expect(collection2).toHaveProperty("id");
+    expect(collection.id).toBe(collection2.id);
+});
 
-test('it should delete a collection', async () => {
-    await chroma.reset()
+test("it should delete a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    let collections = await chroma.listCollections()
-    expect(collections.length).toBe(1)
+    let collections = await chroma.listCollections();
+    expect(collections.length).toBe(1);
     var resp = await chroma.deleteCollection({ name: "test" });
-    collections = await chroma.listCollections()
-    expect(collections.length).toBe(0)
-})
+    collections = await chroma.listCollections();
+    expect(collections.length).toBe(0);
+});
 
-test('it should add single embeddings to a collection', async () => {
-    await chroma.reset()
+test("it should add single embeddings to a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = 'test1'
-    const embeddings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    const metadatas = { test: 'test' }
-    await collection.add({ ids, embeddings, metadatas })
-    const count = await collection.count()
-    expect(count).toBe(1)
-})
+    const ids = "test1";
+    const embeddings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const metadatas = { test: "test" };
+    await collection.add({ ids, embeddings, metadatas });
+    const count = await collection.count();
+    expect(count).toBe(1);
+});
 
-test('it should add batch embeddings to a collection', async () => {
-    await chroma.reset()
+test("it should add batch embeddings to a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = ['test1', 'test2', 'test3']
+    const ids = ["test1", "test2", "test3"];
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    ]
-    await collection.add({ ids, embeddings })
-    const count = await collection.count()
-    expect(count).toBe(3)
-})
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    ];
+    await collection.add({ ids, embeddings });
+    const count = await collection.count();
+    expect(count).toBe(3);
+});
 
-test('it should query a collection', async () => {
-    await chroma.reset()
+test("it should query a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = ['test1', 'test2', 'test3']
+    const ids = ["test1", "test2", "test3"];
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    ]
-    await collection.add({ ids, embeddings })
-    const results = await collection.query({ queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], nResults: 2 })
-    expect(results).toBeDefined()
-    expect(results).toBeInstanceOf(Object)
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    ];
+    await collection.add({ ids, embeddings });
+    const results = await collection.query({
+        queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        nResults: 2,
+    });
+    expect(results).toBeDefined();
+    expect(results).toBeInstanceOf(Object);
     // expect(results.embeddings[0].length).toBe(2)
-    const result: string[] = ['test1', 'test2']
+    const result: string[] = ["test1", "test2"];
     expect(result).toEqual(expect.arrayContaining(results.ids[0]));
-    expect(['test3']).not.toEqual(expect.arrayContaining(results.ids[0]));
-})
+    expect(["test3"]).not.toEqual(expect.arrayContaining(results.ids[0]));
+});
 
-test('it should peek a collection', async () => {
-    await chroma.reset()
+test("it should peek a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = ['test1', 'test2', 'test3']
+    const ids = ["test1", "test2", "test3"];
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    ]
-    await collection.add({ ids, embeddings })
-    const results = await collection.peek({ limit: 2 })
-    expect(results).toBeDefined()
-    expect(results).toBeInstanceOf(Object)
-    expect(results.ids.length).toBe(2)
-    expect(['test1', 'test2']).toEqual(expect.arrayContaining(results.ids));
-})
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    ];
+    await collection.add({ ids, embeddings });
+    const results = await collection.peek({ limit: 2 });
+    expect(results).toBeDefined();
+    expect(results).toBeInstanceOf(Object);
+    expect(results.ids.length).toBe(2);
+    expect(["test1", "test2"]).toEqual(expect.arrayContaining(results.ids));
+});
 
-test('it should get a collection', async () => {
-    await chroma.reset()
+test("it should get a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = ['test1', 'test2', 'test3']
+    const ids = ["test1", "test2", "test3"];
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    ]
-    const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
-    await collection.add({ ids, embeddings, metadatas })
-    const results = await collection.get({ ids: ['test1'] })
-    expect(results).toBeDefined()
-    expect(results).toBeInstanceOf(Object)
-    expect(results.ids.length).toBe(1)
-    expect(['test1']).toEqual(expect.arrayContaining(results.ids));
-    expect(['test2']).not.toEqual(expect.arrayContaining(results.ids));
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    ];
+    const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
+    await collection.add({ ids, embeddings, metadatas });
+    const results = await collection.get({ ids: ["test1"] });
+    expect(results).toBeDefined();
+    expect(results).toBeInstanceOf(Object);
+    expect(results.ids.length).toBe(1);
+    expect(["test1"]).toEqual(expect.arrayContaining(results.ids));
+    expect(["test2"]).not.toEqual(expect.arrayContaining(results.ids));
 
-    const results2 = await collection.get({ where: { 'test': 'test1' } })
-    expect(results2).toBeDefined()
-    expect(results2).toBeInstanceOf(Object)
-    expect(results2.ids.length).toBe(1)
-})
+    const results2 = await collection.get({ where: { test: "test1" } });
+    expect(results2).toBeDefined();
+    expect(results2).toBeInstanceOf(Object);
+    expect(results2.ids.length).toBe(1);
+});
 
-test('it should delete a collection', async () => {
-    await chroma.reset()
+test("it should delete a collection", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = ['test1', 'test2', 'test3']
+    const ids = ["test1", "test2", "test3"];
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    ]
-    const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
-    await collection.add({ ids, embeddings, metadatas })
-    let count = await collection.count()
-    expect(count).toBe(3)
-    var resp = await collection.delete({ where: { 'test': 'test1' } })
-    count = await collection.count()
-    expect(count).toBe(2)
-})
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    ];
+    const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
+    await collection.add({ ids, embeddings, metadatas });
+    let count = await collection.count();
+    expect(count).toBe(3);
+    var resp = await collection.delete({ where: { test: "test1" } });
+    count = await collection.count();
+    expect(count).toBe(2);
+});
 
-test('wrong code returns an error', async () => {
-    await chroma.reset()
+test("wrong code returns an error", async () => {
+    await chroma.reset();
     const collection = await chroma.createCollection({ name: "test" });
-    const ids = ['test1', 'test2', 'test3']
+    const ids = ["test1", "test2", "test3"];
     const embeddings = [
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    ]
-    const metadatas = [{ test: 'test1' }, { test: 'test2' }, { test: 'test3' }]
-    await collection.add({ ids, embeddings, metadatas })
-    // @ts-ignore - supposed to fail
-    const results = await collection.get({ where: { "test": { "$contains": "hello" } } });
-    expect(results.error).toBeDefined()
-    expect(results.error).toBe("ValueError('Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got $contains')")
-})
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    ];
+    const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
+    await collection.add({ ids, embeddings, metadatas });
+    const results = await collection.get({
+        // @ts-ignore - supposed to fail
+        where: { test: { $contains: "hello" } },
+    });
+    expect(results.error).toBeDefined();
+    expect(results.error).toBe(
+        "ValueError('Expected one of $gt, $lt, $gte, $lte, $ne, $eq, got $contains')"
+    );
+});


### PR DESCRIPTION
## Description of changes

In https://github.com/hwchase17/langchainjs/issues/687 it is remarked that the JS chroma client does not implement the persist() API. This PR fixes that. 

There is a bit of a wrinkle --

## Test plan
- Confirmed manually that calling this API from a Node.js program successfully causes a DB persistence when CHROMA_DB_IMPL is set to `duckdb+parquet`. 
- Added a test to the js client tests which tests that the persist function throws an exception using the standard test configuration, which uses the clickhouse backend, which doesn't support manual persist (presumably because it is superfluous)

## Documentation Changes
Added jsdoc for persist API

## Additional funkiness with this PR
### Testing
In the best of all worlds, there would be a test which would verify that persistence occurs correctly on db impls that support it. Unfortunately, at present, the js client tests all run with `docker-compose.test.yml` which invokes a test server that uses the clickhouse db impl. 

What I would do would be to make so that there are different test suites for different backends. Each backend test suite would share a common set of tests (probably the vast majority of tests) with the other backend test suites but then have distinct tests, e.g. clickhouse would test that persist throws, and duckdb would test that persist, well, persists.

 Then, I would modify docker-compose.test.yml to create multiple chroma servers for the different backends to be tested, or perhaps have different docker-compose files for the different test backends. 

Finally I would probably write a ts script to run tests with the different configs, rather than depending on package.json scripts, which are being stretched pretty far for the current test commands, imo.

All of this might not be what the project admins would choose to expend resources to do immediately, but at least its good to think through what the right thing would be. Happy to do a follow-on PR for it if that were considered useful or appropriate.

### Formatting
My local vscode configuration makes it so when I save files they are automatically prettier'd using the project prettier config. The default prettier config has indents as 2 spaces, so the save caused a massive (whitespace-only) diff. I modified the prettier config to use what seems to be the project standard 4 spaces. But there are other diffs generated with the current prettier config, in particular the test file has inconsistent use of single and double quotes.

What I don't understand is why it is not the case that running `yarn prettier` in the clients/js directory doesn't cause a massive whitespace diff for other project contributors. It does for me. 