### PR TITLE
[ENH] Refactor system to allow mutable handles, wrapped messages, single M recievers

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -4,18 +4,22 @@
 # for now we nest it in the worker directory
 
 worker:
-  my_ip: "10.244.0.90"
-  num_indexing_threads: 4
-  pulsar_url: "pulsar://127.0.0.1:6650"
-  pulsar_tenant: "public"
-  pulsar_namespace: "default"
-  kube_namespace: "chroma"
-  assignment_policy:
-      RendezvousHashing:
-          hasher: Murmur3
-  memberlist_provider:
-      CustomResource:
-          memberlist_name: "worker-memberlist"
-          queue_size: 100
-  ingest:
-      queue_size: 100
+    my_ip: "10.244.0.90"
+    num_indexing_threads: 4
+    pulsar_url: "pulsar://127.0.0.1:6650"
+    pulsar_tenant: "public"
+    pulsar_namespace: "default"
+    kube_namespace: "chroma"
+    assignment_policy:
+        RendezvousHashing:
+            hasher: Murmur3
+    memberlist_provider:
+        CustomResource:
+            memberlist_name: "worker-memberlist"
+            queue_size: 100
+    ingest:
+        queue_size: 100
+    sysdb:
+        Grpc:
+            host: "localhost"
+            port: 50051

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -105,6 +105,7 @@ pub(crate) struct WorkerConfig {
     pub(crate) assignment_policy: crate::assignment::config::AssignmentPolicyConfig,
     pub(crate) memberlist_provider: crate::memberlist::config::MemberlistProviderConfig,
     pub(crate) ingest: crate::ingest::config::IngestConfig,
+    pub(crate) sysdb: crate::sysdb::config::SysDbConfig,
 }
 
 /// # Description
@@ -146,6 +147,11 @@ mod tests {
                             queue_size: 100
                     ingest:
                         queue_size: 100
+                    sysdb:
+                        GrpcSysDb:
+                            host: "localhost"
+                            port: 50051
+
                 "#,
             );
             let config = RootConfig::load();
@@ -180,6 +186,10 @@ mod tests {
                             queue_size: 100
                     ingest:
                         queue_size: 100
+                    sysdb:
+                        GrpcSysDb:
+                            host: "localhost"
+                            port: 50051
 
                 "#,
             );
@@ -230,6 +240,10 @@ mod tests {
                             queue_size: 100
                     ingest:
                         queue_size: 100
+                    sysdb:
+                        GrpcSysDb:
+                            host: "localhost"
+                            port: 50051
 
                 "#,
             );
