### PR TITLE
single escape for writing SQL execution

### DIFF
--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -150,7 +150,7 @@ class Clickhouse(DB):
         if ids is not None:
             where_clauses.append(
                 f" id IN {tuple(ids)}".replace("'", "''").replace('"', "'")
-                if '"' in str(ids)
+                if '"' in f" id IN {tuple(ids)}"
                 else f" id IN {tuple(ids)}"
                 )
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -148,7 +148,11 @@ class Clickhouse(DB):
             where_clauses.extend(where_document_clauses)
 
         if ids is not None:
-            where_clauses.append(f" id IN {tuple(ids)}".replace("'", "''").replace('"', "'"))
+            where_clauses.append(
+                f" id IN {tuple(ids)}".replace("'", "''").replace('"', "'")
+                if '"' in str(ids)
+                else f" id IN {tuple(ids)}"
+                )
 
         where_clauses.append(f"collection_uuid = '{collection_uuid}'")
         where_str = " AND ".join(where_clauses)

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -148,7 +148,7 @@ class Clickhouse(DB):
             where_clauses.extend(where_document_clauses)
 
         if ids is not None:
-            where_clauses.append(f" id IN {tuple(ids)}")
+            where_clauses.append(f" id IN {tuple(ids)}".replace("'", "''").replace('"', "'"))
 
         where_clauses.append(f"collection_uuid = '{collection_uuid}'")
         where_str = " AND ".join(where_clauses)


### PR DESCRIPTION
`self._conn.execute` (line 296 of chromadb/db/duckdb.py) will throw a Binder Error if `ids` given to Clickhouse._create_where_clause (line 136 of chromadb/db/clickhouse.py) contains single quote. And the solution is to escape single quotes by replacing them to double single quotes (see https://stackoverflow.com/questions/1586560/how-do-i-escape-a-single-quote-in-sql-server). Meanwhile, single quotes will cause the tuple formatted with double quotes, which will cause other problem (see https://stackoverflow.com/questions/75671499/duckdb-binder-error-referenced-column-not-found-in-from-clause), therefore a two-step-replacement is performed.