### PR TITLE
[ENH] Verify clients use HTTP 1.1 + 

### DIFF
--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -57,10 +57,18 @@ class InvalidUUIDError(ChromaError):
         return "InvalidUUID"
 
 
+class InvalidHTTPVersion(ChromaError):
+    @classmethod
+    @overrides
+    def name(cls) -> str:
+        return "InvalidHTTPVersion"
+
+
 error_types: Dict[str, Type[ChromaError]] = {
     "InvalidDimension": InvalidDimensionException,
     "InvalidCollection": InvalidCollectionException,
     "IDAlreadyExists": IDAlreadyExistsError,
     "DuplicateID": DuplicateIDError,
     "InvalidUUID": InvalidUUIDError,
+    "InvalidHTTPVersion": InvalidHTTPVersion,
 }


### PR DESCRIPTION
## Description of changes

This change adds FastAPI server-side verification that clients are using HTTP 1.1 or 2, and adds an appropriate `ChromaError` called `InvalidHTTPVersion` if they're not. 

The `requests` library used by the Chroma python client uses 1.1 by default so no changes are needed. 

## Test plan
Tested manually by setting 

https://github.com/chroma-core/chroma/blob/2e6602072a3191407a2aff189e398ba73ba952fc/chromadb/server/fastapi/__init__.py#L95

to instead be

```python
 http_version not in ["1"]
```

And observed that attempting to connect raises the appropriate exception, propagated from the server:

```
Traceback (most recent call last):
  File "/Users/antontroynikov/Projects/chroma/chromadb/api/client.py", line 427, in _validate_tenant_database
    self._admin_client.get_tenant(name=tenant)
  File "/Users/antontroynikov/Projects/chroma/chromadb/api/client.py", line 472, in get_tenant
    return self._server.get_tenant(name=name)
  File "/Users/antontroynikov/Projects/chroma/chromadb/telemetry/opentelemetry/__init__.py", line 127, in wrapper
    return f(*args, **kwargs)
  File "/Users/antontroynikov/Projects/chroma/chromadb/api/fastapi.py", line 198, in get_tenant
    raise_chroma_error(resp)
  File "/Users/antontroynikov/Projects/chroma/chromadb/api/fastapi.py", line 625, in raise_chroma_error
    raise chroma_error
chromadb.errors.InvalidHTTPVersion: HTTP version 1.1 is not supported
```

The same test with the Javascript client returns a `400` error as expected. 

## Documentation Changes
N/A

## TODO
- [x] Check Javascript client