### PR TITLE
[ENH]: Add new Where / WhereDocument operators

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -204,7 +204,8 @@ def validate_embedding_function(
     function_signature = signature(
         embedding_function.__class__.__call__
     ).parameters.keys()
-    protocol_signature = signature(EmbeddingFunction.__call__).parameters.keys()
+    protocol_signature = signature(
+        EmbeddingFunction.__call__).parameters.keys()
 
     if not function_signature == protocol_signature:
         raise ValueError(
@@ -213,7 +214,9 @@ def validate_embedding_function(
             "Please note the recent change to the EmbeddingFunction interface: https://docs.trychroma.com/migration#migration-to-0416---november-7-2023 \n"
         )
 
+
 L = TypeVar("L", covariant=True)
+
 
 class DataLoader(Protocol[L]):
     def __call__(self, uris: URIs) -> L:
@@ -259,11 +262,13 @@ def validate_ids(ids: IDs) -> IDs:
 def validate_metadata(metadata: Metadata) -> Metadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats or bools"""
     if not isinstance(metadata, dict) and metadata is not None:
-        raise ValueError(f"Expected metadata to be a dict or None, got {metadata}")
+        raise ValueError(
+            f"Expected metadata to be a dict or None, got {metadata}")
     if metadata is None:
         return metadata
     if len(metadata) == 0:
-        raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
+        raise ValueError(
+            f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
             raise ValueError(
@@ -280,11 +285,13 @@ def validate_metadata(metadata: Metadata) -> Metadata:
 def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats or bools"""
     if not isinstance(metadata, dict) and metadata is not None:
-        raise ValueError(f"Expected metadata to be a dict or None, got {metadata}")
+        raise ValueError(
+            f"Expected metadata to be a dict or None, got {metadata}")
     if metadata is None:
         return metadata
     if len(metadata) == 0:
-        raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
+        raise ValueError(
+            f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected metadata key to be a str, got {key}")
@@ -315,7 +322,8 @@ def validate_where(where: Where) -> Where:
     if not isinstance(where, dict):
         raise ValueError(f"Expected where to be a dict, got {where}")
     if len(where) != 1:
-        raise ValueError(f"Expected where to have exactly one operator, got {where}")
+        raise ValueError(
+            f"Expected where to have exactly one operator, got {where}")
     for key, value in where.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected where key to be a str, got {key}")
@@ -324,6 +332,8 @@ def validate_where(where: Where) -> Where:
             and key != "$or"
             and key != "$in"
             and key != "$nin"
+            and key != "$like"
+            and key != "$regex"
             and not isinstance(value, (str, int, float, dict))
         ):
             raise ValueError(
@@ -360,6 +370,11 @@ def validate_where(where: Where) -> Where:
                         raise ValueError(
                             f"Expected operand value to be an list for operator {operator}, got {operand}"
                         )
+                if operator in ["$like", "$regex"]:
+                    if not isinstance(operand, str):
+                        raise ValueError(
+                            f"Expected operand value to be a string for operator {operator}, got {operand}"
+                        )
                 if operator not in [
                     "$gt",
                     "$gte",
@@ -369,6 +384,8 @@ def validate_where(where: Where) -> Where:
                     "$eq",
                     "$in",
                     "$nin",
+                    "$like",
+                    "$regex"
                 ]:
                     raise ValueError(
                         f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, "
@@ -404,7 +421,7 @@ def validate_where_document(where_document: WhereDocument) -> WhereDocument:
             f"Expected where document to have exactly one operator, got {where_document}"
         )
     for operator, operand in where_document.items():
-        if operator not in ["$contains", "$and", "$or"]:
+        if operator not in ["$contains", "$and", "$or", "$regex"]:
             raise ValueError(
                 f"Expected where document operator to be one of $contains, $and, $or, got {operator}"
             )
@@ -440,7 +457,8 @@ def validate_include(include: Include, allow_distances: bool) -> Include:
     for item in include:
         if not isinstance(item, str):
             raise ValueError(f"Expected include item to be a str, got {item}")
-        allowed_values = ["embeddings", "documents", "metadatas", "uris", "data"]
+        allowed_values = ["embeddings", "documents",
+                          "metadatas", "uris", "data"]
         if allow_distances:
             allowed_values.append("distances")
         if item not in allowed_values:

--- a/chromadb/db/impl/sqlite_pool.py
+++ b/chromadb/db/impl/sqlite_pool.py
@@ -3,6 +3,26 @@ from abc import ABC, abstractmethod
 from typing import Any, Set
 import threading
 from overrides import override
+import re
+
+
+def regex(expr, item):
+    """Define a simple regex matching function.
+
+    Args:
+        expr (str): the expression we want to find
+        item (str): the string in which we will look
+
+    Returns:
+        bool, based on whether there is a match
+
+    References:
+        Thanks to [aGuegu on StackOverflow](https://stackoverflow.com/a/24053719) for sharing his sqlite3 regex solution, which inspired this one.
+
+    Note:
+        We can also use re.search.
+    """
+    return bool(re.findall(expr, item))
 
 
 class Connection:
@@ -21,6 +41,8 @@ class Connection:
             db_file, timeout=1000, check_same_thread=False, uri=is_uri, *args, **kwargs
         )  # type: ignore
         self._conn.isolation_level = None  # Handle commits explicitly
+
+        self._conn.create_function(name="REGEX", narg=2, func=regex)
 
     def execute(self, sql: str, parameters=...) -> sqlite3.Cursor:  # type: ignore
         if parameters is ...:

--- a/chromadb/test/segment/test_metadata.py
+++ b/chromadb/test/segment/test_metadata.py
@@ -249,12 +249,23 @@ def test_get(
     result = segment.get_metadata(where={"int_key": {"$ne": 5}})
     assert len(result) == 8
 
+    # Get with $like
+    result = segment.get_metadata(where={"str_key": {'$like': 'value%'}})
+    assert len(result) == 9
+
+    # Get with $regex
+    result = segment.get_metadata(
+        where={"str_key": {'$regex': 'value_[2|4|6|8]'}})
+    assert len(result) == 4
+
     # get with multiple heterogenous conditions
-    result = segment.get_metadata(where={"div_by_three": "true", "int_key": {"$gt": 5}})
+    result = segment.get_metadata(
+        where={"div_by_three": "true", "int_key": {"$gt": 5}})
     assert len(result) == 2
 
     # get with OR conditions
-    result = segment.get_metadata(where={"$or": [{"int_key": 1}, {"int_key": 2}]})
+    result = segment.get_metadata(
+        where={"$or": [{"int_key": 1}, {"int_key": 2}]})
     assert len(result) == 2
 
     # get with AND conditions

--- a/examples/basic_functionality/where_filtering.ipynb
+++ b/examples/basic_functionality/where_filtering.ipynb
@@ -87,7 +87,9 @@
        "{'ids': ['id7'],\n",
        " 'embeddings': None,\n",
        " 'metadatas': [{'status': 'read'}],\n",
-       " 'documents': ['A document that discusses international affairs']}"
+       " 'documents': ['A document that discusses international affairs'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
       ]
      },
      "execution_count": 5,
@@ -112,7 +114,9 @@
        " 'embeddings': None,\n",
        " 'metadatas': [{'status': 'read'}, {'status': 'unread'}],\n",
        " 'documents': ['A document that discusses domestic policy',\n",
-       "  'A document that discusses global affairs']}"
+       "  'A document that discusses global affairs'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
       ]
      },
      "execution_count": 6,
