### PR TITLE
[ENH] Add ingest dispatch + scheduler + segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,6 +3771,7 @@ dependencies = [
  "murmur3",
  "num-bigint",
  "num_cpus",
+ "parking_lot",
  "prost 0.12.3",
  "prost-types 0.12.3",
  "pulsar",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -31,6 +31,7 @@ schemars = "0.8.16"
 kube = { version = "0.87.1", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.20.0", features = ["latest"] }
 bytes = "1.5.0"
+parking_lot = "0.12.1"
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -23,3 +23,5 @@ worker:
         Grpc:
             host: "localhost"
             port: 50051
+    segment_manager:
+        storage_path: "./tmp/segment_manager/"

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -106,6 +106,7 @@ pub(crate) struct WorkerConfig {
     pub(crate) memberlist_provider: crate::memberlist::config::MemberlistProviderConfig,
     pub(crate) ingest: crate::ingest::config::IngestConfig,
     pub(crate) sysdb: crate::sysdb::config::SysDbConfig,
+    pub(crate) segment_manager: crate::segment::config::SegmentManagerConfig,
 }
 
 /// # Description
@@ -151,6 +152,8 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50051
+                    segment_manager:
+                        storage_path: "/tmp"
 
                 "#,
             );
@@ -190,6 +193,8 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50051
+                    segment_manager:
+                        storage_path: "/tmp"
 
                 "#,
             );
@@ -244,6 +249,8 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50051
+                    segment_manager:
+                        storage_path: "/tmp"
 
                 "#,
             );
@@ -279,6 +286,8 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50051
+                    segment_manager:
+                        storage_path: "/tmp"
                 "#,
             );
             let config = RootConfig::load();

--- a/rust/worker/src/index/mod.rs
+++ b/rust/worker/src/index/mod.rs
@@ -3,4 +3,5 @@ mod types;
 mod utils;
 
 // Re-export types
+pub(crate) use hnsw::*;
 pub(crate) use types::*;

--- a/rust/worker/src/ingest/ingest.rs
+++ b/rust/worker/src/ingest/ingest.rs
@@ -22,9 +22,7 @@ use crate::{
     types::{EmbeddingRecord, EmbeddingRecordConversionError, SeqId},
 };
 
-use pulsar::{
-    consumer::topic, Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor,
-};
+use pulsar::{Consumer, DeserializeMessage, Payload, Pulsar, SubType, TokioExecutor};
 use thiserror::Error;
 
 use super::message_id::PulsarMessageIdWrapper;

