### PR TITLE
bump JS to 1.5.9

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Bump to release to 1.5.9 to release https://github.com/chroma-core/chroma/pull/1142

