### PR TITLE
TYP: Fixed `type annotations` based on required python versions

### DIFF
--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -42,7 +42,7 @@ def to_proto_vector(vector: Vector, encoding: ScalarEncoding) -> proto.Vector:
 
 def from_proto_vector(vector: proto.Vector) -> Tuple[Embedding, ScalarEncoding]:
     encoding = vector.encoding
-    as_array: array.array[float] | array.array[int]
+    as_array: Union[array.array[float], array.array[int]]
     if encoding == proto.ScalarEncoding.FLOAT32:
         as_array = array.array("f")
         out_encoding = ScalarEncoding.FLOAT32

--- a/chromadb/segment/impl/manager/distributed.py
+++ b/chromadb/segment/impl/manager/distributed.py
@@ -78,7 +78,7 @@ class DistributedSegmentManager(SegmentManager):
         OpenTelemetryGranularity.OPERATION_AND_SEGMENT,
     )
     @override
-    def get_segment(self, collection_id: UUID, type: type[S]) -> S:
+    def get_segment(self, collection_id: UUID, type: Type[S]) -> S:
         if type == MetadataReader:
             scope = SegmentScope.METADATA
         elif type == VectorReader:

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -486,7 +486,7 @@ class SqliteMetadataSegment(MetadataReader):
     def _where_map_criterion(
         self, q: QueryBuilder, where: Where, metadata_t: Table, embeddings_t: Table
     ) -> Criterion:
-        clause: list[Criterion] = []
+        clause: List[Criterion] = []
         for k, v in where.items():
             if k == "$and":
                 criteria = [


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
1. In the following line we are using `|` instead of `Union`.
https://github.com/chroma-core/chroma/blob/47447b6f9846fb63cc17d3f458df405387f46127/chromadb/proto/convert.py#L45

2. Here we are using `type[S]` instead of `Type[S]`
https://github.com/chroma-core/chroma/blob/47447b6f9846fb63cc17d3f458df405387f46127/chromadb/segment/impl/manager/distributed.py#L81

3. Here we are annotation using `list` instead of `List`
https://github.com/chroma-core/chroma/blob/47447b6f9846fb63cc17d3f458df405387f46127/chromadb/segment/impl/metadata/sqlite.py#L489

I see that project targets Python versions <= 3.10 and >=3.8.
So, if someone is using Python 3.8 or 3.9 using these annotations will cause runtime errors.



Closes #1581 

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
No documentation changes are needed.