### PR TITLE
[BLD] Remove hosted chroma workflow dispatches

### DIFF
--- a/.github/workflows/chroma-release.yml
+++ b/.github/workflows/chroma-release.yml
@@ -141,39 +141,3 @@ jobs:
         artifacts: "dist/chroma-${{steps.version.outputs.version}}.tar.gz"
         allowUpdates: true
         prerelease: true
-    - name: Trigger Hosted Chroma FE Release
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
-        script: |
-          const result = await github.rest.actions.createWorkflowDispatch({
-            owner: 'chroma-core',
-            repo: 'hosted-chroma',
-            workflow_id: 'build-and-publish-frontend.yaml',
-            ref: 'main'
-          })
-          console.log(result)
-    - name: Trigger Hosted Chroma Coordinator Release
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
-        script: |
-          const result = await github.rest.actions.createWorkflowDispatch({
-            owner: 'chroma-core',
-            repo: 'hosted-chroma',
-            workflow_id: 'build-and-deploy-coordinator.yaml',
-            ref: 'main'
-          })
-          console.log(result)
-    - name: Trigger Hosted Worker Release
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
-        script: |
-          const result = await github.rest.actions.createWorkflowDispatch({
-            owner: 'chroma-core',
-            repo: 'hosted-chroma',
-            workflow_id: 'build-and-deploy-worker.yaml',
-            ref: 'main'
-          })
-          console.log(result)


### PR DESCRIPTION
Will be put back once hosted-chroma k8s is in its proper state -- this is a temporary measure to keep OSS CI green
