### PR TITLE
[ENH] Pythonic Metadata Filters

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -7,6 +7,7 @@ from chromadb.telemetry import Telemetry
 from chromadb.config import Settings, System
 from chromadb.api import API
 from chromadb.api.models.Collection import Collection
+from chromadb.utils.query_helper import WhereFilter
 from chromadb.api.types import (
     CollectionMetadata,
     Documents,
@@ -37,6 +38,7 @@ __all__ = [
     "UpdateCollectionMetadata",
     "QueryResult",
     "GetResult",
+    "WhereFilter",
 ]
 
 

--- a/chromadb/test/property/test_pythonic_filters.py
+++ b/chromadb/test/property/test_pythonic_filters.py
@@ -1,6 +1,6 @@
 import string
-from typing import get_args, Any
-
+from typing import Any
+from typing_extensions import get_args
 from hypothesis import strategies as st, given
 from hypothesis.strategies import SearchStrategy
 

--- a/chromadb/test/property/test_pythonic_filters.py
+++ b/chromadb/test/property/test_pythonic_filters.py
@@ -1,0 +1,108 @@
+import string
+from typing import get_args, Any
+
+from hypothesis import strategies as st, given
+from hypothesis.strategies import SearchStrategy
+
+from chromadb import Where
+from chromadb.types import WhereOperator, InclusionExclusionOperator
+from chromadb.utils.query_helper import Filter
+
+
+def join_to_str(terms: Any) -> str:
+    return " ".join(
+        [
+            f'"{term}"'
+            if isinstance(term, str)
+            and term
+            not in ["==", "!=", ">", ">=", "<", "<=", "and", "or", "in", "not in"]
+            else str(term)
+            for term in terms
+        ]
+    )
+
+
+def join_with_logical(terms: Any, operator: str) -> str:
+    return f"({f' {operator} '.join(terms)})"
+
+
+equal_operators = st.sampled_from(["==", "!="])
+comp_operators = st.sampled_from([">", ">=", "<", "<="])
+logical_operators = st.sampled_from(["and", "or"])
+set_operators = st.sampled_from(["in", "not in"])
+
+set_values = st.one_of(
+    st.lists(st.integers(), min_size=1, max_size=4),
+    st.lists(st.text(), min_size=1, max_size=4),
+    st.lists(st.booleans(), min_size=1, max_size=4),
+)
+
+
+def escape_special_chars(s: str) -> str:
+    return s.encode("unicode_escape").decode()
+
+
+def filter_quotes(s: str) -> bool:
+    return '"' not in s and "'''" not in s and '"""' not in s
+
+
+escaped_text = st.text().map(escape_special_chars).filter(filter_quotes)
+
+values = st.one_of(st.integers(), escaped_text, st.booleans())
+
+valid_chars = string.digits + string.ascii_letters + "_-"
+variables = st.text(alphabet=valid_chars, min_size=1, max_size=5).filter(
+    lambda x: x[0]
+    not in ["==", "!=", ">", ">=", "<", "<=", "and", "or", "in", "not in"]
+)
+
+basic_expr_equal = st.tuples(variables, equal_operators, values).map(join_to_str)
+basic_expr_comp = st.tuples(variables, comp_operators, st.integers()).map(join_to_str)
+basic_expr_set = st.tuples(variables, set_operators, set_values).map(
+    lambda x: f'"{x[0]}" {x[1]} {x[2]}'
+)
+
+basic_expr = st.one_of(basic_expr_equal, basic_expr_comp, basic_expr_set)
+
+
+class ComplexExprGen:
+    def __init__(self, logical_ops: SearchStrategy[str]) -> None:
+        self.logical_ops = logical_ops
+
+    def __call__(self, exprs: Any) -> SearchStrategy[str]:
+        return st.tuples(
+            st.lists(exprs, min_size=2, max_size=4), st.one_of(self.logical_ops)
+        ).map(lambda x: join_with_logical(x[0], x[1]))
+
+
+final_expr_strategy = st.recursive(
+    basic_expr, ComplexExprGen(logical_operators), max_leaves=10
+)
+
+allowed_operators = set(
+    x.__args__[0]
+    for x in get_args(WhereOperator) + get_args(InclusionExclusionOperator)
+)
+
+
+def validate_where_expression(expr: Where) -> bool:
+    for k, v in expr.items():
+        if k in ["$and", "$or"]:
+            if not isinstance(v, list):
+                return False
+            for sub_expr in v:
+                if not validate_where_expression(sub_expr):
+                    return False
+        else:
+            if isinstance(v, dict):
+                if not all(op in allowed_operators for op in v.keys()):
+                    return False
+            elif not isinstance(v, (str, int, float, bool)):
+                return False
+    return True
+
+
+@given(expr=final_expr_strategy)
+def test_expr(expr: str) -> None:
+    v = validate_where_expression(Filter.where(expr))
+    assert v is True, f"Failed for {expr}"

--- a/chromadb/test/property/test_pythonic_filters.py
+++ b/chromadb/test/property/test_pythonic_filters.py
@@ -6,7 +6,7 @@ from hypothesis.strategies import SearchStrategy
 
 from chromadb import Where
 from chromadb.types import WhereOperator, InclusionExclusionOperator
-from chromadb.utils.query_helper import Filter
+from chromadb.utils.query_helper import WhereFilter
 
 
 def join_to_str(terms: Any) -> str:
@@ -104,5 +104,5 @@ def validate_where_expression(expr: Where) -> bool:
 
 @given(expr=final_expr_strategy)
 def test_expr(expr: str) -> None:
-    v = validate_where_expression(Filter.where(expr))
+    v = validate_where_expression(WhereFilter(expr))  # type: ignore
     assert v is True, f"Failed for {expr}"

--- a/chromadb/utils/query_helper.py
+++ b/chromadb/utils/query_helper.py
@@ -1,0 +1,195 @@
+import ast
+import inspect
+import os.path
+import traceback
+from types import FrameType
+from typing import Any, Dict, cast, get_args, Union, Optional
+
+from chromadb.types import (
+    WhereOperator,
+    InclusionExclusionOperator,
+    LiteralValue,
+    Where,
+)
+
+
+def _map_ast_operator_to_where_operator(
+    operator: Union[
+        ast.Eq, ast.NotEq, ast.In, ast.NotIn, ast.Gt, ast.GtE, ast.Lt, ast.LtE
+    ]
+) -> Union[WhereOperator, InclusionExclusionOperator]:
+    if isinstance(operator, ast.Eq):
+        return "$eq"
+    elif isinstance(operator, ast.NotEq):
+        return "$ne"
+    elif isinstance(operator, ast.Gt):
+        return "$gt"
+    elif isinstance(operator, ast.GtE):
+        return "$gte"
+    elif isinstance(operator, ast.Lt):
+        return "$lt"
+    elif isinstance(operator, ast.LtE):
+        return "$lte"
+    elif isinstance(operator, ast.In):
+        return "$in"
+    elif isinstance(operator, ast.NotIn):
+        return "$nin"
+    else:
+        raise ValueError(f"Unsupported operator: {operator}")
+
+
+def process_ast_compare(node: ast.Compare) -> Dict[str, Any]:
+    if isinstance(node.left, ast.Name):
+        left = node.left.id
+    elif isinstance(node.left, ast.Attribute):
+        left = node.left.attr
+    elif isinstance(node.left, ast.Str):
+        left = node.left.s
+    else:
+        raise ValueError(
+            f"Unsupported left hand side type: {type(node.left)}. Must be a string."
+        )
+    operator = node.ops[0]
+    # print(f"operator: {operator}")
+    right = node.comparators[0]
+    if not isinstance(
+        operator,
+        (ast.Eq, ast.NotEq, ast.In, ast.NotIn, ast.Gt, ast.GtE, ast.Lt, ast.LtE),
+    ):
+        raise ValueError(f"Unsupported operator: {operator}")
+    if isinstance(right, (ast.Str, ast.Num, ast.Constant)):
+        right_value = right.value
+    elif isinstance(right, ast.List):
+        right_value = [_process_ast(value) for value in right.elts]
+    elif isinstance(right, ast.UnaryOp):
+        if isinstance(right.op, ast.USub) and isinstance(right.operand, ast.Num):
+            right_value = f"-{right.operand.n}"
+        else:
+            raise ValueError(
+                f"Unsupported right hand side type: {type(right)}. Must be a string or a list of strings."
+            )
+    else:
+        raise ValueError(
+            f"Unsupported right hand side type: {type(right)}. Must be a string or a list of strings."
+        )
+    if isinstance(
+        operator,
+        (ast.Eq, ast.NotEq, ast.In, ast.NotIn, ast.Gt, ast.GtE, ast.Lt, ast.LtE),
+    ):
+        return {
+            f"{left}": {f"{_map_ast_operator_to_where_operator(operator)}": right_value}
+        }
+    else:
+        raise ValueError(
+            f"Unsupported right hand side type: {type(right)}. Must be a string or a list of strings."
+        )
+
+
+def _process_ast(node: Any) -> Union[LiteralValue, Dict[str, Any]]:
+    # print(f"Processing node: {node}")
+    if isinstance(node, ast.BoolOp):
+        if isinstance(node.op, ast.And):
+            return {"$and": [_process_ast(value) for value in node.values]}
+        elif isinstance(node.op, ast.Or):
+            return {"$or": [_process_ast(value) for value in node.values]}
+    elif isinstance(node, ast.Compare):
+        return process_ast_compare(node)
+    elif isinstance(node, ast.Module):
+        return _process_ast(node.body[0])
+    elif isinstance(node, ast.Expr):
+        return _process_ast(node.value)
+    elif isinstance(node, get_args(LiteralValue)) or isinstance(node, ast.Constant):
+        return cast(LiteralValue, node.value)
+    # elif isinstance(node, ) and isinstance(
+    #     node.value, get_args(LiteralValue)
+    # ):
+    #     return cast(LiteralValue, node.value)
+    elif isinstance(node, ast.UnaryOp):
+        if isinstance(node.op, ast.USub) and isinstance(node.operand, ast.Num):
+            return f"-{node.operand.n}"
+        else:
+            raise ValueError(
+                f"Unsupported right hand side type: {type(node)}. Must be a string or a list of strings."
+            )
+    raise ValueError(f"Unsupported node type: {type(node)}")
+
+
+def extract_conditions_text(
+    line: str, where_function_name: str = "Filter.where"
+) -> str:
+    start = line[line.find(where_function_name) + len(where_function_name) :]
+    condition = ""
+    stack = []
+    for c in start:
+        if c == "(":
+            stack.append(c)
+        elif c == ")" and stack:
+            stack.pop()
+        if len(stack) > 0:
+            condition += c
+        if len(stack) == 0:
+            break
+    if len(stack) > 0:
+        raise ValueError(
+            "Invalid expression. For multi-line expression, "
+            "use quotes to wrap your expression. The environment you're using "
+            "does not support pure python expressions parsing from source (e.g. Jupyter notebook)."
+        )
+    condition = condition[1:]
+    return condition
+
+
+def extract_conditions_fame(
+    frame: Optional[FrameType], where_function_name: str
+) -> str:
+    if not frame:
+        raise ValueError("Unable to extract conditions from the current frame.")
+    filename = frame.f_code.co_filename
+    lineno = frame.f_lineno
+
+    with open(filename, "r") as f:
+        lines = f.readlines()
+
+    condition = ""
+    stack = []
+    for li, line in enumerate(lines[lineno - 1 :]):
+        if li == 0:
+            line = line[line.find(where_function_name) :]
+        for c in line:
+            if c == "(":
+                stack.append(c)
+            elif c == ")":
+                if stack:
+                    stack.pop()
+            if len(stack) > 0:
+                condition += c
+
+        if len(stack) == 0:
+            break
+    if where_function_name in condition:
+        return (
+            condition[len(where_function_name) + 2 :][:-1]
+            .replace("\n", "")
+            .replace("  ", "")
+        )
+    else:
+        return condition[1:].replace("\n", "").replace("  ", "")
+
+
+class Filter(object):
+    @staticmethod
+    def where(e: Union[str, bool]) -> Where:
+        if isinstance(e, str):
+            _filter_expr = _process_ast(ast.parse(e))
+        else:
+            stack = traceback.extract_stack()
+            filename, _, _, text = stack[-2]
+            if os.path.exists(filename):
+                frame = inspect.currentframe()
+                _expr = extract_conditions_fame(
+                    frame.f_back if frame else None, "Filter.where"
+                )
+            else:
+                _expr = extract_conditions_text(text)
+            _filter_expr = _process_ast(ast.parse(_expr))
+        return cast(Where, _filter_expr)

--- a/chromadb/utils/query_helper.py
+++ b/chromadb/utils/query_helper.py
@@ -2,8 +2,8 @@ import ast
 import inspect
 import linecache
 from types import FrameType
-from typing import Any, Dict, cast, get_args, Union, Optional
-
+from typing import Any, Dict, cast, Union, Optional
+from typing_extensions import get_args
 from chromadb.types import (
     WhereOperator,
     InclusionExclusionOperator,

--- a/chromadb/utils/query_helper.py
+++ b/chromadb/utils/query_helper.py
@@ -1,7 +1,6 @@
 import ast
 import inspect
-import os.path
-import traceback
+import linecache
 from types import FrameType
 from typing import Any, Dict, cast, get_args, Union, Optional
 
@@ -50,7 +49,6 @@ def process_ast_compare(node: ast.Compare) -> Dict[str, Any]:
             f"Unsupported left hand side type: {type(node.left)}. Must be a string."
         )
     operator = node.ops[0]
-    # print(f"operator: {operator}")
     right = node.comparators[0]
     if not isinstance(
         operator,
@@ -86,7 +84,6 @@ def process_ast_compare(node: ast.Compare) -> Dict[str, Any]:
 
 
 def _process_ast(node: Any) -> Union[LiteralValue, Dict[str, Any]]:
-    # print(f"Processing node: {node}")
     if isinstance(node, ast.BoolOp):
         if isinstance(node.op, ast.And):
             return {"$and": [_process_ast(value) for value in node.values]}
@@ -100,10 +97,6 @@ def _process_ast(node: Any) -> Union[LiteralValue, Dict[str, Any]]:
         return _process_ast(node.value)
     elif isinstance(node, get_args(LiteralValue)) or isinstance(node, ast.Constant):
         return cast(LiteralValue, node.value)
-    # elif isinstance(node, ) and isinstance(
-    #     node.value, get_args(LiteralValue)
-    # ):
-    #     return cast(LiteralValue, node.value)
     elif isinstance(node, ast.UnaryOp):
         if isinstance(node.op, ast.USub) and isinstance(node.operand, ast.Num):
             return f"-{node.operand.n}"
@@ -114,31 +107,6 @@ def _process_ast(node: Any) -> Union[LiteralValue, Dict[str, Any]]:
     raise ValueError(f"Unsupported node type: {type(node)}")
 
 
-def extract_conditions_text(
-    line: str, where_function_name: str = "Filter.where"
-) -> str:
-    start = line[line.find(where_function_name) + len(where_function_name) :]
-    condition = ""
-    stack = []
-    for c in start:
-        if c == "(":
-            stack.append(c)
-        elif c == ")" and stack:
-            stack.pop()
-        if len(stack) > 0:
-            condition += c
-        if len(stack) == 0:
-            break
-    if len(stack) > 0:
-        raise ValueError(
-            "Invalid expression. For multi-line expression, "
-            "use quotes to wrap your expression. The environment you're using "
-            "does not support pure python expressions parsing from source (e.g. Jupyter notebook)."
-        )
-    condition = condition[1:]
-    return condition
-
-
 def extract_conditions_fame(
     frame: Optional[FrameType], where_function_name: str
 ) -> str:
@@ -147,15 +115,13 @@ def extract_conditions_fame(
     filename = frame.f_code.co_filename
     lineno = frame.f_lineno
 
-    with open(filename, "r") as f:
-        lines = f.readlines()
-
     condition = ""
     stack = []
-    for li, line in enumerate(lines[lineno - 1 :]):
-        if li == 0:
-            line = line[line.find(where_function_name) :]
-        for c in line:
+    for i in range(lineno, lineno + 50):
+        c_line = linecache.getline(filename, i).strip()
+        if c_line.find(where_function_name) != -1:
+            c_line = c_line[c_line.find(where_function_name) :]
+        for c in c_line:
             if c == "(":
                 stack.append(c)
             elif c == ")":
@@ -176,20 +142,24 @@ def extract_conditions_fame(
         return condition[1:].replace("\n", "").replace("  ", "")
 
 
-class Filter(object):
+class WhereFilter(object):
+    def __new__(cls, e: Union[str, bool]) -> Where:  # type: ignore
+        frame = inspect.currentframe()
+        name = cls.__name__
+        if frame and frame.f_back:
+            for k, v in frame.f_back.f_globals.items():
+                if v == cls:
+                    name = k
+        return cls.where(e, name)
+
     @staticmethod
-    def where(e: Union[str, bool]) -> Where:
+    def where(e: Union[str, bool], f_name: str = "WhereFilter") -> Where:
         if isinstance(e, str):
             _filter_expr = _process_ast(ast.parse(e))
         else:
-            stack = traceback.extract_stack()
-            filename, _, _, text = stack[-2]
-            if os.path.exists(filename):
-                frame = inspect.currentframe()
-                _expr = extract_conditions_fame(
-                    frame.f_back if frame else None, "Filter.where"
-                )
-            else:
-                _expr = extract_conditions_text(text)
+            frame = inspect.currentframe()
+            _expr = extract_conditions_fame(
+                frame.f_back.f_back if frame and frame.f_back else None, f_name
+            )
             _filter_expr = _process_ast(ast.parse(_expr))
         return cast(Where, _filter_expr)

--- a/docs/CIP_6_Pythonic_Metadata_Filters.md
+++ b/docs/CIP_6_Pythonic_Metadata_Filters.md
@@ -1,0 +1,78 @@
+- https://chat.openai.com/share/82173746-d590-427c-b40e-537bea57ab99
+
+# CIP-6: Pythonic Metadata Filters
+
+## Status
+
+Current Status: `Under Discussion`
+
+## **Motivation**
+
+The main motivation for fluid filter is to promote the use of filters use through improved developer experience.
+
+## **Public Interfaces**
+
+This change does not involve any changes to public interfaces.
+
+## **Proposed Changes**
+
+We propose this change to ship as a utility library that can be used instead of the standard filter syntax.
+
+We propose the following syntax:
+
+```python
+collection.get(where=Filter.where("category" == "chroma" and ("author" == "john" or "author" == "jack")))
+```
+
+Compared to existing approach:
+
+```python
+collection.get(where={"$and": [{"category": "chroma"}, {"$or": [{"author": "john"}, {"author": "jack"}]}]})
+```
+
+We believe that the proposed approach is easier to read and understand (with minor exception of the quoted attribute
+names).
+
+## **Compatibility, Deprecation, and Migration Plan**
+
+The proposed change is fully compatible with the current implementation and does not require any migration.
+
+## **Test Plan**
+
+New property unit tests to be added to the existing test suite.
+
+## **Rejected Alternatives**
+
+1. Filter.where(attr("k") == "10").And((attr("p") == "x").Or(attr("p") == "y"))
+2. Filter.where(attr.k == "10").And((attr.p == "x").Or(attr.p == "y"))
+3. attr("k").Eq(10).And((attr("p").Eq("x")).Or(attr("p").Eq("y")))
+
+### Filter.where(attr("k") == "10").And((attr("p") == "x").Or(attr("p") == "y"))
+
+Developer Experience: Moderate; need to remember where, And, Or.
+Pythonic: Not really, too many custom methods.
+Fluidity: Moderate; relies on chained methods.
+Ease of Use: Moderate; can get complex quickly.
+
+Reason for rejection: While this is a good approach, it still is not frictionless and requires the use of for
+attributes.
+
+### Filter.where(attr.k == "10").And((attr.p == "x").Or(attr.p == "y"))
+
+Developer Experience: Better due to attribute-style access.
+Pythonic: More Pythonic than the first; leverages attributes.
+Fluidity: Good; fluent style.
+Ease of Use: Good; easier due to attributes.
+
+[Reason for rejection: While this is a good approach, it still is not frictionless and requires the use of for
+]()attributes. Additionally chaining of logical operators is difficult to follow.
+
+### attr("k").Eq(10).And((attr("p").Eq("x")).Or(attr("p").Eq("y")))
+
+Developer Experience: Okay; need to remember Eq, And, Or.
+Pythonic: Not really; too many custom methods.
+Fluidity: Okay; fluent but verbose.
+Ease of Use: Moderate; verbose.
+
+Rejection reason: While ok with the use of methods for the operators, it is not very easy to read and understand. Can
+get messy with more complicated expressions.

--- a/examples/basic_functionality/pythonic_filters.ipynb
+++ b/examples/basic_functionality/pythonic_filters.ipynb
@@ -15,8 +15,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-09-05T20:37:11.464465Z",
-     "start_time": "2023-09-05T20:37:10.986610Z"
+     "end_time": "2023-09-05T23:31:24.887049Z",
+     "start_time": "2023-09-05T23:31:24.444644Z"
     }
    },
    "outputs": [
@@ -25,8 +25,7 @@
      "output_type": "stream",
      "text": [
       "{'ids': ['id7'], 'embeddings': None, 'metadatas': [{'status': 'read'}], 'documents': ['A document that discusses international affairs']}\n",
-      "{'ids': ['id7'], 'embeddings': None, 'metadatas': [{'status': 'read'}], 'documents': ['A document that discusses international affairs']}\n",
-      "{'ids': ['id7'], 'embeddings': None, 'metadatas': [{'status': 'read'}], 'documents': ['A document that discusses international affairs']}\n"
+      "{'ids': ['id2', 'id7', 'id8'], 'embeddings': None, 'metadatas': [{'status': 'unread'}, {'status': 'read'}, {'status': 'unread'}], 'documents': ['A document that discusses international affairs', 'A document that discusses international affairs', 'A document that discusses global affairs']}\n"
      ]
     }
    ],
@@ -35,7 +34,7 @@
     "client = chromadb.Client()\n",
     "# Create a new chroma collection\n",
     "collection_name = \"filter_example_collection\"\n",
-    "collection = client.create_collection(name=collection_name)\n",
+    "collection = client.get_or_create_collection(name=collection_name)\n",
     "# Add some data to the collection\n",
     "collection.add(\n",
     "    embeddings=[\n",
@@ -61,25 +60,19 @@
     "    documents=[\"A document that discusses domestic policy\", \"A document that discusses international affairs\", \"A document that discusses kittens\", \"A document that discusses dogs\", \"A document that discusses chocolate\", \"A document that is sixth that discusses government\", \"A document that discusses international affairs\", \"A document that discusses global affairs\"],\n",
     "    ids=[\"id1\", \"id2\", \"id3\", \"id4\", \"id5\", \"id6\", \"id7\", \"id8\"],\n",
     ")\n",
-    "from chromadb.utils.query_helper import Filter\n",
-    "\n",
+    "from chromadb import WhereFilter\n",
     "# Get documents that are read and about affairs\n",
     "simple_query=collection.get(\n",
-    "    where=Filter.where(\"status\"== \"read\"), \n",
+    "    where=WhereFilter(\"status\"== \"read\"), \n",
     "    where_document={\"$contains\": \"affairs\"})\n",
     "\n",
-    "quoted=collection.get(\n",
-    "    where=Filter.where('\"status\"== \"read\"'),\n",
-    "    where_document={\"$contains\": \"affairs\"})\n",
-    "\n",
-    "multi_line_quoted=collection.get(\n",
-    "    where=Filter.where('\"status\"'\n",
-    "                       '== \"read\"'),\n",
+    "multi_line=collection.get(\n",
+    "    where=WhereFilter(\"status\"== \"read\" \n",
+    "                       or \"status\"== \"unread\"),\n",
     "    where_document={\"$contains\": \"affairs\"})\n",
     "\n",
     "print(simple_query)\n",
-    "print(quoted)\n",
-    "print(multi_line_quoted)"
+    "print(multi_line)"
    ]
   },
   {
@@ -98,23 +91,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Add of existing embedding ID: 1\n",
-      "Add of existing embedding ID: 2\n",
-      "Add of existing embedding ID: 3\n",
-      "Add of existing embedding ID: 1\n",
-      "Add of existing embedding ID: 2\n",
-      "Add of existing embedding ID: 3\n",
-      "Insert of existing embedding ID: 1\n",
-      "Insert of existing embedding ID: 2\n",
-      "Insert of existing embedding ID: 3\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -133,15 +111,74 @@
     "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"])\n",
     "\n",
     "q1=collection.get(where={\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]})\n",
