### PR TITLE
Enable SQLite URI filename capability

### DIFF
--- a/chromadb/db/impl/sqlite_pool.py
+++ b/chromadb/db/impl/sqlite_pool.py
@@ -18,11 +18,11 @@ class Connection:
         self._pool = pool
         self._db_file = db_file
         self._conn = sqlite3.connect(
-            db_file, timeout=1000, check_same_thread=False, *args, **kwargs
-        )
+            db_file, timeout=1000, check_same_thread=False, uri=is_uri, *args, **kwargs
+        )  # type: ignore
         self._conn.isolation_level = None  # Handle commits explicitly
 
-    def execute(self, sql, parameters=...) -> sqlite3.Cursor:
+    def execute(self, sql: str, parameters=...) -> sqlite3.Cursor:  # type: ignore
         if parameters is ...:
             return self._conn.execute(sql)
         return self._conn.execute(sql, parameters)


### PR DESCRIPTION
## Description of changes
Ensures that the `uri=is_uri` is passed to `sqlite3.connect` so that SQLite will have [URI filenames enabled](https://www.sqlite.org/uri.html) and correctly create an in-memory database instead of a file named `file::memory:?cache=shared `

 - Improvements & Bug fixes
          - closes: #822 


## Test plan
Existing tests are passing

```python
import chromadb
client = chromadb.Client()
```
does not create a file 


## Documentation Changes

