### PR TITLE
Opentelemetry requirements in Python client

### DIFF
--- a/.github/workflows/chroma-release-python-client.yml
+++ b/.github/workflows/chroma-release-python-client.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install Client Dev Dependencies
-      run: python -m pip install -r requirements_dev.txt
+      run: python -m pip install -r ./clients/python/requirements.txt && python -m pip install -r ./clients/python/requirements_dev.txt
     - name: Build Client
       run: ./clients/python/build_python_thin_client.sh
     - name: Install setuptools_scm

--- a/.github/workflows/chroma-release-python-client.yml
+++ b/.github/workflows/chroma-release-python-client.yml
@@ -50,7 +50,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,12 +15,15 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'requests >= 2.28',
-  'pydantic>=1.9',
   'numpy >= 1.22.5',
-  'posthog >= 2.4.0',
-  'typing_extensions >= 4.5.0',
+  'opentelemetry-api>=1.2.0',
+  'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
+  'opentelemetry-sdk>=1.2.0',
   'overrides >= 7.3.1',
+  'posthog >= 2.4.0',
+  'pydantic>=1.9',
+  'requests >= 2.28',
+  'typing_extensions >= 4.5.0',
 ]
 
 [tool.black]

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,0 +1,9 @@
+numpy >= 1.22.5
+opentelemetry-api>=1.2.0
+opentelemetry-exporter-otlp-proto-grpc>=1.2.0
+opentelemetry-sdk>=1.2.0
+overrides >= 7.3.1
+posthog >= 2.4.0
+pydantic>=1.9
+requests >= 2.28
+typing_extensions >= 4.5.0

--- a/clients/python/requirements_dev.txt
+++ b/clients/python/requirements_dev.txt
@@ -1,0 +1,7 @@
+fastapi>=0.95.2
+hypothesis
+hypothesis[numpy]
+opentelemetry-instrumentation-fastapi>=0.41b0
+pypika==0.48.9
+pytest
+uvicorn[standard]==0.18.3


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Python client now has correct dependencies.

## Test plan
*How are these changes tested?*

Prior to this change (in a virtualenv with only `chromadb-client` installed):
```python
import chromadb

client = chromadb.HttpClient()

client.create_collection('test1231231232321')


File ~/experiments/chroma-experiments/client-embedding-f-issue-1429/venv/lib/python3.11/site-packages/chromadb/api/fastapi.py:36
     15 from chromadb.api.types import (
     16     DataLoader,
     17     Documents,
   (...)
     31     validate_batch,
     32 )
     33 from chromadb.auth import (
     34     ClientAuthProvider,
     35 )
---> 36 from chromadb.auth.providers import RequestsClientAuthProtocolAdapter
     37 from chromadb.auth.registry import resolve_provider
     38 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System

File ~/experiments/chroma-experiments/client-embedding-f-issue-1429/venv/lib/python3.11/site-packages/chromadb/auth/providers.py:19
     17 from chromadb.auth.registry import register_provider, resolve_provider
     18 from chromadb.config import System
---> 19 from chromadb.telemetry.opentelemetry import (
     20     OpenTelemetryGranularity,
     21     trace_method,
     22 )
     24 T = TypeVar("T")
     26 logger = logging.getLogger(__name__)

File ~/experiments/chroma-experiments/client-embedding-f-issue-1429/venv/lib/python3.11/site-packages/chromadb/telemetry/opentelemetry/__init__.py:5
      2 from enum import Enum
      3 from typing import Any, Callable, Dict, Optional, Sequence, Union
----> 5 from opentelemetry import trace
      6 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
      7 from opentelemetry.sdk.trace import TracerProvider

ImportError: cannot import name 'trace' from 'opentelemetry' (unknown location)
```

After manually installing the new deps into my virtualenv:
```python
>>> import chromadb
>>> client = chromadb.HttpClient()
>>> client.create_collection('test1231231232321')
Collection(name=test1231231232321)
```

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
