### PR TITLE
[ENH]: CIP-4: In and Not In Metadata Filters

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -207,6 +207,8 @@ def validate_where(where: Where) -> Where:
         if (
             key != "$and"
             and key != "$or"
+            and key != "$in"
+            and key != "$nin"
             and not isinstance(value, (str, int, float, dict))
         ):
             raise ValueError(
@@ -238,13 +240,26 @@ def validate_where(where: Where) -> Where:
                         raise ValueError(
                             f"Expected operand value to be an int or a float for operator {operator}, got {operand}"
                         )
-
-                if operator not in ["$gt", "$gte", "$lt", "$lte", "$ne", "$eq"]:
+                if operator in ["$in", "$nin"]:
+                    if not isinstance(operand, list):
+                        raise ValueError(
+                            f"Expected operand value to be an list for operator {operator}, got {operand}"
+                        )
+                if operator not in [
+                    "$gt",
+                    "$gte",
+                    "$lt",
+                    "$lte",
+                    "$ne",
+                    "$eq",
+                    "$in",
+                    "$nin",
+                ]:
                     raise ValueError(
-                        f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, got {operator}"
+                        f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, got {operator}"
                     )
 
-                if not isinstance(operand, (str, int, float)):
+                if not isinstance(operand, (str, int, float, list)):
                     raise ValueError(
                         f"Expected where operand value to be a str, int, or float, got {operand}"
                     )

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -264,6 +264,14 @@ def validate_where(where: Where) -> Where:
                     raise ValueError(
                         f"Expected where operand value to be a str, int, float, or list of those type, got {operand}"
                     )
+                if isinstance(operand, list) and (
+                    len(operand) == 0
+                    or not all(isinstance(x, type(operand[0])) for x in operand)
+                ):
+                    raise ValueError(
+                        f"Expected where operand value to be a non-empty list, and all values to obe of the same type "
+                        f"got {operand}"
+                    )
     return where
 
 

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -262,7 +262,7 @@ def validate_where(where: Where) -> Where:
 
                 if not isinstance(operand, (str, int, float, list)):
                     raise ValueError(
-                        f"Expected where operand value to be a str, int, or float, got {operand}"
+                        f"Expected where operand value to be a str, int, float, or list of those type, got {operand}"
                     )
     return where
 

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -256,7 +256,8 @@ def validate_where(where: Where) -> Where:
                     "$nin",
                 ]:
                     raise ValueError(
-                        f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, got {operator}"
+                        f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, "
+                        f"got {operator}"
                     )
 
                 if not isinstance(operand, (str, int, float, list)):

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -458,7 +458,6 @@ def opposite_value(value: LiteralValue) -> SearchStrategy[Any]:
             lambda x: x != value
         )
     elif isinstance(value, str):
-        # allow only printable ascii characters
         return safe_text.filter(lambda x: x != value)
     elif isinstance(value, bool):
         return st.booleans().filter(lambda x: x != value)

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -492,11 +492,11 @@ def where_clause(draw: st.DrawFn, collection: Collection) -> types.Where:
     elif op == "$in":
         if isinstance(value, str) and not value:
             return {}
-        return {key: {op: [value]}}
+        return {key: {op: [value, *[draw(opposite_value(value)) for _ in range(3)]]}}
     elif op == "$nin":
         if isinstance(value, str) and not value:
             return {}
-        return {key: {op: [draw(opposite_value(value))]}}
+        return {key: {op: [draw(opposite_value(value)) for _ in range(3)]}}
     else:
         return {key: {op: value}}
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -451,7 +451,7 @@ class DeterministicRuleStrategy(SearchStrategy):  # type: ignore
 
 def opposite_value(value: LiteralValue) -> SearchStrategy[Any]:
     """
-    Strategy for generating opposite values of the given value - testing of $nin
+    Returns a strategy that will generate all valid values except the input value - testing of $nin
     """
     if isinstance(value, float):
         return st.floats(allow_nan=False, allow_infinity=False).filter(
@@ -459,9 +459,7 @@ def opposite_value(value: LiteralValue) -> SearchStrategy[Any]:
         )
     elif isinstance(value, str):
         # allow only printable ascii characters
