### PR TITLE
[CLN]: remove duplicated types in chromadb/api/types.py

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -141,14 +141,6 @@ OperatorExpression = OperatorExpression
 Where = Where
 WhereDocumentOperator = WhereDocumentOperator
 
-Embeddable = Union[Documents, Images]
-D = TypeVar("D", bound=Embeddable, contravariant=True)
-
-
-class EmbeddingFunction(Protocol[D]):
-    def __call__(self, input: D) -> Embeddings:
-        ...
-
 
 Loadable = List[Optional[Image]]
 L = TypeVar("L", covariant=True, bound=Loadable)
@@ -215,11 +207,6 @@ def validate_embedding_function(
 
 
 L = TypeVar("L", covariant=True)
-
-
-class DataLoader(Protocol[L]):
-    def __call__(self, uris: URIs) -> L:
-        ...
 
 
 def validate_ids(ids: IDs) -> IDs:


### PR DESCRIPTION
It looks like some types are duplicated in the above file. For example, `Embeddable` appears twice, in https://github.com/chroma-core/chroma/blob/main/chromadb/api/types.py#L144 and in https://github.com/chroma-core/chroma/blob/main/chromadb/api/types.py#L192. Is this intentional?

 - Improvements & Bug fixes
	 - remove the following duplicated types; `Embeddable, D, EmbeddingFunction,  DataLoader`

## Test plan
- [X] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
None
