### PR TITLE
support lists in metadatas

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -121,16 +121,22 @@ def validate_ids(ids: IDs) -> IDs:
 
 
 def validate_metadata(metadata: Metadata) -> Metadata:
-    """Validates metadata to ensure it is a dictionary of strings to strings, ints, or floats"""
+    """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats, or lists of each"""
     if not isinstance(metadata, dict):
         raise ValueError(f"Expected metadata to be a dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected metadata key to be a str, got {key}")
-        if not isinstance(value, (str, int, float)):
+        if not isinstance(value, (str, int, float, list)):
             raise ValueError(
-                f"Expected metadata value to be a str, int, or float, got {value}"
+                f"Expected metadata value to be a str, int, float, or list, got {value}"
             )
+        if isinstance(value, list):
+            for item in value:
+                if not isinstance(item, (str, int, float)):
+                    raise ValueError(
+                        f"Expected metadata value to be a str, int, or float, got {item}"
+                    )
     return metadata
 
 

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -3,8 +3,10 @@ from typing_extensions import Literal, TypedDict, TypeVar
 from uuid import UUID
 from enum import Enum
 
-Metadata = Mapping[str, Union[str, int, float]]
-UpdateMetadata = Mapping[str, Union[int, float, str, None]]
+Metadata = Mapping[str, Union[str, int, float, List[Union[str, int, float]]]]
+UpdateMetadata = Mapping[
+    str, Union[int, float, str, List[Union[str, int, float]], None]
+]
 
 # Namespaced Names are mechanically just strings, but we use this type to indicate that
 # the intent is for the value to be globally unique and semantically meaningful.


### PR DESCRIPTION
## Description of changes
closes #227 

 - New functionality
	 - Lists can be added to metadatas
	 - `$eq` and `$ne` operators can be applied to lists in Where filters

## Test plan
- Added new unit tests for adding lists to metadata
- Unit tests passed locally


## Documentation Changes
- Should update docs on allowed values of metadatas and how where filters work with lists