-        return st.text(
-            st.characters(min_codepoint=32, max_codepoint=126), min_size=1
-        ).filter(lambda x: x != value)
+        return safe_text.filter(lambda x: x != value)
     elif isinstance(value, bool):
         return st.booleans().filter(lambda x: x != value)
     elif isinstance(value, int):
@@ -495,7 +493,6 @@ def where_clause(draw: st.DrawFn, collection: Collection) -> types.Where:
     elif op == "$in":
         if isinstance(value, str) and not value:
             return {}
-        # *st.lists(st.from_type(type(value)).filter(lambda x: x != value), min_size=1, max_size=5).example()
         return {key: {op: [value]}}
     elif op == "$nin":
         if isinstance(value, str) and not value:

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -122,7 +122,11 @@ WhereOperator = Union[
     Literal["$ne"],
     Literal["$eq"],
 ]
-OperatorExpression = Dict[Union[WhereOperator, LogicalOperator], LiteralValue]
+InclusionExclusionOperator = Union[Literal["$in"], Literal["$nin"]]
+OperatorExpression = Union[
+    Dict[Union[WhereOperator, LogicalOperator], LiteralValue],
+    Dict[InclusionExclusionOperator, List[LiteralValue]],
+]
 
 Where = Dict[
     Union[str, LogicalOperator], Union[LiteralValue, OperatorExpression, List["Where"]]

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -191,5 +191,5 @@ test('wrong code returns an error', async () => {
     // @ts-ignore - supposed to fail
     const results = await collection.get({ where: { "test": { "$contains": "hello" } } });
     expect(results.error).toBeDefined()
-    expect(results.error).toBe("ValueError('Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, got $contains')")
+    expect(results.error).toContain("ValueError('Expected where operator")
 })

--- a/docs/CIP_4_In_Nin_Metadata_Filters.md
+++ b/docs/CIP_4_In_Nin_Metadata_Filters.md
@@ -8,8 +8,6 @@ Current Status: `Under Discussion`
 
 Currently, Chroma does not provide a way to filter metadata through `in` and `not in`. This appears to be
 
-> Observation: We consider the Auth to be applicable to client-server mode.
-
 ## **Public Interfaces**
 
 The changes will affect the following public interfaces:
@@ -51,4 +49,3 @@ TBD (property testing with hypothesis)
 ## **Rejected Alternatives**
 
 TBD
-

--- a/docs/CIP_4_In_Nin_Metadata_Filters.md
+++ b/docs/CIP_4_In_Nin_Metadata_Filters.md
@@ -6,7 +6,8 @@ Current Status: `Under Discussion`
 
 ## **Motivation**
 
-Currently, Chroma does not provide a way to filter metadata through `in` and `not in`. This appears to be
+Currently, Chroma does not provide a way to filter metadata through `in` and `not in`. This appears to be a frequent ask
+from community members.
 
 ## **Public Interfaces**
 
@@ -28,7 +29,7 @@ We suggest the following new operator definition:
 InclusionExclusionOperator = Union[Literal["$in"], Literal["$nin"]]
 ```
 
-Additionally we suggest that those operators are added to `OperatorExpression` for seamless integration with
+Additionally, we suggest that those operators are added to `OperatorExpression` for seamless integration with
 existing `Where` semantics:
 
 ```python
@@ -38,14 +39,23 @@ OperatorExpression = Union[
 ]
 ```
 
+An example of a query using the new operators would be:
+
+```python
+collection.query(query_texts=query,
+                 where={"$and": [{"author": {'$in': ['john', 'jill']}}, {"article_type": {"$eq": "blog"}}]},
+                 n_results=3)
+```
+
 ## **Compatibility, Deprecation, and Migration Plan**
 
-TBD
+The change is compatible with existing release 0.4.x.
 
 ## **Test Plan**
 
-TBD (property testing with hypothesis)
+Property tests will be updated to ensure boundary conditions are covered as well as interoperability with existing `Where`
+operators.
 
 ## **Rejected Alternatives**
 
-TBD
+N/A

--- a/docs/CIP_4_In_Nin_Metadata_Filters.md
+++ b/docs/CIP_4_In_Nin_Metadata_Filters.md
@@ -1,0 +1,54 @@
+# CIP-4: In and Not In Metadata Filters Proposal
+
+## Status
+
+Current Status: `Under Discussion`
+
+## **Motivation**
+
+Currently, Chroma does not provide a way to filter metadata through `in` and `not in`. This appears to be
+
+> Observation: We consider the Auth to be applicable to client-server mode.
+
+## **Public Interfaces**
+
+The changes will affect the following public interfaces:
+
+- `Where` and `OperatorExpression`
+  classes - https://github.com/chroma-core/chroma/blob/48700dd07f14bcfd8b206dc3b2e2795d5531094d/chromadb/types.py#L125-L129
+- `collection.get()`
+- `collection.query()`
+
+## **Proposed Changes**
+
+We suggest the introduction of two new operators `$in` and `$nin` that will be used to filter metadata. We call these
+operators `InclusionExclusionOperator`.
+
+We suggest the following new operator definition:
+
+```python
+InclusionExclusionOperator = Union[Literal["$in"], Literal["$nin"]]
+```
+
+Additionally we suggest that those operators are added to `OperatorExpression` for seamless integration with
+existing `Where` semantics:
+
+```python
+OperatorExpression = Union[
+    Dict[Union[WhereOperator, LogicalOperator], LiteralValue],
+    Dict[InclusionExclusionOperator, List[LiteralValue]],
+]
+```
+
+## **Compatibility, Deprecation, and Migration Plan**
+
+TBD
+
+## **Test Plan**
+
+TBD (property testing with hypothesis)
+
+## **Rejected Alternatives**
+
+TBD
+

--- a/examples/basic_functionality/in_not_in_filtering.ipynb
+++ b/examples/basic_functionality/in_not_in_filtering.ipynb
@@ -2,21 +2,28 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "id": "initial_id",
    "metadata": {
     "collapsed": true,
     "ExecuteTime": {
-     "end_time": "2023-08-23T15:37:05.771154Z",
-     "start_time": "2023-08-23T15:37:05.678479Z"
+     "end_time": "2023-08-30T12:48:38.227653Z",
+     "start_time": "2023-08-30T12:48:27.744069Z"
     }
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Number of requested results 10 is greater than number of elements in index 3, updating n_results = 3\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'ids': [['1', '3']], 'distances': [[0.28824201226234436, 1.017508625984192]], 'embeddings': None, 'metadatas': [[{'author': 'john'}, {'author': 'jill'}]], 'documents': [['Article by john', 'Article by Jill']]}\n",
+      "{'ids': [['1', '3']], 'distances': [[0.28824201226234436, 1.017508625984192]], 'metadatas': [[{'author': 'john'}, {'author': 'jill'}]], 'embeddings': None, 'documents': [['Article by john', 'Article by Jill']]}\n",
       "{'ids': ['1', '3'], 'embeddings': None, 'metadatas': [{'author': 'john'}, {'author': 'jill'}], 'documents': ['Article by john', 'Article by Jill']}\n"
      ]
     }
@@ -29,9 +36,9 @@
     "sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=\"all-MiniLM-L6-v2\")\n",
     "\n",
     "\n",
-    "client = chromadb.HttpClient()\n",
-    "client.heartbeat()\n",
-    "client.reset()\n",
+    "client = chromadb.Client()\n",
+    "# client.heartbeat()\n",
+    "# client.reset()\n",
     "collection = client.get_or_create_collection(\"test-where-list\", embedding_function=sentence_transformer_ef)\n",
     "collection.add(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
     "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"])\n",
@@ -45,18 +52,67 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "# Interactions with existing Where operators"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "752cef843ba2f900"
+  },
+  {
    "cell_type": "code",
-   "execution_count": 9,
-   "outputs": [],
-   "source": [],
+   "execution_count": 2,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'ids': [['1']],\n 'distances': [[0.28824201226234436]],\n 'metadatas': [[{'article_type': 'blog', 'author': 'john'}]],\n 'embeddings': None,\n 'documents': [['Article by john']]}"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection.upsert(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
+    "               metadatas=[{\"author\": \"john\",\"article_type\":\"blog\"}, {\"author\": \"jack\",\"article_type\":\"social\"}, {\"author\": \"jill\",\"article_type\":\"paper\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "\n",
+    "collection.query(query_texts=query,where={\"$and\":[{\"author\": {'$in': ['john', 'jill']}},{\"article_type\":{\"$eq\":\"blog\"}}]}, n_results=3)"
+   ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-08-11T13:05:16.526314Z",
-     "start_time": "2023-08-11T13:05:16.512459Z"
+     "end_time": "2023-08-30T12:48:49.974353Z",
+     "start_time": "2023-08-30T12:48:49.938985Z"
     }
    },
-   "id": "2489d5f5458f3df2"
+   "id": "ca56cda318f9e94d"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'ids': [['1', '3']],\n 'distances': [[0.28824201226234436, 1.017508625984192]],\n 'metadatas': [[{'article_type': 'blog', 'author': 'john'},\n   {'article_type': 'paper', 'author': 'jill'}]],\n 'embeddings': None,\n 'documents': [['Article by john', 'Article by Jill']]}"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection.query(query_texts=query,where={\"$or\":[{\"author\": {'$in': ['john']}},{\"article_type\":{\"$in\":[\"paper\"]}}]}, n_results=3)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-30T12:48:53.501431Z",
+     "start_time": "2023-08-30T12:48:53.481571Z"
+    }
+   },
+   "id": "f10e79ec90c797c1"
   },
   {
    "cell_type": "code",
@@ -66,7 +122,7 @@
    "metadata": {
     "collapsed": false
    },
-   "id": "f10e79ec90c797c1"
+   "id": "d97b8b6dd96261d0"
   }
  ],
  "metadata": {

--- a/examples/basic_functionality/in_not_in_filtering.ipynb
+++ b/examples/basic_functionality/in_not_in_filtering.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2023-08-23T15:37:05.771154Z",
+     "start_time": "2023-08-23T15:37:05.678479Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': [['1', '3']], 'distances': [[0.28824201226234436, 1.017508625984192]], 'embeddings': None, 'metadatas': [[{'author': 'john'}, {'author': 'jill'}]], 'documents': [['Article by john', 'Article by Jill']]}\n",
+      "{'ids': ['1', '3'], 'embeddings': None, 'metadatas': [{'author': 'john'}, {'author': 'jill'}], 'documents': ['Article by john', 'Article by Jill']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import chromadb\n",
+    "\n",
+    "from chromadb.utils import embedding_functions\n",
+    "\n",
+    "sentence_transformer_ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=\"all-MiniLM-L6-v2\")\n",
+    "\n",
+    "\n",
+    "client = chromadb.HttpClient()\n",
+    "client.heartbeat()\n",
+    "client.reset()\n",
+    "collection = client.get_or_create_collection(\"test-where-list\", embedding_function=sentence_transformer_ef)\n",
+    "collection.add(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
+    "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "\n",
+    "query = [\"Give me articles by john\"]\n",
+    "res = collection.query(query_texts=query,where={'author': {'$in': ['john', 'jill']}}, n_results=10)\n",
+    "print(res)\n",
+    "\n",
+    "res_get = collection.get(where={'author': {'$in': ['john', 'jill']}})\n",
+    "print(res_get)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-08-11T13:05:16.526314Z",
+     "start_time": "2023-08-11T13:05:16.512459Z"
+    }
+   },
+   "id": "2489d5f5458f3df2"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "f10e79ec90c797c1"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Cherry-picked from #1029

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Added support for `$in` and `$nin` metadata filters

> Note: See CIP in `docs/` or example notebook for more info

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
TBD
