### PR TITLE
Always pass Tenant and DB as query params

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -171,8 +171,8 @@ class FastAPI(ServerAPI):
     ) -> Database:
         """Returns a database"""
         resp = self._session.get(
-            self._api_url + "/databases/" + name,
-            params={"tenant": tenant},
+            self._api_url + "/databases",
+            params={"tenant": tenant, "database": name},
         )
         raise_chroma_error(resp)
         resp_json = resp.json()
@@ -193,7 +193,8 @@ class FastAPI(ServerAPI):
     @override
     def get_tenant(self, name: str) -> Tenant:
         resp = self._session.get(
-            self._api_url + "/tenants/" + name,
+            self._api_url + "/tenants",
+            params={"tenant": name},
         )
         raise_chroma_error(resp)
         resp_json = resp.json()

--- a/chromadb/auth/fastapi.py
+++ b/chromadb/auth/fastapi.py
@@ -9,11 +9,6 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp
 
-from chromadb.server.fastapi.types import (
-    CreateDatabase,
-    CreateTenant,
-)
-
 from chromadb.config import DEFAULT_TENANT, System
 from chromadb.auth import (
     AuthorizationContext,
@@ -223,18 +218,14 @@ def authz_context(
                 # the request tenant and DB however they like and we simply overwrite it.
                 if overwrite_singleton_tenant_database_access_from_auth:
                     desired_tenant = request.state.user_identity.get_user_tenant()
-                    if desired_tenant and "tenant" in kwargs:
+                    if desired_tenant and "tenant" not in kwargs:
                         if isinstance(kwargs["tenant"], str):
                             kwargs["tenant"] = desired_tenant
-                        elif isinstance(kwargs["tenant"], CreateTenant):
-                            kwargs["tenant"].name = desired_tenant
                     databases = request.state.user_identity.get_user_databases()
-                    if databases and len(databases) == 1 and "database" in kwargs:
+                    if databases and len(databases) == 1 and "database" not in kwargs:
                         desired_database = databases[0]
                         if isinstance(kwargs["database"], str):
                             kwargs["database"] = desired_database
-                        elif isinstance(kwargs["database"], CreateDatabase):
-                            kwargs["database"].name = desired_database
 
             return f(*args, **kwargs)
 

--- a/chromadb/auth/fastapi_utils.py
+++ b/chromadb/auth/fastapi_utils.py
@@ -1,43 +1,6 @@
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Sequence, cast
+from typing import Any, Callable, Dict, cast
 from chromadb.api import ServerAPI
-from chromadb.auth import AuthzResourceTypes
-
-
-def find_key_with_value_of_type(
-    type: AuthzResourceTypes, **kwargs: Any
-) -> Dict[str, Any]:
-    from chromadb.server.fastapi.types import (
-        CreateCollection,
-        CreateDatabase,
-        CreateTenant,
-    )
-
-    for key, value in kwargs.items():
-        if type == AuthzResourceTypes.DB and isinstance(value, CreateDatabase):
-            return dict(value)
-        elif type == AuthzResourceTypes.COLLECTION and isinstance(
-            value, CreateCollection
-        ):
-            return dict(value)
-        elif type == AuthzResourceTypes.TENANT and isinstance(value, CreateTenant):
-            return dict(value)
-    return {}
-
-
-def attr_from_resource_object(
-    type: AuthzResourceTypes,
-    additional_attrs: Optional[Sequence[str]] = None,
-    **kwargs: Any,
-) -> Callable[..., Dict[str, Any]]:
-    def _wrap(**wkwargs: Any) -> Dict[str, Any]:
-        obj = find_key_with_value_of_type(type, **wkwargs)
-        if additional_attrs:
-            obj.update({k: wkwargs["function_kwargs"][k]
-                       for k in additional_attrs})
-        return obj
-
-    return partial(_wrap, **kwargs)
 
 
 def attr_from_collection_lookup(

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -61,11 +61,3 @@ class CreateCollection(BaseModel):
 class UpdateCollection(BaseModel):
     new_name: Optional[str] = None
     new_metadata: Optional[CollectionMetadata] = None
-
-
-class CreateDatabase(BaseModel):
-    name: str
-
-
-class CreateTenant(BaseModel):
-    name: str


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Always pass tenant and db as query params. This makes db-scoped auth tokens cleaner since we no longer overwrite the request's specified tenant and db -- we only overwrite them if they're not set.
	 - As part of this, we can delete the `CreateTenant` and `CreateDatabase` type and some auth code which only existed because of their existence.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
