### PR TITLE
[BUG] Make sure Client parameters are strings

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -148,7 +148,7 @@ def PersistentClient(
 
 def HttpClient(
     host: str = "localhost",
-    port: str = "8000",
+    port: int = 8000,
     ssl: bool = False,
     headers: Optional[Dict[str, str]] = None,
     settings: Optional[Settings] = None,
@@ -175,7 +175,7 @@ def HttpClient(
 
     # https://github.com/chroma-core/chroma/issues/1573
     host = str(host)
-    port = str(port)
+    port = int(port)
     ssl = bool(ssl)
     _stringify_headers(headers)
     tenant = str(tenant)
@@ -205,7 +205,7 @@ def CloudClient(
     settings: Optional[Settings] = None,
     *,  # Following arguments are keyword-only, intended for testing only.
     cloud_host: str = "api.trychroma.com",
-    cloud_port: str = "8000",
+    cloud_port: int = 8000,
     enable_ssl: bool = True,
 ) -> ClientAPI:
     """
@@ -238,7 +238,7 @@ def CloudClient(
     database = str(database)
     api_key = str(api_key)
     cloud_host = str(cloud_host)
-    cloud_port = str(cloud_port)
+    cloud_port = int(cloud_port)
     enable_ssl = bool(enable_ssl)
 
     settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -112,7 +112,7 @@ def EphemeralClient(
         settings = Settings()
     settings.is_persistent = False
 
-    # https://github.com/chroma-core/chroma/issues/1573
+    # Make sure paramaters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 
@@ -139,7 +139,7 @@ def PersistentClient(
     settings.persist_directory = path
     settings.is_persistent = True
 
-    # https://github.com/chroma-core/chroma/issues/1573
+    # Make sure paramaters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 
@@ -173,11 +173,10 @@ def HttpClient(
     if settings is None:
         settings = Settings()
 
-    # https://github.com/chroma-core/chroma/issues/1573
+    # Make sure paramaters are the correct types -- users can pass anything.
     host = str(host)
     port = int(port)
     ssl = bool(ssl)
-    headers = _stringify_headers(headers)
     tenant = str(tenant)
     database = str(database)
 
@@ -233,7 +232,7 @@ def CloudClient(
     if settings is None:
         settings = Settings()
 
-    # https://github.com/chroma-core/chroma/issues/1573
+    # Make sure paramaters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
     api_key = str(api_key)
@@ -268,7 +267,7 @@ def Client(
     database: The database to use for this client. Defaults to the default database.
     """
 
-    # https://github.com/chroma-core/chroma/issues/1573
+    # Make sure paramaters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 
@@ -282,10 +281,3 @@ def AdminClient(settings: Settings = Settings()) -> AdminAPI:
 
     """
     return AdminClientCreator(settings=settings)
-
-
-# Despite type hints, users may pass in non-string values for headers.
-def _stringify_headers(headers: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
-    if headers is not None:
-        return {key: str(value) for key, value in headers.items()}
-    return None

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -177,7 +177,7 @@ def HttpClient(
     host = str(host)
     port = int(port)
     ssl = bool(ssl)
-    _stringify_headers(headers)
+    headers = _stringify_headers(headers)
     tenant = str(tenant)
     database = str(database)
 
@@ -284,7 +284,8 @@ def AdminClient(settings: Settings = Settings()) -> AdminAPI:
     return AdminClientCreator(settings=settings)
 
 
-def _stringify_headers(headers: Optional[Dict[str, str]]) -> None:
+# Despite type hints, users may pass in non-string values for headers.
+def _stringify_headers(headers: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
     if headers is not None:
-        for key, value in headers.items():
-            headers[key] = str(value)
+        return {key: str(value) for key, value in headers.items()}
+    return None

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -112,6 +112,10 @@ def EphemeralClient(
         settings = Settings()
     settings.is_persistent = False
 
+    # https://github.com/chroma-core/chroma/issues/1573
+    tenant = str(tenant)
+    database = str(database)
+
     return ClientCreator(settings=settings, tenant=tenant, database=database)
 
 
@@ -134,6 +138,10 @@ def PersistentClient(
         settings = Settings()
     settings.persist_directory = path
     settings.is_persistent = True
+
+    # https://github.com/chroma-core/chroma/issues/1573
+    tenant = str(tenant)
+    database = str(database)
 
     return ClientCreator(tenant=tenant, database=database, settings=settings)
 
@@ -164,6 +172,14 @@ def HttpClient(
 
     if settings is None:
         settings = Settings()
+
+    # https://github.com/chroma-core/chroma/issues/1573
+    host = str(host)
+    port = str(port)
+    ssl = bool(ssl)
+    _stringify_headers(headers)
+    tenant = str(tenant)
+    database = str(database)
 
     settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
     if settings.chroma_server_host and settings.chroma_server_host != host:
@@ -217,6 +233,14 @@ def CloudClient(
     if settings is None:
         settings = Settings()
 
+    # https://github.com/chroma-core/chroma/issues/1573
+    tenant = str(tenant)
+    database = str(database)
+    api_key = str(api_key)
+    cloud_host = str(cloud_host)
+    cloud_port = str(cloud_port)
+    enable_ssl = bool(enable_ssl)
+
     settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
     settings.chroma_server_host = cloud_host
     settings.chroma_server_http_port = cloud_port
@@ -242,8 +266,11 @@ def Client(
 
     tenant: The tenant to use for this client. Defaults to the default tenant.
     database: The database to use for this client. Defaults to the default database.
-
     """
+
+    # https://github.com/chroma-core/chroma/issues/1573
+    tenant = str(tenant)
+    database = str(database)
 
     return ClientCreator(tenant=tenant, database=database, settings=settings)
 
@@ -255,3 +282,9 @@ def AdminClient(settings: Settings = Settings()) -> AdminAPI:
 
     """
     return AdminClientCreator(settings=settings)
+
+
+def _stringify_headers(headers: Optional[Dict[str, str]]) -> None:
+    if headers is not None:
+        for key, value in headers.items():
+            headers[key] = str(value)

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -109,7 +109,7 @@ class FastAPI(ServerAPI):
 
         self._api_url = FastAPI.resolve_url(
             chroma_server_host=str(system.settings.chroma_server_host),
-            chroma_server_http_port=int(str(system.settings.chroma_server_http_port)),
+            chroma_server_http_port=system.settings.chroma_server_http_port,
             chroma_server_ssl_enabled=system.settings.chroma_server_ssl_enabled,
             default_api_path=system.settings.chroma_server_api_default_path,
         )

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -118,10 +118,10 @@ class Settings(BaseSettings):  # type: ignore
 
     chroma_server_host: Optional[str] = None
     chroma_server_headers: Optional[Dict[str, str]] = None
-    chroma_server_http_port: Optional[str] = None
+    chroma_server_http_port: Optional[int] = None
     chroma_server_ssl_enabled: Optional[bool] = False
     chroma_server_api_default_path: Optional[str] = "/api/v1"
-    chroma_server_grpc_port: Optional[str] = None
+    chroma_server_grpc_port: Optional[int] = None
     # eg ["http://localhost:3000"]
     chroma_server_cors_allow_origins: List[str] = []
 
@@ -134,8 +134,8 @@ class Settings(BaseSettings):  # type: ignore
     chroma_server_nofile: Optional[int] = None
 
     pulsar_broker_url: Optional[str] = None
-    pulsar_admin_port: Optional[str] = "8080"
-    pulsar_broker_port: Optional[str] = "6650"
+    pulsar_admin_port: Optional[int] = 8080
+    pulsar_broker_port: Optional[int] = 6650
 
     chroma_server_auth_provider: Optional[str] = None
 

--- a/chromadb/test/client/test_cloud_client.py
+++ b/chromadb/test/client/test_cloud_client.py
@@ -61,7 +61,7 @@ def mock_cloud_server(valid_token: str) -> Generator[System, None, None]:
     settings = Settings(
         chroma_api_impl="chromadb.api.fastapi.FastAPI",
         chroma_server_host=TEST_CLOUD_HOST,
-        chroma_server_http_port=str(port),
+        chroma_server_http_port=port,
         chroma_client_auth_provider="chromadb.auth.token.TokenAuthClientProvider",
         chroma_client_auth_credentials=valid_token,
         chroma_client_auth_token_transport_header=TOKEN_TRANSPORT_HEADER,
@@ -82,7 +82,7 @@ def test_valid_key(mock_cloud_server: System, valid_token: str) -> None:
         database=DEFAULT_DATABASE,
         api_key=valid_token,
         cloud_host=TEST_CLOUD_HOST,
-        cloud_port=mock_cloud_server.settings.chroma_server_http_port,  # type: ignore
+        cloud_port=mock_cloud_server.settings.chroma_server_http_port or 8000,
         enable_ssl=False,
     )
 
@@ -98,7 +98,7 @@ def test_invalid_key(mock_cloud_server: System, valid_token: str) -> None:
             database=DEFAULT_DATABASE,
             api_key=invalid_token,
             cloud_host=TEST_CLOUD_HOST,
-            cloud_port=mock_cloud_server.settings.chroma_server_http_port,  # type: ignore
+            cloud_port=mock_cloud_server.settings.chroma_server_http_port or 8000,
             enable_ssl=False,
         )
         client.heartbeat()

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -205,7 +205,7 @@ def _fastapi_fixture(
     settings = Settings(
         chroma_api_impl="chromadb.api.fastapi.FastAPI",
         chroma_server_host="localhost",
-        chroma_server_http_port=str(port),
+        chroma_server_http_port=port,
         allow_reset=True,
         chroma_client_auth_provider=chroma_client_auth_provider,
         chroma_client_auth_credentials=chroma_client_auth_credentials,
@@ -234,7 +234,7 @@ def fastapi_persistent() -> Generator[System, None, None]:
 def basic_http_client() -> Generator[System, None, None]:
     settings = Settings(
         chroma_api_impl="chromadb.api.fastapi.FastAPI",
-        chroma_server_http_port="8000",
+        chroma_server_http_port=8000,
         allow_reset=True,
     )
     system = System(settings)

--- a/chromadb/test/test_chroma.py
+++ b/chromadb/test/test_chroma.py
@@ -66,7 +66,7 @@ class GetAPITest(unittest.TestCase):
                 chroma_api_impl="chromadb.api.fastapi.FastAPI",
                 persist_directory="./foo",
                 chroma_server_host="foo",
-                chroma_server_http_port="80",
+                chroma_server_http_port=80,
             )
         )
         assert mock.called
@@ -78,7 +78,7 @@ class GetAPITest(unittest.TestCase):
         settings = chromadb.config.Settings(
             chroma_api_impl="chromadb.api.fastapi.FastAPI",
             chroma_server_host="foo",
-            chroma_server_http_port="80",
+            chroma_server_http_port=80,
             chroma_server_headers={"foo": "bar"},
         )
         client = chromadb.Client(settings)
@@ -106,7 +106,7 @@ def test_legacy_values() -> None:
                 chroma_api_impl="chromadb.api.local.LocalAPI",
                 persist_directory="./foo",
                 chroma_server_host="foo",
-                chroma_server_http_port="80",
+                chroma_server_http_port=80,
             )
         )
         client.clear_system_cache()

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -60,9 +60,9 @@ def test_http_client_with_inconsistent_host_settings() -> None:
 def test_http_client_with_inconsistent_port_settings() -> None:
     try:
         chromadb.HttpClient(
-            port="8002",
+            port=8002,
             settings=Settings(
-                chroma_server_http_port="8001",
+                chroma_server_http_port=8001,
             ),
         )
     except ValueError as e:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Stringify all paremeters to `Client`s which are meant to be strings. At present some parameters -- `port` in particular -- can be reasonably passed as integers which causes weird and unexpected behavior.
	 - Fixes #1573

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
