### PR TITLE
[ENH]: Local clients thread safety

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -91,6 +91,7 @@ def get_settings() -> Settings:
     return __settings
 
 
+@synchronized
 def EphemeralClient(settings: Settings = Settings()) -> API:
     """
     Creates an in-memory instance of Chroma. This is useful for testing and

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -18,6 +18,7 @@ from chromadb.api.types import (
     WhereDocument,
     UpdateCollectionMetadata,
 )
+from chromadb.utils.locking import synchronized
 
 # Re-export types from chromadb.types
 __all__ = [
@@ -100,6 +101,7 @@ def EphemeralClient(settings: Settings = Settings()) -> API:
     return Client(settings)
 
 
+@synchronized
 def PersistentClient(path: str = "./chroma", settings: Settings = Settings()) -> API:
     """
     Creates a persistent instance of Chroma that saves to disk. This is useful for

--- a/chromadb/utils/locking.py
+++ b/chromadb/utils/locking.py
@@ -1,0 +1,18 @@
+import threading
+from functools import wraps
+from typing import Callable
+
+lock = threading.RLock()
+
+
+def synchronized(function: Callable) -> Callable:  # type: ignore
+    """
+    Decorator to synchronize a function call on a global lock. This allows us to 
+    ensure thread safety while allowing multiple persistent or ephemeral clients to 
+    be created.
+    """
+    @wraps(function)
+    def wrapped(*args, **kwargs):
+        with lock:
+            return function(*args, **kwargs)
+    return wrapped


### PR DESCRIPTION
Refs: #1209,  #1234

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Added serialized access to local clients (PersistentClient, EphemeralClient) and `SegmentAPI`

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

Test setup for multi-treading:
```python
import random
import threading
from time import sleep
import chromadb
import shutil

# Delete the database if it exists
try:
    shutil.rmtree("chroma-test")
except:
    pass

def worker():
    client = chromadb.PersistentClient(path="chroma-test")
    client.heartbeat()
    sleep(random.randint(1,10))
    client.get_or_create_collection("test")
    sleep(random.randint(1, 10))
    try:
        client.delete_collection("test")
    except ValueError:
        pass




# Creating threads
thread1 = threading.Thread(target=worker)
thread2 = threading.Thread(target=worker)
thread3 = threading.Thread(target=worker)
thread4 = threading.Thread(target=worker)
# Starting threads
thread1.start()
thread2.start()
thread3.start()
thread4.start()
# Wait for both threads to complete
thread1.join()
thread2.join()
thread3.join()
thread4.join()
```
## Documentation Changes

N/A


