### PR TITLE
[BUG] Add dep fix for pydantic in thin client

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
   'requests >= 2.28',
-  'pydantic >= 1.9',
+  'pydantic>=1.9,<2.0',
   'numpy >= 1.21.6',
   'posthog >= 2.4.0',
   'typing_extensions >= 4.5.0',


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - #799 introduced a max version for pydantic but this change was not propagated to the thin client. This makes the same change in the thin client.
 - New functionality
	 - ...

## Test plan
Existing tests for client

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
None