@@ -261,6 +275,10 @@ mod tests {
                             queue_size: 100
                     ingest:
                         queue_size: 100
+                    sysdb:
+                        GrpcSysDb:
+                            host: "localhost"
+                            port: 50051
                 "#,
             );
             let config = RootConfig::load();

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -148,7 +148,7 @@ mod tests {
                     ingest:
                         queue_size: 100
                     sysdb:
-                        GrpcSysDb:
+                        Grpc:
                             host: "localhost"
                             port: 50051
 
@@ -187,7 +187,7 @@ mod tests {
                     ingest:
                         queue_size: 100
                     sysdb:
-                        GrpcSysDb:
+                        Grpc:
                             host: "localhost"
                             port: 50051
 
@@ -241,7 +241,7 @@ mod tests {
                     ingest:
                         queue_size: 100
                     sysdb:
-                        GrpcSysDb:
+                        Grpc:
                             host: "localhost"
                             port: 50051
 
@@ -276,7 +276,7 @@ mod tests {
                     ingest:
                         queue_size: 100
                     sysdb:
-                        GrpcSysDb:
+                        Grpc:
                             host: "localhost"
                             port: 50051
                 "#,

--- a/rust/worker/src/ingest/ingest.rs
+++ b/rust/worker/src/ingest/ingest.rs
@@ -137,7 +137,6 @@ impl Handler<Memberlist> for Ingest {
     async fn handle(&mut self, msg: Memberlist, ctx: &ComponentContext<Self>) {
         let mut new_assignments = HashSet::new();
         let candidate_topics: Vec<String> = self.get_topics();
-        println!("Candidate topics: {:?}", candidate_topics);
         // Scope for assigner write lock to be released so we don't hold it over await
         {
             let mut assigner = match self.assignment_policy.write() {

--- a/rust/worker/src/ingest/ingest.rs
+++ b/rust/worker/src/ingest/ingest.rs
@@ -1,317 +1,347 @@
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::{StreamExt, TryStreamExt};
-use prost::Message;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{Arc, RwLock},
-};
+// use async_trait::async_trait;
+// use bytes::Bytes;
+// use futures::{StreamExt, TryStreamExt};
+// use prost::Message;
+// use std::{
+//     collections::{HashMap, HashSet},
+//     sync::{Arc, RwLock},
+// };
 
-use crate::{
-    assignment::{
-        self,
-        assignment_policy::{self, AssignmentPolicy},
-    },
-    chroma_proto,
-    config::{Configurable, WorkerConfig},
-    errors::{ChromaError, ErrorCodes},
-    memberlist::{CustomResourceMemberlistProvider, Memberlist},
-    system::{Component, ComponentContext, ComponentHandle, Handler, StreamHandler},
-    types::{EmbeddingRecord, EmbeddingRecordConversionError, SeqId},
-};
+// use crate::{
+//     assignment::{
+//         self,
+//         assignment_policy::{self, AssignmentPolicy},
+//     },
+//     chroma_proto,
+//     config::{Configurable, WorkerConfig},
+//     errors::{ChromaError, ErrorCodes},
+//     memberlist::{CustomResourceMemberlistProvider, Memberlist},
+//     sysdb::sysdb::{GrpcSysDb, SysDb},
+//     system::{Component, ComponentContext, ComponentHandle, Handler, StreamHandler},
+//     types::{EmbeddingRecord, EmbeddingRecordConversionError, SeqId},
+// };
 
-use pulsar::{
-    consumer::topic, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
-};
-use thiserror::Error;
+// use pulsar::{
+//     consumer::topic, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
+// };
+// use thiserror::Error;
 
-use super::message_id::PulsarMessageIdWrapper;
+// use super::message_id::PulsarMessageIdWrapper;
 
-/// An ingest component is responsible for ingesting data into the system from the log
-/// stream.
-/// # Notes
-/// The only current implementation of the ingest is the Pulsar ingest.
-pub(crate) struct Ingest {
-    assignment_policy: RwLock<Box<dyn AssignmentPolicy + Sync + Send>>,
-    assigned_topics: RwLock<Vec<String>>,
-    topic_to_handle: RwLock<HashMap<String, ComponentHandle>>,
-    queue_size: usize,
-    my_ip: String,
-    pulsar_tenant: String,
-    pulsar_namespace: String,
-    pulsar: Pulsar<TokioExecutor>,
-}
+// /// An ingest component is responsible for ingesting data into the system from the log
+// /// stream.
+// /// # Notes
+// /// The only current implementation of the ingest is the Pulsar ingest.
+// pub(crate) struct Ingest {
+//     assignment_policy: RwLock<Box<dyn AssignmentPolicy + Sync + Send>>,
+//     assigned_topics: RwLock<Vec<String>>,
+//     topic_to_handle: RwLock<HashMap<String, ComponentHandle>>,
+//     queue_size: usize,
+//     my_ip: String,
+//     pulsar_tenant: String,
+//     pulsar_namespace: String,
+//     pulsar: Pulsar<TokioExecutor>,
+//     sysdb: Arc<dyn SysDb>,
+// }
 
-impl Component for Ingest {
-    fn queue_size(&self) -> usize {
-        self.queue_size
-    }
-}
+// impl Component for Ingest {
+//     fn queue_size(&self) -> usize {
+//         self.queue_size
+//     }
+// }
 
-#[derive(Error, Debug)]
-pub(crate) enum IngestConfigurationError {
-    #[error(transparent)]
-    PulsarError(#[from] pulsar::Error),
-}
+// #[derive(Error, Debug)]
+// pub(crate) enum IngestConfigurationError {
+//     #[error(transparent)]
+//     PulsarError(#[from] pulsar::Error),
+// }
 
-impl ChromaError for IngestConfigurationError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            IngestConfigurationError::PulsarError(_e) => ErrorCodes::Internal,
-        }
-    }
-}
+// impl ChromaError for IngestConfigurationError {
+//     fn code(&self) -> ErrorCodes {
+//         match self {
+//             IngestConfigurationError::PulsarError(_e) => ErrorCodes::Internal,
+//         }
+//     }
+// }
 
-// TODO: Nest the ingest assignment policy inside the ingest component config so its
-// specific to the ingest component and can be used here
-#[async_trait]
-impl Configurable for Ingest {
-    async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
-        let assignment_policy = assignment_policy::RendezvousHashingAssignmentPolicy::new(
-            worker_config.pulsar_tenant.clone(),
-            worker_config.pulsar_namespace.clone(),
-        );
-        let pulsar = match Pulsar::builder(worker_config.pulsar_url.clone(), TokioExecutor)
-            .build()
-            .await
-        {
-            Ok(pulsar) => pulsar,
-            Err(e) => {
-                return Err(Box::new(IngestConfigurationError::PulsarError(e)));
-            }
-        };
-        let ingest = Ingest {
-            assignment_policy: RwLock::new(Box::new(assignment_policy)),
-            assigned_topics: RwLock::new(vec![]),
-            topic_to_handle: RwLock::new(HashMap::new()),
-            queue_size: worker_config.ingest.queue_size,
-            my_ip: worker_config.my_ip.clone(),
-            pulsar: pulsar,
-            pulsar_tenant: worker_config.pulsar_tenant.clone(),
-            pulsar_namespace: worker_config.pulsar_namespace.clone(),
-        };
-        Ok(ingest)
-    }
-}
+// // TODO: Nest the ingest assignment policy inside the ingest component config so its
+// // specific to the ingest component and can be used here
+// #[async_trait]
+// impl Configurable for Ingest {
+//     async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
+//         let assignment_policy = assignment_policy::RendezvousHashingAssignmentPolicy::new(
+//             worker_config.pulsar_tenant.clone(),
+//             worker_config.pulsar_namespace.clone(),
+//         );
 
-impl Ingest {
-    fn get_topics(&self) -> Vec<String> {
-        // This mirrors the current python and go code, which assumes a fixed set of topics
-        let mut topics = Vec::with_capacity(16);
-        for i in 0..16 {
-            let topic = format!(
-                "persistent://{}/{}/chroma_log_{}",
-                self.pulsar_tenant, self.pulsar_namespace, i
-            );
-            topics.push(topic);
-        }
-        return topics;
-    }
-}
+//         let pulsar = match Pulsar::builder(worker_config.pulsar_url.clone(), TokioExecutor)
+//             .build()
+//             .await
+//         {
+//             Ok(pulsar) => pulsar,
+//             Err(e) => {
+//                 return Err(Box::new(IngestConfigurationError::PulsarError(e)));
+//             }
+//         };
 
-#[async_trait]
-impl Handler<Memberlist> for Ingest {
-    async fn handle(&self, msg: Memberlist, ctx: &ComponentContext<Memberlist, Self>) {
-        let mut new_assignments = HashSet::new();
-        let candidate_topics: Vec<String> = self.get_topics();
+//         // TODO: Sysdb should have a dynamic resolution in sysdb
+//         let sysdb = GrpcSysDb::try_from_config(worker_config).await;
+//         let sysdb = match sysdb {
+//             Ok(sysdb) => sysdb,
+//             Err(err) => {
+//                 return Err(err);
+//             }
+//         };
 
-        // Scope for assigner write lock to be released so we don't hold it over await
-        {
-            let mut assigner = match self.assignment_policy.write() {
-                Ok(assigner) => assigner,
-                Err(err) => {
-                    println!("Failed to read assignment policy: {:?}", err);
-                    return;
-                }
-            };
+//         let ingest = Ingest {
+//             assignment_policy: RwLock::new(Box::new(assignment_policy)),
+//             assigned_topics: RwLock::new(vec![]),
+//             topic_to_handle: RwLock::new(HashMap::new()),
+//             queue_size: worker_config.ingest.queue_size,
+//             my_ip: worker_config.my_ip.clone(),
+//             pulsar: pulsar,
+//             pulsar_tenant: worker_config.pulsar_tenant.clone(),
+//             pulsar_namespace: worker_config.pulsar_namespace.clone(),
+//             sysdb: Arc::new(sysdb),
+//         };
+//         Ok(ingest)
+//     }
+// }
 
-            // Use the assignment policy to assign topics to this worker
-            assigner.set_members(msg);
-            for topic in candidate_topics.iter() {
-                let assignment = assigner.assign(topic);
-                let assignment = match assignment {
-                    Ok(assignment) => assignment,
-                    Err(err) => {
-                        // TODO: Log error
-                        continue;
-                    }
-                };
-                if assignment == self.my_ip {
-                    new_assignments.insert(topic);
-                }
-            }
-        }
+// impl Ingest {
+//     fn get_topics(&self) -> Vec<String> {
+//         // This mirrors the current python and go code, which assumes a fixed set of topics
+//         let mut topics = Vec::with_capacity(16);
+//         for i in 0..16 {
+//             let topic = format!(
+//                 "persistent://{}/{}/chroma_log_{}",
+//                 self.pulsar_tenant, self.pulsar_namespace, i
+//             );
+//             topics.push(topic);
+//         }
+//         return topics;
+//     }
+// }
 
-        // Compute the topics we need to add/remove
-        let mut to_remove = Vec::new();
-        let mut to_add = Vec::new();
+// #[async_trait]
+// impl Handler<Memberlist> for Ingest {
+//     async fn handle(&mut self, msg: Memberlist, ctx: &ComponentContext<Memberlist, Self>) {
+//         let mut new_assignments = HashSet::new();
+//         let candidate_topics: Vec<String> = self.get_topics();
 
-        // Scope for assigned topics read lock to be released so we don't hold it over await
-        {
-            let assigned_topics_handle = self.assigned_topics.read();
-            match assigned_topics_handle {
-                Ok(assigned_topics) => {
-                    // Compute the diff between the current assignments and the new assignments
-                    for topic in assigned_topics.iter() {
-                        if !new_assignments.contains(topic) {
-                            to_remove.push(topic.to_string());
-                        }
-                    }
-                    for topic in new_assignments.iter() {
-                        if !assigned_topics.contains(*topic) {
-                            to_add.push(topic.to_string());
-                        }
-                    }
-                }
-                Err(err) => {
-                    // TODO: Log error and handle lock poisoning
-                }
-            }
-        }
+//         // Scope for assigner write lock to be released so we don't hold it over await
+//         {
+//             let mut assigner = match self.assignment_policy.write() {
+//                 Ok(assigner) => assigner,
+//                 Err(err) => {
+//                     println!("Failed to read assignment policy: {:?}", err);
+//                     return;
+//                 }
+//             };
 
-        // Unsubscribe from topics we no longer need to listen to
-        for topic in to_remove.iter() {
-            match self.topic_to_handle.write() {
-                Ok(mut topic_to_handle) => {
-                    let handle = topic_to_handle.remove(topic);
-                    match handle {
-                        Some(mut handle) => {
-                            handle.stop();
-                        }
-                        None => {
-                            // TODO: This should log an error
-                            println!("No handle found for topic: {}", topic);
-                        }
-                    }
-                }
-                Err(err) => {
-                    // TODO: Log an error and handle lock poisoning
-                }
-            }
-        }
+//             // Use the assignment policy to assign topics to this worker
+//             assigner.set_members(msg);
+//             for topic in candidate_topics.iter() {
+//                 let assignment = assigner.assign(topic);
+//                 let assignment = match assignment {
+//                     Ok(assignment) => assignment,
+//                     Err(err) => {
+//                         // TODO: Log error
+//                         continue;
+//                     }
+//                 };
+//                 if assignment == self.my_ip {
+//                     new_assignments.insert(topic);
+//                 }
+//             }
+//         }
 
-        // Subscribe to new topics
-        for topic in to_add.iter() {
-            println!("Adding topic: {}", topic);
-            // Do the subscription and register the stream to this ingest component
-            let consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor> = self
-                .pulsar
-                .consumer()
-                .with_topic(topic.to_string())
-                .with_subscription_type(SubType::Exclusive)
-                .build()
-                .await
-                .unwrap();
+//         // Compute the topics we need to add/remove
+//         let mut to_remove = Vec::new();
+//         let mut to_add = Vec::new();
 
-            let ingest_topic_component = PulsarIngestTopic::new(consumer);
+//         // Scope for assigned topics read lock to be released so we don't hold it over await
+//         {
+//             let assigned_topics_handle = self.assigned_topics.read();
+//             match assigned_topics_handle {
+//                 Ok(assigned_topics) => {
+//                     // Compute the diff between the current assignments and the new assignments
+//                     for topic in assigned_topics.iter() {
+//                         if !new_assignments.contains(topic) {
+//                             to_remove.push(topic.to_string());
+//                         }
+//                     }
+//                     for topic in new_assignments.iter() {
+//                         if !assigned_topics.contains(*topic) {
+//                             to_add.push(topic.to_string());
+//                         }
+//                     }
+//                 }
+//                 Err(err) => {
+//                     // TODO: Log error and handle lock poisoning
+//                 }
+//             }
+//         }
 
-            let (handle, _) = ctx.system.clone().start_component(ingest_topic_component);
+//         // Unsubscribe from topics we no longer need to listen to
+//         for topic in to_remove.iter() {
+//             match self.topic_to_handle.write() {
+//                 Ok(mut topic_to_handle) => {
+//                     let handle = topic_to_handle.remove(topic);
+//                     match handle {
+//                         Some(mut handle) => {
+//                             handle.stop();
+//                         }
+//                         None => {
+//                             // TODO: This should log an error
+//                             println!("No handle found for topic: {}", topic);
+//                         }
+//                     }
+//                 }
+//                 Err(err) => {
+//                     // TODO: Log an error and handle lock poisoning
+//                 }
+//             }
+//         }
 
-            // Bookkeep the handle so we can shut the stream down later
-            match self.topic_to_handle.write() {
-                Ok(mut topic_to_handle) => {
-                    topic_to_handle.insert(topic.to_string(), handle);
-                }
-                Err(err) => {
-                    // TODO: log error and handle lock poisoning
-                    println!("Failed to write topic to handle: {:?}", err);
-                }
-            }
-        }
-    }
-}
+//         // Subscribe to new topics
+//         for topic in to_add.iter() {
+//             println!("Adding topic: {}", topic);
+//             // Do the subscription and register the stream to this ingest component
+//             let consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor> = self
+//                 .pulsar
+//                 .consumer()
+//                 .with_topic(topic.to_string())
+//                 .with_subscription_type(SubType::Exclusive)
+//                 .build()
+//                 .await
+//                 .unwrap();
 
-impl DeserializeMessage for chroma_proto::SubmitEmbeddingRecord {
-    type Output = Self;
+//             let ingest_topic_component = PulsarIngestTopic::new(consumer, self.sysdb.clone());
 
-    fn deserialize_message(payload: &Payload) -> chroma_proto::SubmitEmbeddingRecord {
-        // Its a bit strange to unwrap here, but the pulsar api doesn't give us a way to
-        // return an error, so we have to panic if we can't decode the message
-        // also we are forced to clone since the api doesn't give us a way to borrow the bytes
-        // TODO: can we not clone?
-        // TODO: I think just typing this to Result<> would allow errors to propagate
-        let record =
-            chroma_proto::SubmitEmbeddingRecord::decode(Bytes::from(payload.data.clone())).unwrap();
-        return record;
-    }
-}
+//             let (handle, _) = ctx.system.clone().start_component(ingest_topic_component);
 
-struct PulsarIngestTopic {
-    consumer: RwLock<Option<Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>>>,
-}
+//             // Bookkeep the handle so we can shut the stream down later
+//             match self.topic_to_handle.write() {
+//                 Ok(mut topic_to_handle) => {
+//                     topic_to_handle.insert(topic.to_string(), handle);
+//                 }
+//                 Err(err) => {
+//                     // TODO: log error and handle lock poisoning
+//                     println!("Failed to write topic to handle: {:?}", err);
+//                 }
+//             }
+//         }
+//     }
+// }
 
-impl PulsarIngestTopic {
-    fn new(consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>) -> Self {
-        PulsarIngestTopic {
-            consumer: RwLock::new(Some(consumer)),
-        }
-    }
-}
+// impl DeserializeMessage for chroma_proto::SubmitEmbeddingRecord {
+//     type Output = Self;
 
-impl Component for PulsarIngestTopic {
-    fn queue_size(&self) -> usize {
-        1000
-    }
-}
+//     fn deserialize_message(payload: &Payload) -> chroma_proto::SubmitEmbeddingRecord {
+//         // Its a bit strange to unwrap here, but the pulsar api doesn't give us a way to
+//         // return an error, so we have to panic if we can't decode the message
+//         // also we are forced to clone since the api doesn't give us a way to borrow the bytes
+//         // TODO: can we not clone?
+//         // TODO: I think just typing this to Result<> would allow errors to propagate
+//         let record =
+//             chroma_proto::SubmitEmbeddingRecord::decode(Bytes::from(payload.data.clone())).unwrap();
+//         return record;
+//     }
+// }
 
-#[async_trait]
-impl Handler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
-    async fn handle(
-        &self,
-        _message: Option<Arc<EmbeddingRecord>>,
-        _ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, PulsarIngestTopic>,
-    ) -> () {
-        // No-op
-    }
+// struct PulsarIngestTopic {
+//     consumer: RwLock<Option<Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>>>,
+//     sysdb: Arc<dyn SysDb>,
+// }
 
-    fn on_start(&self, ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, Self>) -> () {
-        let stream = match self.consumer.write() {
-            Ok(mut consumer_handle) => consumer_handle.take(),
-            Err(err) => None,
-        };
-        let stream = match stream {
-            Some(stream) => stream,
-            None => {
-                return;
-            }
-        };
-        let stream = stream.then(|result| async {
-            match result {
-                Ok(msg) => {
-                    // Convert the Pulsar Message to an EmbeddingRecord
-                    let proto_embedding_record = msg.deserialize();
-                    let id = msg.message_id;
-                    let seq_id: SeqId = PulsarMessageIdWrapper(id).into();
-                    let embedding_record: Result<EmbeddingRecord, EmbeddingRecordConversionError> =
-                        (proto_embedding_record, seq_id).try_into();
-                    match embedding_record {
-                        Ok(embedding_record) => {
-                            return Some(Arc::new(embedding_record));
-                        }
-                        Err(err) => {
-                            // TODO: Handle and log
-                        }
-                    }
-                    None
-                }
-                Err(err) => {
-                    // TODO: Log an error
-                    // Put this on a dead letter queue, this concept does not exist in our
-                    // system yet
-                    None
-                }
-            }
-        });
-        self.register_stream(stream, ctx);
-    }
-}
+// impl PulsarIngestTopic {
+//     fn new(
+//         consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>,
+//         sysdb: Arc<dyn SysDb>,
+//     ) -> Self {
+//         PulsarIngestTopic {
+//             consumer: RwLock::new(Some(consumer)),
+//             sysdb: sysdb,
+//         }
+//     }
+// }
 
-#[async_trait]
-impl StreamHandler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
-    async fn handle(
-        &self,
-        message: Option<Arc<EmbeddingRecord>>,
-        _ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, PulsarIngestTopic>,
-    ) -> () {
-    }
-}
+// impl Component for PulsarIngestTopic {
+//     fn queue_size(&self) -> usize {
+//         1000
+//     }
+// }
+
+// #[async_trait]
+// impl Handler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
+//     async fn handle(
+//         &mut self,
+//         _message: Option<Arc<EmbeddingRecord>>,
+//         _ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, PulsarIngestTopic>,
+//     ) -> () {
+//         // No-op
+//     }
+
+//     fn on_start(&self, ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, Self>) -> () {
+//         let stream = match self.consumer.write() {
+//             Ok(mut consumer_handle) => consumer_handle.take(),
+//             Err(err) => None,
+//         };
+//         let stream = match stream {
+//             Some(stream) => stream,
+//             None => {
+//                 return;
+//             }
+//         };
+//         let stream = stream.then(|result| async {
+//             match result {
+//                 Ok(msg) => {
+//                     // Convert the Pulsar Message to an EmbeddingRecord
+//                     let proto_embedding_record = msg.deserialize();
+//                     let id = msg.message_id;
+//                     let seq_id: SeqId = PulsarMessageIdWrapper(id).into();
+//                     let embedding_record: Result<EmbeddingRecord, EmbeddingRecordConversionError> =
+//                         (proto_embedding_record, seq_id).try_into();
+//                     match embedding_record {
+//                         Ok(embedding_record) => {
+//                             return Some(Arc::new(embedding_record));
+//                         }
+//                         Err(err) => {
+//                             // TODO: Handle and log
+//                         }
+//                     }
+//                     None
+//                 }
+//                 Err(err) => {
+//                     // TODO: Log an error
+//                     // Put this on a dead letter queue, this concept does not exist in our
+//                     // system yet
+//                     None
+//                 }
+//             }
+//         });
+//         self.register_stream(stream, ctx);
+//     }
+// }
+
+// #[async_trait]
+// impl StreamHandler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
+//     async fn handle(
+//         &mut self,
+//         message: Option<Arc<EmbeddingRecord>>,
+//         _ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, PulsarIngestTopic>,
+//     ) -> () {
+//         // Use the sysdb to tenant id for the embedding record
+//         let embedding_record = match message {
+//             Some(embedding_record) => embedding_record,
+//             None => {
+//                 return;
+//             }
+//         };
+//         let coll = self
+//             .sysdb
+//             .get_collections(Some(embedding_record.collection_id), None, None, None, None)
+//             .await;
+//     }
+// }

--- a/rust/worker/src/ingest/ingest.rs
+++ b/rust/worker/src/ingest/ingest.rs
@@ -42,7 +42,7 @@ pub(crate) struct Ingest {
     pulsar_tenant: String,
     pulsar_namespace: String,
     pulsar: Pulsar<TokioExecutor>,
-    sysdb: Arc<dyn SysDb>,
+    sysdb: Box<dyn SysDb>,
 }
 
 impl Component for Ingest {
@@ -111,7 +111,7 @@ impl Configurable for Ingest {
             pulsar: pulsar,
             pulsar_tenant: worker_config.pulsar_tenant.clone(),
             pulsar_namespace: worker_config.pulsar_namespace.clone(),
-            sysdb: Arc::new(sysdb),
+            sysdb: Box::new(sysdb),
         };
         Ok(ingest)
     }
@@ -260,7 +260,7 @@ impl DeserializeMessage for chroma_proto::SubmitEmbeddingRecord {
 
 struct PulsarIngestTopic {
     consumer: RwLock<Option<Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>>>,
-    sysdb: Arc<dyn SysDb>,
+    sysdb: Box<dyn SysDb>,
 }
 
 impl Debug for PulsarIngestTopic {
@@ -272,7 +272,7 @@ impl Debug for PulsarIngestTopic {
 impl PulsarIngestTopic {
     fn new(
         consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>,
-        sysdb: Arc<dyn SysDb>,
+        sysdb: Box<dyn SysDb>,
     ) -> Self {
         PulsarIngestTopic {
             consumer: RwLock::new(Some(consumer)),
@@ -342,10 +342,10 @@ impl Handler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
                 return;
             }
         };
-        // let coll = self
-        //     .sysdb
-        //     .get_collections(Some(embedding_record.collection_id), None, None, None, None)
-        //     .await;
+        let coll = self
+            .sysdb
+            .get_collections(Some(embedding_record.collection_id), None, None, None, None)
+            .await;
     }
 }
 

--- a/rust/worker/src/ingest/ingest.rs
+++ b/rust/worker/src/ingest/ingest.rs
@@ -1,347 +1,354 @@
-// use async_trait::async_trait;
-// use bytes::Bytes;
-// use futures::{StreamExt, TryStreamExt};
-// use prost::Message;
-// use std::{
-//     collections::{HashMap, HashSet},
-//     sync::{Arc, RwLock},
-// };
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{StreamExt, TryStreamExt};
+use prost::Message;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    sync::{Arc, RwLock},
+};
 
-// use crate::{
-//     assignment::{
-//         self,
-//         assignment_policy::{self, AssignmentPolicy},
-//     },
-//     chroma_proto,
-//     config::{Configurable, WorkerConfig},
-//     errors::{ChromaError, ErrorCodes},
-//     memberlist::{CustomResourceMemberlistProvider, Memberlist},
-//     sysdb::sysdb::{GrpcSysDb, SysDb},
-//     system::{Component, ComponentContext, ComponentHandle, Handler, StreamHandler},
-//     types::{EmbeddingRecord, EmbeddingRecordConversionError, SeqId},
-// };
+use crate::{
+    assignment::{
+        self,
+        assignment_policy::{self, AssignmentPolicy},
+    },
+    chroma_proto,
+    config::{Configurable, WorkerConfig},
+    errors::{ChromaError, ErrorCodes},
+    memberlist::{CustomResourceMemberlistProvider, Memberlist},
+    sysdb::sysdb::{GrpcSysDb, SysDb},
+    system::{Component, ComponentContext, ComponentHandle, Handler, StreamHandler},
+    types::{EmbeddingRecord, EmbeddingRecordConversionError, SeqId},
+};
 
-// use pulsar::{
-//     consumer::topic, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
-// };
-// use thiserror::Error;
+use pulsar::{
+    consumer::topic, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
+};
+use thiserror::Error;
 
-// use super::message_id::PulsarMessageIdWrapper;
+use super::message_id::PulsarMessageIdWrapper;
 
-// /// An ingest component is responsible for ingesting data into the system from the log
-// /// stream.
-// /// # Notes
-// /// The only current implementation of the ingest is the Pulsar ingest.
-// pub(crate) struct Ingest {
-//     assignment_policy: RwLock<Box<dyn AssignmentPolicy + Sync + Send>>,
-//     assigned_topics: RwLock<Vec<String>>,
-//     topic_to_handle: RwLock<HashMap<String, ComponentHandle>>,
-//     queue_size: usize,
-//     my_ip: String,
-//     pulsar_tenant: String,
-//     pulsar_namespace: String,
-//     pulsar: Pulsar<TokioExecutor>,
-//     sysdb: Arc<dyn SysDb>,
-// }
+/// An ingest component is responsible for ingesting data into the system from the log
+/// stream.
+/// # Notes
+/// The only current implementation of the ingest is the Pulsar ingest.
+pub(crate) struct Ingest {
+    assignment_policy: RwLock<Box<dyn AssignmentPolicy + Sync + Send>>,
+    assigned_topics: RwLock<Vec<String>>,
+    topic_to_handle: RwLock<HashMap<String, ComponentHandle<PulsarIngestTopic>>>,
+    queue_size: usize,
+    my_ip: String,
+    pulsar_tenant: String,
+    pulsar_namespace: String,
+    pulsar: Pulsar<TokioExecutor>,
+    sysdb: Arc<dyn SysDb>,
+}
 
-// impl Component for Ingest {
-//     fn queue_size(&self) -> usize {
-//         self.queue_size
-//     }
-// }
+impl Component for Ingest {
+    fn queue_size(&self) -> usize {
+        return self.queue_size;
+    }
+}
 
-// #[derive(Error, Debug)]
-// pub(crate) enum IngestConfigurationError {
-//     #[error(transparent)]
-//     PulsarError(#[from] pulsar::Error),
-// }
+impl Debug for Ingest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ingest")
+            .field("queue_size", &self.queue_size)
+            .finish()
+    }
+}
 
-// impl ChromaError for IngestConfigurationError {
-//     fn code(&self) -> ErrorCodes {
-//         match self {
-//             IngestConfigurationError::PulsarError(_e) => ErrorCodes::Internal,
-//         }
-//     }
-// }
+#[derive(Error, Debug)]
+pub(crate) enum IngestConfigurationError {
+    #[error(transparent)]
+    PulsarError(#[from] pulsar::Error),
+}
 
-// // TODO: Nest the ingest assignment policy inside the ingest component config so its
-// // specific to the ingest component and can be used here
-// #[async_trait]
-// impl Configurable for Ingest {
-//     async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
-//         let assignment_policy = assignment_policy::RendezvousHashingAssignmentPolicy::new(
-//             worker_config.pulsar_tenant.clone(),
-//             worker_config.pulsar_namespace.clone(),
-//         );
+impl ChromaError for IngestConfigurationError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            IngestConfigurationError::PulsarError(_e) => ErrorCodes::Internal,
+        }
+    }
+}
 
