### PR TITLE
remove pandas

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Sequence, Optional
-import pandas as pd
 from uuid import UUID
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
@@ -242,7 +241,7 @@ class API(Component, ABC):
             page_size: The number of embeddings to return per page. Defaults to None.
 
         Returns:
-            pd.DataFrame: A pandas dataframe containing the embeddings and metadata
+            List: Lists of the requested information: eg ids, embeddings, metadatas, and documents
 
         """
         pass
@@ -296,19 +295,6 @@ class API(Component, ABC):
 
         Returns:
             None
-        """
-        pass
-
-    @abstractmethod
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        """Runs a raw SQL query against the database
-        ⚠️ This method should not be used directly.
-
-        Args:
-            sql: The SQL query to run
-
-        Returns:
-            pd.DataFrame: A pandas dataframe containing the results of the query
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -15,7 +15,6 @@ from chromadb.api.types import (
     CollectionMetadata,
 )
 import chromadb.utils.embedding_functions as ef
-import pandas as pd
 import requests
 import json
 from typing import Sequence
@@ -350,15 +349,6 @@ class FastAPI(API):
         resp = requests.post(self._api_url + "/persist")
         raise_chroma_error(resp)
         return cast(bool, resp.json())
-
-    @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        """Runs a raw SQL query against the database"""
-        resp = requests.post(
-            self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql})
-        )
-        raise_chroma_error(resp)
-        return pd.DataFrame.from_dict(resp.json())
 
     @override
     def create_index(self, collection_name: str) -> bool:

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -28,7 +28,6 @@ import re
 from chromadb.telemetry import Telemetry
 from chromadb.telemetry.events import CollectionAddEvent, CollectionDeleteEvent
 from overrides import override
-import pandas as pd
 
 
 # mimics s3 bucket requirements for naming
@@ -514,10 +513,6 @@ class LocalAPI(API):
             query_result["ids"].append(ids)
 
         return query_result
-
-    @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        return self._db.raw_sql(sql)  # type: ignore
 
     @override
     def create_index(self, collection_name: str) -> bool:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -72,7 +72,7 @@ class Collection(BaseModel):
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
         increment_index: bool = True,
-    ) -> None:
+    ) -> bool:
         """Add embeddings to the data store.
         Args:
             ids: The ids of the embeddings you wish to add
@@ -96,7 +96,7 @@ class Collection(BaseModel):
             ids, embeddings, metadatas, documents
         )
 
-        self._client._add(
+        return self._client._add(
             ids, self.id, embeddings, metadatas, documents, increment_index
         )
 

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -120,17 +120,13 @@ class DB(Component):
         embeddings: Optional[Embeddings] = None,
         n_results: int = 10,
         where_document: WhereDocument = {},
-    ) -> Tuple[List[List[UUID]], npt.NDArray]:
+    ) -> Tuple[List[List[UUID]], npt.NDArray]:  # type: ignore
         pass
 
     @abstractmethod
     def get_by_ids(
         self, uuids: List[UUID], columns: Optional[List[str]] = None
     ) -> Sequence:  # type: ignore
-        pass
-
-    @abstractmethod
-    def raw_sql(self, raw_sql):  # type: ignore
         pass
 
     @abstractmethod

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -651,7 +651,3 @@ class Clickhouse(DB):
         self._create_table_embeddings(conn)
 
         self.reset_indexes()
-
-    @override
-    def raw_sql(self, raw_sql):
-        return self._get_conn().query(raw_sql).result_rows

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -9,7 +9,6 @@ from chromadb.db.clickhouse import (
     COLLECTION_TABLE_SCHEMA,
 )
 from typing import List, Optional, Sequence
-import pandas as pd
 import json
 import duckdb
 import uuid
@@ -379,8 +378,8 @@ class DuckDB(Clickhouse):
             raise TypeError(f"Expected ids to be a list, got {uuids}")
 
         if not uuids:
-            # create an empty pandas dataframe
-            return pd.DataFrame()
+            # return an empty sequence
+            return []
 
         columns = columns + ["uuid"] if columns else ["uuid"]
 
@@ -402,10 +401,6 @@ class DuckDB(Clickhouse):
         )
 
         return response
