### PR TITLE
WIP: remove numpy as depedency

### DIFF
--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 from typing import List, Sequence, Optional, Tuple
 from uuid import UUID
-import numpy.typing as npt
 from chromadb.api.types import (
     Embeddings,
     Documents,
@@ -120,7 +119,7 @@ class DB(Component):
         embeddings: Optional[Embeddings] = None,
         n_results: int = 10,
         where_document: WhereDocument = {},
-    ) -> Tuple[List[List[UUID]], npt.NDArray]:
+    ) -> Tuple[List[List[UUID]], List[List[float]]]:
         pass
 
     @abstractmethod

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -19,7 +19,6 @@ import logging
 from uuid import UUID
 from chromadb.config import System
 from overrides import override
-import numpy.typing as npt
 from chromadb.api.types import Metadata
 
 logger = logging.getLogger(__name__)
@@ -587,7 +586,7 @@ class Clickhouse(DB):
         embeddings: Optional[Embeddings] = None,
         n_results: int = 10,
         where_document: WhereDocument = {},
-    ) -> Tuple[List[List[UUID]], npt.NDArray]:
+    ) -> Tuple[List[List[UUID]], List[List[float]]]:
         # Either the collection name or the collection uuid must be provided
         if collection_uuid is None:
             raise TypeError("Argument collection_uuid cannot be None")

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
-  'numpy >= 1.21.6',
   'posthog >= 2.4.0',
   'typing_extensions >= 4.5.0',
   'overrides >= 7.3.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   'duckdb >= 0.7.1',
   'fastapi >= 0.85.1',
   'uvicorn[standard] >= 0.18.3',
-  'numpy >= 1.21.6',
   'posthog >= 2.4.0',
   'typing_extensions >= 4.5.0',
   'pulsar-client>=3.1.0',

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,7 @@ build
 httpx
 hypothesis
 hypothesis[numpy]
+numpy==1.21.6
 pre-commit
 pytest
 pytest-asyncio


### PR DESCRIPTION
WIP to remove numpy as a dep. 

The blocker is that we use it in our default embedding model https://github.com/chroma-core/chroma/blob/main/chromadb/utils/embedding_functions.py#L248. We like making chroma "batteries-included" - so we don't want to force an install if you try to use it. It should JustWork:tm:

We could replace it with pure python... not sure what the speed tradeoff is yet (havent profiled) 