### PR TITLE
[BUG] install jq in migration, not sysdb

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" make
 
 FROM alpine:3.17.3
 
-RUN apk add --no-cache bash bash-completion jq findutils
+RUN apk add --no-cache bash bash-completion findutils
 
 # As of 6 Dec 2023, the atlas package isn't in Alpine's main package manager, only
 # testing. So we have to add the testing repository to get it.

--- a/go/Dockerfile.migration
+++ b/go/Dockerfile.migration
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 
 RUN apt update
 RUN apt upgrade -y
-RUN apt install -y curl
+RUN apt install -y curl jq
 RUN curl -sSf https://atlasgo.sh | sh -s -- --community
 
 COPY ./go/migrations migrations


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - We use jq for some env var stuff. We need it in the migration, not the sysdb service (which knows how to correctly URL-escape args)

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
