### PR TITLE
[ENH] Add rust assignmenment policy and config management

### DIFF
--- a/rust/worker/src/assignment/assignment_policy.rs
+++ b/rust/worker/src/assignment/assignment_policy.rs
@@ -1,0 +1,102 @@
+use crate::config::{Configurable, WorkerConfig};
+
+use super::{
+    config::{AssignmentPolicyConfig, HasherType},
+    rendezvous_hash::{assign, AssignmentError, Murmur3Hasher},
+};
+use uuid::Uuid;
+
+/*
+===========================================
+Interfaces
+===========================================
+*/
+
+/// AssignmentPolicy is a trait that defines how to assign a collection to a topic.
+/// # Notes
+/// This trait mirrors the go and python versions of the assignment policy
+/// interface.
+/// # Methods
+/// - assign: Assign a collection to a topic.
+/// - get_topics: Get the topics that can be assigned to.
+/// # Notes
+/// An assignment policy is not responsible for creating the topics it assigns to.
+/// It is the responsibility of the caller to ensure that the topics exist.
+/// An assignment policy must be Send.
+pub(crate) trait AssignmentPolicy: Send {
+    fn assign(&self, collection_id: Uuid) -> Result<String, AssignmentError>;
+    fn get_topics(&self) -> Vec<String>;
+}
+
+/*
+===========================================
+Implementation
+===========================================
+*/
+
+pub(crate) struct RendezvousHashingAssignmentPolicy {
+    // The pulsar tenant and namespace being in this implementation of the assignment policy
+    // is purely a temporary measure while the topic propagation is being worked on.
+    // TODO: Remove pulsar_tenant and pulsar_namespace from this struct once topic propagation
+    // is implemented.
+    pulsar_tenant: String,
+    pulsar_namespace: String,
+    hasher: Murmur3Hasher,
+}
+
+impl RendezvousHashingAssignmentPolicy {
+    // Rust beginners note
+    // The reason we take String and not &str is because we need to put the strings into our
+    // struct, and we can't do that with references so rather than clone the strings, we just
+    // take ownership of them and put the responsibility on the caller to clone them if they
+    // need to. This is the general pattern we should follow in rust - put the burden of cloning
+    // on the caller, and if they don't need to clone, they can pass ownership.
+    pub fn new(
+        pulsar_tenant: String,
+        pulsar_namespace: String,
+    ) -> RendezvousHashingAssignmentPolicy {
+        return RendezvousHashingAssignmentPolicy {
+            pulsar_tenant: pulsar_tenant,
+            pulsar_namespace: pulsar_namespace,
+            hasher: Murmur3Hasher {},
+        };
+    }
+}
+
+impl Configurable for RendezvousHashingAssignmentPolicy {
+    fn from_config(config: WorkerConfig) -> Self {
+        let assignment_policy_config = match config.assignment_policy {
+            AssignmentPolicyConfig::RendezvousHashing(config) => config,
+        };
+        let hasher = match assignment_policy_config.hasher {
+            HasherType::Murmur3 => Murmur3Hasher {},
+        };
+        return RendezvousHashingAssignmentPolicy {
+            pulsar_tenant: config.pulsar_tenant,
+            pulsar_namespace: config.pulsar_namespace,
+            hasher: hasher,
+        };
+    }
+}
+
+impl AssignmentPolicy for RendezvousHashingAssignmentPolicy {
+    fn assign(&self, collection_id: Uuid) -> Result<String, AssignmentError> {
+        let collection_id = collection_id.to_string();
+        let topics = self.get_topics();
+        let topic = assign(&collection_id, topics, &self.hasher);
+        return topic;
+    }
+
+    fn get_topics(&self) -> Vec<String> {
+        // This mirrors the current python and go code, which assumes a fixed set of topics
+        let mut topics = Vec::with_capacity(16);
+        for i in 0..16 {
+            let topic = format!(
+                "persistent://{}/{}/chroma_log_{}",
+                self.pulsar_tenant, self.pulsar_namespace, i
+            );
+            topics.push(topic);
+        }
+        return topics;
+    }
+}

--- a/rust/worker/src/assignment/config.rs
+++ b/rust/worker/src/assignment/config.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+/// The type of hasher to use.
+/// # Options
+/// - Murmur3: The murmur3 hasher.
+pub(crate) enum HasherType {
+    Murmur3,
+}
+
+#[derive(Deserialize)]
+/// The configuration for the assignment policy.
+/// # Options
+/// - RendezvousHashing: The rendezvous hashing assignment policy.
+/// # Notes
+/// See config.rs in the root of the worker crate for an example of how to use
+/// config files to configure the worker.
+pub(crate) enum AssignmentPolicyConfig {
+    RendezvousHashing(RendezvousHashingAssignmentPolicyConfig),
+}
+
+#[derive(Deserialize)]
+/// The configuration for the rendezvous hashing assignment policy.
+/// # Fields
+/// - hasher: The type of hasher to use.
+pub(crate) struct RendezvousHashingAssignmentPolicyConfig {
+    pub(crate) hasher: HasherType,
+}

--- a/rust/worker/src/assignment/mod.rs
+++ b/rust/worker/src/assignment/mod.rs
@@ -1,1 +1,3 @@
+mod assignment_policy;
+pub(crate) mod config;
 mod rendezvous_hash;

--- a/rust/worker/src/assignment/rendezvous_hash.rs
+++ b/rust/worker/src/assignment/rendezvous_hash.rs
@@ -10,13 +10,13 @@ use thiserror::Error;
 use murmur3::murmur3_x64_128;
 
 /// A trait for hashing a member and a key to a score.
-trait Hasher {
+pub(crate) trait Hasher {
     fn hash(&self, member: &str, key: &str) -> Result<u64, AssignmentError>;
 }
 
 /// Error codes for assignment
 #[derive(Error, Debug)]
-enum AssignmentError {
+pub(crate) enum AssignmentError {
     #[error("Cannot assign empty key")]
     EmptyKey,
     #[error("No members to assign to")]
@@ -49,7 +49,7 @@ impl ChromaError for AssignmentError {
 /// # Notes
 /// This implementation mirrors the rendezvous hash implementation
 /// in the go and python services.
-fn assign<H: Hasher>(
+pub(crate) fn assign<H: Hasher>(
     key: &str,
     members: impl IntoIterator<Item = impl AsRef<str>>,
     hasher: &H,
@@ -97,7 +97,7 @@ fn merge_hashes(x: u64, y: u64) -> u64 {
     acc
 }
 
-struct Murmur3Hasher {}
+pub(crate) struct Murmur3Hasher {}
 
 impl Hasher for Murmur3Hasher {
     fn hash(&self, member: &str, key: &str) -> Result<u64, AssignmentError> {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds the `configurable` trait for static configuration of components. 
	 - In rust, our pattern will be that a root worker configurable object is consumed by components implementing the "Configurable" trait. Structs can then initialize themselves if the valid config exists. DI dispatch will happen by adding a dispatch type in the config.rs method of each module (not included here). Without any fancy macro programming, I think this is the best way to do it. 
	 - Calling code can `Box<dyn configurable>` and pass in the worker config to any components in need of configuration.
 - New functionality
	 - Adds the rust assignment policy based on the python and go versions

## Test plan
Added tests for booting the assignment policy config
- [x] Tests pass locally with `cargo test`

## Documentation Changes
None required. Feedback welcome on in-code documentation.