-//         let pulsar = match Pulsar::builder(worker_config.pulsar_url.clone(), TokioExecutor)
-//             .build()
-//             .await
-//         {
-//             Ok(pulsar) => pulsar,
-//             Err(e) => {
-//                 return Err(Box::new(IngestConfigurationError::PulsarError(e)));
-//             }
-//         };
+// TODO: Nest the ingest assignment policy inside the ingest component config so its
+// specific to the ingest component and can be used here
+#[async_trait]
+impl Configurable for Ingest {
+    async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
+        let assignment_policy = assignment_policy::RendezvousHashingAssignmentPolicy::new(
+            worker_config.pulsar_tenant.clone(),
+            worker_config.pulsar_namespace.clone(),
+        );
 
-//         // TODO: Sysdb should have a dynamic resolution in sysdb
-//         let sysdb = GrpcSysDb::try_from_config(worker_config).await;
-//         let sysdb = match sysdb {
-//             Ok(sysdb) => sysdb,
-//             Err(err) => {
-//                 return Err(err);
-//             }
-//         };
+        let pulsar = match Pulsar::builder(worker_config.pulsar_url.clone(), TokioExecutor)
+            .build()
+            .await
+        {
+            Ok(pulsar) => pulsar,
+            Err(e) => {
+                return Err(Box::new(IngestConfigurationError::PulsarError(e)));
+            }
+        };
 
-//         let ingest = Ingest {
-//             assignment_policy: RwLock::new(Box::new(assignment_policy)),
-//             assigned_topics: RwLock::new(vec![]),
-//             topic_to_handle: RwLock::new(HashMap::new()),
-//             queue_size: worker_config.ingest.queue_size,
-//             my_ip: worker_config.my_ip.clone(),
-//             pulsar: pulsar,
-//             pulsar_tenant: worker_config.pulsar_tenant.clone(),
-//             pulsar_namespace: worker_config.pulsar_namespace.clone(),
-//             sysdb: Arc::new(sysdb),
-//         };
-//         Ok(ingest)
-//     }
-// }
+        // TODO: Sysdb should have a dynamic resolution in sysdb
+        let sysdb = GrpcSysDb::try_from_config(worker_config).await;
+        let sysdb = match sysdb {
+            Ok(sysdb) => sysdb,
+            Err(err) => {
+                return Err(err);
+            }
+        };
 
-// impl Ingest {
-//     fn get_topics(&self) -> Vec<String> {
-//         // This mirrors the current python and go code, which assumes a fixed set of topics
-//         let mut topics = Vec::with_capacity(16);
-//         for i in 0..16 {
-//             let topic = format!(
-//                 "persistent://{}/{}/chroma_log_{}",
-//                 self.pulsar_tenant, self.pulsar_namespace, i
-//             );
-//             topics.push(topic);
-//         }
-//         return topics;
-//     }
-// }
+        let ingest = Ingest {
+            assignment_policy: RwLock::new(Box::new(assignment_policy)),
+            assigned_topics: RwLock::new(vec![]),
+            topic_to_handle: RwLock::new(HashMap::new()),
+            queue_size: worker_config.ingest.queue_size,
+            my_ip: worker_config.my_ip.clone(),
+            pulsar: pulsar,
+            pulsar_tenant: worker_config.pulsar_tenant.clone(),
+            pulsar_namespace: worker_config.pulsar_namespace.clone(),
+            sysdb: Arc::new(sysdb),
+        };
+        Ok(ingest)
+    }
+}
 
-// #[async_trait]
-// impl Handler<Memberlist> for Ingest {
-//     async fn handle(&mut self, msg: Memberlist, ctx: &ComponentContext<Memberlist, Self>) {
-//         let mut new_assignments = HashSet::new();
-//         let candidate_topics: Vec<String> = self.get_topics();
+impl Ingest {
+    fn get_topics(&self) -> Vec<String> {
+        // This mirrors the current python and go code, which assumes a fixed set of topics
+        let mut topics = Vec::with_capacity(16);
+        for i in 0..16 {
+            let topic = format!(
+                "persistent://{}/{}/chroma_log_{}",
+                self.pulsar_tenant, self.pulsar_namespace, i
+            );
+            topics.push(topic);
+        }
+        return topics;
+    }
+}
 
