### PR TITLE
[BUG]: Local Segment Dir Removal

### DIFF
--- a/chromadb/segment/__init__.py
+++ b/chromadb/segment/__init__.py
@@ -39,6 +39,11 @@ class SegmentImplementation(Component):
         segment. Validation errors will be reported to the user."""
         return None
 
+    @abstractmethod
+    def delete(self) -> None:
+        """Delete the segment and all its data"""
+        ...
+
 
 S = TypeVar("S", bound=SegmentImplementation)
 

--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -112,6 +112,9 @@ class LocalSegmentManager(SegmentManager):
         segments = self._sysdb.get_segments(collection=collection_id)
         for segment in segments:
             if segment["id"] in self._instances:
+                if segment["type"] == SegmentType.HNSW_LOCAL_PERSISTED.value:
+                    instance = self.get_segment(collection_id, VectorReader)
+                    instance.delete()
                 del self._instances[segment["id"]]
             if collection_id in self._segment_cache:
                 if segment["scope"] in self._segment_cache[collection_id]:

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -466,6 +466,10 @@ class SqliteMetadataSegment(MetadataReader):
                 raise ValueError(f"Unknown where_doc operator {k}")
         raise ValueError("Empty where_doc")
 
+    @override
+    def delete(self) -> None:
+        raise NotImplementedError()
+
 
 def _encode_seq_id(seq_id: SeqId) -> bytes:
     """Encode a SeqID into a byte array"""

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -305,3 +305,7 @@ class LocalHnswSegment(VectorReader):
                     batch.apply(record, label is not None)
 
             self._apply_batch(batch)
+
+    @override
+    def delete(self) -> None:
+        raise NotImplementedError()

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -79,6 +79,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
     _sync_threshold: int
     _persist_data: PersistentData
     _persist_directory: str
+    _allow_reset: bool
 
     def __init__(self, system: System, segment: Segment):
         super().__init__(system, segment)
@@ -86,7 +87,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
         self._params = PersistentHnswParams(segment["metadata"] or {})
         self._batch_size = self._params.batch_size
         self._sync_threshold = self._params.sync_threshold
-
+        self._allow_reset = system.settings.allow_reset
         self._persist_directory = system.settings.require("persist_directory")
         self._curr_batch = Batch()
         self._brute_force_index = None
@@ -395,9 +396,18 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
 
     @override
     def reset_state(self) -> None:
+        if self._allow_reset:
+            data_path = self._get_storage_folder()
+            if os.path.exists(data_path):
+                self.close_persistent_index()
+                shutil.rmtree(data_path, ignore_errors=True)
+
+    @override
+    def delete(self) -> None:
         data_path = self._get_storage_folder()
         if os.path.exists(data_path):
-            shutil.rmtree(data_path, ignore_errors=True)
+            self.close_persistent_index()
+            shutil.rmtree(data_path, ignore_errors=False)
 
     @staticmethod
     def get_file_handle_count() -> int:

--- a/chromadb/test/segment/test_vector.py
+++ b/chromadb/test/segment/test_vector.py
@@ -1,7 +1,6 @@
 import pytest
 from typing import Generator, List, Callable, Iterator, Type, cast
 from chromadb.config import System, Settings
-from chromadb.segment.impl.metadata.sqlite import SqliteMetadataSegment
 from chromadb.test.conftest import ProducerFn
 from chromadb.types import (
     SubmitEmbeddingRecord,

--- a/chromadb/test/segment/test_vector.py
+++ b/chromadb/test/segment/test_vector.py
@@ -1,6 +1,7 @@
 import pytest
 from typing import Generator, List, Callable, Iterator, Type, cast
 from chromadb.config import System, Settings
+from chromadb.segment.impl.metadata.sqlite import SqliteMetadataSegment
 from chromadb.test.conftest import ProducerFn
 from chromadb.types import (
     SubmitEmbeddingRecord,
@@ -516,3 +517,153 @@ def test_delete_without_add(
         producer.submit_embedding(topic, delete_record)
     except BaseException:
         pytest.fail("Unexpected error. Deleting on an empty segment should not raise.")
+
+
+def test_delete_with_local_segment_storage(
+    system: System,
+    sample_embeddings: Iterator[SubmitEmbeddingRecord],
+    vector_reader: Type[VectorReader],
+    produce_fns: ProducerFn,
+) -> None:
+    producer = system.instance(Producer)
+    system.reset_state()
+    segment_definition = create_random_segment_definition()
+    topic = str(segment_definition["topic"])
+
+    segment = vector_reader(system, segment_definition)
+    segment.start()
+
+    embeddings, seq_ids = produce_fns(
+        producer=producer, topic=topic, embeddings=sample_embeddings, n=5
+    )
+
+    sync(segment, seq_ids[-1])
+    assert segment.count() == 5
+
+    delete_record = SubmitEmbeddingRecord(
+        id=embeddings[0]["id"],
+        embedding=None,
+        encoding=None,
+        metadata=None,
+        operation=Operation.DELETE,
+    )
+    assert isinstance(seq_ids, List)
+    seq_ids.append(
+        produce_fns(
+            producer=producer,
+            topic=topic,
+            n=1,
+            embeddings=(delete_record for _ in range(1)),
+        )[1][0]
+    )
+
+    sync(segment, seq_ids[-1])
+
+    # Assert that the record is gone using `count`
+    assert segment.count() == 4
+
+    # Assert that the record is gone using `get`
+    assert segment.get_vectors(ids=[embeddings[0]["id"]]) == []
+    results = segment.get_vectors()
+    assert len(results) == 4
+    # get_vectors returns results in arbitrary order
+    results = sorted(results, key=lambda v: v["id"])
+    for actual, expected in zip(results, embeddings[1:]):
+        assert actual["id"] == expected["id"]
+        assert approx_equal_vector(
+            actual["embedding"], cast(Vector, expected["embedding"])
+        )
+
+    # Assert that the record is gone from KNN search
+    vector = cast(Vector, embeddings[0]["embedding"])
+    query = VectorQuery(
+        vectors=[vector], k=10, allowed_ids=None, options=None, include_embeddings=False
+    )
+    knn_results = segment.query_vectors(query)
+    assert len(results) == 4
+    assert set(r["id"] for r in knn_results[0]) == set(e["id"] for e in embeddings[1:])
+
+    # Delete is idempotent
+    if isinstance(segment, PersistentLocalHnswSegment):
+        assert os.path.exists(segment._get_storage_folder())
+        segment.delete()
+        assert not os.path.exists(segment._get_storage_folder())
+        segment.delete()  # should not raise
+    elif isinstance(segment, LocalHnswSegment):
+        with pytest.raises(NotImplementedError):
+            segment.delete()
+
+
+def test_reset_state_ignored_for_allow_reset_false(
+    system: System,
+    sample_embeddings: Iterator[SubmitEmbeddingRecord],
+    vector_reader: Type[VectorReader],
+    produce_fns: ProducerFn,
+) -> None:
+    producer = system.instance(Producer)
+    system.reset_state()
+    segment_definition = create_random_segment_definition()
+    topic = str(segment_definition["topic"])
+
+    segment = vector_reader(system, segment_definition)
+    segment.start()
+
+    embeddings, seq_ids = produce_fns(
+        producer=producer, topic=topic, embeddings=sample_embeddings, n=5
+    )
+
+    sync(segment, seq_ids[-1])
+    assert segment.count() == 5
+
+    delete_record = SubmitEmbeddingRecord(
+        id=embeddings[0]["id"],
+        embedding=None,
+        encoding=None,
+        metadata=None,
+        operation=Operation.DELETE,
+    )
+    assert isinstance(seq_ids, List)
+    seq_ids.append(
+        produce_fns(
+            producer=producer,
+            topic=topic,
+            n=1,
+            embeddings=(delete_record for _ in range(1)),
+        )[1][0]
+    )
+
+    sync(segment, seq_ids[-1])
+
+    # Assert that the record is gone using `count`
+    assert segment.count() == 4
+
+    # Assert that the record is gone using `get`
+    assert segment.get_vectors(ids=[embeddings[0]["id"]]) == []
+    results = segment.get_vectors()
+    assert len(results) == 4
+    # get_vectors returns results in arbitrary order
+    results = sorted(results, key=lambda v: v["id"])
+    for actual, expected in zip(results, embeddings[1:]):
+        assert actual["id"] == expected["id"]
+        assert approx_equal_vector(
+            actual["embedding"], cast(Vector, expected["embedding"])
+        )
+
+    # Assert that the record is gone from KNN search
+    vector = cast(Vector, embeddings[0]["embedding"])
+    query = VectorQuery(
+        vectors=[vector], k=10, allowed_ids=None, options=None, include_embeddings=False
+    )
+    knn_results = segment.query_vectors(query)
+    assert len(results) == 4
+    assert set(r["id"] for r in knn_results[0]) == set(e["id"] for e in embeddings[1:])
+
+    if isinstance(segment, PersistentLocalHnswSegment):
+        if segment._allow_reset:
+            assert os.path.exists(segment._get_storage_folder())
+            segment.reset_state()
+            assert not os.path.exists(segment._get_storage_folder())
+        else:
+            assert os.path.exists(segment._get_storage_folder())
+            segment.reset_state()
+            assert os.path.exists(segment._get_storage_folder())


### PR DESCRIPTION
Note:  Cherry-picked from original PR #1010

Refs: 1009

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixed an issue where the collection's persistent segment dir was not removed; thus, many dirs with segment data were left on the device.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
N/A
