### PR TITLE
[ENH]: FTS5 Document Keyword Search

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -213,7 +213,9 @@ def validate_embedding_function(
             "Please note the recent change to the EmbeddingFunction interface: https://docs.trychroma.com/migration#migration-to-0416---november-7-2023 \n"
         )
 
+
 L = TypeVar("L", covariant=True)
+
 
 class DataLoader(Protocol[L]):
     def __call__(self, uris: URIs) -> L:
@@ -404,9 +406,9 @@ def validate_where_document(where_document: WhereDocument) -> WhereDocument:
             f"Expected where document to have exactly one operator, got {where_document}"
         )
     for operator, operand in where_document.items():
-        if operator not in ["$contains", "$and", "$or"]:
+        if operator not in ["$contains", "$keyword", "$and", "$or"]:
             raise ValueError(
-                f"Expected where document operator to be one of $contains, $and, $or, got {operator}"
+                f"Expected where document operator to be one of $contains, $keyword, $and, $or, got {operator}"
             )
         if operator == "$and" or operator == "$or":
             if not isinstance(operand, list):

--- a/chromadb/db/base.py
+++ b/chromadb/db/base.py
@@ -6,6 +6,8 @@ from threading import local
 from overrides import override, EnforceOverrides
 import pypika
 import pypika.queries
+from pypika.terms import Field, Term, BasicCriterion
+from pypika.enums import Comparator
 from chromadb.config import System, Component
 from uuid import UUID
 from itertools import islice, count
