### PR TITLE
[WIP] [CLN] [ENH] Parameter refactor

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -3,6 +3,7 @@ from typing import Sequence, Optional
 from uuid import UUID
 
 from overrides import override
+from chromadb.api.configuration import CollectionConfiguration
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
@@ -67,6 +68,7 @@ class BaseAPI(ABC):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
+        configuration: Optional[CollectionConfiguration] = None,
     ) -> Collection:
         """Create a new collection with the given name and metadata.
         Args:
@@ -133,6 +135,7 @@ class BaseAPI(ABC):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
+        configuration: Optional[CollectionConfiguration] = None,
     ) -> Collection:
         """Get or create a collection with the given name and metadata.
         Args:
@@ -512,6 +515,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
+        configuration: Optional[CollectionConfiguration] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Collection:
@@ -542,6 +546,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
+        configuration: Optional[CollectionConfiguration] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Collection:

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -5,6 +5,7 @@ import uuid
 from overrides import override
 import requests
 from chromadb.api import AdminAPI, ClientAPI, ServerAPI
+from chromadb.api.configuration import CollectionConfiguration
 from chromadb.api.types import (
     CollectionMetadata,
     DataLoader,
@@ -184,6 +185,7 @@ class Client(SharedSystemClient, ClientAPI):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
+        configuration: Optional[CollectionConfiguration] = None,
     ) -> Collection:
         return self._server.create_collection(
             name=name,
@@ -223,10 +225,12 @@ class Client(SharedSystemClient, ClientAPI):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
+        configuration: Optional[CollectionConfiguration] = None,
     ) -> Collection:
         return self._server.get_or_create_collection(
             name=name,
             metadata=metadata,
+            configuration=configuration,
             embedding_function=embedding_function,
             data_loader=data_loader,
             tenant=self.tenant,

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -191,6 +191,7 @@ class Client(SharedSystemClient, ClientAPI):
             name=name,
             metadata=metadata,
             embedding_function=embedding_function,
+            configuration=configuration,
             data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,

--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -1,0 +1,154 @@
+from abc import abstractmethod
+from typing import ClassVar, Dict, List, Optional, Protocol, Union
+from multiprocessing import cpu_count
+
+
+class StaticParameterError(Exception):
+    """Represents an error that occurs when a static parameter is set."""
+
+    pass
+
+
+class ParameterValidator(Protocol):
+    """Represents an abstract parameter validator."""
+
+    @abstractmethod
+    def __call__(self, value: Union[str, int, float, bool]) -> bool:
+        """Returns whether the given value is valid."""
+        raise NotImplementedError()
+
+
+ParameterValue = Union[str, int, float, bool]
+
+
+class ConfigurationDefinition:
+    """Represents the definition of a configuration."""
+
+    name: str
+    validator: ParameterValidator
+    is_static: bool
+    default_value: ParameterValue
+
+    def __init__(
+        self,
+        name: str,
+        validator: ParameterValidator,
+        is_static: bool,
+        default_value: ParameterValue,
+    ):
+        self.name = name
+        self.validator = validator
+        self.is_static = is_static
+        self.default_value = default_value
+
+
+class ConfigurationParameter:
+    """Represents a parameter of a configuration."""
+
+    name: str
+    value: ParameterValue
+
+    def __init__(self, name: str, value: ParameterValue):
+        self.name = name
+        self.value = value
+
+
+class Configuration:
+    """Represents an abstract configuration."""
+
+    # The internal data structure used to store the parameters
+    # All expected parameters must be present with defaults or None values at initialization
+    parameter_map: Dict[str, ConfigurationParameter]
+    definitions: ClassVar[Dict[str, ConfigurationDefinition]]
+
+    def __init__(self, parameters: List[ConfigurationParameter]):
+        """Initializes a new instance of the Configuration class."""
+        self.parameter_map = {}
+        for parameter in parameters:
+            if parameter.name not in self.definitions:
+                raise ValueError(f"Invalid parameter name: {parameter.name}")
+
+            definition = self.definitions[parameter.name]
+            if not isinstance(parameter.value, type(definition.default_value)):
+                raise ValueError(f"Invalid parameter value: {parameter.value}")
+
+            validator = definition.validator
+            if not validator(parameter.value):
+                raise ValueError(f"Invalid parameter value: {parameter.value}")
+            self.parameter_map[parameter.name] = parameter
+
+    def get_parameters(self) -> List[ConfigurationParameter]:
+        """Returns the parameters of the configuration."""
+        return list(self.parameter_map.values())
+
+    def get_parameter(self, name: str) -> Optional[ConfigurationParameter]:
+        """Returns the parameter with the given name or None if it does not exist."""
+        return self.parameter_map.get(name, None)
+
+    def set_parameter(self, name: str, value: Union[str, int, float, bool]) -> None:
+        """Sets the parameter with the given name to the given value."""
+        if name not in self.definitions:
+            raise ValueError(f"Invalid parameter name: {name}")
+        definition = self.definitions[name]
+        parameter = self.parameter_map[name]
+        if definition.is_static:
+            raise StaticParameterError(f"Cannot set static parameter: {name}")
+        if not definition.validator(value):
+            raise ValueError(f"Invalid value for parameter {name}: {value}")
+        parameter.value = value
+
+
+class CollectionConfiguration(Configuration):
+    """The configuration for a collection."""
+
+    definitions = {
+        "space": ConfigurationDefinition(
+            name="space",
+            validator=lambda value: isinstance(value, str)
+            and value in ["l2", "ip", "cosine"],
+            is_static=True,
+            default_value="l2",
+        ),
+        "ef_construction": ConfigurationDefinition(
+            name="ef_construction",
+            validator=lambda value: isinstance(value, int) and value >= 1,
+            is_static=True,
+            default_value=100,
+        ),
+        "ef_search": ConfigurationDefinition(
+            name="ef_search",
+            validator=lambda value: isinstance(value, int) and value >= 1,
+            is_static=False,
+            default_value=10,
+        ),
+        "num_threads": ConfigurationDefinition(
+            name="num_threads",
+            validator=lambda value: isinstance(value, int) and value >= 1,
+            is_static=False,
+            default_value=cpu_count(),
+        ),
+        "M": ConfigurationDefinition(
+            name="M",
+            validator=lambda value: isinstance(value, int) and value >= 1,
+            is_static=True,
+            default_value=16,
+        ),
+        "resize_factor": ConfigurationDefinition(
+            name="resize_factor",
+            validator=lambda value: isinstance(value, float) and value >= 1,
+            is_static=True,
+            default_value=1.2,
+        ),
+        "batch_size": ConfigurationDefinition(
+            name="batch_size",
+            validator=lambda value: isinstance(value, int) and value >= 1,
+            is_static=True,
+            default_value=1000,
+        ),
+        "sync_threashold": ConfigurationDefinition(
+            name="sync_threashold",
+            validator=lambda value: isinstance(value, int) and value >= 1,
+            is_static=True,
+            default_value=100,
+        ),
+    }

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -243,7 +243,7 @@ class FastAPI(ServerAPI):
                 {
                     "name": name,
                     "metadata": metadata,
-                    "configuration": configuration,  # TODO: support json serialization of configuration
+                    "configuration": configuration.to_json() if configuration else None,
                     "get_or_create": get_or_create,
                 }
             ),

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -112,7 +112,7 @@ class Collection:
 
     @property
     def configuration(self) -> Optional[CollectionConfiguration]:
