### PR TITLE
feat: add prometheus support for observation

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -8,6 +8,7 @@ from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
 
+from prometheus_fastapi_instrumentator import Instrumentator
 import pandas as pd
 
 import chromadb
@@ -178,7 +179,7 @@ class FastAPI(chromadb.server.Server):
         )
 
         self._app.include_router(self.router)
-
+        Instrumentator().instrument(self._app).expose(self._app)
         use_route_names_as_operation_ids(self._app)
 
     def app(self) -> fastapi.FastAPI:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 chroma-hnswlib==0.7.2
 fastapi>=0.95.2, <0.100.0
+prometheus-fastapi-instrumentator==6.1.0
 graphlib_backport==1.0.3; python_version < '3.9'
 importlib-resources
 numpy==1.21.6


### PR DESCRIPTION
Enhance chroma observation by enable [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator).

## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - enable prometheus endpoint /metrics
 - Improvements & Bug fixes
	 - N/A

## Test plan
*How are these changes tested?*
- Manual test by local docker deployment

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

Yes, we could add /metrics as a endpoint to get metrics data by prometheus. 
