### PR TITLE
make it easier to work with chroma in JS via objects instead of columns

### DIFF
--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -72,3 +72,13 @@ export type AddResponse = {
 }
 
 export type CollectionMetadata = Record<string, unknown>;
+
+export type CollectionItem = {
+  id: ID,
+  embedding?: Embedding | null,
+  metadata?: Metadata | null,
+  document?: Document | null,
+  distance?: number | null,
+}
+
+export type CollectionItems = CollectionItem[];

--- a/clients/js/src/utils.ts
+++ b/clients/js/src/utils.ts
@@ -1,5 +1,7 @@
 import { Api } from "./generated"
 import Count200Response = Api.Count200Response;
+import { CollectionItem, CollectionItems, ID, IDs, Embeddings, Documents, Metadatas, QueryResponse } from "./types";
+import { Collection } from "./Collection";
 
 // a function to convert a non-Array object to an Array
 export function toArray<T>(obj: T | Array<T>): Array<T> {
@@ -62,4 +64,48 @@ export async function handleSuccess(response: Response | string | Count200Respon
         default:
             return repack(response);
     }
+}
+
+export function addCollectionItems(items: CollectionItem | CollectionItems): {
+    ids: IDs,
+    embeddings: Embeddings,
+    documents: Documents,
+    metadatas: Metadatas,
+} {
+    const ids: IDs = [];
+    const embeddings: Embeddings = [];
+    const documents: Documents = [];
+    const metadatas: Metadatas = [];
+
+    if (!Array.isArray(items)) {
+        items = [items];
+    }
+
+    for (const item of items) {
+        ids.push(item.id);
+        embeddings.push(item.embedding || []);
+        documents.push(item.document || "");
+        metadatas.push(item.metadata || {});
+    }
+
+    return { ids, embeddings, documents, metadatas };
+}
+
+export function asCollectionItems(queryResponse: QueryResponse): CollectionItems[] {
+    const queryResponseItems: CollectionItems[] = [];
+    for (let i = 0; i < queryResponse.ids.length; i++) {
+        const items: CollectionItems = [];
+        for (let j = 0; j < queryResponse.ids[i].length; j++) {
+            var collectionItem: CollectionItem = {
+                id: queryResponse.ids[i][j],
+                embedding: queryResponse.embeddings ? queryResponse.embeddings[i][j] : null,
+                document: queryResponse.documents ? queryResponse.documents[i][j] : null,
+                metadata: queryResponse.metadatas ? queryResponse.metadatas[i][j] : null,
+                distance: queryResponse.distances ? queryResponse.distances[i][j] : null,
+            };
+            items.push(collectionItem);
+        }
+        queryResponseItems.push(items);
+    }
+    return queryResponseItems;
 }

--- a/clients/js/test/utils.test.ts
+++ b/clients/js/test/utils.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@jest/globals';
+import chroma from './initClient'
+import { CollectionItem, CollectionItems, IncludeEnum } from '../src/types';
+import { addCollectionItems, asCollectionItems } from '../src/utils';
+
+
+test('toCollection util should work', async () => {
+    await chroma.reset()
+    const collection = await chroma.createCollection({ name: "test" });
+    const ids = ['test1', 'test2', 'test3']
+    const embeddings = [
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+        [1, 2, 4, 4, 4, 6, 7, 8, 9, 10],
+    ]
+
+    const collectionItems: CollectionItems = [
+        {
+            id: ids[0],
+            embedding: embeddings[0]
+        },
+        {
+            id: ids[1],
+            embedding: embeddings[1]
+        }
+    ]
+
+    await collection.add(addCollectionItems(collectionItems))
+    const count = await collection.count()
+    expect(count).toBe(2)
+
+    const newItem: CollectionItem = {
+        id: ids[2],
+        embedding: embeddings[2]
+    }
+
+    await collection.add(addCollectionItems(newItem))
+    const count2 = await collection.count()
+    expect(count2).toBe(3)
+})
+
+test('test asCollectionItems util', async () => {
+    await chroma.reset()
+    const collection = await chroma.createCollection({ name: "test" });
+    const ids = ['test1', 'test2', 'test3']
+    const embeddings = [
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+        [1, 2, 4, 4, 4, 6, 7, 8, 9, 10],
+    ]
+    const documents = ['This is a test', 'This is another test', 'This is a test']
+    const metadatas = [{ test: 'test' }, { test: 'test' }, { test: 'test' }]
+
+    const collectionItems: CollectionItems = [
+        {
+            id: ids[0],
+            embedding: embeddings[0],
+            document: documents[0],
+            metadata: metadatas[0]
+        },
+        {
+            id: ids[1],
+            embedding: embeddings[1],
+            document: documents[1],
+            metadata: metadatas[1]
+        }
+    ]
+
+    await collection.add(addCollectionItems(collectionItems))
+    const count = await collection.count()
+    expect(count).toBe(2)
+
+    const result = asCollectionItems(await collection.query({
+        queryEmbeddings: embeddings[0],
+        nResults: 3,
+        include: [IncludeEnum.Embeddings, IncludeEnum.Documents, IncludeEnum.Metadatas, IncludeEnum.Distances]
+    }))
+
+    expect(result).toBeDefined()
+    expect(result).toBeInstanceOf(Array)
+    expect(result.length).toBe(1)
+    expect(result[0].length).toBe(2)
+    expect(result[0][0].metadata).toEqual(metadatas[0])
+})


### PR DESCRIPTION
Proposal to make it easier to use our current column-oriented API with rows. 

Add 2 util functions `addCollectionItems` and `asCollectionItems` as well as types - see examples of usage in the tests. 

What do we think about this? @HammadB @atroyn 

We can easily replicate this in python as well. 

The other option is making the API fully row-oriented and/or polymorphic. The approach in this PR may be too much of a bandaid?