### PR TITLE
Add docs, and minor logging fix

### DIFF
--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -2,4 +2,5 @@
 
 echo "Rebuilding hnsw to ensure architecture compatibility"
 pip install --force-reinstall --no-cache-dir chroma-hnswlib
+export IS_PERSISTENT=1
 uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config log_config.yml

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "Rebuilding hnsw to ensure architecture compatibility"
-pip install --force-reinstall --no-cache-dir hnswlib
+pip install --force-reinstall --no-cache-dir chroma-hnswlib
 uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config log_config.yml

--- a/bin/templates/docker-compose.yml
+++ b/bin/templates/docker-compose.yml
@@ -9,37 +9,12 @@ services:
     image: ghcr.io/chroma-core/chroma:${ChromaVersion}
     volumes:
       - index_data:/index_data
-    environment:
-      - CHROMA_DB_IMPL=clickhouse
-      - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_PORT=8123
     ports:
       - 8000:8000
-    depends_on:
-      - clickhouse
-    networks:
-      - net
-
-  clickhouse:
-    image: clickhouse/clickhouse-server:22.9-alpine
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - CLICKHOUSE_TCP_PORT=9000
-      - CLICKHOUSE_HTTP_PORT=8123
-    ports:
-      - '8123:8123'
-      - '9000:9000'
-    volumes:
-      - clickhouse_data:/bitnami/clickhouse
-      - backups:/backups
-      - ./config/backup_disk.xml:/etc/clickhouse-server/config.d/backup_disk.xml
-      - ./config/chroma_users.xml:/etc/clickhouse-server/users.d/chroma.xml
     networks:
       - net
 
 volumes:
-  clickhouse_data:
-    driver: local
   index_data:
     driver: local
   backups:

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -309,9 +309,12 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
 
         # Overquery by updated and deleted elements layered on the index because they may
         # hide the real nearest neighbors in the hnsw index
