### PR TITLE
add verison range for pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
   'pandas >= 1.3',
   'requests >= 2.28',
-  'pydantic==1.9',
+  'pydantic>=1.9,<2.0',
   'hnswlib >= 0.7',
   'clickhouse_connect >= 0.5.7',
   'duckdb >= 0.7.1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ overrides==7.3.1
 pandas==1.3.5
 posthog==2.4.0
 pulsar-client==3.1.0
-pydantic==1.9.0
+pydantic>=1.9,<2.0
 pypika==0.48.9
 requests==2.28.1
 tokenizers==0.13.2


### PR DESCRIPTION
[dont hard pin to ](https://github.com/chroma-core/chroma/issues/774) jump to pydantic v2

we dont want to go there yet so we pinned to 1.9, but langchian uses 1.10. this PR adds a valid range from 1.9 to < 2.0