### PR TITLE
[BUG]: GoogleVertex EF now raises and error when requests dep is missing

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -428,6 +428,12 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction):
         project_id: str = "cloud-large-language-models",
         region: str = "us-central1",
     ):
+        try:
+            import requests
+        except ImportError:
+            raise ValueError(
+                "The requests python package is not installed. Please install it with `pip install requests`"
+            )
         self._api_url = f"https://{region}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{region}/publishers/goole/models/{model_name}:predict"
         self._session = requests.Session()
         self._session.headers.update({"Authorization": f"Bearer {api_key}"})


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - The Goolge Vertex EF did not check for `requests` dependency install, which does not come by default with Chroma. A check has been added

## Test plan
Local tests are passing. No new tests added.

## Documentation Changes
No docs update