-//         // Scope for assigner write lock to be released so we don't hold it over await
-//         {
-//             let mut assigner = match self.assignment_policy.write() {
-//                 Ok(assigner) => assigner,
-//                 Err(err) => {
-//                     println!("Failed to read assignment policy: {:?}", err);
-//                     return;
-//                 }
-//             };
+#[async_trait]
+impl Handler<Memberlist> for Ingest {
+    async fn handle(&mut self, msg: Memberlist, ctx: &ComponentContext<Self>) {
+        let mut new_assignments = HashSet::new();
+        let candidate_topics: Vec<String> = self.get_topics();
+        println!("Candidate topics: {:?}", candidate_topics);
+        // Scope for assigner write lock to be released so we don't hold it over await
+        {
+            let mut assigner = match self.assignment_policy.write() {
+                Ok(assigner) => assigner,
+                Err(err) => {
+                    println!("Failed to read assignment policy: {:?}", err);
+                    return;
+                }
+            };
 
-//             // Use the assignment policy to assign topics to this worker
-//             assigner.set_members(msg);
-//             for topic in candidate_topics.iter() {
-//                 let assignment = assigner.assign(topic);
-//                 let assignment = match assignment {
-//                     Ok(assignment) => assignment,
-//                     Err(err) => {
-//                         // TODO: Log error
-//                         continue;
-//                     }
-//                 };
-//                 if assignment == self.my_ip {
-//                     new_assignments.insert(topic);
-//                 }
-//             }
-//         }
+            // Use the assignment policy to assign topics to this worker
+            assigner.set_members(msg);
+            for topic in candidate_topics.iter() {
+                let assignment = assigner.assign(topic);
+                let assignment = match assignment {
+                    Ok(assignment) => assignment,
+                    Err(err) => {
+                        // TODO: Log error
+                        continue;
+                    }
+                };
+                if assignment == self.my_ip {
+                    new_assignments.insert(topic);
+                }
+            }
+        }
 
-//         // Compute the topics we need to add/remove
-//         let mut to_remove = Vec::new();
-//         let mut to_add = Vec::new();
+        // Compute the topics we need to add/remove
+        let mut to_remove = Vec::new();
+        let mut to_add = Vec::new();
 
-//         // Scope for assigned topics read lock to be released so we don't hold it over await
-//         {
-//             let assigned_topics_handle = self.assigned_topics.read();
-//             match assigned_topics_handle {
-//                 Ok(assigned_topics) => {
-//                     // Compute the diff between the current assignments and the new assignments
-//                     for topic in assigned_topics.iter() {
-//                         if !new_assignments.contains(topic) {
-//                             to_remove.push(topic.to_string());
-//                         }
-//                     }
-//                     for topic in new_assignments.iter() {
-//                         if !assigned_topics.contains(*topic) {
-//                             to_add.push(topic.to_string());
-//                         }
-//                     }
-//                 }
-//                 Err(err) => {
-//                     // TODO: Log error and handle lock poisoning
-//                 }
-//             }
-//         }
+        // Scope for assigned topics read lock to be released so we don't hold it over await
+        {
+            let assigned_topics_handle = self.assigned_topics.read();
+            match assigned_topics_handle {
+                Ok(assigned_topics) => {
+                    // Compute the diff between the current assignments and the new assignments
+                    for topic in assigned_topics.iter() {
+                        if !new_assignments.contains(topic) {
+                            to_remove.push(topic.to_string());
+                        }
+                    }
+                    for topic in new_assignments.iter() {
+                        if !assigned_topics.contains(*topic) {
+                            to_add.push(topic.to_string());
+                        }
+                    }
+                }
+                Err(err) => {
+                    // TODO: Log error and handle lock poisoning
+                }
+            }
+        }
 
-//         // Unsubscribe from topics we no longer need to listen to
-//         for topic in to_remove.iter() {
-//             match self.topic_to_handle.write() {
-//                 Ok(mut topic_to_handle) => {
-//                     let handle = topic_to_handle.remove(topic);
-//                     match handle {
-//                         Some(mut handle) => {
-//                             handle.stop();
-//                         }
-//                         None => {
-//                             // TODO: This should log an error
-//                             println!("No handle found for topic: {}", topic);
-//                         }
-//                     }
-//                 }
-//                 Err(err) => {
-//                     // TODO: Log an error and handle lock poisoning
-//                 }
-//             }
-//         }
+        // Unsubscribe from topics we no longer need to listen to
+        for topic in to_remove.iter() {
+            match self.topic_to_handle.write() {
+                Ok(mut topic_to_handle) => {
+                    let handle = topic_to_handle.remove(topic);
+                    match handle {
+                        Some(mut handle) => {
+                            handle.stop();
+                        }
+                        None => {
+                            // TODO: This should log an error
+                            println!("No handle found for topic: {}", topic);
+                        }
+                    }
+                }
+                Err(err) => {
+                    // TODO: Log an error and handle lock poisoning
+                }
+            }
+        }
 
-//         // Subscribe to new topics
-//         for topic in to_add.iter() {
-//             println!("Adding topic: {}", topic);
-//             // Do the subscription and register the stream to this ingest component
-//             let consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor> = self
-//                 .pulsar
-//                 .consumer()
-//                 .with_topic(topic.to_string())
-//                 .with_subscription_type(SubType::Exclusive)
-//                 .build()
-//                 .await
-//                 .unwrap();
+        // Subscribe to new topics
+        for topic in to_add.iter() {
+            println!("Adding topic: {}", topic);
+            // Do the subscription and register the stream to this ingest component
+            let consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor> = self
+                .pulsar
+                .consumer()
+                .with_topic(topic.to_string())
+                .with_subscription_type(SubType::Exclusive)
+                .build()
+                .await
+                .unwrap();
 
-//             let ingest_topic_component = PulsarIngestTopic::new(consumer, self.sysdb.clone());
+            let ingest_topic_component = PulsarIngestTopic::new(consumer, self.sysdb.clone());
 
-//             let (handle, _) = ctx.system.clone().start_component(ingest_topic_component);
+            let handle = ctx.system.clone().start_component(ingest_topic_component);
 
-//             // Bookkeep the handle so we can shut the stream down later
-//             match self.topic_to_handle.write() {
-//                 Ok(mut topic_to_handle) => {
-//                     topic_to_handle.insert(topic.to_string(), handle);
-//                 }
-//                 Err(err) => {
-//                     // TODO: log error and handle lock poisoning
-//                     println!("Failed to write topic to handle: {:?}", err);
-//                 }
-//             }
-//         }
-//     }
-// }
+            // Bookkeep the handle so we can shut the stream down later
+            match self.topic_to_handle.write() {
+                Ok(mut topic_to_handle) => {
+                    topic_to_handle.insert(topic.to_string(), handle);
+                }
+                Err(err) => {
+                    // TODO: log error and handle lock poisoning
+                    println!("Failed to write topic to handle: {:?}", err);
+                }
+            }
+        }
+    }
+}
 
-// impl DeserializeMessage for chroma_proto::SubmitEmbeddingRecord {
-//     type Output = Self;
+impl DeserializeMessage for chroma_proto::SubmitEmbeddingRecord {
+    type Output = Self;
 
-//     fn deserialize_message(payload: &Payload) -> chroma_proto::SubmitEmbeddingRecord {
-//         // Its a bit strange to unwrap here, but the pulsar api doesn't give us a way to
-//         // return an error, so we have to panic if we can't decode the message
-//         // also we are forced to clone since the api doesn't give us a way to borrow the bytes
-//         // TODO: can we not clone?
-//         // TODO: I think just typing this to Result<> would allow errors to propagate
-//         let record =
-//             chroma_proto::SubmitEmbeddingRecord::decode(Bytes::from(payload.data.clone())).unwrap();
-//         return record;
-//     }
-// }
+    fn deserialize_message(payload: &Payload) -> chroma_proto::SubmitEmbeddingRecord {
+        // Its a bit strange to unwrap here, but the pulsar api doesn't give us a way to
+        // return an error, so we have to panic if we can't decode the message
+        // also we are forced to clone since the api doesn't give us a way to borrow the bytes
+        // TODO: can we not clone?
+        // TODO: I think just typing this to Result<> would allow errors to propagate
+        let record =
+            chroma_proto::SubmitEmbeddingRecord::decode(Bytes::from(payload.data.clone())).unwrap();
+        return record;
+    }
+}
 
-// struct PulsarIngestTopic {
-//     consumer: RwLock<Option<Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>>>,
-//     sysdb: Arc<dyn SysDb>,
-// }
+struct PulsarIngestTopic {
+    consumer: RwLock<Option<Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>>>,
+    sysdb: Arc<dyn SysDb>,
+}
 
-// impl PulsarIngestTopic {
-//     fn new(
-//         consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>,
-//         sysdb: Arc<dyn SysDb>,
-//     ) -> Self {
-//         PulsarIngestTopic {
-//             consumer: RwLock::new(Some(consumer)),
-//             sysdb: sysdb,
-//         }
-//     }
-// }
+impl Debug for PulsarIngestTopic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PulsarIngestTopic").finish()
+    }
+}
 
-// impl Component for PulsarIngestTopic {
-//     fn queue_size(&self) -> usize {
-//         1000
-//     }
-// }
+impl PulsarIngestTopic {
+    fn new(
+        consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor>,
+        sysdb: Arc<dyn SysDb>,
+    ) -> Self {
+        PulsarIngestTopic {
+            consumer: RwLock::new(Some(consumer)),
+            sysdb: sysdb,
+        }
+    }
+}
 
-// #[async_trait]
-// impl Handler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
-//     async fn handle(
-//         &mut self,
-//         _message: Option<Arc<EmbeddingRecord>>,
-//         _ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, PulsarIngestTopic>,
-//     ) -> () {
-//         // No-op
-//     }
+impl Component for PulsarIngestTopic {
+    fn queue_size(&self) -> usize {
+        1000
+    }
 
-//     fn on_start(&self, ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, Self>) -> () {
-//         let stream = match self.consumer.write() {
-//             Ok(mut consumer_handle) => consumer_handle.take(),
-//             Err(err) => None,
-//         };
-//         let stream = match stream {
-//             Some(stream) => stream,
-//             None => {
-//                 return;
-//             }
-//         };
-//         let stream = stream.then(|result| async {
-//             match result {
-//                 Ok(msg) => {
-//                     // Convert the Pulsar Message to an EmbeddingRecord
-//                     let proto_embedding_record = msg.deserialize();
-//                     let id = msg.message_id;
-//                     let seq_id: SeqId = PulsarMessageIdWrapper(id).into();
-//                     let embedding_record: Result<EmbeddingRecord, EmbeddingRecordConversionError> =
-//                         (proto_embedding_record, seq_id).try_into();
-//                     match embedding_record {
-//                         Ok(embedding_record) => {
-//                             return Some(Arc::new(embedding_record));
-//                         }
-//                         Err(err) => {
-//                             // TODO: Handle and log
-//                         }
-//                     }
-//                     None
-//                 }
-//                 Err(err) => {
-//                     // TODO: Log an error
-//                     // Put this on a dead letter queue, this concept does not exist in our
-//                     // system yet
-//                     None
-//                 }
-//             }
-//         });
-//         self.register_stream(stream, ctx);
-//     }
-// }
+    fn on_start(&self, ctx: &ComponentContext<Self>) -> () {
+        let stream = match self.consumer.write() {
+            Ok(mut consumer_handle) => consumer_handle.take(),
+            Err(err) => None,
+        };
+        let stream = match stream {
+            Some(stream) => stream,
+            None => {
+                return;
+            }
+        };
+        let stream = stream.then(|result| async {
+            match result {
+                Ok(msg) => {
+                    // Convert the Pulsar Message to an EmbeddingRecord
+                    let proto_embedding_record = msg.deserialize();
+                    let id = msg.message_id;
+                    let seq_id: SeqId = PulsarMessageIdWrapper(id).into();
+                    let embedding_record: Result<EmbeddingRecord, EmbeddingRecordConversionError> =
+                        (proto_embedding_record, seq_id).try_into();
+                    match embedding_record {
+                        Ok(embedding_record) => {
+                            return Some(Arc::new(embedding_record));
+                        }
+                        Err(err) => {
+                            // TODO: Handle and log
+                        }
+                    }
+                    None
+                }
+                Err(err) => {
+                    // TODO: Log an error
+                    // Put this on a dead letter queue, this concept does not exist in our
+                    // system yet
+                    None
+                }
+            }
+        });
+        self.register_stream(stream, ctx);
+    }
+}
 
-// #[async_trait]
-// impl StreamHandler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
-//     async fn handle(
-//         &mut self,
-//         message: Option<Arc<EmbeddingRecord>>,
-//         _ctx: &ComponentContext<Option<Arc<EmbeddingRecord>>, PulsarIngestTopic>,
-//     ) -> () {
-//         // Use the sysdb to tenant id for the embedding record
-//         let embedding_record = match message {
-//             Some(embedding_record) => embedding_record,
-//             None => {
-//                 return;
-//             }
-//         };
-//         let coll = self
-//             .sysdb
-//             .get_collections(Some(embedding_record.collection_id), None, None, None, None)
-//             .await;
-//     }
-// }
+#[async_trait]
+impl Handler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {
+    async fn handle(
+        &mut self,
+        message: Option<Arc<EmbeddingRecord>>,
+        _ctx: &ComponentContext<PulsarIngestTopic>,
+    ) -> () {
+        // Use the sysdb to tenant id for the embedding record
+        let embedding_record = match message {
+            Some(embedding_record) => embedding_record,
+            None => {
+                return;
+            }
+        };
+        // let coll = self
+        //     .sysdb
+        //     .get_collections(Some(embedding_record.collection_id), None, None, None, None)
+        //     .await;
+    }
+}
+
+#[async_trait]
+impl StreamHandler<Option<Arc<EmbeddingRecord>>> for PulsarIngestTopic {}

