### PR TITLE
RW_Lock

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -22,6 +22,56 @@ def get_settings() -> Settings:
     return __settings
 
 
+def EphemeralClient(settings: Settings = Settings()) -> API:
+    """
+    Creates an in-memory instance of Chroma. This is useful for testing and
+    development, but not recommended for production use.
+    """
+    settings.is_persistent = False
+
+    return Client(settings)
+
+
+def PersistentClient(path: str = "./chroma", settings: Settings = Settings()) -> API:
+    """
+    Creates a persistent instance of Chroma that saves to disk. This is useful for
+    testing and development, but not recommended for production use.
+
+    Args:
+        path: The directory to save Chroma's data to. Defaults to "./chroma".
+    """
+    settings.persist_directory = path
+    settings.is_persistent = True
+
+    return Client(settings)
+
+
+def HttpClient(
+    host: str = "localhost",
+    port: str = "8000",
+    ssl: bool = False,
+    settings: Settings = Settings(),
+) -> API:
+    """
+    Creates a client that connects to a remote Chroma server. This supports
+    many clients connecting to the same server, and is the recommended way to
+    use Chroma in production.
+
+    Args:
+        host: The hostname of the Chroma server. Defaults to "localhost".
+        port: The port of the Chroma server. Defaults to "8000".
+        ssl: Whether to use SSL to connect to the Chroma server. Defaults to False.
+    """
+
+    settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
+    settings.chroma_server_host = host
+    settings.chroma_server_http_port = port
+    settings.chroma_server_ssl_enabled = ssl
+    # TODO: auth headers
+
+    return Client(settings)
+
+
 def Client(settings: Settings = __settings) -> API:
     """Return a running chroma.API instance"""
 

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -16,7 +16,7 @@ from chromadb.api.types import (
     GetResult,
     WhereDocument,
 )
-from chromadb.config import Component
+from chromadb.config import Component, Settings
 import chromadb.utils.embedding_functions as ef
 
 
@@ -329,6 +329,16 @@ class API(Component, ABC):
 
         Returns:
             str: The version of Chroma
