### PR TITLE
[BUG] UUID should be uuid type not str

### DIFF
--- a/chromadb/auth/fastapi_utils.py
+++ b/chromadb/auth/fastapi_utils.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Sequence, cast
+from chromadb.server.fastapi.utils import string_to_uuid
 from chromadb.api import ServerAPI
 from chromadb.auth import AuthzResourceTypes
 
@@ -46,7 +47,7 @@ def attr_from_collection_lookup(
     def _wrap(**kwargs: Any) -> Dict[str, Any]:
         _api = cast(ServerAPI, kwargs["api"])
         col = _api.get_collection(
-            id=kwargs["function_kwargs"][collection_id_arg])
+            id=string_to_uuid(kwargs["function_kwargs"][collection_id_arg]))
         return {"tenant": col.tenant, "database": col.database}
 
     return partial(_wrap, **kwargs)

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -32,7 +32,6 @@ import chromadb.api
 from chromadb.api import ServerAPI
 from chromadb.errors import (
     ChromaError,
-    InvalidUUIDError,
     InvalidDimensionException,
     InvalidHTTPVersion,
 )
@@ -51,7 +50,7 @@ from starlette.requests import Request
 
 import logging
 
-from chromadb.server.fastapi.utils import fastapi_json_response
+from chromadb.server.fastapi.utils import fastapi_json_response, string_to_uuid as _uuid
 from chromadb.telemetry.opentelemetry.fastapi import instrument_fastapi
 from chromadb.types import Database, Tenant
 from chromadb.telemetry.product import ServerContext, ProductTelemetryClient
@@ -94,13 +93,6 @@ async def check_http_version_middleware(
     if http_version not in ["1.1", "2"]:
         raise InvalidHTTPVersion(f"HTTP version {http_version} is not supported")
     return await call_next(request)
-
-
-def _uuid(uuid_str: str) -> UUID:
-    try:
-        return UUID(uuid_str)
-    except ValueError:
-        raise InvalidUUIDError(f"Could not parse {uuid_str} as a UUID")
 
 
 class ChromaAPIRouter(fastapi.APIRouter):  # type: ignore

--- a/chromadb/server/fastapi/utils.py
+++ b/chromadb/server/fastapi/utils.py
@@ -1,6 +1,7 @@
+from uuid import UUID
 from starlette.responses import JSONResponse
 
-from chromadb.errors import ChromaError
+from chromadb.errors import ChromaError, InvalidUUIDError
 
 
 def fastapi_json_response(error: ChromaError) -> JSONResponse:
@@ -8,3 +9,9 @@ def fastapi_json_response(error: ChromaError) -> JSONResponse:
         content={"error": error.name(), "message": error.message()},
         status_code=error.code(),
     )
+
+def string_to_uuid(uuid_str: str) -> UUID:
+    try:
+        return UUID(uuid_str)
+    except ValueError:
+        raise InvalidUUIDError(f"Could not parse {uuid_str} as a UUID")


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - fastapi_utils needs to push the uuid as a UUID type not str to get_collection.
	 - Refactored _uuid into a util
 - New functionality
	 - None