### PR TITLE
remove create_index which we dont use

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -377,19 +377,6 @@ class API(Component, ABC):
         pass
 
     @abstractmethod
-    def create_index(self, collection_name: str) -> bool:
-        """Creates an index for the given collection
-
-        Args:
-            collection_name: The collection to create the index for. Defaults to None.
-
-        Returns:
-            bool: True if the index was created successfully
-
-        """
-        pass
-
-    @abstractmethod
     def get_version(self) -> str:
         """Get the version of Chroma.
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -236,8 +236,6 @@ class FastAPI(API):
         """
         Adds a batch of embeddings to the database
         - pass in column oriented data lists
-        - by default, the index is progressively built up as you add more data. If for ingestion performance reasons you want to disable this, set increment_index to False
-        -   and then manually create the index yourself with collection.create_index()
         """
         resp = self._session.post(
             self._api_url + "/collections/" + str(collection_id) + "/add",
@@ -363,15 +361,6 @@ class FastAPI(API):
         )
         raise_chroma_error(resp)
         return pd.DataFrame.from_dict(resp.json())
-
-    @override
-    def create_index(self, collection_name: str) -> bool:
-        """Soon deprecated"""
-        resp = self._session.post(
-            self._api_url + "/collections/" + collection_name + "/create_index"
-        )
-        raise_chroma_error(resp)
-        return cast(bool, resp.json())
 
     @override
     def get_version(self) -> str:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -331,9 +331,6 @@ class Collection(BaseModel):
         )
         self._client._delete(self.id, ids, where, where_document)
 
-    def create_index(self) -> None:
-        self._client.create_index(self.name)
-
     def _validate_embedding_set(
         self,
         ids: OneOrMany[ID],

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -499,13 +499,6 @@ class SegmentAPI(API):
         raise NotImplementedError()
 
     @override
-    def create_index(self, collection_name: str) -> bool:
-        logger.warning(
-            "Calling create_index is unnecessary, data is now automatically indexed"
-        )
-        return True
-
-    @override
     def get_settings(self) -> Settings:
         return self._settings
 

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -125,7 +125,3 @@ class DB(Component):
     @abstractmethod
     def raw_sql(self, raw_sql):  # type: ignore
         pass
-
-    @abstractmethod
-    def create_index(self, collection_uuid: UUID):  # type: ignore
-        pass

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -153,12 +153,6 @@ class FastAPI(chromadb.server.Server):
             response_model=None,
         )
         self.router.add_api_route(
-            "/api/v1/collections/{collection_name}/create_index",
-            self.create_index,
-            methods=["POST"],
-            response_model=None,
-        )
-        self.router.add_api_route(
             "/api/v1/collections/{collection_name}",
             self.get_collection,
             methods=["GET"],
@@ -292,6 +286,3 @@ class FastAPI(chromadb.server.Server):
 
     def raw_sql(self, raw_sql: RawSql) -> pd.DataFrame:
         return self._api.raw_sql(raw_sql.raw_sql)
-
-    def create_index(self, collection_name: str) -> bool:
-        return self._api.create_index(collection_name)

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -236,7 +236,6 @@ def test_get_nearest_neighbors(api):
     api.reset()
     collection = api.create_collection("testspace")
     collection.add(**batch_records)
-    # assert api.create_index(collection_name="testspace") # default is auto now
 
     nn = collection.query(
         query_embeddings=[1.1, 2.3, 3.2],
@@ -367,24 +366,6 @@ def test_increment_index_on(api):
     assert collection.count() == 2
 
     # increment index
-    # collection.create_index(index_type="hnsw", index_params={"M": 16, "efConstruction": 200})
-    nn = collection.query(
-        query_embeddings=[[1.1, 2.3, 3.2]],
-        n_results=1,
-        include=["embeddings", "documents", "metadatas", "distances"],
-    )
-    for key in nn.keys():
-        assert len(nn[key]) == 1
-
-
-def test_increment_index_off(api):
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records, increment_index=False)
-    assert collection.count() == 2
-
-    # incremental index
-    collection.create_index()
     nn = collection.query(
         query_embeddings=[[1.1, 2.3, 3.2]],
         n_results=1,


### PR DESCRIPTION
This PR is another breaking change - though we don't expect to affect any users. This removes the `create_index` function from the API, which we no longer use. 