### PR TITLE
Use MemoryCatalog in coordinator for now

### DIFF
--- a/go/coordinator/internal/coordinator/coordinator.go
+++ b/go/coordinator/internal/coordinator/coordinator.go
@@ -28,7 +28,7 @@ func NewCoordinator(ctx context.Context, assignmentPolicy CollectionAssignmentPo
 	}
 
 	// catalog := coordinator.NewMemoryCatalog()
-	catalog := coordinator.NewTableCatalog(dbcore.NewTxImpl(), dao.NewMetaDomain())
+	catalog := coordinator.NewMemoryCatalog(dbcore.NewTxImpl(), dao.NewMetaDomain())
 	meta, err := NewMetaTable(s.ctx, catalog)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Use `MemoryCatalog` in the coordinator for now. This will allow us to prototype more easily. We'll need to add flags to control persistence behavior in the near future.

## Test plan
*How are these changes tested?*

- CI

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
