### PR TITLE
[ENH] Add uint blockfile key/val

### DIFF
--- a/rust/worker/src/blockstore/arrow_blockfile/block/iterator.rs
+++ b/rust/worker/src/blockstore/arrow_blockfile/block/iterator.rs
@@ -1,6 +1,6 @@
 use super::types::Block;
 use crate::blockstore::types::{BlockfileKey, Key, KeyType, Value, ValueType};
-use arrow::array::{Array, BooleanArray, Int32Array, ListArray, StringArray};
+use arrow::array::{Array, BooleanArray, Int32Array, ListArray, StringArray, UInt32Array};
 
 /// An iterator over the contents of a block.
 /// This is a simple wrapper around the Arrow array data that is stored in the block.
@@ -75,6 +75,10 @@ impl Iterator for BlockIterator {
             },
             KeyType::Bool => match key.as_any().downcast_ref::<BooleanArray>() {
                 Some(key) => Key::Bool(key.value(self.index)),
+                None => return None,
+            },
+            KeyType::Uint => match key.as_any().downcast_ref::<UInt32Array>() {
+                Some(key) => Key::Uint(key.value(self.index) as u32),
                 None => return None,
             },
         };

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -86,7 +86,7 @@ impl FullTextIndex for BlockfileFullTextIndex {
         for (key, value) in self.uncommitted_frequencies.drain() {
             let blockfilekey = BlockfileKey::new("".to_string(), Key::String(key.to_string()));
             self.frequencies_blockfile
-                .set(blockfilekey, Value::Int32Value(value));
+                .set(blockfilekey, Value::IntValue(value));
         }
         self.posting_lists_blockfile.commit_transaction()?;
         self.frequencies_blockfile.commit_transaction()?;
@@ -135,7 +135,7 @@ impl FullTextIndex for BlockfileFullTextIndex {
                 BlockfileKey::new("".to_string(), Key::String(token.text.to_string()));
             let value = self.frequencies_blockfile.get(blockfilekey);
             match value {
-                Ok(Value::Int32Value(frequency)) => {
+                Ok(Value::IntValue(frequency)) => {
                     token_frequencies.push((token.text.to_string(), frequency));
                 }
                 Ok(_) => {
@@ -230,7 +230,7 @@ mod tests {
             .create("pl", KeyType::String, ValueType::PositionalPostingList)
             .unwrap();
         let freq_blockfile = provider
-            .create("freq", KeyType::String, ValueType::Int32)
+            .create("freq", KeyType::String, ValueType::Int)
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
             NgramTokenizer::new(1, 1, false).unwrap(),
@@ -245,7 +245,7 @@ mod tests {
             .create("pl", KeyType::String, ValueType::PositionalPostingList)
             .unwrap();
         let freq_blockfile = provider
-            .create("freq", KeyType::String, ValueType::Int32)
+            .create("freq", KeyType::String, ValueType::Int)
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
             NgramTokenizer::new(1, 1, false).unwrap(),
@@ -266,7 +266,7 @@ mod tests {
             .create("pl", KeyType::String, ValueType::PositionalPostingList)
             .unwrap();
         let freq_blockfile = provider
-            .create("freq", KeyType::String, ValueType::Int32)
+            .create("freq", KeyType::String, ValueType::Int)
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
             NgramTokenizer::new(1, 1, false).unwrap(),
@@ -287,7 +287,7 @@ mod tests {
             .create("pl", KeyType::String, ValueType::PositionalPostingList)
             .unwrap();
         let freq_blockfile = provider
-            .create("freq", KeyType::String, ValueType::Int32)
+            .create("freq", KeyType::String, ValueType::Int)
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
             NgramTokenizer::new(1, 1, false).unwrap(),
@@ -318,7 +318,7 @@ mod tests {
             .create("pl", KeyType::String, ValueType::PositionalPostingList)
             .unwrap();
         let freq_blockfile = provider
-            .create("freq", KeyType::String, ValueType::Int32)
+            .create("freq", KeyType::String, ValueType::Int)
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
             NgramTokenizer::new(1, 1, false).unwrap(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Lets the blockfile use uint vals and keys.
	 - Some name cleanup / unification
 - New functionality
	 - /

## Test plan
*How are these changes tested?*
Basic sanity tests.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None