### PR TITLE
requirement and pyproject.toml sync checking

### DIFF
--- a/bin/dependency_sync.sh
+++ b/bin/dependency_sync.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+REQUIREMENTS_FILE="requirements.txt"
+PYPROJECT_FILE="pyproject.toml"
+
+# Checking if the files exist
+if [ ! -f "$REQUIREMENTS_FILE" ]; then
+    echo "Error: $REQUIREMENTS_FILE does not exist."
+    exit 1
+fi
+
+if [ ! -f "$PYPROJECT_FILE" ]; then
+    echo "Error: $PYPROJECT_FILE does not exist."
+    exit 1
+fi
+
+# Extracting dependencies from requirements.txt
+REQUIREMENTS_DEPS=$(grep -vE '^\s*#|^\s*$' "$REQUIREMENTS_FILE")
+
+# Extracting dependencies from pyproject.toml using Python
+PYPROJECT_DEPS=$(python - <<END
+import toml
+
+def extract_dependencies(data):
+    dependencies = []
+
+    # Look for dependencies in various possible locations within pyproject.toml
+    if 'project' in data and 'dependencies' in data['project']:
+        dependencies.extend(data['project']['dependencies'])
+
+    return dependencies
+
+try:
+    with open('$PYPROJECT_FILE', 'r') as f:
+        data = toml.load(f)
+        deps = extract_dependencies(data)
+        print('\n'.join(deps))
+except Exception as e:
+    print(e)
+END
+)
+
+# Checking if there are any differences
+if [ "$REQUIREMENTS_DEPS" == "$PYPROJECT_DEPS" ]; then
+    echo "Dependencies in $REQUIREMENTS_FILE and $PYPROJECT_FILE are in sync."
+else
+    echo "Dependencies in $REQUIREMENTS_FILE and $PYPROJECT_FILE are NOT in sync."
+    echo "Dependencies in $REQUIREMENTS_FILE:"
+    echo "$REQUIREMENTS_DEPS"
+    echo "Dependencies in $PYPROJECT_FILE:"
+    echo "$PYPROJECT_DEPS"
+fi


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - solves for Issue [Bug]: Ensure pyproject.toml is correct as part of CI for PRs. #564 
 - New functionality
	 - Introduces a bash Script to check if we have dependencies in 'pyproject.toml' and 'requirements.txt' in sync

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*