### PR TITLE
[PERF]: Minor docker compose quality of life improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ COPY --from=builder /install /usr/local
 COPY ./bin/docker_entrypoint.sh /docker_entrypoint.sh
 COPY ./ /chroma
 
-RUN chmod +x /docker_entrypoint.sh
+RUN apt-get update --fix-missing && apt-get install -y curl && \
+    chmod +x /docker_entrypoint.sh && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV CHROMA_HOST_ADDR "0.0.0.0"
 ENV CHROMA_HOST_PORT 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,15 @@ services:
       - CHROMA_OTEL_SERVICE_NAME=${CHROMA_OTEL_SERVICE_NAME}
       - CHROMA_OTEL_GRANULARITY=${CHROMA_OTEL_GRANULARITY}
       - CHROMA_SERVER_NOFILE=${CHROMA_SERVER_NOFILE}
+    restart: unless-stopped # possible values are: "no", always", "on-failure", "unless-stopped"
     ports:
-      - 8000:8000
+      - "8000:8000"
+    healthcheck:
+      # below test does not require curl or wget to be installed
+      test: [ "CMD", "/bin/bash", "-c", "cat < /dev/null > /dev/tcp/localhost/8000" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     networks:
       - net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     ports:
       - "8000:8000"
     healthcheck:
-      # below test does not require curl or wget to be installed
-      test: [ "CMD", "/bin/bash", "-c", "cat < /dev/null > /dev/tcp/localhost/8000" ]
+      # Adjust below to match your container port
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - added docker compose restart policy - "unless-stopped" as default
	 - added docker compose health checks
	 - added ports in quotes to follow the docker spec

## Test plan
*How are these changes tested?*

Manual tests
```bash
(venv) [chroma-core-taz-sprint-8]docker compose ps
NAME                                IMAGE     COMMAND                  SERVICE   CREATED              STATUS                        PORTS
chroma-core-taz-sprint-8-server-1   server    "/docker_entrypoint.…"   server    About a minute ago   Up About a minute (healthy)   0.0.0.0:8000->8000/tcp
(venv) [chroma-core-taz-sprint-8]       


(venv) [chroma-core-taz-sprint-8]docker exec chroma-core-taz-sprint-8-server-1 /bin/bash -c "kill 1"
(venv) [chroma-core-taz-sprint-8]docker compose ps
NAME                                IMAGE     COMMAND                  SERVICE   CREATED          STATUS                            PORTS
chroma-core-taz-sprint-8-server-1   server    "/docker_entrypoint.…"   server    25 minutes ago   Up 3 seconds (health: starting)   0.0.0.0:8000->8000/tcp
```
## Documentation Changes
N/A
