### PR TITLE
Fix hnswlib reinstall always

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,12 @@ WORKDIR /install
 
 COPY ./requirements.txt requirements.txt
 
-RUN pip install --no-cache-dir --upgrade --prefix="/install" -r requirements.txt
+# RUN pip install --no-cache-dir --upgrade --prefix="/install" -r requirements.txt
+
+## This approach uses cache to save each package installation
+## so no need to redownload the packages if there's no upgrade available
+## at the time of the build or restart
+RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade --prefix="/install" -r requirements.txt 
 
 FROM python:3.10-slim-bookworm as final
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,6 @@ WORKDIR /install
 
 COPY ./requirements.txt requirements.txt
 
-# RUN pip install --no-cache-dir --upgrade --prefix="/install" -r requirements.txt
-
-## This approach uses cache to save each package installation
-## so no need to redownload the packages if there's no upgrade available
-## at the time of the build or restart
 RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade --prefix="/install" -r requirements.txt 
 
 FROM python:3.10-slim-bookworm as final


### PR DESCRIPTION
## Description of changes
The pip install command in the `Dockerfile` has been modified to cache the packages downloaded within the container during initial build, but to still look out for updates just as before. In this way, the container restarts seamlessly if there are no updates to the `chroma-hnswlib` and `numpy` packages which were prone to being re-downloaded with each restart regardless of version updates

Cc: @tazarov
#1587 

 - Improvements & Bug fixes
	 - Faster container restart if there are no updates to pip packages
	 - Less susceptibility to container start/restart errors due to low network bandwidth
 - New functionality
	 - None

## Test plan
- [x] Container build is successful
- [x] Troubleshooting the restart process shows no re-downloads on restart

## Documentation Changes
Not sure any changes need to be made to documentation as it's a minor fix.
