### PR TITLE
Fix otel startup bug

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -179,7 +179,7 @@ class Settings(BaseSettings):  # type: ignore
     chroma_otel_collection_endpoint: Optional[str] = ""
     chroma_otel_service_name: Optional[str] = "chromadb"
     chroma_otel_collection_headers: Dict[str, str] = {}
-    chroma_otel_granularity: Optional[str] = "none"
+    chroma_otel_granularity: Optional[str] = None
 
     allow_reset: bool = False
 

--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -49,7 +49,11 @@ class OpenTelemetryClient(Component):
             system.settings.chroma_otel_service_name,
             system.settings.chroma_otel_collection_endpoint,
             system.settings.chroma_otel_collection_headers,
-            OpenTelemetryGranularity(system.settings.chroma_otel_granularity),
+            OpenTelemetryGranularity(
+                system.settings.chroma_otel_granularity
+                if system.settings.chroma_otel_granularity
+                else "none"
+            ),
         )
 
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixes https://github.com/chroma-core/chroma/issues/1260#issuecomment-1771207121
	 - TL;DR the default `chroma_otel_tracing_granularity` ends up set to `""` which isn't a valid enum value.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*

- CI
- The `docker-compose` startup flow works now

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
