### PR TITLE
Fix sysdb test flakiness

### DIFF
--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -668,7 +668,7 @@ def test_create_get_delete_segments(sysdb: SysDB) -> None:
     assert result == sample_segments[:1]
 
     result = sysdb.get_segments(type="test_type_b")
-    assert sorted(result, key=lambda c: c["type"]) == sample_segments[1:]
+    assert sorted(result, key=lambda c: c["id"]) == sample_segments[1:]
 
     # Find by collection ID
     result = sysdb.get_segments(collection=sample_collections[0]["id"])
@@ -693,7 +693,7 @@ def test_create_get_delete_segments(sysdb: SysDB) -> None:
     results = sysdb.get_segments()
     assert s1 not in results
     assert len(results) == len(sample_segments) - 1
-    assert sorted(results, key=lambda c: c["type"]) == sample_segments[1:]
+    assert sorted(results, key=lambda c: c["id"]) == sample_segments[1:]
 
     # Duplicate delete throws an exception
     with pytest.raises(NotFoundError):


### PR DESCRIPTION
We need to sort by segment ID not type, since two of these have the same type and may be returned in either order by sysdb.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fix sysdb test flakiness by sorting by ID instead of type
	
## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
