### PR TITLE
[ENH] Metric batching and more metrics

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -2,8 +2,6 @@ from typing import Dict
 import logging
 import sqlite3
 import chromadb.config
-from chromadb.telemetry.events import ClientStartEvent
-from chromadb.telemetry import Telemetry
 from chromadb.config import Settings, System
 from chromadb.api import API
 from chromadb.api.models.Collection import Collection
@@ -38,6 +36,8 @@ __all__ = [
     "QueryResult",
     "GetResult",
 ]
+from chromadb.telemetry.events import ClientStartEvent
+from chromadb.telemetry import Telemetry
 
 
 logger = logging.getLogger(__name__)

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -314,9 +314,9 @@ class SegmentAPI(API):
             CollectionUpdateEvent(
                 collection_uuid=str(collection_id),
                 update_amount=len(ids),
-                with_embeddings=embeddings is not None,
-                with_metadata=metadatas is not None,
-                with_documents=documents is not None,
+                with_embeddings=len(embeddings) if embeddings else 0,
+                with_metadata=len(metadatas) if metadatas else 0,
+                with_documents=len(documents) if documents else 0,
             )
         )
 

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -277,9 +277,8 @@ class SegmentAPI(API):
             CollectionAddEvent(
                 collection_uuid=str(collection_id),
                 add_amount=len(ids),
-                with_embeddings=embeddings is not None,
-                with_metadata=metadatas is not None,
-                with_documents=documents is not None,
+                with_metadata=len(ids) if metadatas is not None else 0,
+                with_documents=len(ids) if documents is not None else 0,
             )
         )
         return True
@@ -479,7 +478,9 @@ class SegmentAPI(API):
         self._producer.submit_embeddings(coll["topic"], records_to_submit)
 
         self._telemetry_client.capture(
-            CollectionDeleteEvent(str(collection_id), len(ids_to_delete))
+            CollectionDeleteEvent(
+                collection_uuid=str(collection_id), delete_amount=len(ids_to_delete)
+            )
         )
         return ids_to_delete
 

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -22,7 +22,6 @@ class ServerContext(Enum):
 
 
 class TelemetryEvent:
-    name: ClassVar[str]
     max_batch_size: ClassVar[int] = 1
     batch_size: int
 
@@ -32,6 +31,10 @@ class TelemetryEvent:
     @property
     def properties(self) -> Dict[str, Any]:
         return self.__dict__
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
 
     # A batch key is used to determine whether two events can be batched together.
     # If a TelemetryEvent's max_batch_size > 1, batch_key() and batch() MUST be implemented.

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from dataclasses import asdict, dataclass
 import os
 from typing import Callable, ClassVar, Dict, Any
 import uuid
@@ -22,14 +21,17 @@ class ServerContext(Enum):
     FASTAPI = "FastAPI"
 
 
-@dataclass
 class TelemetryEvent:
     name: ClassVar[str]
-    batch_size: ClassVar[int] = 1
+    max_batch_size: ClassVar[int] = 1
+    batch_size: int
+
+    def __init__(self, batch_size: int = 1):
+        self.batch_size = batch_size
 
     @property
     def properties(self) -> Dict[str, Any]:
-        return asdict(self)
+        return self.__dict__
 
     def can_batch(self, other: "TelemetryEvent") -> bool:
         raise NotImplementedError

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -25,7 +25,7 @@ class ServerContext(Enum):
 @dataclass
 class TelemetryEvent:
     name: ClassVar[str]
-    max_batch_size: ClassVar[int] = 1
+    batch_size: ClassVar[int] = 1
 
     @property
     def properties(self) -> Dict[str, Any]:

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -25,10 +25,17 @@ class ServerContext(Enum):
 @dataclass
 class TelemetryEvent:
     name: ClassVar[str]
+    max_batch_size: ClassVar[int] = 1
 
     @property
     def properties(self) -> Dict[str, Any]:
         return asdict(self)
+
+    def can_batch(self, other: "TelemetryEvent") -> bool:
+        raise NotImplementedError
+
+    def batch(self, other: "TelemetryEvent") -> "TelemetryEvent":
+        raise NotImplementedError
 
 
 class RepeatedTelemetry:

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -33,6 +33,9 @@ class TelemetryEvent:
     def properties(self) -> Dict[str, Any]:
         return self.__dict__
 
