### PR TITLE
Make build an explicit dependency for client

### DIFF
--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,3 +1,4 @@
+build >= 1.0.3
 numpy >= 1.22.5
 opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+  'build >= 1.0.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
   'chroma-hnswlib==0.7.3',


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Add `build` back as a dependency for the client. A do-over of https://github.com/chroma-core/chroma/pull/1561 now that main CI is passing.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
