### PR TITLE
[BUG] Provide azure_deployment to AzureOpenAI embedding function

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -168,6 +168,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                     api_key=api_key,
                     api_version=api_version,
                     azure_endpoint=api_base,
+                    azure_deployment=deployment_id,
                     default_headers=default_headers,
                 ).embeddings
             else:


### PR DESCRIPTION
## Description of changes  
  
*Summarize the changes made by this PR.*  
 - Improvements & Bug fixes  
    - Pass in `azure_deployment` parameter to `AzureOpenAI` embedding function (Issue [#1770](https://github.com/chroma-core/chroma/issues/1770)) 
  
## Test plan  
*How are these changes tested?*  
  
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust  
	 
## Documentation Changes  
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
