### PR TITLE
[ENH]: AWS Deployment

### DIFF
--- a/examples/deployments/aws-terraform/README.md
+++ b/examples/deployments/aws-terraform/README.md
@@ -1,0 +1,155 @@
+# AWS EC2 Basic Deployment
+
+This is an example deployment to AWS EC2 Compute using [terraform](https://www.terraform.io/).
+
+This deployment will do the following:
+
+- Create a security group with required ports open (22 and 8000)
+- Create EC2 instance with Ubuntu 22 and deploy Chroma using docker compose
+- Create a data volume for Chroma data
+- Mount the data volume to the EC2 instance
+- Format the data volume with ext4
+- Start Chroma
+
+## Requirements
+
+- [Terraform CLI v1.3.4+](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli)
+
+## Deployment with terraform
+
+This deployment uses Ubuntu 22 as foundation, but you'd like to use a different AMI (non-Debian based image) you may have to adjust the startup script.
+
+To find AWS EC2 AMIs you can use:
+
+```bash
+# 099720109477 is Canonical
+aws ec2 describe-images \
+    --owners 099720109477 \
+    --filters 'Name=name,Values=ubuntu/images/*/ubuntu-jammy*' \
+    --query 'sort_by(Images,&CreationDate)[-1].ImageId'
+```
+
+### 2. Init your terraform state
+```bash
+terraform init
+```
+
+### 3. Deploy your application
+
+Generate SSH key to use with your chroma instance (so you can login to the EC2):
+
+> Note: This is optional. You can use your own existing SSH key if you prefer.
+
+```bash
+ssh-keygen -t RSA -b 4096 -C "Chroma AWS Key" -N "" -f ./chroma-aws && chmod 400 ./chroma-aws
+```
+
+Set up your Terraform variables and deploy your instance:
+
+```bash
+export TF_VAR_AWS_ACCESS_KEY=<AWS_ACCESS_KEY> #take note of this as it must be present in all of the subsequent steps
+export TF_VAR_AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> #take note of this as it must be present in all of the subsequent steps
+export TF_ssh_public_key="./chroma-aws.pub" #path to the public key you generated above (or can be different if you want to use your own key)
+export TF_ssh_private_key="./chroma-aws" #path to the private key you generated above (or can be different if you want to use your own key) - used for formatting the Chroma data volume
+export TF_VAR_chroma_release=0.4.8 #set the chroma release to deploy
+export TF_VAR_region="us-west-1" # AWS region to deploy the chroma instance to
+export TF_VAR_public_access="true" #enable public access to the chroma instance on port 8000
+export TF_VAR_enable_auth="true" #enable basic auth for the chroma instance
+export TF_VAR_auth_type="token" #The auth type to use for the chroma instance (token or basic)
+terraform apply -auto-approve
+```
+> Note: Basic Auth is supported by Chroma v0.4.7+
+
+### 4. Check your public IP and that Chroma is running
+
+Get the public IP of your instance
+
+```bash
+terraform output instance_public_ip
+```
+
+Check that chroma is running (It should take up several minutes for the instance to be ready)
+
+```bash
+export instance_public_ip=$(terraform output instance_public_ip | sed 's/"//g')
+curl -v http://$instance_public_ip:8000/api/v1/heartbeat
+```
+
+#### 4.1 Checking Auth
+
+##### Basic
+When basic auth is enabled you can check the get the credentials from Terraform state by running:
+
+```bash
+terraform output chroma_auth_basic
+```
+
+You should see something of the form:
+
+```bash
+chroma:VuA8I}QyNrm0@QLq
+```
+
+You can then export these credentials:
+
+```bash
+export CHROMA_AUTH=$(terraform output chroma_auth_basic)
+```
+
+Using the credentials:
+
+```bash
+curl -v http://$instance_public_ip:8000/api/v1/collections -u "${CHROMA_AUTH}"
+```
+
+> Note: Without `-u` you should be getting 401 Unauthorized response
+
+
+##### Token
+When token auth is enabled you can check the get the credentials from Terraform state by running:
+
+```bash
+terraform output chroma_auth_token
+```
+
+You should see something of the form:
+
+```bash
+PVcQ4qUUnmahXwUgAf3UuYZoMlos6MnF
+```
+
+You can then export these credentials:
+
+```bash
+export CHROMA_AUTH=$(terraform output chroma_auth_token)
+```
+
+Using the credentials:
+
+```bash
+curl -v http://$instance_public_ip:8000/api/v1/collections -H "Authorization: Bearer ${CHROMA_AUTH}"
+```
+
+#### 4.2 SSH to your instance
+
+
+To SSH to your instance:
+
+```bash
+ssh -i ./chroma-aws ubuntu@$instance_public_ip
+```
+
+### 5. Destroy your Chroma instance
+```bash
+terraform destroy -auto-approve
+```
+
+## Extras
+
+You can visualize your infrastructure with:
+
+```bash
+terraform graph | dot -Tsvg > graph.svg
+```
+
+>Note: You will need graphviz installed for this to work

--- a/examples/deployments/aws-terraform/README.md
+++ b/examples/deployments/aws-terraform/README.md
@@ -93,7 +93,7 @@ chroma:VuA8I}QyNrm0@QLq
 You can then export these credentials:
 
 ```bash
-export CHROMA_AUTH=$(terraform output chroma_auth_basic)
+export CHROMA_AUTH=$(terraform output chroma_auth_basic | sed 's/"//g')
 ```
 
 Using the credentials:
