### PR TITLE
[BUG]: Fixed BF index overflow issue with subsequent delete

### DIFF
--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -230,9 +230,8 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                 if op == Operation.DELETE:
                     if exists_in_index:
                         self._curr_batch.apply(record)
-                        self._brute_force_index.delete(
-                            [record]
-                        ) if exists_in_bf_index else None
+                        if exists_in_bf_index:
+                            self._brute_force_index.delete([record])
                     else:
                         logger.warning(f"Delete of nonexisting embedding ID: {id}")
 

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -225,11 +225,14 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                 exists_in_index = self._id_to_label.get(
                     id, None
                 ) is not None or self._brute_force_index.has_id(id)
+                exists_in_bf_index = self._brute_force_index.has_id(id)
 
                 if op == Operation.DELETE:
                     if exists_in_index:
                         self._curr_batch.apply(record)
-                        self._brute_force_index.delete([record])
+                        self._brute_force_index.delete(
+                            [record]
+                        ) if exists_in_bf_index else None
                     else:
                         logger.warning(f"Delete of nonexisting embedding ID: {id}")
 


### PR DESCRIPTION


Refs: #989

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
    - When the BF index overflows (batch_size upon insertion of large batch it is cleared, if a subsequent delete request comes to delete Ids which were in the cleared BF index a warning is raised for non-existent embedding. The issue was resolved by separately checking if BF the record exists in the BF index and conditionally execute the BF removal

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
N/A