--- a/rust/worker/src/ingest/message_id.rs
+++ b/rust/worker/src/ingest/message_id.rs
@@ -1,10 +1,22 @@
+use std::ops::Deref;
+
 // mirrors chromadb/utils/messageid.py
 use num_bigint::BigInt;
-use pulsar::proto::MessageIdData;
+use pulsar::{consumer::data::MessageData, proto::MessageIdData};
 
 use crate::types::SeqId;
 
-pub(crate) fn pulsar_to_int(message_id: &MessageIdData) -> SeqId {
+pub(crate) struct PulsarMessageIdWrapper(pub(crate) MessageData);
+
+impl Deref for PulsarMessageIdWrapper {
+    type Target = MessageIdData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.id
+    }
+}
+
+pub(crate) fn pulsar_to_int(message_id: PulsarMessageIdWrapper) -> SeqId {
     let ledger_id = message_id.ledger_id;
     let entry_id = message_id.entry_id;
     let batch_index = message_id.batch_index.unwrap_or(0);
@@ -24,4 +36,13 @@ pub(crate) fn pulsar_to_int(message_id: &MessageIdData) -> SeqId {
 
     let res = ledger_id << 128 | entry_id << 96 | batch_index << 64 | partition;
     res
+}
+
+// We can't use From because we don't own the type
+// So the pattern is to wrap it in a newtype and implement TryFrom for that
+// And implement Dereference for the newtype to the underlying type
+impl From<PulsarMessageIdWrapper> for SeqId {
+    fn from(message_id: PulsarMessageIdWrapper) -> Self {
+        return pulsar_to_int(message_id);
+    }
 }

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -9,42 +9,43 @@ mod system;
 mod types;
 
 use config::Configurable;
-// use memberlist::MemberlistProvider;
+use memberlist::MemberlistProvider;
 
 mod chroma_proto {
     tonic::include_proto!("chroma");
 }
 
-// pub async fn worker_entrypoint() {
-//     let config = config::RootConfig::load();
-//     // Create all the core components and start them
-//     // TODO: This should be handled by an Application struct and we can push the config into it
-//     // for now we expose the config to pub and inject it into the components
+pub async fn worker_entrypoint() {
+    let config = config::RootConfig::load();
+    // Create all the core components and start them
+    // TODO: This should be handled by an Application struct and we can push the config into it
+    // for now we expose the config to pub and inject it into the components
 
-//     // The two root components are ingest, and the gRPC server
+    // The two root components are ingest, and the gRPC server
 
-//     let ingest = match ingest::Ingest::try_from_config(&config.worker).await {
-//         Ok(ingest) => ingest,
-//         Err(err) => {
-//             println!("Failed to create ingest component: {:?}", err);
-//             return;
-//         }
-//     };
+    let ingest = match ingest::Ingest::try_from_config(&config.worker).await {
+        Ok(ingest) => ingest,
+        Err(err) => {
+            println!("Failed to create ingest component: {:?}", err);
+            return;
+        }
+    };
 
-//     let memberlist =
-//         match memberlist::CustomResourceMemberlistProvider::try_from_config(&config.worker).await {
-//             Ok(memberlist) => memberlist,
-//             Err(err) => {
-//                 println!("Failed to create memberlist component: {:?}", err);
-//                 return;
-//             }
-//         };
+    let mut memberlist =
+        match memberlist::CustomResourceMemberlistProvider::try_from_config(&config.worker).await {
+            Ok(memberlist) => memberlist,
+            Err(err) => {
+                println!("Failed to create memberlist component: {:?}", err);
+                return;
+            }
+        };
 
-//     // Boot the system
-//     let mut system = system::System::new();
-//     let (mut ingest_handle, ingest_sender) = system.start_component(ingest);
-//     memberlist.subscribe(ingest_sender);
-//     let (mut memberlist_handle, _) = system.start_component(memberlist);
-//     // Join on all handles
-//     let _ = tokio::join!(ingest_handle.join(), memberlist_handle.join());
-// }
+    // Boot the system
+    let mut system = system::System::new();
+    let mut ingest_handle = system.start_component(ingest);
+    let recv = ingest_handle.receiver();
+    memberlist.subscribe(recv);
+    let mut memberlist_handle = system.start_component(memberlist);
+    // Join on all handles
+    let _ = tokio::join!(ingest_handle.join(), memberlist_handle.join());
+}

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -9,42 +9,42 @@ mod system;
 mod types;
 
 use config::Configurable;
-use memberlist::MemberlistProvider;
+// use memberlist::MemberlistProvider;
 
 mod chroma_proto {
     tonic::include_proto!("chroma");
 }
 
-pub async fn worker_entrypoint() {
-    let config = config::RootConfig::load();
-    // Create all the core components and start them
-    // TODO: This should be handled by an Application struct and we can push the config into it
-    // for now we expose the config to pub and inject it into the components
+// pub async fn worker_entrypoint() {
+//     let config = config::RootConfig::load();
+//     // Create all the core components and start them
+//     // TODO: This should be handled by an Application struct and we can push the config into it
+//     // for now we expose the config to pub and inject it into the components
 
-    // The two root components are ingest, and the gRPC server
+//     // The two root components are ingest, and the gRPC server
 
-    let ingest = match ingest::Ingest::try_from_config(&config.worker).await {
-        Ok(ingest) => ingest,
-        Err(err) => {
-            println!("Failed to create ingest component: {:?}", err);
-            return;
-        }
-    };
+//     let ingest = match ingest::Ingest::try_from_config(&config.worker).await {
+//         Ok(ingest) => ingest,
+//         Err(err) => {
+//             println!("Failed to create ingest component: {:?}", err);
+//             return;
+//         }
+//     };
 
-    let memberlist =
-        match memberlist::CustomResourceMemberlistProvider::try_from_config(&config.worker).await {
-            Ok(memberlist) => memberlist,
-            Err(err) => {
-                println!("Failed to create memberlist component: {:?}", err);
-                return;
-            }
-        };
+//     let memberlist =
+//         match memberlist::CustomResourceMemberlistProvider::try_from_config(&config.worker).await {
+//             Ok(memberlist) => memberlist,
+//             Err(err) => {
+//                 println!("Failed to create memberlist component: {:?}", err);
+//                 return;
+//             }
+//         };
 
-    // Boot the system
-    let mut system = system::System::new();
-    let (mut ingest_handle, ingest_sender) = system.start_component(ingest);
-    memberlist.subscribe(ingest_sender);
-    let (mut memberlist_handle, _) = system.start_component(memberlist);
-    // Join on all handles
-    let _ = tokio::join!(ingest_handle.join(), memberlist_handle.join());
-}
+//     // Boot the system
+//     let mut system = system::System::new();
+//     let (mut ingest_handle, ingest_sender) = system.start_component(ingest);
+//     memberlist.subscribe(ingest_sender);
+//     let (mut memberlist_handle, _) = system.start_component(memberlist);
+//     // Join on all handles
+//     let _ = tokio::join!(ingest_handle.join(), memberlist_handle.join());
+// }

--- a/rust/worker/src/sysdb/config.rs
+++ b/rust/worker/src/sysdb/config.rs
@@ -1,0 +1,12 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(crate) struct GrpcSysDbConfig {
+    pub(crate) host: String,
+    pub(crate) port: u16,
+}
+
+#[derive(Deserialize)]
+pub(crate) enum SysDbConfig {
+    Grpc(GrpcSysDbConfig),
+}

--- a/rust/worker/src/sysdb/mod.rs
+++ b/rust/worker/src/sysdb/mod.rs
@@ -1,2 +1,2 @@
 pub(crate) mod config;
-mod sysdb;
+pub(crate) mod sysdb;

--- a/rust/worker/src/sysdb/mod.rs
+++ b/rust/worker/src/sysdb/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod config;
 mod sysdb;

--- a/rust/worker/src/sysdb/sysdb.rs
+++ b/rust/worker/src/sysdb/sysdb.rs
@@ -1,258 +1,258 @@
-// use async_trait::async_trait;
-// use uuid::Uuid;
+use async_trait::async_trait;
+use uuid::Uuid;
 
-// use crate::config::{Configurable, WorkerConfig};
-// use crate::types::{CollectionConversionError, SegmentConversionError};
-// use crate::{chroma_proto, worker_entrypoint};
-// use crate::{
-//     chroma_proto::sys_db_client,
-//     errors::{ChromaError, ErrorCodes},
-//     types::{Collection, Segment, SegmentScope},
-// };
-// use thiserror::Error;
+use crate::chroma_proto;
+use crate::config::{Configurable, WorkerConfig};
+use crate::types::{CollectionConversionError, SegmentConversionError};
+use crate::{
+    chroma_proto::sys_db_client,
+    errors::{ChromaError, ErrorCodes},
+    types::{Collection, Segment, SegmentScope},
+};
+use thiserror::Error;
 
-// use super::config::SysDbConfig;
+use super::config::SysDbConfig;
 
-// const DEFAULT_DATBASE: &str = "default_database";
-// const DEFAULT_TENANT: &str = "default_tenant";
+const DEFAULT_DATBASE: &str = "default_database";
+const DEFAULT_TENANT: &str = "default_tenant";
 
-// #[async_trait]
-// pub(crate) trait SysDb: Send + Sync + SysDbClone {
-//     async fn get_collections(
-//         &mut self,
-//         collection_id: Option<Uuid>,
-//         topic: Option<String>,
-//         name: Option<String>,
-//         tenant: Option<String>,
-//         database: Option<String>,
-//     ) -> Result<Vec<Collection>, GetCollectionsError>;
+#[async_trait]
+pub(crate) trait SysDb: Send + Sync + SysDbClone {
+    async fn get_collections(
+        &mut self,
+        collection_id: Option<Uuid>,
+        topic: Option<String>,
+        name: Option<String>,
+        tenant: Option<String>,
+        database: Option<String>,
+    ) -> Result<Vec<Collection>, GetCollectionsError>;
 
-//     async fn get_segments(
-//         &mut self,
-//         id: Option<Uuid>,
-//         r#type: Option<String>,
-//         scope: Option<SegmentScope>,
-//         topic: Option<String>,
-//         collection: Option<Uuid>,
-//     ) -> Result<Vec<Segment>, GetSegmentsError>;
-// }
+    async fn get_segments(
+        &mut self,
+        id: Option<Uuid>,
+        r#type: Option<String>,
+        scope: Option<SegmentScope>,
+        topic: Option<String>,
+        collection: Option<Uuid>,
+    ) -> Result<Vec<Segment>, GetSegmentsError>;
+}
 
-// // We'd like to be able to clone the trait object, so we need to use the
-// // "clone box" pattern. See https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object#comment48814207_30353928
-// // https://chat.openai.com/share/b3eae92f-0b80-446f-b79d-6287762a2420
-// pub(crate) trait SysDbClone {
-//     fn clone_box(&self) -> Box<dyn SysDb>;
-// }
+// We'd like to be able to clone the trait object, so we need to use the
+// "clone box" pattern. See https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object#comment48814207_30353928
+// https://chat.openai.com/share/b3eae92f-0b80-446f-b79d-6287762a2420
+pub(crate) trait SysDbClone {
+    fn clone_box(&self) -> Box<dyn SysDb>;
+}
 
-// impl<T> SysDbClone for T
-// where
-//     T: 'static + SysDb + Clone,
-// {
-//     fn clone_box(&self) -> Box<dyn SysDb> {
-//         Box::new(self.clone())
-//     }
-// }
+impl<T> SysDbClone for T
+where
+    T: 'static + SysDb + Clone,
+{
+    fn clone_box(&self) -> Box<dyn SysDb> {
+        Box::new(self.clone())
+    }
+}
 
-// impl Clone for Box<dyn SysDb> {
-//     fn clone(&self) -> Box<dyn SysDb> {
-//         self.clone_box()
-//     }
-// }
+impl Clone for Box<dyn SysDb> {
+    fn clone(&self) -> Box<dyn SysDb> {
+        self.clone_box()
+    }
+}
 
-// #[derive(Clone)]
-// // Since this uses tonic transport channel, cloning is cheap. Each client only supports
-// // one inflight request at a time, so we need to clone the client for each requester.
-// pub(crate) struct GrpcSysDb {
-//     client: sys_db_client::SysDbClient<tonic::transport::Channel>,
-// }
+#[derive(Clone)]
+// Since this uses tonic transport channel, cloning is cheap. Each client only supports
+// one inflight request at a time, so we need to clone the client for each requester.
+pub(crate) struct GrpcSysDb {
+    client: sys_db_client::SysDbClient<tonic::transport::Channel>,
+}
 
-// #[derive(Error, Debug)]
-// pub(crate) enum GrpcSysDbError {
-//     #[error("Failed to connect to sysdb")]
-//     FailedToConnect(#[from] tonic::transport::Error),
-// }
+#[derive(Error, Debug)]
+pub(crate) enum GrpcSysDbError {
+    #[error("Failed to connect to sysdb")]
+    FailedToConnect(#[from] tonic::transport::Error),
+}
 
-// impl ChromaError for GrpcSysDbError {
-//     fn code(&self) -> ErrorCodes {
-//         match self {
-//             GrpcSysDbError::FailedToConnect(_) => ErrorCodes::Internal,
-//         }
-//     }
-// }
+impl ChromaError for GrpcSysDbError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            GrpcSysDbError::FailedToConnect(_) => ErrorCodes::Internal,
+        }
+    }
+}
 
