### PR TITLE
feat: Improved GCP deployment instructions

### DIFF
--- a/examples/deployments/google-cloud-compute/README.md
+++ b/examples/deployments/google-cloud-compute/README.md
@@ -35,7 +35,7 @@ terraform output instance_public_ip
 
 Check that chroma is running
 ```bash
-export instance_public_ip=$(terraform output instance_public_ip)
+export instance_public_ip=$(terraform output instance_public_ip | sed 's/"//g')
 curl -v http://$instance_public_ip:8000/api/v1
 ```
 

--- a/examples/deployments/google-cloud-compute/README.md
+++ b/examples/deployments/google-cloud-compute/README.md
@@ -25,7 +25,7 @@ export TF_VAR_chroma_release=0.4.5 #set the chroma release to deploy
 terraform apply -auto-approve
 ```
 
-### 4. Check your public IP and that croma is running
+### 4. Check your public IP and that Chroma is running
 
 Get the public IP of your instance
 
@@ -36,7 +36,7 @@ terraform output instance_public_ip
 Check that chroma is running
 ```bash
 export instance_public_ip=$(terraform output instance_public_ip | sed 's/"//g')
-curl -v http://$instance_public_ip:8000/api/v1
+curl -v http://$instance_public_ip:8000/api/v1/heartbeat
 ```
 
 ### 5. Destroy your application

--- a/examples/deployments/google-cloud-compute/README.md
+++ b/examples/deployments/google-cloud-compute/README.md
@@ -19,6 +19,27 @@ terraform init
 ```
 
 ### 3. Deploy your application
-```angular2html
-terraform apply -var="project_id=<your_project_id> -auto-approve"
+```bash
+export TF_VAR_project_id=<your_project_id> #take note of this as it must be present in all of the subsequent steps
+export TF_VAR_chroma_release=0.4.5 #set the chroma release to deploy
+terraform apply -auto-approve
+```
+
+### 4. Check your public IP and that croma is running
+
+Get the public IP of your instance
+
+```bash
+terraform output instance_public_ip
+```
+
+Check that chroma is running
+```bash
+export instance_public_ip=$(terraform output instance_public_ip)
+curl -v http://$instance_public_ip:8000/api/v1
+```
+
+### 5. Destroy your application
+```bash
+terraform destroy -auto-approve
 ```

--- a/examples/deployments/google-cloud-compute/chroma.tf
+++ b/examples/deployments/google-cloud-compute/chroma.tf
@@ -21,7 +21,7 @@ resource "google_compute_instance" "chroma1" {
     }
   }
 
-  metadata_startup_script = file("${path.module}/startup.sh")
+  metadata_startup_script = templatefile("${path.module}/startup.sh", { chroma_release = var.chroma_release })
 }
 
 resource "google_compute_firewall" "default" {
@@ -41,4 +41,10 @@ resource "google_compute_firewall" "default" {
   source_ranges = ["0.0.0.0/0"]
 
   target_tags = ["chroma"]
+}
+
+
+output "instance_public_ip" {
+  description = "The public IP address of the instance."
+  value       = google_compute_instance.chroma1.network_interface[0].access_config[0].nat_ip
 }

--- a/examples/deployments/google-cloud-compute/startup.sh
+++ b/examples/deployments/google-cloud-compute/startup.sh
@@ -12,68 +12,11 @@ echo \
 apt-get update -y
 chmod a+r /etc/apt/keyrings/docker.gpg
 apt-get update -y
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git
 
-cat << EOF > docker-compose.yaml
-version: "3.9"
-services:
-  server:
-    container_name: server
-    image: ghcr.io/chroma-core/chroma:0.3.14
-    volumes:
-      - ./index_data:/index_data
-    environment:
-      - CHROMA_DB_IMPL=clickhouse
-      - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_PORT=8123
-    ports:
-      - '8000:8000'
-    depends_on:
-      - clickhouse
-  clickhouse:
-    container_name: clickhouse
-    image: clickhouse/clickhouse-server:22.9-alpine
-    volumes:
-      - ./clickhouse_data:/bitnami/clickhouse
-      - ./backups:/backups
-      - ./config/backup_disk.xml:/etc/clickhouse-server/config.d/backup_disk.xml
-      - ./config/chroma_users.xml:/etc/clickhouse-server/users.d/chroma.xml
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - CLICKHOUSE_TCP_PORT=9000
-      - CLICKHOUSE_HTTP_PORT=8123
-    ports:
-      - '8123:8123'
-      - '9000:9000'
-EOF
+git clone https://github.com/chroma-core/chroma.git
+cd chroma
+git fetch --tags
+git checkout tags/${chroma_release}
 
-mkdir config
-cat << EOF > config/backup_disk.xml
-<clickhouse>
-    <storage_configuration>
-        <disks>
-            <backups>
-                <type>local</type>
-                <path>/etc/clickhouse-server/</path>
-            </backups>
-        </disks>
-    </storage_configuration>
-    <backups>
-        <allowed_disk>backups</allowed_disk>
-        <allowed_path>/etc/clickhouse-server/</allowed_path>
-    </backups>
-</clickhouse>
-EOF
-
-cat << EOF > config/chroma_users.xml
-<clickhouse>
-    <profiles>
-        <default>
-            <allow_experimental_lightweight_delete>1</allow_experimental_lightweight_delete>
-            <mutations_sync>1</mutations_sync>
-        </default>
-    </profiles>
-</clickhouse>
-EOF
-
-COMPOSE_PROJECT_NAME=chroma docker compose up -d
+COMPOSE_PROJECT_NAME=chroma docker compose up -d --build

--- a/examples/deployments/google-cloud-compute/variables.tf
+++ b/examples/deployments/google-cloud-compute/variables.tf
@@ -1,6 +1,11 @@
 variable "project_id" {
   type = string
 }
+variable "chroma_release" {
+  description = "The chroma release to deploy"
+  type        = string
+  default     = "0.4.5"
+}
 
 variable "zone" {
   type    = string


### PR DESCRIPTION
- The project will now clone the chroma repo and deploy docker-compose from it
- Introduced a new TF var chroma_release to be able to deploy a any (oh well almost any, chroma version, defaults to 0.4.5)
- Added output instance_public_ip var to print out the IP address of the VM

Refs: #950

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Made it possible to deploy any version of chroma through TF var chroma_release (defaults to 0.4.5)
	 - Made it so that the VM would clone the repo and checkout the release tag then run docker compose from it
	 - Added output of the public IP of the VM after TF deployment
	 - Improved slightly the README.md

## Test plan
*How are these changes tested?*

```bash
gcloud auth application-default login
cd examples/deployments/google-cloud-compute
terraform init
export TF_VAR_project_id=<your_project_id> #take note of this as it must be present in all of the subsequent steps
export TF_VAR_chroma_release=0.4.5 #set the chroma release to deploy
terraform apply -auto-approve
terraform output instance_public_ip
export instance_public_ip=$(terraform output instance_public_ip)
curl -v http://$instance_public_ip:8000/api/v1
terraform destroy -auto-approve
```

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
