### PR TITLE
Make embeddings cjs and esm compatible

### DIFF
--- a/clients/js/src/embeddings/CohereEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/CohereEmbeddingFunction.ts
@@ -1,30 +1,55 @@
+import { importOptionalModule } from "../utils";
 import { IEmbeddingFunction } from "./IEmbeddingFunction";
 
 let CohereAiApi: any;
 
+async function loadCohereAiApi() {
+  return importOptionalModule("cohere-ai")
+    .then((module) => {
+      CohereAiApi = module;
+      return true;
+    })
+    .catch(() => {
+      throw new Error(
+        "Please install the cohere-ai package to use the CohereEmbeddingFunction, `npm install -S cohere-ai`"
+      );
+    });
+}
+
 export class CohereEmbeddingFunction implements IEmbeddingFunction {
-    private api_key: string;
-    private model: string;
+  private api_key: string;
+  private model: string;
+  private isInitialized = false;
 
-    constructor({ cohere_api_key, model }: { cohere_api_key: string, model?: string }) {
-        try {
-            // eslint-disable-next-line global-require,import/no-extraneous-dependencies
-            CohereAiApi = require("cohere-ai");
-            CohereAiApi.init(cohere_api_key);
-        } catch {
-            throw new Error(
-                "Please install the cohere-ai package to use the CohereEmbeddingFunction, `npm install -S cohere-ai`"
-            );
-        }
-        this.api_key = cohere_api_key;
-        this.model = model || "large";
+  constructor({
+    cohere_api_key,
+    model,
+  }: {
+    cohere_api_key: string;
+    model?: string;
+  }) {
+    this.api_key = cohere_api_key;
+    this.model = model || "large";
+
+    loadCohereAiApi()
+      .then(() => {
+        CohereAiApi.init(this.api_key);
+        this.isInitialized = true;
+      })
+      .catch((error) => {
+        console.error("Could not load CohereAiApi:", error);
+      });
+  }
+
+  public async generate(texts: string[]) {
+    if (!this.isInitialized) {
+      throw new Error("Cohere API is not initialized.");
     }
 
-    public async generate(texts: string[]) {
-        const response = await CohereAiApi.embed({
-            texts: texts,
-            model: this.model,
-        });
-        return response.body.embeddings;
-    }
+    const response = await CohereAiApi.embed({
+      texts: texts,
+      model: this.model,
+    });
+    return response.body.embeddings;
+  }
 }

--- a/clients/js/src/embeddings/OpenAIEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/OpenAIEmbeddingFunction.ts
@@ -1,125 +1,144 @@
-import {IEmbeddingFunction} from "./IEmbeddingFunction";
+import { importOptionalModule } from "../utils";
+import { IEmbeddingFunction } from "./IEmbeddingFunction";
 
 let OpenAIApi: any;
 let openAiVersion = null;
 let openAiMajorVersion = null;
 
 interface OpenAIAPI {
-    createEmbedding: (params: {
-        model: string;
-        input: string[];
-        user?: string;
-    }) => Promise<number[][]>;
+  createEmbedding: (params: {
+    model: string;
+    input: string[];
+    user?: string;
+  }) => Promise<number[][]>;
 }
 
 class OpenAIAPIv3 implements OpenAIAPI {
-    private readonly configuration: any;
-    private openai: any;
+  private readonly configuration: any;
+  private openai: any;
 
-    constructor(configuration: { organization: string, apiKey: string }) {
-        this.configuration = new OpenAIApi.Configuration({
-            organization: configuration.organization,
-            apiKey: configuration.apiKey,
-        });
-        this.openai = new OpenAIApi.OpenAIApi(this.configuration);
-    }
+  constructor(configuration: { organization: string; apiKey: string }) {
+    this.configuration = new OpenAIApi.Configuration({
+      organization: configuration.organization,
+      apiKey: configuration.apiKey,
+    });
+    this.openai = new OpenAIApi.OpenAIApi(this.configuration);
+  }
 
-    public async createEmbedding(params: {
-        model: string,
-        input: string[],
-        user?: string
-    }): Promise<number[][]> {
-        const embeddings: number[][] = [];
-        const response = await this.openai.createEmbedding({
-            model: params.model,
-            input: params.input,
-        }).catch((error: any) => {
-            throw error;
-        });
-        // @ts-ignore
-        const data = response.data["data"];
-        for (let i = 0; i < data.length; i += 1) {
-            embeddings.push(data[i]["embedding"]);
-        }
-        return embeddings
+  public async createEmbedding(params: {
+    model: string;
+    input: string[];
+    user?: string;
+  }): Promise<number[][]> {
+    const embeddings: number[][] = [];
+    const response = await this.openai
+      .createEmbedding({
+        model: params.model,
+        input: params.input,
+      })
+      .catch((error: any) => {
+        throw error;
+      });
+    const data = response.data["data"];
+    for (let i = 0; i < data.length; i += 1) {
+      embeddings.push(data[i]["embedding"]);
     }
+    return embeddings;
+  }
 }
 
 class OpenAIAPIv4 implements OpenAIAPI {
-    private readonly apiKey: any;
-    private openai: any;
+  private readonly apiKey: any;
+  private openai: any;
 
-    constructor(apiKey: any) {
-        this.apiKey = apiKey;
-        this.openai = new OpenAIApi({
-            apiKey: this.apiKey,
-        });
-    }
+  constructor(apiKey: any) {
+    this.apiKey = apiKey;
+    this.openai = new OpenAIApi({
+      apiKey: this.apiKey,
+    });
+  }
 
-    public async createEmbedding(params: {
-        model: string,
-        input: string[],
-        user?: string
-    }): Promise<number[][]> {
-        const embeddings: number[][] = [];
-        const response = await this.openai.embeddings.create(params);
-        const data = response["data"];
-        for (let i = 0; i < data.length; i += 1) {
-            embeddings.push(data[i]["embedding"]);
-        }
-        return embeddings
+  public async createEmbedding(params: {
+    model: string;
+    input: string[];
+    user?: string;
+  }): Promise<number[][]> {
+    const embeddings: number[][] = [];
+    const response = await this.openai.embeddings.create(params);
+    const data = response["data"];
+    for (let i = 0; i < data.length; i += 1) {
+      embeddings.push(data[i]["embedding"]);
     }
+    return embeddings;
+  }
+}
+
+async function loadOpenAIApi(): Promise<void> {
+  return importOptionalModule("openai").then((module) => {
+    OpenAIApi = module;
+  });
 }
 
 export class OpenAIEmbeddingFunction implements IEmbeddingFunction {
-    private api_key: string;
-    private org_id: string;
-    private model: string;
-    private openaiApi: OpenAIAPI;
+  private api_key: string;
+  private org_id: string;
+  private model: string;
+  private openaiApi: any;
+  private isInitialized: boolean;
 
-    constructor({openai_api_key, openai_model, openai_organization_id}: {
-        openai_api_key: string,
-        openai_model?: string,
-        openai_organization_id?: string
-    }) {
+  constructor({
+    openai_api_key,
+    openai_model,
+    openai_organization_id,
+  }: {
+    openai_api_key: string;
+    openai_model?: string;
+    openai_organization_id?: string;
+  }) {
+    this.api_key = openai_api_key;
+    this.org_id = openai_organization_id || "";
+    this.model = openai_model || "text-embedding-ada-002";
+    this.isInitialized = false;
+
+    loadOpenAIApi()
+      .then(() => {
+        let version = null;
         try {
-            // eslint-disable-next-line global-require,import/no-extraneous-dependencies
-            OpenAIApi = require("openai");
-            let version = null;
-            try {
-                const {VERSION} = require('openai/version');
-                version = VERSION;
-            } catch (e) {
-                version = "3.x";
-            }
-            openAiVersion = version.replace(/[^0-9.]/g, '');
-            openAiMajorVersion = openAiVersion.split('.')[0];
-        } catch (_a) {
-            // @ts-ignore
-            if (_a.code === 'MODULE_NOT_FOUND') {
-                throw new Error("Please install the openai package to use the OpenAIEmbeddingFunction, `npm install -S openai`");
-            }
-            throw _a; // Re-throw other errors
+          version = OpenAIApi.VERSION || "3.x";
+          this.isInitialized = true;
+        } catch (error) {
+          version = "3.x";
         }
-        this.api_key = openai_api_key;
-        this.org_id = openai_organization_id || "";
-        this.model = openai_model || "text-embedding-ada-002";
+
+        const openAiVersion = version.replace(/[^0-9.]/g, "");
+        const openAiMajorVersion = parseInt(openAiVersion.split(".")[0]);
+
         if (openAiMajorVersion > 3) {
-            this.openaiApi = new OpenAIAPIv4(this.api_key);
+          this.openaiApi = new OpenAIAPIv4(this.api_key);
         } else {
-            this.openaiApi = new OpenAIAPIv3({
-                organization: this.org_id,
-                apiKey: this.api_key,
-            });
+          this.openaiApi = new OpenAIAPIv3({
+            organization: this.org_id,
+            apiKey: this.api_key,
+          });
         }
+      })
+      .catch((error) => {
+        console.error("Could not load OpenAIApi:", error);
+      });
+  }
+
+  public async generate(texts: string[]): Promise<number[][]> {
+    if (!this.isInitialized) {
+      throw new Error("OpenAI API is not initialized.");
     }
 
-    public async generate(texts: string[]): Promise<number[][]> {
-        return await this.openaiApi.createEmbedding({
-            model: this.model,
-            input: texts,
-        }).catch((error: any) => {
-            throw error;
-        });
-    }
+    return await this.openaiApi
+      .createEmbedding({
+        model: this.model,
+        input: texts,
+      })
+      .catch((error: any) => {
+        throw error;
+      });
+  }
 }


### PR DESCRIPTION
## Description of changes

This is a fix for issue #1012 

 - Improvements & Bug fixes
	 - Made `OpenAIEmbeddingFunction.ts` compatible with both CommonJS and ESModules
	 - Made `CohereEmbeddingFunction.ts` compatible with both CommonJS and ESModules

We are now dynamically importing the required packages. The dynamic import ensures that the code will run irrespective of whether the consuming project is using CommonJS or ESM. Some projects might still be using CommonJS, and others might have transitioned to using ESM. By dynamically importing, you don't have to decide upfront which module system to support—you can support both.

**Important:** The other embeddings have not been fixed. This is just a start to get things rolling. If you try to run this in ESM, you will get an error for the `WebAIEmbeddingFunction.ts` file for example.

## Test plan
*How are these changes tested?*

- Both main and module builds tested in Node with both a CommonJS and ESModules project.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
