### PR TITLE
Fix sqllite filtering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
     hooks:
     -   id: mypy
         args: [--strict, --ignore-missing-imports, --follow-imports=silent, --disable-error-code=type-abstract]
-        additional_dependencies: ["types-requests", "pydantic", "overrides", "hypothesis", "pytest"]
+        additional_dependencies: ["types-requests", "pydantic", "overrides", "hypothesis", "pytest", "pypika"]

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -249,9 +249,9 @@ def document(draw, collection: Collection):
     if collection.known_document_keywords:
         known_words_st = st.sampled_from(collection.known_document_keywords)
     else:
-        known_words_st = st.text(min_size=1)
+        known_words_st = safe_text
 
-    random_words_st = st.text(min_size=1)
+    random_words_st = safe_text
     words = draw(st.lists(st.one_of(known_words_st, random_words_st), min_size=1))
     return " ".join(words)
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -246,12 +246,20 @@ def metadata(draw, collection: Collection):
 def document(draw, collection: Collection):
     """Strategy for generating documents that could be a part of the given collection"""
 
+    # Blacklist certain unicode characters that affect sqlite processing.
+    # For example, the null (/x00) character makes sqlite stop processing a string.
+    blacklist_categories = ("Cc", "Cs")
     if collection.known_document_keywords:
         known_words_st = st.sampled_from(collection.known_document_keywords)
     else:
-        known_words_st = safe_text
+        known_words_st = st.text(
+            min_size=1,
+            alphabet=st.characters(blacklist_categories=blacklist_categories),
+        )
 
-    random_words_st = safe_text
+    random_words_st = st.text(
+        min_size=1, alphabet=st.characters(blacklist_categories=blacklist_categories)
+    )
     words = draw(st.lists(st.one_of(known_words_st, random_words_st), min_size=1))
     return " ".join(words)
 


### PR DESCRIPTION
## Description of changes
Sqlite treats _ as a wildcard operator and % as one or many operator. When using LIKE we have to escape these characters and then use the ESCAPE keyword. This PR adds a custom pypika function for doing escaped like queries. 

Additionally, sqllite stops processing strings after the null (\x00) character. We should not generate this in our tests, and users should likely sanitize this character. 

## Test plan
These are fixes to make tests pass.

## Documentation Changes
None required.