-// #[async_trait]
-// impl Configurable for GrpcSysDb {
-//     async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
-//         match &worker_config.sysdb {
-//             SysDbConfig::Grpc(my_config) => {
-//                 let host = &my_config.host;
-//                 let port = &my_config.port;
-//                 let connection_string = format!("http://{}:{}", host, port);
-//                 let client = sys_db_client::SysDbClient::connect(connection_string).await;
-//                 match client {
-//                     Ok(client) => {
-//                         return Ok(GrpcSysDb { client: client });
-//                     }
-//                     Err(e) => {
-//                         return Err(Box::new(GrpcSysDbError::FailedToConnect(e)));
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
+#[async_trait]
+impl Configurable for GrpcSysDb {
+    async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
+        match &worker_config.sysdb {
+            SysDbConfig::Grpc(my_config) => {
+                let host = &my_config.host;
+                let port = &my_config.port;
+                let connection_string = format!("http://{}:{}", host, port);
+                let client = sys_db_client::SysDbClient::connect(connection_string).await;
+                match client {
+                    Ok(client) => {
+                        return Ok(GrpcSysDb { client: client });
+                    }
+                    Err(e) => {
+                        return Err(Box::new(GrpcSysDbError::FailedToConnect(e)));
+                    }
+                }
+            }
+        }
+    }
+}
 
-// #[async_trait]
-// impl SysDb for GrpcSysDb {
-//     async fn get_collections(
-//         &mut self,
-//         collection_id: Option<Uuid>,
-//         topic: Option<String>,
-//         name: Option<String>,
-//         tenant: Option<String>,
-//         database: Option<String>,
-//     ) -> Result<Vec<Collection>, GetCollectionsError> {
-//         // TODO: move off of status into our own error type
-//         let collection_id_str;
-//         match collection_id {
-//             Some(id) => {
-//                 collection_id_str = Some(id.to_string());
-//             }
-//             None => {
-//                 collection_id_str = None;
-//             }
-//         }
+#[async_trait]
+impl SysDb for GrpcSysDb {
+    async fn get_collections(
+        &mut self,
+        collection_id: Option<Uuid>,
+        topic: Option<String>,
+        name: Option<String>,
+        tenant: Option<String>,
+        database: Option<String>,
+    ) -> Result<Vec<Collection>, GetCollectionsError> {
+        // TODO: move off of status into our own error type
+        let collection_id_str;
+        match collection_id {
+            Some(id) => {
+                collection_id_str = Some(id.to_string());
+            }
+            None => {
+                collection_id_str = None;
+            }
+        }
 
-//         let res = self
-//             .client
-//             .get_collections(chroma_proto::GetCollectionsRequest {
-//                 id: collection_id_str,
-//                 topic: topic,
-//                 name: name,
-//                 tenant: if tenant.is_some() {
-//                     tenant.unwrap()
-//                 } else {
-//                     DEFAULT_TENANT.to_string()
-//                 },
-//                 database: if database.is_some() {
-//                     database.unwrap()
-//                 } else {
-//                     DEFAULT_DATBASE.to_string()
-//                 },
-//             })
-//             .await;
+        let res = self
+            .client
+            .get_collections(chroma_proto::GetCollectionsRequest {
+                id: collection_id_str,
+                topic: topic,
+                name: name,
+                tenant: if tenant.is_some() {
+                    tenant.unwrap()
+                } else {
+                    DEFAULT_TENANT.to_string()
+                },
+                database: if database.is_some() {
+                    database.unwrap()
+                } else {
+                    DEFAULT_DATBASE.to_string()
+                },
+            })
+            .await;
 
-//         match res {
-//             Ok(res) => {
-//                 let collections = res.into_inner().collections;
+        match res {
+            Ok(res) => {
+                let collections = res.into_inner().collections;
 
-//                 let collections = collections
-//                     .into_iter()
-//                     .map(|proto_collection| proto_collection.try_into())
-//                     .collect::<Result<Vec<Collection>, CollectionConversionError>>();
+                let collections = collections
+                    .into_iter()
+                    .map(|proto_collection| proto_collection.try_into())
+                    .collect::<Result<Vec<Collection>, CollectionConversionError>>();
 
-//                 match collections {
-//                     Ok(collections) => {
-//                         return Ok(collections);
-//                     }
-//                     Err(e) => {
-//                         return Err(GetCollectionsError::ConversionError(e));
-//                     }
-//                 }
-//             }
-//             Err(e) => {
-//                 return Err(GetCollectionsError::FailedToGetCollections(e));
-//             }
-//         }
-//     }
+                match collections {
+                    Ok(collections) => {
+                        return Ok(collections);
+                    }
+                    Err(e) => {
+                        return Err(GetCollectionsError::ConversionError(e));
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(GetCollectionsError::FailedToGetCollections(e));
+            }
+        }
+    }
 
-//     async fn get_segments(
-//         &mut self,
-//         id: Option<Uuid>,
-//         r#type: Option<String>,
-//         scope: Option<SegmentScope>,
-//         topic: Option<String>,
-//         collection: Option<Uuid>,
-//     ) -> Result<Vec<Segment>, GetSegmentsError> {
-//         let res = self
-//             .client
-//             .get_segments(chroma_proto::GetSegmentsRequest {
-//                 // TODO: modularize
-//                 id: if id.is_some() {
-//                     Some(id.unwrap().to_string())
-//                 } else {
-//                     None
-//                 },
-//                 r#type: r#type,
-//                 scope: if scope.is_some() {
-//                     Some(scope.unwrap() as i32)
-//                 } else {
-//                     None
-//                 },
-//                 topic: topic,
-//                 collection: if collection.is_some() {
-//                     Some(collection.unwrap().to_string())
-//                 } else {
-//                     None
-//                 },
-//             })
-//             .await;
-//         match res {
-//             Ok(res) => {
-//                 let segments = res.into_inner().segments;
-//                 let converted_segments = segments
-//                     .into_iter()
-//                     .map(|proto_segment| proto_segment.try_into())
-//                     .collect::<Result<Vec<Segment>, SegmentConversionError>>();
+    async fn get_segments(
+        &mut self,
+        id: Option<Uuid>,
+        r#type: Option<String>,
+        scope: Option<SegmentScope>,
+        topic: Option<String>,
+        collection: Option<Uuid>,
+    ) -> Result<Vec<Segment>, GetSegmentsError> {
+        let res = self
+            .client
+            .get_segments(chroma_proto::GetSegmentsRequest {
+                // TODO: modularize
+                id: if id.is_some() {
+                    Some(id.unwrap().to_string())
+                } else {
+                    None
+                },
+                r#type: r#type,
+                scope: if scope.is_some() {
+                    Some(scope.unwrap() as i32)
+                } else {
+                    None
+                },
+                topic: topic,
+                collection: if collection.is_some() {
+                    Some(collection.unwrap().to_string())
+                } else {
+                    None
+                },
+            })
+            .await;
+        match res {
+            Ok(res) => {
+                let segments = res.into_inner().segments;
+                let converted_segments = segments
+                    .into_iter()
+                    .map(|proto_segment| proto_segment.try_into())
+                    .collect::<Result<Vec<Segment>, SegmentConversionError>>();
 
-//                 match converted_segments {
-//                     Ok(segments) => {
-//                         return Ok(segments);
-//                     }
-//                     Err(e) => {
-//                         return Err(GetSegmentsError::ConversionError(e));
-//                     }
-//                 }
-//             }
-//             Err(e) => {
-//                 return Err(GetSegmentsError::FailedToGetSegments(e));
-//             }
-//         }
-//     }
-// }
+                match converted_segments {
+                    Ok(segments) => {
+                        return Ok(segments);
+                    }
+                    Err(e) => {
+                        return Err(GetSegmentsError::ConversionError(e));
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(GetSegmentsError::FailedToGetSegments(e));
+            }
+        }
+    }
+}
 
-// #[derive(Error, Debug)]
-// // TODO: This should use our sysdb errors from the proto definition
-// // We will have to do an error uniformization pass at some point
-// pub(crate) enum GetCollectionsError {
-//     #[error("Failed to fetch")]
-//     FailedToGetCollections(#[from] tonic::Status),
-//     #[error("Failed to convert proto collection")]
-//     ConversionError(#[from] CollectionConversionError),
-// }
+#[derive(Error, Debug)]
+// TODO: This should use our sysdb errors from the proto definition
+// We will have to do an error uniformization pass at some point
+pub(crate) enum GetCollectionsError {
+    #[error("Failed to fetch")]
+    FailedToGetCollections(#[from] tonic::Status),
+    #[error("Failed to convert proto collection")]
+    ConversionError(#[from] CollectionConversionError),
+}
 
-// impl ChromaError for GetCollectionsError {
-//     fn code(&self) -> ErrorCodes {
-//         match self {
-//             GetCollectionsError::FailedToGetCollections(_) => ErrorCodes::Internal,
-//             GetCollectionsError::ConversionError(_) => ErrorCodes::Internal,
-//         }
-//     }
-// }
+impl ChromaError for GetCollectionsError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            GetCollectionsError::FailedToGetCollections(_) => ErrorCodes::Internal,
+            GetCollectionsError::ConversionError(_) => ErrorCodes::Internal,
+        }
+    }
+}
 
-// #[derive(Error, Debug)]
-// pub(crate) enum GetSegmentsError {
-//     #[error("Failed to fetch")]
-//     FailedToGetSegments(#[from] tonic::Status),
-//     #[error("Failed to convert proto segment")]
-//     ConversionError(#[from] SegmentConversionError),
-// }
+#[derive(Error, Debug)]
+pub(crate) enum GetSegmentsError {
+    #[error("Failed to fetch")]
+    FailedToGetSegments(#[from] tonic::Status),
+    #[error("Failed to convert proto segment")]
+    ConversionError(#[from] SegmentConversionError),
+}
 
-// impl ChromaError for GetSegmentsError {
-//     fn code(&self) -> ErrorCodes {
-//         match self {
-//             GetSegmentsError::FailedToGetSegments(_) => ErrorCodes::Internal,
-//             GetSegmentsError::ConversionError(_) => ErrorCodes::Internal,
-//         }
-//     }
-// }
+impl ChromaError for GetSegmentsError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            GetSegmentsError::FailedToGetSegments(_) => ErrorCodes::Internal,
+            GetSegmentsError::ConversionError(_) => ErrorCodes::Internal,
+        }
+    }
+}

--- a/rust/worker/src/sysdb/sysdb.rs
+++ b/rust/worker/src/sysdb/sysdb.rs
@@ -1,258 +1,258 @@
-use async_trait::async_trait;
-use uuid::Uuid;
+// use async_trait::async_trait;
+// use uuid::Uuid;
 
-use crate::config::{Configurable, WorkerConfig};
-use crate::types::{CollectionConversionError, SegmentConversionError};
-use crate::{chroma_proto, worker_entrypoint};
-use crate::{
-    chroma_proto::sys_db_client,
-    errors::{ChromaError, ErrorCodes},
-    types::{Collection, Segment, SegmentScope},
-};
-use thiserror::Error;
+// use crate::config::{Configurable, WorkerConfig};
+// use crate::types::{CollectionConversionError, SegmentConversionError};
+// use crate::{chroma_proto, worker_entrypoint};
+// use crate::{
+//     chroma_proto::sys_db_client,
+//     errors::{ChromaError, ErrorCodes},
+//     types::{Collection, Segment, SegmentScope},
+// };
+// use thiserror::Error;
 
-use super::config::SysDbConfig;
+// use super::config::SysDbConfig;
 
-const DEFAULT_DATBASE: &str = "default_database";
-const DEFAULT_TENANT: &str = "default_tenant";
+// const DEFAULT_DATBASE: &str = "default_database";
+// const DEFAULT_TENANT: &str = "default_tenant";
 
-#[async_trait]
-pub(crate) trait SysDb: Send + Sync + SysDbClone {
-    async fn get_collections(
-        &mut self,
-        collection_id: Option<Uuid>,
-        topic: Option<String>,
-        name: Option<String>,
-        tenant: Option<String>,
-        database: Option<String>,
-    ) -> Result<Vec<Collection>, GetCollectionsError>;
+// #[async_trait]
+// pub(crate) trait SysDb: Send + Sync + SysDbClone {
+//     async fn get_collections(
+//         &mut self,
+//         collection_id: Option<Uuid>,
+//         topic: Option<String>,
+//         name: Option<String>,
+//         tenant: Option<String>,
+//         database: Option<String>,
+//     ) -> Result<Vec<Collection>, GetCollectionsError>;
 
-    async fn get_segments(
-        &mut self,
-        id: Option<Uuid>,
-        r#type: Option<String>,
-        scope: Option<SegmentScope>,
-        topic: Option<String>,
-        collection: Option<Uuid>,
-    ) -> Result<Vec<Segment>, GetSegmentsError>;
-}
+//     async fn get_segments(
+//         &mut self,
+//         id: Option<Uuid>,
+//         r#type: Option<String>,
+//         scope: Option<SegmentScope>,
+//         topic: Option<String>,
+//         collection: Option<Uuid>,
+//     ) -> Result<Vec<Segment>, GetSegmentsError>;
+// }
 
-// We'd like to be able to clone the trait object, so we need to use the
-// "clone box" pattern. See https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object#comment48814207_30353928
-// https://chat.openai.com/share/b3eae92f-0b80-446f-b79d-6287762a2420
-pub(crate) trait SysDbClone {
-    fn clone_box(&self) -> Box<dyn SysDb>;
-}
+// // We'd like to be able to clone the trait object, so we need to use the
+// // "clone box" pattern. See https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object#comment48814207_30353928
+// // https://chat.openai.com/share/b3eae92f-0b80-446f-b79d-6287762a2420
+// pub(crate) trait SysDbClone {
+//     fn clone_box(&self) -> Box<dyn SysDb>;
+// }
 
-impl<T> SysDbClone for T
-where
-    T: 'static + SysDb + Clone,
-{
-    fn clone_box(&self) -> Box<dyn SysDb> {
-        Box::new(self.clone())
-    }
-}
+// impl<T> SysDbClone for T
+// where
+//     T: 'static + SysDb + Clone,
+// {
+//     fn clone_box(&self) -> Box<dyn SysDb> {
+//         Box::new(self.clone())
+//     }
+// }
 
-impl Clone for Box<dyn SysDb> {
-    fn clone(&self) -> Box<dyn SysDb> {
-        self.clone_box()
-    }
-}
+// impl Clone for Box<dyn SysDb> {
+//     fn clone(&self) -> Box<dyn SysDb> {
+//         self.clone_box()
+//     }
+// }
 
-#[derive(Clone)]
-// Since this uses tonic transport channel, cloning is cheap. Each client only supports
-// one inflight request at a time, so we need to clone the client for each requester.
-pub(crate) struct GrpcSysDb {
-    client: sys_db_client::SysDbClient<tonic::transport::Channel>,
-}
+// #[derive(Clone)]
+// // Since this uses tonic transport channel, cloning is cheap. Each client only supports
+// // one inflight request at a time, so we need to clone the client for each requester.
+// pub(crate) struct GrpcSysDb {
+//     client: sys_db_client::SysDbClient<tonic::transport::Channel>,
+// }
 
-#[derive(Error, Debug)]
-pub(crate) enum GrpcSysDbError {
-    #[error("Failed to connect to sysdb")]
-    FailedToConnect(#[from] tonic::transport::Error),
-}
+// #[derive(Error, Debug)]
+// pub(crate) enum GrpcSysDbError {
+//     #[error("Failed to connect to sysdb")]
+//     FailedToConnect(#[from] tonic::transport::Error),
+// }
 
-impl ChromaError for GrpcSysDbError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            GrpcSysDbError::FailedToConnect(_) => ErrorCodes::Internal,
-        }
-    }
-}
+// impl ChromaError for GrpcSysDbError {
+//     fn code(&self) -> ErrorCodes {
+//         match self {
+//             GrpcSysDbError::FailedToConnect(_) => ErrorCodes::Internal,
+//         }
+//     }
+// }
 
