### PR TITLE
ENH: add new setting for configuring the db migration hashing algorithm (add sha256)

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -228,6 +228,9 @@ class Settings(BaseSettings):  # type: ignore
     allow_reset: bool = False
 
     migrations: Literal["none", "validate", "apply"] = "apply"
+    # you cannot change the hash_algorithm after migrations have already been applied once
+    # this is intended to be a first-time setup configuration
+    migrations_hash_algorithm: Literal["md5", "sha256"] = "md5"
 
     def require(self, key: str) -> Any:
         """Return the value of a required config key, or raise an exception if it is not

--- a/chromadb/db/migrations.py
+++ b/chromadb/db/migrations.py
@@ -52,7 +52,7 @@ class InconsistentVersionError(Exception):
 class InconsistentHashError(Exception):
     def __init__(self, path: str, db_hash: str, source_hash: str):
         super().__init__(
-            f"Inconsistent MD5 hashes in {path}:"
+            f"Inconsistent hashes in {path}:"
             + f"db hash was {db_hash}, source has was {source_hash}."
             + " Was the migration file modified after being applied to the DB?"
         )

--- a/chromadb/db/migrations.py
+++ b/chromadb/db/migrations.py
@@ -58,6 +58,11 @@ class InconsistentHashError(Exception):
         )
 
 
+class InvalidHashError(Exception):
+    def __init__(self, alg: str):
+        super().__init__(f"Invalid hash algorithm specified: {alg}")
+
+
 class InvalidMigrationFilename(Exception):
     pass
 
@@ -141,7 +146,11 @@ class MigratableDB(SqlDB):
             raise UninitializedMigrationsError()
         for dir in self.migration_dirs():
             db_migrations = self.db_migrations(dir)
-            source_migrations = find_migrations(dir, self.migration_scope())
+            source_migrations = find_migrations(
+                dir,
+                self.migration_scope(),
+                self._settings.require("migrations_hash_algorithm"),
+            )
             unapplied_migrations = verify_migration_sequence(
                 db_migrations, source_migrations
             )
@@ -155,7 +164,11 @@ class MigratableDB(SqlDB):
         self.setup_migrations()
         for dir in self.migration_dirs():
             db_migrations = self.db_migrations(dir)
-            source_migrations = find_migrations(dir, self.migration_scope())
+            source_migrations = find_migrations(
+                dir,
+                self.migration_scope(),
+                self._settings.require("migrations_hash_algorithm"),
+            )
             unapplied_migrations = verify_migration_sequence(
                 db_migrations, source_migrations
             )
@@ -218,7 +231,7 @@ def verify_migration_sequence(
     return source_migrations[len(db_migrations) :]
 
 
-def find_migrations(dir: Traversable, scope: str) -> Sequence[Migration]:
+def find_migrations(dir: Traversable, scope: str, hash_alg: str) -> Sequence[Migration]:
     """Return a list of all migration present in the given directory, in ascending
     order. Filter by scope."""
     files = [
@@ -228,17 +241,24 @@ def find_migrations(dir: Traversable, scope: str) -> Sequence[Migration]:
     ]
     files = list(filter(lambda f: f["scope"] == scope, files))
     files = sorted(files, key=lambda f: f["version"])
-    return [_read_migration_file(f) for f in files]
+    return [_read_migration_file(f, hash_alg) for f in files]
 
 
-def _read_migration_file(file: MigrationFile) -> Migration:
+def _read_migration_file(file: MigrationFile, hash_alg: str) -> Migration:
     """Read a migration file"""
     if "path" not in file or not file["path"].is_file():
         raise FileNotFoundError(
             f"No migration file found for dir {file['dir']} with filename {file['filename']} and scope {file['scope']} at version {file['version']}"
         )
     sql = file["path"].read_text()
-    hash = hashlib.md5(sql.encode("utf-8")).hexdigest()
+
+    if hash_alg == "md5":
+        hash = hashlib.md5(sql.encode("utf-8")).hexdigest()
+    elif hash_alg == "sha256":
+        hash = hashlib.sha256(sql.encode("utf-8")).hexdigest()
+    else:
+        raise InvalidHashError(alg=hash_alg)
+
     return {
         "hash": hash,
         "sql": sql,

--- a/chromadb/db/migrations.py
+++ b/chromadb/db/migrations.py
@@ -231,7 +231,7 @@ def verify_migration_sequence(
     return source_migrations[len(db_migrations) :]
 
 
-def find_migrations(dir: Traversable, scope: str, hash_alg: str) -> Sequence[Migration]:
+def find_migrations(dir: Traversable, scope: str, hash_alg: str = "md5") -> Sequence[Migration]:
     """Return a list of all migration present in the given directory, in ascending
     order. Filter by scope."""
     files = [

--- a/chromadb/test/db/test_hash.py
+++ b/chromadb/test/db/test_hash.py
@@ -1,0 +1,66 @@
+import os
+import pytest
+from unittest.mock import patch, Mock
+
+import chromadb
+
+
+@pytest.mark.parametrize("migrations_hash_algorithm", [None, "md5", "sha256"])
+@patch("chromadb.api.fastapi.FastAPI", autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+def test_settings_valid_hash_algorithm(
+    mock: Mock, migrations_hash_algorithm: str
+) -> None:
+    """
+    Ensure that when no hash algorithm or a valid one is provided, the client is set up
+    with that value
+    """
+    if migrations_hash_algorithm:
+        settings = chromadb.config.Settings(
+            chroma_api_impl="chromadb.api.fastapi.FastAPI",
+            migrations_hash_algorithm=migrations_hash_algorithm,
+        )
+    else:
+        settings = chromadb.config.Settings(
+            chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        )
+
+    client = chromadb.Client(settings)
+
+    # Check that the mock was called
+    assert mock.called
+
+    # Retrieve the arguments with which the mock was called
+    # `call_args` returns a tuple, where the first element is a tuple of positional arguments
+    # and the second element is a dictionary of keyword arguments. We assume here that
+    # the settings object is passed as a positional argument.
+    args, kwargs = mock.call_args
+    passed_settings = args[0] if args else None
+
+    # Check if the default hash algorith was set
+    expected_migrations_hash_algorithm = migrations_hash_algorithm or "md5"
+    assert passed_settings
+    assert (
+        getattr(passed_settings.settings, "migrations_hash_algorithm", None)
+        == expected_migrations_hash_algorithm
+    )
+
+    client.clear_system_cache()
+
+
+@patch("chromadb.api.fastapi.FastAPI", autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+def test_settings_invalid_hash_algorithm(mock: Mock) -> None:
+    """
+    Ensure that providing an invalid hash results in a raised exception and the client
+    is not called
+    """
+    with pytest.raises(Exception):
+        settings = chromadb.config.Settings(
+            chroma_api_impl="chromadb.api.fastapi.FastAPI",
+            migrations_hash_algorithm="invalid_hash_alg",
+        )
+
+        chromadb.Client(settings)
+
+    assert not mock.called

--- a/chromadb/test/db/test_hash.py
+++ b/chromadb/test/db/test_hash.py
@@ -92,6 +92,11 @@ def test_hashlib_alg(hashlib_mock: MagicMock, migrations_hash_algorithm: str) ->
     # replace the real migration application call with a mock we can check
     db.apply_migration = MagicMock()  # type: ignore [method-assign]
 
+    # we don't want this to run since a) we're not testing that functionality and
+    # b) db may be cached between tests and we're changing the algorithm so it may
+    # fail
+    db.verify_migration_sequence = MagicMock()  # type: ignore [method-assign]
+
     db.start()
 
     assert db.apply_migration.called

--- a/chromadb/test/db/test_hash.py
+++ b/chromadb/test/db/test_hash.py
@@ -1,15 +1,17 @@
 import os
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch, MagicMock
 
 import chromadb
+from chromadb.db.impl.sqlite import SqliteDB
+from chromadb.config import System, Settings
 
 
 @pytest.mark.parametrize("migrations_hash_algorithm", [None, "md5", "sha256"])
-@patch("chromadb.api.fastapi.FastAPI", autospec=True)
+@patch("chromadb.api.fastapi.FastAPI")
 @patch.dict(os.environ, {}, clear=True)
 def test_settings_valid_hash_algorithm(
-    mock: Mock, migrations_hash_algorithm: str
+    api_mock: MagicMock, migrations_hash_algorithm: str
 ) -> None:
     """
     Ensure that when no hash algorithm or a valid one is provided, the client is set up
