### PR TITLE
Only url.QueryEscape() username and password

### DIFF
--- a/go/coordinator/internal/metastore/db/dbcore/core.go
+++ b/go/coordinator/internal/metastore/db/dbcore/core.go
@@ -32,8 +32,8 @@ type DBConfig struct {
 }
 
 func Connect(cfg DBConfig) (*gorm.DB, error) {
-	dsn := url.QueryEscape(fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d",
-		cfg.Address, cfg.Username, cfg.Password, cfg.DBName, cfg.Port))
+	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d",
+		cfg.Address, url.QueryEscape(cfg.Username), url.QueryEscape(cfg.Password), cfg.DBName, cfg.Port)
 
 	ormLogger := logger.Default
 	ormLogger.LogMode(logger.Info)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Only call `url.QueryEscape` on `username` and `password`. At present we format out the `=` and other characters in the string so the connection doesn't work.

## Test plan
*How are these changes tested?*

- [ ] Built and ran locally

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
