### PR TITLE
[ENH] Prevent unrestricted delete

### DIFF
--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -328,24 +328,6 @@ class Collection(BaseModel):
             validate_where_document(where_document) if where_document else None
         )
 
-        # You must have at least one of non-empty ids, where, or where_document.
-        if (
-            (ids is None or (ids is not None and len(ids) == 0))
-            and (where is None or (where is not None and len(where) == 0))
-            and (
-                where_document is None
-                or (where_document is not None and len(where_document) == 0)
-            )
-        ):
-            raise ValueError(
-                """
-                You must provide either ids, where, or where_document to delete. If
-                you want to delete all data in a collection you can delete the
-                collection itself using the delete_collection method. Or alternatively,
-                you can get() all the relevant ids and then delete them.
-                """
-            )
-
         self._client._delete(self.id, ids, where, where_document)
 
     def _validate_embedding_set(

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -122,11 +122,9 @@ class Collection(BaseModel):
             GetResult: A GetResult object containing the results.
 
         """
-        where = validate_where(where) if where is not None else None
+        where = validate_where(where) if where else None
         where_document = (
-            validate_where_document(where_document)
-            if where_document is not None
-            else None
+            validate_where_document(where_document) if where_document else None
         )
         ids = validate_ids(maybe_cast_one_to_many(ids)) if ids else None
         include = validate_include(include, allow_distances=False)
@@ -179,11 +177,9 @@ class Collection(BaseModel):
             ValueError: If you provide both query_embeddings and query_texts
 
         """
-        where = validate_where(where) if where is not None else None
+        where = validate_where(where) if where else None
         where_document = (
-            validate_where_document(where_document)
-            if where_document is not None
-            else None
+            validate_where_document(where_document) if where_document else None
         )
         query_embeddings = (
             validate_embeddings(maybe_cast_one_to_many(query_embeddings))
@@ -322,26 +318,32 @@ class Collection(BaseModel):
 
         Returns:
             None
+
+        Raises:
+            ValueError: If you don't provide either ids, where, or where_document
         """
         ids = validate_ids(maybe_cast_one_to_many(ids)) if ids else None
-        where = validate_where(where) if where is not None else None
+        where = validate_where(where) if where else None
         where_document = (
-            validate_where_document(where_document)
-            if where_document is not None
-            else None
+            validate_where_document(where_document) if where_document else None
         )
 
-        # You must have at least one of ids, where, or where_document.
+        # You must have at least one of non-empty ids, where, or where_document.
         if (
             (ids is None or (ids is not None and len(ids) == 0))
-            and where is None
-            and where_document is None
+            and (where is None or (where is not None and len(where) == 0))
+            and (
+                where_document is None
+                or (where_document is not None and len(where_document) == 0)
+            )
         ):
             raise ValueError(
-                "You must provide either ids, where, or where_document to delete. If \
-                you want to delete all data in a collection you can delete the \
-                collection itself using the delete_collection method. Or alternatively,\
-                you can get() all the relevant ids and then delete them."
+                """
+                You must provide either ids, where, or where_document to delete. If
+                you want to delete all data in a collection you can delete the
+                collection itself using the delete_collection method. Or alternatively,
+                you can get() all the relevant ids and then delete them.
+                """
             )
 
         self._client._delete(self.id, ids, where, where_document)

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -122,9 +122,11 @@ class Collection(BaseModel):
             GetResult: A GetResult object containing the results.
 
         """
-        where = validate_where(where) if where else None
+        where = validate_where(where) if where is not None else None
         where_document = (
-            validate_where_document(where_document) if where_document else None
+            validate_where_document(where_document)
+            if where_document is not None
+            else None
         )
         ids = validate_ids(maybe_cast_one_to_many(ids)) if ids else None
         include = validate_include(include, allow_distances=False)
@@ -177,9 +179,11 @@ class Collection(BaseModel):
             ValueError: If you provide both query_embeddings and query_texts
 
         """
-        where = validate_where(where) if where else None
+        where = validate_where(where) if where is not None else None
         where_document = (
-            validate_where_document(where_document) if where_document else None
+            validate_where_document(where_document)
+            if where_document is not None
+            else None
         )
         query_embeddings = (
             validate_embeddings(maybe_cast_one_to_many(query_embeddings))
@@ -320,10 +324,26 @@ class Collection(BaseModel):
             None
         """
         ids = validate_ids(maybe_cast_one_to_many(ids)) if ids else None
-        where = validate_where(where) if where else None
+        where = validate_where(where) if where is not None else None
         where_document = (
-            validate_where_document(where_document) if where_document else None
+            validate_where_document(where_document)
+            if where_document is not None
+            else None
         )
+
+        # You must have at least one of ids, where, or where_document.
+        if (
+            (ids is None or (ids is not None and len(ids) == 0))
+            and where is None
+            and where_document is None
+        ):
+            raise ValueError(
+                "You must provide either ids, where, or where_document to delete. If \
+                you want to delete all data in a collection you can delete the \
+                collection itself using the delete_collection method. Or alternatively,\
+                you can get() all the relevant ids and then delete them."
+            )
+
         self._client._delete(self.id, ids, where, where_document)
 
     def _validate_embedding_set(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -371,8 +371,6 @@ class SegmentAPI(API):
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.DELETE)
 
-        # TODO: Do we want to warn the user that unrestricted _delete() is 99% of the
-        # time a bad idea?
         if (where or where_document) or not ids:
             metadata_segment = self._manager.get_segment(collection_id, MetadataReader)
             records = metadata_segment.get_metadata(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -368,6 +368,24 @@ class SegmentAPI(API):
             else None
         )
 
+        # You must have at least one of non-empty ids, where, or where_document.
+        if (
+            (ids is None or (ids is not None and len(ids) == 0))
+            and (where is None or (where is not None and len(where) == 0))
+            and (
+                where_document is None
+                or (where_document is not None and len(where_document) == 0)
+            )
+        ):
+            raise ValueError(
+                """
+                You must provide either ids, where, or where_document to delete. If
+                you want to delete all data in a collection you can delete the
+                collection itself using the delete_collection method. Or alternatively,
+                you can get() all the relevant ids and then delete them.
+                """
+            )
+
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.DELETE)
 
@@ -379,6 +397,9 @@ class SegmentAPI(API):
             ids_to_delete = [r["id"] for r in records]
         else:
             ids_to_delete = ids
+
+        if len(ids_to_delete) == 0:
+            return []
 
         records_to_submit = []
         for r in _records(t.Operation.DELETE, ids_to_delete):

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -25,6 +25,7 @@ import socket
 import multiprocessing
 
 from chromadb.types import SeqId, SubmitEmbeddingRecord
+from chromadb.db.mixins import embeddings_queue
 
 root_logger = logging.getLogger()
 root_logger.setLevel(logging.DEBUG)  # This will only run when testing
@@ -257,3 +258,7 @@ def produce_fns(
     request: pytest.FixtureRequest,
 ) -> Generator[ProducerFn, None, None]:
     yield request.param
+
+
+def pytest_configure(config):
+    embeddings_queue._called_from_test = True

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -368,20 +368,31 @@ def test_escape_chars_in_ids(api: API) -> None:
 def test_delete_empty_fails(api: API):
     api.reset()
     coll = api.create_collection(name="foo")
-    with pytest.raises(ValueError):
+
+    error_valid = (
+        lambda e: "You must provide either ids, where, or where_document to delete."
+        in e
+    )
+
+    with pytest.raises(Exception) as e:
         coll.delete()
+    assert error_valid(str(e))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         coll.delete(ids=[])
+    assert error_valid(str(e))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         coll.delete(where={})
+    assert error_valid(str(e))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         coll.delete(where_document={})
+    assert error_valid(str(e))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         coll.delete(where_document={}, where={})
+    assert error_valid(str(e))
 
     # Should not raise
     coll.delete(where_document={"$contains": "bar"})

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -363,3 +363,25 @@ def test_escape_chars_in_ids(api: API) -> None:
     assert coll.count() == 1
     coll.delete(ids=[id])
     assert coll.count() == 0
+
+
+def test_delete_empty_fails(api: API):
+    api.reset()
+    coll = api.create_collection(name="foo")
+    with pytest.raises(ValueError):
+        coll.delete()
+
+    with pytest.raises(ValueError):
+        coll.delete(ids=[])
+
+    with pytest.raises(ValueError):
+        coll.delete(where={})
+
+    with pytest.raises(ValueError):
+        coll.delete(where_document={})
+
+    with pytest.raises(ValueError):
+        coll.delete(ids=["a"], where_document={})
+
+    with pytest.raises(ValueError):
+        coll.delete(where_document={}, where={})

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -381,7 +381,12 @@ def test_delete_empty_fails(api: API):
         coll.delete(where_document={})
 
     with pytest.raises(ValueError):
-        coll.delete(ids=["a"], where_document={})
-
-    with pytest.raises(ValueError):
         coll.delete(where_document={}, where={})
+
+    # Should not raise
+    coll.delete(where_document={"$contains": "bar"})
+    coll.delete(where={"foo": "bar"})
+    coll.delete(ids=["foo"])
+    coll.delete(ids=["foo"], where={"foo": "bar"})
+    coll.delete(ids=["foo"], where_document={"$contains": "bar"})
+    coll.delete(ids=["foo"], where_document={"$contains": "bar"}, where={"foo": "bar"})

--- a/chromadb/test/segment/test_vector.py
+++ b/chromadb/test/segment/test_vector.py
@@ -488,3 +488,29 @@ def test_upsert(
     result = segment.get_vectors(ids=["no_such_record"])
     assert len(result) == 1
     assert approx_equal_vector(result[0]["embedding"], [42, 42])
+
+
+def test_delete_without_add(
+    system: System,
+    sample_embeddings: Iterator[SubmitEmbeddingRecord],
+    vector_reader: Type[VectorReader],
+    produce_fns: ProducerFn,
+) -> None:
+    producer = system.instance(Producer)
+    system.reset_state()
+    segment_definition = create_random_segment_definition()
+    topic = str(segment_definition["topic"])
+
+    segment = vector_reader(system, segment_definition)
+    segment.start()
+
+    assert segment.count() == 0
+
+    delete_record = SubmitEmbeddingRecord(
+        id="not_in_db",
+        embedding=None,
+        encoding=None,
+        metadata=None,
+        operation=Operation.DELETE,
+    )
+    producer.submit_embedding(topic, delete_record)

--- a/chromadb/test/segment/test_vector.py
+++ b/chromadb/test/segment/test_vector.py
@@ -492,9 +492,7 @@ def test_upsert(
 
 def test_delete_without_add(
     system: System,
-    sample_embeddings: Iterator[SubmitEmbeddingRecord],
     vector_reader: Type[VectorReader],
-    produce_fns: ProducerFn,
 ) -> None:
     producer = system.instance(Producer)
     system.reset_state()
@@ -513,4 +511,8 @@ def test_delete_without_add(
         metadata=None,
         operation=Operation.DELETE,
     )
-    producer.submit_embedding(topic, delete_record)
+
+    try:
+        producer.submit_embedding(topic, delete_record)
+    except BaseException:
+        pytest.fail("Unexpected error. Deleting on an empty segment should not raise.")

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -271,7 +271,7 @@ def test_delete(api):
     collection.add(**batch_records)
     assert collection.count() == 2
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         collection.delete()
 
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -271,8 +271,8 @@ def test_delete(api):
     collection.add(**batch_records)
     assert collection.count() == 2
 
-    collection.delete()
-    assert collection.count() == 0
+    with pytest.raises(ValueError):
+        collection.delete()
 
 
 def test_delete_with_index(api):


### PR DESCRIPTION
## Description of changes

Addresses #948, #583, #970

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Prevent unrestricted deletes and instead point users to more explicit alternatives. 
	 - Make embeddings_queue properly log the exception in mock_async mode
	 - In tests, reraise from embeddings_queue
	 - Fix a related bug where delete() on an empty segment throws a misleading error by checking if index in segment is initialized (#970)
 - New functionality
	 - None

## Test plan
Added unit tests validating that error cases are properly error'ing. Existing tests should make sure delete still works.

## Documentation Changes
None required.