### PR TITLE
GitHub action to run Chroma database server

### DIFF
--- a/.github/workflows/chromadb-action-test.yml
+++ b/.github/workflows/chromadb-action-test.yml
@@ -1,0 +1,25 @@
+name: Test ChromaDB action
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Start ChromaDB
+      uses: ./
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+    - name: Install dev dependencies
+      run: npm install --save-dev typescript jest
+      working-directory: ./clients/js
+    - name: Build TypeScript files
+      run: tsc
+      working-directory: ./clients/js
+    - name: Run tests
+      run: npm run test:run -- --testPathPattern=test/action
+      working-directory: ./clients/js

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -62,6 +62,14 @@ Unit tests are in the `/chromadb/test` directory.
 
 To run unit tests using your current environment, run `pytest`.
 
+## Github Action
+Github action for running Chroma database server in your workflow:
+```yml
+- name: Start ChromaDB
+  uses: CakeCrusher/chroma@v1.0.2
+```
+Runs the Chroma database server on port `8000`.
+
 ## Manual Build
 
 To manually build a distribution, run `python -m build`.

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -66,7 +66,7 @@ To run unit tests using your current environment, run `pytest`.
 Github action for running Chroma database server in your workflow:
 ```yml
 - name: Start ChromaDB
-  uses: CakeCrusher/chroma@v1.0.2
+  uses: chroma-core/chroma@v1.0.0
 ```
 Runs the Chroma database server on port `8000`.
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,12 @@ runs:
     - name: Checkout current repository
       uses: actions/checkout@v2
 
+    - name: Setup C++ compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++
+      shell: bash
+
     - name: Start server by running docker-compose
       run: docker-compose up -d
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ runs:
     - name: Checkout ChromaDB repository
       uses: actions/checkout@v2
       with:
-        repository: 'CakeCrusher/chroma'
-        path: './chroma' # Clones the repo to a 'chroma' subdirectory
+        repository: 'chroma-core/chroma'
+        path: './chroma'
 
     - name: Setup C++ compiler
       run: |

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,11 @@ branding:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout current repository
+    - name: Checkout ChromaDB repository
       uses: actions/checkout@v2
+      with:
+        repository: 'CakeCrusher/chroma'
+        path: './chroma' # Clones the repo to a 'chroma' subdirectory
 
     - name: Setup C++ compiler
       run: |
@@ -17,7 +20,7 @@ runs:
       shell: bash
 
     - name: Start server by running docker-compose
-      run: docker-compose up -d
+      run: cd ./chroma && docker-compose up -d
       shell: bash
 
     - name: Wait for server to be ready

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,23 @@
+name: 'ChromaDB'
+description: 'Instantiates a chroma database server.'
+branding:
+  icon: 'database'
+  color: 'yellow'
+  
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v2
+
+    - name: Start server by running docker-compose
+      run: docker-compose up -d
+      shell: bash
+
+    - name: Wait for server to be ready
+      run: |
+        while ! curl -s http://localhost:8000 > /dev/null; do
+          echo "Waiting for server..."
+          sleep 5
+        done
+      shell: bash

--- a/clients/js/test/action.test.ts
+++ b/clients/js/test/action.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@jest/globals';
+import { ChromaClient } from "../src/ChromaClient";
+
+test("verify that server is running and functional within runner", async () => {
+  const chroma = new ChromaClient({ path: "http://localhost:8000" });
+  const collection = await chroma.createCollection({ name: "test" });
+  const preliminaryCount = await collection.count();
+  expect(preliminaryCount).toBe(0);
+  await collection.add({
+    ids: ["id1"],
+    metadatas: [{"chapter": "3", "verse": "16"}], 
+    documents: ["lorem ipsum..."],
+    embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]] 
+  })
+  const getAll = await collection.get()
+  console.log("getAll:\n", getAll)
+  const count = await collection.count();
+  expect(count).toBe(1);
+});

--- a/clients/js/test/action.test.ts
+++ b/clients/js/test/action.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '@jest/globals';
-import { ChromaClient } from "../src/ChromaClient";
+import chroma from './initClient'
 
 test("verify that server is running and functional within runner", async () => {
-  const chroma = new ChromaClient({ path: "http://localhost:8000" });
   const collection = await chroma.createCollection({ name: "test" });
   const preliminaryCount = await collection.count();
   expect(preliminaryCount).toBe(0);


### PR DESCRIPTION
## Description of changes
- Added a `action.yml` metadata file to create a composite Github action.
- Created a `action.test.yml` test file to quickly test that the action is functional.
- Created a `chromadb-action-test.yml` workflow file to test that the action works.
*Summarize the changes made by this PR.*
 - New functionality
	 - Creates an Github action that (once published) anyone can incorporate into their CICD workflow to run an ephemeral Chroma database server on their runner.
	 - Incorporated CI testing for the action

## Test plan
*How are these changes tested?*
The `chromadb-action-test.yml` wokflow tests the action with `action.test.yml` on the node client.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
Documentation was added to the `DEVELOP.md` file, adding it to the docs repository might be worthwhile as the action is extended.

## Future development and improvements
- Create (preferable though an automated workflow) images for the `server` and `clickhouse` so that the `docker-compose up` build is run much faster
- Add input options for the action starting with `port`.

#665 @jeffchuber 