--- a/rust/worker/src/ingest/ingest.rs
+++ b/rust/worker/src/ingest/ingest.rs
@@ -221,7 +221,7 @@ impl Handler<Memberlist> for Ingest {
 
         // Subscribe to new topics
         for topic in to_add.iter() {
-            println!("HERE Adding topic: {}", topic);
+            println!("Adding topic: {}", topic);
             // Do the subscription and register the stream to this ingest component
             let consumer: Consumer<chroma_proto::SubmitEmbeddingRecord, TokioExecutor> = self
                 .pulsar

--- a/rust/worker/src/ingest/mod.rs
+++ b/rust/worker/src/ingest/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod config;
 mod ingest;
 mod message_id;
+mod scheduler;
 
 // Re-export the ingest provider for use in the worker
 pub(crate) use ingest::*;
+pub(crate) use scheduler::*;

--- a/rust/worker/src/ingest/scheduler.rs
+++ b/rust/worker/src/ingest/scheduler.rs
@@ -1,0 +1,176 @@
+// A scheduler recieves embedding records for a given batch of documents
+// and schedules them to be ingested to the segment manager
+
+use crate::{
+    system::{Component, ComponentContext, Handler, Receiver},
+    types::EmbeddingRecord,
+};
+use async_trait::async_trait;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::{Debug, Formatter, Result},
+    sync::{atomic::AtomicBool, Arc},
+};
+use tokio::{io::Empty, select};
+
+pub(crate) struct RoundRobinScheduler {
+    // The segment manager to schedule to, a segment manager is a component
+    // segment_manager: SegmentManager
+    curr_wake_up: Option<tokio::sync::oneshot::Sender<WakeMessage>>,
+    tenant_to_queue: HashMap<String, tokio::sync::mpsc::Sender<Arc<EmbeddingRecord>>>,
+    new_tenant_channel: Option<tokio::sync::mpsc::Sender<NewTenantMessage>>,
+}
+
+impl Debug for RoundRobinScheduler {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.debug_struct("Scheduler").finish()
+    }
+}
+
+impl RoundRobinScheduler {
+    pub(crate) fn new() -> Self {
+        RoundRobinScheduler {
+            curr_wake_up: None,
+            tenant_to_queue: HashMap::new(),
+            new_tenant_channel: None,
+        }
+    }
+}
+
+impl Component for RoundRobinScheduler {
+    fn queue_size(&self) -> usize {
+        1000
+    }
+
+    fn on_start(&mut self, ctx: &ComponentContext<Self>) {
+        println!("Starting scheduler");
+        let sleep_sender = ctx.sender.clone();
+        let (new_tenant_tx, mut new_tenant_rx) = tokio::sync::mpsc::channel(1000);
+        self.new_tenant_channel = Some(new_tenant_tx);
+        let cancellation_token = ctx.cancellation_token.clone();
+        tokio::spawn(async move {
+            let mut tenant_queues: HashMap<
+                String,
+                tokio::sync::mpsc::Receiver<Arc<EmbeddingRecord>>,
+            > = HashMap::new();
+            loop {
+                // TODO: handle cancellation
+                let mut did_work = false;
+                for tenant_queue in tenant_queues.values_mut() {
+                    match tenant_queue.try_recv() {
+                        Ok(message) => {
+                            // TODO: Send the message to the segment manager in a spawned task
+                            // so we can continue polling
+                            did_work = true;
+                        }
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                            continue;
+                        }
+                        Err(_) => {
+                            // TODO: Handle a erroneous channel
+                            // log an error
+                            continue;
+                        }
+                    };
+                }
+
+                match new_tenant_rx.try_recv() {
+                    Ok(new_tenant_message) => {
+                        tenant_queues.insert(new_tenant_message.tenant, new_tenant_message.channel);
+                    }
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                        // no - op
+                    }
+                    Err(_) => {
+                        // TODO: handle erroneous channel
+                        // log an error
+                        continue;
+                    }
+                };
+
+                if !did_work {
+                    // Send a sleep message to the sender
+                    let (wake_tx, wake_rx) = tokio::sync::oneshot::channel();
+                    let sleep_res = sleep_sender.send(SleepMessage { sender: wake_tx }).await;
+                    let wake_res = wake_rx.await;
+                    println!("Scheduler awake");
+                }
+            }
+        });
+    }
+}
+
+#[async_trait]
+impl Handler<(String, Arc<EmbeddingRecord>)> for RoundRobinScheduler {
+    async fn handle(
+        &mut self,
+        message: (String, Arc<EmbeddingRecord>),
+        _ctx: &ComponentContext<Self>,
+    ) {
+        let (tenant, embedding_record) = message;
+        // Check if the tenant is already in the tenant set, if not we need to inform the scheduler loop
+        // of a new tenant
+        if self.tenant_to_queue.get(&tenant).is_none() {
+            // Create a new channel for the tenant
+            let (sender, reciever) = tokio::sync::mpsc::channel(1000);
+            // Add the tenant to the tenant set
+            self.tenant_to_queue.insert(tenant.clone(), sender);
+            // Send the new tenant message to the scheduler loop
+            let new_tenant_channel = match self.new_tenant_channel {
+                Some(ref mut channel) => channel,
+                None => {
+                    // TODO: this is an error
+                    // It should always be populated by on_start
+                    return;
+                }
+            };
+            let res = new_tenant_channel
+                .send(NewTenantMessage {
+                    tenant: tenant.clone(),
+                    channel: reciever,
+                })
+                .await;
+            // TODO: handle this res
+        }
+
+        // Send the embedding record to the tenant's channel
+        let res = self
+            .tenant_to_queue
+            .get(&tenant)
+            .unwrap()
+            .send(embedding_record)
+            .await;
+        // TODO: handle this res
+
+        // Check if the scheduler is sleeping, if so wake it up
+        if self.curr_wake_up.is_some() {
+            // Send a wake up message to the scheduler loop
+            let res = self.curr_wake_up.take().unwrap().send(WakeMessage {});
+            // TOOD: handle this res
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<SleepMessage> for RoundRobinScheduler {
+    async fn handle(&mut self, message: SleepMessage, _ctx: &ComponentContext<Self>) {
+        // Set the current wake up channel
+        self.curr_wake_up = Some(message.sender);
+    }
+}
+
+/// Used by round robin scheduler to wake its scheduler loop
+#[derive(Debug)]
+struct WakeMessage {}
+
+/// The round robin scheduler will sleep when there is no work to be done and send a sleep message
+/// this allows the manager to wake it up when there is work to be scheduled
+#[derive(Debug)]
+struct SleepMessage {
+    sender: tokio::sync::oneshot::Sender<WakeMessage>,
+}
+
+struct NewTenantMessage {
+    tenant: String,
+    channel: tokio::sync::mpsc::Receiver<Arc<EmbeddingRecord>>,
+}

--- a/rust/worker/src/ingest/scheduler.rs
+++ b/rust/worker/src/ingest/scheduler.rs
@@ -81,7 +81,11 @@ impl Component for RoundRobinScheduler {
                             // Randomly pick a subscriber to send the message to
                             // This serves as a crude load balancing between available threads
                             // Future improvements here could be
-                            // -
+                            // - Use a work stealing scheduler
+                            // - Use rayon
+                            // - We need to enforce partial order over writes to a given key
+                            //   so we need a mechanism to ensure that all writes to a given key
+                            //   occur in order
                             let mut subscriber = None;
                             {
                                 let mut rng = rand::thread_rng();

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -23,7 +23,7 @@ pub async fn worker_entrypoint() {
 
     // The two root components are ingest, and the gRPC server
 
-    let ingest = match ingest::Ingest::try_from_config(&config.worker).await {
+    let mut ingest = match ingest::Ingest::try_from_config(&config.worker).await {
         Ok(ingest) => ingest,
         Err(err) => {
             println!("Failed to create ingest component: {:?}", err);
@@ -40,12 +40,23 @@ pub async fn worker_entrypoint() {
             }
         };
 
+    let scheduler = ingest::RoundRobinScheduler::new();
+
     // Boot the system
+    // memberlist -> ingest -> scheduler
     let mut system = system::System::new();
+    let mut scheduler_handler = system.start_component(scheduler);
+    ingest.subscribe(scheduler_handler.receiver());
+
     let mut ingest_handle = system.start_component(ingest);
     let recv = ingest_handle.receiver();
     memberlist.subscribe(recv);
     let mut memberlist_handle = system.start_component(memberlist);
+
     // Join on all handles
-    let _ = tokio::join!(ingest_handle.join(), memberlist_handle.join());
+    let _ = tokio::join!(
+        ingest_handle.join(),
+        memberlist_handle.join(),
+        scheduler_handler.join()
+    );
 }

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -180,7 +180,7 @@ impl Component for CustomResourceMemberlistProvider {
         self.queue_size
     }
 
-    fn on_start(&self, ctx: &ComponentContext<CustomResourceMemberlistProvider>) {
+    fn on_start(&mut self, ctx: &ComponentContext<CustomResourceMemberlistProvider>) {
         self.connect_to_kube_stream(ctx);
     }
 }

--- a/rust/worker/src/segment/config.rs
+++ b/rust/worker/src/segment/config.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+
+/// The configuration for the custom resource memberlist provider.
+/// # Fields
+/// - storage_path: The path to use for temporary storage in the segment manager, if needed.
+#[derive(Deserialize)]
+pub(crate) struct SegmentManagerConfig {
+    pub(crate) storage_path: String,
+}

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -1,0 +1,65 @@
+use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+use crate::errors::ChromaError;
+use crate::index::{HnswIndex, HnswIndexConfig, Index, IndexConfig};
+use crate::types::{EmbeddingRecord, Operation};
+
+pub(crate) struct DistributedHNSWSegment {
+    index: Arc<RwLock<HnswIndex>>,
+    id: AtomicUsize,
+    index_config: IndexConfig,
+    hnsw_config: HnswIndexConfig,
+}
+
+impl DistributedHNSWSegment {
+    pub(crate) fn new(
+        index_config: IndexConfig,
+        hnsw_config: HnswIndexConfig,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let hnsw_index = HnswIndex::init(&index_config, Some(&hnsw_config));
+        let hnsw_index = match hnsw_index {
+            Ok(index) => index,
+            Err(e) => {
+                // TODO: log + handle an error that we failed to init the index
+                return Err(e);
+            }
+        };
+        let index = Arc::new(RwLock::new(hnsw_index));
+        return Ok(DistributedHNSWSegment {
+            index: index,
+            id: AtomicUsize::new(0),
+            index_config: index_config,
+            hnsw_config,
+        });
+    }
+
+    pub(crate) fn write_records(&mut self, records: Vec<Box<EmbeddingRecord>>) {
+        for record in records {
+            let op = Operation::try_from(record.operation);
+            match op {
+                Ok(Operation::Add) => {
+                    // TODO: make lock xor lock
+                    match record.embedding {
+                        Some(vector) => {
+                            let next_id = self.id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            println!("Adding item: {}", next_id);
+                            self.index.write().add(next_id, &vector);
+                        }
+                        None => {
+                            // TODO: log an error
+                            println!("No vector found in record");
+                        }
+                    }
+                }
+                Ok(Operation::Upsert) => {}
+                Ok(Operation::Update) => {}
+                Ok(Operation::Delete) => {}
+                Err(_) => {
+                    println!("Error parsing operation");
+                }
+            }
+        }
+    }
+}

--- a/rust/worker/src/segment/mod.rs
+++ b/rust/worker/src/segment/mod.rs
@@ -1,3 +1,6 @@
+mod distributed_hnsw_segment;
 mod segment_ingestor;
+mod segment_manager;
 
-pub use segment_ingestor::*;
+pub(crate) use segment_ingestor::*;
+pub(crate) use segment_manager::*;

--- a/rust/worker/src/segment/mod.rs
+++ b/rust/worker/src/segment/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod config;
 mod distributed_hnsw_segment;
 mod segment_ingestor;
 mod segment_manager;

--- a/rust/worker/src/segment/mod.rs
+++ b/rust/worker/src/segment/mod.rs
@@ -1,0 +1,3 @@
+mod segment_ingestor;
+
+pub use segment_ingestor::*;

--- a/rust/worker/src/segment/segment_ingestor.rs
+++ b/rust/worker/src/segment/segment_ingestor.rs
@@ -40,8 +40,8 @@ impl SegmentIngestor {
 }
 
 #[async_trait]
-impl Handler<Arc<EmbeddingRecord>> for SegmentIngestor {
-    async fn handle(&mut self, message: Arc<EmbeddingRecord>, ctx: &ComponentContext<Self>) {
+impl Handler<Box<EmbeddingRecord>> for SegmentIngestor {
+    async fn handle(&mut self, message: Box<EmbeddingRecord>, ctx: &ComponentContext<Self>) {
         println!("INGEST: ID of embedding is {}", message.id);
         self.segment_manager.write_record(message).await;
     }

--- a/rust/worker/src/segment/segment_ingestor.rs
+++ b/rust/worker/src/segment/segment_ingestor.rs
@@ -10,7 +10,11 @@ use crate::{
     types::EmbeddingRecord,
 };
 
-pub(crate) struct SegmentIngestor {}
+use super::segment_manager::{self, SegmentManager};
+
+pub(crate) struct SegmentIngestor {
+    segment_manager: SegmentManager,
+}
 
 impl Component for SegmentIngestor {
     fn queue_size(&self) -> usize {
@@ -28,8 +32,10 @@ impl Debug for SegmentIngestor {
 }
 
 impl SegmentIngestor {
-    pub(crate) fn new() -> Self {
-        SegmentIngestor {}
+    pub(crate) fn new(segment_manager: SegmentManager) -> Self {
+        SegmentIngestor {
+            segment_manager: segment_manager,
+        }
     }
 }
 
@@ -37,8 +43,6 @@ impl SegmentIngestor {
 impl Handler<Arc<EmbeddingRecord>> for SegmentIngestor {
     async fn handle(&mut self, message: Arc<EmbeddingRecord>, ctx: &ComponentContext<Self>) {
         println!("INGEST: ID of embedding is {}", message.id);
-        // let segment_manager = ctx.system.get_segment_manager();
-        // let segment = segment_manager.get_segment(&tenant);
-        // segment.ingest(embedding);
+        self.segment_manager.write_record(message).await;
     }
 }

--- a/rust/worker/src/segment/segment_ingestor.rs
+++ b/rust/worker/src/segment/segment_ingestor.rs
@@ -1,0 +1,44 @@
+// A segment ingestor is a component that ingests embeddings into a segment
+// Its designed to consume from a async_channel that guarantees exclusive consumption
+// They are spawned onto a dedicated thread runtime since ingesting is cpu bound
+
+use async_trait::async_trait;
+use std::{fmt::Debug, sync::Arc};
+
+use crate::{
+    system::{Component, ComponentContext, ComponentRuntime, Handler},
+    types::EmbeddingRecord,
+};
+
+pub(crate) struct SegmentIngestor {}
+
+impl Component for SegmentIngestor {
+    fn queue_size(&self) -> usize {
+        1000
+    }
+    fn runtime() -> ComponentRuntime {
+        ComponentRuntime::Dedicated
+    }
+}
+
+impl Debug for SegmentIngestor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentIngestor").finish()
+    }
+}
+
+impl SegmentIngestor {
+    pub(crate) fn new() -> Self {
+        SegmentIngestor {}
+    }
+}
+
+#[async_trait]
+impl Handler<Arc<EmbeddingRecord>> for SegmentIngestor {
+    async fn handle(&mut self, message: Arc<EmbeddingRecord>, ctx: &ComponentContext<Self>) {
+        println!("INGEST: ID of embedding is {}", message.id);
+        // let segment_manager = ctx.system.get_segment_manager();
+        // let segment = segment_manager.get_segment(&tenant);
+        // segment.ingest(embedding);
+    }
+}

--- a/rust/worker/src/segment/segment_manager.rs
+++ b/rust/worker/src/segment/segment_manager.rs
@@ -1,0 +1,159 @@
+use crate::{
+    config::{Configurable, WorkerConfig},
+    errors::ChromaError,
+    sysdb::sysdb::{GrpcSysDb, SysDb},
+};
+use async_trait::async_trait;
+use parking_lot::{
+    MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::distributed_hnsw_segment::DistributedHNSWSegment;
+use crate::types::{EmbeddingRecord, MetadataValue, Segment, SegmentScope};
+
+#[derive(Clone)]
+pub(crate) struct SegmentManager {
+    inner: Arc<Inner>,
+    sysdb: Box<dyn SysDb>,
+}
+
+struct Inner {
+    vector_segments: RwLock<HashMap<Uuid, Box<DistributedHNSWSegment>>>,
+    collection_to_segment_cache: RwLock<HashMap<Uuid, Vec<Segment>>>,
+}
+
+impl SegmentManager {
+    pub(crate) fn new(sysdb: Box<dyn SysDb>) -> Self {
+        SegmentManager {
+            inner: Arc::new(Inner {
+                vector_segments: RwLock::new(HashMap::new()),
+                collection_to_segment_cache: RwLock::new(HashMap::new()),
+            }),
+            sysdb: sysdb,
+        }
+    }
+
+    pub(crate) async fn write_record(&mut self, record: Arc<EmbeddingRecord>) {
+        println!(
+            "Manager is writing record for collection: {}",
+            record.collection_id
+        );
+        let collection_id = record.collection_id;
+        let mut target_segment_id = None;
+
+        // TODO: don't assume 1:1 mapping between collection and segment
+        {
+            let segments = self.get_segments(&collection_id).await;
+            // For now we assume segment is 1:1 with collection
+            target_segment_id = match segments {
+                Ok(segments) => {
+                    if segments.len() == 0 {
+                        return; // TODO: handle no segment found
+                    }
+                    Some(segments[0].id)
+                }
+                Err(_) => None,
+            };
+        }
+
+        if target_segment_id.is_none() {
+            return; // TODO: handle no segment found
+        }
+        // let target_segment_id = target_segment_id.unwrap();
+        println!("Writing record to segment: {}", target_segment_id.unwrap());
+
+        // let segment_cache = self.inner.vector_segments.upgradable_read();
+        // match segment_cache.get(&target_segment_id) {
+        //     Some(segment) => {
+        //         segment.write_records(vec![record]);
+        //     }
+        //     None => {
+        //         let mut segment_cache = RwLockUpgradableReadGuard::upgrade(segment_cache);
+        //         // Parse metadata from the segment and hydrate the params for the segment
+        //         let new_segment = Box::new(DistributedHNSWSegment::new(
+        //             "ip".to_string(),
+        //             100000,
+        //             "./test/".to_string(),
+        //             100,
+        //             10000,
+        //         ));
+        //         segment_cache.insert(target_segment_id.clone(), new_segment);
+        //         let segment_cache = RwLockWriteGuard::downgrade(segment_cache);
+        //         let segment = RwLockReadGuard::map(segment_cache, |cache| {
+        //             return cache.get(&target_segment_id).unwrap();
+        //         });
+        //         segment.write_records(vec![record]);
+        //     }
+        // }
+    }
+
+    async fn get_segments(
+        &mut self,
+        collection_uuid: &Uuid,
+    ) -> Result<MappedRwLockReadGuard<Vec<Segment>>, &'static str> {
+        let cache_guard = self.inner.collection_to_segment_cache.read();
+        // This lets us return a reference to the segments with the lock. The caller is responsible
+        // dropping the lock.
+        let segments =
+            RwLockReadGuard::try_map(cache_guard, |cache: &HashMap<Uuid, Vec<Segment>>| {
+                return cache.get(&collection_uuid);
+            });
+        match segments {
+            Ok(segments) => {
+                return Ok(segments);
+            }
+            Err(_) => {
+                // Data was not in the cache, so we need to get it from the database
+                // Drop the lock since we need to upgrade it
+                // Mappable locks cannot be upgraded, so we need to drop the lock and re-acquire it
+                // https://github.com/Amanieu/parking_lot/issues/83
+                drop(segments);
+
+                let segments = self
+                    .sysdb
+                    .get_segments(
+                        None,
+                        None,
+                        Some(SegmentScope::VECTOR),
+                        None,
+                        Some(collection_uuid.clone()),
+                    )
+                    .await;
+                match segments {
+                    Ok(segments) => {
+                        let mut cache_guard = self.inner.collection_to_segment_cache.write();
+                        cache_guard.insert(collection_uuid.clone(), segments);
+                        let cache_guard = RwLockWriteGuard::downgrade(cache_guard);
+                        let segments = RwLockReadGuard::map(cache_guard, |cache| {
+                            // This unwrap is safe because we just inserted the segments into the cache and currently,
+                            // there is no way to remove segments from the cache.
+                            return cache.get(&collection_uuid).unwrap();
+                        });
+                        return Ok(segments);
+                    }
+                    Err(e) => {
+                        return Err("Failed to get segments for collection from SysDB");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Configurable for SegmentManager {
+    async fn try_from_config(worker_config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
+        // TODO: Sysdb should have a dynamic resolution in sysdb
+        let sysdb = GrpcSysDb::try_from_config(worker_config).await;
+        let sysdb = match sysdb {
+            Ok(sysdb) => sysdb,
+            Err(err) => {
+                return Err(err);
+            }
+        };
+        Ok(SegmentManager::new(Box::new(sysdb)))
+    }
+}

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -25,13 +25,14 @@ impl System {
         }
     }
 
-    pub(crate) fn start_component<C>(&mut self, component: C) -> ComponentHandle<C>
+    pub(crate) fn start_component<C>(&mut self, mut component: C) -> ComponentHandle<C>
     where
         C: Component + Send + 'static,
     {
         let (tx, rx) = tokio::sync::mpsc::channel(component.queue_size());
         let sender = Sender::new(tx);
         let cancel_token = tokio_util::sync::CancellationToken::new();
+        println!("Starting component: {:?}", component);
         let _ = component.on_start(&ComponentContext {
             system: self.clone(),
             sender: sender.clone(),

--- a/rust/worker/src/system/types.rs
+++ b/rust/worker/src/system/types.rs
@@ -29,7 +29,7 @@ pub(crate) enum ComponentState {
 /// - on_start: Called when the component is started
 pub(crate) trait Component: Send + Sized + Debug + 'static {
     fn queue_size(&self) -> usize;
-    fn on_start(&self, ctx: &ComponentContext<Self>) -> () {}
+    fn on_start(&mut self, ctx: &ComponentContext<Self>) -> () {}
 }
 
 /// A handler is a component that can process messages of a given type.
@@ -105,7 +105,7 @@ impl<C: Component> ComponentHandle<C> {
         return &self.state;
     }
 
-    pub(crate) fn receiver<M>(&self) -> Box<dyn Receiver<M> + Send>
+    pub(crate) fn receiver<M>(&self) -> Box<dyn Receiver<M>>
     where
         C: Handler<M>,
         M: Send + Debug + 'static,
@@ -121,8 +121,8 @@ where
     C: Component + 'static,
 {
     pub(crate) system: System,
-    pub(super) sender: Sender<C>,
-    pub(super) cancellation_token: tokio_util::sync::CancellationToken,
+    pub(crate) sender: Sender<C>,
+    pub(crate) cancellation_token: tokio_util::sync::CancellationToken,
 }
 
 #[cfg(test)]
@@ -162,7 +162,7 @@ mod tests {
             return self.queue_size;
         }
 
-        fn on_start(&self, ctx: &ComponentContext<TestComponent>) -> () {
+        fn on_start(&mut self, ctx: &ComponentContext<TestComponent>) -> () {
             let test_stream = stream::iter(vec![1, 2, 3]);
             self.register_stream(test_stream, ctx);
         }

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -59,6 +59,39 @@ pub(crate) enum MetadataValue {
     Str(String),
 }
 
+impl TryFrom<&MetadataValue> for i32 {
+    type Error = MetadataValueConversionError;
+
+    fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
+        match value {
+            MetadataValue::Int(value) => Ok(*value),
+            _ => Err(MetadataValueConversionError::InvalidValue),
+        }
+    }
+}
+
+impl TryFrom<&MetadataValue> for f64 {
+    type Error = MetadataValueConversionError;
+
+    fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
+        match value {
+            MetadataValue::Float(value) => Ok(*value),
+            _ => Err(MetadataValueConversionError::InvalidValue),
+        }
+    }
+}
+
+impl TryFrom<&MetadataValue> for String {
+    type Error = MetadataValueConversionError;
+
+    fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
+        match value {
+            MetadataValue::Str(value) => Ok(value.clone()),
+            _ => Err(MetadataValueConversionError::InvalidValue),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub(crate) enum MetadataValueConversionError {
     #[error("Invalid metadata value, valid values are: Int, Float, Str")]


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	- Adds a tenant-level RR scheduler and uses sysdb to look up tenants, this is not cached for now.
         - The scheduler can be slept/awoken
        - Adds a segment concept with tracking for user ids -> internal ids
 - New functionality
	 - /

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `cargo test`

Apologies for the larger diff, my stack got messed up

