### PR TITLE
[BUG] Escape URLs in coordinator

### DIFF
--- a/go/coordinator/internal/metastore/db/dbcore/core.go
+++ b/go/coordinator/internal/metastore/db/dbcore/core.go
@@ -3,6 +3,7 @@ package dbcore
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
 
 	"github.com/chroma/chroma-coordinator/internal/common"
@@ -31,8 +32,8 @@ type DBConfig struct {
 }
 
 func Connect(cfg DBConfig) (*gorm.DB, error) {
-	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d",
-		cfg.Address, cfg.Username, cfg.Password, cfg.DBName, cfg.Port)
+	dsn := url.QueryEscape(fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d",
+		cfg.Address, cfg.Username, cfg.Password, cfg.DBName, cfg.Port))
 
 	ormLogger := logger.Default
 	ormLogger.LogMode(logger.Info)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Escape the postgres URL in the coordinator. Right now it breaks if the password contains special characters.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js
- [ ] Rolled a coordinator with this change and deployed it to staging. Verified it doesn't complain anymore.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
