### PR TITLE
ENH: Validate response of embedding function to be in the expected format during runtime

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -183,6 +183,17 @@ class EmbeddingFunction(Protocol[D]):
     def __call__(self, input: D) -> Embeddings:
         ...
 
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        # Raise an exception if __call__ is not defined since it is expected to be defined
+        call = getattr(cls, "__call__")
+
+        def __call__(self: EmbeddingFunction[D], input: D) -> Embeddings:
+            result = call(self, input)
+            return validate_embeddings(maybe_cast_one_to_many_embedding(result))
+
+        setattr(cls, "__call__", __call__)
+
 
 def validate_embedding_function(
     embedding_function: EmbeddingFunction[Embeddable],

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -1,0 +1,40 @@
+import pytest
+from typing import List, cast
+from chromadb.api.types import EmbeddingFunction, Documents, Image, Document, Embeddings
+import numpy as np
+
+
+def random_embeddings() -> Embeddings:
+    return cast(Embeddings, np.random.random(size=(10, 10)).tolist())
+
+
+def random_image() -> Image:
+    return np.random.randint(0, 255, size=(10, 10, 3), dtype=np.int32)
+
+
+def random_documents() -> List[Document]:
+    return [str(random_image()) for _ in range(10)]
+
+
+def test_embedding_function_with_valid_response() -> None:
+    valid_embeddings = random_embeddings()
+
+    class TestEmbeddingFunction(EmbeddingFunction[Documents]):
+        def __call__(self, input: Documents) -> Embeddings:
+            return valid_embeddings
+
+    ef = TestEmbeddingFunction()
+    assert valid_embeddings == ef(random_documents())
+
+
+def test_embedding_function_with_invalid_response() -> None:
+    invalid_embedding = {"error": "test"}
+
+    class TestEmbeddingFunction(EmbeddingFunction[Documents]):
+        def __call__(self, input: Documents) -> Embeddings:
+            return cast(Embeddings, invalid_embedding)
+
+    ef = TestEmbeddingFunction()
+    with pytest.raises(ValueError) as e:
+        ef(random_documents())
+    assert "Expected embeddings to be a list, got {'error': 'test'}" == str(e.value)

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -16,7 +16,7 @@ def random_documents() -> List[Document]:
     return [str(random_image()) for _ in range(10)]
 
 
-def test_embedding_function_with_valid_response() -> None:
+def test_embedding_function_results_format_when_response_is_valid() -> None:
     valid_embeddings = random_embeddings()
 
     class TestEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -27,7 +27,7 @@ def test_embedding_function_with_valid_response() -> None:
     assert valid_embeddings == ef(random_documents())
 
 
-def test_embedding_function_with_invalid_response() -> None:
+def test_embedding_function_results_format_when_response_is_invalid() -> None:
     invalid_embedding = {"error": "test"}
 
     class TestEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -37,4 +37,4 @@ def test_embedding_function_with_invalid_response() -> None:
     ef = TestEmbeddingFunction()
     with pytest.raises(ValueError) as e:
         ef(random_documents())
-    assert "Expected embeddings to be a list, got {'error': 'test'}" == str(e.value)
+    assert e.type is ValueError


### PR DESCRIPTION
## Description of changes
Requested in https://github.com/chroma-core/chroma/issues/1488
 - Improvements & Bug fixes
	 - Raise an exception when an external embedding function doesn't return embeddings in the expected format

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
