### PR TITLE
refactor: uniformly not use apostrophes for ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - CLICKHOUSE_TCP_PORT=9000
       - CLICKHOUSE_HTTP_PORT=8123
     ports:
-      - '8123:8123'
-      - '9000:9000'
+      - 8123:8123
+      - 9000:9000
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - clickhouse_logs:/var/log/clickhouse-server


### PR DESCRIPTION
server is not using apostrophes around the ports, while clickhouse is.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - refactor
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
