### PR TITLE
[BUG]: Added allow_reuse=True to pydantic validators

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -93,7 +93,7 @@ class Settings(BaseSettings):  # type: ignore
 
     chroma_server_auth_provider: Optional[str] = None
 
-    @validator("chroma_server_auth_provider", pre=True, always=True)
+    @validator("chroma_server_auth_provider", pre=True, always=True, allow_reuse=True)
     def chroma_server_auth_provider_non_empty(
         cls: Type["Settings"], v: str
     ) -> Optional[str]:
@@ -109,7 +109,9 @@ class Settings(BaseSettings):  # type: ignore
     chroma_server_auth_credentials_file: Optional[str] = None
     chroma_server_auth_credentials: Optional[str] = None
 
-    @validator("chroma_server_auth_credentials_file", pre=True, always=True)
+    @validator(
+        "chroma_server_auth_credentials_file", pre=True, always=True, allow_reuse=True
+    )
     def chroma_server_auth_credentials_file_non_empty_file_exists(
         cls: Type["Settings"], v: str
     ) -> Optional[str]:


### PR DESCRIPTION
Note: Cross-version testing was failing as it was loading config twice which caused the issue with pydantic.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixing `chromadb/test/property/test_cross_version_persist.py` test failures.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
No docs need updating
