### PR TITLE
[BUG] docker-compose default persistent directory path updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 
 index_data
 
+# Default configuration for persist_directory in chromadb/config.py
+# Currently it's located in "./chroma/"
+chroma/
+
 venv
 .env
 .chroma

--- a/docker-compose.server.example.yml
+++ b/docker-compose.server.example.yml
@@ -5,7 +5,7 @@ networks:
     driver: bridge
 services:
   server:
-    image: ghcr.io/chroma-core/chroma:0.4.7
+    image: ghcr.io/chroma-core/chroma:latest
     volumes:
       # Default configuration for persist_directory in chromadb/config.py
       # Currently it's located in "/chroma/chroma/"

--- a/docker-compose.server.example.yml
+++ b/docker-compose.server.example.yml
@@ -5,16 +5,18 @@ networks:
     driver: bridge
 services:
   server:
-    image: ghcr.io/chroma-core/chroma:latest
+    image: ghcr.io/chroma-core/chroma:0.4.7
     volumes:
-      - index_data:/chroma/.chroma/index
+      # Default configuration for persist_directory in chromadb/config.py
+      # Currently it's located in "/chroma/chroma/"
+      - chroma_persistent_folder:/chroma/chroma/
     ports:
       - 8000:8000
     networks:
       - net
 
 volumes:
-  index_data:
-    driver: local
   backups:
+    driver: local
+  chroma_persistent_folder:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/chroma
-      - index_data:/index_data
+      # Be aware that indexed data are located in "/chroma/chroma/"
+      # Default configuration for persist_directory in chromadb/config.py
     command: uvicorn chromadb.app:app --reload --workers 1 --host 0.0.0.0 --port 8000 --log-config log_config.yml
     environment:
       - IS_PERSISTENT=TRUE
@@ -26,7 +27,5 @@ services:
       - net
 
 volumes:
-  index_data:
-    driver: local
   backups:
     driver: local


### PR DESCRIPTION
Fixes #1035

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Default persistent directory isn't `/index_data` it's located at `/chroma/chroma/` [config.py#L85](https://github.com/chroma-core/chroma/blob/main/chromadb/config.py#L85) fixing it in serveur core docker-compose
	 - Removing misleading volume `/index_data` in main docker-compose.yaml file, that clearly induce in error users
	 - Adding comment in main docker-compose.yaml file so that Chroma users won't waste time seeking for this directory path
 - New functionality

Does it introduce a breaking change ?

- With this change data will now be persistent for users using `docker-compose.server.example.yml` as it's a exemple file this shouldn't be considered as a breaking change.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js
- [x] Start Chroma server with `docker-compose up -d` create a collection, stop Chroma server with `docker-compose down` and start it again `docker-compose up -d`, check the created collection still exists.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
