### PR TITLE
Fix empty metadata, partial updates. 

### DIFF
--- a/.github/workflows/chroma-client-integration-test.yml
+++ b/.github/workflows/chroma-client-integration-test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - '*'
 
 jobs:
   test:

--- a/.github/workflows/chroma-integration-test.yml
+++ b/.github/workflows/chroma-integration-test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main
-      - team/hypothesis-tests
+      - '*'
 
 jobs:
   test:

--- a/.github/workflows/chroma-test.yml
+++ b/.github/workflows/chroma-test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main
-      - team/hypothesis-tests
+      - '*'
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
     hooks:
     -   id: mypy
         args: [--strict, --ignore-missing-imports, --follow-imports=silent, --disable-error-code=type-abstract]
-        additional_dependencies: ["types-requests", "pydantic", "overrides", "hypothesis", "pytest"]
+        additional_dependencies: ["types-requests", "pydantic", "overrides", "hypothesis", "pytest", "pypika"]

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -3,7 +3,6 @@ import time
 from uuid import UUID
 from typing import List, Optional, Sequence, cast
 from chromadb import __version__
-import chromadb.errors as errors
 from chromadb.api import API
 from chromadb.db import DB
 from chromadb.api.types import (

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -19,6 +19,7 @@ from chromadb.api.types import (
     Where,
     WhereDocument,
     CollectionMetadata,
+    validate_metadata,
 )
 from chromadb.api.models.Collection import Collection
 from chromadb.config import System
@@ -107,6 +108,9 @@ class LocalAPI(API):
         """
         check_index_name(name)
 
+        if metadata is not None:
+            validate_metadata(metadata)
+
         res = self._db.create_collection(name, metadata, get_or_create)
         return Collection(
             client=self,
@@ -138,6 +142,10 @@ class LocalAPI(API):
             # collection(name="my_collection", metadata={})
             ```
         """
+
+        if metadata is not None:
+            validate_metadata(metadata)
+
         return self.create_collection(
             name, metadata, embedding_function, get_or_create=True
         )

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -259,19 +259,25 @@ class LocalAPI(API):
             valid_indices = [i for i, id in enumerate(ids) if id not in existing_ids]
             if len(valid_indices) == 0:
                 return False
-            ids = []
-            embeddings = []
+            filtered_ids: IDs = []
+            filtered_embeddings: Embeddings = []
             if metadatas is not None:
-                metadatas = []
+                filtered_metadatas: Metadatas = []
             if documents is not None:
-                documents = []
+                filtered_documents: Documents = []
             for index in valid_indices:
-                ids.append(ids[index])
-                embeddings.append(embeddings[index])
+                filtered_ids.append(ids[index])
+                filtered_embeddings.append(embeddings[index])
                 if metadatas is not None:
-                    metadatas.append(metadatas[index])
+                    filtered_metadatas.append(metadatas[index])
                 if documents is not None:
-                    documents.append(documents[index])
+                    filtered_documents.append(documents[index])
+            ids = filtered_ids
+            embeddings = filtered_embeddings
+            if metadatas is not None:
+                metadatas = filtered_metadatas
+            if documents is not None:
+                documents = filtered_documents
 
         added_uuids = self._db.add(
             collection_id,

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -252,9 +252,16 @@ class LocalAPI(API):
     ) -> bool:
         existing_ids = self._get(collection_id, ids=ids, include=[])["ids"]
         if len(existing_ids) > 0:
-            raise errors.IDAlreadyExistsError(
-                f"IDs {existing_ids} already exist in collection {collection_id}"
-            )
+            # Partially add the items that don't already exist
+            valid_indices = [i for i, id in enumerate(ids) if id not in existing_ids]
+            if len(valid_indices) == 0:
+                return False
+            ids = [ids[i] for i in valid_indices]
+            embeddings = [embeddings[i] for i in valid_indices]
+            if metadatas is not None:
+                metadatas = [metadatas[i] for i in valid_indices]
+            if documents is not None:
+                documents = [documents[i] for i in valid_indices]
 
         added_uuids = self._db.add(
             collection_id,

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -20,6 +20,7 @@ from chromadb.api.types import (
     maybe_cast_one_to_many,
     validate_ids,
     validate_include,
+    validate_metadata,
     validate_metadatas,
     validate_where,
     validate_where_document,
@@ -241,6 +242,9 @@ class Collection(BaseModel):
         Returns:
             None
         """
+        if metadata is not None:
+            validate_metadata(metadata)
+
         self._client._modify(id=self.id, new_name=name, new_metadata=metadata)
         if name:
             self.name = name

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -76,6 +76,9 @@ class SegmentAPI(API):
     ) -> Collection:
         existing = self._sysdb.get_collections(name=name)
 
+        if metadata is not None:
+            validate_metadata(metadata)
+
         if existing:
             if get_or_create:
                 if metadata and existing[0]["metadata"] != metadata:
@@ -93,9 +96,6 @@ class SegmentAPI(API):
 
         # backwards compatibility in naming requirements (for now)
         old_api.check_index_name(name)
-
-        if metadata:
-            validate_metadata(metadata)
 
         id = uuid4()
         coll = t.Collection(

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -126,6 +126,8 @@ def validate_metadata(metadata: Metadata) -> Metadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, or floats"""
     if not isinstance(metadata, dict):
         raise ValueError(f"Expected metadata to be a dict, got {metadata}")
+    if len(metadata) == 0:
+        raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected metadata key to be a str, got {key}")
@@ -140,6 +142,8 @@ def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, or floats"""
     if not isinstance(metadata, dict):
         raise ValueError(f"Expected metadata to be a dict, got {metadata}")
+    if len(metadata) == 0:
+        raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected metadata key to be a str, got {key}")

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -386,11 +386,11 @@ class SqlSysDB(SqlDB, SysDB):
         metadata: Dict[str, Union[str, int, float]] = {}
         for row in rows:
             key = str(row[-4])
-            if row[-3]:
+            if row[-3] is not None:
                 metadata[key] = str(row[-3])
-            elif row[-2]:
+            elif row[-2] is not None:
                 metadata[key] = int(row[-2])
-            elif row[-1]:
+            elif row[-1] is not None:
                 metadata[key] = float(row[-1])
         return metadata or None
 

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -213,6 +213,9 @@ class SqliteMetadataSegment(MetadataReader):
                 return self._update_record(cur, record)
             else:
                 logger.warning(f"Insert of existing embedding ID: {record['id']}")
+                # We are trying to add for a record that already exists. Fail the call.
+                # We don't throw an exception since this is in principal an async path
+                return
 
         if record["metadata"]:
             self._update_metadata(cur, id, record["metadata"])

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -258,13 +258,6 @@ def ann_accuracy(
                     == query_results["documents"][i][j]
                 )
             if normalized_record_set["metadatas"] is not None:
-                if (
-                    normalized_record_set["metadatas"][index]
-                    != query_results["metadatas"][i][j]
-                ):
-                    print(
-                        f"expected: {normalized_record_set['metadatas'][index]}, got: {query_results['metadatas'][i][j]}"
-                    )
                 assert (
                     normalized_record_set["metadatas"][index]
                     == query_results["metadatas"][i][j]

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -156,6 +156,12 @@ def _exact_distances(
     return np.argsort(distances).tolist(), distances.tolist()
 
 
+def is_metadata_valid(normalized_record_set: NormalizedRecordSet) -> bool:
+    if normalized_record_set["metadatas"] is None:
+        return True
+    return not any([len(m) == 0 for m in normalized_record_set["metadatas"]])
+
+
 def ann_accuracy(
     collection: Collection,
     record_set: RecordSet,

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -252,6 +252,13 @@ def ann_accuracy(
                     == query_results["documents"][i][j]
                 )
             if normalized_record_set["metadatas"] is not None:
+                if (
+                    normalized_record_set["metadatas"][index]
+                    != query_results["metadatas"][i][j]
+                ):
+                    print(
+                        f"expected: {normalized_record_set['metadatas'][index]}, got: {query_results['metadatas'][i][j]}"
+                    )
                 assert (
                     normalized_record_set["metadatas"][index]
                     == query_results["metadatas"][i][j]

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -249,9 +249,9 @@ def document(draw, collection: Collection):
     if collection.known_document_keywords:
         known_words_st = st.sampled_from(collection.known_document_keywords)
     else:
-        known_words_st = st.text(min_size=1)
+        known_words_st = safe_text
 
-    random_words_st = st.text(min_size=1)
+    random_words_st = safe_text
     words = draw(st.lists(st.one_of(known_words_st, random_words_st), min_size=1))
     return " ".join(words)
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -246,12 +246,20 @@ def metadata(draw, collection: Collection):
 def document(draw, collection: Collection):
     """Strategy for generating documents that could be a part of the given collection"""
 
+    # Blacklist certain unicode characters that affect sqlite processing.
+    # For example, the null (/x00) character makes sqlite stop processing a string.
+    blacklist_categories = ("Cc", "Cs")
     if collection.known_document_keywords:
         known_words_st = st.sampled_from(collection.known_document_keywords)
     else:
-        known_words_st = safe_text
+        known_words_st = st.text(
+            min_size=1,
+            alphabet=st.characters(blacklist_categories=blacklist_categories),
+        )
 
-    random_words_st = safe_text
+    random_words_st = st.text(
+        min_size=1, alphabet=st.characters(blacklist_categories=blacklist_categories)
+    )
     words = draw(st.lists(st.one_of(known_words_st, random_words_st), min_size=1))
     return " ".join(words)
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -25,9 +25,15 @@ def test_add(
         metadata=collection.metadata,
         embedding_function=collection.embedding_function,
     )
+    normalized_record_set = invariants.wrap_all(record_set)
+
+    if not invariants.is_metadata_valid(normalized_record_set):
+        with pytest.raises(Exception):
+            collection.add(**normalized_record_set)
+        return
+
     coll.add(**record_set)
 
-    normalized_record_set = invariants.wrap_all(record_set)
     invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
     n_results = max(1, (len(normalized_record_set["ids"]) // 10))
     invariants.ann_accuracy(

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -236,7 +236,6 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
                 if normalized_record_set["metadatas"] is not None:
                     # Sqlite merges the metadata, as opposed to old
                     # implementations which overwrites it
-                    # TODO: change to metadb to check for the type
                     record_set_state = self.record_set_state["metadatas"][target_idx]
                     if (
                         hasattr(self.api, "_sysdb")

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -146,7 +146,7 @@ recordset_st = st.shared(
     filters=st.lists(strategies.filters(collection_st, recordset_st), min_size=1),
 )
 def test_filterable_metadata_get(
-    caplog, api: API, collection, record_set, filters
+    caplog, api: API, collection: strategies.Collection, record_set, filters
 ) -> None:
     caplog.set_level(logging.ERROR)
 
@@ -156,6 +156,12 @@ def test_filterable_metadata_get(
         metadata=collection.metadata,
         embedding_function=collection.embedding_function,
     )
+
+    if not invariants.is_metadata_valid(invariants.wrap_all(record_set)):
+        with pytest.raises(Exception):
+            coll.add(**record_set)
+        return
+
     coll.add(**record_set)
 
     for filter in filters:
@@ -193,8 +199,14 @@ def test_filterable_metadata_query(
         metadata=collection.metadata,
         embedding_function=collection.embedding_function,
     )
-    coll.add(**record_set)
     normalized_record_set = invariants.wrap_all(record_set)
+
+    if not invariants.is_metadata_valid(normalized_record_set):
+        with pytest.raises(Exception):
+            coll.add(**record_set)
+        return
+
+    coll.add(**record_set)
     total_count = len(normalized_record_set["ids"])
     # Pick a random vector
     random_query: Embedding

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -60,6 +60,11 @@ def test_persist(
         embedding_function=collection_strategy.embedding_function,
     )
 
+    if not invariants.is_metadata_valid(invariants.wrap_all(embeddings_strategy)):
+        with pytest.raises(Exception):
+            coll.add(**embeddings_strategy)
+        return
+
     coll.add(**embeddings_strategy)
 
     invariants.count(coll, embeddings_strategy)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
1. The new sqlite refactor cannot represent None and the empty dict in metadata. We make the choice here to change all of our code to validate against the empty dict for metadata. The metadata can now only be None or a non-empty dictionary. We add validation for this and modify the old and new clients to match the behavior. These changes affect both collection and embedding metadata.
2. The new API allows partial updates for existing ID's. If we add 1,2,3 and then add 1,2,3,4. 4 will still get added while 1,2,3 will silently fail. We modify the old API to match this behavior. 
3. The new API will merge metadata on upsert, the tests special case this for the new api as porting this to the old api is not worth the investment at this time. 
4. The Sqlite code was preventing falsy (such as 0) metadata values from being read. This addresses that. 

## Test plan
These are all tested via old or modified tests.

## Documentation Changes
We should update the docs to discuss:
- Partial success
- Merging of metadata in update/upsert