### PR TITLE
[ENH] Add Rust Configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +245,22 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "figment"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649f3e5d826594057e9a519626304d8da859ea8a0b18ce99500c586b8d45faee"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -442,6 +473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +504,16 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -553,6 +600,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +716,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -802,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +940,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+dependencies = [
+ "indexmap 2.1.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +960,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
@@ -1059,10 +1190,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "uncased"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "uuid"
@@ -1085,6 +1231,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -1273,11 +1425,20 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cc",
+ "figment",
+ "num_cpus",
  "rand",
  "rayon",
+ "serde",
  "tokio",
  "tokio-util",
  "tonic",
  "tonic-build",
  "uuid",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -11,6 +11,9 @@ rand = "0.8.5"
 rayon = "1.8.0"
 async-trait = "0.1.74"
 uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
+figment = { version = "0.10.12", features = ["env", "yaml", "test"] }
+serde = { version = "1.0.193", features = ["derive"] }
+num_cpus = "1.16.0"
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -1,0 +1,179 @@
+use figment::providers::{Env, Format, Serialized, Yaml};
+use serde::Deserialize;
+
+const DEFAULT_CONFIG_PATH: &str = "chroma_config.yaml";
+const ENV_PREFIX: &str = "CHROMA_";
+
+#[derive(Deserialize)]
+/// # Description
+/// The RootConfig for all chroma services this is a YAML file that
+/// is shared between all services, and secondarily, fields can be
+/// populated from environment variables. The environment variables
+/// are prefixed with CHROMA_ and are uppercase. Values in the envionment
+/// variables take precedence over values in the YAML file.
+/// By default, it is read from the current working directory,
+/// with the filename chroma_config.yaml.
+struct RootConfig {
+    // The root config object wraps the worker config object so that
+    // we can share the same config file between multiple services.
+    worker: WorkerConfig,
+}
+
+impl RootConfig {
+    /// # Description
+    /// Load the config from the default location.
+    /// # Returns
+    /// The config object.
+    /// # Panics
+    /// - If the config file cannot be read.
+    /// - If the config file is not valid YAML.
+    /// - If the config file does not contain the required fields.
+    /// - If the config file contains invalid values.
+    /// - If the environment variables contain invalid values.
+    /// # Notes
+    /// The default location is the current working directory, with the filename chroma_config.yaml.
+    /// The environment variables are prefixed with CHROMA_ and are uppercase.
+    /// Values in the envionment variables take precedence over values in the YAML file.
+    pub fn load() -> Self {
+        return Self::load_from_path(DEFAULT_CONFIG_PATH);
+    }
+
+    /// # Description
+    /// Load the config from a specific location.
+    /// # Arguments
+    /// - path: The path to the config file.
+    /// # Returns
+    /// The config object.
+    /// # Panics
+    /// - If the config file cannot be read.
+    /// - If the config file is not valid YAML.
+    /// - If the config file does not contain the required fields.
+    /// - If the config file contains invalid values.
+    /// - If the environment variables contain invalid values.
+    /// # Notes
+    /// The environment variables are prefixed with CHROMA_ and are uppercase.
+    /// Values in the envionment variables take precedence over values in the YAML file.
+    pub fn load_from_path(path: &str) -> Self {
+        // Unfortunately, figment doesn't support environment variables with underscores. So we have to map and replace them.
+        // Excluding our own environment variables, which are prefixed with CHROMA_.
+        let mut f = figment::Figment::from(Env::prefixed("CHROMA_").map(|k| match k {
+            k if k == "num_indexing_threads" => k.into(),
+            k if k == "my_ip" => k.into(),
+            k => k.as_str().replace("__", ".").into(),
+        }));
+        if std::path::Path::new(path).exists() {
+            f = figment::Figment::from(Yaml::file(path)).merge(f);
+        }
+        // Apply defaults - this seems to be the best way to do it.
+        // https://github.com/SergioBenitez/Figment/issues/77#issuecomment-1642490298
+        f = f.join(Serialized::default(
+            "worker.num_indexing_threads",
+            num_cpus::get(),
+        ));
+        let res = f.extract();
+        match res {
+            Ok(config) => return config,
+            Err(e) => panic!("Error loading config: {}", e),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+/// # Description
+/// The primary config for the worker service.
+/// ## Description of parameters
+/// - my_ip: The IP address of the worker service. Used for memberlist assignment. Must be provided
+/// - num_indexing_threads: The number of indexing threads to use. If not provided, defaults to the number of cores on the machine.
+/// # Notes
+/// In order to set the enviroment variables, you must prefix them with CHROMA_WORKER__<FIELD_NAME>.
+/// For example, to set my_ip, you would set CHROMA_WORKER__MY_IP.
+struct WorkerConfig {
+    my_ip: String,
+    num_indexing_threads: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use figment::Jail;
+
+    #[test]
+    fn test_config_from_default_path() {
+        Jail::expect_with(|jail| {
+            let _ = jail.create_file(
+                "chroma_config.yaml",
+                r#"
+                worker:
+                    my_ip: "192.0.0.1"
+                    num_indexing_threads: 4
+                "#,
+            );
+            let config = RootConfig::load();
+            assert_eq!(config.worker.my_ip, "192.0.0.1");
+            assert_eq!(config.worker.num_indexing_threads, 4);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_config_from_specific_path() {
+        Jail::expect_with(|jail| {
+            let _ = jail.create_file(
+                "random_path.yaml",
+                r#"
+                worker:
+                    my_ip: "192.0.0.1"
+                    num_indexing_threads: 4
+                "#,
+            );
+            let config = RootConfig::load_from_path("random_path.yaml");
+            assert_eq!(config.worker.my_ip, "192.0.0.1");
+            assert_eq!(config.worker.num_indexing_threads, 4);
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_config_missing_required_field() {
+        Jail::expect_with(|jail| {
+            let _ = jail.create_file(
+                "chroma_config.yaml",
+                r#"
+                worker:
+                    num_indexing_threads: 4
+                "#,
+            );
+            let _ = RootConfig::load();
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_missing_default_field() {
+        Jail::expect_with(|jail| {
+            let _ = jail.create_file(
+                "chroma_config.yaml",
+                r#"
+                worker:
+                    my_ip: "192.0.0.1"
+                "#,
+            );
+            let config = RootConfig::load();
+            assert_eq!(config.worker.my_ip, "192.0.0.1");
+            assert_eq!(config.worker.num_indexing_threads, num_cpus::get() as u32);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_config_with_env_override() {
+        Jail::expect_with(|jail| {
+            let _ = jail.set_env("CHROMA_WORKER__MY_IP", "192.0.0.1");
+            let config = RootConfig::load();
+            assert_eq!(config.worker.my_ip, "192.0.0.1");
+            assert_eq!(config.worker.num_indexing_threads, num_cpus::get() as u32);
+            Ok(())
+        });
+    }
+}

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -1,0 +1,1 @@
+mod config;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - None
 - New functionality
	 - Adds a boot up config management system for rust, this allows for a file chroma_config.yaml in the CWD, enviornment variables for the worker and specifying the path.
	 - The explicit decision is made to panic if configuration boot up fails


## Test plan
*How are these changes tested?*
Added tests which validate defaults, loading from the default file, the standard file etc.

- [x] Tests pass locally with `cargo test`

## Documentation Changes
None required. The code is well documented for internal use.
