### PR TITLE
feat: support conditional exports in js client

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -19,7 +19,11 @@
     "typescript": "^5.0.4"
   },
   "main": "dist/main/index.js",
-  "module": "dist/module/index.js",
+  "module": "dist/module/index.js",  
+  "exports": {
+    "require": "./dist/main/index.js",
+    "import": "./dist/module/index.js"
+  },
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
## Description of changes
Currently not all bundlers will chose the correct CJS/ESM build when importing the js client because we don't define them using [conditional-exports](https://nodejs.org/api/packages.html#conditional-exports). This change adds the required configuration in the package.json to fix that.

 - Improvements & Bug fixes
	 - support conditional exports in js client


## Test plan
I have tested this manually. We have a Next.js setup which throws an error with v1.5.6, we make use of that to detect which build (cjs/esm) nextjs tries to load. In both cases we expect an error with the path from which nextjs loads the module.


### Reproduce the issue
- checkout https://github.com/jeffchuber/nextjs-chroma/commit/2df1a216866b383f4205eb319a37c5c7d88ad02c
- run yarn && yarn dev
- open http://localhost:3000/
- you should see the following error in the browser
```
Failed to compile

./node_modules/chromadb/dist/main/embeddings/WebAIEmbeddingFunction.js:157:0
Module not found: Can't resolve '@visheratin/web-ai'

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
./node_modules/chromadb/dist/main/index.js
./src/app/page.js

This error occurred during the build process and can only be dismissed by fixing the error.
```
Nextjs loads the cjs build from `dist/main`.

### Confirm the change resolves the issue
- checkout https://github.com/jeffchuber/nextjs-chroma/commit/2df1a216866b383f4205eb319a37c5c7d88ad02c
- remove current chromadb package (1.5.6) using `yarn remove chromadb`
- install chromadb client with the [change in this pr](https://github.com/chroma-core/chroma/commit/450159ec232a5388fbd42251109a9e240382003e) using package linking or using verdaccio
- open http://localhost:3000/
- you should see the following error in the browser
```
Failed to compile

./node_modules/chromadb/dist/module/embeddings/WebAIEmbeddingFunction.js:131:0
Module not found: Can't resolve '@visheratin/web-ai'

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
./node_modules/chromadb/dist/module/index.js
./src/app/page.js

This error occurred during the build process and can only be dismissed by fixing the error.
```
Nextjs now loads the esm build from `dist/module`

## Documentation Changes
I added a reference to https://nodejs.org/api/packages.html#conditional-exports in the commit message
