### PR TITLE
helm cluster manifests

### DIFF
--- a/k8s/helm/.helmignore
+++ b/k8s/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: chromadb
+description: The AI-native open-source vector embedding database.
+
+type: application
+
+version: 0.1.0
+
+appVersion: "0.4.14"

--- a/k8s/helm/crds/memberlist_crd.yaml
+++ b/k8s/helm/crds/memberlist_crd.yaml
@@ -1,0 +1,36 @@
+# These kubernetes manifests are UNDER ACTIVE  DEVELOPMENT and are not yet ready for production use.
+# They will be used for the upcoming distributed version of chroma. They are not even ready
+# for testing yet. Please do not use them unless you are working on the distributed version of chroma.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: memberlists.chroma.cluster
+spec:
+  group: chroma.cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                members:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      url:
+                        type: string
+                        pattern: '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$'
+  scope: Namespaced
+  names:
+    plural: memberlists
+    singular: memberlist
+    kind: MemberList
+    shortNames:
+      - ml

--- a/k8s/helm/templates/chroma-namespace.yaml
+++ b/k8s/helm/templates/chroma-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chroma

--- a/k8s/helm/templates/frontend-server-service.yaml
+++ b/k8s/helm/templates/frontend-server-service.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-server
+  namespace: chroma
+spec:
+  ports:
+    - name: frontend-server
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: frontend-server
+  type: LoadBalancer
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-server
+  namespace: chroma
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend-server
+  template:
+    metadata:
+      labels:
+        app: frontend-server
+    spec:
+      containers:
+        - name: frontend-server
+          image: "{{ .Values.imageUrl }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: chroma
+              mountPath: /test
+          env:
+            - name: IS_PERSISTENT
+              value: "TRUE"
+            - name: CHROMA_PRODUCER_IMPL
+              value: "chromadb.ingest.impl.pulsar.PulsarProducer"
+            - name: CHROMA_CONSUMER_IMPL
+              value: "chromadb.ingest.impl.pulsar.PulsarConsumer"
+            - name: CHROMA_SEGMENT_MANAGER_IMPL
+              value: "chromadb.segment.impl.manager.distributed.DistributedSegmentManager"
+            - name: PULSAR_BROKER_URL
+              value: "pulsar.chroma"
+            - name: PULSAR_BROKER_PORT
+              value: "6650"
+            - name: PULSAR_ADMIN_PORT
+              value: "8080"
+          # readinessProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 8000
+          #   initialDelaySeconds: 10
+          #   periodSeconds: 5
+          # livenessProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 8000
+          #   initialDelaySeconds: 20
+          #   periodSeconds: 10
+      # Ephemeral for now
+      volumes:
+        - name: chroma
+          emptyDir: {}

--- a/k8s/helm/templates/pulsar-service.yaml
+++ b/k8s/helm/templates/pulsar-service.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pulsar
+  namespace: chroma
+spec:
+  ports:
+    - name: pulsar-port
+      port: 6650
+      targetPort: 6650
+    - name: admin-port
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: pulsar
+  type: ClusterIP
+
+---
+
+# TODO: Should be stateful set locally or managed via terraform into streamnative for cloud deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pulsar
+  namespace: chroma
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pulsar
+  template:
+    metadata:
+      labels:
+        app: pulsar
+    spec:
+      containers:
+        - name: pulsar
+          image: apachepulsar/pulsar
+          command: [ "/pulsar/bin/pulsar", "standalone" ]
+          ports:
+            - containerPort: 6650
+            - containerPort: 8080
+          volumeMounts:
+            - name: pulsardata
+              mountPath: /pulsar/data
+          # readinessProbe:
+          #   httpGet:
+          #     path: /admin/v2/brokers/health
+          #     port: 8080
+          #   initialDelaySeconds: 10
+          #   periodSeconds: 5
+          # livenessProbe:
+          #   httpGet:
+          #     path: /admin/v2/brokers/health
+          #     port: 8080
+          #   initialDelaySeconds: 20
+          #   periodSeconds: 10
+      volumes:
+        - name: pulsardata
+          emptyDir: {}

--- a/k8s/helm/templates/segment-server-service.yaml
+++ b/k8s/helm/templates/segment-server-service.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: segment-server
+  namespace: chroma
+spec:
+  ports:
+    - name: segment-server-port
+      port: 50051
+      targetPort: 50051
+  selector:
+    app: segment-server
+  type: ClusterIP
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: segment-server
+  namespace: chroma
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: segment-server
+  template:
+    metadata:
+      labels:
+        app: segment-server
+    spec:
+      containers:
+        - name: segment-server
+          image: "{{ .Values.imageUrl }}"
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "chromadb.segment.impl.distributed.server"]
+          ports:
+            - containerPort: 50051
+          volumeMounts:
+            - name: chroma
+              mountPath: /index_data
+          env:
+            - name: IS_PERSISTENT
+              value: "TRUE"
+            - name: CHROMA_PRODUCER_IMPL
+              value: "chromadb.ingest.impl.pulsar.PulsarProducer"
+            - name: CHROMA_CONSUMER_IMPL
+              value: "chromadb.ingest.impl.pulsar.PulsarConsumer"
+            - name: PULSAR_BROKER_URL
+              value: "pulsar.chroma"
+            - name: PULSAR_BROKER_PORT
+              value: "6650"
+            - name: PULSAR_ADMIN_PORT
+              value: "8080"
+            - name: chroma_server_grpc_port
+              value: "50051"
+          # readinessProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 50051
+          #   initialDelaySeconds: 10
+          #   periodSeconds: 5
+          # livenessProbe:
+          #   httpGet:
+          #     path: /healthz
+          #     port: 50051
+          #   initialDelaySeconds: 20
+          #   periodSeconds: 10
+      volumes:
+        - name: chroma
+          emptyDir: {}

--- a/k8s/helm/templates/worker-memberlist-cr.yaml
+++ b/k8s/helm/templates/worker-memberlist-cr.yaml
@@ -1,0 +1,43 @@
+# These kubernetes manifests are UNDER ACTIVE  DEVELOPMENT and are not yet ready for production use.
+# They will be used for the upcoming distributed version of chroma. They are not even ready
+# for testing yet. Please do not use them unless you are working on the distributed version of chroma.
+
+# Create a memberlist called worker-memberlist
+apiVersion: chroma.cluster/v1
+kind: MemberList
+metadata:
+  name: worker-memberlist
+  namespace: chroma
+spec:
+  members:
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: worker-memberlist-reader
+rules:
+- apiGroups:
+  - chroma.cluster
+  resources:
+  - memberlists
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: worker-memberlist-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: worker-memberlist-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: chroma

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -1,0 +1,1 @@
+imageUrl: "registry-1.docker.io/chromadb/chroma:latest"


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - None
 - New functionality
	 - Put K8s configs into a helm chart. Right now we're duplicating config -- sometime soon I would like to point our minikube tests to here so we can delete the other k8s stuff.

## Test plan
*How are these changes tested?*

- Pointed this at my staging cluster:

```sh
0 beggers % helm template . | kubectl apply -f -

namespace/chroma configured
clusterrole.rbac.authorization.k8s.io/worker-memberlist-reader unchanged
clusterrolebinding.rbac.authorization.k8s.io/worker-memberlist-reader-binding unchanged
service/frontend-server created 
service/pulsar configured
service/segment-server configured 
deployment.apps/frontend-server created 
deployment.apps/pulsar configured
deployment.apps/segment-server configured 
memberlist.chroma.cluster/worker-memberlist created
```

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

None needed.
