### PR TITLE
#913 Persistent vector segments to be cleaned up on reset()

### DIFF
--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -92,6 +92,7 @@ class LocalSegmentManager(SegmentManager):
     def reset_state(self) -> None:
         for instance in self._instances.values():
             instance.stop()
+            instance.reset_state()
         self._instances = {}
         self._segment_cache = defaultdict(dict)
         super().reset_state()

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from overrides import override
 import pickle
 from typing import Dict, List, Optional, Sequence, Set, cast
@@ -378,13 +379,19 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                     results.append(curr_results)
             return results
 
+    @override
+    def reset_state(self) -> None:
+        data_path = self._get_storage_folder()
+        if os.path.exists(data_path):
+            shutil.rmtree(data_path, ignore_errors=True)
+
     @staticmethod
     def get_file_handle_count() -> int:
         """Return how many file handles are used by the index"""
         hnswlib_count = hnswlib.Index.file_handle_count
         hnswlib_count = cast(int, hnswlib_count)
         # One extra for the metadata file
-        return hnswlib_count + 1
+        return hnswlib_count + 1  # type: ignore
 
     def open_persistent_index(self) -> None:
         """Open the persistent index"""


### PR DESCRIPTION
## Description of changes

Close #913.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Previously we were not reset'ing() in vector segments which persist data to disk. Leading to orphaned files since the sqlite db was reset. This cleans up the index files. 
 - New functionality
	 - ...

## Test plan
Manually verified that after reset()'ing, vector index files are cleared.

## Documentation Changes
None required. 