### PR TITLE
[BUG] fix docker don't shutdown gracefully

### DIFF
--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -4,4 +4,4 @@ echo "Rebuilding hnsw to ensure architecture compatibility"
 pip install --force-reinstall --no-cache-dir chroma-hnswlib
 export IS_PERSISTENT=1
 export CHROMA_SERVER_NOFILE=65535
-uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config chromadb/log_config.yml --timeout-keep-alive 30
+exec uvicorn chromadb.app:app --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config chromadb/log_config.yml --timeout-keep-alive 30


### PR DESCRIPTION
## Description of changes
- Docker gracefully shutdown (#1646  )


## Test plan
*How are these changes tested?*
Tested locally with docker.

```
[notice] A new release of pip is available: 23.0.1 -> 23.3.2
[notice] To update, run: pip install --upgrade pip
DEBUG:    [16-01-2024 23:24:47] Registering provider: token_config
DEBUG:    [16-01-2024 23:24:47] Registering provider: user_token_config
DEBUG:    [16-01-2024 23:24:47] Registering provider: token
DEBUG:    [16-01-2024 23:24:47] Registering provider: token
WARNING:  [16-01-2024 23:24:47] chroma_server_nofile is set to 65535, but this is less than current soft limit of 1048576. chroma_server_nofile will not be set.
INFO:     [16-01-2024 23:24:47] Anonymized telemetry enabled. See                     https://docs.trychroma.com/telemetry for more information.
DEBUG:    [16-01-2024 23:24:47] Starting component System
DEBUG:    [16-01-2024 23:24:47] Starting component OpenTelemetryClient
DEBUG:    [16-01-2024 23:24:47] Starting component SimpleAssignmentPolicy
DEBUG:    [16-01-2024 23:24:47] Starting component SqliteDB
DEBUG:    [16-01-2024 23:24:47] Starting component Posthog
DEBUG:    [16-01-2024 23:24:47] Starting component LocalSegmentManager
DEBUG:    [16-01-2024 23:24:47] Starting component SegmentAPI
INFO:     [16-01-2024 23:24:47] Started server process [1]
INFO:     [16-01-2024 23:24:47] Waiting for application startup.
INFO:     [16-01-2024 23:24:47] Application startup complete.
INFO:     [16-01-2024 23:24:47] Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
^CINFO:     [16-01-2024 23:24:52] Shutting down
INFO:     [16-01-2024 23:24:52] Waiting for application shutdown.
INFO:     [16-01-2024 23:24:52] Application shutdown complete.
INFO:     [16-01-2024 23:24:52] Finished server process [1]
```
