### PR TITLE
remove raw_sql and pandas

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Sequence, Optional
-import pandas as pd
 from uuid import UUID
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
@@ -361,18 +360,6 @@ class API(Component, ABC):
 
         Returns:
             bool: True if the database was reset successfully.
-        """
-        pass
-
-    @abstractmethod
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        """Runs a raw SQL query against the database
-
-        Args:
-            sql: The SQL query to run
-
-        Returns:
-            pd.DataFrame: A pandas dataframe containing the results of the query
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -15,7 +15,6 @@ from chromadb.api.types import (
     CollectionMetadata,
 )
 import chromadb.utils.embedding_functions as ef
-import pandas as pd
 import requests
 import json
 from typing import Sequence
@@ -354,15 +353,6 @@ class FastAPI(API):
         resp = self._session.post(self._api_url + "/reset")
         raise_chroma_error(resp)
         return cast(bool, resp.json())
-
-    @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        """Runs a raw SQL query against the database"""
-        resp = self._session.post(
-            self._api_url + "/raw_sql", data=json.dumps({"raw_sql": sql})
-        )
-        raise_chroma_error(resp)
-        return pd.DataFrame.from_dict(resp.json())
 
     @override
     def create_index(self, collection_name: str) -> bool:

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -34,7 +34,6 @@ import chromadb.types as t
 from typing import Optional, Sequence, Generator, List, cast, Set, Dict
 from overrides import override
 from uuid import UUID, uuid4
-import pandas as pd
 import time
 import logging
 import re
@@ -493,10 +492,6 @@ class SegmentAPI(API):
     def reset(self) -> bool:
         self._system.reset_state()
         return True
-
-    @override
-    def raw_sql(self, sql: str) -> pd.DataFrame:
-        raise NotImplementedError()
 
     @override
     def create_index(self, collection_name: str) -> bool:

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -123,9 +123,5 @@ class DB(Component):
         pass
 
     @abstractmethod
-    def raw_sql(self, raw_sql):  # type: ignore
-        pass
-
-    @abstractmethod
     def create_index(self, collection_uuid: UUID):  # type: ignore
         pass

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -8,7 +8,6 @@ from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
 
-import pandas as pd
 
 import chromadb
 from chromadb.api.models.Collection import Collection
@@ -26,7 +25,6 @@ from chromadb.server.fastapi.types import (
     DeleteEmbedding,
     GetEmbedding,
     QueryEmbedding,
-    RawSql,  # Results,
     CreateCollection,
     UpdateCollection,
     UpdateEmbedding,
@@ -92,9 +90,6 @@ class FastAPI(chromadb.server.Server):
         self.router.add_api_route("/api/v1/reset", self.reset, methods=["POST"])
         self.router.add_api_route("/api/v1/version", self.version, methods=["GET"])
         self.router.add_api_route("/api/v1/heartbeat", self.heartbeat, methods=["GET"])
-        self.router.add_api_route(
-            "/api/v1/raw_sql", self.raw_sql, methods=["POST"], response_model=None
-        )
 
         self.router.add_api_route(
             "/api/v1/collections",
@@ -289,9 +284,6 @@ class FastAPI(chromadb.server.Server):
             include=query.include,
         )
         return nnresult
-
-    def raw_sql(self, raw_sql: RawSql) -> pd.DataFrame:
-        return self._api.raw_sql(raw_sql.raw_sql)
 
     def create_index(self, collection_name: str) -> bool:
         return self._api.create_index(collection_name)

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -46,10 +46,6 @@ class GetEmbedding(BaseModel):  # type: ignore
     include: Include = ["metadatas", "documents"]
 
 
-class RawSql(BaseModel):  # type: ignore
-    raw_sql: str
-
-
 class DeleteEmbedding(BaseModel):  # type: ignore
     ids: Optional[List[str]] = None
     where: Optional[Dict[Any, Any]] = None

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
   'numpy >= 1.21.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'pandas >= 1.3',
   'requests >= 2.28',
   'pydantic>=1.9,<2.0',
   'chroma-hnswlib==0.7.1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ importlib-resources
 numpy==1.21.6
 onnxruntime==1.14.1
 overrides==7.3.1
-pandas==1.3.5
 posthog==2.4.0
 pulsar-client==3.1.0
 pydantic>=1.9,<2.0


### PR DESCRIPTION
This is technically a breaking change since we remove the endpoint for `raw_sql`. `raw_sql` was an undocumented internal tool so we should discuss how we want to handle this. 