-    "q2=collection.get(where=Filter.where(\"author\"==\"john\" or \"author\"==\"jack\"))\n",
+    "q2=collection.get(where=WhereFilter(\"author\"==\"john\" or \"author\"==\"jack\"))\n",
     "print(q1)\n",
     "print(q2)"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-05T19:23:17.106640Z",
-     "start_time": "2023-09-05T19:23:17.018786Z"
+     "end_time": "2023-09-05T23:31:26.832221Z",
+     "start_time": "2023-09-05T23:31:26.639494Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n",
+      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And Logical Operator Filtering\n",
+    "collection = client.get_or_create_collection(\"test-where-list\")\n",
+    "collection.upsert(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
+    "               metadatas=[{\"author\": \"john\",\"category\":\"chroma\"}, {\"author\": \"jack\",\"category\":\"ml\"}, {\"author\": \"jill\",\"category\":\"lifestyle\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"john\"}]})\n",
+    "q2=collection.get(where=WhereFilter(\"category\"==\"chroma\" and \"author\"==\"john\"))\n",
+    "print(q1)\n",
+    "print(q2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-05T23:31:27.891126Z",
+     "start_time": "2023-09-05T23:31:27.813233Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}\n",
+      "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And logical that doesn't match anything\n",
+    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"jill\"}]})\n",
+    "q2=collection.get(where=WhereFilter(\"category\"==\"chroma\" and \"author\"==\"jill\"))\n",
+    "print(q1)\n",
+    "print(q2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-05T23:31:28.744516Z",
+     "start_time": "2023-09-05T23:31:28.730424Z"
     }
    }
   },