+        hnsw_k = k + self._curr_batch.update_count + self._curr_batch.delete_count
+        if hnsw_k > len(self._id_to_label):
+            hnsw_k = len(self._id_to_label)
         hnsw_query = VectorQuery(
             vectors=query["vectors"],
-            k=k + self._curr_batch.update_count + self._curr_batch.delete_count,
+            k=hnsw_k,
             allowed_ids=query["allowed_ids"],
             include_embeddings=query["include_embeddings"],
             options=query["options"],

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -16,11 +16,8 @@ To connect to your server and perform operations using the client only library, 
 
 ```python
 import chromadb
-from chromadb.config import Settings
 # Example setup of the client to connect to your chroma server
-client = chromadb.Client(Settings(chroma_api_impl="rest",
-                                  chroma_server_host="localhost",
-                                  chroma_server_http_port=8000))
+client = chromadb.HttpClient(host="localhost", port=8000)
 
 collection = client.create_collection("all-my-documents")
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - ANONYMIZED_TELEMETRY=False
       - ALLOW_RESET=True
+      - IS_PERSISTENT=TRUE
     ports:
       - ${CHROMA_PORT}:8000
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - ./:/chroma
       - index_data:/index_data
     command: uvicorn chromadb.app:app --reload --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml
+    environment:
+      - IS_PERSISTENT=TRUE
     ports:
       - 8000:8000
     networks:

--- a/examples/basic_functionality/alternative_embeddings.ipynb
+++ b/examples/basic_functionality/alternative_embeddings.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -12,7 +13,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -21,24 +22,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 2,
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Using embedded DuckDB without persistence: data will be transient\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "client = chromadb.Client()"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 3,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -47,30 +40,30 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 4,
       "metadata": {},
       "outputs": [],
       "source": [
         "# Using OpenAI Embeddings. This assumes you have the openai package installed\n",
         "openai_ef = embedding_functions.OpenAIEmbeddingFunction(\n",
-        "    api_key=\"OPENAI_API_KEY\", # Replace with your own OpenAI API key\n",
+        "    api_key=\"OPENAI_KEY\", # Replace with your own OpenAI API key\n",
         "    model_name=\"text-embedding-ada-002\"\n",
         ")"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 5,
       "metadata": {},
       "outputs": [],
       "source": [
         "# Create a new chroma collection\n",
-        "openai_collection = client.create_collection(name=\"openai_embeddings\", embedding_function=openai_ef)"
+        "openai_collection = client.get_or_create_collection(name=\"openai_embeddings\", embedding_function=openai_ef)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -83,20 +76,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
           "data": {
             "text/plain": [
               "{'ids': [['id1', 'id2']],\n",
-              " 'embeddings': None,\n",
-              " 'documents': [['This is a document', 'This is another document']],\n",
+              " 'distances': [[0.1385088860988617, 0.2017185091972351]],\n",
               " 'metadatas': [[{'source': 'my_source'}, {'source': 'my_source'}]],\n",
-              " 'distances': [[0.13865342736244202, 0.20187020301818848]]}"
+              " 'embeddings': None,\n",
+              " 'documents': [['This is a document', 'This is another document']]}"
             ]
           },
-          "execution_count": 8,
+          "execution_count": 7,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -324,7 +317,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.6"
+      "version": "3.10.8"
     }
   },
   "nbformat": 4,

--- a/examples/basic_functionality/local_persistence.ipynb
+++ b/examples/basic_functionality/local_persistence.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Local Peristence Demo\n",
-    "This notebook demonstrates how to persist the in-memory version of Chroma to disk, then load it back in. "
+    "This notebook demonstrates how to configure Chroma to persist to disk, then load it back in. "
    ]
   },
   {
@@ -15,55 +15,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import chromadb\n",
-    "from chromadb.config import Settings"
+    "import chromadb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a new Chroma client with persistence enabled. \n",
+    "persist_directory = \"db\"\n",
+    "\n",
+    "client = chromadb.PersistentClient(path=persist_directory)\n",
+    "\n",
+    "# Create a new chroma collection\n",
+    "collection_name = \"peristed_collection\"\n",
+    "collection = client.get_or_create_collection(name=collection_name)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running Chroma using direct local API.\n",
-      "No existing DB found in db, skipping load\n",
-      "No existing DB found in db, skipping load\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/antontroynikov/miniforge3/envs/chroma/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create a new Chroma client with persistence enabled. \n",
-    "persist_directory = \"db\"\n",
-    "\n",
-    "client = chromadb.Client(\n",
-    "    Settings(\n",
-    "        persist_directory=persist_directory,\n",
-    "        chroma_db_impl=\"duckdb+parquet\",\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "# Start from scratch\n",
-    "client.reset()\n",
-    "\n",
-    "# Create a new chroma collection\n",
-    "collection_name = \"peristed_collection\"\n",
-    "collection = client.create_collection(name=collection_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,56 +69,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Persisting DB to disk, putting it in the save folder db\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Persist the DB. This also happens automatically when the client is garbage collected.\n",
-    "# In a notebook, prefer to call persist explicitly.\n",
-    "client.persist()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running Chroma using direct local API.\n",
-      "loaded in 8 embeddings\n",
-      "loaded in 1 collections\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create a new client with the same settings\n",
-    "client = chromadb.Client(\n",
-    "    Settings(\n",
-    "        persist_directory=persist_directory,\n",
-    "        chroma_db_impl=\"duckdb+parquet\",\n",
-    "    )\n",
-    ")\n",
+    "client = chromadb.PersistentClient(path=persist_directory)\n",
     "\n",
     "# Load the collection\n",
     "collection = client.get_collection(collection_name)"
@@ -153,14 +82,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'embeddings': [[[1.1, 2.3, 3.2]]], 'documents': [['doc5']], 'ids': [['id5']], 'metadatas': [[{'uri': 'img5.png', 'style': 'style1'}]], 'distances': [[0.0]]}\n"
+      "{'ids': [['id1']], 'distances': [[5.1159076593562386e-15]], 'metadatas': [[{'style': 'style1', 'uri': 'img1.png'}]], 'embeddings': None, 'documents': [['doc1']]}\n"
      ]
     }
    ],
@@ -176,25 +105,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Persisting DB to disk, putting it in the save folder db\n"
-     ]
+     "data": {
+      "text/plain": [
+       "{'ids': ['id1', 'id2', 'id3', 'id4', 'id5', 'id6', 'id7', 'id8'],\n",
+       " 'embeddings': [[1.100000023841858, 2.299999952316284, 3.200000047683716],\n",
+       "  [4.5, 6.900000095367432, 4.400000095367432],\n",
+       "  [1.100000023841858, 2.299999952316284, 3.200000047683716],\n",
+       "  [4.5, 6.900000095367432, 4.400000095367432],\n",
+       "  [1.100000023841858, 2.299999952316284, 3.200000047683716],\n",
+       "  [4.5, 6.900000095367432, 4.400000095367432],\n",
+       "  [1.100000023841858, 2.299999952316284, 3.200000047683716],\n",
+       "  [4.5, 6.900000095367432, 4.400000095367432]],\n",
+       " 'metadatas': [{'style': 'style1', 'uri': 'img1.png'},\n",
+       "  {'style': 'style2', 'uri': 'img2.png'},\n",
+       "  {'style': 'style1', 'uri': 'img3.png'},\n",
+       "  {'style': 'style1', 'uri': 'img4.png'},\n",
+       "  {'style': 'style1', 'uri': 'img5.png'},\n",
+       "  {'style': 'style1', 'uri': 'img6.png'},\n",
+       "  {'style': 'style1', 'uri': 'img7.png'},\n",
+       "  {'style': 'style1', 'uri': 'img8.png'}],\n",
+       " 'documents': ['doc1', 'doc2', 'doc3', 'doc4', 'doc5', 'doc6', 'doc7', 'doc8']}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Clean up\n",
-    "client.reset()\n",
-    "client.persist()\n",
-    "\n",
-    "# You can also just delete the persist directory\n",
-    "!rm -rf db/"
+    "collection.get(include=[\"embeddings\", \"metadatas\", \"documents\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up\n",
+    "! rm -rf db"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -213,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.8"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/examples/basic_functionality/where_filtering.ipynb
+++ b/examples/basic_functionality/where_filtering.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,34 +20,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using embedded DuckDB without persistence: data will be transient\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "client = chromadb.Client()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No embedding_function provided, using default embedding function: SentenceTransformerEmbeddingFunction\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create a new chroma collection\n",
     "collection_name = \"filter_example_collection\"\n",
@@ -56,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -97,11 +81,11 @@
       "text/plain": [
        "{'ids': ['id7'],\n",
        " 'embeddings': None,\n",
-       " 'documents': ['A document that discusses international affairs'],\n",
-       " 'metadatas': [{'status': 'read'}]}"
+       " 'metadatas': [{'status': 'read'}],\n",
+       " 'documents': ['A document that discusses international affairs']}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -113,20 +97,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'ids': ['id8', 'id1'],\n",
+       "{'ids': ['id1', 'id8'],\n",
        " 'embeddings': None,\n",
-       " 'documents': ['A document that discusses global affairs',\n",
-       "  'A document that discusses domestic policy'],\n",
-       " 'metadatas': [{'status': 'unread'}, {'status': 'read'}]}"
+       " 'metadatas': [{'status': 'read'}, {'status': 'unread'}],\n",
+       " 'documents': ['A document that discusses domestic policy',\n",
+       "  'A document that discusses global affairs']}"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,24 +122,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'ids': [['id7', 'id2', 'id8']],\n",
-       " 'embeddings': None,\n",
-       " 'documents': [['A document that discusses international affairs',\n",
-       "   'A document that discusses international affairs',\n",
-       "   'A document that discusses global affairs']],\n",
+       " 'distances': [[16.740001678466797, 87.22000122070312, 87.22000122070312]],\n",
        " 'metadatas': [[{'status': 'read'},\n",
        "   {'status': 'unread'},\n",
        "   {'status': 'unread'}]],\n",
-       " 'distances': [[16.740001678466797, 87.22000122070312, 87.22000122070312]]}"
+       " 'embeddings': None,\n",
+       " 'documents': [['A document that discusses international affairs',\n",
+       "   'A document that discusses international affairs',\n",
+       "   'A document that discusses global affairs']]}"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -165,6 +149,13 @@
     "# Outputs 3 docs because collection only has 3 docs about affairs\n",
     "collection.query(query_embeddings=[[0, 0, 0]], where_document={\"$contains\": \"affairs\"}, n_results=5)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description of changes
Updates various docs and examples to be relevant for the sqlite refactor, adds a small QoL fix to prevent a confusing log.

1. Update docker-entrypoint.sh to point to chroma-hnswlib
2. Update docker-compose in bin/templates to not use clickhouse
3. Update local_persistent_hnsw to not overquery underlying index past its size as it will result in a confusing double log. This doesn't modify the logic as the underlying index was re-performing this logic before. But it led to a confusing log where we repeatedly told you we were changing your query
4. Update the thin client readme to use HttpClient
5. Make the dockerfile and compose files use IS_PERSISTENT=TRUE since its false by default and the default client/server path should be persistent.
6. Update all notebooks that used the old client by modifying + rerunning


## Test plan
Existing tests, or they are notebooks which I ran

## Documentation Changes
None
