### PR TITLE
[DRAFT] New Telemetry

### DIFF
--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -46,7 +46,6 @@ class CollectionQueryEvent(TelemetryEvent):
     collection_uuid: str
     with_metadata_filter: bool
     with_document_filter: bool
-    query_with_embeddings: bool
     query_size: int
     n_neighbors: int
     including: str

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -14,10 +14,52 @@ class ServerStartEvent(TelemetryEvent):
 
 
 @dataclass
+class ClientCreateCollectionEvent(TelemetryEvent):
+    name: ClassVar[str] = "client_create_collection"
+    collection_uuid: str
+    embedding_function: str
+
+
+@dataclass
 class CollectionAddEvent(TelemetryEvent):
     name: ClassVar[str] = "collection_add"
     collection_uuid: str
     add_amount: int
+    with_embeddings: bool
+    with_metadatas: bool
+    with_documents: bool
+
+
+@dataclass
+class CollectionUpdateEvent(TelemetryEvent):
+    name: ClassVar[str] = "collection_update"
+    collection_uuid: str
+    update_amount: int
+    with_embeddings: bool
+    with_metadatas: bool
+    with_documents: bool
+
+
+@dataclass
+class CollectionQueryEvent(TelemetryEvent):
+    name: ClassVar[str] = "collection_query"
+    collection_uuid: str
+    with_metadata_filter: bool
+    with_document_filter: bool
+    query_with_embeddings: bool
+    query_size: int
+    n_neighbors: int
+    including: str
+
+
+@dataclass
+class CollectionGetEvent(TelemetryEvent):
+    name: ClassVar[str] = "collection_get"
+    collection_uuid: str
+    with_ids: bool
+    with_metadata_filter: bool
+    with_document_filter: bool
+    including: str
 
 
 @dataclass


### PR DESCRIPTION
## Description of changes

This PR adds additional telemetry to send. It includes some new event types:

- `ClientCreateCollectionEvent` Fires when a collection is created, and tells us which embedding function is set. 
- `CollectionUpdateEvent` Fires when the collection is updated. 
- `CollectionQueryEvent` Fires when a collection is queried. It tells us whether filters were used, the size of the query, the number of neighbors, and which results were `include`d. I would also like to check whether we query with docs or with embeddings, but there's not a nice clean way to do that right now.
- `CollectionGetEvent` Fires when `get` is called, tells us whether filters are used and what is `include`d

The `CollectionAddEvent` is also extended to tell us what was added, i.e. documents, metadata, and/or embeddings.


## Test plan
None

## Documentation Changes
We should update the [telemetry](https://docs.trychroma.com/telemetry) doc on the site to include the new events and their descriptions. 