@@ -190,3 +192,14 @@ def get_sql(
     sql = query.get_sql()
     params = tuple(_context.values)
     return sql, params
+
+
+class ExtendedMatching(Comparator):
+    match = " MATCH "
+
+
+class CustomTerm(Field, Term):
+    def match(self, expr: str) -> BasicCriterion:
+        return BasicCriterion(
+            ExtendedMatching.match, self, self.wrap_constant(expr)  # type: ignore
+        )

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -65,6 +65,8 @@ def _filter_where_clause(clause: Where, metadata: Metadata) -> bool:
         return key in metadata and metadata_key in val
     elif op == "$nin":
         return key in metadata and metadata_key not in val
+    elif op == "$keyword":
+        return key in metadata and metadata_key == val
 
     # The following conditions only make sense for numeric values
     assert isinstance(metadata_key, int) or isinstance(metadata_key, float)
@@ -100,6 +102,9 @@ def _filter_where_doc_clause(clause: WhereDocument, doc: Document) -> bool:
             expr = expr.replace("%", ".").replace("_", ".")
             return re.search(expr, doc) is not None
         return expr in doc
+    if key == "$keyword":
+        keywords = expr.split(" ")
+        return all(keyword in doc for keyword in keywords)
     else:
         raise ValueError("Unknown operator: {}".format(key))
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -809,6 +809,18 @@ def test_get_where_document(api):
     items = collection.get(where_document={"$contains": "bad"})
     assert len(items["metadatas"]) == 0
 
+    items = collection.get(where_document={"$keyword": "great"})
+    assert len(items["metadatas"]) == 2
+
+    items = collection.get(where_document={"$keyword": "doc1 OR doc3"})
+    assert len(items["metadatas"]) == 1
+
+    items = collection.get(where_document={"$keyword": "doc1 AND doc3"})
+    assert len(items["metadatas"]) == 0
+
+    items = collection.get(where_document={"$keyword": "doc1 AND great"})
+    assert len(items["metadatas"]) == 1
+
 
 def test_query_where_document(api):
     api.reset()

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -156,7 +156,9 @@ Where = Dict[
     Union[str, LogicalOperator], Union[LiteralValue, OperatorExpression, List["Where"]]
 ]
 
-WhereDocumentOperator = Union[Literal["$contains"], LogicalOperator]
+WhereDocumentOperator = Union[
+    Literal["$contains"], Literal["$keyword"], LogicalOperator
+]
 WhereDocument = Dict[WhereDocumentOperator, Union[str, List["WhereDocument"]]]
 
 

--- a/examples/basic_functionality/keyword_document_search.ipynb
+++ b/examples/basic_functionality/keyword_document_search.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/tazarov/experiments/chroma-experiments/document_keyword_search\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Number of requested results 10 is greater than number of elements in index 5, updating n_results = 5\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': [['0', '3', '4', '1']],\n",
+       " 'distances': [[0.6140892505645752,\n",
+       "   0.8985650539398193,\n",
+       "   1.242105484008789,\n",
+       "   1.30079185962677]],\n",
+       " 'metadatas': [[None, None, None, None]],\n",
+       " 'embeddings': None,\n",
+       " 'documents': [['AI is increasing technological innovation pace.',\n",
+       "   'Mobile technologies are changing the world of telecommunication at a steady pace.',\n",
+       "   'Latest technology can be found in the spanish telenovela.',\n",
+       "   'This article is about telecommunication technology.']],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%cd ../../\n",
+    "import chromadb\n",
+    "from chromadb.config import Settings\n",
+    "\n",
+    "client = chromadb.EphemeralClient(settings=Settings(allow_reset=True))\n",
+    "\n",
+    "client.reset()\n",
+    "col = client.get_or_create_collection(\"test\")\n",
+    "docs = [\"AI is increasing technological innovation pace.\", \n",
+    "        \"This article is about telecommunication technology.\",\n",
+    "        \"RAG and fine-tuning have their strengths and weakness.\", \n",
+    "        \"Mobile technologies are changing the world of telecommunication at a steady pace.\",\n",
+    "        \"Latest technology can be found in the spanish telenovela.\"]\n",
+    "col.upsert(ids=[f\"{i}\" for i in range(len(docs))], documents=docs)\n",
+    "col.query(query_texts=[\"Technological pace\"], where_document={\"$or\": [{\"$contains\": \"technology\"}, {\"$contains\":\"pace\"}]})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above is great and we get the results we want, but what if we don't want articles about mobile or telecommunications?\n",
+    "Enter keyword search in FTS5 and MATCH queries (read more here [https://sqlite.org/fts5.html](https://sqlite.org/fts5.html), particularly section 3.6)\n",
+    "\n",
+    "Let's see an example where we only exclude mobile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Number of requested results 10 is greater than number of elements in index 5, updating n_results = 5\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': [['0', '4', '1']],\n",
+       " 'distances': [[0.6140892505645752, 1.242105484008789, 1.30079185962677]],\n",
+       " 'metadatas': [[None, None, None]],\n",
+       " 'embeddings': None,\n",
+       " 'documents': [['AI is increasing technological innovation pace.',\n",
+       "   'Latest technology can be found in the spanish telenovela.',\n",
+       "   'This article is about telecommunication technology.']],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "col.query(query_texts=[\"Technological pace\"], where_document={\n",
+    "          \"$keyword\": \"(technology OR pace) NOT mobile\"})\n",
+    "# as expected three documents are returned"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's try excluding another term, telecommunication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Number of requested results 10 is greater than number of elements in index 5, updating n_results = 5\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': [['0', '4']],\n",
+       " 'distances': [[0.6140892505645752, 1.242105484008789]],\n",
+       " 'metadatas': [[None, None]],\n",
+       " 'embeddings': None,\n",
+       " 'documents': [['AI is increasing technological innovation pace.',\n",
+       "   'Latest technology can be found in the spanish telenovela.']],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "col.query(query_texts=[\"Technological pace\"], where_document={\n",
+    "          \"$keyword\": \"(technology OR pace) NOT mobile NOT telecommunication\"})\n",
+    "# as expected two documents are returned"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's have some more fun and try to exclude only keywords that start with telecom. This will include the telenovela document, but exclude the telecommunications document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Number of requested results 10 is greater than number of elements in index 5, updating n_results = 5\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'ids': [['0', '4']],\n",
+       " 'distances': [[0.6140892505645752, 1.242105484008789]],\n",
+       " 'metadatas': [[None, None]],\n",
+       " 'embeddings': None,\n",
+       " 'documents': [['AI is increasing technological innovation pace.',\n",
+       "   'Latest technology can be found in the spanish telenovela.']],\n",
+       " 'uris': None,\n",
+       " 'data': None}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "col.query(query_texts=[\"Technological pace\"], where_document={\n",
+    "          \"$keyword\": \"(technology OR pace) NOT mobile NOT NEAR(telecom)\"})\n",
+    "# as expected two documents are returned, one of which is our telenovela"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - It is now possible to perform keyword searches with logical, boolean/unary operators (https://sqlite.org/fts5.html)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes

Examples found at `examples/basic_functionality/keyword_document_search.ipynb`
