### PR TITLE
Resolve PydanticImportError by installing pydantic-settings

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings
+# from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from typing import Optional, List, Any, Dict, TypeVar, Set, cast, Iterable, Type
 from typing_extensions import Literal
 from abc import ABC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   'tokenizers >= 0.13.2',
   'tqdm >= 4.65.0',
   'overrides >= 7.3.1',
-  'graphlib_backport >= 1.0.3; python_version < "3.9"'
+  'graphlib_backport >= 1.0.3; python_version < "3.9"',
+  'pydantic_settings >= 2.0.1'
 ]
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ tokenizers==0.13.2
 tqdm==4.65.0
 typing_extensions==4.5.0
 uvicorn[standard]==0.18.3
+pydantic_settings==2.0.1


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
This PR resolves the PydanticImportError by installing the pydantic-settings package. The error occurred when trying to import chromadb due to the BaseSettings class being moved to the pydantic-settings package.
[Bug]: Chromadb import error. Dependency issue: Install pydantic-settings package #774

 - Improvements & Bug fixes
	 - Resolved PydanticImportError
	 - Installed pydantic-settings package

## Test plan
*How are these changes tested?*
The changes can be tested by running the code that previously resulted in the import error and verifying that the error no longer occurs.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
There are no specific documentation changes required for this fix. However, it is important to ensure that the updated dependency on pydantic-settings is mentioned in the project's documentation or any relevant installation instructions if applicable.
