### PR TITLE
Replcae `engine` with `model` in embedding API call

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -118,7 +118,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction):
         texts = [t.replace("\n", " ") for t in texts]
 
         # Call the OpenAI Embedding API
-        embeddings = self._client.create(input=texts, engine=self._model_name)["data"]
+        embeddings = self._client.create(input=texts, model=self._model_name)["data"]
 
         # Sort resulting embeddings by index
         sorted_embeddings = sorted(embeddings, key=lambda e: e["index"])  # type: ignore


### PR DESCRIPTION
## Replcae `engine` with `model` in embedding API call

solve the problem of

```python
File "/usr/local/lib/python3.11/site-packages/chromadb/api/models/Collection.py", line 213, in query
    query_embeddings = self._embedding_function(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/chromadb/utils/embedding_functions.py", line 121, in __call__
    embeddings = self._client.create(input=texts, engine=self._model_name)["data"]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openai/api_resources/embedding.py", line 33, in create
    response = super().create(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 153, in create
    response, _, api_key = requestor.request(
                           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openai/api_requestor.py", line 226, in request
    resp, got_stream = self._interpret_response(result, stream)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openai/api_requestor.py", line 620, in _interpret_response
    self._interpret_response_line(
  File "/usr/local/lib/python3.11/site-packages/openai/api_requestor.py", line 683, in _interpret_response_line
    raise self.handle_error_response(
openai.error.InvalidRequestError: API not found: POST:/v1/engines/text-embedding-ada-002/embeddings
```

## Test plan
N/A

## Documentation Changes
N/A