### PR TITLE
ENH: Fixed raising `TypeError` instead or `ValueError` for invalid type

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -251,7 +251,7 @@ def validate_metadata(metadata: Metadata) -> Metadata:
         raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
-            raise ValueError(
+            raise TypeError(
                 f"Expected metadata key to be a str, got {key} which is a {type(key)}"
             )
         # isinstance(True, int) evaluates to True, so we need to check for bools separately

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -325,7 +325,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
         start = start or self._next_seq_id()
         end = end or self.max_seqid()
         if not isinstance(start, int) or not isinstance(end, int):
-            raise ValueError("SeqIDs must be integers for sql-based EmbeddingsDB")
+            raise TypeError("SeqIDs must be integers for sql-based EmbeddingsDB")
         if start >= end:
             raise ValueError(f"Invalid SeqID range: {start} to {end}")
         return start, end

--- a/chromadb/ingest/impl/pulsar.py
+++ b/chromadb/ingest/impl/pulsar.py
@@ -276,7 +276,7 @@ class PulsarConsumer(Consumer, EnforceOverrides):
         start = start or pulsar_to_int(pulsar.MessageId.latest)
         end = end or self.max_seqid()
         if not isinstance(start, int) or not isinstance(end, int):
-            raise ValueError("SeqIDs must be integers")
+            raise TypeError("SeqIDs must be integers")
         if start >= end:
             raise ValueError(f"Invalid SeqID range: {start} to {end}")
         return start, end


### PR DESCRIPTION
## Description of changes
At few places in the codebase we are checking the type of something but raising `ValueError` instead of `TypeError`. 
**Improvements & Bug fixes**
Raising Proper error messages will be good for both the developers and users.


## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
No documentation changes needed