### PR TITLE
fix: update api request

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -369,19 +369,23 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction):
     def __init__(
         self,
         api_key: str,
-        model_name: str = "textembedding-gecko-001",
+        model_name: str = "textembedding-gecko",
         project_id: str = "cloud-large-language-models",
         region: str = "us-central1",
     ):
-        self._api_url = f"https://{region}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{region}/endpoints/{model_name}:predict"
+        self._api_url = f"https://{region}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{region}/publishers/goole/models/{model_name}:predict"
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {api_key}"})
 
     def __call__(self, texts: Documents) -> Embeddings:
-        response = self._session.post(
-            self._api_url, json={"instances": [{"content": texts}]}
-        ).json()
 
-        if "predictions" in response:
-            return response["predictions"]
-        return []
+        embeddings = []
+        for text in texts:
+            response = self._session.post(
+                self._api_url, json={"instances": [{"content": text}]}
+            ).json()
+
+            if "predictions" in response:
+                embeddings.append(response["predictions"]["embeddings"]["values"])
+
+        return embeddings


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Update the API endpoint for Google VertexEmbedding
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*
At the moment, there is any unit test for embedding function. However I have tested the new code change locally and it worked.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

1. The default model_name should be textembedding-gecko instead of textembedding-gecko-001
2. The _api_url should be changed to
3. The json payload should take in only 1 string instead of array of strings. Thus I made a for loop to call the api endpoint in the event there are arrays of text documents passed into the _call() function
