### PR TITLE
[BUG]: Removed defaulting HttpClient headers to empty dict

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -160,8 +160,6 @@ def HttpClient(
         database: The database to use for this client. Defaults to the default database.
     """
 
-    if headers is None:
-        headers = {}
     if settings is None:
         settings = Settings()
 


### PR DESCRIPTION
Refs: #1302

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Removed defaulting of headers for HttpClient as this causes differences in settings when clients are initialized from HttpClient and Client with the same settings which raises an error

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
N/A