@@ -121,7 +121,7 @@ PVcQ4qUUnmahXwUgAf3UuYZoMlos6MnF
 You can then export these credentials:
 
 ```bash
-export CHROMA_AUTH=$(terraform output chroma_auth_token)
+export CHROMA_AUTH=$(terraform output chroma_auth_token | sed 's/"//g')
 ```
 
 Using the credentials:

--- a/examples/deployments/aws-terraform/chroma.tf
+++ b/examples/deployments/aws-terraform/chroma.tf
@@ -1,0 +1,168 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Define provider
+variable "AWS_ACCESS_KEY" {}
+variable "AWS_SECRET_ACCESS_KEY" {}
+
+provider "aws" {
+  access_key = var.AWS_ACCESS_KEY
+  secret_key = var.AWS_SECRET_ACCESS_KEY
+  region     = var.region
+}
+
+# Create security group
+resource "aws_security_group" "chroma_sg" {
+  name        = "chroma-cluster-sg"
+  description = "Security group for the cluster nodes"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  dynamic "ingress" {
+    for_each = var.public_access ? [1] : []
+    content {
+      from_port   = 8000
+      to_port     = 8000
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+  #
+  #  ingress {
+  #    from_port        = 0
+  #    to_port          = 0
+  #    protocol         = "-1"
+  #    self             = true
+  #  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "chroma"
+  }
+}
+
+resource "aws_key_pair" "chroma-keypair" {
+  key_name   = "chroma-keypair"  # Replace with your desired key pair name
+  public_key = file(var.ssh_public_key)  # Replace with the path to your public key file
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+# Create EC2 instances
+resource "aws_instance" "chroma_instance" {
+  ami             = data.aws_ami.ubuntu.id
+  instance_type   = var.instance_type
+  key_name        = "chroma-keypair"
+  security_groups = [aws_security_group.chroma_sg.name]
+
+  user_data = templatefile("${path.module}/startup.sh", {
+    chroma_release         = var.chroma_release,
+    enable_auth            = var.enable_auth,
+    auth_type              = var.auth_type,
+    basic_auth_credentials = "${local.basic_auth_credentials.username}:${local.basic_auth_credentials.password}",
+    token_auth_credentials = random_password.chroma_token.result,
+  })
+
+  tags = {
+    Name = "chroma"
+  }
+
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    volume_size = var.chroma_instance_volume_size  # size in GBs, set as you need
+  }
+}
+
+
+resource "aws_ebs_volume" "chroma-volume" {
+  availability_zone = aws_instance.chroma_instance.availability_zone
+  size              = var.chroma_data_volume_size
+
+  tags = {
+    Name = "chroma"
+  }
+
+#  lifecycle {
+#    prevent_destroy = true
+#  }
+}
+
+locals {
+  cleaned_volume_id = replace(aws_ebs_volume.chroma-volume.id, "-", "")
+}
+
+resource "aws_volume_attachment" "chroma_volume_attachment" {
+  device_name = "/dev/sdh"
+  volume_id   = aws_ebs_volume.chroma-volume.id
+  instance_id = aws_instance.chroma_instance.id
+  provisioner "remote-exec" {
+    inline = [
+      "export VOLUME_ID=${local.cleaned_volume_id} && sudo mkfs -t ext4 /dev/$(lsblk -o +SERIAL | grep $VOLUME_ID | awk '{print $1}')",
+      "sudo mkdir /chroma-data",
+      "export VOLUME_ID=${local.cleaned_volume_id} && sudo mount /dev/$(lsblk -o +SERIAL | grep $VOLUME_ID | awk '{print $1}') /chroma-data"
+    ]
+
+    connection {
+      host = aws_instance.chroma_instance.public_ip
+      type = "ssh"
+      user = "ubuntu"
+      private_key = file(var.ssh_private_key)
+    }
+  }
+    depends_on = [aws_instance.chroma_instance, aws_ebs_volume.chroma-volume]
+}
+
+
+output "instance_public_ip" {
+  value = aws_instance.chroma_instance.public_ip
+}
+
+output "instance_private_ip" {
+  value = aws_instance.chroma_instance.private_ip
+}
+
+output "chroma_auth_token" {
+  value = random_password.chroma_token.result
+  sensitive = true
+}
+
+
+output "chroma_auth_basic" {
+  value = "${local.basic_auth_credentials.username}:${local.basic_auth_credentials.password}"
+  sensitive = true
+}

--- a/examples/deployments/aws-terraform/chroma.tf
+++ b/examples/deployments/aws-terraform/chroma.tf
@@ -38,13 +38,6 @@ resource "aws_security_group" "chroma_sg" {
       cidr_blocks = ["0.0.0.0/0"]
     }
   }