@@ -159,77 +196,27 @@
     }
    ],
    "source": [
-    "# And Logical Operator Filtering\n",
-    "collection = client.get_or_create_collection(\"test-where-list\")\n",
-    "collection.upsert(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
-    "               metadatas=[{\"author\": \"john\",\"category\":\"chroma\"}, {\"author\": \"jack\",\"category\":\"ml\"}, {\"author\": \"jill\",\"category\":\"lifestyle\"}], ids=[\"1\", \"2\", \"3\"])\n",
-    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"john\"}]})\n",
-    "q2=collection.get(where=Filter.where(\"category\"==\"chroma\" and \"author\"==\"john\"))\n",
-    "print(q1)\n",
-    "print(q2)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-09-05T19:24:12.044661Z",
-     "start_time": "2023-09-05T19:24:11.934234Z"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}\n",
-      "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}\n"
-     ]
-    }
-   ],
-   "source": [
-    "# And logical that doesn't match anything\n",
-    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"jill\"}]})\n",
-    "q2=collection.get(where=Filter.where(\"category\"==\"chroma\" and \"author\"==\"jill\"))\n",
-    "print(q1)\n",
-    "print(q2)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-09-05T19:24:43.729793Z",
-     "start_time": "2023-09-05T19:24:43.710129Z"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n",
-      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n"
-     ]
-    }
-   ],
-   "source": [
     "# Combined And and Or Logical Operator Filtering\n",
     "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]}]})\n",
-    "q2=collection.get(where=Filter.where(\"category\"==\"chroma\" and (\"author\"==\"john\" or \"author\"==\"jack\")))\n",
+    "q2=collection.get(where=WhereFilter(\"category\"==\"chroma\" and (\"author\"==\"john\" or \"author\"==\"jack\")))\n",
     "print(q1)\n",
     "print(q2)"
    ],
    "metadata": {
     "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-09-05T19:25:28.289481Z",
-     "start_time": "2023-09-05T19:25:28.272493Z"
+     "end_time": "2023-09-05T23:31:29.935463Z",
+     "start_time": "2023-09-05T23:31:29.925332Z"
     }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
    }
   }
  ],

