### PR TITLE
Serve resources from API routes ending in /

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -70,13 +70,23 @@ def _uuid(uuid_str: str) -> UUID:
 
 
 class APIRouter(fastapi.APIRouter):
+    # A simple subclass of fastapi's APIRouter which treats URLs with a trailing "/" the
+    # same as URLs without. Docs will only contain URLs without trailing "/"s.
     def add_api_route(self, path: str, *args: Any, **kwargs: Any) -> None:
-        fastapi.APIRouter.add_api_route(self, path, *args, **kwargs)
+        include_in_schema_passed = "include_in_schema" in kwargs
+
+        if not include_in_schema_passed:
+            kwargs["include_in_schema"] = not path.endswith("/")
+        super().add_api_route(path, *args, **kwargs)
+
         if path.endswith("/"):
             path = path[:-1]
         else:
             path = path + "/"
-        fastapi.APIRouter.add_api_route(self, path, *args, **kwargs)
+
+        if not include_in_schema_passed:
+            kwargs["include_in_schema"] = not path.endswith("/")
+        super().add_api_route(path, *args, **kwargs)
 
 
 class FastAPI(chromadb.server.Server):

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -69,6 +69,16 @@ def _uuid(uuid_str: str) -> UUID:
         raise InvalidUUIDError(f"Could not parse {uuid_str} as a UUID")
 
 
+class APIRouter(fastapi.APIRouter):
+    def add_api_route(self, path: str, *args: Any, **kwargs: Any) -> None:
+        fastapi.APIRouter.add_api_route(self, path, *args, **kwargs)
+        if path.endswith("/"):
+            path = path[:-1]
+        else:
+            path = path + "/"
+        fastapi.APIRouter.add_api_route(self, path, *args, **kwargs)
+
+
 class FastAPI(chromadb.server.Server):
     def __init__(self, settings: Settings):
         super().__init__(settings)
@@ -84,7 +94,7 @@ class FastAPI(chromadb.server.Server):
             allow_methods=["*"],
         )
 
-        self.router = fastapi.APIRouter()
+        self.router = APIRouter()
 
         self.router.add_api_route("/api/v1", self.root, methods=["GET"])
         self.router.add_api_route("/api/v1/reset", self.reset, methods=["POST"])


### PR DESCRIPTION
## Description of changes

https://github.com/chroma-core/chroma/issues/895

Serve registered API routes regardless of whether they end in "/".

In the linked bug @HammadB and I discussed looping over all the routes at the end of `__init__`, but the typechecker complains: the only thing we know about `self._app.routes` is that they're instances of `BaseRoute`, which may not have the fields we need. Rather than do type coercion I subclassed `fastapi.APIRouter`.

The logic to set `kwargs["include_in_schema"]` is maybe too clever, should we just do an if-else instead?

## Test plan

```
0 ~ beggers % curl http://localhost:8000/api/v1/collections/ -v
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api/v1/collections/ HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< date: Thu, 03 Aug 2023 19:14:01 GMT
< server: uvicorn
< content-length: 2
< content-type: application/json
< 
* Connection #0 to host localhost left intact
[]%                                                                                   
0 ~ beggers % curl http://localhost:8000/api/v1/collections -v 
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /api/v1/collections HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< date: Thu, 03 Aug 2023 19:14:02 GMT
< server: uvicorn
< content-length: 2
< content-type: application/json
< 
* Connection #0 to host localhost left intact
[]%
```

Also, `pytest` locally and CI. I'd like to confirm this doesn't break JS client generation and doc generation -- how can I do that?

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

No documentation changes needed for this.
