### PR TITLE
Hotfix for #774

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Sequence, Optional
-import pandas as pd
 from uuid import UUID
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
@@ -293,19 +292,6 @@ class API(Component, ABC):
             None
         Returns:
             None
-        """
-        pass
-
-    @abstractmethod
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        """Runs a raw SQL query against the database
-        ⚠️ This method should not be used directly.
-
-        Args:
-            sql: The SQL query to run
-
-        Returns:
-            pd.DataFrame: A pandas dataframe containing the results of the query
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -353,15 +353,6 @@ class FastAPI(API):
         return cast(bool, resp.json())
 
     @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        """Runs a raw SQL query against the database"""
-        resp = requests.post(
-            self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql})
-        )
-        raise_chroma_error(resp)
-        return pd.DataFrame.from_dict(resp.json())
-
-    @override
     def create_index(self, collection_name: str) -> bool:
         """Creates an index for the given space key"""
         resp = requests.post(

--- a/chromadb/api/local.py
+++ b/chromadb/api/local.py
@@ -548,10 +548,6 @@ class LocalAPI(API):
         return query_result
 
     @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        return self._db.raw_sql(sql)  # type: ignore
-
-    @override
     def create_index(self, collection_name: str) -> bool:
         collection_uuid = self._db.get_collection_uuid_from_name(collection_name)
         self._db.create_index(collection_uuid=collection_uuid)

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -428,10 +428,6 @@ class SegmentAPI(API):
         return True
 
     @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        raise NotImplementedError()
-
-    @override
     def create_index(self, collection_name: str) -> bool:
         logger.warning(
             "Calling create_index is unnecessary, data is now automatically indexed"

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -123,10 +123,6 @@ class DB(Component):
         pass
 
     @abstractmethod
-    def raw_sql(self, raw_sql):  # type: ignore
-        pass
-
-    @abstractmethod
     def create_index(self, collection_uuid: UUID):  # type: ignore
         pass
 

--- a/chromadb/db/clickhouse.py
+++ b/chromadb/db/clickhouse.py
@@ -650,7 +650,3 @@ class Clickhouse(DB):
         self._create_table_embeddings(conn)
 
         self.reset_indexes()
-
-    @override
-    def raw_sql(self, raw_sql):
-        return self._get_conn().query(raw_sql).result_rows

--- a/chromadb/db/duckdb.py
+++ b/chromadb/db/duckdb.py
@@ -9,7 +9,6 @@ from chromadb.db.clickhouse import (
     COLLECTION_TABLE_SCHEMA,
 )
 from typing import List, Optional, Sequence
-import pandas as pd
 import json
 import duckdb
 import uuid
@@ -402,10 +401,6 @@ class DuckDB(Clickhouse):
         )
 
         return response
-
-    @override
-    def raw_sql(self, raw_sql):
-        return self._conn.execute(raw_sql).df()
 
     # TODO: This method should share logic with clickhouse impl
     @override

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -8,8 +8,6 @@ from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
 
-import pandas as pd
-
 import chromadb
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import GetResult, QueryResult
@@ -26,7 +24,6 @@ from chromadb.server.fastapi.types import (
     DeleteEmbedding,
     GetEmbedding,
     QueryEmbedding,
-    RawSql,  # Results,
     CreateCollection,
     UpdateCollection,
     UpdateEmbedding,
@@ -93,7 +90,6 @@ class FastAPI(chromadb.server.Server):
         self.router.add_api_route("/api/v1/version", self.version, methods=["GET"])
         self.router.add_api_route("/api/v1/heartbeat", self.heartbeat, methods=["GET"])
         self.router.add_api_route("/api/v1/persist", self.persist, methods=["POST"])
-        self.router.add_api_route("/api/v1/raw_sql", self.raw_sql, methods=["POST"])
 
         self.router.add_api_route(
             "/api/v1/collections", self.list_collections, methods=["GET"]
@@ -264,9 +260,6 @@ class FastAPI(chromadb.server.Server):
             include=query.include,
         )
         return nnresult
-
-    def raw_sql(self, raw_sql: RawSql) -> pd.DataFrame:
-        return self._api.raw_sql(raw_sql.raw_sql)
 
     def create_index(self, collection_name: str) -> bool:
         return self._api.create_index(collection_name)

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -46,10 +46,6 @@ class GetEmbedding(BaseModel):  # type: ignore
     include: Include = ["metadatas", "documents"]
 
 
-class RawSql(BaseModel):  # type: ignore
-    raw_sql: str
-
-
 class DeleteEmbedding(BaseModel):  # type: ignore
     ids: Optional[List[str]] = None
     where: Optional[Dict[Any, Any]] = None

--- a/clients/js/DEVELOP.md
+++ b/clients/js/DEVELOP.md
@@ -10,7 +10,7 @@ This readme is helpful for local dev.
 ### Generating
 
 1. `yarn` to install deps
-2. `yarn genapi-zsh` if you have zsh
+2. `yarn genapi`
 3. Examples are in the `examples` folder. There is one for the browser and one for node. Run them with `yarn dev`, eg `cd examples/browser && yarn dev`
 
 ### Running test

--- a/clients/js/src/generated/api.ts
+++ b/clients/js/src/generated/api.ts
@@ -440,43 +440,6 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 			};
 		},
 		/**
-		 * @summary Raw Sql
-		 * @param {Api.RawSql} request
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		rawSql(request: Api.RawSql, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'request' is not null or undefined
-			if (request === null || request === undefined) {
-				throw new RequiredError('request', 'Required parameter request was null or undefined when calling rawSql.');
-			}
-			let localVarPath = `/api/v1/raw_sql`;
-			const localVarPathQueryStart = localVarPath.indexOf("?");
-			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
-			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
-			const localVarQueryParameter = new URLSearchParams(localVarPathQueryStart !== -1 ? localVarPath.substring(localVarPathQueryStart + 1) : "");
-			if (localVarPathQueryStart !== -1) {
-				localVarPath = localVarPath.substring(0, localVarPathQueryStart);
-			}
-
-			localVarHeaderParameter.set('Content-Type', 'application/json');
-
-			localVarRequestOptions.headers = localVarHeaderParameter;
-
-			if (request !== undefined) {
-				localVarRequestOptions.body = JSON.stringify(request || {});
-			}
-
-			const localVarQueryParameterString = localVarQueryParameter.toString();
-			if (localVarQueryParameterString) {
-				localVarPath += "?" + localVarQueryParameterString;
-			}
-			return {
-				url: localVarPath,
-				options: localVarRequestOptions,
-			};
-		},
-		/**
 		 * @summary Reset
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
@@ -1024,35 +987,6 @@ export const ApiApiFp = function(configuration?: Configuration) {
 			};
 		},
 		/**
-		 * @summary Raw Sql
-		 * @param {Api.RawSql} request
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		rawSql(request: Api.RawSql, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.RawSql200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).rawSql(request, options);
-			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
-				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-					const contentType = response.headers.get('Content-Type');
-					const mimeType = contentType ? contentType.replace(/;.*/, '') : undefined;
-
-					if (response.status === 200) {
-						if (mimeType === 'application/json') {
-							return response.json() as any;
-						}
-						throw response;
-					}
-					if (response.status === 422) {
-						if (mimeType === 'application/json') {
-							throw response;
-						}
-						throw response;
-					}
-					throw response;
-				});
-			};
-		},
-		/**
 		 * @summary Reset
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
@@ -1345,16 +1279,6 @@ export class ApiApi extends BaseAPI {
 	 */
 	public persist(options?: RequestInit) {
 		return ApiApiFp(this.configuration).persist(options)(this.fetch, this.basePath);
-	}
-
-	/**
-	 * @summary Raw Sql
-	 * @param {Api.RawSql} request
-	 * @param {RequestInit} [options] Override http request option.
-	 * @throws {RequiredError}
-	 */
-	public rawSql(request: Api.RawSql, options?: RequestInit) {
-		return ApiApiFp(this.configuration).rawSql(request, options)(this.fetch, this.basePath);
 	}
 
 	/**

--- a/clients/js/src/generated/models.ts
+++ b/clients/js/src/generated/models.ts
@@ -17,10 +17,10 @@ export namespace Api {
 	}
 
 	export interface AddEmbedding {
-		embeddings: Api.AddEmbedding.Embedding[];
-		metadatas?: Api.AddEmbedding.Metadatas.ArrayValue[] | Api.AddEmbedding.Metadatas.ObjectValue;
-		documents?: string | Api.AddEmbedding.Documents.ArrayValue[];
-		ids?: string | Api.AddEmbedding.Ids.ArrayValue[];
+		embeddings?: Api.AddEmbedding.Embedding[];
+		metadatas?: Api.AddEmbedding.Metadata[];
+		documents?: string[];
+		ids: string[];
 		'increment_index'?: boolean;
 	}
 
@@ -32,43 +32,7 @@ export namespace Api {
 		export interface Embedding {
 		}
 
-		export type Metadatas = Api.AddEmbedding.Metadatas.ArrayValue[] | Api.AddEmbedding.Metadatas.ObjectValue;
-
-		/**
-		 * @export
-		 * @namespace Metadatas
-		 */
-		export namespace Metadatas {
-			export interface ArrayValue {
-			}
-
-			export interface ObjectValue {
-			}
-
-		}
-
-		export type Documents = string | Api.AddEmbedding.Documents.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Documents
-		 */
-		export namespace Documents {
-			export interface ArrayValue {
-			}
-
-		}
-
-		export type Ids = string | Api.AddEmbedding.Ids.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Ids
-		 */
-		export namespace Ids {
-			export interface ArrayValue {
-			}
-
+		export interface Metadata {
 		}
 
 	}
