### PR TITLE
[BUG]: FTS delete

### DIFF
--- a/chromadb/migrations/metadb/00005-fts-secure-delete.sqlite.sql
+++ b/chromadb/migrations/metadb/00005-fts-secure-delete.sqlite.sql
@@ -1,2 +1,0 @@
--- Ref: https://www.sqlite.org/fts5.html#the_secure_delete_configuration_option
-INSERT INTO embedding_fulltext_search(string_value, rank) VALUES('secure-delete', 1);

--- a/chromadb/migrations/metadb/00005-fts-secure-delete.sqlite.sql
+++ b/chromadb/migrations/metadb/00005-fts-secure-delete.sqlite.sql
@@ -1,0 +1,2 @@
+-- Ref: https://www.sqlite.org/fts5.html#the_secure_delete_configuration_option
+INSERT INTO embedding_fulltext_search(string_value, rank) VALUES('secure-delete', 1);

--- a/chromadb/test/segment/test_metadata.py
+++ b/chromadb/test/segment/test_metadata.py
@@ -657,3 +657,23 @@ def test_delete_segment(
         res = cur.execute(sql, params)
         # assert that the segment is gone
         assert len(res.fetchall()) == 0
+
+    fts_t = Table("embedding_fulltext_search")
+    q_fts = (
+        _db.querybuilder()
+        .from_(fts_t)
+        .select()
+        .where(
+            fts_t.rowid.isin(
+                _db.querybuilder()
+                .from_(t)
+                .select(t.id)
+                .where(t.segment_id == ParameterValue(_db.uuid_to_db(_id)))
+            )
+        )
+    )
+    sql, params = get_sql(q_fts)
+    with _db.tx() as cur:
+        res = cur.execute(sql, params)
+        # assert that all FTS rows are gone
+        assert len(res.fetchall()) == 0


### PR DESCRIPTION
Without FTS clean-up, the SQLite file grows over time as collections are added and removed:

No clean-up:

![image](https://github.com/chroma-core/chroma/assets/1157440/fdea6f36-8a7f-4d5d-8810-40feea9c7c91)


With clean-up:

![image](https://github.com/chroma-core/chroma/assets/1157440/c1ea757f-3cb7-4eca-a090-ebfe0c45c067)

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Enabled secure-delete option in FTS
         - Removing entries for deleted segments from FTS

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
