### PR TITLE
[ENH] Cloud client

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -190,6 +190,7 @@ def CloudClient(
     *,  # Following arguments are keyword-only, intended for testing only.
     cloud_host: str = "api.trychroma.com",
     cloud_port: str = "8000",
+    enable_ssl: bool = True,
 ) -> ClientAPI:
     """
     Creates a client to connect to a tennant and database on the Chroma cloud.
@@ -220,7 +221,7 @@ def CloudClient(
     settings.chroma_server_host = cloud_host
     settings.chroma_server_http_port = cloud_port
     # Always use SSL for cloud
-    settings.chroma_server_ssl_enabled = True
+    settings.chroma_server_ssl_enabled = enable_ssl
 
     settings.chroma_client_auth_provider = "chromadb.auth.token.TokenAuthClientProvider"
     settings.chroma_client_auth_credentials = api_key

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -186,6 +186,9 @@ def CloudClient(
     database: str,
     api_key: Optional[str] = None,
     settings: Optional[Settings] = None,
+    *,  # Following arguments are keyword-only, intended for testing only.
+    cloud_host: str = "api.trychroma.com",
+    cloud_port: str = "8000",
 ) -> ClientAPI:
     """
     Creates a client to connect to a tennant and database on the Chroma cloud.
@@ -195,9 +198,6 @@ def CloudClient(
         database: The database to use for this client.
         api_key: The api key to use for this client.
     """
-
-    CLOUD_HOST = "api.trychroma.com"
-    CLOUD_PORT = "443"
 
     # If no API key is provided, try to load it from the environment variable
     if api_key is None:
@@ -216,8 +216,8 @@ def CloudClient(
         settings = Settings()
 
     settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
-    settings.chroma_server_host = CLOUD_HOST
-    settings.chroma_server_http_port = CLOUD_PORT
+    settings.chroma_server_host = cloud_host
+    settings.chroma_server_http_port = cloud_port
     # Always use SSL for cloud
     settings.chroma_server_ssl_enabled = True
 

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -223,7 +223,7 @@ def CloudClient(
 
     settings.chroma_client_auth_provider = "token"
     settings.chroma_client_auth_credentials = api_key
-    settings.chroma_client_auth_token_transport_header = "X_CHROMA_TOKEN"
+    settings.chroma_client_auth_token_transport_header = "x-chroma-token"
 
     return ClientCreator(tenant=tenant, database=database, settings=settings)
 

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional
 import logging
 from chromadb.api.client import Client as ClientCreator
 from chromadb.api.client import AdminClient as AdminClientCreator
+from chromadb.auth.token import TokenTransportHeader
 import chromadb.config
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings
 from chromadb.api import AdminAPI, ClientAPI
@@ -221,9 +222,11 @@ def CloudClient(
     # Always use SSL for cloud
     settings.chroma_server_ssl_enabled = True
 
-    settings.chroma_client_auth_provider = "token"
+    settings.chroma_client_auth_provider = "chromadb.auth.token.TokenAuthClientProvider"
     settings.chroma_client_auth_credentials = api_key
-    settings.chroma_client_auth_token_transport_header = "x-chroma-token"
+    settings.chroma_client_auth_token_transport_header = (
+        TokenTransportHeader.X_CHROMA_TOKEN.name
+    )
 
     return ClientCreator(tenant=tenant, database=database, settings=settings)
 

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, Dict, Optional, Sequence
 from uuid import UUID
+import uuid
 
 from overrides import override
 import requests
@@ -22,6 +23,7 @@ from chromadb.api.types import (
 from chromadb.config import Settings, System
 from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE
 from chromadb.api.models.Collection import Collection
+from chromadb.errors import ChromaError
 from chromadb.telemetry.product import ProductTelemetryClient
 from chromadb.telemetry.product.events import ClientStartEvent
 from chromadb.types import Database, Tenant, Where, WhereDocument
@@ -78,9 +80,8 @@ class SharedSystemClient:
                     "ephemeral"  # TODO: support pathing and  multiple ephemeral clients
                 )
         elif api_impl == "chromadb.api.fastapi.FastAPI":
-            identifier = (
-                f"{settings.chroma_server_host}:{settings.chroma_server_http_port}"
-            )
+            # FastAPI clients can all use unique system identifiers since their configurations can be independent, e.g. different auth tokens
+            identifier = str(uuid.uuid4())
         else:
             raise ValueError(f"Unsupported Chroma API implementation {api_impl}")
 
@@ -429,6 +430,9 @@ class Client(SharedSystemClient, ClientAPI):
             raise ValueError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
+        # Propagate ChromaErrors
+        except ChromaError as e:
+            raise e
         except Exception:
             raise ValueError(
                 f"Could not connect to tenant {tenant}. Are you sure it exists?"

--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -436,14 +436,3 @@ class ServerAuthorizationConfigurationProvider(Component, Generic[T]):
     @abstractmethod
     def get_configuration(self) -> T:
         pass
-
-
-class AuthorizationError(ChromaError):
-    @override
-    def code(self) -> int:
-        return 403
-
-    @classmethod
-    @override
-    def name(cls) -> str:
-        return "AuthorizationError"

--- a/chromadb/auth/fastapi.py
+++ b/chromadb/auth/fastapi.py
@@ -6,13 +6,12 @@ from typing import Callable, Optional, Dict, List, Union, cast, Any
 from overrides import override
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import Response, JSONResponse
+from starlette.responses import Response
 from starlette.types import ASGIApp
 
 from chromadb.config import DEFAULT_TENANT, System
 from chromadb.auth import (
     AuthorizationContext,
-    AuthorizationError,
     AuthorizationRequestContext,
     AuthzAction,
     AuthzResource,
@@ -28,6 +27,7 @@ from chromadb.auth import (
     ServerAuthorizationProvider,
 )
 from chromadb.auth.registry import resolve_provider
+from chromadb.errors import AuthorizationError
 from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
@@ -143,7 +143,8 @@ class FastAPIChromaAuthMiddlewareWrapper(BaseHTTPMiddleware):  # type: ignore
             FastAPIServerAuthenticationRequest(request)
         )
         if not response or not response.success():
-            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+            return AuthorizationError("Unauthorized").fastapi_json_response()
+
         request.state.user_identity = response.get_user_identity()
         return await call_next(request)
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -251,22 +251,6 @@ class Settings(BaseSettings):  # type: ignore
         env_file = ".env"
         env_file_encoding = "utf-8"
 
-    # We override equality to ignore values which may differ between instances
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Settings):
-            return False
-
-        _whitelist = {"chroma_client_auth_credentials"}
-
-        # Check for equality of all attributes except those in the whitelist
-        for attr in self.__dict__:
-            if attr in _whitelist:
-                continue
-            if getattr(self, attr) != getattr(other, attr):
-                return False
-
-        return True
-
 
 T = TypeVar("T", bound="Component")
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -251,6 +251,22 @@ class Settings(BaseSettings):  # type: ignore
         env_file = ".env"
         env_file_encoding = "utf-8"
 
+    # We override equality to ignore values which may differ between instances
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Settings):
+            return False
+
+        _whitelist = {"chroma_client_auth_credentials"}
+
+        # Check for equality of all attributes except those in the whitelist
+        for attr in self.__dict__:
+            if attr in _whitelist:
+                continue
+            if getattr(self, attr) != getattr(other, attr):
+                return False
+
+        return True
+
 
 T = TypeVar("T", bound="Component")
 

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -74,7 +74,7 @@ class InvalidHTTPVersion(ChromaError):
 class AuthorizationError(ChromaError):
     @overrides
     def code(self) -> int:
-        return 403
+        return 401
 
     @classmethod
     @overrides

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import Dict, Type
 from overrides import overrides, EnforceOverrides
+from fastapi.responses import JSONResponse
 
 
 class ChromaError(Exception, EnforceOverrides):
@@ -13,9 +14,15 @@ class ChromaError(Exception, EnforceOverrides):
 
     @classmethod
     @abstractmethod
-    def name(self) -> str:
+    def name(cls) -> str:
         """Return the error name"""
         pass
+
+    def fastapi_json_response(self) -> JSONResponse:
+        return JSONResponse(
+            content={"error": self.name(), "message": self.message()},
+            status_code=self.code(),
+        )
 
 
 class InvalidDimensionException(ChromaError):
@@ -64,6 +71,17 @@ class InvalidHTTPVersion(ChromaError):
         return "InvalidHTTPVersion"
 
 
+class AuthorizationError(ChromaError):
+    @overrides
+    def code(self) -> int:
+        return 403
+
+    @classmethod
+    @overrides
+    def name(cls) -> str:
+        return "AuthorizationError"
+
+
 error_types: Dict[str, Type[ChromaError]] = {
     "InvalidDimension": InvalidDimensionException,
     "InvalidCollection": InvalidCollectionException,
@@ -71,4 +89,5 @@ error_types: Dict[str, Type[ChromaError]] = {
     "DuplicateID": DuplicateIDError,
     "InvalidUUID": InvalidUUIDError,
     "InvalidHTTPVersion": InvalidHTTPVersion,
+    "AuthorizationError": AuthorizationError,
 }

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -80,9 +80,7 @@ async def catch_exceptions_middleware(
     try:
         return await call_next(request)
     except ChromaError as e:
-        return JSONResponse(
-            content={"error": e.name(), "message": e.message()}, status_code=e.code()
-        )
+        return e.fastapi_json_response()
     except Exception as e:
         logger.exception(e)
         return JSONResponse(content={"error": repr(e)}, status_code=500)

--- a/chromadb/test/client/test_cloud_client.py
+++ b/chromadb/test/client/test_cloud_client.py
@@ -76,8 +76,7 @@ def mock_cloud_server(valid_token: str) -> Generator[System, None, None]:
 
 
 def test_cloud_client(mock_cloud_server: System, valid_token: str) -> None:
-    # Connect to the default tenant and database
-    client = CloudClient(
+    valid_client = CloudClient(
         tenant=DEFAULT_TENANT,
         database=DEFAULT_DATABASE,
         api_key=valid_token,
@@ -86,4 +85,17 @@ def test_cloud_client(mock_cloud_server: System, valid_token: str) -> None:
         enable_ssl=False,
     )
 
-    client.get_version()
+    assert valid_client.heartbeat()
+
+    # Try to connect to the default tenant and database with an invalid token
+    invalid_token = valid_token + "_invalid"
+    client = CloudClient(
+        tenant=DEFAULT_TENANT,
+        database=DEFAULT_DATABASE,
+        api_key=invalid_token,
+        cloud_host=TEST_CLOUD_HOST,
+        cloud_port=mock_cloud_server.settings.chroma_server_http_port,  # type: ignore
+        enable_ssl=False,
+    )
+
+    print(client.list_collections())

--- a/chromadb/test/client/test_cloud_client.py
+++ b/chromadb/test/client/test_cloud_client.py
@@ -1,0 +1,93 @@
+import multiprocessing
+from typing import Any, Dict, Generator, Optional, Tuple
+import pytest
+from chromadb import CloudClient
+from chromadb.api import ServerAPI
+from chromadb.api.client import AdminClient
+from chromadb.auth.token import TokenTransportHeader
+from chromadb.config import Settings, System
+
+from chromadb.test.conftest import _await_server, _run_server, find_free_port
+
+TOKEN_TRANSPORT_HEADER = TokenTransportHeader.X_CHROMA_TOKEN.name
+
+
+@pytest.fixture(scope="module")
+def valid_token() -> str:
+    return "valid_token"
+
+
+@pytest.fixture(scope="module")
+def mock_cloud_server(valid_token: str) -> Generator[System, None, None]:
+    chroma_server_auth_provider: str = "chromadb.auth.token.TokenAuthServerProvider"
+    chroma_server_auth_credentials_provider: str = (
+        "chromadb.auth.token.TokenConfigServerAuthCredentialsProvider"
+    )
+    chroma_server_auth_credentials: str = valid_token
+    chroma_server_auth_token_transport_header: str = TOKEN_TRANSPORT_HEADER
+
+    port = find_free_port()
+
+    args: Tuple[
+        int,
+        bool,
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[Dict[str, Any]],
+    ] = (
+        port,
+        False,
+        None,
+        chroma_server_auth_provider,
+        chroma_server_auth_credentials_provider,
+        None,
+        chroma_server_auth_credentials,
+        chroma_server_auth_token_transport_header,
+        None,
+        None,
+        None,
+    )
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_run_server, args=args, daemon=True)
+    proc.start()
+
+    settings = Settings(
+        chroma_api_impl="chromadb.api.fastapi.FastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=str(port),
+        allow_reset=True,
+        chroma_client_auth_provider="chromadb.auth.token.TokenAuthClientProvider",
+        chroma_client_auth_credentials=valid_token,
+        chroma_client_auth_token_transport_header=TOKEN_TRANSPORT_HEADER,
+        chroma_server_ssl_enabled=True,
+    )
+
+    system = System(settings)
+    api = system.instance(ServerAPI)
+    system.start()
+    _await_server(api)
+    yield system
+    system.stop()
+    proc.kill()
+
+
+def test_cloud_client(mock_cloud_server: System, valid_token: str) -> None:
+    # Create a new database in the default tenant
+    admin_client = AdminClient.from_system(mock_cloud_server)
+    admin_client.create_database("test_db")
+
+    client = CloudClient(
+        tenant="test_tenant",
+        database="test_db",
+        api_key=valid_token,
+        cloud_host="localhost",
+        cloud_port=mock_cloud_server.settings.chroma_server_http_port,  # type: ignore
+    )
+
+    client.get_version()


### PR DESCRIPTION
## Description of changes

This PR adds the Chroma `CloudClient` as a client type. It takes an API key (or reads it from the environment, or prompts the user for it if it's not found) , and tries to connect to the Chroma cloud using the API key.

Under the hood, this is a specialized HTTPClient with ssl always turned on, and which uses token-based authentication with the API key as the token. 

This PR also moves the `AuthorizationError` from auth to the general set of errors, so it can be handled elsewhere by the Chroma system. 

## Test plan

Added a new test, `test_cloud_client`, which creates a mock 'cloud' server and then tests connection with valid and invalid API keys. 

## Documentation Changes

Cloud is not yet available, so `CloudClient` is for now not to be used by external users of Chroma. Therefore, we won't land documentation changes with this PR. 

## TODOs
- [x] Tests
- [ ] JavaScript @jeffchuber to take a look
- [ ] ~Docs~