@@ -108,7 +72,7 @@ export namespace Api {
 	}
 
 	export interface DeleteEmbedding {
-		ids?: Api.DeleteEmbedding.Id[];
+		ids?: string[];
 		where?: Api.DeleteEmbedding.Where;
 		'where_document'?: Api.DeleteEmbedding.WhereDocument;
 	}
@@ -118,9 +82,6 @@ export namespace Api {
 	 * @namespace DeleteEmbedding
 	 */
 	export namespace DeleteEmbedding {
-		export interface Id {
-		}
-
 		export interface Where {
 		}
 
@@ -133,7 +94,7 @@ export namespace Api {
 	}
 
 	export interface GetEmbedding {
-		ids?: Api.GetEmbedding.Id[];
+		ids?: string[];
 		where?: Api.GetEmbedding.Where;
 		'where_document'?: Api.GetEmbedding.WhereDocument;
 		sort?: string;
@@ -147,7 +108,7 @@ export namespace Api {
 		 * @memberof GetEmbedding
 		 */
 		offset?: number;
-		include?: Api.GetEmbedding.IncludeEnum[];
+		include?: (Api.GetEmbedding.Include.EnumValueEnum | Api.GetEmbedding.Include.EnumValueEnum2 | Api.GetEmbedding.Include.EnumValueEnum3 | Api.GetEmbedding.Include.EnumValueEnum4)[];
 	}
 
 	/**
@@ -155,20 +116,35 @@ export namespace Api {
 	 * @namespace GetEmbedding
 	 */
 	export namespace GetEmbedding {
-		export interface Id {
-		}
-
 		export interface Where {
 		}
 
 		export interface WhereDocument {
 		}
 
-		export enum IncludeEnum {
-			Documents = 'documents',
-			Embeddings = 'embeddings',
-			Metadatas = 'metadatas',
-			Distances = 'distances'
+		export type Include = Api.GetEmbedding.Include.EnumValueEnum | Api.GetEmbedding.Include.EnumValueEnum2 | Api.GetEmbedding.Include.EnumValueEnum3 | Api.GetEmbedding.Include.EnumValueEnum4;
+
+		/**
+		 * @export
+		 * @namespace Include
+		 */
+		export namespace Include {
+			export enum EnumValueEnum {
+				Documents = 'documents'
+			}
+
+			export enum EnumValueEnum2 {
+				Embeddings = 'embeddings'
+			}
+
+			export enum EnumValueEnum3 {
+				Metadatas = 'metadatas'
+			}
+
+			export enum EnumValueEnum4 {
+				Distances = 'distances'
+			}
+
 		}
 
 	}
@@ -198,7 +174,7 @@ export namespace Api {
 		 * @memberof QueryEmbedding
 		 */
 		'n_results'?: number;
-		include?: Api.QueryEmbedding.IncludeEnum[];
+		include?: (Api.QueryEmbedding.Include.EnumValueEnum | Api.QueryEmbedding.Include.EnumValueEnum2 | Api.QueryEmbedding.Include.EnumValueEnum3 | Api.QueryEmbedding.Include.EnumValueEnum4)[];
 	}
 
 	/**
@@ -215,20 +191,31 @@ export namespace Api {
 		export interface QueryEmbedding2 {
 		}
 
-		export enum IncludeEnum {
-			Documents = 'documents',
-			Embeddings = 'embeddings',
-			Metadatas = 'metadatas',
-			Distances = 'distances'
+		export type Include = Api.QueryEmbedding.Include.EnumValueEnum | Api.QueryEmbedding.Include.EnumValueEnum2 | Api.QueryEmbedding.Include.EnumValueEnum3 | Api.QueryEmbedding.Include.EnumValueEnum4;
+
+		/**
+		 * @export
+		 * @namespace Include
+		 */
+		export namespace Include {
+			export enum EnumValueEnum {
+				Documents = 'documents'
+			}
+
+			export enum EnumValueEnum2 {
+				Embeddings = 'embeddings'
+			}
+
+			export enum EnumValueEnum3 {
+				Metadatas = 'metadatas'
+			}
+
+			export enum EnumValueEnum4 {
+				Distances = 'distances'
+			}
+
 		}
 
-	}
-
-	export interface RawSql {
-		'raw_sql'?: string;
-	}
-
-	export interface RawSql200Response {
 	}
 
 	export interface Reset200Response {
@@ -260,9 +247,9 @@ export namespace Api {
 
 	export interface UpdateEmbedding {
 		embeddings?: Api.UpdateEmbedding.Embedding[];
-		metadatas?: Api.UpdateEmbedding.Metadatas.ArrayValue[] | Api.UpdateEmbedding.Metadatas.ObjectValue;
-		documents?: string | Api.UpdateEmbedding.Documents.ArrayValue[];
-		ids?: string | Api.UpdateEmbedding.Ids.ArrayValue[];
+		metadatas?: Api.UpdateEmbedding.Metadata[];
+		documents?: string[];
+		ids: string[];
 		'increment_index'?: boolean;
 	}
 
@@ -274,43 +261,7 @@ export namespace Api {
 		export interface Embedding {
 		}
 
-		export type Metadatas = Api.UpdateEmbedding.Metadatas.ArrayValue[] | Api.UpdateEmbedding.Metadatas.ObjectValue;
-
-		/**
-		 * @export
-		 * @namespace Metadatas
-		 */
-		export namespace Metadatas {
-			export interface ArrayValue {
-			}
-
-			export interface ObjectValue {
-			}
-
-		}
-
-		export type Documents = string | Api.UpdateEmbedding.Documents.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Documents
-		 */
-		export namespace Documents {
-			export interface ArrayValue {
-			}
-
-		}
-
-		export type Ids = string | Api.UpdateEmbedding.Ids.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Ids
-		 */
-		export namespace Ids {
-			export interface ArrayValue {
-			}
-
+		export interface Metadata {
 		}
 
 	}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
 dependencies = [
   'pandas >= 1.3',
   'requests >= 2.28',
-  'pydantic >= 1.9',
+  'pydantic >= 1.9.0, <=1.10.11',
   'hnswlib >= 0.7',
   'clickhouse_connect >= 0.5.7',
   'duckdb >= 0.7.1',
-  'fastapi >= 0.85.1',
+  'fastapi >=0.85.1, <=0.99.1',
   'uvicorn[standard] >= 0.18.3',
   'numpy >= 1.21.6',
   'posthog >= 2.4.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-chroma-hnswlib==0.7.0
+chroma-hnswlib
 clickhouse-connect==0.5.7
 duckdb==0.7.1
-fastapi==0.85.1
+fastapi >=0.85.1, <=0.99.1
 graphlib_backport==1.0.3; python_version < '3.9'
 numpy==1.21.6
 onnxruntime==1.14.1
@@ -9,7 +9,7 @@ overrides==7.3.1
 pandas==1.3.5
 posthog==2.4.0
 pulsar-client==3.1.0
-pydantic==1.9.0
+pydantic >= 1.9.0, <=1.10.11
 pypika==0.48.9
 requests==2.28.1
 tokenizers==0.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chroma-hnswlib
+chroma-hnswlib==0.7.0
 clickhouse-connect==0.5.7
 duckdb==0.7.1
 fastapi >=0.85.1, <=0.99.1


### PR DESCRIPTION
## Description of changes
Fixes #774 by capping the max versions of fastapi and pydantic supported. We should, in the future, revisit this and change the code to work with newer versions but to minimize potentially introducing errors, we will cap it for now.

Newer versions of pydantic don't work with pandas return types. Since we want to deprecate raw_sql, that change is made here so that our fastapi routes don't use pandas datatypes. 

## Test plan
Existing tests

## Documentation Changes
None
