### PR TITLE
[ENH]: Support for numpy data types for embeddings

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -51,7 +51,7 @@ def maybe_cast_one_to_many_ids(target: OneOrMany[ID]) -> IDs:
 
 # Embeddings
 Embedding = Vector
-Embeddings = List[Embedding]
+Embeddings = Union[List[Embedding], np.ndarray]
 
 
 def maybe_cast_one_to_many_embedding(target: OneOrMany[Embedding]) -> Embeddings:
@@ -213,7 +213,9 @@ def validate_embedding_function(
             "Please note the recent change to the EmbeddingFunction interface: https://docs.trychroma.com/migration#migration-to-0416---november-7-2023 \n"
         )
 
+
 L = TypeVar("L", covariant=True)
+
 
 class DataLoader(Protocol[L]):
     def __call__(self, uris: URIs) -> L:
@@ -477,7 +479,12 @@ def validate_embeddings(embeddings: Embeddings) -> Embeddings:
             f"Expected each embedding in the embeddings to be a list, got {embeddings}"
         )
     for embedding in embeddings:
-        if not all([isinstance(value, (int, float)) for value in embedding]):
+        if not all(
+            [
+                isinstance(value, (int, float)) and not isinstance(value, bool)
+                for value in embedding
+            ]
+        ):
             raise ValueError(
                 f"Expected each value in the embedding to be a int or float, got {embeddings}"
             )

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -184,6 +184,18 @@ def create_embeddings(
     return embeddings
 
 
+def create_embeddings_ndarray(
+    dim: int,
+    count: int,
+    dtype: npt.DTypeLike,
+) -> np.ndarray[Any, Any]:
+    return np.random.uniform(
+        low=-1.0,
+        high=1.0,
+        size=(count, dim),
+    ).astype(dtype)
+
+
 class hashing_embedding_function(types.EmbeddingFunction[Documents]):
     def __init__(self, dim: int, dtype: npt.DTypeLike) -> None:
         self.dim = dim

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -1,9 +1,10 @@
 import pytest
 import logging
 import hypothesis.strategies as st
-from typing import Dict, Set, cast, Union, DefaultDict
+from hypothesis import given
+from typing import Dict, Set, cast, Union, DefaultDict, Type, Any
 from dataclasses import dataclass
-from chromadb.api.types import ID, Include, IDs
+from chromadb.api.types import ID, Include, IDs, validate_embeddings
 import chromadb.errors as errors
 from chromadb.api import ServerAPI
 from chromadb.api.models.Collection import Collection
@@ -403,3 +404,54 @@ def test_delete_success(api: ServerAPI, kwargs: dict):
     coll = api.create_collection(name="foo")
     # Should not raise
     coll.delete(**kwargs)
+
+
+@given(supported_types=st.sampled_from([np.float32, np.int32, np.int64, int, float]))
+def test_autocasting_validate_embeddings_for_compatible_types(
+    supported_types: list[Type[Any]],
+) -> None:
+    embds = strategies.create_embeddings(10, 10, supported_types)
+    validated_embeddings = validate_embeddings(Collection._normalize_embeddings(embds))
+    assert all(
+        [
+            isinstance(value, list)
+            and all(
+                [
+                    isinstance(vec, (int, float)) and not isinstance(vec, bool)
+                    for vec in value
+                ]
+            )
+            for value in validated_embeddings
+        ]
+    )
+
+
+@given(supported_types=st.sampled_from([np.float32, np.int32, np.int64, int, float]))
+def test_autocasting_validate_embeddings_with_ndarray(
+    supported_types: list[Type[Any]],
+) -> None:
+    embds = strategies.create_embeddings_ndarray(10, 10, supported_types)
+    validated_embeddings = validate_embeddings(Collection._normalize_embeddings(embds))
+    assert all(
+        [
+            isinstance(value, list)
+            and all(
+                [
+                    isinstance(vec, (int, float)) and not isinstance(vec, bool)
+                    for vec in value
+                ]
+            )
+            for value in validated_embeddings
+        ]
+    )
+
+
+@given(unsupported_types=st.sampled_from([str, bool]))
+def test_autocasting_validate_embeddings_incompatible_types(
+    unsupported_types: list[Type[Any]],
+) -> None:
+    embds = strategies.create_embeddings(10, 10, unsupported_types)
+    with pytest.raises(ValueError) as e:
+        validate_embeddings(Collection._normalize_embeddings(embds))
+
+    assert "Expected each value in the embedding to be a int or float" in str(e)

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -1,4 +1,6 @@
 from typing import Optional, Union, Sequence, Dict, Mapping, List
+
+import numpy as np
 from typing_extensions import Literal, TypedDict, TypeVar
 from uuid import UUID
 from enum import Enum
@@ -73,7 +75,9 @@ class Operation(Enum):
     DELETE = "DELETE"
 
 
-Vector = Union[Sequence[float], Sequence[int]]
+Vector = Union[
+    Sequence[float], Sequence[int], Sequence[np.integer], Sequence[np.floating]
+]
 
 
 class VectorEmbeddingRecord(TypedDict):


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Embeddings now can be `ndarray` with `np.integer` or `np.floating`
	 - Mutating changes to convert ndarray happen within `Collection`
	 - Minor bugfix for arrays if `bool`s as the current check for `instanceof` `int` or `float` results in success - `bool` is a subclass of `int`

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
N/A

Supersedes #1014 