### PR TITLE
[ENH] Upgrade tests and release to Python 3.12

### DIFF
--- a/.github/workflows/chroma-client-integration-test.yml
+++ b/.github/workflows/chroma-client-integration-test.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/chroma-release-python-client.yml
+++ b/.github/workflows/chroma-release-python-client.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install Client Dev Dependencies
       run: python -m pip install -r ./clients/python/requirements.txt && python -m pip install -r ./clients/python/requirements_dev.txt
     - name: Build Client

--- a/.github/workflows/chroma-test.yml
+++ b/.github/workflows/chroma-test.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         platform: [ubuntu-latest, windows-latest]
         testfile: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/auth/test_simple_rbac_authz.py'",
                    "chromadb/test/auth/test_simple_rbac_authz.py",

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -6,8 +6,6 @@ https://packaging.python.org.
 
 ## Setup
 
-Because of the dependencies it relies on (like `pytorch`), this project does not support Python version >3.10.0.
-
 Set up a virtual environment and install the project's requirements
 and dev requirements:
 
@@ -51,14 +49,14 @@ api = chromadb.HttpClient(host="localhost", port="8000")
 print(api.heartbeat())
 ```
 ## Local dev setup for distributed chroma
-We use tilt for providing local dev setup. Tilt is an open source project 
+We use tilt for providing local dev setup. Tilt is an open source project
 ##### Requirement
 - Docker
 - Local Kubernetes cluster (Recommended: [OrbStack](https://orbstack.dev/) for mac, [Kind](https://kind.sigs.k8s.io/) for linux)
 - [Tilt](https://docs.tilt.dev/)
 
 For starting the distributed Chroma in the workspace, use `tilt up`. It will create all the required resources and build the necessary Docker image in the current kubectl context.
-Once done, it will expose Chroma on port 8000. You can also visit the Tilt dashboard UI at http://localhost:10350/. To clean and remove all the resources created by Tilt, use `tilt down`.             
+Once done, it will expose Chroma on port 8000. You can also visit the Tilt dashboard UI at http://localhost:10350/. To clean and remove all the resources created by Tilt, use `tilt down`.
 
 ## Testing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pypika==0.48.9
 PyYAML>=6.0.0
 requests==2.28.1
 tenacity>=8.2.3
-tokenizers==0.13.2
+tokenizers>=0.13.2
 tqdm>=4.65.0
 typer>=0.9.0
 typing_extensions>=4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ opentelemetry-instrumentation-fastapi>=0.41b0
 opentelemetry-sdk>=1.2.0
 overrides==7.3.1
 posthog==2.4.0
-pulsar-client==3.1.0
+pulsar-client>=3.1.0
 pydantic>=1.9
 pypika==0.48.9
 PyYAML>=6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-bcrypt==4.0.1
-chroma-hnswlib==0.7.3
+bcrypt>=4.0.1
+chroma-hnswlib>=0.7.3
 fastapi>=0.95.2
 graphlib_backport==1.0.3; python_version < '3.9'
 grpcio>=1.58.0
@@ -12,17 +12,17 @@ opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.2.0
 opentelemetry-instrumentation-fastapi>=0.41b0
 opentelemetry-sdk>=1.2.0
-overrides==7.3.1
-posthog==2.4.0
+overrides>=7.3.1
+posthog>=2.4.0
 pulsar-client>=3.1.0
 pydantic>=1.9
-pypika==0.48.9
+pypika>=0.48.9
 PyYAML>=6.0.0
-requests==2.28.1
+requests>=2.28.1
 tenacity>=8.2.3
 tokenizers>=0.13.2
 tqdm>=4.65.0
 typer>=0.9.0
 typing_extensions>=4.5.0
-uvicorn[standard]==0.18.3
+uvicorn[standard]>=0.18.3
 orjson>=3.9.12


### PR DESCRIPTION
## Description of changes

Chroma did not support Python 3.12 because of our dependency on the ONNX runtime for our default embedding function. As of version 1.17.0, ONNX supports python 3.12: https://github.com/microsoft/onnxruntime/issues/17842#issuecomment-1936484800

This already automatically fixes the issue for Chroma users when they install the new version of ONNX / reinstall Chroma. This PR is just to update our test and release actions to also use python 3.12. 

## Test plan

These are changes to test workers. 

## Documentation Changes
N/A