-  #
-  #  ingress {
-  #    from_port        = 0
-  #    to_port          = 0
-  #    protocol         = "-1"
-  #    self             = true
-  #  }
 
   egress {
     from_port        = 0
@@ -104,7 +97,7 @@ resource "aws_instance" "chroma_instance" {
 
   ebs_block_device {
     device_name = "/dev/sda1"
-    volume_size = var.chroma_instance_volume_size  # size in GBs, set as you need
+    volume_size = var.chroma_instance_volume_size  # size in GBs
   }
 }
 
@@ -117,9 +110,9 @@ resource "aws_ebs_volume" "chroma-volume" {
     Name = "chroma"
   }
 
-#  lifecycle {
-#    prevent_destroy = true
-#  }
+  lifecycle {
+    prevent_destroy = var.prevent_chroma_data_volume_delete # size in GBs
+  }
 }
 
 locals {

--- a/examples/deployments/aws-terraform/startup.sh
+++ b/examples/deployments/aws-terraform/startup.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+
+# Note: This is run as root
+
+cd ~
+export enable_auth="${enable_auth}"
+export basic_auth_credentials="${basic_auth_credentials}"
+export auth_type="${auth_type}"
+export token_auth_credentials="${token_auth_credentials}"
+apt-get update -y
+apt-get install -y ca-certificates curl gnupg lsb-release
+mkdir -m 0755 -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update -y
+chmod a+r /etc/apt/keyrings/docker.gpg
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git
+usermod -aG docker ubuntu
+git clone https://github.com/chroma-core/chroma.git && cd chroma
+git fetch --tags
+git checkout tags/${chroma_release}
+
+if [ "$${enable_auth}" = "true" ] && [ "$${auth_type}" = "basic" ] && [ ! -z "$${basic_auth_credentials}" ]; then
+  username=$(echo $basic_auth_credentials | cut -d: -f1)
+  password=$(echo $basic_auth_credentials | cut -d: -f2)
+  docker run --rm --entrypoint htpasswd httpd:2 -Bbn $username $password > server.htpasswd
+  cat <<EOF > .env
+CHROMA_SERVER_AUTH_CREDENTIALS_FILE="/chroma/server.htpasswd"
+CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER='chromadb.auth.providers.HtpasswdFileServerAuthCredentialsProvider'
+CHROMA_SERVER_AUTH_PROVIDER='chromadb.auth.basic.BasicAuthServerProvider'
+EOF
+fi
+
+if [ "$${enable_auth}" = "true" ] && [ "$${auth_type}" = "token" ] && [ ! -z "$${token_auth_credentials}" ]; then
+  cat <<EOF > .env
+CHROMA_SERVER_AUTH_CREDENTIALS="$${token_auth_credentials}" \
+CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER='chromadb.auth.token.TokenConfigServerAuthCredentialsProvider'
+CHROMA_SERVER_AUTH_PROVIDER='chromadb.auth.token.TokenAuthServerProvider'
+EOF
+fi
+
+cat <<EOF > docker-compose.override.yaml
+version: '3.8'
+services:
+  server:
+    volumes:
+      - /chroma-data:/chroma/chroma
+EOF
+
+COMPOSE_PROJECT_NAME=chroma docker compose up -d --build

--- a/examples/deployments/aws-terraform/variables.tf
+++ b/examples/deployments/aws-terraform/variables.tf
@@ -1,0 +1,88 @@
+variable "chroma_release" {
+  description = "The chroma release to deploy"
+  type        = string
+  default     = "0.4.8"
+}
+
+variable "region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-west-1"
+}
+
+variable "instance_type" {
+  description = "AWS EC2 Instance Type"
+  type        = string
+  default     = "t3.medium"
+}
+
+
+variable "public_access" {
+  description = "Enable public ingress on port 8000"
+  type        = bool
+  default     = true // or true depending on your needs
+}
+
+variable "enable_auth" {
+  description = "Enable authentication"
+  type        = bool
+  default     = true // or false depending on your needs
+}
+
+variable "auth_type" {
+  description = "Authentication type"
+  type        = string
+  default     = "token" // or token depending on your needs
+  validation {
+    condition     = contains(["basic", "token"], var.auth_type)
+    error_message = "The auth type must be either basic or token"
+  }
+}
+
+resource "random_password" "chroma_password" {
+  length  = 16
+  special = true
+  lower   = true
+  upper   = true
+}
+
+resource "random_password" "chroma_token" {
+  length  = 32
+  special = false
+  lower   = true
+  upper   = true
+}
+
+
+locals {
+  basic_auth_credentials = {
+    username = "chroma"
+    password = random_password.chroma_password.result
+  }
+  token_auth_credentials = {
+    token = random_password.chroma_token.result
+  }
+}
+
+variable "ssh_public_key" {
+  description = "SSH Public Key"
+  type        = string
+  default     = "./chroma-aws.pub"
+}
+variable "ssh_private_key" {
+  description = "SSH Private Key"
+  type        = string
+  default     = "./chroma-aws"
+}
+
+variable "chroma_instance_volume_size" {
+  description = "The size of the instance volume - the root volume"
+  type        = number
+  default     = 30
+}
+
+variable "chroma_data_volume_size" {
+  description = "EBS Volume Size of the attached data volume where your chroma data is stored"
+  type        = number
+  default     = 20
+}

--- a/examples/deployments/aws-terraform/variables.tf
+++ b/examples/deployments/aws-terraform/variables.tf
@@ -86,3 +86,9 @@ variable "chroma_data_volume_size" {
   type        = number
   default     = 20
 }
+
+variable "prevent_chroma_data_volume_delete" {
+    description = "Prevent the chroma data volume from being deleted when the instance is terminated"
+    type        = bool
+    default     = false
+}


### PR DESCRIPTION
Refactored and Rebased version of #1059

## Description of changes

This template includes the following:

- Create a security group with required ports open (22 and 8000)
- Create EC2 instance with Ubuntu 22 and deploy Chroma using docker compose
- Create a data volume (ESB) for Chroma data
- Mount the data volume to the EC2 instance
- Format the data volume with ext4
- Start Chroma
- Enable (by default) Token Auth with randomly generated token

## Test plan
*How are these changes tested?*

- Terraform tests performed

## Documentation Changes
The template contains README with a tutorial on how to use it.
