### PR TITLE
export IncludeEnum as it is required by #get and #query

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -5,3 +5,4 @@ export { OpenAIEmbeddingFunction } from './embeddings/OpenAIEmbeddingFunction';
 export { CohereEmbeddingFunction } from './embeddings/CohereEmbeddingFunction';
 export { WebAIEmbeddingFunction } from './embeddings/WebAIEmbeddingFunction';
 export { TransformersEmbeddingFunction } from './embeddings/TransformersEmbeddingFunction';
+export { IncludeEnum } from './types';


### PR DESCRIPTION
## Description of changes

The `IncludeEnum` enum is not exported, cause lint errors when using `.get` or `.query`, as follows:

```js
const result = await collection.query({
    queryTexts: [query],
    // THIS LINE WILL PRODUCE LINT ERROR as it needs IncludeEnum.Distances etc.
    include: ['distances', 'documents', 'metadatas'],
    nResults: 2,
})
```

## Test plan

Nil

## Documentation Changes

Nil