-#[async_trait]
-impl Configurable for GrpcSysDb {
-    async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
-        match &worker_config.sysdb {
-            SysDbConfig::Grpc(my_config) => {
-                let host = &my_config.host;
-                let port = &my_config.port;
-                let connection_string = format!("http://{}:{}", host, port);
-                let client = sys_db_client::SysDbClient::connect(connection_string).await;
-                match client {
-                    Ok(client) => {
-                        return Ok(GrpcSysDb { client: client });
-                    }
-                    Err(e) => {
-                        return Err(Box::new(GrpcSysDbError::FailedToConnect(e)));
-                    }
-                }
-            }
-        }
-    }
-}
+// #[async_trait]
+// impl Configurable for GrpcSysDb {
+//     async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
+//         match &worker_config.sysdb {
+//             SysDbConfig::Grpc(my_config) => {
+//                 let host = &my_config.host;
+//                 let port = &my_config.port;
+//                 let connection_string = format!("http://{}:{}", host, port);
+//                 let client = sys_db_client::SysDbClient::connect(connection_string).await;
+//                 match client {
+//                     Ok(client) => {
+//                         return Ok(GrpcSysDb { client: client });
+//                     }
+//                     Err(e) => {
+//                         return Err(Box::new(GrpcSysDbError::FailedToConnect(e)));
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
 
-#[async_trait]
-impl SysDb for GrpcSysDb {
-    async fn get_collections(
-        &mut self,
-        collection_id: Option<Uuid>,
-        topic: Option<String>,
-        name: Option<String>,
-        tenant: Option<String>,
-        database: Option<String>,
-    ) -> Result<Vec<Collection>, GetCollectionsError> {
-        // TODO: move off of status into our own error type
-        let collection_id_str;
-        match collection_id {
-            Some(id) => {
-                collection_id_str = Some(id.to_string());
-            }
-            None => {
-                collection_id_str = None;
-            }
-        }
+// #[async_trait]
+// impl SysDb for GrpcSysDb {
+//     async fn get_collections(
+//         &mut self,
+//         collection_id: Option<Uuid>,
+//         topic: Option<String>,
+//         name: Option<String>,
+//         tenant: Option<String>,
+//         database: Option<String>,
+//     ) -> Result<Vec<Collection>, GetCollectionsError> {
+//         // TODO: move off of status into our own error type
+//         let collection_id_str;
+//         match collection_id {
+//             Some(id) => {
+//                 collection_id_str = Some(id.to_string());
+//             }
+//             None => {
+//                 collection_id_str = None;
+//             }
+//         }
 
-        let res = self
-            .client
-            .get_collections(chroma_proto::GetCollectionsRequest {
-                id: collection_id_str,
-                topic: topic,
-                name: name,
-                tenant: if tenant.is_some() {
-                    tenant.unwrap()
-                } else {
-                    DEFAULT_TENANT.to_string()
-                },
-                database: if database.is_some() {
-                    database.unwrap()
-                } else {
-                    DEFAULT_DATBASE.to_string()
-                },
-            })
-            .await;
+//         let res = self
+//             .client
+//             .get_collections(chroma_proto::GetCollectionsRequest {
+//                 id: collection_id_str,
+//                 topic: topic,
+//                 name: name,
+//                 tenant: if tenant.is_some() {
+//                     tenant.unwrap()
+//                 } else {
+//                     DEFAULT_TENANT.to_string()
+//                 },
+//                 database: if database.is_some() {
+//                     database.unwrap()
+//                 } else {
+//                     DEFAULT_DATBASE.to_string()
+//                 },
+//             })
+//             .await;
 
-        match res {
-            Ok(res) => {
-                let collections = res.into_inner().collections;
+//         match res {
+//             Ok(res) => {
+//                 let collections = res.into_inner().collections;
 
-                let collections = collections
-                    .into_iter()
-                    .map(|proto_collection| proto_collection.try_into())
-                    .collect::<Result<Vec<Collection>, CollectionConversionError>>();
+//                 let collections = collections
+//                     .into_iter()
+//                     .map(|proto_collection| proto_collection.try_into())
+//                     .collect::<Result<Vec<Collection>, CollectionConversionError>>();
 
-                match collections {
-                    Ok(collections) => {
-                        return Ok(collections);
-                    }
-                    Err(e) => {
-                        return Err(GetCollectionsError::ConversionError(e));
-                    }
-                }
-            }
-            Err(e) => {
-                return Err(GetCollectionsError::FailedToGetCollections(e));
-            }
-        }
-    }
+//                 match collections {
+//                     Ok(collections) => {
+//                         return Ok(collections);
+//                     }
+//                     Err(e) => {
+//                         return Err(GetCollectionsError::ConversionError(e));
+//                     }
+//                 }
+//             }
+//             Err(e) => {
+//                 return Err(GetCollectionsError::FailedToGetCollections(e));
+//             }
+//         }
+//     }
 
-    async fn get_segments(
-        &mut self,
-        id: Option<Uuid>,
-        r#type: Option<String>,
-        scope: Option<SegmentScope>,
-        topic: Option<String>,
-        collection: Option<Uuid>,
-    ) -> Result<Vec<Segment>, GetSegmentsError> {
-        let res = self
-            .client
-            .get_segments(chroma_proto::GetSegmentsRequest {
-                // TODO: modularize
-                id: if id.is_some() {
-                    Some(id.unwrap().to_string())
-                } else {
-                    None
-                },
-                r#type: r#type,
-                scope: if scope.is_some() {
-                    Some(scope.unwrap() as i32)
-                } else {
-                    None
-                },
-                topic: topic,
-                collection: if collection.is_some() {
-                    Some(collection.unwrap().to_string())
-                } else {
-                    None
-                },
-            })
-            .await;
-        match res {
-            Ok(res) => {
-                let segments = res.into_inner().segments;
-                let converted_segments = segments
-                    .into_iter()
-                    .map(|proto_segment| proto_segment.try_into())
-                    .collect::<Result<Vec<Segment>, SegmentConversionError>>();
+//     async fn get_segments(
+//         &mut self,
+//         id: Option<Uuid>,
+//         r#type: Option<String>,
+//         scope: Option<SegmentScope>,
+//         topic: Option<String>,
+//         collection: Option<Uuid>,
+//     ) -> Result<Vec<Segment>, GetSegmentsError> {
+//         let res = self
+//             .client
+//             .get_segments(chroma_proto::GetSegmentsRequest {
+//                 // TODO: modularize
+//                 id: if id.is_some() {
+//                     Some(id.unwrap().to_string())
+//                 } else {
+//                     None
+//                 },
+//                 r#type: r#type,
+//                 scope: if scope.is_some() {
+//                     Some(scope.unwrap() as i32)
+//                 } else {
+//                     None
+//                 },
+//                 topic: topic,
+//                 collection: if collection.is_some() {
+//                     Some(collection.unwrap().to_string())
+//                 } else {
+//                     None
+//                 },
+//             })
+//             .await;
+//         match res {
+//             Ok(res) => {
+//                 let segments = res.into_inner().segments;
+//                 let converted_segments = segments
+//                     .into_iter()
+//                     .map(|proto_segment| proto_segment.try_into())
+//                     .collect::<Result<Vec<Segment>, SegmentConversionError>>();
 
-                match converted_segments {
-                    Ok(segments) => {
-                        return Ok(segments);
-                    }
-                    Err(e) => {
-                        return Err(GetSegmentsError::ConversionError(e));
-                    }
-                }
-            }
-            Err(e) => {
-                return Err(GetSegmentsError::FailedToGetSegments(e));
-            }
-        }
-    }
-}
+//                 match converted_segments {
+//                     Ok(segments) => {
+//                         return Ok(segments);
+//                     }
+//                     Err(e) => {
+//                         return Err(GetSegmentsError::ConversionError(e));
+//                     }
+//                 }
+//             }
+//             Err(e) => {
+//                 return Err(GetSegmentsError::FailedToGetSegments(e));
+//             }
+//         }
+//     }
+// }
 
