### PR TITLE
Ignore .conda in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 venv
+.conda
 .git
 examples
 clients


### PR DESCRIPTION
Ignore .conda from docker build ,which is huge for local development (500M+)

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - imporve the local docker build speed
 - New functionality
	 - N/A

## Test plan
*How are these changes tested?*
- build with local machine

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A