### PR TITLE
[BUG]: CIP-2 Auth Providers - Clean-up

### DIFF
--- a/chromadb/auth/registry.py
+++ b/chromadb/auth/registry.py
@@ -1,7 +1,7 @@
 import importlib
 import logging
 import pkgutil
-from typing import Union, Dict, Type, Callable
+from typing import Union, Dict, Type, Callable  # noqa: F401
 
 from chromadb.auth import (
     ClientAuthConfigurationProvider,
@@ -47,7 +47,7 @@ def register_provider(
     short_hand: str,
 ) -> Callable[[Type[ProviderTypes]], Type[ProviderTypes]]:
     def decorator(cls: Type[ProviderTypes]) -> Type[ProviderTypes]:
-        logger.error("Registering provider: %s", short_hand)
+        logger.debug("Registering provider: %s", short_hand)
         global _provider_registry
         if issubclass(cls, ClientAuthProvider):
             _provider_registry["client_auth_providers"][short_hand] = cls

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -128,8 +128,6 @@ class Settings(BaseSettings):  # type: ignore
         "/api/v1": ["GET"],
         "/api/v1/heartbeat": ["GET"],
         "/api/v1/version": ["GET"],
-        "/docs": ["GET"],
-        "/openapi.json": ["GET"],
     }
 
     chroma_client_auth_credentials_provider: Optional[

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -128,6 +128,8 @@ class Settings(BaseSettings):  # type: ignore
         "/api/v1": ["GET"],
         "/api/v1/heartbeat": ["GET"],
         "/api/v1/version": ["GET"],
+        "/docs": ["GET"],
+        "/openapi.json": ["GET"],
     }
 
     chroma_client_auth_credentials_provider: Optional[

--- a/docs/CIP_2_Auth_Providers_Proposal.md
+++ b/docs/CIP_2_Auth_Providers_Proposal.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Current Status: `Under Discussion`
+Current Status: `Accepted`
 
 ## **Motivation**
 


### PR DESCRIPTION
- Updated logger level to avoid confusion

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Changed logger level message when registering new Auth providers to debug to avoid confusing developers.
	 - Change the status of the CIP to `Accepted`
	 - Added `/docs` and `/openapi.json` to the publicly accessible endpoints (this may or many not be a security concern - TBD)

## Test plan

Local tests are passing—no new tests.

## Documentation Changes
N/A
