### PR TITLE
[ENH] Run the sysdb migration in sh so we can do env var substitition

### DIFF
--- a/go/Dockerfile.migration
+++ b/go/Dockerfile.migration
@@ -1,4 +1,9 @@
-FROM arigaio/atlas:latest
-workdir /app
+FROM debian:bookworm-slim
+
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y curl
+RUN curl -sSf https://atlasgo.sh | sh -s -- --community
+
 COPY ./go/migrations migrations
 COPY ./go/atlas.hcl atlas.hcl

--- a/k8s/distributed-chroma/templates/sysdb-migration.yaml
+++ b/k8s/distributed-chroma/templates/sysdb-migration.yaml
@@ -11,11 +11,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
-        - args:
-            - 'migrate'
-            - 'apply'
-            - '--url'
-            - "postgres://{{ .Values.sysdbMigration.username }}:{{ .Values.sysdbMigration.password }}@{{ .Values.sysdbMigration.netloc }}:{{ .Values.sysdbMigration.port }}/{{ .Values.sysdbMigration.dbName }}?sslmode={{ .Values.sysdbMigration.sslmode }}"
+        - command:
+            - "/bin/sh"
+            - "-c"
+            - "atlas migrate apply --url postgres://{{ .Values.sysdbMigration.username }}:{{ .Values.sysdbMigration.password }}@{{ .Values.sysdbMigration.netloc }}:{{ .Values.sysdbMigration.port }}/{{ .Values.sysdbMigration.dbName }}?sslmode={{ .Values.sysdbMigration.sslmode }}"
           image: "{{ .Values.sysdbMigration.image.repository }}:{{ .Values.sysdbMigration.image.tag }}"
           imagePullPolicy: IfNotPresent
           name: migration


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Run the SysDB migration in `/bin/sh` so we can sub in env vars as needed. This requires installing atlas into a debian image instead of using the atlas image directly.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
