### PR TITLE
[STACKED #1229] [ENH] Add a CollectionAssignmentPolicy and move topic creation into SysDB using the policy

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -67,6 +67,7 @@ _abstract_type_keys: Dict[str, str] = {
     "chromadb.telemetry.Telemetry": "chroma_telemetry_impl",
     "chromadb.ingest.Producer": "chroma_producer_impl",
     "chromadb.ingest.Consumer": "chroma_consumer_impl",
+    "chromadb.ingest.CollectionAssignmentPolicy": "chroma_collection_assignment_policy_impl",  # noqa
     "chromadb.db.system.SysDB": "chroma_sysdb_impl",
     "chromadb.segment.SegmentManager": "chroma_segment_manager_impl",
     "chromadb.segment.distributed.SegmentDirectory": "chroma_segment_directory_impl",
@@ -77,7 +78,8 @@ _abstract_type_keys: Dict[str, str] = {
 class Settings(BaseSettings):  # type: ignore
     environment: str = ""
 
-    # Legacy config has to be kept around because pydantic will error on nonexisting keys
+    # Legacy config has to be kept around because pydantic will error
+    # on nonexisting keys
     chroma_db_impl: Optional[str] = None
 
     chroma_api_impl: str = "chromadb.api.segment.SegmentAPI"  # Can be "chromadb.api.segment.SegmentAPI" or "chromadb.api.fastapi.FastAPI"
@@ -94,6 +96,9 @@ class Settings(BaseSettings):  # type: ignore
     # Distributed architecture specific components
     chroma_segment_directory_impl: str = "chromadb.segment.impl.distributed.segment_directory.RendezvousHashSegmentDirectory"
     chroma_memberlist_provider_impl: str = "chromadb.segment.impl.distributed.segment_directory.CustomResourceMemberlistProvider"
+    chroma_collection_assignment_policy_impl: str = (
+        "chromadb.ingest.impl.simple_policy.SimpleAssignmentPolicy"
+    )
     worker_memberlist_name: str = "worker-memberlist"
     chroma_coordinator_host = "localhost"
 

--- a/chromadb/db/system.py
+++ b/chromadb/db/system.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from uuid import UUID
 from chromadb.types import (
     Collection,
+    Metadata,
     Segment,
     SegmentScope,
     OptionalArgument,
@@ -52,13 +53,21 @@ class SysDB(Component):
         pass
 
     @abstractmethod
-    def create_collection(self, collection: Collection) -> None:
-        """Create a new collection any associated resources in the SysDB."""
+    def create_collection(
+        self,
+        id: UUID,
+        name: str,
+        metadata: Optional[Metadata] = None,
+        dimension: Optional[int] = None,
+    ) -> Collection:
+        """Create a new collection any associated resources
+        (Such as the necessary topics) in the SysDB."""
         pass
 
     @abstractmethod
     def delete_collection(self, id: UUID) -> None:
-        """Delete a topic and all associated segments from the SysDB"""
+        """Delete a collection, topic, all associated segments and any associate resources
+        from the SysDB and the system at large."""
         pass
 
     @abstractmethod

--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -118,3 +118,12 @@ class Consumer(Component):
     def max_seqid(self) -> SeqId:
         """Return the maximum possible SeqID in this implementation."""
         pass
+
+
+class CollectionAssignmentPolicy(Component):
+    """Interface for assigning collections to topics"""
+
+    @abstractmethod
+    def assign_collection(self, collection_id: UUID) -> str:
+        """Return the topic that should be used for the given collection"""
+        pass

--- a/chromadb/ingest/impl/simple_policy.py
+++ b/chromadb/ingest/impl/simple_policy.py
@@ -1,0 +1,25 @@
+from uuid import UUID
+from overrides import overrides
+from chromadb.config import System
+from chromadb.ingest import CollectionAssignmentPolicy
+from chromadb.ingest.impl.utils import create_topic_name
+
+
+class SimpleAssignmentPolicy(CollectionAssignmentPolicy):
+    """Simple assignment policy that assigns a 1 collection to 1 topic based on the
+    id of the collection."""
+
+    _tenant_id: str
+    _topic_ns: str
+
+    def __init__(self, system: System):
+        self._tenant_id = system.settings.tenant_id
+        self._topic_ns = system.settings.topic_namespace
+        super().__init__(system)
+
+    def _topic(self, collection_id: UUID) -> str:
+        return create_topic_name(self._tenant_id, self._topic_ns, str(collection_id))
+
+    @overrides
+    def assign_collection(self, collection_id: UUID) -> str:
+        return self._topic(collection_id)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds a CollectionAssignmentPolicy and moves topic creation down into SysDB
	 - Changes SysDB to not accept a Collection Object in create_collection() but params instead 
 - New functionality
       - None

TODO: 
- [x] delete topic should also live in the sysdb now.

## Test plan
*How are these changes tested?*
Existing tests were modified with the refactor and ensured to pass.

## Documentation Changes
None required
