### PR TITLE
[BUG]: Added cohere version 6.x support in peer dependencies

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -65,7 +65,7 @@
     "isomorphic-fetch": "^3.0.0"
   },
   "peerDependencies": {
-    "cohere-ai": "^5.1.0",
+    "cohere-ai": "^5.0.0 || ^6.0.0",
     "openai": "^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -4,6 +4,7 @@ import { DOCUMENTS, EMBEDDINGS, IDS } from './data';
 import { METADATAS } from './data';
 import { IncludeEnum } from "../src/types";
 import {OpenAIEmbeddingFunction} from "../src/embeddings/OpenAIEmbeddingFunction";
+import {CohereEmbeddingFunction} from "../src/embeddings/CohereEmbeddingFunction";
 test("it should add single embeddings to a collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
@@ -43,6 +44,27 @@ if (!process.env.OPENAI_API_KEY) {
   test("it should add OpenAI embeddings", async () => {
     await chroma.reset();
     const embedder = new OpenAIEmbeddingFunction({ openai_api_key: process.env.OPENAI_API_KEY || "" })
+    const collection = await chroma.createCollection({ name: "test" ,embeddingFunction: embedder});
+    const embeddings = await embedder.generate(DOCUMENTS);
+    await collection.add({ ids: IDS, embeddings: embeddings });
+    const count = await collection.count();
+    expect(count).toBe(3);
+    var res = await collection.get({
+      ids: IDS, include: [
+        IncludeEnum.Embeddings,
+      ]
+    });
+    expect(res.embeddings).toEqual(embeddings); // reverse because of the order of the ids
+  });
+}
+
+if (!process.env.COHERE_API_KEY) {
+  test.skip("it should add Cohere embeddings", async () => {
+  });
+} else {
+  test("it should add Cohere embeddings", async () => {
+    await chroma.reset();
+    const embedder = new CohereEmbeddingFunction({ cohere_api_key: process.env.COHERE_API_KEY || "" })
     const collection = await chroma.createCollection({ name: "test" ,embeddingFunction: embedder});
     const embeddings = await embedder.generate(DOCUMENTS);
     await collection.add({ ids: IDS, embeddings: embeddings });


### PR DESCRIPTION
Refs: #1104

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Expanding Cohere version also to support 6.x This plays nice with the rest of the ecosystem

## Test plan
*How are these changes tested?*

- [x] `yarn test` for js

## Documentation Changes
N/A
