### PR TITLE
bump version and release instructions

### DIFF
--- a/clients/js/DEVELOP.md
+++ b/clients/js/DEVELOP.md
@@ -22,7 +22,7 @@ This readme is helpful for local dev.
 
 The goal of the design is that this will be added to our github action releases so that the JS API is always up to date and pinned against the python backend API.
 
-`yarn release` pushes the `package.json` defined packaged to the package manager for authenticated users. It will build, test, and then publish the new version.
+`npm run release` pushes the `package.json` defined packaged to the package manager for authenticated users. It will build, test, and then publish the new version.
 
 ### Useful links
 

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
- bump to 1.5.5 (already released)
- fix release instructions