### PR TITLE
fix db migration column name

### DIFF
--- a/chromadb/migrations/sysdb/00002-segments.sqlite.sql
+++ b/chromadb/migrations/sysdb/00002-segments.sqlite.sql
@@ -3,7 +3,7 @@ CREATE TABLE segments (
     type TEXT NOT NULL,
     scope TEXT NOT NULL,
     topic TEXT,
-    collection TEXT REFERENCES collection(id)
+    collection TEXT REFERENCES collections(id)
 );
 
 CREATE TABLE segment_metadata (


### PR DESCRIPTION
## Description of changes

Fixes a typo on the column name `collection(id)` to `collections(id)` on the migration file `00002-segments.sqlite.sql`

I discovered this bug while trying to load the database with SQLAlchemy which throws an error related to this column. 
