### PR TITLE
[WIP] LRU File Limit Thresholding

### DIFF
--- a/.github/workflows/ssh-debug.yml
+++ b/.github/workflows/ssh-debug.yml
@@ -1,0 +1,25 @@
+name: SSH Debug
+
+on:
+ push:
+    branches:
+      - hammad/file_lru_threshold
+
+jobs:
+  debug:
+    strategy:
+        matrix:
+          python: ['3.10']
+          platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install test dependencies
+      run: python -m pip install -r requirements.txt && python -m pip install -r requirements_dev.txt
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1

--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -52,6 +52,7 @@ class LocalSegmentManager(SegmentManager):
     ]  # Tracks which segments are loaded for a given collection
     _vector_segment_type: SegmentType = SegmentType.HNSW_LOCAL_MEMORY
     _lock: Lock
+    _max_file_handles: int
 
     def __init__(self, system: System):
         super().__init__(system)
@@ -63,30 +64,52 @@ class LocalSegmentManager(SegmentManager):
 
         if self._system.settings.require("is_persistent"):
             self._vector_segment_type = SegmentType.HNSW_LOCAL_PERSISTED
-            # This is a "reasonable" default for the number of file handles to use for vector segments.
-            # To inform this, https://www.mongodb.com/docs/manual/reference/ulimit/#recommended-ulimit-settings as well
-            # as our resource needs for the vector segment are considered.
-            hard_limit = 64000
             if platform.system() != "Windows":
-                # Increase the max number of file handles to the limit set by the OS
-                _, os_hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-                hard_limit = min(hard_limit, os_hard_limit)
-                resource.setrlimit(resource.RLIMIT_NOFILE, (hard_limit, os_hard_limit))
+                self._max_file_handles = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
             else:
-                # On windows, there is no soft, hard limit. Instead, 2048 is the max number of file handles by default.
-                # Newer systems support 8192, but we'll use this safe default for now as a fallback maximum.
-                os_hard_limit = max(2048, ctypes.windll.msvcrt._getmaxstdio())  # type: ignore
-                hard_limit = min(hard_limit, os_hard_limit)
-                ctypes.windll.msvcrt._setmaxstdio(hard_limit)  # type: ignore
-            # Use a fixed percentage in LRU cache to manage file handles, this is not ideal but is a reasonable
-            # In the future, we can make this configurable.
-            max_file_handles = int(hard_limit * 0.75)
+                self._max_file_handles = ctypes.windll.msvcrt._getmaxstdio()  # type: ignore
             segment_limit = (
-                max_file_handles // PersistentLocalHnswSegment.get_file_handle_count()
+                self._max_file_handles
+                // PersistentLocalHnswSegment.get_file_handle_count()
             )
-            self._vector_instances_file_handle_cache = LRUCache[
-                UUID, PersistentLocalHnswSegment
-            ](segment_limit, callback=lambda _, v: v.close_persistent_index())
+            self._vector_instances_file_handle_cache = LRUCache(
+                segment_limit, callback=lambda _, v: v.close_persistent_index()
+            )
+
+    # def __init__(self, system: System):
+    #     super().__init__(system)
+    #     self._sysdb = self.require(SysDB)
+    #     self._system = system
+    #     self._instances = {}
+    #     self._segment_cache = defaultdict(dict)
+    #     self._lock = Lock()
+
+    #     if self._system.settings.require("is_persistent"):
+    #         self._vector_segment_type = SegmentType.HNSW_LOCAL_PERSISTED
+    #         # This is a "reasonable" default for the number of file handles to use for vector segments.
+    #         # To inform this, https://www.mongodb.com/docs/manual/reference/ulimit/#recommended-ulimit-settings as well
+    #         # as our resource needs for the vector segment are considered.
+    #         hard_limit = 64000
+    #         if platform.system() != "Windows":
+    #             # Increase the max number of file handles to the limit set by the OS
+    #             _, os_hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    #             hard_limit = min(hard_limit, os_hard_limit)
+    #             resource.setrlimit(resource.RLIMIT_NOFILE, (hard_limit, os_hard_limit))
+    #         else:
+    #             # On windows, there is no soft, hard limit. Instead, 2048 is the max number of file handles by default.
+    #             # Newer systems support 8192, but we'll use this safe default for now as a fallback maximum.
+    #             os_hard_limit = max(2048, ctypes.windll.msvcrt._getmaxstdio())  # type: ignore
+    #             hard_limit = min(hard_limit, os_hard_limit)
+    #             ctypes.windll.msvcrt._setmaxstdio(hard_limit)  # type: ignore
+    #         # Use a fixed percentage in LRU cache to manage file handles, this is not ideal but is a reasonable
+    #         # In the future, we can make this configurable.
+    #         max_file_handles = int(hard_limit * 0.75)
+    #         segment_limit = (
+    #             max_file_handles // PersistentLocalHnswSegment.get_file_handle_count()
+    #         )
+    #         self._vector_instances_file_handle_cache = LRUCache[
+    #             UUID, PersistentLocalHnswSegment
+    #         ](segment_limit, callback=lambda _, v: v.close_persistent_index())
 
     @override
     def start(self) -> None:

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -95,7 +95,7 @@ def _run_server(
             chroma_server_auth_token_transport_header=chroma_server_auth_token_transport_header,
         )
     server = chromadb.server.fastapi.FastAPI(settings)
