### PR TITLE
[ENH]: Single-node Chroma manual collection unloading

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -190,6 +190,25 @@ class BaseAPI(ABC):
         """
         pass
 
+    @abstractmethod
+    def _unload(
+        self,
+        collection_id: UUID,
+    ) -> None:
+        """Unload a collection from memory by removing it vector and metedata segments.
+        Args:
+            collection_id: The collection name to unload from memory.
+
+        Raises:
+            ValueError: If the collection does not exist.
+
+        Examples:
+            ```python
+            collection.unload()
+            ```
+        """
+        pass
+
     #
     # ITEM METHODS
     #
@@ -552,6 +571,16 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
     def delete_collection(
         self,
         name: str,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> None:
+        pass
+
+    @abstractmethod
+    @override
+    def _unload(
+        self,
+        collection_id: UUID,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> None:

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -256,6 +256,17 @@ class Client(SharedSystemClient, ClientAPI):
             database=self.database,
         )
 
+    @override
+    def _unload(
+        self,
+        collection_id: UUID,
+    ) -> None:
+        return self._server._unload(
+            collection_id=collection_id,
+            tenant=self.tenant,
+            database=self.database,
+        )
+
     #
     # ITEM METHODS
     #

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -465,6 +465,19 @@ class Collection(BaseModel):
             uris=uris,
         )
 
+    def unload(
+        self,
+    ) -> None:
+        """Unload the collection from memory
+
+        Returns:
+            None
+        """
+
+        self._client._unload(
+            collection_id=self.id,
+        )
+
     def delete(
         self,
         ids: Optional[IDs] = None,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -328,6 +328,24 @@ class SegmentAPI(ServerAPI):
         else:
             raise ValueError(f"Collection {name} does not exist.")
 
+    @trace_method("SegmentAPI._unload", OpenTelemetryGranularity.OPERATION)
+    @override
+    def _unload(
+        self,
+        collection_id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+    ) -> None:
+        existing = self._sysdb.get_collections(
+            id=collection_id, tenant=tenant, database=database
+        )
+        if existing:
+            self._manager.unload_segment(existing[0]["id"])
+            if existing and existing[0]["id"] in self._collection_cache:
+                del self._collection_cache[existing[0]["id"]]
+        else:
+            raise ValueError(f"Collection {collection_id} does not exist.")
+
     @trace_method("SegmentAPI._add", OpenTelemetryGranularity.OPERATION)
     @override
     def _add(

--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -313,6 +313,7 @@ class AuthzResourceActions(str, Enum):
     UPDATE = "update"
     UPSERT = "upsert"
     RESET = "reset"
+    UNLOAD = "unload"
 
 
 @dataclass

--- a/chromadb/segment/__init__.py
+++ b/chromadb/segment/__init__.py
@@ -126,3 +126,8 @@ class SegmentManager(Component):
         it can preload segments as needed. This is only a hint, and implementations are
         free to ignore it."""
         pass
+
+    @abstractmethod
+    def unload_segment(self, collection_id: UUID) -> None:
+        """Unload a segment from memory"""
+        pass

--- a/chromadb/segment/impl/manager/distributed.py
+++ b/chromadb/segment/impl/manager/distributed.py
@@ -107,6 +107,14 @@ class DistributedSegmentManager(SegmentManager):
         return cast(S, instance)
 
     @trace_method(
+        "DistributedSegmentManager.unload_segment",
+        OpenTelemetryGranularity.OPERATION_AND_SEGMENT,
+    )
+    @override
+    def unload_segment(self, collection_id: UUID) -> None:
+        raise NotImplementedError()
+
+    @trace_method(
         "DistributedSegmentManager.hint_use_collection",
         OpenTelemetryGranularity.OPERATION_AND_SEGMENT,
     )

--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -160,6 +160,21 @@ class LocalSegmentManager(SegmentManager):
         return cast(S, instance)
 
     @trace_method(
+        "LocalSegmentManager.unload_segment",
+        OpenTelemetryGranularity.OPERATION_AND_SEGMENT,
+    )
+    @override
+    def unload_segment(self, collection_id: UUID) -> None:
+        """Unload the segment from memory"""
+        if collection_id in self._segment_cache:
+            for scope in self._segment_cache[collection_id]:
+                _seg = self._segment_cache[collection_id][scope]
+                _seg_instance = self._instances[_seg["id"]]
+                _seg_instance.stop()
+                del self._instances[_seg["id"]]
+            del self._segment_cache[collection_id]
+
+    @trace_method(
         "LocalSegmentManager.hint_use_collection",
         OpenTelemetryGranularity.OPERATION_AND_SEGMENT,
     )

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -456,3 +456,14 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
         """Close the persistent index"""
         if self._index is not None:
             self._index.close_file_handles()
+
+    def _unload(self) -> None:
+        """Unload the persistent index"""
+        self.close_persistent_index()
+        self._persist_data = None
+        self._index = None
+
+    @override
+    def stop(self) -> None:
+        self._unload()
+        super().stop()

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -245,6 +245,12 @@ class FastAPI(chromadb.server.Server):
             response_model=None,
         )
         self.router.add_api_route(
+            "/api/v1/collections/{collection_id}/unload",
+            self.unload,
+            methods=["POST"],
+            response_model=None,
+        )
+        self.router.add_api_route(
             "/api/v1/collections/{collection_id}/count",
             self.count,
             methods=["GET"],
@@ -541,6 +547,18 @@ class FastAPI(chromadb.server.Server):
             collection_id=_uuid(collection_id),
             where_document=delete.where_document,
         )