--- a/examples/basic_functionality/pythonic_filters.ipynb
+++ b/examples/basic_functionality/pythonic_filters.ipynb
@@ -1,0 +1,263 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pythonic Filters\n",
+    "This notebook demonstrates how to use pythonic filters to query your Chroma collection.\n",
+    "> Note: Pythonic filters currently apply only to `where` (metadata) filters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-09-05T20:37:11.464465Z",
+     "start_time": "2023-09-05T20:37:10.986610Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': ['id7'], 'embeddings': None, 'metadatas': [{'status': 'read'}], 'documents': ['A document that discusses international affairs']}\n",
+      "{'ids': ['id7'], 'embeddings': None, 'metadatas': [{'status': 'read'}], 'documents': ['A document that discusses international affairs']}\n",
+      "{'ids': ['id7'], 'embeddings': None, 'metadatas': [{'status': 'read'}], 'documents': ['A document that discusses international affairs']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import chromadb\n",
+    "client = chromadb.Client()\n",
+    "# Create a new chroma collection\n",
+    "collection_name = \"filter_example_collection\"\n",
+    "collection = client.create_collection(name=collection_name)\n",
+    "# Add some data to the collection\n",
+    "collection.add(\n",
+    "    embeddings=[\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "        [1.1, 2.3, 3.2],\n",
+    "        [4.5, 6.9, 4.4],\n",
+    "    ],\n",
+    "    metadatas=[\n",
+    "        {\"status\": \"read\"},\n",
+    "        {\"status\": \"unread\"},\n",
+    "        {\"status\": \"read\"},\n",
+    "        {\"status\": \"unread\"},\n",
+    "        {\"status\": \"read\"},\n",
+    "        {\"status\": \"unread\"},\n",
+    "        {\"status\": \"read\"},\n",
+    "        {\"status\": \"unread\"},\n",
+    "    ],\n",
+    "    documents=[\"A document that discusses domestic policy\", \"A document that discusses international affairs\", \"A document that discusses kittens\", \"A document that discusses dogs\", \"A document that discusses chocolate\", \"A document that is sixth that discusses government\", \"A document that discusses international affairs\", \"A document that discusses global affairs\"],\n",
+    "    ids=[\"id1\", \"id2\", \"id3\", \"id4\", \"id5\", \"id6\", \"id7\", \"id8\"],\n",
+    ")\n",
+    "from chromadb.utils.query_helper import Filter\n",
+    "\n",
+    "# Get documents that are read and about affairs\n",
+    "simple_query=collection.get(\n",
+    "    where=Filter.where(\"status\"== \"read\"), \n",
+    "    where_document={\"$contains\": \"affairs\"})\n",
+    "\n",
+    "quoted=collection.get(\n",
+    "    where=Filter.where('\"status\"== \"read\"'),\n",
+    "    where_document={\"$contains\": \"affairs\"})\n",
+    "\n",
+    "multi_line_quoted=collection.get(\n",
+    "    where=Filter.where('\"status\"'\n",
+    "                       '== \"read\"'),\n",
+    "    where_document={\"$contains\": \"affairs\"})\n",
+    "\n",
+    "print(simple_query)\n",
+    "print(quoted)\n",
+    "print(multi_line_quoted)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Where Filtering With Logical Operators\n",
+    "This section demonstrates how one can use the logical operators in `where` filtering.\n",
+    "\n",
+    "Chroma currently supports: `$and` and `$or`operators.\n",
+    "\n",
+    "> Note: Logical operators can be nested"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Add of existing embedding ID: 1\n",
+      "Add of existing embedding ID: 2\n",
+      "Add of existing embedding ID: 3\n",
+      "Add of existing embedding ID: 1\n",
+      "Add of existing embedding ID: 2\n",
+      "Add of existing embedding ID: 3\n",
+      "Insert of existing embedding ID: 1\n",
+      "Insert of existing embedding ID: 2\n",
+      "Insert of existing embedding ID: 3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': ['1', '2'], 'embeddings': None, 'metadatas': [{'author': 'john'}, {'author': 'jack'}], 'documents': ['Article by john', 'Article by Jack']}\n",
+      "{'ids': ['1', '2'], 'embeddings': None, 'metadatas': [{'author': 'john'}, {'author': 'jack'}], 'documents': ['Article by john', 'Article by Jack']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Or Logical Operator Filtering\n",
+    "# import chromadb\n",
+    "client = chromadb.Client()\n",
+    "collection = client.get_or_create_collection(\"test-where-list\")\n",
+    "collection.add(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
+    "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "\n",
+    "q1=collection.get(where={\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]})\n",
+    "q2=collection.get(where=Filter.where(\"author\"==\"john\" or \"author\"==\"jack\"))\n",
+    "print(q1)\n",
+    "print(q2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-05T19:23:17.106640Z",
+     "start_time": "2023-09-05T19:23:17.018786Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n",
+      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And Logical Operator Filtering\n",
+    "collection = client.get_or_create_collection(\"test-where-list\")\n",
+    "collection.upsert(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
+    "               metadatas=[{\"author\": \"john\",\"category\":\"chroma\"}, {\"author\": \"jack\",\"category\":\"ml\"}, {\"author\": \"jill\",\"category\":\"lifestyle\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"john\"}]})\n",
+    "q2=collection.get(where=Filter.where(\"category\"==\"chroma\" and \"author\"==\"john\"))\n",
+    "print(q1)\n",
+    "print(q2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-05T19:24:12.044661Z",
+     "start_time": "2023-09-05T19:24:11.934234Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}\n",
+      "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And logical that doesn't match anything\n",
+    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"jill\"}]})\n",
+    "q2=collection.get(where=Filter.where(\"category\"==\"chroma\" and \"author\"==\"jill\"))\n",
+    "print(q1)\n",
+    "print(q2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-05T19:24:43.729793Z",
+     "start_time": "2023-09-05T19:24:43.710129Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n",
+      "{'ids': ['1'], 'embeddings': None, 'metadatas': [{'author': 'john', 'category': 'chroma'}], 'documents': ['Article by john']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Combined And and Or Logical Operator Filtering\n",
+    "q1=collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]}]})\n",
+    "q2=collection.get(where=Filter.where(\"category\"==\"chroma\" and (\"author\"==\"john\" or \"author\"==\"jack\")))\n",
+    "print(q1)\n",
+    "print(q2)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-09-05T19:25:28.289481Z",
+     "start_time": "2023-09-05T19:25:28.272493Z"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "2395417914bce3169eff793a7d01bf858f95b138000d8d354eed93ead856f5e6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description of changes
This PR supersedes #1089 as I need to amend it to make it pass tests but I do not have write permissions to akimos-tech/chroma.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Pure Pythonic `where` metadata filters

## Test plan
*How are these changes tested?*
New tests were added to test the where filter construction.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
A notebook was added. In 4.11 we should add documentation to the website and cutover to this way being the default.
