### PR TITLE
[BUG]: Fixed Static Auth Token range of allowed chars

### DIFF
--- a/chromadb/auth/token/__init__.py
+++ b/chromadb/auth/token/__init__.py
@@ -68,7 +68,10 @@ class TokenAuthClientAuthResponse(ClientAuthResponse):
 
 def check_token(token: str) -> None:
     token_str = str(token)
-    if not all(c in string.ascii_letters + string.digits for c in token_str):
+    if not all(
+        c in string.digits + string.ascii_letters + string.punctuation
+        for c in token_str
+    ):
         raise ValueError("Invalid token. Must contain only ASCII letters and digits.")
 
 

--- a/chromadb/test/auth/test_token_auth.py
+++ b/chromadb/test/auth/test_token_auth.py
@@ -25,7 +25,11 @@ def token_config(draw: st.DrawFn) -> Dict[str, Any]:
         )
     )
     token = draw(
-        st.text(alphabet=string.ascii_letters + string.digits, min_size=1, max_size=50)
+        st.text(
+            alphabet=string.digits + string.ascii_letters + string.punctuation,
+            min_size=1,
+            max_size=50,
+        )
     )
     persistence = draw(st.booleans())
     return {
@@ -75,7 +79,7 @@ def random_token(draw: st.DrawFn) -> str:
 @st.composite
 def invalid_token(draw: st.DrawFn) -> str:
     opposite_alphabet = set(string.printable) - set(
-        string.ascii_letters + string.digits
+        string.digits + string.ascii_letters + string.punctuation
     )
     token = draw(st.text(alphabet=list(opposite_alphabet), min_size=1, max_size=50))
     return token


### PR DESCRIPTION
Refs: #1066

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Small bugfix to extend the range of allowed characters to include printable ascii without whitespaces

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes

Docs updated - https://github.com/chroma-core/docs/pull/128
