### PR TITLE
release JS to 1.7.1

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Bump JS client to 1.7.1 to release new functionality
- multi-tenancy
- gemini embedding support