-        return self._model.configuration
+        return self._model.get_configuration()
 
     @property
     def tenant(self) -> str:

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -171,7 +171,7 @@ class SegmentAPI(ServerAPI):
             metadata=metadata,
             tenant=tenant,
             database=database,
-            configuration=configuration or CollectionConfiguration(),
+            configuration=configuration if configuration else CollectionConfiguration(),
             topic=None,  # This will be populated by the SysDB service
             dimension=None,  # This will be lazily populated upon the first add
         )
@@ -226,6 +226,7 @@ class SegmentAPI(ServerAPI):
         return self.create_collection(  # type: ignore
             name=name,
             metadata=metadata,
+            configuration=configuration,
             embedding_function=embedding_function,
             data_loader=data_loader,
             get_or_create=True,

--- a/chromadb/db/impl/grpc/server.py
+++ b/chromadb/db/impl/grpc/server.py
@@ -310,7 +310,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
                     code=409, reason=f"Collection {request.name} already exists"
                 )
             )
-
+        print("Assigning using: {}".format(type(self._assignment_policy)))
         id = UUID(hex=request.id)
         new_collection = Collection(
             id=id,

--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -197,7 +197,7 @@ class LocalSegmentManager(SegmentManager):
 def _segment(type: SegmentType, scope: SegmentScope, collection: Collection) -> Segment:
     """Create a metadata dict, propagating metadata correctly for the given segment type."""
     cls = get_class(SEGMENT_TYPE_IMPLS[type], SegmentImplementation)
-    collection_metadata = collection.get("metadata", None)
+    collection_metadata = collection.metadata if collection.metadata else None
     metadata: Optional[Metadata] = None
     if collection_metadata:
         metadata = cls.propagate_collection_metadata(collection_metadata)

--- a/chromadb/serde.py
+++ b/chromadb/serde.py
@@ -1,0 +1,46 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generic, Protocol, TypeVar
+from pydantic import BaseModel
+import json
+
+T = TypeVar('T', bound='JSONSerializable', covariant=True)
+
+
+class JSONSerializable(Protocol[T]):
+    """ A generic interface for objects that can be serialized to JSON"""
+
+    def to_json_str(self) -> str:
+        """Serializes the object to JSON"""
+        ...
+    
+    def to_json(self) -> Dict[str, Any]:
+        """Serializes the object to a JSON compatible dictionary"""
+        ...
+
+    @classmethod
+    def from_json(cls, json_map: Dict[str, Any]) -> T:
+        """Deserializes the object from JSON"""
+        ...
+
+
+class BaseModelJSONSerializable(Generic[T]):
+    """A mixin for BaseModels that allows a class to be serialized to JSON"""
+
+    def to_json_str(self) -> str:
+        """Serializes the object to JSON"""
+        return self.model_dump_json()
+
+    def to_json(self) -> Dict[str, Any]:
+        """Serializes the object to a JSON compatible dictionary"""
+        return json.loads(self.model_dump_json())
+    
+    @abstractmethod
+    def model_dump_json(self) -> str:
+        """Abstract method that should be implemented to dump the model to JSON"""
+        pass
+
+    @classmethod
+    def from_json(cls, json_map: Dict[str, Any]) -> T:
+        """Deserializes the object from JSON"""
+        return cls(**json_map)
+

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -8,6 +8,7 @@ from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
 import chromadb
+from chromadb.api.configuration import CollectionConfiguration
 from chromadb.api.types import GetResult, QueryResult
 from chromadb.auth import (
     AuthzDynamicParams,
@@ -377,6 +378,7 @@ class FastAPI(chromadb.server.Server):
         api_collection = self._api.create_collection(
             name=collection.name,
             metadata=collection.metadata,
+            configuration=CollectionConfiguration.from_json(collection.configuration) if collection.configuration else None,
             get_or_create=collection.get_or_create,
             tenant=tenant,
             database=database,

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -55,6 +55,7 @@ class DeleteEmbedding(BaseModel):
 class CreateCollection(BaseModel):
     name: str
     metadata: Optional[CollectionMetadata] = None
+    configuration: Optional[Dict[str, Any]] = None
     get_or_create: bool = False
 
 

--- a/chromadb/test/api/test_collection_configuration.py
+++ b/chromadb/test/api/test_collection_configuration.py
@@ -1,0 +1,33 @@
+
+from chromadb.api import ClientAPI
+from chromadb.api.configuration import CollectionConfiguration, ConfigurationParameter
+
+
+
+# Client level tests
+def test_default_collection_configuration(client: ClientAPI):
+    """Test the default values of a collection configuration."""
+    client.reset()
+    configuration = CollectionConfiguration()
+
+    collection = client.create_collection("test")
+    assert collection.configuration == configuration
+
+def test_create_collection_configuration(client: ClientAPI):
+    """Test the creation default of a collection configuration."""
+    client.reset()
+    configuration = CollectionConfiguration(parameters=[ConfigurationParameter("space", "cosine"), ConfigurationParameter("ef_construction", 1000)])
+
+    collection = client.create_collection("test", configuration=configuration)
+    assert collection.configuration == configuration
+
+def test_create_get_collection_configuration(client: ClientAPI):
+    """Test the creation and retrieval of a collection configuration."""
+    client.reset()
+    configuration = CollectionConfiguration()
+
+    collection = client.create_collection("test", configuration=configuration)
+    assert collection.configuration == configuration
+
+    retrieved_collection = client.get_collection("test")
+    assert retrieved_collection.configuration == configuration


### PR DESCRIPTION
## Description of changes

This is a WIP, full PR description to come. 

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Refactors Collection API wrapper to consume a collection model and wrap it, making the seperation more explicit
	 - Adds a proper configuration management layer
	 - Adds JSONSerializable as a protocol
	 - Fixes (WIP) a long standing API inconsistency where metadata updates on collections don't result in merged updates but in overwrites, as opposed to record metadata.
 - New functionality
	 - Allows for configuration management at the collection level
	 -

TODO
- Robust configurable testing 
- Segment configurable inheritance 
- Finish proper metadata update semantics
- Move configuration out of api
- Make user facing api a typed dict so it’s easier to author and less clunky off an api

## Test plan
*How are these changes tested?*
WIP - we will need to modify tests to expect the new collection metadata merge behavior.


- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
Will add documentation
