### PR TITLE
[BUG] Fix config in go service to use default bind address. reverts p…

### DIFF
--- a/go/coordinator/cmd/grpccoordinator/cmd.go
+++ b/go/coordinator/cmd/grpccoordinator/cmd.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/chroma/chroma-coordinator/cmd/flag"
 	"github.com/chroma/chroma-coordinator/internal/grpccoordinator"
 	"github.com/chroma/chroma-coordinator/internal/grpccoordinator/grpcutils"
 	"github.com/chroma/chroma-coordinator/internal/utils"
@@ -26,7 +27,7 @@ var (
 func init() {
 
 	// GRPC
-	Cmd.Flags().StringVar(&conf.GrpcConfig.BindAddress, "grpc-bind-address", "", "GRPC bind address")
+	flag.GRPCAddr(Cmd, &conf.GrpcConfig.BindAddress)
 
 	// System Catalog
 	Cmd.Flags().StringVar(&conf.SystemCatalogProvider, "system-catalog-provider", "memory", "System catalog provider")


### PR DESCRIPTION
Reverts part of #1553

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Use the default bind addr in go cmd line
 - New functionality
	 - /

## Test plan
*How are these changes tested?*
Manually minikube

## Documentation Changes
None