### PR TITLE
Colab SQLite Workaround

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -12,6 +12,28 @@ __settings = Settings()
 
 __version__ = "0.4.1"
 
+# Workaround to deal with Colab's old sqlite3 version
+try:
+    import google.colab  # noqa: F401
+
+    IN_COLAB = True
+except ImportError:
+    IN_COLAB = False
+
+if IN_COLAB:
+    # Check the version of sqlite3, hotswap to pysqlite-binary if it's too old
+    import sqlite3
+
+    if sqlite3.sqlite_version_info < (3, 35, 0):
+        import subprocess
+        import sys
+
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "pysqlite3-binary"]
+        )
+        __import__("pysqlite3")
+        sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
+
 
 def configure(**kwargs) -> None:  # type: ignore
     """Override Chroma's default settings, environment variables or .env files"""


### PR DESCRIPTION
## Description of changes

Because the Colab python environment uses a very old version of SQLite, Chroma would break for users in Colab notebooks. This workaround hotswaps the system `sqlite3` module with the binary `pysqlite3-binary` module when Chroma is imported, bypassing the issue. 

We didn't catch this when addressing other issues with SQLite because we didn't try to `collection.add`. 

This addresses:
https://github.com/chroma-core/chroma/issues/850

## Test plan
- Tests pass
- Tested locally by bumping the required version to `(3, 70, 0)`
- Tested with a pytest version in colab using:

```python
!python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple chromadb==0.4.2.dev2

import chromadb
client = chromadb.Client()

collection = client.get_or_create_collection("test")

collection.add(
    embeddings=[
        [1.1, 2.3, 3.2],
        [4.5, 6.9, 4.4],
        [1.1, 2.3, 3.2],
        [4.5, 6.9, 4.4],
        [1.1, 2.3, 3.2],
        [4.5, 6.9, 4.4],
        [1.1, 2.3, 3.2],
        [4.5, 6.9, 4.4],
    ],
    metadatas=[
        {"uri": "img1.png", "style": "style1"},
        {"uri": "img2.png", "style": "style2"},
        {"uri": "img3.png", "style": "style1"},
        {"uri": "img4.png", "style": "style1"},
        {"uri": "img5.png", "style": "style1"},
        {"uri": "img6.png", "style": "style1"},
        {"uri": "img7.png", "style": "style1"},
        {"uri": "img8.png", "style": "style1"},
    ],
    documents=["doc1", "doc2", "doc3", "doc4", "doc5", "doc6", "doc7", "doc8"],
    ids=["id1", "id2", "id3", "id4", "id5", "id6", "id7", "id8"],
)

query_result = collection.query(
        query_embeddings=[[1.1, 2.3, 3.2], [5.1, 4.3, 2.2]],
        n_results=2,
    )

print(query_result)

```

## Documentation Changes
N/A
