### PR TITLE
[CLN] Fix CI and a couple other cleanups

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -67,7 +67,7 @@ k8s_resource('pulsar', resource_deps=['k8s_setup'], labels=["infrastructure"], p
 k8s_resource('migration', resource_deps=['postgres'], labels=["chroma"])
 k8s_resource('logservice', resource_deps=['migration'], labels=["chroma"])
 k8s_resource('frontend-server', resource_deps=['pulsar'],labels=["chroma"], port_forwards=8000 )
-k8s_resource('coordinator', resource_deps=['pulsar'], labels=["chroma"], port_forwards=50051)
+k8s_resource('coordinator', resource_deps=['pulsar', 'frontend-server'], labels=["chroma"], port_forwards=50051)
 k8s_resource('worker', resource_deps=['coordinator'],labels=["chroma"])
 
 # Extra stuff to make debugging and testing easier

--- a/Tiltfile
+++ b/Tiltfile
@@ -64,10 +64,10 @@ k8s_resource(
 # Production Chroma
 k8s_resource('postgres', resource_deps=['k8s_setup'], labels=["infrastructure"])
 k8s_resource('pulsar', resource_deps=['k8s_setup'], labels=["infrastructure"], port_forwards=['6650:6650', '8080:8080'])
-k8s_resource('migration', resource_deps=['postgres'], labels=["chroma"])
+k8s_resource('migration', resource_deps=['postgres'], labels=["infrastructure"])
 k8s_resource('logservice', resource_deps=['migration'], labels=["chroma"])
 k8s_resource('frontend-server', resource_deps=['pulsar'],labels=["chroma"], port_forwards=8000 )
-k8s_resource('coordinator', resource_deps=['pulsar', 'frontend-server'], labels=["chroma"], port_forwards=50051)
+k8s_resource('coordinator', resource_deps=['pulsar', 'frontend-server', 'migration'], labels=["chroma"], port_forwards=50051)
 k8s_resource('worker', resource_deps=['coordinator'],labels=["chroma"])
 
 # Extra stuff to make debugging and testing easier

--- a/bin/cluster-test.sh
+++ b/bin/cluster-test.sh
@@ -6,9 +6,6 @@ export CHROMA_CLUSTER_TEST_ONLY=1
 export CHROMA_SERVER_HOST=localhost:8000
 export PULSAR_BROKER_URL=localhost
 export CHROMA_COORDINATOR_HOST=localhost
-export CHROMA_SERVER_GRPC_PORT="50051"
-
-
 
 echo "Chroma Server is running at port $CHROMA_SERVER_HOST"
 echo "Pulsar Broker is running at port $PULSAR_BROKER_URL"

--- a/bin/cluster-test.sh
+++ b/bin/cluster-test.sh
@@ -11,9 +11,9 @@ echo "Chroma Server is running at port $CHROMA_SERVER_HOST"
 echo "Pulsar Broker is running at port $PULSAR_BROKER_URL"
 echo "Chroma Coordinator is running at port $CHROMA_COORDINATOR_HOST"
 
-kubectl -n chroma port-forward svc/coordinator 50051:50051 &
-kubectl -n chroma port-forward svc/pulsar 6650:6650 &
-kubectl -n chroma port-forward svc/pulsar 8080:8080 &
+kubectl -n chroma port-forward svc/coordinator-lb 50051:50051 &
+kubectl -n chroma port-forward svc/pulsar-lb 6650:6650 &
+kubectl -n chroma port-forward svc/pulsar-lb 8080:8080 &
 kubectl -n chroma port-forward svc/frontend-server 8000:8000 &
 
 "$@"

--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -127,6 +127,7 @@ def grpc_with_real_server() -> Generator[SysDB, None, None]:
         Settings(
             allow_reset=True,
             chroma_collection_assignment_policy_impl="chromadb.test.db.test_system.MockAssignmentPolicy",
+            chroma_server_grpc_port=50051,
         )
     )
     client = system.instance(GrpcSysDB)

--- a/k8s/distributed-chroma/templates/coordinator.yaml
+++ b/k8s/distributed-chroma/templates/coordinator.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   ports:
     - name: grpc
-      port: {{ .Values.coordinator.port }}
+      port: 50001
       targetPort: grpc
   selector:
     app: coordinator

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -4,4 +4,3 @@ namespace: "chroma"
 
 coordinator:
   replicaCount: 1
-  port: 50051


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - `port-forward` to `-lb` services correctly. This fixes the hanging CI.
	 - Remove unused var in cluster-test.sh.
	 - Remove `coordinator.port` helm chart config for consistency -- we can add them all later.
	 - Fix tiltfile deps so the cluster comes up correctly.
	 - Explicitly pass coordinator port to sysdb client instantiation in tests.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
