### PR TITLE
[BUG] Update requirements for 3.11 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ fastapi>=0.95.2
 graphlib_backport==1.0.3; python_version < '3.9'
 importlib-resources
 numpy==1.21.6; python_version < '3.8'
-numpy==1.22.4; python_version >= '3.8'
-onnxruntime==1.14.1
+numpy>=1.22.4; python_version >= '3.8'
+onnxruntime>=1.14.1
 overrides==7.3.1
 posthog==2.4.0
 pulsar-client==3.1.0


### PR DESCRIPTION
## Description of changes
Our pyproject.toml is less restrictive than requirements.txt, which makes the published package support 3.11, but not in local dev. 

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Updates requirements.txt to resolve for 3.11
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Pyenv was updated to 3.11.4 and tested locally. 

- [x] Tests pass locally with `pytest` for python, `yarn test` for js - **Yes, tested on 3.11.4**

## Documentation Changes
We can update docs to remove any verbiage restricting 3.11.