@@ -133,15 +137,17 @@
     {
      "data": {
       "text/plain": [
-       "{'ids': [['id7', 'id2', 'id8']],\n",
+       "{'ids': [['id7', 'id8', 'id2']],\n",
        " 'distances': [[16.740001678466797, 87.22000122070312, 87.22000122070312]],\n",
        " 'metadatas': [[{'status': 'read'},\n",
        "   {'status': 'unread'},\n",
        "   {'status': 'unread'}]],\n",
        " 'embeddings': None,\n",
        " 'documents': [['A document that discusses international affairs',\n",
-       "   'A document that discusses international affairs',\n",
-       "   'A document that discusses global affairs']]}"
+       "   'A document that discusses global affairs',\n",
+       "   'A document that discusses international affairs']],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
       ]
      },
      "execution_count": 7,
@@ -157,6 +163,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Where Filtering With Logical Operators\n",
     "This section demonstrates how one can use the logical operators in `where` filtering.\n",
@@ -164,25 +173,29 @@
     "Chroma currently supports: `$and` and `$or`operators.\n",
     "\n",
     "> Note: Logical operators can be nested"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-11T18:45:52.663345Z",
+     "start_time": "2023-08-11T18:42:50.970414Z"
+    },
+    "collapsed": false
+   },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/tazarov/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx.tar.gz: 100%|██████████| 79.3M/79.3M [02:59<00:00, 463kiB/s] \n"
-     ]
-    },
-    {
      "data": {
-      "text/plain": "{'ids': ['1', '2'],\n 'embeddings': None,\n 'metadatas': [{'author': 'john'}, {'author': 'jack'}],\n 'documents': ['Article by john', 'Article by Jack']}"
+      "text/plain": [
+       "{'ids': ['1', '2'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john'}, {'author': 'jack'}],\n",
+       " 'documents': ['Article by john', 'Article by Jack'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
      },
      "execution_count": 8,
      "metadata": {},
@@ -195,25 +208,35 @@
     "client = chromadb.Client()\n",
     "collection = client.get_or_create_collection(\"test-where-list\")\n",
     "collection.add(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
-    "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"],\n",
+    "               embeddings=[[1.1, 2.3, 3.2],\n",
+    "                           [4.5, 6.9, 4.4],\n",
+    "                           [1.1, 2.3, 3.2]])\n",
     "\n",
-    "collection.get(where={\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]})\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-08-11T18:45:52.663345Z",
-     "start_time": "2023-08-11T18:42:50.970414Z"
-    }
-   }
+    "collection.get(where={\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]})"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-11T18:49:31.174811Z",
+     "start_time": "2023-08-11T18:49:31.056618Z"
+    },
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "{'ids': ['1'],\n 'embeddings': None,\n 'metadatas': [{'author': 'john', 'category': 'chroma'}],\n 'documents': ['Article by john']}"
+      "text/plain": [
+       "{'ids': ['1'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'}],\n",
+       " 'documents': ['Article by john'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
      },
      "execution_count": 9,
      "metadata": {},
