### PR TITLE
Edit to follow host machine's timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 networks:
   net:
@@ -13,6 +13,8 @@ services:
     volumes:
       - ./:/chroma
       - index_data:/index_data
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: uvicorn chromadb.app:app --reload --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml
     environment:
       - IS_PERSISTENT=TRUE


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - When you see chroma.log, timezone is different between host machine and docker container.
 - New functionality
	 - It makes container to follow host machine's timezone

## Test plan
*How are these changes tested?*
  make container up and check chroma.log

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?* no
