### PR TITLE
[BLD] Add docker arg to build in release mode

### DIFF
--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.74.1 as builder
 ARG CHROMA_KUBERNETES_INTEGRATION=0
+ARG RELEASE_MODE=0
 ENV CHROMA_KUBERNETES_INTEGRATION $CHROMA_KUBERNETES_INTEGRATION
 
 WORKDIR /
@@ -15,7 +16,8 @@ RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/cargo CARGO_TARGET_DIR=/root/.cache/cargo cargo build
+ENV CARGO_TARGET_DIR=/root/.cache/cargo
+RUN --mount=type=cache,target=/root/.cache/cargo if [ "$RELEASE_MODE" = "1" ]; then cargo build --release; else cargo build; fi
 
 WORKDIR /chroma/rust/worker
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds the ability to build dockerfile for rust worker in release mdoe
 - New functionality
	 - /

## Test plan
*How are these changes tested?*
I manually modified the arg and made sure the expected control flow was followed.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None required.
