### PR TITLE
GKE support for Chroma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /install
 COPY ./requirements.txt requirements.txt
 
 RUN pip install --no-cache-dir --upgrade --prefix="/install" -r requirements.txt
+RUN pip install chroma-hnswlib
 
 FROM python:3.10-slim-bookworm as final
 
@@ -30,4 +31,6 @@ COPY ./ /chroma
 
 EXPOSE 8000
 
-CMD ["/docker_entrypoint.sh"]
+ENV IS_PERSISTENT=1
+CMD ["uvicorn", "chromadb.app:app", "--workers", "1", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--log-config", "log_config.yml"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN mkdir /chroma
 WORKDIR /chroma
 
 COPY --from=builder /install /usr/local
-COPY ./bin/docker_entrypoint.sh /docker_entrypoint.sh
 COPY ./ /chroma
 
 EXPOSE 8000


### PR DESCRIPTION
## Description of changes

There are issues with getting hung up on commands issued in the docker_entrypoint.sh file when deploying to GKE. These changes to the docker file allow chroma to run smoothly in GKE.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Migrated docker_entrypoint.sh commands to Dockerfile
	 - Image does not get hung up on docker_entrypoint.sh commands when deploying to GKE

## Test plan
*How are these changes tested?*
These changes have been tested by building the image, testing locally and testing on a deployed instance of GKE. 

These changes **need** to be tested with the docker compose files.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

Yes, no changes were made other than in the Dockerfile
