### PR TITLE
[ENH]: make rust docker image build faster with cache

### DIFF
--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /
 RUN git clone https://github.com/chroma-core/hnswlib.git
 
 WORKDIR /chroma/
-COPY . .
 
 ENV PROTOC_ZIP=protoc-25.1-linux-x86_64.zip
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/$PROTOC_ZIP \
@@ -14,7 +13,9 @@ RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1
     && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
     && rm -f $PROTOC_ZIP
 
-RUN cargo build
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/cargo CARGO_TARGET_DIR=/root/.cache/cargo cargo build
 
 WORKDIR /chroma/rust/worker
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Use docker cache for faster tilt restart.

## Test plan
*How are these changes tested?*

- With tilt
