### PR TITLE
Add missing telemetry from segment.py

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -26,6 +26,7 @@ from chromadb.api.types import (
     validate_where,
     validate_where_document,
 )
+from chromadb.telemetry.events import CollectionAddEvent, CollectionDeleteEvent
 
 import chromadb.types as t
 
@@ -244,6 +245,7 @@ class SegmentAPI(API):
             self._validate_embedding_record(coll, r)
             self._producer.submit_embedding(coll["topic"], r)
 
+        self._telemetry_client.capture(CollectionAddEvent(str(collection_id), len(ids)))
         return True
 
     @override
@@ -376,6 +378,9 @@ class SegmentAPI(API):
             self._validate_embedding_record(coll, r)
             self._producer.submit_embedding(coll["topic"], r)
 
+        self._telemetry_client.capture(
+            CollectionDeleteEvent(str(collection_id), len(ids_to_delete))
+        )
         return ids_to_delete
 
     @override

--- a/clients/js/src/Collection.ts
+++ b/clients/js/src/Collection.ts
@@ -195,6 +195,7 @@ export class Collection {
                 embeddings: embeddingsArray as number[][], // We know this is defined because of the validate function
                 // @ts-ignore
                 documents: documentsArray,
+                // @ts-ignore
                 metadatas: metadatasArray,
             }, this.api.options)
             .then(handleSuccess)
@@ -248,6 +249,7 @@ export class Collection {
                 embeddings: embeddingsArray as number[][], // We know this is defined because of the validate function
                 //@ts-ignore
                 documents: documentsArray,
+                //@ts-ignore
                 metadatas: metadatasArray,
             },
             this.api.options
@@ -361,6 +363,7 @@ export class Collection {
                 where,
                 limit,
                 offset,
+                //@ts-ignore
                 include,
                 where_document: whereDocument,
             }, this.api.options)
@@ -512,6 +515,7 @@ export class Collection {
                 where,
                 n_results: nResults,
                 where_document: whereDocument,
+                //@ts-ignore
                 include: include,
             }, this.api.options)
             .then(handleSuccess)


### PR DESCRIPTION
## Description of changes
The new segment based API was missing telemetry. This adds it in.

## Test plan
They are not tested explicitly. We should see the new api_impl fire events in posthog.

## Documentation Changes
None required.