@@ -223,25 +246,41 @@
    "source": [
     "# And Logical Operator Filtering\n",
     "collection = client.get_or_create_collection(\"test-where-list\")\n",
-    "collection.upsert(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
-    "               metadatas=[{\"author\": \"john\",\"category\":\"chroma\"}, {\"author\": \"jack\",\"category\":\"ml\"}, {\"author\": \"jill\",\"category\":\"lifestyle\"}], ids=[\"1\", \"2\", \"3\"])\n",
+    "collection.upsert(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\", \"article by Mindy\"],\n",
+    "                  metadatas=[{\"author\": \"john\", \"category\": \"chroma\"}, \n",
+    "                             {\"author\": \"jack\", \"category\": \"ml\"}, \n",
+    "                             {\"author\": \"jill\", \"category\": \"lifestyle\"},\n",
+    "                             {\"author\": \"mindy\", \"category\": \"chromadb\"}], \n",
+    "                  ids=[\"1\", \"2\", \"3\", \"4\"],\n",
+    "                  embeddings=[[1.1, 2.3, 3.2],\n",
+    "                              [4.5, 6.9, 4.4],\n",
+    "                              [1.1, 2.3, 3.2],\n",
+    "                              [4.5, 6.9, 4.4]])\n",
+    "\n",
     "collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"john\"}]})"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-08-11T18:49:31.174811Z",
-     "start_time": "2023-08-11T18:49:31.056618Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-11T18:49:35.758816Z",
+     "start_time": "2023-08-11T18:49:35.741477Z"
+    },
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "{'ids': [], 'embeddings': None, 'metadatas': [], 'documents': []}"
+      "text/plain": [
+       "{'ids': [],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [],\n",
+       " 'documents': [],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
      },
      "execution_count": 10,
      "metadata": {},
@@ -251,22 +290,29 @@
    "source": [
     "# And logical that doesn't match anything\n",
     "collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"author\": \"jill\"}]})"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-08-11T18:49:35.758816Z",
-     "start_time": "2023-08-11T18:49:35.741477Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-08-11T18:49:40.463045Z",
+     "start_time": "2023-08-11T18:49:40.450240Z"
+    },
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "{'ids': ['1'],\n 'embeddings': None,\n 'metadatas': [{'author': 'john', 'category': 'chroma'}],\n 'documents': ['Article by john']}"
+      "text/plain": [
+       "{'ids': ['1'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'}],\n",
+       " 'documents': ['Article by john'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
      },
      "execution_count": 11,
      "metadata": {},
