### PR TITLE
Update error message to be more verbose

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -19,7 +19,18 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-LEGACY_ERROR = "You are using a deprecated configuration of Chroma. Please pip install chroma-migrate and run `chroma-migrate` to upgrade your configuration. See https://docs.trychroma.com/migration for more information or join our discord at https://discord.gg/8g5FESbj for help!"
+LEGACY_ERROR = """You are using a deprecated configuration of Chroma.
+
+If you do not have data you wish to migrate, you only need to change how you construct
+your Chroma client. Please see the "New Clients" section of https://docs.trychroma.com/migration.
+________________________________________________________________________________________________
+
+If you do have data you wish to migrate, we have a migration tool you can use in order to
+migrate your data to the new Chroma architecture.
+Please `pip install chroma-migrate` and run `chroma-migrate` to migrate your data and then
+change how you construct your Chroma client.
+
+See https://docs.trychroma.com/migration for more information or join our discord at https://discord.gg/8g5FESbj for help!"""
 
 _legacy_config_keys = {
     "chroma_db_impl",

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -19,9 +19,9 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-LEGACY_ERROR = """You are using a deprecated configuration of Chroma.
+LEGACY_ERROR = """\033[91mYou are using a deprecated configuration of Chroma.
 
-If you do not have data you wish to migrate, you only need to change how you construct
+\033[94mIf you do not have data you wish to migrate, you only need to change how you construct
 your Chroma client. Please see the "New Clients" section of https://docs.trychroma.com/migration.
 ________________________________________________________________________________________________
 
@@ -30,7 +30,7 @@ migrate your data to the new Chroma architecture.
 Please `pip install chroma-migrate` and run `chroma-migrate` to migrate your data and then
 change how you construct your Chroma client.
 
-See https://docs.trychroma.com/migration for more information or join our discord at https://discord.gg/8g5FESbj for help!"""
+See https://docs.trychroma.com/migration for more information or join our discord at https://discord.gg/8g5FESbj for help!\033[0m"""
 
 _legacy_config_keys = {
     "chroma_db_impl",


### PR DESCRIPTION
## Description of changes
Update error message to be more verbose in the case of users who do not want to migrate any data and are just following an old guide.
<img width="1204" alt="Screenshot 2023-07-18 at 12 31 31 PM" src="https://github.com/chroma-core/chroma/assets/5598697/7b87b35f-09fb-498e-88fa-fcb6bcb6dd42">

## Test plan
Manually verified the error

## Documentation Changes
None required.