### PR TITLE
Fix typo in query example notebook

### DIFF
--- a/examples/basic_functionality/in_not_in_filtering.ipynb
+++ b/examples/basic_functionality/in_not_in_filtering.ipynb
@@ -43,7 +43,7 @@
     "collection.add(documents=[\"Article by john\", \"Article by Jack\", \"Article by Jill\"],\n",
     "               metadatas=[{\"author\": \"john\"}, {\"author\": \"jack\"}, {\"author\": \"jill\"}], ids=[\"1\", \"2\", \"3\"])\n",
     "\n",
-    "query = [\"Give me articles by john\"]\n",
+    "query = [\"Give me articles by john or jill\"]\n",
     "res = collection.query(query_texts=query,where={'author': {'$in': ['john', 'jill']}}, n_results=10)\n",
     "print(res)\n",
     "\n",


### PR DESCRIPTION
Fix typo in example

## Description of changes

The prompt should say "documents by john and jill" since that's what the code is querying and not just "documents by john"

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fix documentation
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

N/A - documentation update only

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

N/A - no code changed

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

Not needed