@@ -18,23 +20,27 @@ def test_settings_valid_hash_algorithm(
     if migrations_hash_algorithm:
         settings = chromadb.config.Settings(
             chroma_api_impl="chromadb.api.fastapi.FastAPI",
+            is_persistent=True,
+            persist_directory="./foo",
             migrations_hash_algorithm=migrations_hash_algorithm,
         )
     else:
         settings = chromadb.config.Settings(
             chroma_api_impl="chromadb.api.fastapi.FastAPI",
+            is_persistent=True,
+            persist_directory="./foo",
         )
 
     client = chromadb.Client(settings)
 
     # Check that the mock was called
-    assert mock.called
+    assert api_mock.called
 
     # Retrieve the arguments with which the mock was called
     # `call_args` returns a tuple, where the first element is a tuple of positional arguments
     # and the second element is a dictionary of keyword arguments. We assume here that
     # the settings object is passed as a positional argument.
-    args, kwargs = mock.call_args
+    args, kwargs = api_mock.call_args
     passed_settings = args[0] if args else None
 
     # Check if the default hash algorith was set
@@ -44,13 +50,12 @@ def test_settings_valid_hash_algorithm(
         getattr(passed_settings.settings, "migrations_hash_algorithm", None)
         == expected_migrations_hash_algorithm
     )
-
     client.clear_system_cache()
 
 
-@patch("chromadb.api.fastapi.FastAPI", autospec=True)
+@patch("chromadb.api.fastapi.FastAPI")
 @patch.dict(os.environ, {}, clear=True)
-def test_settings_invalid_hash_algorithm(mock: Mock) -> None:
+def test_settings_invalid_hash_algorithm(mock: MagicMock) -> None:
     """
     Ensure that providing an invalid hash results in a raised exception and the client
     is not called
@@ -59,8 +64,48 @@ def test_settings_invalid_hash_algorithm(mock: Mock) -> None:
         settings = chromadb.config.Settings(
             chroma_api_impl="chromadb.api.fastapi.FastAPI",
             migrations_hash_algorithm="invalid_hash_alg",
+            persist_directory="./foo",
         )
 
         chromadb.Client(settings)
 
     assert not mock.called
+
+
+@pytest.mark.parametrize("migrations_hash_algorithm", ["md5", "sha256"])
+@patch("chromadb.db.migrations.hashlib")
+@patch.dict(os.environ, {}, clear=True)
+def test_hashlib_alg(hashlib_mock: MagicMock, migrations_hash_algorithm: str) -> None:
+    """
+    Test that only the appropriate hashlib functions are called
+    """
+    db = SqliteDB(
+        System(
+            Settings(
+                migrations="apply",
+                allow_reset=True,
+                migrations_hash_algorithm=migrations_hash_algorithm,
+            )
+        )
+    )
+
+    # replace the real migration application call with a mock we can check
+    db.apply_migration = MagicMock()  # type: ignore [method-assign]
+
+    db.start()
+
+    assert db.apply_migration.called
+
+    # Check if the default hash algorith was set
+    expected_migrations_hash_algorithm = migrations_hash_algorithm or "md5"
+
+    # check that the right algorithm was used
+    if expected_migrations_hash_algorithm == "md5":
+        assert hashlib_mock.md5.called
+        assert not hashlib_mock.sha256.called
+    elif expected_migrations_hash_algorithm == "sha256":
+        assert not hashlib_mock.md5.called
+        assert hashlib_mock.sha256.called
+    else:
+        # we only support the algorithms above
+        assert False


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Support FIPS-compliance by allowing SHA256 hashing algorithm for database migrations (instead of MD5)
 - New functionality
	 - New configuration setting to allow changing the migration hashing algorithm to SHA256 (defaults to MD5)

## Test plan
*How are these changes tested?*

I've tested creating a new client with settings and ensured they're passed through. I also tested that the right hashlib alg actually gets called. These are the scenarios:

- without specifying the hashing algorithm (should default to MD5)
- with "md5" (should end up with MD5)
- with "sha256" (should use sha256)
- and an invalid hashing algorithm (should raise an exception)

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

I don't believe there are any places that need an update, I couldn't find an existing place where the migrations logic is exposed in such detail.