### PR TITLE
Normalized embeddings

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -25,7 +25,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
         self,
         model_name: str = "all-MiniLM-L6-v2",
         device: str = "cpu",
-        normalized_embeddings: bool = False,
+        normalize_embeddings: bool = False,
     ):
         if model_name not in self.models:
             try:
@@ -36,13 +36,13 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
                 )
             self.models[model_name] = SentenceTransformer(model_name, device=device)
         self._model = self.models[model_name]
-        self._normalized_embeddings = normalized_embeddings
+        self._normalize_embeddings = normalize_embeddings
 
     def __call__(self, texts: Documents) -> Embeddings:
         return self._model.encode(
             list(texts),
             convert_to_numpy=True,
-            normalized_embeddings=self._normalized_embeddings,
+            normalize_embeddings=self._normalize_embeddings,
         ).tolist()
 
 

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -21,7 +21,12 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
 
     # If you have a beefier machine, try "gtr-t5-large".
     # for a full list of options: https://huggingface.co/sentence-transformers, https://www.sbert.net/docs/pretrained_models.html
-    def __init__(self, model_name: str = "all-MiniLM-L6-v2", device: str = "cpu"):
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        device: str = "cpu",
+        normalized_embeddings: bool = False,
+    ):
         if model_name not in self.models:
             try:
                 from sentence_transformers import SentenceTransformer
@@ -31,9 +36,14 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
                 )
             self.models[model_name] = SentenceTransformer(model_name, device=device)
         self._model = self.models[model_name]
+        self._normalized_embeddings = normalized_embeddings
 
     def __call__(self, texts: Documents) -> Embeddings:
-        return self._model.encode(list(texts), convert_to_numpy=True).tolist()  # type: ignore # noqa E501
+        return self._model.encode(
+            list(texts),
+            convert_to_numpy=True,
+            normalized_embeddings=self._normalized_embeddings,
+        ).tolist()
 
 
 class Text2VecEmbeddingFunction(EmbeddingFunction):


### PR DESCRIPTION
## Description of changes
Added support to the use of normalize embeddings in the `SentenceTransformerEmbeddingFunction` class by adding a new attribute to the class and use it when calling the `encode` function.

## Test plan
I was planning to add a new test case where an object was created with `normalize_embeddings=True` but I haven't found any test which is currently testing `SentenceTransformerEmbeddingFunction` (I guess that should be in the folder `test/utils`).

## Documentation Changes
The document talking about [embeddings] should be changed. In the section *Sentence Transformers* it should be mentioned the possiblitiy of using an optional parameter `normalize_embeddings`. A similar text to the one in the SentenceTransformer documentation could be used (or adapted):

> If set to True, returned vectors will have length 1. In that case, the faster dot-product (util.dot_score) instead of cosine similarity can be used.