### PR TITLE
FIX: Revert integration test to older state 

### DIFF
--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -668,7 +668,7 @@ def test_create_get_delete_segments(sysdb: SysDB) -> None:
     assert result == sample_segments[:1]
 
     result = sysdb.get_segments(type="test_type_b")
-    assert sorted(result, key=lambda c: c["type"]) == sample_segments[1:]
+    assert result == sample_segments[1:]
 
     # Find by collection ID
     result = sysdb.get_segments(collection=sample_collections[0]["id"])


### PR DESCRIPTION
## Description of changes

The `test_create_get_delete_segments` test in its current state fails in my local machine, and it looks like it fails in other PRs (see
https://github.com/chroma-core/chroma/pull/1570#issuecomment-1875964253)

I revert this specific test back to its older state.