-    uvicorn.run(server.app(), host="0.0.0.0", port=port, log_level="error")
+    uvicorn.run(server.app(), host="0.0.0.0", port=port, log_level="info")
 
 
 def _await_server(api: API, attempts: int = 0) -> None:

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -3,8 +3,10 @@ import numpy as np
 
 from chromadb.api import API
 from chromadb.api.models.Collection import Collection
+import pytest
 
 
+@pytest.mark.parametrize("execution_number", range(10))
 def test_many_collections(api: API) -> None:
     """Test that we can create a large number of collections and that the system
     # remains responsive."""

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -7,7 +7,7 @@ import pytest
 
 
 @pytest.mark.parametrize("execution_number", range(10))
-def test_many_collections(api: API) -> None:
+def test_many_collections(api: API, execution_number) -> None:
     """Test that we can create a large number of collections and that the system
     # remains responsive."""
     api.reset()

--- a/chromadb/test/test_multithreaded.py
+++ b/chromadb/test/test_multithreaded.py
@@ -10,6 +10,7 @@ import chromadb.test.property.invariants as invariants
 from chromadb.test.property.strategies import RecordSet
 from chromadb.test.property.strategies import test_hnsw_config
 from chromadb.types import Metadata
+import pytest
 
 
 def generate_data_shape() -> Tuple[int, int]:
@@ -207,6 +208,7 @@ def _test_interleaved_add_query(api: API, N: int, D: int, num_workers: int) -> N
     )
 
 
+@pytest.mark.parametrize("execution_number", range(10))
 def test_multithreaded_add(api: API) -> None:
     for i in range(3):
         num_workers = random.randint(2, multiprocessing.cpu_count() * 2)
@@ -214,6 +216,7 @@ def test_multithreaded_add(api: API) -> None:
         _test_multithreaded_add(api, N, D, num_workers)
 
 
+@pytest.mark.parametrize("execution_number", range(10))
 def test_interleaved_add_query(api: API) -> None:
     for i in range(3):
         num_workers = random.randint(2, multiprocessing.cpu_count() * 2)

--- a/chromadb/test/test_multithreaded.py
+++ b/chromadb/test/test_multithreaded.py
@@ -209,7 +209,7 @@ def _test_interleaved_add_query(api: API, N: int, D: int, num_workers: int) -> N
 
 
 @pytest.mark.parametrize("execution_number", range(10))
-def test_multithreaded_add(api: API) -> None:
+def test_multithreaded_add(api: API, execution_number) -> None:
     for i in range(3):
         num_workers = random.randint(2, multiprocessing.cpu_count() * 2)
         N, D = generate_data_shape()
@@ -217,7 +217,7 @@ def test_multithreaded_add(api: API) -> None:
 
 
 @pytest.mark.parametrize("execution_number", range(10))
-def test_interleaved_add_query(api: API) -> None:
+def test_interleaved_add_query(api: API, execution_number) -> None:
     for i in range(3):
         num_workers = random.randint(2, multiprocessing.cpu_count() * 2)
         N, D = generate_data_shape()


### PR DESCRIPTION
Only use a percentage of the os max file limit after increasing it or… capping it to a reasonable maximum. We should ideally understand the resource usage of a given file and base it off that, but this works for now

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - In testing, it is possible for the test runner to add many files, thus pushing the system utilization over the limit. This caps chromas usage to a % of the max, since the test runner is in the same process and eats the usage. This is also useful because a user may use chroma in-process and need some buffer on their file usage. In the future we can make this configurable 
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Existing tests capture these changes.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
None
