### PR TITLE
[ENH] Max batch size warning

### DIFF
--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -59,7 +59,15 @@ class Producer(Component):
         """Add a batch of embedding records to the given topic. Returns the SeqIDs of
         the records. The returned SeqIDs will be in the same order as the given
         SubmitEmbeddingRecords. However, it is not guaranteed that the SeqIDs will be
-        processed in the same order as the given SubmitEmbeddingRecords."""
+        processed in the same order as the given SubmitEmbeddingRecords. If the number
+        of records exceeds the maximum batch size, an exception will be thrown."""
+        pass
+
+    @property
+    @abstractmethod
+    def max_batch_size(self) -> int:
+        """Return the maximum number of records that can be submitted in a single call
+        to submit_embeddings."""
         pass
 
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - In v0.4.6 we introduced batching at the sqlite layer for the embeddings_queue to maximize throughput through submit_embeddings calls. SQlite has a max size of variables it can bind at once that is defined at compile time. This changes makes the embeddings_queue introspect its compile time flags to inform its max_batch_size. Max_batch_size is a new property method added to the Producer class that indicates the maximum batch size submit_embeddings() will accept. Right now we use the error internal to submit_embeddings in the sqlite impl, but callers could use this to pre-validate input and throw a message as well. 
 - New functionality
	 - None

## Test plan
Added a test for the below and above batch size cases.

## Documentation Changes
We should update the usage guide to cover this caveat. 