@@ -276,22 +322,71 @@
    "source": [
     "# Combined And and Or Logical Operator Filtering\n",
     "collection.get(where={\"$and\": [{\"category\": \"chroma\"}, {\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]}]})"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
-    "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2023-08-11T18:49:40.463045Z",
-     "start_time": "2023-08-11T18:49:40.450240Z"
+     "end_time": "2023-08-11T18:51:12.328062Z",
+     "start_time": "2023-08-11T18:51:12.315943Z"
+    },
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': ['1'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'}],\n",
+       " 'documents': ['Article by john'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-   }
+   ],
+   "source": [
+    "collection.get(where_document={\"$contains\": \"Article\"},where={\"$and\": [{\"category\": \"chroma\"}, {\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]}]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# Where and WhereDocument Filtering With String Operators: `$like` and `$regex`\n",
+    "\n",
+    "This section will demonstrate the usage of `$like` and `$regex` operators."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/plain": "{'ids': ['1'],\n 'embeddings': None,\n 'metadatas': [{'author': 'john', 'category': 'chroma'}],\n 'documents': ['Article by john']}"
+      "text/plain": [
+       "{'ids': ['1', '2', '3', '4'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'},\n",
+       "  {'author': 'jack', 'category': 'ml'},\n",
+       "  {'author': 'jill', 'category': 'lifestyle'},\n",
+       "  {'author': 'mindy', 'category': 'chromadb'}],\n",
+       " 'documents': ['Article by john',\n",
+       "  'Article by Jack',\n",
+       "  'Article by Jill',\n",
+       "  'article by Mindy'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
      },
      "execution_count": 13,
      "metadata": {},
@@ -299,24 +394,96 @@
     }
    ],
    "source": [
-    "collection.get(where_document={\"$contains\": \"Article\"},where={\"$and\": [{\"category\": \"chroma\"}, {\"$or\": [{\"author\": \"john\"}, {\"author\": \"jack\"}]}]})"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-08-11T18:51:12.328062Z",
-     "start_time": "2023-08-11T18:51:12.315943Z"
-    }
-   }
+    "# Documents mentioning \"article\" or \"Article\"\n",
+    "collection.get(where_document={'$regex': \"[Aa]rticle\"})"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [],
-   "metadata": {
-    "collapsed": false
-   }
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': ['1', '2', '3', '4'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'},\n",
+       "  {'author': 'jack', 'category': 'ml'},\n",
+       "  {'author': 'jill', 'category': 'lifestyle'},\n",
+       "  {'author': 'mindy', 'category': 'chromadb'}],\n",
+       " 'documents': ['Article by john',\n",
+       "  'Article by Jack',\n",
+       "  'Article by Jill',\n",
+       "  'article by Mindy'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Empty regex gives back all entries\n",
+    "collection.get(where={'category': {\"$regex\": \"\"}})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': ['1', '4'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'},\n",
+       "  {'author': 'mindy', 'category': 'chromadb'}],\n",
+       " 'documents': ['Article by john', 'article by Mindy'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Documents belonging to categories beginning with \"chroma\"\n",
+    "collection.get(where={'category': {\"$like\": \"chroma%\"}})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': ['1', '4'],\n",
+       " 'embeddings': None,\n",
+       " 'metadatas': [{'author': 'john', 'category': 'chroma'},\n",
+       "  {'author': 'mindy', 'category': 'chromadb'}],\n",
+       " 'documents': ['Article by john', 'article by Mindy'],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can use the regex operator to achieve the same result\n",
+    "# Documents belonging to categories beginning with \"chroma\"\n",
+    "collection.get(where={'category': {\"$regex\": \"chroma.*\"}})"
+   ]
   }
  ],
  "metadata": {
@@ -335,7 +502,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Updated the where_filtering.ipynb Jupyter Notebook with example usages of the new operators
	 - (Partially) resolves #1195
 - New functionality
	 - Added $like and $regex operators for where and where_document filtering

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
Documentation (e.g. [Usage Guide](https://docs.trychroma.com/usage-guide#using-where-filters)) should be changed to include the new operators.

## References/Sources/Thank Yous
- [thomasnield in oreilly_intermediate_sql_for_data issue #5](https://github.com/thomasnield/oreilly_intermediate_sql_for_data/issues/5#issuecomment-1151564634)
- [sqlite docs, chapter 5](https://www.sqlite.org/lang_expr.html)
- [sqlite docs, defining new SQL functions](https://www.sqlite.org/appfunc.html)
- [Ronald Bouman on Stack Overflow: How to create custom functions in SQLite](https://stackoverflow.com/a/2108921)
- [sqlite3 docs - create function](https://docs.python.org/3/library/sqlite3.html?highlight=create_function#sqlite3.Connection.create_function)
- [aGuegu on Stack Overflow: How do I use regex in a SQLite query?](https://stackoverflow.com/a/24053719)
- [PyPika docs - Custom Functions](https://pypika.readthedocs.io/en/latest/2_tutorial.html?highlight=CUSTOM%20OP#custom-functions)
- [u/shiningmatcha on r/LearnPython](https://www.reddit.com/r/learnpython/comments/jib9xs/how_does_the_rfstring_r_string_and_f_string/?rdt=34419)