### PR TITLE
Add LRU cache FD management

### DIFF
--- a/.github/workflows/chroma-test.yml
+++ b/.github/workflows/chroma-test.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         python: ['3.7']
         platform: ['16core-64gb-ubuntu-latest', '16core-64gb-windows-latest']
-        testfile: ["chromadb/test/stress/*"]
+        testfile: ["'chromadb/test/stress/'"]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout

--- a/.github/workflows/chroma-test.yml
+++ b/.github/workflows/chroma-test.yml
@@ -46,7 +46,7 @@ jobs:
         python: ['3.7']
         platform: ['large-ubuntu-latest', 'large-windows-latest']
         testfile: ["chromadb/test/stress/*"]
-      runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/chroma-test.yml
+++ b/.github/workflows/chroma-test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10']
         platform: [ubuntu-latest, windows-latest]
-        testfile: ["--ignore-glob 'chromadb/test/property/*'",
+        testfile: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*'",
                    "chromadb/test/property/test_add.py",
                    "chromadb/test/property/test_collections.py",
                    "chromadb/test/property/test_cross_version_persist.py",
@@ -25,6 +25,28 @@ jobs:
                    "chromadb/test/property/test_filtering.py",
                    "chromadb/test/property/test_persist.py"]
     runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install test dependencies
+      run: python -m pip install -r requirements.txt && python -m pip install -r requirements_dev.txt
+    - name: Upgrade SQLite
+      run: python bin/windows_upgrade_sqlite.py
+      if: runner.os == 'Windows'
+    - name: Test
+      run: python -m pytest ${{ matrix.testfile }}
+  stress-test:
+    timeout-minutes: 90
+    strategy:
+      matrix:
+        python: ['3.7']
+        platform: ['large-ubuntu-latest', 'large-windows-latest']
+        testfile: ["chromadb/test/stress/*"]
+      runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/chroma-test.yml
+++ b/.github/workflows/chroma-test.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.7']
-        platform: ['large-ubuntu-latest', 'large-windows-latest']
+        platform: ['16core-64gb-ubuntu-latest', '16core-64gb-windows-latest']
         testfile: ["chromadb/test/stress/*"]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -23,7 +23,6 @@ from chromadb.types import (
 )
 import hnswlib
 import logging
-import psutil
 
 from chromadb.utils.read_write_lock import ReadRWLock, WriteRWLock
 
@@ -187,13 +186,8 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
         self._persist_data.label_to_id = self._label_to_id
         self._persist_data.id_to_seq_id = self._id_to_seq_id
 
-        try:
-            with open(self._get_metadata_file(), "wb") as metadata_file:
-                pickle.dump(self._persist_data, metadata_file, pickle.HIGHEST_PROTOCOL)
-        except Exception as e:
-            proc = psutil.Process()
-            print(proc.open_files())
-            raise e
+        with open(self._get_metadata_file(), "wb") as metadata_file:
+            pickle.dump(self._persist_data, metadata_file, pickle.HIGHEST_PROTOCOL)
 
     @override
     def _apply_batch(self, batch: Batch) -> None:

--- a/chromadb/test/stress/test_high_collections.py
+++ b/chromadb/test/stress/test_high_collections.py
@@ -10,7 +10,11 @@ def test_high_collections(api: API) -> None:
     # remains responsive."""
     api.reset()
 
+    N = 10
+    D = 10
+
     metadata = None
+    # TODO: done
     if api.get_settings().is_persistent:
         metadata = {"hnsw:batch_size": 3, "hnsw:sync_threshold": 3}
     else:
@@ -24,14 +28,9 @@ def test_high_collections(api: API) -> None:
             metadata=metadata,
         )
         collections.append(new_collection)
-        if i % 100 == 0:
-            print(f"Created {i} collections")
 
     # Add a few embeddings to each collection
-    N = 10
-    D = 10
     data = np.random.rand(N, D).tolist()
     ids = [f"test_id_{i}" for i in range(N)]
     for i in range(num_collections):
         collections[i].add(ids, data)
-        print(f"Added embeddings to {i} collections")

