### PR TITLE
clean up JS API, remove increment_index, createIndex and rawSql

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",

--- a/clients/js/src/ChromaClient.ts
+++ b/clients/js/src/ChromaClient.ts
@@ -42,7 +42,7 @@ export class ChromaClient {
     /**
      * Resets the state of the object by making an API call to the reset endpoint.
      *
-     * @returns {Promise<Api.Reset200Response>} A promise that resolves when the reset operation is complete.
+     * @returns {Promise<boolean>} A promise that resolves when the reset operation is complete.
      * @throws {Error} If there is an issue resetting the state.
      *
      * @example
@@ -50,7 +50,7 @@ export class ChromaClient {
      * await client.reset();
      * ```
      */
-    public async reset(): Promise<Api.Reset200Response> {
+    public async reset(): Promise<boolean> {
         return await this.api.reset(this.api.options);
     }
 

--- a/clients/js/src/generated/api.ts
+++ b/clients/js/src/generated/api.ts
@@ -223,38 +223,6 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 			};
 		},
 		/**
-		 * @summary Create Index
-		 * @param {string} collectionName
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		createIndex(collectionName: string, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'collectionName' is not null or undefined
-			if (collectionName === null || collectionName === undefined) {
-				throw new RequiredError('collectionName', 'Required parameter collectionName was null or undefined when calling createIndex.');
-			}
-			let localVarPath = `/api/v1/collections/{collection_name}/create_index`
-				.replace('{collection_name}', encodeURIComponent(String(collectionName)));
-			const localVarPathQueryStart = localVarPath.indexOf("?");
-			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
-			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
-			const localVarQueryParameter = new URLSearchParams(localVarPathQueryStart !== -1 ? localVarPath.substring(localVarPathQueryStart + 1) : "");
-			if (localVarPathQueryStart !== -1) {
-				localVarPath = localVarPath.substring(0, localVarPathQueryStart);
-			}
-
-			localVarRequestOptions.headers = localVarHeaderParameter;
-
-			const localVarQueryParameterString = localVarQueryParameter.toString();
-			if (localVarQueryParameterString) {
-				localVarPath += "?" + localVarQueryParameterString;
-			}
-			return {
-				url: localVarPath,
-				options: localVarRequestOptions,
-			};
-		},
-		/**
 		 * @summary Delete Collection
 		 * @param {string} collectionName
 		 * @param {RequestInit} [options] Override http request option.
@@ -403,43 +371,6 @@ export const ApiApiFetchParamCreator = function (configuration?: Configuration) 
 			}
 
 			localVarRequestOptions.headers = localVarHeaderParameter;
-
-			const localVarQueryParameterString = localVarQueryParameter.toString();
-			if (localVarQueryParameterString) {
-				localVarPath += "?" + localVarQueryParameterString;
-			}
-			return {
-				url: localVarPath,
-				options: localVarRequestOptions,
-			};
-		},
-		/**
-		 * @summary Raw Sql
-		 * @param {Api.RawSql} request
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		rawSql(request: Api.RawSql, options: RequestInit = {}): FetchArgs {
-			// verify required parameter 'request' is not null or undefined
-			if (request === null || request === undefined) {
-				throw new RequiredError('request', 'Required parameter request was null or undefined when calling rawSql.');
-			}
-			let localVarPath = `/api/v1/raw_sql`;
-			const localVarPathQueryStart = localVarPath.indexOf("?");
-			const localVarRequestOptions: RequestInit = Object.assign({ method: 'POST' }, options);
-			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();
-			const localVarQueryParameter = new URLSearchParams(localVarPathQueryStart !== -1 ? localVarPath.substring(localVarPathQueryStart + 1) : "");
-			if (localVarPathQueryStart !== -1) {
-				localVarPath = localVarPath.substring(0, localVarPathQueryStart);
-			}
-
-			localVarHeaderParameter.set('Content-Type', 'application/json');
-
-			localVarRequestOptions.headers = localVarHeaderParameter;
-
-			if (request !== undefined) {
-				localVarRequestOptions.body = JSON.stringify(request || {});
-			}
 
 			const localVarQueryParameterString = localVarQueryParameter.toString();
 			if (localVarQueryParameterString) {
@@ -815,35 +746,6 @@ export const ApiApiFp = function(configuration?: Configuration) {
 			};
 		},
 		/**
-		 * @summary Create Index
-		 * @param {string} collectionName
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		createIndex(collectionName: string, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.CreateIndex200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).createIndex(collectionName, options);
-			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
-				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-					const contentType = response.headers.get('Content-Type');
-					const mimeType = contentType ? contentType.replace(/;.*/, '') : undefined;
-
-					if (response.status === 200) {
-						if (mimeType === 'application/json') {
-							return response.json() as any;
-						}
-						throw response;
-					}
-					if (response.status === 422) {
-						if (mimeType === 'application/json') {
-							throw response;
-						}
-						throw response;
-					}
-					throw response;
-				});
-			};
-		},
-		/**
 		 * @summary Delete Collection
 		 * @param {string} collectionName
 		 * @param {RequestInit} [options] Override http request option.
@@ -936,7 +838,7 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		heartbeat(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Heartbeat200Response> {
+		heartbeat(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<{ [name: string]: number }> {
 			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).heartbeat(options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -976,40 +878,11 @@ export const ApiApiFp = function(configuration?: Configuration) {
 			};
 		},
 		/**
-		 * @summary Raw Sql
-		 * @param {Api.RawSql} request
-		 * @param {RequestInit} [options] Override http request option.
-		 * @throws {RequiredError}
-		 */
-		rawSql(request: Api.RawSql, options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.RawSql200Response> {
-			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).rawSql(request, options);
-			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
-				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
-					const contentType = response.headers.get('Content-Type');
-					const mimeType = contentType ? contentType.replace(/;.*/, '') : undefined;
-
-					if (response.status === 200) {
-						if (mimeType === 'application/json') {
-							return response.json() as any;
-						}
-						throw response;
-					}
-					if (response.status === 422) {
-						if (mimeType === 'application/json') {
-							throw response;
-						}
-						throw response;
-					}
-					throw response;
-				});
-			};
-		},
-		/**
 		 * @summary Reset
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		reset(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Reset200Response> {
+		reset(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<boolean> {
 			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).reset(options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -1031,7 +904,7 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		root(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Root200Response> {
+		root(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<{ [name: string]: number }> {
 			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).root(options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -1143,7 +1016,7 @@ export const ApiApiFp = function(configuration?: Configuration) {
 		 * @param {RequestInit} [options] Override http request option.
 		 * @throws {RequiredError}
 		 */
