### PR TITLE
Return ns since epoch on /heartbeat

### DIFF
--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -66,10 +66,10 @@ class LocalAPI(API):
         """Ping the database to ensure it is alive
 
         Returns:
-            The current time in milliseconds
+            The current time in nanoseconds since epoch
 
         """
-        return int(1000 * time.time_ns())
+        return int(time.time_ns())
 
     #
     # COLLECTION METHODS

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -6,6 +6,7 @@ import chromadb.server.fastapi
 import pytest
 import tempfile
 import numpy as np
+from datetime import datetime, timedelta
 from chromadb.utils.embedding_functions import (
     DefaultEmbeddingFunction,
 )
@@ -140,7 +141,12 @@ def test_persist(api_fixture, request):
 
 
 def test_heartbeat(api):
-    assert isinstance(api.heartbeat(), int)
+    heartbeat_ns = api.heartbeat()
+    assert isinstance(heartbeat_ns, int)
+
+    heartbeat_s = heartbeat_ns // 10**9
+    heartbeat = datetime.fromtimestamp(heartbeat_s)
+    assert heartbeat > datetime.now() - timedelta(seconds=10)
 
 
 batch_records = {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Return ns since epoch on /heartbeat, fixes #711 

## Test plan
*How are these changes tested?*

- Updated the unit tests to check that the returned time is _near_ now and implicitly that it can be parsed as nanoseconds

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

- This makes the code match the [documentated returned vlaue](https://docs.trychroma.com/usage-guide#initiating-the-chroma-client)

> client.heartbeat() # returns a nanosecond heartbeat. Useful for making sure the client remains connected.
