### PR TITLE
remove increment index

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -182,7 +182,6 @@ class API(Component, ABC):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ) -> bool:
         """[Internal] Add embeddings to a collection specified by UUID.
         If (some) ids already exist, only the new embeddings will be added.
@@ -230,7 +229,6 @@ class API(Component, ABC):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ) -> bool:
         """[Internal] Add or update entries in the a collection specified by UUID.
         If an entry with the same id already exists, it will be updated,
@@ -242,8 +240,6 @@ class API(Component, ABC):
             embeddings: The sequence of embeddings to add
             metadatas: The metadata to associate with the embeddings. Defaults to None.
             documents: The documents to associate with the embeddings. Defaults to None.
-            increment_index: If True, will incrementally add to the ANN index.
-                                          Defaults to True.
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -231,13 +231,10 @@ class FastAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ) -> bool:
         """
         Adds a batch of embeddings to the database
         - pass in column oriented data lists
-        - by default, the index is progressively built up as you add more data. If for ingestion performance reasons you want to disable this, set increment_index to False
-        -   and then manually create the index yourself with collection.create_index()
         """
         resp = self._session.post(
             self._api_url + "/collections/" + str(collection_id) + "/add",
@@ -247,7 +244,6 @@ class FastAPI(API):
                     "embeddings": embeddings,
                     "metadatas": metadatas,
                     "documents": documents,
-                    "increment_index": increment_index,
                 }
             ),
         )
@@ -291,7 +287,6 @@ class FastAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ) -> bool:
         """
         Upserts a batch of embeddings in the database
@@ -305,7 +300,6 @@ class FastAPI(API):
                     "embeddings": embeddings,
                     "metadatas": metadatas,
                     "documents": documents,
-                    "increment_index": increment_index,
                 }
             ),
         )

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -72,7 +72,6 @@ class Collection(BaseModel):
         embeddings: Optional[OneOrMany[Embedding]] = None,
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
-        increment_index: bool = True,
     ) -> None:
         """Add embeddings to the data store.
         Args:
@@ -97,9 +96,7 @@ class Collection(BaseModel):
             ids, embeddings, metadatas, documents
         )
 
-        self._client._add(
-            ids, self.id, embeddings, metadatas, documents, increment_index
-        )
+        self._client._add(ids, self.id, embeddings, metadatas, documents)
 
     def get(
         self,
@@ -281,7 +278,6 @@ class Collection(BaseModel):
         embeddings: Optional[OneOrMany[Embedding]] = None,
         metadatas: Optional[OneOrMany[Metadata]] = None,
         documents: Optional[OneOrMany[Document]] = None,
-        increment_index: bool = True,
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist.
 
@@ -305,7 +301,6 @@ class Collection(BaseModel):
             embeddings=embeddings,
             metadatas=metadatas,
             documents=documents,
-            increment_index=increment_index,
         )
 
     def delete(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -239,7 +239,6 @@ class SegmentAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ) -> bool:
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.ADD)
@@ -277,7 +276,6 @@ class SegmentAPI(API):
         embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
-        increment_index: bool = True,
     ) -> bool:
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.UPSERT)

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -60,12 +60,6 @@ class DB(Component):
         pass
 
     @abstractmethod
-    def add_incremental(
-        self, collection_uuid: UUID, ids: List[UUID], embeddings: Embeddings
-    ) -> None:
-        pass
-
-    @abstractmethod
     def get(
         self,
         where: Where = {},

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -226,7 +226,6 @@ class FastAPI(chromadb.server.Server):
                 metadatas=add.metadatas,
                 documents=add.documents,
                 ids=add.ids,
-                increment_index=add.increment_index,
             )
         except InvalidDimensionException as e:
             raise HTTPException(status_code=500, detail=str(e))
@@ -248,7 +247,6 @@ class FastAPI(chromadb.server.Server):
             embeddings=upsert.embeddings,
             documents=upsert.documents,
             metadatas=upsert.metadatas,
-            increment_index=upsert.increment_index,
         )
 
     def get(self, collection_id: str, get: GetEmbedding) -> GetResult:

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -14,7 +14,6 @@ class AddEmbedding(BaseModel):  # type: ignore
     metadatas: Optional[List[Dict[Any, Any]]] = None
     documents: Optional[List[str]] = None
     ids: List[str]
-    increment_index: bool = True
 
 
 class UpdateEmbedding(BaseModel):  # type: ignore
@@ -22,7 +21,6 @@ class UpdateEmbedding(BaseModel):  # type: ignore
     metadatas: Optional[List[Dict[Any, Any]]] = None
     documents: Optional[List[str]] = None
     ids: List[str]
-    increment_index: bool = True
 
 
 class QueryEmbedding(BaseModel):  # type: ignore

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -377,35 +377,6 @@ def test_increment_index_on(api):
         assert len(nn[key]) == 1
 
 
-def test_increment_index_off(api):
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records, increment_index=False)
-    assert collection.count() == 2
-
-    # incremental index
-    collection.create_index()
-    nn = collection.query(
-        query_embeddings=[[1.1, 2.3, 3.2]],
-        n_results=1,
-        include=["embeddings", "documents", "metadatas", "distances"],
-    )
-    for key in nn.keys():
-        assert len(nn[key]) == 1
-
-
-def skipping_indexing_will_fail(api):
-    api.reset()
-    collection = api.create_collection("testspace")
-    collection.add(**batch_records, increment_index=False)
-    assert collection.count() == 2
-
-    # incremental index
-    with pytest.raises(Exception) as e:
-        collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
-    assert str(e.value).__contains__("index not found")
-
-
 def test_add_a_collection(api):
     api.reset()
     api.create_collection("testspace")


### PR DESCRIPTION
Removes increment index which is no longer in use.

Technically a breaking change, but I dont think anyone is using it since it is technically a no-op.