-		version(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<Api.Version200Response> {
+		version(options?: RequestInit): (fetch?: FetchAPI, basePath?: string) => Promise<string> {
 			const localVarFetchArgs = ApiApiFetchParamCreator(configuration).version(options);
 			return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
 				return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -1232,16 +1105,6 @@ export class ApiApi extends BaseAPI {
 	}
 
 	/**
-	 * @summary Create Index
-	 * @param {string} collectionName
-	 * @param {RequestInit} [options] Override http request option.
-	 * @throws {RequiredError}
-	 */
-	public createIndex(collectionName: string, options?: RequestInit) {
-		return ApiApiFp(this.configuration).createIndex(collectionName, options)(this.fetch, this.basePath);
-	}
-
-	/**
 	 * @summary Delete Collection
 	 * @param {string} collectionName
 	 * @param {RequestInit} [options] Override http request option.
@@ -1288,16 +1151,6 @@ export class ApiApi extends BaseAPI {
 	 */
 	public listCollections(options?: RequestInit) {
 		return ApiApiFp(this.configuration).listCollections(options)(this.fetch, this.basePath);
-	}
-
-	/**
-	 * @summary Raw Sql
-	 * @param {Api.RawSql} request
-	 * @param {RequestInit} [options] Override http request option.
-	 * @throws {RequiredError}
-	 */
-	public rawSql(request: Api.RawSql, options?: RequestInit) {
-		return ApiApiFp(this.configuration).rawSql(request, options)(this.fetch, this.basePath);
 	}
 
 	/**

--- a/clients/js/src/generated/models.ts
+++ b/clients/js/src/generated/models.ts
@@ -21,7 +21,6 @@ export namespace Api {
 		metadatas?: Api.AddEmbedding.Metadata[];
 		documents?: string[];
 		ids: string[];
-		'increment_index'?: boolean;
 	}
 
 	/**
@@ -63,9 +62,6 @@ export namespace Api {
 	}
 
 	export interface CreateCollection200Response {
-	}
-
-	export interface CreateIndex200Response {
 	}
 
 	export interface DeleteCollection200Response {
@@ -152,9 +148,6 @@ export namespace Api {
 	export interface GetNearestNeighbors200Response {
 	}
 
-	export interface Heartbeat200Response {
-	}
-
 	export interface HTTPValidationError {
 		detail?: Api.ValidationError[];
 	}
@@ -215,19 +208,6 @@ export namespace Api {
 
 	}
 
-	export interface RawSql {
-		'raw_sql': string;
-	}
-
-	export interface RawSql200Response {
-	}
-
-	export interface Reset200Response {
-	}
-
-	export interface Root200Response {
-	}
-
 	export interface Update200Response {
 	}
 
@@ -254,7 +234,6 @@ export namespace Api {
 		metadatas?: Api.UpdateEmbedding.Metadata[];
 		documents?: string[];
 		ids: string[];
-		'increment_index'?: boolean;
 	}
 
 	/**
@@ -277,9 +256,6 @@ export namespace Api {
 		loc: (string | number)[];
 		msg: string;
 		'type': string;
-	}
-
-	export interface Version200Response {
 	}
 
 }


### PR DESCRIPTION
This cleans up the JS API
- remove `increment_index`
- removes `createIndex`
- removes `rawSql`

It also bumps the version to 1.5.6 (not yet released) and fixes a type that changed. 