--- a/chromadb/test/stress/test_high_collections.py
+++ b/chromadb/test/stress/test_high_collections.py
@@ -1,0 +1,37 @@
+from typing import List
+import numpy as np
+
+from chromadb.api import API
+from chromadb.api.models.Collection import Collection
+
+
+def test_high_collections(api: API) -> None:
+    """Test that we can create a large number of collections and that the system
+    # remains responsive."""
+    api.reset()
+
+    metadata = None
+    if api.get_settings().is_persistent:
+        metadata = {"hnsw:batch_size": 3, "hnsw:sync_threshold": 3}
+    else:
+        return  # FOR NOW
+
+    num_collections = 10000
+    collections: List[Collection] = []
+    for i in range(num_collections):
+        new_collection = api.create_collection(
+            f"test_collection_{i}",
+            metadata=metadata,
+        )
+        collections.append(new_collection)
+        if i % 100 == 0:
+            print(f"Created {i} collections")
+
+    # Add a few embeddings to each collection
+    N = 10
+    D = 10
+    data = np.random.rand(N, D).tolist()
+    ids = [f"test_id_{i}" for i in range(N)]
+    for i in range(num_collections):
+        collections[i].add(ids, data)
+        print(f"Added embeddings to {i} collections")

--- a/chromadb/test/stress/test_high_collections.py
+++ b/chromadb/test/stress/test_high_collections.py
@@ -14,11 +14,10 @@ def test_high_collections(api: API) -> None:
     D = 10
 
     metadata = None
-    # TODO: done
     if api.get_settings().is_persistent:
         metadata = {"hnsw:batch_size": 3, "hnsw:sync_threshold": 3}
     else:
-        return  # FOR NOW
+        return  # We only want to test persistent configurations in this way, since the main point is to test the file handle limit
 
     num_collections = 10000
     collections: List[Collection] = []

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -5,7 +5,7 @@ from chromadb.api import API
 from chromadb.api.models.Collection import Collection
 
 
-def test_high_collections(api: API) -> None:
+def test_many_collections(api: API) -> None:
     """Test that we can create a large number of collections and that the system
     # remains responsive."""
     api.reset()

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -17,7 +17,9 @@ def test_many_collections(api: API) -> None:
     if api.get_settings().is_persistent:
         metadata = {"hnsw:batch_size": 3, "hnsw:sync_threshold": 3}
     else:
-        return  # We only want to test persistent configurations in this way, since the main point is to test the file handle limit
+        # We only want to test persistent configurations in this way, since the main
+        # point is to test the file handle limit
+        return
 
     num_collections = 10000
     collections: List[Collection] = []

--- a/chromadb/utils/lru_cache.py
+++ b/chromadb/utils/lru_cache.py
@@ -1,0 +1,32 @@
+from collections import OrderedDict
+from typing import Any, Callable, Generic, Optional, TypeVar
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LRUCache(Generic[K, V]):
+    """A simple LRU cache implementation, based on the OrderedDict class, which allows
+    for a callback to be invoked when an item is evicted from the cache."""
+
+    def __init__(self, capacity: int, callback: Optional[Callable[[K, V], Any]] = None):
+        self.capacity = capacity
+        self.cache: OrderedDict[K, V] = OrderedDict()
+        self.callback = callback
+
+    def get(self, key: K) -> Optional[V]:
+        if key not in self.cache:
+            return None
+        value = self.cache.pop(key)
+        self.cache[key] = value
+        return value
+
+    def set(self, key: K, value: V) -> None:
+        if key in self.cache:
+            self.cache.pop(key)
+        elif len(self.cache) == self.capacity:
+            evicted_key, evicted_value = self.cache.popitem(last=False)
+            if self.callback:
+                self.callback(evicted_key, evicted_value)
+        self.cache[key] = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic>=1.9,<2.0',
-  'chroma-hnswlib==0.7.1',
+  'chroma-hnswlib==0.7.2',
   'fastapi>=0.95.2, <0.100.0',
   'uvicorn[standard] >= 0.18.3',
   'numpy >= 1.21.6',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chroma-hnswlib @ git+https://github.com/chroma-core/hnswlib@42d66eba13c6dffdcc23e41dd314b49d00381a18
+chroma-hnswlib==0.7.2
 fastapi>=0.95.2, <0.100.0
 graphlib_backport==1.0.3; python_version < '3.9'
 importlib-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chroma-hnswlib==0.7.1
+chroma-hnswlib @ git+https://github.com/chroma-core/hnswlib@42d66eba13c6dffdcc23e41dd314b49d00381a18
 fastapi>=0.95.2, <0.100.0
 graphlib_backport==1.0.3; python_version < '3.9'
 importlib-resources


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds an LRU cache for segment file handle management to make sure we respect OS file handle limits
 - New functionality
	 - ...

## Test plan
Added a stress test which creates many collections and forces them to open index files by writing to them

## Documentation Changes
We should add a troubleshooting section about filesystem limits so that users can set max limits more appropriately - similar to https://www.mongodb.com/docs/manual/reference/ulimit/