### PR TITLE
[BUG]: Unpinned tqdm version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pypika==0.48.9
 requests==2.28.1
 tenacity>=8.2.3
 tokenizers==0.13.2
-tqdm==4.65.0
+tqdm>=4.65.0
 typer>=0.9.0
 typing_extensions>=4.5.0
 uvicorn[standard]==0.18.3


### PR DESCRIPTION
#1235 

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - TQDM version pinning was causing issues with other deps that required a higher version.

## Test plan
*How are these changes tested?*

Local pip install tests.

## Documentation Changes
N/A
