### PR TITLE
BUG: Clean the client path of trailing slashes

### DIFF
--- a/clients/js/src/ChromaClient.ts
+++ b/clients/js/src/ChromaClient.ts
@@ -48,8 +48,10 @@ export class ChromaClient {
         this.tenant = tenant;
         this.database = database;
 
+        const basePath = path.replace(/\/+$/, '');
+
         const apiConfig: Configuration = new Configuration({
-            basePath: path,
+            basePath,
         });
 
         if (auth !== undefined) {
@@ -60,7 +62,7 @@ export class ChromaClient {
         }
 
         this._adminClient = new AdminClient({
-            path: path,
+            path: basePath,
             fetchOptions: fetchOptions,
             auth: auth,
             tenant: tenant,


### PR DESCRIPTION
## Description of changes

I fixed the basePath thing.
 - Improvements & Bug fixes
	 - Fixed #1709 

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js

^ OpenAI changed their stuff (unrelated side-note) (tested everything with, works fine)

```
src/embeddings/OpenAIEmbeddingFunction.ts:143:22 - error TS2741: Property 'OpenAI' is missing in type 'typeof OpenAI' but required in type 'typeof import("/home/elal/Projects/almtech/ingenuity/chroma/clients/js/node_modules/.pnpm/openai@4.27.0/node_modules/openai/index")'.
``` 

## Documentation Changes
N/A
