### PR TITLE
Fix broken peer OpenAI dep dependency range

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -62,7 +62,7 @@
     "@visheratin/web-ai-node": "^1.0.0",
     "@xenova/transformers": "^2.0.0",
     "cohere-ai": "^6.0.0",
-    "openai": "^3.0.0 | ^4.0.0"
+    "openai": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@visheratin/web-ai": {


### PR DESCRIPTION
https://semver.npmjs.com/

<img width="1362" alt="Screenshot 2023-09-13 at 3 51 28 PM" src="https://github.com/chroma-core/chroma/assets/6952323/ab7752f2-9a82-4ea6-8a9b-f92b13b124b0">

<img width="1414" alt="Screenshot 2023-09-13 at 3 51 16 PM" src="https://github.com/chroma-core/chroma/assets/6952323/c7761348-e499-4541-a775-b5436abff749">

npm strictly checks peer dep ranges, which means the `npm install` of anything with a peer dep on Chroma was affected by this.