### PR TITLE
Sqlite Concurrency

### DIFF
--- a/chromadb/db/impl/sqlite_pool.py
+++ b/chromadb/db/impl/sqlite_pool.py
@@ -5,26 +5,38 @@ import threading
 from overrides import override
 
 
-class Connection(sqlite3.Connection):
+class Connection:
     """A threadpool connection that returns itself to the pool on close()"""
 
-    pool: "Pool"
-    db_file: str
+    _pool: "Pool"
+    _db_file: str
+    _conn: sqlite3.Connection
 
     def __init__(
         self, pool: "Pool", db_file: str, is_uri: bool, *args: Any, **kwargs: Any
     ):
         self._pool = pool
         self._db_file = db_file
-        super().__init__(db_file, check_same_thread=False, uri=is_uri, *args, **kwargs)
+        self._conn = sqlite3.connect(db_file, check_same_thread=False, *args, **kwargs)
+        self._conn.isolation_level = None  # Handle commits explicitly
 
-    def close(self) -> None:
-        """Returns the connection to the pool"""
-        self._pool.return_to_pool(self)
+    def execute(self, sql, parameters=...) -> sqlite3.Cursor:
+        if parameters is ...:
+            return self._conn.execute(sql)
+        return self._conn.execute(sql, parameters)
+
+    def commit(self) -> None:
+        self._conn.commit()
+
+    def rollback(self) -> None:
+        self._conn.rollback()
+
+    def cursor(self) -> sqlite3.Cursor:
+        return self._conn.cursor()
 
     def close_actual(self) -> None:
         """Actually closes the connection to the db"""
-        super().close()
+        self._conn.close()
 
 
 class Pool(ABC):
@@ -50,46 +62,59 @@ class Pool(ABC):
         pass
 
 
-class EmptyPool(Pool):
-    """A pool that creates a new connection each time connect() is called. It never holds
-    connections and is therefore empty.
+class LockPool(Pool):
+    """A pool that has a single connection per thread but uses a lock to ensure that only one thread can use it at a time.
+    This is used because sqlite does not support multithreaded access with connection timeouts when using the
+    shared cache mode. We use the shared cache mode to allow multiple threads to share a database.
     """
 
     _connections: Set[Connection]
-    _lock: threading.Lock
+    _lock: threading.RLock
+    _connection: threading.local
     _db_file: str
     _is_uri: bool
 
     def __init__(self, db_file: str, is_uri: bool = False):
         self._connections = set()
-        self._lock = threading.Lock()
+        self._connection = threading.local()
+        self._lock = threading.RLock()
         self._db_file = db_file
         self._is_uri = is_uri
 
     @override
     def connect(self, *args: Any, **kwargs: Any) -> Connection:
-        new_connection = Connection(self, self._db_file, self._is_uri, *args, **kwargs)
-        with self._lock:
+        self._lock.acquire()
+        if hasattr(self._connection, "conn") and self._connection.conn is not None:
+            return self._connection.conn  # type: ignore # cast doesn't work here for some reason
+        else:
+            new_connection = Connection(
+                self, self._db_file, self._is_uri, *args, **kwargs
+            )
+            self._connection.conn = new_connection
             self._connections.add(new_connection)
-        return new_connection
+            return new_connection
 
     @override
     def return_to_pool(self, conn: Connection) -> None:
-        conn.close_actual()
-        with self._lock:
-            self._connections.remove(conn)
+        try:
+            self._lock.release()
+        except RuntimeError:
+            pass
 
     @override
     def close(self) -> None:
-        with self._lock:
-            for conn in self._connections:
-                conn.close_actual()
-            self._connections.clear()
+        for conn in self._connections:
+            conn.close_actual()
+        self._connections.clear()
+        self._connection = threading.local()
+        try:
+            self._lock.release()
+        except RuntimeError:
+            pass
 
 
 class PerThreadPool(Pool):
-    """Maintains a connection per thread. This should be used with in-memory sqlite dbs.
-    For now this does not maintain a cap on the number of connections, but it could be
+    """Maintains a connection per thread. For now this does not maintain a cap on the number of connections, but it could be
     extended to do so and block on connect() if the cap is reached.
     """
 

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -80,7 +80,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
         self._curr_batch = Batch()
         self._brute_force_index = None
         if not os.path.exists(self._get_storage_folder()):
