### PR TITLE
[ENH] Add Segment Interfaces

### DIFF
--- a/rust/worker/src/segment/mod.rs
+++ b/rust/worker/src/segment/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod config;
 mod distributed_hnsw_segment;
 mod segment_ingestor;
 mod segment_manager;
+mod types;
 
 pub(crate) use segment_ingestor::*;
 pub(crate) use segment_manager::*;

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -7,6 +7,6 @@ trait SegmentImpl {
     fn rollback_transaction(&self);
 }
 
-trait OffsetIdAssigner {
+trait OffsetIdAssigner: SegmentImpl {
     fn assign_offset_ids(&self, records: Vec<Box<EmbeddingRecord>>) -> Vec<u32>;
 }

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -1,6 +1,6 @@
 use crate::types::EmbeddingRecord;
 
-trait Segment {
+trait SegmentImpl {
     fn begin_transaction(&self);
     fn write_records(&self, records: Vec<Box<EmbeddingRecord>>, offset_ids: Vec<u32>);
     fn commit_transaction(&self);

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -1,12 +1,12 @@
 use crate::types::EmbeddingRecord;
 
-trait SegmentImpl {
+trait SegmentWriter {
     fn begin_transaction(&self);
     fn write_records(&self, records: Vec<Box<EmbeddingRecord>>, offset_ids: Vec<u32>);
     fn commit_transaction(&self);
     fn rollback_transaction(&self);
 }
 
-trait OffsetIdAssigner: SegmentImpl {
+trait OffsetIdAssigner: SegmentWriter {
     fn assign_offset_ids(&self, records: Vec<Box<EmbeddingRecord>>) -> Vec<u32>;
 }

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -1,0 +1,12 @@
+use crate::types::EmbeddingRecord;
+
+trait Segment {
+    fn begin_transaction(&self);
+    fn write_records(&self, records: Vec<Box<EmbeddingRecord>>, offset_ids: Vec<u32>);
+    fn commit_transaction(&self);
+    fn rollback_transaction(&self);
+}
+
+trait OffsetIdAssigner {
+    fn assign_offset_ids(&self, records: Vec<Box<EmbeddingRecord>>) -> Vec<u32>;
+}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds an interface type for segments. We can add flush etc here in the future. I will move hnsw to use this in a stacked PR.
 - New functionality
	 - None.

## Test plan
*How are these changes tested?*
No logical changes. These are just interfaces.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
