### PR TITLE
[ENH] Remove ONNX Logspam

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -506,11 +506,17 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
             raise ValueError(
                 f"Preferred providers must be subset of available providers: {self.ort.get_available_providers()}"
             )
+
+        # Suppress onnxruntime warnings. This produces logspew, mainly when onnx tries to use CoreML, which doesn't fit this model.
+        so = self.ort.SessionOptions()
+        so.log_severity_level = 3
+
         return self.ort.InferenceSession(
             os.path.join(self.DOWNLOAD_PATH, self.EXTRACTED_FOLDER_NAME, "model.onnx"),
             # Since 1.9 onnyx runtime requires providers to be specified when there are multiple available - https://onnxruntime.ai/docs/api/python/api_summary.html
             # This is probably not ideal but will improve DX as no exceptions will be raised in multi-provider envs
             providers=self._preferred_providers,
+            sess_options=so,
         )
 
     def __call__(self, input: Documents) -> Embeddings:


### PR DESCRIPTION
## Description of changes

After 1.17, ONNXRuntime produces scary warnings on mac platforms, because it tries to put our default embedding function into the CoreML execution environment, where it doesn't fit. 

This PR suppresses warnings from ONNX within the default embedding function so that users don't see scary warnings. 

## Test plan

Locally tested via the `start_here` notebook.

## Documentation Changes
N/A