-            os.makedirs(self._get_storage_folder())
+            os.makedirs(self._get_storage_folder(), exist_ok=True)
         # Load persist data if it exists already, otherwise create it
         if self._index_exists():
             self._persist_data = PersistentData.load_from_file(

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -60,6 +60,13 @@ def count(collection: Collection, record_set: RecordSet) -> None:
     """The given collection count is equal to the number of embeddings"""
     count = collection.count()
     normalized_record_set = wrap_all(record_set)
+    if count != len(normalized_record_set["ids"]):
+        print(
+            "Exepcted count: ",
+            len(normalized_record_set["ids"]),
+            " Actual count: ",
+            count,
+        )
     assert count == len(normalized_record_set["ids"])
 
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -29,7 +29,7 @@ def test_add(
 
     if not invariants.is_metadata_valid(normalized_record_set):
         with pytest.raises(Exception):
-            collection.add(**normalized_record_set)
+            coll.add(**normalized_record_set)
         return
 
     coll.add(**record_set)

--- a/chromadb/test/property/test_concurrency.py
+++ b/chromadb/test/property/test_concurrency.py
@@ -1,0 +1,82 @@
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+import multiprocessing
+from typing import Any, List, cast
+import hypothesis.strategies as st
+from hypothesis import given, settings
+import pytest
+import random
+
+from chromadb.api import API
+import chromadb.test.property.strategies as strategies
+import chromadb.test.property.invariants as invariants
+
+collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="coll")
+
+
+@given(
+    collection=collection_st,
+    record_set=strategies.recordsets(collection_st, min_size=10),
+    num_workers=st.integers(min_value=2, max_value=multiprocessing.cpu_count() * 2),
+)
+@settings(deadline=None)
+def test_many_threads_add(
+    api: API,
+    collection: strategies.Collection,
+    record_set: strategies.RecordSet,
+    num_workers: int,
+) -> None:
+    api.reset()
+
+    coll = api.create_collection(
+        name=collection.name,
+        metadata=collection.metadata,
+        embedding_function=collection.embedding_function,
+    )
+    normalized_record_set = invariants.wrap_all(record_set)
+
+    if not invariants.is_metadata_valid(normalized_record_set):
+        with pytest.raises(Exception):
+            coll.add(**normalized_record_set)
+        return
+
+    with ThreadPoolExecutor(max_workers=multiprocessing.cpu_count() // 2) as executor:
+        # Submit to the executor random batches of the record set until we have sent all of it
+        # to the executor.
+        total_sent = 0
+        futures: List[Future[Any]] = []
+        while total_sent < len(normalized_record_set["ids"]):
+            to_send = random.randint(
+                1, (len(record_set["ids"]) - total_sent) // num_workers
+            )
+            start = total_sent
+            end = total_sent + to_send + 1
+            future = executor.submit(
+                coll.add,
+                ids=normalized_record_set["ids"][start:end],
+                embeddings=normalized_record_set["embeddings"][start:end]
+                if normalized_record_set["embeddings"] is not None
+                else None,
+                metadatas=normalized_record_set["metadatas"][start:end]
+                if normalized_record_set["metadatas"] is not None
+                else None,
+                documents=normalized_record_set["documents"][start:end]
+                if normalized_record_set["documents"] is not None
+                else None,
+            )
+            futures.append(future)
+            total_sent += to_send
+        wait(futures, timeout=120, return_when="FIRST_EXCEPTION")
+
+    for future in futures:
+        exception = future.exception()
+        if exception is not None:
+            raise exception
+
+    invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
+    n_results = max(1, (len(normalized_record_set["ids"]) // 10))
+    invariants.ann_accuracy(
+        coll,
+        cast(strategies.RecordSet, normalized_record_set),
+        n_results=n_results,
+        embedding_function=collection.embedding_function,
+    )

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -41,7 +41,7 @@ def settings(request: pytest.FixtureRequest) -> Generator[Settings, None, None]:
     save_path = configuration.persist_directory
     # Create if it doesn't exist
     if not os.path.exists(save_path):
-        os.makedirs(save_path)
+        os.makedirs(save_path, exist_ok=True)
     yield configuration
     # Remove if it exists
     if os.path.exists(save_path):
@@ -166,7 +166,7 @@ class PersistEmbeddingsStateMachine(EmbeddingStateMachine):
         else:
             self.last_persist_delay -= 1
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.api.reset()
 
 


### PR DESCRIPTION
]1. The sqlite pool was previously incorrectly creating Connections(), we should be using sqlite3.connect() instead.
2. The sqlite pool was slightly modified to make return_to_pool explicit on the caller rather than overload the meaning of close
3. Shared cache sqlite3 does not allow concurrent access mediated by busy_timeout. Busy_timeout seems to be ignored and instead the connection fails immediately. We add a lockedpool which only lets one thread acccess db at a time. We must do this because shared cache sqlite3 does not seem to support multithreaded lock waiting. Rather than implement retry at the connection level, we opt to just enforce serialized access to the db.
4. Add a concurrency test that was used to catch this issue.

## Test plan
A new test test_concurrency was added which interleaves multiple threads accessing the db and then validates the invariants are held.

## Documentation Changes
None required. 
