### PR TITLE
[ENH]: Improved HttpClient URL support

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -88,6 +88,7 @@ class Settings(BaseSettings):  # type: ignore
     chroma_server_headers: Optional[Dict[str, str]] = None
     chroma_server_http_port: Optional[str] = None
     chroma_server_ssl_enabled: Optional[bool] = False
+    chroma_server_api_default_path: Optional[str] = "/api/v1"
     chroma_server_grpc_port: Optional[str] = None
     chroma_server_cors_allow_origins: List[str] = []  # eg ["http://localhost:3000"]
 

--- a/chromadb/test/property/test_client_url.py
+++ b/chromadb/test/property/test_client_url.py
@@ -1,0 +1,105 @@
+from typing import Optional
+from urllib.parse import urlparse
+
+from hypothesis import given, strategies as st
+
+from chromadb.api.fastapi import FastAPI
+
+
+def hostname_strategy() -> st.SearchStrategy[str]:
+    label = st.text(
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122),  # a-z
+        min_size=1,
+        max_size=63,
+    )
+    return st.lists(label, min_size=1, max_size=3).map("-".join)
+
+
+tld_list = ["com", "org", "net", "edu"]
+
+
+def domain_strategy() -> st.SearchStrategy[str]:
+    label = st.text(
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122),  # a-z
+        min_size=1,
+        max_size=63,
+    )
+    tld = st.sampled_from(tld_list)
+    return st.tuples(label, tld).map(".".join)
+
+
+port_strategy = st.integers(min_value=1, max_value=65535)
+
+ssl_enabled_strategy = st.booleans()
+
+
+def url_path_strategy() -> st.SearchStrategy[str]:
+    path_segment = st.text(
+        alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz/-_"),
+        min_size=1,
+        max_size=10,
+    )
+    return (
+        st.lists(path_segment, min_size=1, max_size=5)
+        .map("/".join)
+        .map(lambda x: "/" + x)
+    )
+
+
+def is_valid_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+        return all([parsed.scheme, parsed.netloc])
+    except Exception:
+        return False
+
+
+def generate_valid_domain_url() -> st.SearchStrategy[str]:
+    # hostname = draw(domain_strategy())
+    # url_scheme = st.sampled_from(["http", "https"])
+    # url_path = draw(url_path_strategy())
+    #
+    # return f"{url_scheme}://{hostname}{url_path}"
+    return st.builds(
+        lambda url_scheme, hostname, url_path: f"{url_scheme}://{hostname}{url_path}",
+        url_scheme=st.sampled_from(["http", "https"]),
+        hostname=domain_strategy(),
+        url_path=url_path_strategy(),
+    )
+
+
+host_or_domain_strategy = st.one_of(
+    generate_valid_domain_url(), domain_strategy(), st.sampled_from(["localhost"])
+)
+
+
+@given(
+    hostname=host_or_domain_strategy,
+    port=port_strategy,
+    ssl_enabled=ssl_enabled_strategy,
+    # url_path=st.one_of(url_path_strategy(), st.sampled_from(["/api/v1", None])),
+    default_api_path=st.sampled_from(["/api/v1", "/api/v2", None]),
+)
+def test_url_resolve(
+    hostname: str,
+    port: int,
+    ssl_enabled: bool,
+    default_api_path: Optional[str],
+) -> None:
+    # if re.match(r"^[a-z0-9-]{1,63}\.[a-z0-9-]{1,63}\.[a-z0-9-]{1,63}$", hostname):
+    #     print("Domain")
+    #     _host = f"{url_scheme + '://' if url_scheme else ''}{hostname}{url_path if url_path else ''}"
+    # else:
+    #     _host = hostname
+    _url = FastAPI.resolve_url(
+        chroma_server_host=hostname,
+        chroma_server_http_port=port,
+        chroma_server_ssl_enabled=ssl_enabled,
+        default_api_path=default_api_path,
+    )
+    assert is_valid_url(_url), f"Invalid URL: {_url}"
+    assert (
+        _url.startswith("https") if ssl_enabled else _url.startswith("http")
+    ), f"Invalid URL: {_url} - SSL Enabled: {ssl_enabled}"
+    if default_api_path:
+        assert _url.endswith(default_api_path), f"Invalid URL: {_url}"

--- a/chromadb/test/property/test_client_url.py
+++ b/chromadb/test/property/test_client_url.py
@@ -8,7 +8,7 @@ from chromadb.api.fastapi import FastAPI
 
 def hostname_strategy() -> st.SearchStrategy[str]:
     label = st.text(
-        alphabet=st.characters(min_codepoint=97, max_codepoint=122),  # a-z
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122),
         min_size=1,
         max_size=63,
     )
@@ -20,7 +20,7 @@ tld_list = ["com", "org", "net", "edu"]
 
 def domain_strategy() -> st.SearchStrategy[str]:
     label = st.text(
-        alphabet=st.characters(min_codepoint=97, max_codepoint=122),  # a-z
+        alphabet=st.characters(min_codepoint=97, max_codepoint=122),
         min_size=1,
         max_size=63,
     )
@@ -55,11 +55,6 @@ def is_valid_url(url: str) -> bool:
 
 
 def generate_valid_domain_url() -> st.SearchStrategy[str]:
-    # hostname = draw(domain_strategy())
-    # url_scheme = st.sampled_from(["http", "https"])
-    # url_path = draw(url_path_strategy())
-    #
-    # return f"{url_scheme}://{hostname}{url_path}"
     return st.builds(
         lambda url_scheme, hostname, url_path: f"{url_scheme}://{hostname}{url_path}",
         url_scheme=st.sampled_from(["http", "https"]),
@@ -77,7 +72,6 @@ host_or_domain_strategy = st.one_of(
     hostname=host_or_domain_strategy,
     port=port_strategy,
     ssl_enabled=ssl_enabled_strategy,
-    # url_path=st.one_of(url_path_strategy(), st.sampled_from(["/api/v1", None])),
     default_api_path=st.sampled_from(["/api/v1", "/api/v2", None]),
 )
 def test_url_resolve(
@@ -86,11 +80,6 @@ def test_url_resolve(
     ssl_enabled: bool,
     default_api_path: Optional[str],
 ) -> None:
-    # if re.match(r"^[a-z0-9-]{1,63}\.[a-z0-9-]{1,63}\.[a-z0-9-]{1,63}$", hostname):
-    #     print("Domain")
-    #     _host = f"{url_scheme + '://' if url_scheme else ''}{hostname}{url_path if url_path else ''}"
-    # else:
-    #     _host = hostname
     _url = FastAPI.resolve_url(
         chroma_server_host=hostname,
         chroma_server_http_port=port,


### PR DESCRIPTION
Refs: #1019

## Description of changes

The HTTP Client now supports a variety of URIs:

- URLs: `http://example.com/`
- Hostnames: `localhost` or chroma (existing)
- Domains `example.com`
- Paths in URLs/Domains - `http://example.com/my_path`

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
TBD - perhaps some clarifications on the HttpClient