+    # A batch key is used to determine whether two events can be batched together.
+    # If a TelemetryEvent's max_batch_size > 1, batch_key() and batch() MUST be implemented.
+    # Otherwise they are ignored.
     @property
     def batch_key(self) -> str:
         return self.name

--- a/chromadb/telemetry/__init__.py
+++ b/chromadb/telemetry/__init__.py
@@ -33,8 +33,9 @@ class TelemetryEvent:
     def properties(self) -> Dict[str, Any]:
         return self.__dict__
 
-    def can_batch(self, other: "TelemetryEvent") -> bool:
-        raise NotImplementedError
+    @property
+    def batch_key(self) -> str:
+        return self.name
 
     def batch(self, other: "TelemetryEvent") -> "TelemetryEvent":
         raise NotImplementedError

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -16,7 +16,7 @@ class ClientCreateCollectionEvent(TelemetryEvent):
         super().__init__()
         self.collection_uuid = collection_uuid
 
-        embedding_function_names = [name for name, _ in get_builtins()]
+        embedding_function_names = get_builtins()
 
         self.embedding_function = (
             embedding_function

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -28,7 +28,7 @@ class CollectionAddEvent(TelemetryEvent):
     with_embeddings: bool
     with_metadata: bool
     with_documents: bool
-    max_batch_size = 4
+    batch_size = 4
 
     def can_batch(self, other: TelemetryEvent) -> bool:
         return (

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -6,13 +6,11 @@ from chromadb.telemetry import TelemetryEvent
 @dataclass
 class ClientStartEvent(TelemetryEvent):
     name: ClassVar[str] = "client_start"
-    max_batch_size = 1
 
 
 @dataclass
 class ServerStartEvent(TelemetryEvent):
     name: ClassVar[str] = "server_start"
-    max_batch_size = 1
 
 
 @dataclass
@@ -20,7 +18,6 @@ class ClientCreateCollectionEvent(TelemetryEvent):
     name: ClassVar[str] = "client_create_collection"
     collection_uuid: str
     embedding_function: str
-    max_batch_size = 1
 
 
 @dataclass
@@ -63,7 +60,6 @@ class CollectionUpdateEvent(TelemetryEvent):
     with_embeddings: bool
     with_metadata: bool
     with_documents: bool
-    max_batch_size = 1
 
 
 @dataclass
@@ -77,7 +73,6 @@ class CollectionQueryEvent(TelemetryEvent):
     include_metadatas: bool
     include_documents: bool
     include_distances: bool
-    max_batch_size = 1
 
 
 @dataclass
@@ -88,7 +83,6 @@ class CollectionGetEvent(TelemetryEvent):
     limit: int
     include_metadata: bool
     include_documents: bool
-    max_batch_size = 1
 
 
 @dataclass
@@ -96,4 +90,3 @@ class CollectionDeleteEvent(TelemetryEvent):
     name: ClassVar[str] = "collection_delete"
     collection_uuid: str
     delete_amount: int
-    max_batch_size = 1

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -1,6 +1,6 @@
-import inspect
 from typing import cast, ClassVar
 from chromadb.telemetry import TelemetryEvent
+from chromadb.utils.embedding_functions import get_builtins
 
 
 class ClientStartEvent(TelemetryEvent):
@@ -16,13 +16,11 @@ class ClientCreateCollectionEvent(TelemetryEvent):
         super().__init__()
         self.collection_uuid = collection_uuid
 
-        # We have to do this here to avoid a circular import
-        import chromadb.utils.embedding_functions
-
         embedding_function_names = [
-            name
-            for name, _ in inspect.getmembers(chromadb.utils.embedding_functions)
-            if name.endswith("EmbeddingFunction") and name != "EmbeddingFunction"
+            obj.__name__
+            for obj in get_builtins()
+            if obj.__name__.endswith("EmbeddingFunction")
+            and obj.__name__ != "EmbeddingFunction"
         ]
 
         self.embedding_function = (

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -1,16 +1,26 @@
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import cast, ClassVar
 from chromadb.telemetry import TelemetryEvent
 
 
 @dataclass
 class ClientStartEvent(TelemetryEvent):
     name: ClassVar[str] = "client_start"
+    max_batch_size = 1
 
 
 @dataclass
 class ServerStartEvent(TelemetryEvent):
     name: ClassVar[str] = "server_start"
+    max_batch_size = 1
+
+
+@dataclass
+class ClientCreateCollectionEvent(TelemetryEvent):
+    name: ClassVar[str] = "client_create_collection"
+    collection_uuid: str
+    embedding_function: str
+    max_batch_size = 1
 
 
 @dataclass
@@ -18,6 +28,67 @@ class CollectionAddEvent(TelemetryEvent):
     name: ClassVar[str] = "collection_add"
     collection_uuid: str
     add_amount: int
+    with_embeddings: bool
+    with_metadata: bool
+    with_documents: bool
+    max_batch_size = 4
+
+    def can_batch(self, other: TelemetryEvent) -> bool:
+        return (
+            isinstance(other, CollectionAddEvent)
+            and self.collection_uuid == other.collection_uuid
+            and self.with_embeddings == other.with_embeddings
+            and self.with_metadata == other.with_metadata
+            and self.with_documents == other.with_documents
+        )
+
+    def batch(self, other: "TelemetryEvent") -> "CollectionAddEvent":
+        if not self.can_batch(other):
+            raise ValueError("Cannot batch events")
+        other = cast(CollectionAddEvent, other)
+        return CollectionAddEvent(
+            collection_uuid=self.collection_uuid,
+            add_amount=self.add_amount + other.add_amount,
+            with_embeddings=self.with_embeddings,
+            with_metadata=self.with_metadata,
+            with_documents=self.with_documents,
+        )
+
+
+@dataclass
+class CollectionUpdateEvent(TelemetryEvent):
+    name: ClassVar[str] = "collection_update"
+    collection_uuid: str
+    update_amount: int
+    with_embeddings: bool
+    with_metadata: bool
+    with_documents: bool
+    max_batch_size = 1
+
+
+@dataclass
+class CollectionQueryEvent(TelemetryEvent):
+    name: ClassVar[str] = "collection_query"
+    collection_uuid: str
+    query_amount: int
+    with_metadata_filter: bool
+    with_document_filter: bool
+    n_results: int
+    include_metadatas: bool
+    include_documents: bool
+    include_distances: bool
+    max_batch_size = 1
+
+
+@dataclass
+class CollectionGetEvent(TelemetryEvent):
+    name: ClassVar[str] = "collection_get"
+    collection_uuid: str
+    ids_count: int
+    limit: int
+    include_metadata: bool
+    include_documents: bool
+    max_batch_size = 1
 
 
 @dataclass
@@ -25,3 +96,4 @@ class CollectionDeleteEvent(TelemetryEvent):
     name: ClassVar[str] = "collection_delete"
     collection_uuid: str
     delete_amount: int
+    max_batch_size = 1

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import cast, ClassVar
 from chromadb.telemetry import TelemetryEvent
 
@@ -14,7 +15,21 @@ class ClientCreateCollectionEvent(TelemetryEvent):
     def __init__(self, collection_uuid: str, embedding_function: str):
         super().__init__()
         self.collection_uuid = collection_uuid
-        self.embedding_function = embedding_function
+
+        # We have to do this here to avoid a circular import
+        import chromadb.utils.embedding_functions
+
+        embedding_function_names = [
+            name
+            for name, _ in inspect.getmembers(chromadb.utils.embedding_functions)
+            if name.endswith("EmbeddingFunction") and name != "EmbeddingFunction"
+        ]
+
+        self.embedding_function = (
+            embedding_function
+            if embedding_function in embedding_function_names
+            else "custom"
+        )
 
 
 class CollectionAddEvent(TelemetryEvent):

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -65,17 +65,17 @@ class CollectionUpdateEvent(TelemetryEvent):
     name: ClassVar[str] = "collection_update"
     collection_uuid: str
     update_amount: int
-    with_embeddings: bool
-    with_metadata: bool
-    with_documents: bool
+    with_embeddings: int
+    with_metadata: int
+    with_documents: int
 
     def __init__(
         self,
         collection_uuid: str,
         update_amount: int,
-        with_embeddings: bool,
-        with_metadata: bool,
-        with_documents: bool,
+        with_embeddings: int,
+        with_metadata: int,
+        with_documents: int,
     ):
         super().__init__()
         self.collection_uuid = collection_uuid

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -16,12 +16,7 @@ class ClientCreateCollectionEvent(TelemetryEvent):
         super().__init__()
         self.collection_uuid = collection_uuid
 
-        embedding_function_names = [
-            obj.__name__
-            for obj in get_builtins()
-            if obj.__name__.endswith("EmbeddingFunction")
-            and obj.__name__ != "EmbeddingFunction"
-        ]
+        embedding_function_names = [name for name, _ in get_builtins()]
 
         self.embedding_function = (
             embedding_function

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -43,14 +43,12 @@ class CollectionAddEvent(TelemetryEvent):
         self.with_metadata = with_metadata
         self.batch_size = batch_size
 
-    def can_batch(self, other: TelemetryEvent) -> bool:
-        return (
-            isinstance(other, CollectionAddEvent)
-            and self.collection_uuid == other.collection_uuid
-        )
+    @property
+    def batch_key(self) -> str:
+        return self.collection_uuid + self.name
 
     def batch(self, other: "TelemetryEvent") -> "CollectionAddEvent":
-        if not self.can_batch(other):
+        if not self.batch_key == other.batch_key:
             raise ValueError("Cannot batch events")
         other = cast(CollectionAddEvent, other)
         total_amount = self.add_amount + other.add_amount

--- a/chromadb/telemetry/events.py
+++ b/chromadb/telemetry/events.py
@@ -3,14 +3,11 @@ from chromadb.telemetry import TelemetryEvent
 
 
 class ClientStartEvent(TelemetryEvent):
-    name: ClassVar[str] = "client_start"
-
     def __init__(self) -> None:
         super().__init__()
 
 
 class ClientCreateCollectionEvent(TelemetryEvent):
-    name: ClassVar[str] = "client_create_collection"
     collection_uuid: str
     embedding_function: str
 
@@ -21,7 +18,6 @@ class ClientCreateCollectionEvent(TelemetryEvent):
 
 
 class CollectionAddEvent(TelemetryEvent):
-    name: ClassVar[str] = "collection_add"
     max_batch_size: ClassVar[int] = 20
     collection_uuid: str
     add_amount: int
@@ -62,7 +58,6 @@ class CollectionAddEvent(TelemetryEvent):
 
 
 class CollectionUpdateEvent(TelemetryEvent):
-    name: ClassVar[str] = "collection_update"
     collection_uuid: str
     update_amount: int
     with_embeddings: int
@@ -86,7 +81,6 @@ class CollectionUpdateEvent(TelemetryEvent):
 
 
 class CollectionQueryEvent(TelemetryEvent):
-    name: ClassVar[str] = "collection_query"
     collection_uuid: str
     query_amount: int
     with_metadata_filter: bool
@@ -119,7 +113,6 @@ class CollectionQueryEvent(TelemetryEvent):
 
 
 class CollectionGetEvent(TelemetryEvent):
-    name: ClassVar[str] = "collection_get"
     collection_uuid: str
     ids_count: int
     limit: int
@@ -143,7 +136,6 @@ class CollectionGetEvent(TelemetryEvent):
 
 
 class CollectionDeleteEvent(TelemetryEvent):
-    name: ClassVar[str] = "collection_delete"
     collection_uuid: str
     delete_amount: int
 

--- a/chromadb/telemetry/posthog.py
+++ b/chromadb/telemetry/posthog.py
@@ -35,7 +35,7 @@ class Posthog(Telemetry):
             self._direct_capture(event)
             return
         batch_key = event.batch_key
-        if self.batched_events[batch_key] is None:
+        if not self.batched_events[batch_key]:
             self.batched_events[batch_key] = event
             return
         batched_event = self.batched_events[batch_key].batch(event)

--- a/chromadb/telemetry/posthog.py
+++ b/chromadb/telemetry/posthog.py
@@ -30,7 +30,7 @@ class Posthog(Telemetry):
 
     @override
     def capture(self, event: TelemetryEvent) -> None:
-        if event.max_batch_size == 1:
+        if event.batch_size == 1:
             self._direct_capture(event)
             return
         if self.batched_event is None:
@@ -44,7 +44,7 @@ class Posthog(Telemetry):
             return
         self.batched_event = self.batched_event.batch(event)
         self.batch_size += 1
-        if self.batch_size >= self.batched_event.max_batch_size:
+        if self.batch_size >= self.batched_event.batch_size:
             self._direct_capture(self.batched_event)
             self.batched_event = None
             self.batch_size = 0

--- a/chromadb/telemetry/posthog.py
+++ b/chromadb/telemetry/posthog.py
@@ -30,14 +30,14 @@ class Posthog(Telemetry):
 
     @override
     def capture(self, event: TelemetryEvent) -> None:
-        if event.max_batch_size == 1 or event.__class__ not in self.seen_event_types:
-            self.seen_event_types.add(event.__class__)
+        if event.max_batch_size == 1 or event.batch_key not in self.seen_event_types:
+            self.seen_event_types.add(event.batch_key)
             self._direct_capture(event)
             return
         if self.batched_event is None:
             self.batched_event = event
             return
-        if not self.batched_event.can_batch(event):
+        if not self.batched_event.batch_key == event.batch_key:
             self._direct_capture(self.batched_event)
             self.batched_event = event
             return

--- a/chromadb/telemetry/posthog.py
+++ b/chromadb/telemetry/posthog.py
@@ -35,7 +35,7 @@ class Posthog(Telemetry):
             self._direct_capture(event)
             return
         batch_key = event.batch_key
-        if not self.batched_events[batch_key]:
+        if batch_key not in self.batched_events:
             self.batched_events[batch_key] = event
             return
         batched_event = self.batched_events[batch_key].batch(event)

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -481,11 +481,11 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction):
 
 # List of all classes in this module
 _classes = [
-    (name, obj)
+    name
     for name, obj in inspect.getmembers(sys.modules[__name__], inspect.isclass)
     if obj.__module__ == __name__
 ]
 
 
-def get_builtins() -> List[tuple[str, type]]:
+def get_builtins() -> List[str]:
     return _classes

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, cast
 import numpy as np
 import numpy.typing as npt
 import importlib
+import inspect
+import sys
 from typing import Optional
 
 try:
@@ -43,7 +45,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction):
         self._normalize_embeddings = normalize_embeddings
 
     def __call__(self, texts: Documents) -> Embeddings:
-        return self._model.encode(
+        return self._model.encode(  # type: ignore
             list(texts),
             convert_to_numpy=True,
             normalize_embeddings=self._normalize_embeddings,
@@ -224,10 +226,10 @@ class InstructorEmbeddingFunction(EmbeddingFunction):
 
     def __call__(self, texts: Documents) -> Embeddings:
         if self._instruction is None:
-            return self._model.encode(texts).tolist()
+            return self._model.encode(texts).tolist()  # type: ignore
 
         texts_with_instructions = [[self._instruction, text] for text in texts]
-        return self._model.encode(texts_with_instructions).tolist()
+        return self._model.encode(texts_with_instructions).tolist()  # type: ignore
 
 
 # In order to remove dependencies on sentence-transformers, which in turn depends on
@@ -302,12 +304,12 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction):
 
     # Use pytorches default epsilon for division by zero
     # https://pytorch.org/docs/stable/generated/torch.nn.functional.normalize.html
-    def _normalize(self, v: npt.NDArray) -> npt.NDArray:
+    def _normalize(self, v: npt.NDArray) -> npt.NDArray:  # type: ignore
         norm = np.linalg.norm(v, axis=1)
         norm[norm == 0] = 1e-12
-        return v / norm[:, np.newaxis]
+        return v / norm[:, np.newaxis]  # type: ignore
 
-    def _forward(self, documents: List[str], batch_size: int = 32) -> npt.NDArray:
+    def _forward(self, documents: List[str], batch_size: int = 32) -> npt.NDArray:  # type: ignore
         # We need to cast to the correct type because the type checker doesn't know that init_model_and_tokenizer will set the values
         self.tokenizer = cast(self.Tokenizer, self.tokenizer)  # type: ignore
         self.model = cast(self.ort.InferenceSession, self.model)  # type: ignore
@@ -475,3 +477,15 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction):
                 embeddings.append(response["predictions"]["embeddings"]["values"])
 
         return embeddings
+
+
+# List of all classes in this module
+_classes = [
+    obj
+    for name, obj in inspect.getmembers(sys.modules[__name__], inspect.isclass)
+    if obj.__module__ == __name__
+]
+
+
+def get_builtins() -> List[type]:
+    return _classes

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -481,11 +481,11 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction):
 
 # List of all classes in this module
 _classes = [
-    obj
+    (name, obj)
     for name, obj in inspect.getmembers(sys.modules[__name__], inspect.isclass)
     if obj.__module__ == __name__
 ]
 
 
-def get_builtins() -> List[type]:
+def get_builtins() -> List[tuple[str, type]]:
     return _classes


### PR DESCRIPTION
## Description of changes
This PR accomplishes two things:
- Adds batching to metrics to decrease load to Posthog
- Adds more metric instrumentation

Each `TelemetryEvent` type now has a `batch_size` member defining how many of that Event to include in a batch. `TelemetryEvent`s with `batch_size > 1` must also define `can_batch()` and `batch()` methods to do the actual batching -- our posthog client can't do this itself since different `TelemetryEvent`s use different count fields. The Posthog client combines events until they hit their `batch_size` then fires them off as one event.

NB: this means we can drop up to `batch_size` events -- since we only batch `add()` calls right now this seems fine, though we may want to address it in the future.

As for the additional telemetry, I pretty much copied Anton's draft https://github.com/chroma-core/chroma/pull/859 with some minor changes.

Other considerations: Maybe we should implement `can_batch()` and `batch()` on all events, even those which don't currently use them? I'd prefer not to leave dead code hanging around but happy to go either way.

I created a ticket for the type ignores: https://github.com/chroma-core/chroma/issues/1169

## Test plan
pytest passes modulo a couple unrelated failures

With `print(event.properties)` in posthog client's `_direct_capture()`:
```
>>> import chromadb
>>> client = chromadb.Client()
{'batch_size': 1}
>>> collection = client.create_collection("sample_collection")
{'batch_size': 1, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'embedding_function': 'ONNXMiniLM_L6_V2'}
>>> collection.add(
...     documents=["This is document1", "This is document2"], # we embed for you, or bring your own
...     metadatas=[{"source": "notion"}, {"source": "google-docs"}], # filter on arbitrary metadata!
...     ids=["doc1", "doc2"], # must be unique for each doc 
... )
{'batch_size': 1, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'add_amount': 2, 'with_documents': 2, 'with_metadata': 2}
>>> for i in range(50):
...   collection.add(documents=[str(i)], ids=[str(i)])
... 
{'batch_size': 20, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'add_amount': 20, 'with_documents': 20, 'with_metadata': 0}
{'batch_size': 20, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'add_amount': 20, 'with_documents': 20, 'with_metadata': 0}
>>> for i in range(50):
...   collection.add(documents=[str(i) + ' ' + str(n) for n in range(20)], ids=[str(i) + ' ' + str(n) for n in range(20)])
... 
{'batch_size': 20, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'add_amount': 210, 'with_documents': 210, 'with_metadata': 0}
{'batch_size': 20, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'add_amount': 400, 'with_documents': 400, 'with_metadata': 0}
{'batch_size': 20, 'collection_uuid': 'bb19d790-4ec7-436c-b781-46dab047625d', 'add_amount': 400, 'with_documents': 400, 'with_metadata': 0}
```

## Documentation Changes
https://github.com/chroma-core/docs/pull/139
https://github.com/chroma-core/docs/commit/a4fd57d4d2cc3cae00cbb4a9245b938e2f0d1842