### PR TITLE
[ENH]: SHA256 sum check of Chroma's onnx model.

### DIFF
--- a/chromadb/test/ef/test_default_ef.py
+++ b/chromadb/test/ef/test_default_ef.py
@@ -1,4 +1,5 @@
 import shutil
+import os
 from typing import List, Hashable
 
 import hypothesis.strategies as st
@@ -6,11 +7,12 @@ import onnxruntime
 import pytest
 from hypothesis import given, settings
 
-from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2
+from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2, _verify_sha256
 
 
 def unique_by(x: Hashable) -> Hashable:
     return x
+
 
 @settings(deadline=None)
 @given(
@@ -70,3 +72,19 @@ def test_invalid_sha256() -> None:
         ef._MODEL_SHA256 = "invalid"
         ef(["test"])
     assert "does not match expected SHA256 hash" in str(e.value)
+
+
+def test_partial_download() -> None:
+    ef = ONNXMiniLM_L6_V2()
+    shutil.rmtree(ef.DOWNLOAD_PATH, ignore_errors=True)  # clean up any existing models
+    os.makedirs(ef.DOWNLOAD_PATH, exist_ok=True)
+    path = os.path.join(ef.DOWNLOAD_PATH, ef.ARCHIVE_FILENAME)
+    with open(path, "wb") as f:  # create invalid file to simulate partial download
+        f.write(b"invalid")
+    ef._download_model_if_not_exists()  # re-download model
+    assert os.path.exists(path)
+    assert _verify_sha256(
+        str(os.path.join(ef.DOWNLOAD_PATH, ef.ARCHIVE_FILENAME)),
+        ef._MODEL_SHA256,
+    )
+    assert len(ef(["test"])) == 1

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -529,6 +529,9 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
             os.makedirs(self.DOWNLOAD_PATH, exist_ok=True)
             if not os.path.exists(
                 os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME)
+            ) or not _verify_sha256(
+                os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME),
+                self._MODEL_SHA256,
             ):
                 self._download(
                     url=self.MODEL_DOWNLOAD_URL,


### PR DESCRIPTION
Refs: #883

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Verify ONNX all-MiniLM-L6 model model download from s3 with static SHA256 (within the python code)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python

## Documentation Changes
N/A
