### PR TITLE
feat: API Response models are not properly returned in the the spec

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -138,7 +138,7 @@ class API(Component, ABC):
         id: UUID,
         new_name: Optional[str] = None,
         new_metadata: Optional[CollectionMetadata] = None,
-    ) -> None:
+    ) -> Collection:
         """[Internal] Modify a collection by UUID. Can update the name and/or metadata.
 
         Args:
@@ -154,7 +154,7 @@ class API(Component, ABC):
     def delete_collection(
         self,
         name: str,
-    ) -> None:
+    ) -> Collection:
         """Delete a collection with the given name.
         Args:
             name: The name of the collection to delete.


### PR DESCRIPTION
- The returned OAS is now downgraded from 3.1.0 to 3.0.2 as this appears to work better with openapi-codegen toolchain
- The spec now reports description version, title and description of the specification
- Minor changes to chromadb/api/segment.py to make the modify and delete operations return the modified/deleted collection - useful in client side for keeping track of what is being deleted.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
