### PR TITLE
BUG: Handle specific error in raise_chroma_error function

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -649,4 +649,7 @@ def raise_chroma_error(resp: requests.Response) -> None:
     try:
         resp.raise_for_status()
     except requests.HTTPError:
-        raise (Exception(resp.text))
+        if "ValueError" in resp.text:
+            raise ValueError(resp.text)
+        else:
+            raise (Exception(resp.text))


### PR DESCRIPTION
## Description of changes

 - Improvements & Bug fixes
	 - Because the ValueError reported by the ChromaDB server is not recognized as a ValueError exception to the http client this causes the client to raise a generic exception instead. This fix will look at the text of the response from the server and raise a ValueError if it's contained in the response text. 

## Test plan
*How are these changes tested?*

- [ ] Attempt to get a collection that does not exist using an Http client. Verify that a ValueError is thrown. 

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

The documentation states that a ValueError should be thrown so no changes should be necessary to documentation. 
