### PR TITLE
Revert trigram tokenizer

### DIFF
--- a/chromadb/migrations/metadb/00001-embedding-metadata.sqlite.sql
+++ b/chromadb/migrations/metadb/00001-embedding-metadata.sqlite.sql
@@ -21,4 +21,4 @@ CREATE TABLE max_seq_id (
     seq_id BLOB NOT NULL
 );
 
-CREATE VIRTUAL TABLE embedding_fulltext USING fts5(id, string_value, tokenize="trigram");
+CREATE VIRTUAL TABLE embedding_fulltext USING fts5(id, string_value);


### PR DESCRIPTION
## Description of changes

Because of inconsistent bundling, not all python versions on all platforms ship with a SQLite which has the trigrams tokenizer, and the same python version may have different SQLites on different platforms. 

This creates problems for users of Chroma `0.4.0` which uses the trigram tokenizer. This change reverts to using the default tokenizer of whatever SQLite is available on the system. The tradeoff is reduced full-text search performance, but this simplifies installation and maintenance. 

This should address:

https://github.com/chroma-core/chroma/issues/837
https://github.com/chroma-core/chroma/issues/836

## Test plan
The test suite should pass. 
Tested in colab via pypi test.

```python
!pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple chromadb==0.4.1.dev1

import chromadb

client = chromadb.Client()
```

## Documentation Changes
None, not user-facing. 