### PR TITLE
Bugfix/default model extraction

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -350,10 +350,8 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction):
             self._download(
                 self.MODEL_DOWNLOAD_URL, self.DOWNLOAD_PATH / self.ARCHIVE_FILENAME
             )
-            with tarfile.open(
-                self.DOWNLOAD_PATH / self.ARCHIVE_FILENAME, "r:gz"
-            ) as tar:
-                tar.extractall(self.DOWNLOAD_PATH)
+        with tarfile.open(self.DOWNLOAD_PATH / self.ARCHIVE_FILENAME, "r:gz") as tar:
+            tar.extractall(self.DOWNLOAD_PATH)
 
 
 def DefaultEmbeddingFunction() -> Optional[EmbeddingFunction]:
@@ -410,7 +408,6 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction):
         self._session.headers.update({"Authorization": f"Bearer {api_key}"})
 
     def __call__(self, texts: Documents) -> Embeddings:
-
         embeddings = []
         for text in texts:
             response = self._session.post(


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Unziping the onnyx model tarball no longer depends on the archive noe being present. This is useful in situations where the tarball was downloaded but never extracted. One side effect is that we'll always unzip the tarball but then we don't make the assumption that everything is working.

## Test plan
All tests are passing. No new tests addd

## Documentation Changes
No changes do docs

## Side note on security

We could check the file's checksum, which can also be hosted in s3. To prevent possible attack vectors where the model is replaced locally on the machine. An added benefit will be that if there are new versions of the model where the checksum will not match, we can re-download and extract or warn the user about the new version.
