### PR TITLE
[ENH] Types exported through client index js #1399

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -4,5 +4,5 @@ export { Collection } from './Collection';
 export { IEmbeddingFunction } from './embeddings/IEmbeddingFunction';
 export { OpenAIEmbeddingFunction } from './embeddings/OpenAIEmbeddingFunction';
 export { CohereEmbeddingFunction } from './embeddings/CohereEmbeddingFunction';
-export { IncludeEnum, GetParams } from './types';
 export { HuggingFaceEmbeddingServerFunction } from './embeddings/HuggingFaceEmbeddingServerFunction';
+export { IncludeEnum, GetParams, Embedding, Embeddings, Metadata, Metadatas, Document, Documents, ID, IDs, PositiveInteger, Where, WhereDocument, CollectionType, GetResponse, QueryResponse, AddResponse, CollectionMetadata, ConfigOptions } from './types';

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -5,4 +5,22 @@ export { IEmbeddingFunction } from './embeddings/IEmbeddingFunction';
 export { OpenAIEmbeddingFunction } from './embeddings/OpenAIEmbeddingFunction';
 export { CohereEmbeddingFunction } from './embeddings/CohereEmbeddingFunction';
 export { HuggingFaceEmbeddingServerFunction } from './embeddings/HuggingFaceEmbeddingServerFunction';
-export { IncludeEnum, GetParams, Embedding, Embeddings, Metadata, Metadatas, Document, Documents, ID, IDs, PositiveInteger, Where, WhereDocument, CollectionType, GetResponse, QueryResponse, AddResponse, CollectionMetadata, ConfigOptions } from './types';
+export { IncludeEnum, 
+    GetParams, 
+    Embedding, 
+    Embeddings, 
+    Metadata, 
+    Metadatas, 
+    Document, 
+    Documents, 
+    ID, 
+    IDs, 
+    PositiveInteger, 
+    Where, 
+    WhereDocument, 
+    CollectionType, 
+    GetResponse, 
+    QueryResponse, 
+    AddResponse, 
+    CollectionMetadata, 
+    ConfigOptions } from './types';


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - client JS methods have typed inputs, exported types through client index.js making this consumable by other systems.
	 - closes #1399 

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
