### PR TITLE
Allow fast api to consume none for add/update types

### DIFF
--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -11,15 +11,15 @@ class AddEmbedding(BaseModel):  # type: ignore
     # Union[int, float] so we use Any here to ensure data is parsed
     # to its original type.
     embeddings: Optional[List[Any]] = None
-    metadatas: Optional[List[Dict[Any, Any]]] = None
-    documents: Optional[List[str]] = None
+    metadatas: Optional[List[Optional[Dict[Any, Any]]]] = None
+    documents: Optional[List[Optional[str]]] = None
     ids: List[str]
 
 
 class UpdateEmbedding(BaseModel):  # type: ignore
     embeddings: Optional[List[Any]] = None
-    metadatas: Optional[List[Dict[Any, Any]]] = None
-    documents: Optional[List[str]] = None
+    metadatas: Optional[List[Optional[Dict[Any, Any]]]] = None
+    documents: Optional[List[Optional[str]]] = None
     ids: List[str]
 
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -86,3 +86,23 @@ def test_out_of_order_ids(api: API) -> None:
     coll.add(ids=ooo_ids, embeddings=embeddings)
     get_ids = coll.get(ids=ooo_ids)["ids"]
     assert get_ids == ooo_ids
+
+
+def test_add_partial(api: API) -> None:
+    """Tests adding a record set with some of the fields set to None."""
+
+    api.reset()
+
+    coll = api.create_collection("test")
+    # TODO: We need to clean up the api types to support this typing
+    coll.add(
+        ids=["1", "2", "3"],
+        embeddings=[[1, 2, 3], [1, 2, 3], [1, 2, 3]],
+        metadatas=[{"a": 1}, None, {"a": 3}],  # type: ignore
+        documents=["a", "b", None],  # type: ignore
+    )
+
+    results = coll.get()
+    assert results["ids"] == ["1", "2", "3"]
+    assert results["metadatas"] == [{"a": 1}, None, {"a": 3}]
+    assert results["documents"] == ["a", "b", None]


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Allow fast api to consume none for add/update
 - New functionality
	 - ...

## Test plan
Manually tested by passing none to the API. Added a unit test. 

## Documentation Changes
None required.