### PR TITLE
[ENH] Add rust rendezvous hashing and errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1024,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,10 +1452,12 @@ dependencies = [
  "async-trait",
  "cc",
  "figment",
+ "murmur3",
  "num_cpus",
  "rand",
  "rayon",
  "serde",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tonic",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -14,6 +14,8 @@ uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
 figment = { version = "0.10.12", features = ["env", "yaml", "test"] }
 serde = { version = "1.0.193", features = ["derive"] }
 num_cpus = "1.16.0"
+murmur3 = "0.5.2"
+thiserror = "1.0.50"
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/rust/worker/src/assignment/mod.rs
+++ b/rust/worker/src/assignment/mod.rs
@@ -1,0 +1,1 @@
+mod rendezvous_hash;

--- a/rust/worker/src/assignment/rendezvous_hash.rs
+++ b/rust/worker/src/assignment/rendezvous_hash.rs
@@ -1,0 +1,171 @@
+// This implementation mirrors the rendezvous hash implementation
+// in the go and python services.
+// The go implementation is located go/internal/utils/rendezvous_hash.go
+// The python implementation is located chromadb/utils/rendezvous_hash.py
+
+use crate::errors::{ChromaError, ErrorCodes};
+use std::io::Cursor;
+
+use murmur3::murmur3_x64_128;
+
+/// A trait for hashing a member and a key to a score.
+trait Hasher {
+    fn hash(&self, member: &str, key: &str) -> Result<u64, &'static str>;
+}
+
+/// Error codes for the rendezvous hash algorithm.
+enum AssignmentErrors {
+    /// The key is empty.
+    EmptyKey,
+    /// There are no members to assign to.
+    NoMembers,
+    /// There was an error hashing a member.
+    HashError,
+}
+
+impl ChromaError for AssignmentErrors {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            AssignmentErrors::EmptyKey => ErrorCodes::InvalidArgument,
+            AssignmentErrors::NoMembers => ErrorCodes::InvalidArgument,
+            AssignmentErrors::HashError => ErrorCodes::Internal,
+        }
+    }
+}
+
+/// Assign a key to a member using the rendezvous hash algorithm.
+/// # Arguments
+/// - key: The key to assign.
+/// - members: The members to assign to.
+/// - hasher: The hasher to use.
+/// # Returns
+/// The member that the key was assigned to.
+/// # Errors
+/// - If the key is empty.
+/// - If there are no members to assign to.
+/// - If there is an error hashing a member.
+/// # Notes
+/// This implementation mirrors the rendezvous hash implementation
+/// in the go and python services.
+fn assign<H: Hasher>(
+    key: &str,
+    members: impl IntoIterator<Item = impl AsRef<str>>,
+    hasher: &H,
+) -> Result<String, &'static str> {
+    if key.is_empty() {
+        return Err("Cannot assign empty key");
+    }
+
+    let mut iterated = false;
+    let mut max_score = u64::MIN;
+    let mut max_member = None;
+
+    for member in members {
+        if !iterated {
+            iterated = true;
+        }
+        let score = hasher.hash(member.as_ref(), key);
+        let score = match score {
+            Ok(score) => score,
+            Err(err) => return Err(err),
+        };
+        if score > max_score {
+            max_score = score;
+            max_member = Some(member);
+        }
+    }
+
+    if !iterated {
+        return Err("No members to assign to");
+    }
+
+    match max_member {
+        Some(max_member) => return Ok(max_member.as_ref().to_string()),
+        None => return Err("No member to assign to"),
+    }
+}
+
+fn merge_hashes(x: u64, y: u64) -> u64 {
+    let mut acc = x ^ y;
+    acc ^= acc >> 33;
+    acc = acc.wrapping_mul(0xFF51AFD7ED558CCD);
+    acc ^= acc >> 33;
+    acc = acc.wrapping_mul(0xC4CEB9FE1A85EC53);
+    acc ^= acc >> 33;
+    acc
+}
+
+struct Murmur3Hasher {}
+
+impl Hasher for Murmur3Hasher {
+    fn hash(&self, member: &str, key: &str) -> Result<u64, &'static str> {
+        let member_hash = murmur3_x64_128(&mut Cursor::new(member), 0);
+        let key_hash = murmur3_x64_128(&mut Cursor::new(key), 0);
+        // The murmur library returns a 128 bit hash, but we only need 64 bits, grab the first 64 bits
+        match (member_hash, key_hash) {
+            (Ok(member_hash), Ok(key_hash)) => {
+                let member_hash_64 = member_hash as u64;
+                let key_hash_64 = key_hash as u64;
+                let merged = merge_hashes(member_hash_64, key_hash_64);
+                return Ok(merged);
+            }
+            _ => return Err("Error in hashing member or key"),
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockHasher {}
+
+    impl Hasher for MockHasher {
+        fn hash(&self, member: &str, _key: &str) -> Result<u64, &'static str> {
+            match member {
+                "a" => Ok(1),
+                "b" => Ok(2),
+                "c" => Ok(3),
+                _ => Err("No such mock member"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_assign() {
+        let members = vec!["a", "b", "c"];
+        let hasher = MockHasher {};
+        let key = "key";
+        let member = assign(key, members, &hasher).unwrap();
+        assert_eq!(member, "c".to_string());
+    }
+
+    #[test]
+    fn test_even_distribution() {
+        let member_count = 10;
+        let tolerance = 25;
+        let mut nodes = Vec::with_capacity(member_count);
+        let hasher = Murmur3Hasher {};
+
+        for i in 0..member_count {
+            let member = format!("member{}", i);
+            nodes.push(member);
+        }
+
+        let mut counts = vec![0; member_count];
+        let num_keys = 1000;
+        for i in 0..num_keys {
+            let key = format!("key_{}", i);
+            let member = assign(&key, &nodes, &hasher).unwrap();
+            let index = nodes.iter().position(|x| *x == member).unwrap();
+            counts[index] += 1;
+        }
+
+        for i in 0..member_count {
+            let count = counts[i];
+            let expected = num_keys / member_count;
+            let diff = count - expected as i32;
+            assert!(diff.abs() < tolerance);
+        }
+    }
+}

--- a/rust/worker/src/errors.rs
+++ b/rust/worker/src/errors.rs
@@ -39,6 +39,6 @@ pub(crate) enum ErrorCodes {
     DataLoss = 15,
 }
 
-trait ChromaError {
+pub(crate) trait ChromaError {
     fn code(&self) -> ErrorCodes;
 }

--- a/rust/worker/src/errors.rs
+++ b/rust/worker/src/errors.rs
@@ -1,0 +1,44 @@
+// Defines 17 standard error codes based on the error codes defined in the
+// gRPC spec. https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+// Custom errors can use these codes in order to allow for generic handling
+
+pub(crate) enum ErrorCodes {
+    // OK is returned on success, we use "Success" since Ok is a keyword in Rust.
+    Success = 0,
+    // CANCELLED indicates the operation was cancelled (typically by the caller).
+    Cancelled = 1,
+    // UNKNOWN indicates an unknown error.
+    UNKNOWN = 2,
+    // INVALID_ARGUMENT indicates client specified an invalid argument.
+    InvalidArgument = 3,
+    // DEADLINE_EXCEEDED means operation expired before completion.
+    DeadlineExceeded = 4,
+    // NOT_FOUND means some requested entity (e.g., file or directory) was not found.
+    NotFound = 5,
+    // ALREADY_EXISTS means an entity that we attempted to create (e.g., file or directory) already exists.
+    AlreadyExists = 6,
+    // PERMISSION_DENIED indicates the caller does not have permission to execute the specified operation.
+    PermissionDenied = 7,
+    // UNAUTHENTICATED indicates the request does not have valid authentication credentials for the operation.
+    UNAUTHENTICATED = 16,
+    // RESOURCE_EXHAUSTED indicates some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of space.
+    ResourceExhausted = 8,
+    // FAILED_PRECONDITION indicates operation was rejected because the system is not in a state required for the operation's execution.
+    FailedPrecondition = 9,
+    // ABORTED indicates the operation was aborted.
+    Aborted = 10,
+    // OUT_OF_RANGE means operation was attempted past the valid range.
+    OutOfRange = 11,
+    // UNIMPLEMENTED indicates operation is not implemented or not supported/enabled.
+    Unimplemented = 12,
+    // INTERNAL errors are internal errors.
+    Internal = 13,
+    // UNAVAILABLE indicates service is currently unavailable.
+    Unavailable = 14,
+    // DATA_LOSS indicates unrecoverable data loss or corruption.
+    DataLoss = 15,
+}
+
+trait ChromaError {
+    fn code(&self) -> ErrorCodes;
+}

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -1,3 +1,3 @@
 mod assignment;
 mod config;
-pub(crate) mod errors;
+mod errors;

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -1,1 +1,3 @@
+mod assignment;
 mod config;
+pub(crate) mod errors;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - /
 - New functionality
	 - This adds the rendezvous hashing to the rust code so that it may be used by assigners.
	 - It also introduces our philosophy on error handling in the rust codebase. We will use the 17 standard error codes in the  grpc codebase, this is used so lower levels can send their codes higher, and in higher levels of the code we can Box<> a dyn Chroma Error to allow for generic handling over the codes. Lower levels will have to be specific, at the expense of verbosity in the errors they propagate and wrap. We will use the thiserror library, widely adopted in rust, in order to easily derive our errors. If a type needs to wrap a source error, thiserror provides  #[from] in order to allow callers to have more nuanced information. After much research, my philosophy was informed by this post - https://mmapped.blog/posts/12-rust-error-handling.html. 

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `cargo test`

## Documentation Changes
None required. Please evaluate the documentation quality of the code itself.