### PR TITLE
#642 - Fix for hnswlib docker build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim-bullseye as builder
 
 #RUN apt-get update -qq
 #RUN apt-get install python3.10 python3-pip -y --no-install-recommends && rm -rf /var/lib/apt/lists_/*
-RUN apt-get update && apt-get install build-essential -y
+RUN apt-get update --fix-missing && apt-get install -y --fix-missing build-essential
 
 RUN mkdir /install
 WORKDIR /install


### PR DESCRIPTION
I have seen this issue on WSL2, mac, and linux. Sometimes one of the dependencies for build-essential can't be retrieved and this flag should fix this problem. Add --fix-missing flags to address periodically failing hnswlib (build-essential is needed for hnswlib) installs during docker builds.

## Description of changes

Add --fix-missing flags to address periodically failing hnswlib failures during docker builds

## Test plan
Build the docker image, should build successfully. Would be helpful to get the people who reported this issue to test out this fix since it can be difficult to replicate if you have never had build issues.

## Documentation Changes
N/A
