### PR TITLE
[BUG]: Docker entrypoint logging path

### DIFF
--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -3,4 +3,4 @@
 echo "Rebuilding hnsw to ensure architecture compatibility"
 pip install --force-reinstall --no-cache-dir chroma-hnswlib
 export IS_PERSISTENT=1
-uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config log_config.yml
+uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config chromadb/log_config.yml


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Initial CLI PR (https://github.com/chroma-core/chroma/pull/1032) moved the logging config inside chromadb. If image is built with the current setup it will result in Error: Invalid value for '--log-config': Path 'log_config.yml' does not exist.

## Test plan
*How are these changes tested?*

Steps to reproduce (prior to this PR):

- `docker build -t chroma:canary .`
- `docker run --rm -it chroma:canary`


## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