-#[derive(Error, Debug)]
-// TODO: This should use our sysdb errors from the proto definition
-// We will have to do an error uniformization pass at some point
-pub(crate) enum GetCollectionsError {
-    #[error("Failed to fetch")]
-    FailedToGetCollections(#[from] tonic::Status),
-    #[error("Failed to convert proto collection")]
-    ConversionError(#[from] CollectionConversionError),
-}
+// #[derive(Error, Debug)]
+// // TODO: This should use our sysdb errors from the proto definition
+// // We will have to do an error uniformization pass at some point
+// pub(crate) enum GetCollectionsError {
+//     #[error("Failed to fetch")]
+//     FailedToGetCollections(#[from] tonic::Status),
+//     #[error("Failed to convert proto collection")]
+//     ConversionError(#[from] CollectionConversionError),
+// }
 
-impl ChromaError for GetCollectionsError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            GetCollectionsError::FailedToGetCollections(_) => ErrorCodes::Internal,
-            GetCollectionsError::ConversionError(_) => ErrorCodes::Internal,
-        }
-    }
-}
+// impl ChromaError for GetCollectionsError {
+//     fn code(&self) -> ErrorCodes {
+//         match self {
+//             GetCollectionsError::FailedToGetCollections(_) => ErrorCodes::Internal,
+//             GetCollectionsError::ConversionError(_) => ErrorCodes::Internal,
+//         }
+//     }
+// }
 
-#[derive(Error, Debug)]
-pub(crate) enum GetSegmentsError {
-    #[error("Failed to fetch")]
-    FailedToGetSegments(#[from] tonic::Status),
-    #[error("Failed to convert proto segment")]
-    ConversionError(#[from] SegmentConversionError),
-}
+// #[derive(Error, Debug)]
+// pub(crate) enum GetSegmentsError {
+//     #[error("Failed to fetch")]
+//     FailedToGetSegments(#[from] tonic::Status),
+//     #[error("Failed to convert proto segment")]
+//     ConversionError(#[from] SegmentConversionError),
+// }
 
-impl ChromaError for GetSegmentsError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            GetSegmentsError::FailedToGetSegments(_) => ErrorCodes::Internal,
-            GetSegmentsError::ConversionError(_) => ErrorCodes::Internal,
-        }
-    }
-}
+// impl ChromaError for GetSegmentsError {
+//     fn code(&self) -> ErrorCodes {
+//         match self {
+//             GetSegmentsError::FailedToGetSegments(_) => ErrorCodes::Internal,
+//             GetSegmentsError::ConversionError(_) => ErrorCodes::Internal,
+//         }
+//     }
+// }

--- a/rust/worker/src/system/executor.rs
+++ b/rust/worker/src/system/executor.rs
@@ -65,7 +65,6 @@ where
                                         system: self.inner.system.clone(),
                                         sender: self.inner.sender.clone(),
                                         cancellation_token: self.inner.cancellation_token.clone(),
-                                        // executor: self,
                                     }
                                 ).await;
                             }

--- a/rust/worker/src/system/mod.rs
+++ b/rust/worker/src/system/mod.rs
@@ -1,4 +1,5 @@
 mod executor;
+mod sender;
 mod system;
 mod types;
 

--- a/rust/worker/src/system/mod.rs
+++ b/rust/worker/src/system/mod.rs
@@ -4,5 +4,6 @@ mod system;
 mod types;
 
 // Re-export types
+pub(crate) use sender::*;
 pub(crate) use system::*;
 pub(crate) use types::*;

--- a/rust/worker/src/system/sender.rs
+++ b/rust/worker/src/system/sender.rs
@@ -122,8 +122,6 @@ where
 {
     async fn send(&self, message: M) -> Result<(), ChannelError> {
         let res = self.sender.send(wrap(message)).await;
-        println!("Sending message form receiver wrapper");
-        println!("Result: {:?}", res);
         match res {
             Ok(_) => Ok(()),
             Err(_) => Err(ChannelError::SendError),

--- a/rust/worker/src/system/sender.rs
+++ b/rust/worker/src/system/sender.rs
@@ -1,0 +1,87 @@
+use std::fmt::Debug;
+
+use super::{Component, ComponentContext, Handler};
+use async_trait::async_trait;
+
+#[derive(Debug)]
+pub(super) struct Wrapper<C>
+where
+    C: Component,
+{
+    wrapper: Box<dyn WrapperTrait<C>>,
+}
+
+impl<C: Component> Wrapper<C> {
+    pub(super) async fn handle(&mut self, component: &mut C, ctx: &ComponentContext<C>) -> () {
+        self.wrapper.handle(component, ctx).await;
+    }
+}
+
+#[async_trait]
+pub(super) trait WrapperTrait<C>: Debug + Send
+where
+    C: Component,
+{
+    async fn handle(&mut self, component: &mut C, ctx: &ComponentContext<C>) -> ();
+}
+
+#[async_trait]
+impl<C, M> WrapperTrait<C> for Option<M>
+where
+    C: Component + Handler<M>,
+    M: Debug + Send + 'static,
+{
+    async fn handle(&mut self, component: &mut C, ctx: &ComponentContext<C>) -> () {
+        if let Some(message) = self.take() {
+            component.handle(message, ctx).await;
+        }
+    }
+}
+
+pub(crate) fn wrap<C, M>(message: M) -> Wrapper<C>
+where
+    C: Component + Handler<M>,
+    M: Debug + Send + 'static,
+{
+    Wrapper {
+        wrapper: Box::new(Some(message)),
+    }
+}
+
+pub(crate) struct Sender<C>
+where
+    C: Component + Send + 'static,
+{
+    pub(super) sender: tokio::sync::mpsc::Sender<Wrapper<C>>,
+}
+
+impl<C> Sender<C>
+where
+    C: Component + Send + 'static,
+{
+    pub(super) fn new(sender: tokio::sync::mpsc::Sender<Wrapper<C>>) -> Self {
+        Sender { sender }
+    }
+
+    pub(super) async fn send<M>(
+        &self,
+        message: M,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<Wrapper<C>>>
+    where
+        C: Component + Handler<M>,
+        M: Debug + Send + 'static,
+    {
+        return self.sender.send(wrap(message)).await;
+    }
+}
+
+impl<C> Clone for Sender<C>
+where
+    C: Component,
+{
+    fn clone(&self) -> Self {
+        Sender {
+            sender: self.sender.clone(),
+        }
+    }
+}

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -1,11 +1,14 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use futures::Stream;
+use futures::StreamExt;
+use tokio::{pin, select};
 
-use super::executor::StreamComponentExecutor;
+// use super::executor::StreamComponentExecutor;
+use super::sender::{self, Sender, Wrapper};
 use super::{executor, ComponentContext};
 use super::{executor::ComponentExecutor, Component, ComponentHandle, Handler, StreamHandler};
-use std::ptr;
 use std::sync::Mutex;
 
 #[derive(Clone)]
@@ -14,69 +17,86 @@ pub(crate) struct System {
 }
 
 struct Inner {
-    components: Vec<Arc<dyn Component + Send + Sync>>,
+    // components: Vec<Arc<dyn Component + Send + Sync>>,
 }
 
 impl System {
     pub(crate) fn new() -> System {
         System {
             inner: Arc::new(Mutex::new(Inner {
-                components: Vec::new(),
+                // components: Vec::new(),
             })),
         }
     }
 
-    pub(crate) fn start_component<C, M>(
-        &mut self,
-        component: C,
-    ) -> (ComponentHandle, tokio::sync::broadcast::Sender<M>)
+    pub(crate) fn start_component<C>(&mut self, component: C) -> (ComponentHandle, Sender<C>)
     where
-        C: Handler<M> + Component + Send + Sync + 'static,
-        M: Clone + Send + Sync + 'static,
+        C: Component + Send + Sync + 'static,
     {
-        let component = Arc::new(component);
-        // Note: We lock inner since we only have minimal fields but
-        // we can move to a more fine-grained locking scheme if needed.
-        // System is not used in the critical path so this should be fine.
-        match self.inner.lock() {
-            Ok(mut inner) => {
-                inner.components.push(component.clone());
-            }
-            Err(_) => {
-                panic!("Failed to lock system");
-            }
-        }
-        let (tx, rx) = tokio::sync::broadcast::channel(component.queue_size());
+        let (tx, rx) = tokio::sync::mpsc::channel(component.queue_size());
+        let sender = Sender::new(tx);
         let cancel_token = tokio_util::sync::CancellationToken::new();
         let _ = component.on_start(&ComponentContext {
             system: self.clone(),
-            sender: tx.clone(),
+            sender: sender.clone(),
             cancellation_token: cancel_token.clone(),
-            system_component: component.clone(),
         });
         let mut executor = ComponentExecutor::new(
-            tx.clone(),
+            sender.clone(),
             cancel_token.clone(),
-            component.clone(),
             component,
             self.clone(),
         );
         let join_handle = tokio::spawn(async move { executor.run(rx).await });
-        return (ComponentHandle::new(cancel_token, join_handle), tx);
+        return (ComponentHandle::new(cancel_token, join_handle), sender);
     }
 
-    pub(super) fn register_stream<C, M, S>(&self, stream: S, ctx: &ComponentContext<M, C>)
+    pub(super) fn register_stream<C, S, M>(&self, stream: S, ctx: &ComponentContext<C>)
     where
-        C: StreamHandler<M> + Component + Send + Sync + 'static,
-        M: Send + Sync + 'static,
+        C: StreamHandler<M> + Handler<M>,
+        M: Send + Debug + 'static,
         S: Stream + Send + Stream<Item = M> + 'static,
     {
-        let mut executor = StreamComponentExecutor::new(
-            ctx.sender.clone(),
-            ctx.cancellation_token.clone(),
-            ctx.system_component.clone(),
-            ctx.system.clone(),
-        );
-        tokio::spawn(async move { executor.run_from_stream(stream).await });
+        let ctx = ComponentContext {
+            system: self.clone(),
+            sender: ctx.sender.clone(),
+            cancellation_token: ctx.cancellation_token.clone(),
+        };
+        tokio::spawn(async move { stream_loop(stream, &ctx).await });
+    }
+}
+
+async fn stream_loop<C, S, M>(stream: S, ctx: &ComponentContext<C>)
+where
+    C: StreamHandler<M> + Handler<M>,
+    M: Send + Debug + 'static,
+    S: Stream + Send + Stream<Item = M> + 'static,
+{
+    pin!(stream);
+    loop {
+        select! {
+            _ = ctx.cancellation_token.cancelled() => {
+                break;
+            }
+            message = stream.next() => {
+                match message {
+                    Some(message) => {
+                        let res = ctx.sender.send(message).await;
+                        match res {
+                            Ok(_) => {}
+                            Err(e) => {
+                                println!("Failed to send message: {:?}", e);
+                                // TODO: switch to logging
+                                // Terminate the stream
+                                break;
+                            }
+                        }
+                    },
+                    None => {
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -16,22 +16,18 @@ pub(crate) struct System {
     inner: Arc<Mutex<Inner>>,
 }
 
-struct Inner {
-    // components: Vec<Arc<dyn Component + Send + Sync>>,
-}
+struct Inner {}
 
 impl System {
     pub(crate) fn new() -> System {
         System {
-            inner: Arc::new(Mutex::new(Inner {
-                // components: Vec::new(),
-            })),
+            inner: Arc::new(Mutex::new(Inner {})),
         }
     }
 
-    pub(crate) fn start_component<C>(&mut self, component: C) -> (ComponentHandle, Sender<C>)
+    pub(crate) fn start_component<C>(&mut self, component: C) -> ComponentHandle<C>
     where
-        C: Component + Send + Sync + 'static,
+        C: Component + Send + 'static,
     {
         let (tx, rx) = tokio::sync::mpsc::channel(component.queue_size());
         let sender = Sender::new(tx);
@@ -48,7 +44,7 @@ impl System {
             self.clone(),
         );
         let join_handle = tokio::spawn(async move { executor.run(rx).await });
-        return (ComponentHandle::new(cancel_token, join_handle), sender);
+        return ComponentHandle::new(cancel_token, join_handle, sender);
     }
 
     pub(super) fn register_stream<C, S, M>(&self, stream: S, ctx: &ComponentContext<C>)

--- a/rust/worker/src/system/types.rs
+++ b/rust/worker/src/system/types.rs
@@ -111,7 +111,6 @@ impl<C: Component> ComponentHandle<C> {
         M: Send + Debug + 'static,
     {
         let sender = self.sender.sender.clone();
-        println!("Creating sender for component handle");
         Box::new(ReceiverImpl::new(sender))
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This allows the system to have a mutable handle to the component in handlers. Which is needed if you want to avoid wrapping everything in Locks. Since we can now mutate the component in the handler.
        - Adds a Wrapper<> Type so that we can wrap messages and dispatch to the handler without needing to leak the Component Type everywhere
       - Adds a Receiver type that allows us to use the components handle to get a sender pointed at it for a given message, this is used in the Memberlist to allow for subscribing to changes. 
 - New functionality
	 - /

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `cargo test`

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
