### PR TITLE
fix persist dir logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ index_data
 
 venv
 .env
-.chroma
 *.egg-info
 dist
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -51,7 +51,7 @@ class Settings(BaseSettings):
     clickhouse_host: Optional[str] = None
     clickhouse_port: Optional[str] = None
 
-    persist_directory: str = ".chroma"
+    persist_directory: str = "./chromadb"
 
     chroma_server_host: Optional[str] = None
     chroma_server_http_port: Optional[str] = None

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -418,7 +418,7 @@ class DuckDB(Clickhouse):
         self.reset_indexes()
 
     def __del__(self):
-        logger.info("Exiting: Cleaning up .chroma directory")
+        logger.info("Exiting: Cleaning up persist directory")
         self.reset_indexes()
 
     @override
@@ -435,11 +435,6 @@ class PersistentDuckDB(DuckDB):
         super().__init__(system=system)
 
         system.settings.require("persist_directory")
-
-        if system.settings.persist_directory == ".chroma":
-            raise ValueError(
-                "You cannot use chroma's cache directory .chroma/, please set a different directory"
-            )
 
         self._save_folder = system.settings.persist_directory
         self.load()


### PR DESCRIPTION
We were protecting a directory called `.chroma`, but we were not using it for anything. Then we also had that directory as the default for persistence. This fixes all that. (pending tests!) 