### PR TITLE
[CHORE] added support for together ai embeddings endpoint 

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -60,8 +60,9 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
         self,
         api_key: str,
         model_name: str = "togethercomputer/m2-bert-80M-8k-retrieval",
+        api_url = "https://api.together.xyz/v1/embeddings"
     ):
-        self._api_url = "https://api.together.xyz/v1/embeddings"
+        self._api_url = api_url
         self._model_name = model_name
         self._session = requests.Session()
         self._session.headers.update({
@@ -84,6 +85,8 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 response_data = response.json()
                 embedding = response_data.get("data", [])[0].get("embedding", [])
                 embeddings.append(embedding)
+            else:
+                raise ValueError(f"The API request to Together AI Endpoint failed with the status code : {response.status_code}. Refer https://docs.together.ai/reference/embeddings more details")
 
         return embeddings
 

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -55,6 +55,8 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
     # https://docs.together.ai/docs/embeddings-rest
     # Models List
     # https://docs.together.ai/docs/embedding-models
+    # You can get your API Keys from here :
+    # https://api.together.xyz/settings/api-keys
     
     def __init__(
         self,


### PR DESCRIPTION
## Description of changes
Added support for together ai embeddings endpoint which was not present in chromadb
Ref : https://docs.together.ai/docs/embeddings-rest

 - New functionality
	 - together ai embedding endpoint support

## Test plan
*How are these changes tested?*
The change cannot be tested automatically since it requires API keys but I have tried importing them and running it locally on my machine with my API key.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
There is a high possibility that i did not update things properly so please review the doc : https://github.com/chroma-core/docs/pull/223