### PR TITLE
Remove persist() from API

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -324,11 +324,6 @@ class API(Component, ABC):
         pass
 
     @abstractmethod
-    def persist(self) -> bool:
-        """Persist the database to disk"""
-        pass
-
-    @abstractmethod
     def get_version(self) -> str:
         """Get the version of Chroma.
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -346,13 +346,6 @@ class FastAPI(API):
         return cast(bool, resp.json())
 
     @override
-    def persist(self) -> bool:
-        """Persists the database"""
-        resp = requests.post(self._api_url + "/persist")
-        raise_chroma_error(resp)
-        return cast(bool, resp.json())
-
-    @override
     def raw_sql(self, sql: str) -> pd.DataFrame:
         """Runs a raw SQL query against the database"""
         resp = requests.post(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -26,6 +26,7 @@ from chromadb.api.types import (
     validate_where,
     validate_where_document,
 )
+from chromadb.telemetry.events import CollectionAddEvent, CollectionDeleteEvent
 
 import chromadb.types as t
 
@@ -244,6 +245,7 @@ class SegmentAPI(API):
             self._validate_embedding_record(coll, r)
             self._producer.submit_embedding(coll["topic"], r)
 
+        self._telemetry_client.capture(CollectionAddEvent(str(collection_id), len(ids)))
         return True
 
     @override
@@ -376,6 +378,9 @@ class SegmentAPI(API):
             self._validate_embedding_record(coll, r)
             self._producer.submit_embedding(coll["topic"], r)
 
+        self._telemetry_client.capture(
+            CollectionDeleteEvent(str(collection_id), len(ids_to_delete))
+        )
         return ids_to_delete
 
     @override

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -488,13 +488,6 @@ class SegmentAPI(API):
         )
         return True
 
-    @override
-    def persist(self) -> bool:
-        logger.warning(
-            "Calling persist is unnecessary, data is now automatically indexed."
-        )
-        return True
-
     def _topic(self, collection_id: UUID) -> str:
         return f"persistent://{self._tenant_id}/{self._topic_ns}/{collection_id}"
 

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -129,7 +129,3 @@ class DB(Component):
     @abstractmethod
     def create_index(self, collection_uuid: UUID):  # type: ignore
         pass
-
-    @abstractmethod
-    def persist(self) -> None:
-        pass

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -92,7 +92,6 @@ class FastAPI(chromadb.server.Server):
         self.router.add_api_route("/api/v1/reset", self.reset, methods=["POST"])
         self.router.add_api_route("/api/v1/version", self.version, methods=["GET"])
         self.router.add_api_route("/api/v1/heartbeat", self.heartbeat, methods=["GET"])
-        self.router.add_api_route("/api/v1/persist", self.persist, methods=["POST"])
         self.router.add_api_route("/api/v1/raw_sql", self.raw_sql, methods=["POST"])
 
         self.router.add_api_route(
@@ -161,9 +160,6 @@ class FastAPI(chromadb.server.Server):
 
     def heartbeat(self) -> Dict[str, int]:
         return self.root()
-
-    def persist(self) -> None:
-        self._api.persist()
 
     def version(self) -> str:
         return self._api.get_version()

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -13,6 +13,7 @@ from enum import Enum
 # TODO: Telemetry whitelisting for new settings
 TELEMETRY_WHITELISTED_SETTINGS = [
     "chroma_api_impl",
+    "is_persistent",
     "chroma_server_ssl_enabled",
 ]
 

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -204,7 +204,6 @@ def persist_generated_data_with_old_version(
         embedding_id_to_index = {id: i for i, id in enumerate(check_embeddings["ids"])}
         actual_ids = sorted(actual_ids, key=lambda id: embedding_id_to_index[id])
         assert actual_ids == check_embeddings["ids"]
-        api.persist()
     except Exception as e:
         conn.send(e)
         raise e

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -85,7 +85,6 @@ def test_persist(
         embedding_function=collection_strategy.embedding_function,
     )
 
-    api_1.persist()
     del api_1
 
     api_2 = chromadb.Client(settings)
@@ -145,7 +144,6 @@ class PersistEmbeddingsStateMachine(EmbeddingStateMachine):
     @rule()
     def persist(self) -> None:
         self.on_state_change(PersistEmbeddingsStateMachineStates.persist)
-        self.api.persist()
         collection_name = self.collection.name
         # Create a new process and then inside the process run the invariants
         # TODO: Once we switch off of duckdb and onto sqlite we can remove this

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -64,9 +64,6 @@ def test_persist_index_loading(api_fixture, request):
     )
     collection.add(ids="id1", documents="hello")
 
-    api.persist()
-    del api
-
     api2 = request.getfixturevalue("local_persist_api_cache_bust")
     collection = api2.get_collection(
         "test", embedding_function=lambda text: [[1, 2, 3]]
@@ -89,9 +86,6 @@ def test_persist_index_loading_embedding_function(api_fixture, request):
     collection = api.create_collection("test", embedding_function=embedding_function)
     collection.add(ids="id1", documents="hello")
 
-    api.persist()
-    del api
-
     api2 = request.getfixturevalue("local_persist_api_cache_bust")
     collection = api2.get_collection("test", embedding_function=embedding_function)
 
@@ -113,9 +107,6 @@ def test_persist_index_get_or_create_embedding_function(api_fixture, request):
         "test", embedding_function=embedding_function
     )
     collection.add(ids="id1", documents="hello")
-
-    api.persist()
-    del api
 
     api2 = request.getfixturevalue("local_persist_api_cache_bust")
     collection = api2.get_or_create_collection(
@@ -151,9 +142,6 @@ def test_persist(api_fixture, request):
 
     assert collection.count() == 2
 
-    api.persist()
-    del api
-
     api = request.getfixturevalue(api_fixture.__name__)
     collection = api.get_collection(
         "testspace", embedding_function=lambda text: [[1, 2, 3]]
@@ -161,8 +149,6 @@ def test_persist(api_fixture, request):
     assert collection.count() == 2
 
     api.delete_collection("testspace")
-    api.persist()
-    del api
 
     api = request.getfixturevalue(api_fixture.__name__)
     assert api.list_collections() == []
@@ -1133,9 +1119,6 @@ def test_persist_index_loading_params(api, request):
         embedding_function=lambda text: [[1, 2, 3]],
     )
     collection.add(ids="id1", documents="hello")
-
-    api.persist()
-    del api
 
     api2 = request.getfixturevalue("local_persist_api_cache_bust")
     collection = api2.get_collection(

--- a/clients/js/src/ChromaClient.ts
+++ b/clients/js/src/ChromaClient.ts
@@ -84,13 +84,6 @@ export class ChromaClient {
     }
 
     /**
-     * @ignore
-     */
-    public async persist(): Promise<never> {
-        throw new Error("Not implemented in JS client");
-    }
-
-    /**
      * Creates a new collection with the specified properties.
      *
      * @param {Object} params - The parameters for creating a new collection.

--- a/clients/js/src/Collection.ts
+++ b/clients/js/src/Collection.ts
@@ -195,6 +195,7 @@ export class Collection {
                 embeddings: embeddingsArray as number[][], // We know this is defined because of the validate function
                 // @ts-ignore
                 documents: documentsArray,
+                // @ts-ignore
                 metadatas: metadatasArray,
             }, this.api.options)
             .then(handleSuccess)
@@ -248,6 +249,7 @@ export class Collection {
                 embeddings: embeddingsArray as number[][], // We know this is defined because of the validate function
                 //@ts-ignore
                 documents: documentsArray,
+                //@ts-ignore
                 metadatas: metadatasArray,
             },
             this.api.options
@@ -361,6 +363,7 @@ export class Collection {
                 where,
                 limit,
                 offset,
+                //@ts-ignore
                 include,
                 where_document: whereDocument,
             }, this.api.options)
@@ -512,6 +515,7 @@ export class Collection {
                 where,
                 n_results: nResults,
                 where_document: whereDocument,
+                //@ts-ignore
                 include: include,
             }, this.api.options)
             .then(handleSuccess)

--- a/clients/js/src/generated/api.ts
+++ b/clients/js/src/generated/api.ts
@@ -414,32 +414,6 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 			};
 		},
 		/**
-		 * @summary Persist
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		persist(options: RequestInit = {}): FetchArgs {
-			let localVarPath = `/api/v1/persist`;
-			const localVarPathQueryStart = localVarPath.indexOf("?");
-			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
-			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
-			const localVarQueryParameter = new URLSearchParams(localVarPathQueryStart !== -1 ? localVarPath.substring(localVarPathQueryStart + 1) : "");
-			if (localVarPathQueryStart !== -1) {
-				localVarPath = localVarPath.substring(0, localVarPathQueryStart);
-			}
-
-			localVarRequestOptions.headers = localVarHeaderParameter;
-
-			const localVarQueryParameterString = localVarQueryParameter.toString();
-			if (localVarQueryParameterString) {
-				localVarPath += "?" + localVarQueryParameterString;
-			}
-			return {
-				url: localVarPath,
-				options: localVarRequestOptions,
-			};
-		},
-		/**
 		 * @summary Raw Sql
 		 * @param {Api.RawSql} request
 		 * @param {RequestInit} [options] Override http request option.
@@ -1002,28 +976,6 @@ export const ApiApiFp = function(configuration?: Configuration) {
 			};
 		},
 		/**
-		 * @summary Persist
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		persist(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Persist200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).persist(options);
-			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
-				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-					const contentType = response.headers.get('Content-Type');
-					const mimeType = contentType ? contentType.replace(/;.*/, '') : undefined;
-
-					if (response.status === 200) {
-						if (mimeType === 'application/json') {
-							return response.json() as any;
-						}
-						throw response;
-					}
-					throw response;
-				});
-			};
-		},
-		/**
 		 * @summary Raw Sql
 		 * @param {Api.RawSql} request
 		 * @param {RequestInit} [options] Override http request option.
@@ -1336,15 +1288,6 @@ export class ApiApi extends BaseAPI {
 	 */
 	public listCollections(options?: RequestInit) {
 		return ApiApiFp(this.configuration).listCollections(options)(this.fetch, this.basePath);
-	}
-
-	/**
-	 * @summary Persist
-	 * @param {RequestInit} [options] Override http request option.
-	 * @throws {RequiredError}
-	 */
-	public persist(options?: RequestInit) {
-		return ApiApiFp(this.configuration).persist(options)(this.fetch, this.basePath);
 	}
 
 	/**

--- a/clients/js/src/generated/models.ts
+++ b/clients/js/src/generated/models.ts
@@ -17,10 +17,10 @@ export namespace Api {
 	}
 
 	export interface AddEmbedding {
-		embeddings: Api.AddEmbedding.Embedding[];
-		metadatas?: Api.AddEmbedding.Metadatas.ArrayValue[] | Api.AddEmbedding.Metadatas.ObjectValue;
-		documents?: string | Api.AddEmbedding.Documents.ArrayValue[];
-		ids?: string | Api.AddEmbedding.Ids.ArrayValue[];
+		embeddings?: Api.AddEmbedding.Embedding[];
+		metadatas?: Api.AddEmbedding.Metadata[];
+		documents?: string[];
+		ids: string[];
 		'increment_index'?: boolean;
 	}
 
@@ -32,43 +32,7 @@ export namespace Api {
 		export interface Embedding {
 		}
 
-		export type Metadatas = Api.AddEmbedding.Metadatas.ArrayValue[] | Api.AddEmbedding.Metadatas.ObjectValue;
-
-		/**
-		 * @export
-		 * @namespace Metadatas
-		 */
-		export namespace Metadatas {
-			export interface ArrayValue {
-			}
-
-			export interface ObjectValue {
-			}
-
-		}
-
-		export type Documents = string | Api.AddEmbedding.Documents.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Documents
-		 */
-		export namespace Documents {
-			export interface ArrayValue {
-			}
-
-		}
-
-		export type Ids = string | Api.AddEmbedding.Ids.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Ids
-		 */
-		export namespace Ids {
-			export interface ArrayValue {
-			}
-
+		export interface Metadata {
 		}
 
 	}
@@ -108,7 +72,7 @@ export namespace Api {
 	}
 
 	export interface DeleteEmbedding {
-		ids?: Api.DeleteEmbedding.Id[];
+		ids?: string[];
 		where?: Api.DeleteEmbedding.Where;
 		'where_document'?: Api.DeleteEmbedding.WhereDocument;
 	}
@@ -118,9 +82,6 @@ export namespace Api {
 	 * @namespace DeleteEmbedding
 	 */
 	export namespace DeleteEmbedding {
-		export interface Id {
-		}
-
 		export interface Where {
 		}
 
@@ -133,7 +94,7 @@ export namespace Api {
 	}
 
 	export interface GetEmbedding {
-		ids?: Api.GetEmbedding.Id[];
+		ids?: string[];
 		where?: Api.GetEmbedding.Where;
 		'where_document'?: Api.GetEmbedding.WhereDocument;
 		sort?: string;
@@ -147,7 +108,7 @@ export namespace Api {
 		 * @memberof GetEmbedding
 		 */
 		offset?: number;
-		include?: Api.GetEmbedding.IncludeEnum[];
+		include?: (Api.GetEmbedding.Include.EnumValueEnum | Api.GetEmbedding.Include.EnumValueEnum2 | Api.GetEmbedding.Include.EnumValueEnum3 | Api.GetEmbedding.Include.EnumValueEnum4)[];
 	}
 
 	/**
@@ -155,20 +116,35 @@ export namespace Api {
 	 * @namespace GetEmbedding
 	 */
 	export namespace GetEmbedding {
-		export interface Id {
-		}
-
 		export interface Where {
 		}
 
 		export interface WhereDocument {
 		}
 
-		export enum IncludeEnum {
-			Documents = 'documents',
-			Embeddings = 'embeddings',
-			Metadatas = 'metadatas',
-			Distances = 'distances'
+		export type Include = Api.GetEmbedding.Include.EnumValueEnum | Api.GetEmbedding.Include.EnumValueEnum2 | Api.GetEmbedding.Include.EnumValueEnum3 | Api.GetEmbedding.Include.EnumValueEnum4;
+
+		/**
+		 * @export
+		 * @namespace Include
+		 */
+		export namespace Include {
+			export enum EnumValueEnum {
+				Documents = 'documents'
+			}
+
+			export enum EnumValueEnum2 {
+				Embeddings = 'embeddings'
+			}
+
+			export enum EnumValueEnum3 {
+				Metadatas = 'metadatas'
+			}
+
+			export enum EnumValueEnum4 {
+				Distances = 'distances'
+			}
+
 		}
 
 	}
@@ -186,9 +162,6 @@ export namespace Api {
 	export interface ListCollections200Response {
 	}
 
-	export interface Persist200Response {
-	}
-
 	export interface QueryEmbedding {
 		where?: Api.QueryEmbedding.Where;
 		'where_document'?: Api.QueryEmbedding.WhereDocument;
@@ -198,7 +171,7 @@ export namespace Api {
 		 * @memberof QueryEmbedding
 		 */
 		'n_results'?: number;
-		include?: Api.QueryEmbedding.IncludeEnum[];
+		include?: (Api.QueryEmbedding.Include.EnumValueEnum | Api.QueryEmbedding.Include.EnumValueEnum2 | Api.QueryEmbedding.Include.EnumValueEnum3 | Api.QueryEmbedding.Include.EnumValueEnum4)[];
 	}
 
 	/**
@@ -215,17 +188,35 @@ export namespace Api {
 		export interface QueryEmbedding2 {
 		}
 
-		export enum IncludeEnum {
-			Documents = 'documents',
-			Embeddings = 'embeddings',
-			Metadatas = 'metadatas',
-			Distances = 'distances'
+		export type Include = Api.QueryEmbedding.Include.EnumValueEnum | Api.QueryEmbedding.Include.EnumValueEnum2 | Api.QueryEmbedding.Include.EnumValueEnum3 | Api.QueryEmbedding.Include.EnumValueEnum4;
+
+		/**
+		 * @export
+		 * @namespace Include
+		 */
+		export namespace Include {
+			export enum EnumValueEnum {
+				Documents = 'documents'
+			}
+
+			export enum EnumValueEnum2 {
+				Embeddings = 'embeddings'
+			}
+
+			export enum EnumValueEnum3 {
+				Metadatas = 'metadatas'
+			}
+
+			export enum EnumValueEnum4 {
+				Distances = 'distances'
+			}
+
 		}
 
 	}
 
 	export interface RawSql {
-		'raw_sql'?: string;
+		'raw_sql': string;
 	}
 
 	export interface RawSql200Response {
@@ -260,9 +251,9 @@ export namespace Api {
 
 	export interface UpdateEmbedding {
 		embeddings?: Api.UpdateEmbedding.Embedding[];
-		metadatas?: Api.UpdateEmbedding.Metadatas.ArrayValue[] | Api.UpdateEmbedding.Metadatas.ObjectValue;
-		documents?: string | Api.UpdateEmbedding.Documents.ArrayValue[];
-		ids?: string | Api.UpdateEmbedding.Ids.ArrayValue[];
+		metadatas?: Api.UpdateEmbedding.Metadata[];
+		documents?: string[];
+		ids: string[];
 		'increment_index'?: boolean;
 	}
 
@@ -274,43 +265,7 @@ export namespace Api {
 		export interface Embedding {
 		}
 
-		export type Metadatas = Api.UpdateEmbedding.Metadatas.ArrayValue[] | Api.UpdateEmbedding.Metadatas.ObjectValue;
-
-		/**
-		 * @export
-		 * @namespace Metadatas
-		 */
-		export namespace Metadatas {
-			export interface ArrayValue {
-			}
-
-			export interface ObjectValue {
-			}
-
-		}
-
-		export type Documents = string | Api.UpdateEmbedding.Documents.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Documents
-		 */
-		export namespace Documents {
-			export interface ArrayValue {
-			}
-
-		}
-
-		export type Ids = string | Api.UpdateEmbedding.Ids.ArrayValue[];
-
-		/**
-		 * @export
-		 * @namespace Ids
-		 */
-		export namespace Ids {
-			export interface ArrayValue {
-			}
-
+		export interface Metadata {
 		}
 
 	}


### PR DESCRIPTION
## Description of changes
The SQLite storage persists on call, we do not need an explicit persist()

## Test plan
Existing persistence tests still validate that data is saved.

## Documentation Changes
We will want to update documentation to remove references to persist()