### PR TITLE
[ENH] Update SubmitEmbeddingRecord to take collection_id. Update EmbeddingRecord to take collection_id

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -349,6 +349,7 @@ class SegmentAPI(ServerAPI):
         for r in _records(
             t.Operation.ADD,
             ids=ids,
+            collection_id=collection_id,
             embeddings=embeddings,
             metadatas=metadatas,
             documents=documents,
@@ -390,6 +391,7 @@ class SegmentAPI(ServerAPI):
         for r in _records(
             t.Operation.UPDATE,
             ids=ids,
+            collection_id=collection_id,
             embeddings=embeddings,
             metadatas=metadatas,
             documents=documents,
@@ -433,6 +435,7 @@ class SegmentAPI(ServerAPI):
         for r in _records(
             t.Operation.UPSERT,
             ids=ids,
+            collection_id=collection_id,
             embeddings=embeddings,
             metadatas=metadatas,
             documents=documents,
@@ -601,7 +604,9 @@ class SegmentAPI(ServerAPI):
             return []
 
         records_to_submit = []
-        for r in _records(t.Operation.DELETE, ids_to_delete):
+        for r in _records(
+            operation=t.Operation.DELETE, ids=ids_to_delete, collection_id=collection_id
+        ):
             self._validate_embedding_record(coll, r)
             records_to_submit.append(r)
         self._producer.submit_embeddings(coll["topic"], records_to_submit)
@@ -811,6 +816,7 @@ class SegmentAPI(ServerAPI):
 def _records(
     operation: t.Operation,
     ids: IDs,
+    collection_id: UUID,
     embeddings: Optional[Embeddings] = None,
     metadatas: Optional[Metadatas] = None,
     documents: Optional[Documents] = None,
@@ -848,6 +854,7 @@ def _records(
             encoding=t.ScalarEncoding.FLOAT32,  # Hardcode for now
             metadata=metadata,
             operation=operation,
+            collection_id=collection_id,
         )
         yield record
 

--- a/chromadb/proto/chroma_pb2.py
+++ b/chromadb/proto/chroma_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1b\x63hromadb/proto/chroma.proto\x12\x06\x63hroma\"&\n\x06Status\x12\x0e\n\x06reason\x18\x01 \x01(\t\x12\x0c\n\x04\x63ode\x18\x02 \x01(\x05\"0\n\x0e\x43hromaResponse\x12\x1e\n\x06status\x18\x01 \x01(\x0b\x32\x0e.chroma.Status\"U\n\x06Vector\x12\x11\n\tdimension\x18\x01 \x01(\x05\x12\x0e\n\x06vector\x18\x02 \x01(\x0c\x12(\n\x08\x65ncoding\x18\x03 \x01(\x0e\x32\x16.chroma.ScalarEncoding\"\xca\x01\n\x07Segment\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12#\n\x05scope\x18\x03 \x01(\x0e\x32\x14.chroma.SegmentScope\x12\x12\n\x05topic\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ncollection\x18\x05 \x01(\tH\x01\x88\x01\x01\x12-\n\x08metadata\x18\x06 \x01(\x0b\x32\x16.chroma.UpdateMetadataH\x02\x88\x01\x01\x42\x08\n\x06_topicB\r\n\x0b_collectionB\x0b\n\t_metadata\"\xb9\x01\n\nCollection\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\r\n\x05topic\x18\x03 \x01(\t\x12-\n\x08metadata\x18\x04 \x01(\x0b\x32\x16.chroma.UpdateMetadataH\x00\x88\x01\x01\x12\x16\n\tdimension\x18\x05 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x06tenant\x18\x06 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\x07 \x01(\tB\x0b\n\t_metadataB\x0c\n\n_dimension\"4\n\x08\x44\x61tabase\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0e\n\x06tenant\x18\x03 \x01(\t\"\x16\n\x06Tenant\x12\x0c\n\x04name\x18\x01 \x01(\t\"b\n\x13UpdateMetadataValue\x12\x16\n\x0cstring_value\x18\x01 \x01(\tH\x00\x12\x13\n\tint_value\x18\x02 \x01(\x03H\x00\x12\x15\n\x0b\x66loat_value\x18\x03 \x01(\x01H\x00\x42\x07\n\x05value\"\x96\x01\n\x0eUpdateMetadata\x12\x36\n\x08metadata\x18\x01 \x03(\x0b\x32$.chroma.UpdateMetadata.MetadataEntry\x1aL\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x1b.chroma.UpdateMetadataValue:\x02\x38\x01\"\xb5\x01\n\x15SubmitEmbeddingRecord\x12\n\n\x02id\x18\x01 \x01(\t\x12#\n\x06vector\x18\x02 \x01(\x0b\x32\x0e.chroma.VectorH\x00\x88\x01\x01\x12-\n\x08metadata\x18\x03 \x01(\x0b\x32\x16.chroma.UpdateMetadataH\x01\x88\x01\x01\x12$\n\toperation\x18\x04 \x01(\x0e\x32\x11.chroma.OperationB\t\n\x07_vectorB\x0b\n\t_metadata\"S\n\x15VectorEmbeddingRecord\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0e\n\x06seq_id\x18\x02 \x01(\x0c\x12\x1e\n\x06vector\x18\x03 \x01(\x0b\x32\x0e.chroma.Vector\"q\n\x11VectorQueryResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0e\n\x06seq_id\x18\x02 \x01(\x0c\x12\x10\n\x08\x64istance\x18\x03 \x01(\x01\x12#\n\x06vector\x18\x04 \x01(\x0b\x32\x0e.chroma.VectorH\x00\x88\x01\x01\x42\t\n\x07_vector\"@\n\x12VectorQueryResults\x12*\n\x07results\x18\x01 \x03(\x0b\x32\x19.chroma.VectorQueryResult\"(\n\x15SegmentServerResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"4\n\x11GetVectorsRequest\x12\x0b\n\x03ids\x18\x01 \x03(\t\x12\x12\n\nsegment_id\x18\x02 \x01(\t\"D\n\x12GetVectorsResponse\x12.\n\x07records\x18\x01 \x03(\x0b\x32\x1d.chroma.VectorEmbeddingRecord\"\x86\x01\n\x13QueryVectorsRequest\x12\x1f\n\x07vectors\x18\x01 \x03(\x0b\x32\x0e.chroma.Vector\x12\t\n\x01k\x18\x02 \x01(\x05\x12\x13\n\x0b\x61llowed_ids\x18\x03 \x03(\t\x12\x1a\n\x12include_embeddings\x18\x04 \x01(\x08\x12\x12\n\nsegment_id\x18\x05 \x01(\t\"C\n\x14QueryVectorsResponse\x12+\n\x07results\x18\x01 \x03(\x0b\x32\x1a.chroma.VectorQueryResults*8\n\tOperation\x12\x07\n\x03\x41\x44\x44\x10\x00\x12\n\n\x06UPDATE\x10\x01\x12\n\n\x06UPSERT\x10\x02\x12\n\n\x06\x44\x45LETE\x10\x03*(\n\x0eScalarEncoding\x12\x0b\n\x07\x46LOAT32\x10\x00\x12\t\n\x05INT32\x10\x01*(\n\x0cSegmentScope\x12\n\n\x06VECTOR\x10\x00\x12\x0c\n\x08METADATA\x10\x01\x32\x94\x01\n\rSegmentServer\x12?\n\x0bLoadSegment\x12\x0f.chroma.Segment\x1a\x1d.chroma.SegmentServerResponse\"\x00\x12\x42\n\x0eReleaseSegment\x12\x0f.chroma.Segment\x1a\x1d.chroma.SegmentServerResponse\"\x00\x32\xa2\x01\n\x0cVectorReader\x12\x45\n\nGetVectors\x12\x19.chroma.GetVectorsRequest\x1a\x1a.chroma.GetVectorsResponse\"\x00\x12K\n\x0cQueryVectors\x12\x1b.chroma.QueryVectorsRequest\x1a\x1c.chroma.QueryVectorsResponse\"\x00\x42\x43ZAgithub.com/chroma/chroma-coordinator/internal/proto/coordinatorpbb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1b\x63hromadb/proto/chroma.proto\x12\x06\x63hroma\"&\n\x06Status\x12\x0e\n\x06reason\x18\x01 \x01(\t\x12\x0c\n\x04\x63ode\x18\x02 \x01(\x05\"0\n\x0e\x43hromaResponse\x12\x1e\n\x06status\x18\x01 \x01(\x0b\x32\x0e.chroma.Status\"U\n\x06Vector\x12\x11\n\tdimension\x18\x01 \x01(\x05\x12\x0e\n\x06vector\x18\x02 \x01(\x0c\x12(\n\x08\x65ncoding\x18\x03 \x01(\x0e\x32\x16.chroma.ScalarEncoding\"\xca\x01\n\x07Segment\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04type\x18\x02 \x01(\t\x12#\n\x05scope\x18\x03 \x01(\x0e\x32\x14.chroma.SegmentScope\x12\x12\n\x05topic\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ncollection\x18\x05 \x01(\tH\x01\x88\x01\x01\x12-\n\x08metadata\x18\x06 \x01(\x0b\x32\x16.chroma.UpdateMetadataH\x02\x88\x01\x01\x42\x08\n\x06_topicB\r\n\x0b_collectionB\x0b\n\t_metadata\"\xb9\x01\n\nCollection\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\r\n\x05topic\x18\x03 \x01(\t\x12-\n\x08metadata\x18\x04 \x01(\x0b\x32\x16.chroma.UpdateMetadataH\x00\x88\x01\x01\x12\x16\n\tdimension\x18\x05 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x06tenant\x18\x06 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\x07 \x01(\tB\x0b\n\t_metadataB\x0c\n\n_dimension\"4\n\x08\x44\x61tabase\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0e\n\x06tenant\x18\x03 \x01(\t\"\x16\n\x06Tenant\x12\x0c\n\x04name\x18\x01 \x01(\t\"b\n\x13UpdateMetadataValue\x12\x16\n\x0cstring_value\x18\x01 \x01(\tH\x00\x12\x13\n\tint_value\x18\x02 \x01(\x03H\x00\x12\x15\n\x0b\x66loat_value\x18\x03 \x01(\x01H\x00\x42\x07\n\x05value\"\x96\x01\n\x0eUpdateMetadata\x12\x36\n\x08metadata\x18\x01 \x03(\x0b\x32$.chroma.UpdateMetadata.MetadataEntry\x1aL\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12*\n\x05value\x18\x02 \x01(\x0b\x32\x1b.chroma.UpdateMetadataValue:\x02\x38\x01\"\xcc\x01\n\x15SubmitEmbeddingRecord\x12\n\n\x02id\x18\x01 \x01(\t\x12#\n\x06vector\x18\x02 \x01(\x0b\x32\x0e.chroma.VectorH\x00\x88\x01\x01\x12-\n\x08metadata\x18\x03 \x01(\x0b\x32\x16.chroma.UpdateMetadataH\x01\x88\x01\x01\x12$\n\toperation\x18\x04 \x01(\x0e\x32\x11.chroma.Operation\x12\x15\n\rcollection_id\x18\x05 \x01(\tB\t\n\x07_vectorB\x0b\n\t_metadata\"S\n\x15VectorEmbeddingRecord\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0e\n\x06seq_id\x18\x02 \x01(\x0c\x12\x1e\n\x06vector\x18\x03 \x01(\x0b\x32\x0e.chroma.Vector\"q\n\x11VectorQueryResult\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0e\n\x06seq_id\x18\x02 \x01(\x0c\x12\x10\n\x08\x64istance\x18\x03 \x01(\x01\x12#\n\x06vector\x18\x04 \x01(\x0b\x32\x0e.chroma.VectorH\x00\x88\x01\x01\x42\t\n\x07_vector\"@\n\x12VectorQueryResults\x12*\n\x07results\x18\x01 \x03(\x0b\x32\x19.chroma.VectorQueryResult\"(\n\x15SegmentServerResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"4\n\x11GetVectorsRequest\x12\x0b\n\x03ids\x18\x01 \x03(\t\x12\x12\n\nsegment_id\x18\x02 \x01(\t\"D\n\x12GetVectorsResponse\x12.\n\x07records\x18\x01 \x03(\x0b\x32\x1d.chroma.VectorEmbeddingRecord\"\x86\x01\n\x13QueryVectorsRequest\x12\x1f\n\x07vectors\x18\x01 \x03(\x0b\x32\x0e.chroma.Vector\x12\t\n\x01k\x18\x02 \x01(\x05\x12\x13\n\x0b\x61llowed_ids\x18\x03 \x03(\t\x12\x1a\n\x12include_embeddings\x18\x04 \x01(\x08\x12\x12\n\nsegment_id\x18\x05 \x01(\t\"C\n\x14QueryVectorsResponse\x12+\n\x07results\x18\x01 \x03(\x0b\x32\x1a.chroma.VectorQueryResults*8\n\tOperation\x12\x07\n\x03\x41\x44\x44\x10\x00\x12\n\n\x06UPDATE\x10\x01\x12\n\n\x06UPSERT\x10\x02\x12\n\n\x06\x44\x45LETE\x10\x03*(\n\x0eScalarEncoding\x12\x0b\n\x07\x46LOAT32\x10\x00\x12\t\n\x05INT32\x10\x01*(\n\x0cSegmentScope\x12\n\n\x06VECTOR\x10\x00\x12\x0c\n\x08METADATA\x10\x01\x32\x94\x01\n\rSegmentServer\x12?\n\x0bLoadSegment\x12\x0f.chroma.Segment\x1a\x1d.chroma.SegmentServerResponse\"\x00\x12\x42\n\x0eReleaseSegment\x12\x0f.chroma.Segment\x1a\x1d.chroma.SegmentServerResponse\"\x00\x32\xa2\x01\n\x0cVectorReader\x12\x45\n\nGetVectors\x12\x19.chroma.GetVectorsRequest\x1a\x1a.chroma.GetVectorsResponse\"\x00\x12K\n\x0cQueryVectors\x12\x1b.chroma.QueryVectorsRequest\x1a\x1c.chroma.QueryVectorsResponse\"\x00\x42\x43ZAgithub.com/chroma/chroma-coordinator/internal/proto/coordinatorpbb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -23,12 +23,12 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._serialized_options = b'ZAgithub.com/chroma/chroma-coordinator/internal/proto/coordinatorpb'
   _UPDATEMETADATA_METADATAENTRY._options = None
   _UPDATEMETADATA_METADATAENTRY._serialized_options = b'8\001'
-  _globals['_OPERATION']._serialized_start=1762
-  _globals['_OPERATION']._serialized_end=1818
-  _globals['_SCALARENCODING']._serialized_start=1820
-  _globals['_SCALARENCODING']._serialized_end=1860
-  _globals['_SEGMENTSCOPE']._serialized_start=1862
-  _globals['_SEGMENTSCOPE']._serialized_end=1902
+  _globals['_OPERATION']._serialized_start=1785
+  _globals['_OPERATION']._serialized_end=1841
+  _globals['_SCALARENCODING']._serialized_start=1843
+  _globals['_SCALARENCODING']._serialized_end=1883
+  _globals['_SEGMENTSCOPE']._serialized_start=1885
+  _globals['_SEGMENTSCOPE']._serialized_end=1925
   _globals['_STATUS']._serialized_start=39
   _globals['_STATUS']._serialized_end=77
   _globals['_CHROMARESPONSE']._serialized_start=79
@@ -50,25 +50,25 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_UPDATEMETADATA_METADATAENTRY']._serialized_start=862
   _globals['_UPDATEMETADATA_METADATAENTRY']._serialized_end=938
   _globals['_SUBMITEMBEDDINGRECORD']._serialized_start=941
-  _globals['_SUBMITEMBEDDINGRECORD']._serialized_end=1122
-  _globals['_VECTOREMBEDDINGRECORD']._serialized_start=1124
-  _globals['_VECTOREMBEDDINGRECORD']._serialized_end=1207
-  _globals['_VECTORQUERYRESULT']._serialized_start=1209
-  _globals['_VECTORQUERYRESULT']._serialized_end=1322
-  _globals['_VECTORQUERYRESULTS']._serialized_start=1324
-  _globals['_VECTORQUERYRESULTS']._serialized_end=1388
-  _globals['_SEGMENTSERVERRESPONSE']._serialized_start=1390
-  _globals['_SEGMENTSERVERRESPONSE']._serialized_end=1430
-  _globals['_GETVECTORSREQUEST']._serialized_start=1432
-  _globals['_GETVECTORSREQUEST']._serialized_end=1484
-  _globals['_GETVECTORSRESPONSE']._serialized_start=1486
-  _globals['_GETVECTORSRESPONSE']._serialized_end=1554
-  _globals['_QUERYVECTORSREQUEST']._serialized_start=1557
-  _globals['_QUERYVECTORSREQUEST']._serialized_end=1691
-  _globals['_QUERYVECTORSRESPONSE']._serialized_start=1693
-  _globals['_QUERYVECTORSRESPONSE']._serialized_end=1760
-  _globals['_SEGMENTSERVER']._serialized_start=1905
-  _globals['_SEGMENTSERVER']._serialized_end=2053
-  _globals['_VECTORREADER']._serialized_start=2056
-  _globals['_VECTORREADER']._serialized_end=2218
+  _globals['_SUBMITEMBEDDINGRECORD']._serialized_end=1145
+  _globals['_VECTOREMBEDDINGRECORD']._serialized_start=1147
+  _globals['_VECTOREMBEDDINGRECORD']._serialized_end=1230
+  _globals['_VECTORQUERYRESULT']._serialized_start=1232
+  _globals['_VECTORQUERYRESULT']._serialized_end=1345
+  _globals['_VECTORQUERYRESULTS']._serialized_start=1347
+  _globals['_VECTORQUERYRESULTS']._serialized_end=1411
+  _globals['_SEGMENTSERVERRESPONSE']._serialized_start=1413
+  _globals['_SEGMENTSERVERRESPONSE']._serialized_end=1453
+  _globals['_GETVECTORSREQUEST']._serialized_start=1455
+  _globals['_GETVECTORSREQUEST']._serialized_end=1507
+  _globals['_GETVECTORSRESPONSE']._serialized_start=1509
+  _globals['_GETVECTORSRESPONSE']._serialized_end=1577
+  _globals['_QUERYVECTORSREQUEST']._serialized_start=1580
+  _globals['_QUERYVECTORSREQUEST']._serialized_end=1714
+  _globals['_QUERYVECTORSRESPONSE']._serialized_start=1716
+  _globals['_QUERYVECTORSRESPONSE']._serialized_end=1783
+  _globals['_SEGMENTSERVER']._serialized_start=1928
+  _globals['_SEGMENTSERVER']._serialized_end=2076
+  _globals['_VECTORREADER']._serialized_start=2079
+  _globals['_VECTORREADER']._serialized_end=2241
 # @@protoc_insertion_point(module_scope)

--- a/chromadb/proto/chroma_pb2.pyi
+++ b/chromadb/proto/chroma_pb2.pyi
@@ -129,16 +129,18 @@ class UpdateMetadata(_message.Message):
     def __init__(self, metadata: _Optional[_Mapping[str, UpdateMetadataValue]] = ...) -> None: ...
 
 class SubmitEmbeddingRecord(_message.Message):
-    __slots__ = ["id", "vector", "metadata", "operation"]
+    __slots__ = ["id", "vector", "metadata", "operation", "collection_id"]
     ID_FIELD_NUMBER: _ClassVar[int]
     VECTOR_FIELD_NUMBER: _ClassVar[int]
     METADATA_FIELD_NUMBER: _ClassVar[int]
     OPERATION_FIELD_NUMBER: _ClassVar[int]
+    COLLECTION_ID_FIELD_NUMBER: _ClassVar[int]
     id: str
     vector: Vector
     metadata: UpdateMetadata
     operation: Operation
-    def __init__(self, id: _Optional[str] = ..., vector: _Optional[_Union[Vector, _Mapping]] = ..., metadata: _Optional[_Union[UpdateMetadata, _Mapping]] = ..., operation: _Optional[_Union[Operation, str]] = ...) -> None: ...
+    collection_id: str
+    def __init__(self, id: _Optional[str] = ..., vector: _Optional[_Union[Vector, _Mapping]] = ..., metadata: _Optional[_Union[UpdateMetadata, _Mapping]] = ..., operation: _Optional[_Union[Operation, str]] = ..., collection_id: _Optional[str] = ...) -> None: ...
 
 class VectorEmbeddingRecord(_message.Message):
     __slots__ = ["id", "seq_id", "vector"]

--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -122,6 +122,7 @@ def from_proto_submit(
         encoding=encoding,
         metadata=from_proto_update_metadata(submit_embedding_record.metadata),
         operation=from_proto_operation(submit_embedding_record.operation),
+        collection_id=UUID(hex=submit_embedding_record.collection_id),
     )
     return record
 
@@ -252,6 +253,7 @@ def to_proto_submit(
         vector=vector,
         metadata=metadata,
         operation=to_proto_operation(submit_record["operation"]),
+        collection_id=submit_record["collection_id"].hex,
     )
 
 

--- a/chromadb/test/ingest/test_producer_consumer.py
+++ b/chromadb/test/ingest/test_producer_consumer.py
@@ -28,6 +28,7 @@ from chromadb.types import (
 from chromadb.config import System, Settings
 from pytest import FixtureRequest, approx
 from asyncio import Event, wait_for, TimeoutError
+import uuid
 
 
 def sqlite() -> Generator[Tuple[Producer, Consumer], None, None]:
@@ -103,6 +104,7 @@ def sample_embeddings() -> Iterator[SubmitEmbeddingRecord]:
             encoding=ScalarEncoding.FLOAT32,
             metadata=metadata,
             operation=Operation.ADD,
+            collection_id=uuid.uuid4(),
         )
         return record
 

--- a/chromadb/test/segment/test_metadata.py
+++ b/chromadb/test/segment/test_metadata.py
@@ -83,6 +83,7 @@ def sample_embeddings() -> Iterator[SubmitEmbeddingRecord]:
             encoding=ScalarEncoding.FLOAT32,
             metadata=metadata,
             operation=Operation.ADD,
+            collection_id=uuid.UUID(int=0),
         )
         return record
 
@@ -357,6 +358,7 @@ def test_delete(
         encoding=None,
         metadata=None,
         operation=Operation.DELETE,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = produce_fns(producer, topic, (delete_embedding for _ in range(1)), 1)[1][
         -1
@@ -402,6 +404,7 @@ def test_update(
         embedding=None,
         encoding=None,
         operation=Operation.UPDATE,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = producer.submit_embedding(topic, update_record)
     sync(segment, max_id)
@@ -431,6 +434,7 @@ def test_upsert(
         embedding=None,
         encoding=None,
         operation=Operation.UPSERT,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = produce_fns(
         producer=producer,
@@ -470,6 +474,7 @@ def _test_update(
         embedding=None,
         encoding=None,
         operation=op,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = producer.submit_embedding(topic, update_record)
     sync(segment, max_id)
@@ -485,6 +490,7 @@ def _test_update(
         embedding=None,
         encoding=None,
         operation=op,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = producer.submit_embedding(topic, update_record)
     sync(segment, max_id)
@@ -502,6 +508,7 @@ def _test_update(
         embedding=None,
         encoding=None,
         operation=op,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = producer.submit_embedding(topic, update_record)
     sync(segment, max_id)
@@ -515,6 +522,7 @@ def _test_update(
         embedding=None,
         encoding=None,
         operation=op,
+        collection_id=uuid.UUID(int=0),
     )
     max_id = producer.submit_embedding(topic, update_record)
     sync(segment, max_id)

--- a/chromadb/test/segment/test_vector.py
+++ b/chromadb/test/segment/test_vector.py
@@ -91,6 +91,7 @@ def sample_embeddings() -> Iterator[SubmitEmbeddingRecord]:
             encoding=ScalarEncoding.FLOAT32,
             metadata=None,
             operation=Operation.ADD,
+            collection_id=uuid.UUID(int=0),
         )
         return record
 
@@ -301,6 +302,7 @@ def test_delete(
         encoding=None,
         metadata=None,
         operation=Operation.DELETE,
+        collection_id=uuid.UUID(int=0),
     )
     assert isinstance(seq_ids, List)
     seq_ids.append(
@@ -380,6 +382,7 @@ def _test_update(
                 encoding=ScalarEncoding.FLOAT32,
                 metadata=None,
                 operation=operation,
+                collection_id=uuid.UUID(int=0),
             ),
         )
     )
@@ -437,6 +440,7 @@ def test_update(
         encoding=ScalarEncoding.FLOAT32,
         metadata=None,
         operation=Operation.UPDATE,
+        collection_id=uuid.UUID(int=0),
     )
     seq_id = produce_fns(
         producer=producer,
@@ -474,6 +478,7 @@ def test_upsert(
         encoding=ScalarEncoding.FLOAT32,
         metadata=None,
         operation=Operation.UPSERT,
+        collection_id=uuid.UUID(int=0),
     )
     seq_id = produce_fns(
         producer=producer,
@@ -510,6 +515,7 @@ def test_delete_without_add(
         encoding=None,
         metadata=None,
         operation=Operation.DELETE,
+        collection_id=uuid.UUID(int=0),
     )
 
     try:
@@ -545,6 +551,7 @@ def test_delete_with_local_segment_storage(
         encoding=None,
         metadata=None,
         operation=Operation.DELETE,
+        collection_id=uuid.UUID(int=0),
     )
     assert isinstance(seq_ids, List)
     seq_ids.append(
@@ -620,6 +627,7 @@ def test_reset_state_ignored_for_allow_reset_false(
         encoding=None,
         metadata=None,
         operation=Operation.DELETE,
+        collection_id=uuid.UUID(int=0),
     )
     assert isinstance(seq_ids, List)
     seq_ids.append(

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -95,6 +95,16 @@ class EmbeddingRecord(TypedDict):
     encoding: Optional[ScalarEncoding]
     metadata: Optional[UpdateMetadata]
     operation: Operation
+    # The collection the operation is being performed on
+    # This is optional because in the single node version,
+    # topics are 1:1 with collections. So consumers of the ingest queue
+    # implicitly know this mapping. However, in the multi-node version,
+    # topics are shared between collections, so we need to explicitly
+    # specify the collection.
+    # For backwards compatability reasons, we can't make this a required field on
+    # single node, since data written with older versions of the code won't be able to
+    # populate it.
+    collection_id: Optional[UUID]
 
 
 class SubmitEmbeddingRecord(TypedDict):
@@ -103,6 +113,7 @@ class SubmitEmbeddingRecord(TypedDict):
     encoding: Optional[ScalarEncoding]
     metadata: Optional[UpdateMetadata]
     operation: Operation
+    collection_id: UUID  # The collection the operation is being performed on
 
 
 class VectorQuery(TypedDict):

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -86,6 +86,7 @@ message SubmitEmbeddingRecord {
     optional Vector vector = 2;
     optional UpdateMetadata metadata = 3;
     Operation operation = 4;
+    string collection_id = 5;
 }
 
 message VectorEmbeddingRecord {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes

In the distributed architecture, collections are multiplexed onto topics, so messages from the ingest need to be tagged with their collection_id so consumers know which collection it belongs to. In the single node collections are 1:1 with topics so this mapping is not strictly needed since the topic implicitly tells consumers which collection they are reading. This PR adds the collection id to the type that gets written on the log. It also adds an optional collection_id to the type consumed from the log. This must be optional for backwards compatibility on single node chroma. A backfill would have no data to populate that field, and rather than populate it with a bad placeholder, I think its better to be specific that it may not be present and let downstream code decide how to handle that.

 - New functionality
	 - None.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
None required.
