### PR TITLE
[PERF] Improve performance of duplicate ID validator

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -111,14 +111,33 @@ def validate_ids(ids: IDs) -> IDs:
         raise ValueError(f"Expected IDs to be a list, got {ids}")
     if len(ids) == 0:
         raise ValueError(f"Expected IDs to be a non-empty list, got {ids}")
-    for id in ids:
-        if not isinstance(id, str):
-            raise ValueError(f"Expected ID to be a str, got {id}")
-    if len(ids) != len(set(ids)):
-        dups = set([x for x in ids if ids.count(x) > 1])
-        raise errors.DuplicateIDError(
-            f"Expected IDs to be unique, found duplicates for: {dups}"
-        )
+    seen = set()
+    dups = set()
+    for id_ in ids:
+        if not isinstance(id_, str):
+            raise ValueError(f"Expected ID to be a str, got {id_}")
+        if id_ in seen:
+            dups.add(id_)
+        else:
+            seen.add(id_)
+    if dups:
+        n_dups = len(dups)
+        if n_dups < 10:
+            example_string = ", ".join(dups)
+            message = (
+                f"Expected IDs to be unique, found duplicates of: {example_string}"
+            )
+        else:
+            examples = []
+            for idx, dup in enumerate(dups):
+                examples.append(dup)
+                if idx == 10:
+                    break
+            example_string = (
+                f"{', '.join(examples[:5])}, ..., {', '.join(examples[-5:])}"
+            )
+            message = f"Expected IDs to be unique, found {n_dups} duplicated IDs: {example_string}"
+        raise errors.DuplicateIDError(message)
     return ids
 
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Improves the performance of the duplicate ID validator. I noticed this while trying to add > 100k records to a collection. I had duplicates in my ID array (which I didn't know at the time), and I eventually terminated the operation because it was taking so long. I happened to notice in the traceback that it was stuck in the `validate_ids` function, which looks like it might be O(N^2).
	 - This PR currently changes just the implementation. That said, it would be easy to display only the e.g. top 10 most common dupes (so as to avoid printing over 1k IDs to console output, as happened in my case :upside_down_face: ). Let me know if you would prefer that.

## Test plan
*How are these changes tested?*
1. I tested the implementation within a Jupyter notebook on the same list of IDs that I had passed to `collection.add`, and it isolated the dupes in about half a second.
![image](https://github.com/chroma-core/chroma/assets/85196623/d6c3ac89-3c8b-44cd-b01c-59bf6cd01a66)

2. I pip installed this branch, tried to add the same items to the collection, and confirmed that I received the error message without a long delay.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?* No docstrings or documentation changes are needed.