+
+        """
+        pass
+
+    @abstractmethod
+    def get_settings(self) -> Settings:
+        """Get the settings used to initialize the client.
+
+        Returns:
+            Settings: The settings used to initialize the client.
 
         """
         pass

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -1,6 +1,6 @@
 from typing import Optional, cast
 from chromadb.api import API
-from chromadb.config import System
+from chromadb.config import Settings, System
 from chromadb.api.types import (
     Documents,
     Embeddings,
@@ -27,6 +27,8 @@ from overrides import override
 
 
 class FastAPI(API):
+    _settings: Settings
+
     def __init__(self, system: System):
         super().__init__(system)
         url_prefix = "https" if system.settings.chroma_server_ssl_enabled else "http"
@@ -34,6 +36,7 @@ class FastAPI(API):
         system.settings.require("chroma_server_http_port")
         self._api_url = f"{url_prefix}://{system.settings.chroma_server_host}:{system.settings.chroma_server_http_port}/api/v1"
         self._telemetry_client = self.require(Telemetry)
+        self._settings = system.settings
 
     @override
     def heartbeat(self) -> int:
@@ -369,6 +372,11 @@ class FastAPI(API):
         resp = requests.get(self._api_url + "/version")
         raise_chroma_error(resp)
         return cast(str, resp.json())
+
+    @override
+    def get_settings(self) -> Settings:
+        """Returns the settings of the client"""
+        return self._settings
 
 
 def raise_chroma_error(resp: requests.Response) -> None:

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -1,5 +1,5 @@
 from chromadb.api import API
-from chromadb.config import System
+from chromadb.config import Settings, System
 from chromadb.db.system import SysDB
 from chromadb.segment import SegmentManager, MetadataReader, VectorReader
 from chromadb.telemetry import Telemetry
@@ -66,6 +66,7 @@ def check_index_name(index_name: str) -> None:
 class SegmentAPI(API):
     """API implementation utilizing the new segment-based internal architecture"""
 
+    _settings: Settings
     _sysdb: SysDB
     _manager: SegmentManager
     _producer: Producer
@@ -77,6 +78,7 @@ class SegmentAPI(API):
 
     def __init__(self, system: System):
         super().__init__(system)
+        self._settings = system.settings
         self._sysdb = self.require(SysDB)
         self._manager = self.require(SegmentManager)
         self._telemetry_client = self.require(Telemetry)
@@ -493,6 +495,10 @@ class SegmentAPI(API):
             "Calling create_index is unnecessary, data is now automatically indexed"
         )
         return True
+
+    @override
+    def get_settings(self) -> Settings:
+        return self._settings
 
     def _topic(self, collection_id: UUID) -> str:
         return f"persistent://{self._tenant_id}/{self._topic_ns}/{collection_id}"

--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -75,6 +75,8 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
             self._db_file = (
                 self._settings.require("persist_directory") + "/chroma.sqlite3"
             )
+            if not os.path.exists(self._db_file):
+                os.makedirs(os.path.dirname(self._db_file), exist_ok=True)
             self._conn_pool = PerThreadPool(self._db_file)
         self._tx_stack = local()
         super().__init__(system)

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -1,0 +1,37 @@
+import chromadb
+from chromadb.api import API
+import chromadb.server.fastapi
+import pytest
+import tempfile
+
+
+@pytest.fixture
+def ephemeral_api() -> API:
+    return chromadb.EphemeralClient()
+
+
+@pytest.fixture
+def persistent_api() -> API:
+    return chromadb.PersistentClient(
+        path=tempfile.gettempdir() + "/test_server",
+    )
+
+
+@pytest.fixture
+def http_api() -> API:
+    return chromadb.HttpClient()
+
+
+def test_ephemeral_client(ephemeral_api: API) -> None:
+    settings = ephemeral_api.get_settings()
+    assert settings.is_persistent is False
+
+
+def test_persistent_client(persistent_api: API) -> None:
+    settings = persistent_api.get_settings()
+    assert settings.is_persistent is True
+
+
+def test_http_client(http_api: API) -> None:
+    settings = http_api.get_settings()
+    assert settings.chroma_api_impl == "chromadb.api.fastapi.FastAPI"

--- a/chromadb/test/test_multithreaded.py
+++ b/chromadb/test/test_multithreaded.py
@@ -14,7 +14,7 @@ from chromadb.types import Metadata
 
 def generate_data_shape() -> Tuple[int, int]:
     N = random.randint(10, 10000)
-    D = random.randint(10, 2000)
+    D = random.randint(10, 256)
     return (N, D)
 
 
@@ -58,6 +58,8 @@ def _test_multithreaded_add(api: API, N: int, D: int, num_workers: int) -> None:
             to_send = min(batch_size, len(ids) - total_sent)
             start = total_sent + 1
             end = total_sent + to_send + 1
+            if embeddings is not None and len(embeddings[start:end]) == 0:
+                break
             future = executor.submit(
                 coll.add,
                 ids=ids[start:end],

--- a/chromadb/utils/read_write_lock.py
+++ b/chromadb/utils/read_write_lock.py
@@ -1,0 +1,84 @@
+import threading
+from types import TracebackType
+from typing import Optional, Type
+
+
+class ReadWriteLock:
+    def __init__(self) -> None:
+        self._read_ready = threading.Condition(threading.RLock())
+        self._readers = 0
+        self._writers = 0
+        self._writer_active = False
+
+    def acquire_read(self) -> None:
+        """Acquire a read lock. Blocks only if a thread has
+        acquired the write lock."""
+        self._read_ready.acquire()
+        try:
+            while self._writers > 0 or self._writer_active:
+                self._read_ready.wait()
+            self._readers += 1
+        finally:
+            self._read_ready.release()
+
+    def release_read(self) -> None:
+        self._read_ready.acquire()
+        try:
+            self._readers -= 1
+            if self._readers == 0:
+                self._read_ready.notifyAll()
+        finally:
+            self._read_ready.release()
+
+    def acquire_write(self) -> None:
+        self._read_ready.acquire()
+        try:
+            self._writers += 1
+            while self._readers > 0 or self._writer_active:
+                self._read_ready.wait()
+            self._writers -= 1
+            self._writer_active = True
+        finally:
+            self._read_ready.release()
+
+    def release_write(self) -> None:
+        self._read_ready.acquire()
+        try:
+            self._writer_active = False
+            self._read_ready.notifyAll()
+        finally:
+            self._read_ready.release()
+
+
+class ReadRWLock:
+    def __init__(self, rwLock: ReadWriteLock):
+        self.rwLock = rwLock
+
+    def __enter__(self) -> None:
+        self.rwLock.acquire_read()
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.rwLock.release_read()
+        # TODO: handle exceptions
+
+
+class WriteRWLock:
+    def __init__(self, rwLock: ReadWriteLock):
+        self.rwLock = rwLock
+
+    def __enter__(self) -> None:
+        self.rwLock.acquire_write()
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.rwLock.release_write()
+        # TODO: handle exceptions

--- a/chromadb/utils/read_write_lock.py
+++ b/chromadb/utils/read_write_lock.py
@@ -56,7 +56,6 @@ class ReadRWLock:
         traceback: Optional[TracebackType],
     ) -> None:
         self.rwLock.release_read()
-        # TODO: handle exceptions
 
 
 class WriteRWLock:
@@ -73,4 +72,3 @@ class WriteRWLock:
         traceback: Optional[TracebackType],
     ) -> None:
         self.rwLock.release_write()
-        # TODO: handle exceptions

--- a/chromadb/utils/read_write_lock.py
+++ b/chromadb/utils/read_write_lock.py
@@ -4,40 +4,41 @@ from typing import Optional, Type
 
 
 class ReadWriteLock:
+    """A lock object that allows many simultaneous "read locks", but
+    only one "write lock." """
+
     def __init__(self) -> None:
         self._read_ready = threading.Condition(threading.RLock())
         self._readers = 0
-        self._writers = 0
 
     def acquire_read(self) -> None:
         """Acquire a read lock. Blocks only if a thread has
         acquired the write lock."""
         self._read_ready.acquire()
         try:
-            while self._writers > 0:
-                self._read_ready.wait()
             self._readers += 1
         finally:
             self._read_ready.release()
 
     def release_read(self) -> None:
+        """Release a read lock."""
         self._read_ready.acquire()
         try:
             self._readers -= 1
-            if self._readers == 0:
-                self._read_ready.notify_all()
+            if not self._readers:
+                self._read_ready.notifyAll()
         finally:
             self._read_ready.release()
 
     def acquire_write(self) -> None:
+        """Acquire a write lock. Blocks until there are no
+        acquired read or write locks."""
         self._read_ready.acquire()
-        self._writers += 1
         while self._readers > 0:
             self._read_ready.wait()
 
     def release_write(self) -> None:
-        self._writers -= 1
-        self._read_ready.notify_all()
+        """Release a write lock."""
         self._read_ready.release()
 
 


### PR DESCRIPTION
## Description of changes

Upgrades to a RW lock for guarding vector segment. We use a standard implementation of a RW Lock with a reentrant lock in python borrowed from https://www.oreilly.com/library/view/python-cookbook/0596001673/ch06s04.html. This implementation can suffer from writer-starvation, and we can upgrade it in the future.

## Test plan
Existing tests.

## Documentation Changes
None
