### PR TITLE
[BUG]: Client dependency fix

### DIFF
--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 from typing import Dict, Type
 from overrides import overrides, EnforceOverrides
-from fastapi.responses import JSONResponse
 
 
 class ChromaError(Exception, EnforceOverrides):
@@ -17,12 +16,6 @@ class ChromaError(Exception, EnforceOverrides):
     def name(cls) -> str:
         """Return the error name"""
         pass
-
-    def fastapi_json_response(self) -> JSONResponse:
-        return JSONResponse(
-            content={"error": self.name(), "message": self.message()},
-            status_code=self.code(),
-        )
 
 
 class InvalidDimensionException(ChromaError):

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -50,6 +50,8 @@ from chromadb.server.fastapi.types import (
 from starlette.requests import Request
 
 import logging
+
+from chromadb.server.fastapi.utils import fastapi_json_response
 from chromadb.telemetry.opentelemetry.fastapi import instrument_fastapi
 from chromadb.types import Database, Tenant
 from chromadb.telemetry.product import ServerContext, ProductTelemetryClient
@@ -79,7 +81,7 @@ async def catch_exceptions_middleware(
     try:
         return await call_next(request)
     except ChromaError as e:
-        return e.fastapi_json_response()
+        return fastapi_json_response(e)
     except Exception as e:
         logger.exception(e)
         return JSONResponse(content={"error": repr(e)}, status_code=500)

--- a/chromadb/server/fastapi/utils.py
+++ b/chromadb/server/fastapi/utils.py
@@ -1,0 +1,10 @@
+from starlette.responses import JSONResponse
+
+from chromadb.errors import ChromaError
+
+
+def fastapi_json_response(error: ChromaError) -> JSONResponse:
+    return JSONResponse(
+        content={"error": error.name(), "message": error.message()},
+        status_code=error.code(),
+    )

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
   'pydantic>=1.9',
   'requests >= 2.28',
   'typing_extensions >= 4.5.0',
+  'tenacity>=8.2.3',
+  'PyYAML>=6.0.0',
 ]
 
 [tool.black]

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,4 +1,3 @@
-build >= 1.0.3
 numpy >= 1.22.5
 opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.2.0
@@ -6,5 +5,7 @@ opentelemetry-sdk>=1.2.0
 overrides >= 7.3.1
 posthog >= 2.4.0
 pydantic>=1.9
+PyYAML>=6.0.0
 requests >= 2.28
+tenacity>=8.2.3
 typing_extensions >= 4.5.0

--- a/clients/python/requirements_dev.txt
+++ b/clients/python/requirements_dev.txt
@@ -1,3 +1,4 @@
+build>=1.0.3
 fastapi>=0.95.2
 hypothesis
 hypothesis[numpy]


### PR DESCRIPTION
This fix resolved an issue with the latest Python client (`chromed-client-0.4.23.dev0`):

![image](https://github.com/chroma-core/chroma/assets/1157440/13e51b7d-ff8a-4ddc-b0e3-4189b33bb09d)


## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
    - Move build to dev dependencies (it is not a runtime dependency)
    - Remove client dependency on fastapi package by moving fastapi_json_response to a utility module under fastapi server
    - Added tenacity dependency - required for retries
    - Added PyYAML dependency - required for authz (not strictly required for client, future refactor of authz to split the client/server side can be useful)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
N/A
