### PR TITLE
[BUG]: Fixed a typo in metadata sqlite filtering

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -97,7 +97,8 @@ class SqliteMetadataSegment(MetadataReader):
             self._db.querybuilder()
             .from_(embeddings_t)
             .where(
-                embeddings_t.segment_id == ParameterValue(self._db.uuid_to_db(self._id))
+                embeddings_t.segment_id == ParameterValue(
+                    self._db.uuid_to_db(self._id))
             )
             .select(fn.Count(embeddings_t.id))
         )
@@ -139,16 +140,19 @@ class SqliteMetadataSegment(MetadataReader):
                 metadata_t.bool_value,
             )
             .where(
-                embeddings_t.segment_id == ParameterValue(self._db.uuid_to_db(self._id))
+                embeddings_t.segment_id == ParameterValue(
+                    self._db.uuid_to_db(self._id))
             )
             .orderby(embeddings_t.id)
         )
 
         if where:
-            q = q.where(self._where_map_criterion(q, where, embeddings_t, metadata_t))
+            q = q.where(self._where_map_criterion(
+                q, where, embeddings_t, metadata_t))
         if where_document:
             q = q.where(
-                self._where_doc_criterion(q, where_document, embeddings_t, fulltext_t)
+                self._where_doc_criterion(
+                    q, where_document, embeddings_t, fulltext_t)
             )
 
         if ids:
@@ -227,7 +231,8 @@ class SqliteMetadataSegment(MetadataReader):
             if upsert:
                 return self._update_record(cur, record)
             else:
-                logger.warning(f"Insert of existing embedding ID: {record['id']}")
+                logger.warning(
+                    f"Insert of existing embedding ID: {record['id']}")
                 # We are trying to add for a record that already exists. Fail the call.
                 # We don't throw an exception since this is in principal an async path
                 return
@@ -361,7 +366,8 @@ class SqliteMetadataSegment(MetadataReader):
         sql = sql + " RETURNING id"
         result = cur.execute(sql, params).fetchone()
         if result is None:
-            logger.warning(f"Delete of nonexisting embedding ID: {record['id']}")
+            logger.warning(
+                f"Delete of nonexisting embedding ID: {record['id']}")
         else:
             id = result[0]
 
@@ -392,7 +398,8 @@ class SqliteMetadataSegment(MetadataReader):
         sql = sql + " RETURNING id"
         result = cur.execute(sql, params).fetchone()
         if result is None:
-            logger.warning(f"Update of nonexisting embedding ID: {record['id']}")
+            logger.warning(
+                f"Update of nonexisting embedding ID: {record['id']}")
         else:
             id = result[0]
             if record["metadata"]:
@@ -447,7 +454,8 @@ class SqliteMetadataSegment(MetadataReader):
                 ]
                 clause.append(reduce(lambda x, y: x | y, criteria))
             else:
-                expr = cast(Union[LiteralValue, Dict[WhereOperator, LiteralValue]], v)
+                expr = cast(
+                    Union[LiteralValue, Dict[WhereOperator, LiteralValue]], v)
                 sq = (
                     self._db.querybuilder()
                     .from_(metadata_t)
@@ -564,7 +572,7 @@ def _value_criterion(
             col_exprs = [
                 table.string_value.isin(ParameterValue(_v))
                 if op == "$in"
-                else table.str_value.notin(ParameterValue(_v))
+                else table.string_value.notin(ParameterValue(_v))
             ]
         elif isinstance(value[0], bool):
             col_exprs = [


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixed a typo in the sqlite metadata filtering where the name of the should be `string_value` (not `str_value`)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
N/A
