### PR TITLE
Fix coordinator segfault, gitignore tests, CI

### DIFF
--- a/.github/workflows/chroma-coordinator-test.yaml
+++ b/.github/workflows/chroma-coordinator-test.yaml
@@ -19,7 +19,5 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Build
-      run: cd go/coordinator && make
-    - name: Test
-      run: make test
+    - name: Build and test
+      run: cd go/coordinator && make test

--- a/.github/workflows/chroma-coordinator-test.yaml
+++ b/.github/workflows/chroma-coordinator-test.yaml
@@ -1,0 +1,25 @@
+name: Chroma Coordinator Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build
+      run: cd go/coordinator && make
+    - name: Test
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 
 **/__pycache__
 
+go/coordinator/bin/
+go/coordinator/**/testdata/
+
 *.log
 
 **/data__nogit

--- a/go/coordinator/cmd/grpccoordinator/cmd.go
+++ b/go/coordinator/cmd/grpccoordinator/cmd.go
@@ -4,14 +4,16 @@ import (
 	"io"
 	"time"
 
-	"github.com/chroma/chroma-coordinator/cmd/flag"
 	"github.com/chroma/chroma-coordinator/internal/grpccoordinator"
+	"github.com/chroma/chroma-coordinator/internal/grpccoordinator/grpcutils"
 	"github.com/chroma/chroma-coordinator/internal/utils"
 	"github.com/spf13/cobra"
 )
 
 var (
-	conf = grpccoordinator.Config{}
+	conf = grpccoordinator.Config{
+		GrpcConfig: &grpcutils.GrpcConfig{},
+	}
 
 	Cmd = &cobra.Command{
 		Use:   "coordinator",
@@ -24,7 +26,7 @@ var (
 func init() {
 
 	// GRPC
-	flag.GRPCAddr(Cmd, &conf.GrpcConfig.BindAddress)
+	Cmd.Flags().StringVar(&conf.GrpcConfig.BindAddress, "grpc-bind-address", "", "GRPC bind address")
 
 	// System Catalog
 	Cmd.Flags().StringVar(&conf.SystemCatalogProvider, "system-catalog-provider", "memory", "System catalog provider")


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fix coordinator segfault on start due to trying to copy a value into non-initialized struct.
	 - Add coordinator binary and testdata to `.gitignore`
 - New functionality
	 - Coordinator CI

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
