### PR TITLE
Fix failing example terraform

### DIFF
--- a/examples/deployments/aws-terraform/README.md
+++ b/examples/deployments/aws-terraform/README.md
@@ -140,6 +140,9 @@ ssh -i ./chroma-aws ubuntu@$instance_public_ip
 ```
 
 ### 5. Destroy your Chroma instance
+
+You will need to change `prevent_destroy` to `true` in the `aws_ebs_volume` in `chroma.tf`.
+
 ```bash
 terraform destroy -auto-approve
 ```

--- a/examples/deployments/aws-terraform/README.md
+++ b/examples/deployments/aws-terraform/README.md
@@ -141,7 +141,7 @@ ssh -i ./chroma-aws ubuntu@$instance_public_ip
 
 ### 5. Destroy your Chroma instance
 
-You will need to change `prevent_destroy` to `true` in the `aws_ebs_volume` in `chroma.tf`.
+You will need to change `prevent_destroy` to `false` in the `aws_ebs_volume` in `chroma.tf`.
 
 ```bash
 terraform destroy -auto-approve

--- a/examples/deployments/aws-terraform/chroma.tf
+++ b/examples/deployments/aws-terraform/chroma.tf
@@ -111,7 +111,7 @@ resource "aws_ebs_volume" "chroma-volume" {
   }
 
   lifecycle {
-    prevent_destroy = var.prevent_chroma_data_volume_delete # size in GBs
+    prevent_destroy = true
   }
 }
 

--- a/examples/deployments/aws-terraform/variables.tf
+++ b/examples/deployments/aws-terraform/variables.tf
@@ -86,9 +86,3 @@ variable "chroma_data_volume_size" {
   type        = number
   default     = 20
 }
-
-variable "prevent_chroma_data_volume_delete" {
-    description = "Prevent the chroma data volume from being deleted when the instance is terminated"
-    type        = bool
-    default     = false
-}


### PR DESCRIPTION
## Description of changes

`lifecycle` blocks don't allow variables. Right now our example deployment for AWS doesn't work. @tazarov has a fix for this and a few other things in https://github.com/chroma-core/chroma/pull/1173 but I'd like to get the basic fix out before the weekend.

## Test plan
local `terraform init` failed before, now works.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