-
-    @override
-    def raw_sql(self, raw_sql):
-        return self._conn.execute(raw_sql).df()
 
     # TODO: This method should share logic with clickhouse impl
     @override

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Sequence
+from typing import Any, Callable, Dict, Sequence
 import fastapi
 from fastapi import FastAPI as _FastAPI, Response
 from fastapi.responses import JSONResponse
@@ -8,11 +8,9 @@ from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
 
-import pandas as pd
-
 import chromadb
 from chromadb.api.models.Collection import Collection
-from chromadb.api.types import GetResult, QueryResult
+from chromadb.api.types import GetResult, IDs, QueryResult
 from chromadb.config import Settings
 import chromadb.server
 import chromadb.api
@@ -26,7 +24,6 @@ from chromadb.server.fastapi.types import (
     DeleteEmbedding,
     GetEmbedding,
     QueryEmbedding,
-    RawSql,  # Results,
     CreateCollection,
     UpdateCollection,
     UpdateEmbedding,
@@ -93,7 +90,6 @@ class FastAPI(chromadb.server.Server):
         self.router.add_api_route("/api/v1/version", self.version, methods=["GET"])
         self.router.add_api_route("/api/v1/heartbeat", self.heartbeat, methods=["GET"])
         self.router.add_api_route("/api/v1/persist", self.persist, methods=["POST"])
-        self.router.add_api_route("/api/v1/raw_sql", self.raw_sql, methods=["POST"])
 
         self.router.add_api_route(
             "/api/v1/collections", self.list_collections, methods=["GET"]
@@ -193,12 +189,12 @@ class FastAPI(chromadb.server.Server):
     def delete_collection(self, collection_name: str) -> None:
         return self._api.delete_collection(collection_name)
 
-    def add(self, collection_id: str, add: AddEmbedding) -> None:
+    def add(self, collection_id: str, add: AddEmbedding) -> bool:
         try:
             result = self._api._add(
                 collection_id=_uuid(collection_id),
-                embeddings=add.embeddings,
-                metadatas=add.metadatas,
+                embeddings=add.embeddings,  # type: ignore
+                metadatas=add.metadatas,  # type: ignore
                 documents=add.documents,
                 ids=add.ids,
                 increment_index=add.increment_index,
@@ -207,22 +203,22 @@ class FastAPI(chromadb.server.Server):
             raise HTTPException(status_code=500, detail=str(e))
         return result
 
-    def update(self, collection_id: str, add: UpdateEmbedding) -> None:
+    def update(self, collection_id: str, add: UpdateEmbedding) -> bool:
         return self._api._update(
             ids=add.ids,
             collection_id=_uuid(collection_id),
             embeddings=add.embeddings,
             documents=add.documents,
-            metadatas=add.metadatas,
+            metadatas=add.metadatas,  # type: ignore
         )
 
-    def upsert(self, collection_id: str, upsert: AddEmbedding) -> None:
+    def upsert(self, collection_id: str, upsert: AddEmbedding) -> bool:
         return self._api._upsert(
             collection_id=_uuid(collection_id),
             ids=upsert.ids,
-            embeddings=upsert.embeddings,
+            embeddings=upsert.embeddings,  # type: ignore
             documents=upsert.documents,
-            metadatas=upsert.metadatas,
+            metadatas=upsert.metadatas,  # type: ignore
             increment_index=upsert.increment_index,
         )
 
@@ -238,7 +234,7 @@ class FastAPI(chromadb.server.Server):
             include=get.include,
         )
 
-    def delete(self, collection_id: str, delete: DeleteEmbedding) -> List[UUID]:
+    def delete(self, collection_id: str, delete: DeleteEmbedding) -> IDs:
         return self._api._delete(
             where=delete.where,
             ids=delete.ids,
@@ -249,7 +245,7 @@ class FastAPI(chromadb.server.Server):
     def count(self, collection_id: str) -> int:
         return self._api._count(_uuid(collection_id))
 
-    def reset(self) -> bool:
+    def reset(self) -> None:
         return self._api.reset()
 
     def get_nearest_neighbors(
@@ -264,9 +260,6 @@ class FastAPI(chromadb.server.Server):
             include=query.include,
         )
         return nnresult
-
-    def raw_sql(self, raw_sql: RawSql) -> pd.DataFrame:
-        return self._api.raw_sql(raw_sql.raw_sql)
 
     def create_index(self, collection_name: str) -> bool:
         return self._api.create_index(collection_name)

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -6,7 +6,7 @@ from chromadb.api.types import (
 )
 
 
-class AddEmbedding(BaseModel):  # type: ignore
+class AddEmbedding(BaseModel):
     # Pydantic doesn't handle Union types cleanly like Embeddings which has
     # Union[int, float] so we use Any here to ensure data is parsed
     # to its original type.
@@ -17,7 +17,7 @@ class AddEmbedding(BaseModel):  # type: ignore
     increment_index: bool = True
 
 
-class UpdateEmbedding(BaseModel):  # type: ignore
+class UpdateEmbedding(BaseModel):
     embeddings: Optional[List[Any]] = None
     metadatas: Optional[List[Dict[Any, Any]]] = None
     documents: Optional[List[str]] = None
@@ -25,7 +25,7 @@ class UpdateEmbedding(BaseModel):  # type: ignore
     increment_index: bool = True
 
 
-class QueryEmbedding(BaseModel):  # type: ignore
+class QueryEmbedding(BaseModel):
     # TODO: Pydantic doesn't bode well with recursive types so we use generic Dicts
     # for Where and WhereDocument. This is not ideal, but it works for now since
     # there is a lot of downstream validation.
@@ -36,7 +36,7 @@ class QueryEmbedding(BaseModel):  # type: ignore
     include: Include = ["metadatas", "documents", "distances"]
 
 
-class GetEmbedding(BaseModel):  # type: ignore
+class GetEmbedding(BaseModel):
     ids: Optional[List[str]] = None
     where: Optional[Dict[Any, Any]] = None
     where_document: Optional[Dict[Any, Any]] = None
@@ -46,22 +46,18 @@ class GetEmbedding(BaseModel):  # type: ignore
     include: Include = ["metadatas", "documents"]
 
 
-class RawSql(BaseModel):  # type: ignore
-    raw_sql: str
-
-
-class DeleteEmbedding(BaseModel):  # type: ignore
+class DeleteEmbedding(BaseModel):
     ids: Optional[List[str]] = None
     where: Optional[Dict[Any, Any]] = None
     where_document: Optional[Dict[Any, Any]] = None
 
 
-class CreateCollection(BaseModel):  # type: ignore
+class CreateCollection(BaseModel):
     name: str
     metadata: Optional[CollectionMetadata] = None
     get_or_create: bool = False
 
 
-class UpdateCollection(BaseModel):  # type: ignore
+class UpdateCollection(BaseModel):
     new_name: Optional[str] = None
     new_metadata: Optional[CollectionMetadata] = None

--- a/clients/js/test/query.collection.test.ts
+++ b/clients/js/test/query.collection.test.ts
@@ -47,3 +47,24 @@ test("it should get embedding with matching documents", async () => {
   expect(results2.embeddings![0].length).toBe(1);
   expect(results2.embeddings![0][0]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 });
+
+test('deep where types should work', async () => {
+  await chroma.reset();
+  const collection = await chroma.createCollection({ name: "test" });
+  await collection.add({ ids: IDS, embeddings: EMBEDDINGS, metadatas: METADATAS, documents: DOCUMENTS });
+
+  const results = await collection.query({
+    queryEmbeddings: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    nResults: 3,
+    whereDocument: { $contains: "This is a test" },
+    where: {
+      $and: [
+        {
+          c_date: {
+            $lt: 234
+          }
+        }
+      ]
+    }
+  });
+})

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
   'numpy >= 1.21.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
   'hnswlib >= 0.7',

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ hnswlib==0.7.0
 numpy==1.21.6
 onnxruntime==1.14.1
 overrides==7.3.1
-pandas==1.3.5
 posthog==2.4.0
 pulsar-client==3.1.0
 pydantic==1.9.0


### PR DESCRIPTION
This PR 
- removes pandas
- removes `raw_sql` - long planned to deprecate
- cleans up some types
- add a misc JS test `deep where types should work`