### PR TITLE
[BUG]: WAL replay warnings suppression

### DIFF
--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -289,7 +289,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             .where(t.seq_id > ParameterValue(subscription.start))
             .where(t.seq_id <= ParameterValue(subscription.end))
             .select(
-                t.seq_id, t.operation, t.id, t.vector, t.encoding, t.metadata, t.topic
+                t.seq_id, t.operation, t.id, t.vector, t.encoding, t.metadata
             )
             .orderby(t.seq_id)
         )

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -288,7 +288,9 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             .where(t.topic == ParameterValue(subscription.topic_name))
             .where(t.seq_id > ParameterValue(subscription.start))
             .where(t.seq_id <= ParameterValue(subscription.end))
-            .select(t.seq_id, t.operation, t.id, t.vector, t.encoding, t.metadata)
+            .select(
+                t.seq_id, t.operation, t.id, t.vector, t.encoding, t.metadata, t.topic
+            )
             .orderby(t.seq_id)
         )
         with self.tx() as cur:
@@ -312,6 +314,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
                             embedding=vector,
                             encoding=encoding,
                             metadata=json.loads(row[5]) if row[5] else None,
+                            wal_replay=True,
                         )
                     ],
                 )

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -106,6 +106,7 @@ class EmbeddingRecord(TypedDict):
     # single node, since data written with older versions of the code won't be able to
     # populate it.
     collection_id: Optional[UUID]
+    wal_replay: Optional[bool]
 
 
 class SubmitEmbeddingRecord(TypedDict):


### PR DESCRIPTION
Refs:  #1733

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Added a `EmbeddingRecord` flag (`wal_replay`) to suppress warnings in sqlite and local hnsw indices

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
N/A

Colab to reproduce the issue in 0.4.23 (and prior) - https://colab.research.google.com/drive/1CtN0qGoMZoVfwQBnJE1MloLvvdv5KouE?usp=sharing


<img width="1261" alt="Screenshot 2024-03-02 at 21 08 12" src="https://github.com/chroma-core/chroma/assets/1157440/4c67b51f-8546-4d33-b508-a3fa4c254001">

