### PR TITLE
js 1.5.4

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
bump to 1.5.4 to release isomorphic fetch for < node 18 support

needs to be manually released