### PR TITLE
[BUG] Fix coordinator pulsar tenant and namespace

### DIFF
--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -20,13 +20,16 @@ from chromadb.db.base import NotFoundError, UniqueConstraintError
 from pytest import FixtureRequest
 import uuid
 
+PULSAR_TENANT = "default"
+PULSAR_NAMESPACE = "default"
+
 # These are the sample collections that are used in the tests below. Tests can override
 # the fields as needed.
 sample_collections = [
     Collection(
         id=uuid.UUID(int=1),
         name="test_collection_1",
-        topic="persistent://test-tenant/test-topic/00000000-0000-0000-0000-000000000001",
+        topic=f"persistent://{PULSAR_TENANT}/{PULSAR_NAMESPACE}/00000000-0000-0000-0000-000000000001",
         metadata={"test_str": "str1", "test_int": 1, "test_float": 1.3},
         dimension=128,
         database=DEFAULT_DATABASE,
@@ -35,7 +38,7 @@ sample_collections = [
     Collection(
         id=uuid.UUID(int=2),
         name="test_collection_2",
-        topic="persistent://test-tenant/test-topic/00000000-0000-0000-0000-000000000002",
+        topic=f"persistent://{PULSAR_TENANT}/{PULSAR_NAMESPACE}/00000000-0000-0000-0000-000000000002",
         metadata={"test_str": "str2", "test_int": 2, "test_float": 2.3},
         dimension=None,
         database=DEFAULT_DATABASE,
@@ -44,7 +47,7 @@ sample_collections = [
     Collection(
         id=uuid.UUID(int=3),
         name="test_collection_3",
-        topic="persistent://test-tenant/test-topic/00000000-0000-0000-0000-000000000003",
+        topic=f"persistent://{PULSAR_TENANT}/{PULSAR_NAMESPACE}/00000000-0000-0000-0000-000000000003",
         metadata={"test_str": "str3", "test_int": 3, "test_float": 3.3},
         dimension=None,
         database=DEFAULT_DATABASE,

--- a/go/coordinator/cmd/grpccoordinator/cmd.go
+++ b/go/coordinator/cmd/grpccoordinator/cmd.go
@@ -42,7 +42,7 @@ func init() {
 	// Pulsar
 	Cmd.Flags().StringVar(&conf.PulsarAdminURL, "pulsar-admin-url", "http://localhost:8080", "Pulsar admin url")
 	Cmd.Flags().StringVar(&conf.PulsarURL, "pulsar-url", "pulsar://localhost:6650", "Pulsar url")
-	Cmd.Flags().StringVar(&conf.PulsarTenant, "pulsar-tenant", "public", "Pulsar tenant")
+	Cmd.Flags().StringVar(&conf.PulsarTenant, "pulsar-tenant", "default", "Pulsar tenant")
 	Cmd.Flags().StringVar(&conf.PulsarNamespace, "pulsar-namespace", "default", "Pulsar namespace")
 
 	// Notification

--- a/k8s/deployment/kubernetes.yaml
+++ b/k8s/deployment/kubernetes.yaml
@@ -193,9 +193,6 @@ spec:
             - "--pulsar-admin-url=http://pulsar.chroma:8080"
             - "--pulsar-url=pulsar://pulsar.chroma:6650"
             - "--notifier-provider=pulsar"
-            - "--pulsar-tenant=test-tenant"
-            - "--pulsar-namespace=test-topic"
-            - "--assignment-policy=simple"
           image: chroma-coordinator
           imagePullPolicy: IfNotPresent
           name: coordinator

--- a/k8s/deployment/segment-server.yaml
+++ b/k8s/deployment/segment-server.yaml
@@ -43,6 +43,10 @@ spec:
           env:
             - name: CHROMA_WORKER__PULSAR_URL
               value: pulsar://pulsar.chroma:6650
+            - name: CHROMA_WORKER__PULSAR_NAMESPACE
+              value: default
+            - name: CHROMA_WORKER__PULSAR_TENANT
+              value: default
             - name: CHROMA_WORKER__MY_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This aligns the coordinator, rust worker, and python client on default/default as the pulsar tenant/namespace