### PR TITLE
ENH: Added `emojis` for issue templates and a `config.yml` file to redirect to discord for help/doubts/questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
-name: Bug Report
-description: File a bug report with Chroma
+name: 🐛 Bug Report
+description: File a bug report to help us improve Chroma
 title: "[Bug]: "
 labels: ["bug", "triage"]
 # assignees:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🤷🏻‍♀️ Questions
+    url: https://discord.com/invite/MMeYNTmh3x
+    about: Interact with the Chroma community here by asking for help, discussing and more!

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,4 @@
-name: "Feature Request"
+name: 🚀 Feature request
 description: Suggest an idea for Chroma
 title: "[Feature Request]: "
 labels: ["enhancement"]


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
	 - Added emojis to make reporting bugs and feature-requests look better.
 - New functionality
	 - All the big/good repos contain a link to their community as one of their issue templates, I added a similar one for our Chroma which links to the discord.

After merging this PR, It will look similar to this for the `Bug Report`, `Feature-Request`, and `Questions` templates.
![image](https://github.com/chroma-core/chroma/assets/87087741/5521ad73-5298-4974-b12a-bc720ae0c83c)


## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
No documentation changes are needed.
