### PR TITLE
[BUG] validate nofile limit in case of empty string

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -127,7 +127,7 @@ class Settings(BaseSettings):  # type: ignore
 
     @validator("chroma_server_nofile", pre=True, always=True, allow_reuse=True)
     def empty_str_to_none(cls, v: str) -> Optional[str]:
-        if v.strip() == "":
+        if type(v) is str and v.strip() == "":
             return None
         return v
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -124,6 +124,13 @@ class Settings(BaseSettings):  # type: ignore
     chroma_server_grpc_port: Optional[str] = None
     # eg ["http://localhost:3000"]
     chroma_server_cors_allow_origins: List[str] = []
+
+    @validator("chroma_server_nofile", pre=True, always=True, allow_reuse=True)
+    def empty_str_to_none(cls, v: str) -> Optional[str]:
+        if v.strip() == "":
+            return None
+        return v
+
     chroma_server_nofile: Optional[int] = None
 
     pulsar_broker_url: Optional[str] = None


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixes an issue where the empty string was not being handled by pydantic validation. Here we treat the empty string as None.
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
None