+
+    @trace_method("FastAPI.unload", OpenTelemetryGranularity.OPERATION)
+    @authz_context(
+        action=AuthzResourceActions.UNLOAD,
+        resource=DynamicAuthzResource(
+            id=AuthzDynamicParams.from_function_kwargs(arg_name="collection_id"),
+            type=AuthzResourceTypes.COLLECTION,
+            attributes=attr_from_collection_lookup(collection_id_arg="collection_id"),
+        ),
+    )
+    def unload(self, collection_id: str) -> None:
+        return self._api._unload(_uuid(collection_id))
 
     @trace_method("FastAPI.count", OpenTelemetryGranularity.OPERATION)
     @authz_context(

--- a/chromadb/test/auth/test_simple_rbac_authz.py
+++ b/chromadb/test/auth/test_simple_rbac_authz.py
@@ -265,6 +265,12 @@ api_executors = {
         col := Collection(api, f"{mcol.name}", mcol.id),
         col.count(),
     ),
+    "collection:unload": lambda api, mapi, _: (
+        mcol := mapi.create_collection(f"test-count-{uuid.uuid4()}"),
+        mcol.add(documents=["test"], ids=["1"]),
+        col := Collection(api, f"{mcol.name}", mcol.id),
+        col.unload(),
+    ),
 }
 
 

--- a/chromadb/test/auth/test_simple_rbac_authz.py
+++ b/chromadb/test/auth/test_simple_rbac_authz.py
@@ -33,6 +33,7 @@ valid_action_space = [
     "collection:update",
     "collection:upsert",
     "collection:count",
+    "collection:unload",
 ]
 
 role_name = st.text(alphabet=string.ascii_letters, min_size=1, max_size=20)
@@ -87,6 +88,7 @@ def user_role_config(draw: st.DrawFn) -> Tuple[Dict[str, Any], Dict[str, Any]]:
             "collection:update",
             "collection:upsert",
             "collection:count",
+            "collection:unload",
         ]
     ):
         actions_list.append("collection:get_collection")

--- a/docs/cip/CIP-28112023_Collection_Unload.md
+++ b/docs/cip/CIP-28112023_Collection_Unload.md
@@ -1,0 +1,58 @@
+# CIP-28112023 Collection Unload
+
+## Status
+
+Current Status: Under Discussion
+
+## Motivation
+
+Currently, Chroma has no way to unload a collection from memory, unless it is restarted. This limits certain use cases for short-lived collection on a memory budget.
+
+While this is a good feature to have it puts the onus on the user to reason about memory management, which in the many cases users do not need to do. 
+If implemented in its current form there should be a warning to the users that memory management using the `unload` API will have side effects and can lead to OOM is assumptions are not met.
+
+## Public Interfaces
+
+The proposed CIP would introduce the following changes:
+
+- API: `POST /api/v1/collections/<collection_id/unload` (with empty body)
+- New method `Collection.unload()` that will either integrate with SegmentAPI change or the above API (client/server).
+
+
+## Proposed Changes
+
+The proposed changes span across the following components:
+
+- FastAPI server
+- SegmentAPI
+- SegmentManager
+- PersistentLocalHnswSegment
+- BasAPI
+- ServerAPI
+- Client
+- FastAPI client
+- Collection
+
+The crux of the implementation is in the SegmentManager and PersistentLocalHnswSegment where we unload the vector segment from memory and remove references to both MetadataReader and VectorReader. 
+Rest of the changes are just to propagate the API call to the SegmentManager.
+
+### Future work
+
+As future work we anticipate the addition of LRU cache for collections which will allow us to automatically unload collections that are not read for a predefined global interval, configurable by the user via server config.
+
+In addition, an interesting feature would be to allow the user to specify a TTL for a collection, which will automatically unload the collection after the TTL has expired. 
+This is quite similar to the LRU cache, but allows the user to specify the TTL on a per-collection basis.
+
+## Compatibility, Deprecation, and Migration Plan
+
+The changes in a client/server mode will not be compatible between newer clients and older servers versions.
+
+## Test Plan
+
+We provide basic API tests to ensure the API works as expected.
+
+> Note: While
+
+## Rejected Alternatives
+
+

--- a/examples/basic_functionality/authz/authz.yaml
+++ b/examples/basic_functionality/authz/authz.yaml
@@ -18,6 +18,7 @@ resource_type_action: # This is here just for reference
   - collection:count
   - collection:update
   - collection:upsert
+  - collection:unload
 
 roles_mapping:
   admin:
@@ -42,6 +43,7 @@ roles_mapping:
         "collection:update",
         "collection:upsert",
         "collection:count",
+        "collection:unload",
       ]
   write:
     actions:
@@ -62,6 +64,7 @@ roles_mapping:
         "collection:update",
         "collection:upsert",
         "collection:count",
+        "collection:unload",
       ]
   db_read:
     actions:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,4 @@ pytest-asyncio
 setuptools_scm
 types-protobuf
 types-requests==2.30.0.0
+psutil>=5.9.6


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*

 - New functionality
	 - Collection.unload() - allows the user to unload collection metadata and vector segments from memory.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes

API docs should be automatically updated.

Addresses: #1323, #1289
