### PR TITLE
ENH: Chroma types available as top-level imports 

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -6,6 +6,39 @@ from chromadb.telemetry.events import ClientStartEvent
 from chromadb.telemetry import Telemetry
 from chromadb.config import Settings, System
 from chromadb.api import API
+from chromadb.api.models.Collection import Collection
+from chromadb.api.types import (
+    CollectionMetadata,
+    Documents,
+    EmbeddingFunction,
+    Embeddings,
+    IDs,
+    Include,
+    Metadata,
+    Where,
+    QueryResult,
+    GetResult,
+    WhereDocument,
+    UpdateCollectionMetadata,
+)
+
+# Re-export types from chromadb.types
+__all__ = [
+    "Collection",
+    "Metadata",
+    "Where",
+    "WhereDocument",
+    "Documents",
+    "IDs",
+    "Embeddings",
+    "EmbeddingFunction",
+    "Include",
+    "CollectionMetadata",
+    "UpdateCollectionMetadata",
+    "QueryResult",
+    "GetResult",
+]
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
Closes Issue: #923 

Adds the following types available as a top-level import in addition to the `Collection` class:
- `CollectionMetadata`,
- `Documents`,
- `EmbeddingFunction`,
- `Embeddings`,
- `IDs`,
- `Include`,
- `Metadata`,
- `Where`,
- `QueryResult`,
- `GetResult`,
- `WhereDocument`,
- `UpdateCollectionMetadata`,

## Test plan
*How are these changes tested?*
- No additional tests were added

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
- It might make sense to make clear these cans can be used from the top level. 
