### PR TITLE
Optional fields for `get` and `query`

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -55,19 +55,21 @@ Where = Where
 WhereDocumentOperator = WhereDocumentOperator
 
 
-class GetResult(TypedDict):
+class GetResult(TypedDict, total=False):
     ids: List[ID]
     embeddings: Optional[List[Embedding]]
     documents: Optional[List[Document]]
     metadatas: Optional[List[Metadata]]
+    included_fields: Optional[Include]
 
 
-class QueryResult(TypedDict):
+class QueryResult(TypedDict, total=False):
     ids: List[IDs]
     embeddings: Optional[List[List[Embedding]]]
     documents: Optional[List[List[Document]]]
     metadatas: Optional[List[List[Metadata]]]
     distances: Optional[List[List[float]]]
+    included_fields: Optional[Include]
 
 
 class IndexMetadata(TypedDict):


### PR DESCRIPTION
This PR aims to clear up communication around what data users get back when using `.get` and `.query`

Specifically this issue: https://docs.trychroma.com/troubleshooting#using-get-or-query-embeddings-say-none

This PR updates `get` and `query` to only send back the fields you request. To add extra communication, we pass back a new field called `included_fields` that tells you what was included. This is added because we have defaults that a user may not be familiar with. 
<img width="1573" alt="Screenshot 2023-07-18 at 1 25 29 PM" src="https://github.com/chroma-core/chroma/assets/891664/64b40c26-d26a-40eb-a893-360c0f64764f">

If we like this direction: I will continue on and add tests for it and make sure it operates well with the JS client. 

### NOTE: I expect tests to fail right now! 
