### PR TITLE
[ENH] Add query-service server

### DIFF
--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "worker"
-path = "src/bin/worker.rs"
+name = "query_service"
+path = "src/bin/query_service.rs"
 
 [dependencies]
 tonic = "0.10"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -33,3 +33,7 @@ worker:
         Grpc:
             host: "logservice.chroma"
             port: 50052
+    dispatcher:
+        num_worker_threads: 4
+        dispatcher_queue_size: 100
+        worker_queue_size: 100

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -1,0 +1,6 @@
+use worker::query_service_entrypoint;
+
+#[tokio::main]
+async fn main() {
+    query_service_entrypoint().await;
+}

--- a/rust/worker/src/bin/worker.rs
+++ b/rust/worker/src/bin/worker.rs
@@ -1,6 +1,0 @@
-use worker::worker_entrypoint;
-
-#[tokio::main]
-async fn main() {
-    worker_entrypoint().await;
-}

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -110,6 +110,7 @@ pub(crate) struct WorkerConfig {
     pub(crate) segment_manager: crate::segment::config::SegmentManagerConfig,
     pub(crate) storage: crate::storage::config::StorageConfig,
     pub(crate) log: crate::log::config::LogConfig,
+    pub(crate) dispatcher: crate::execution::config::DispatcherConfig,
 }
 
 /// # Description
@@ -165,6 +166,10 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50052
+                    dispatcher:
+                        num_worker_threads: 4
+                        dispatcher_queue_size: 100
+                        worker_queue_size: 100
                 "#,
             );
             let config = RootConfig::load();
@@ -213,6 +218,10 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50052
+                    dispatcher:
+                        num_worker_threads: 4
+                        dispatcher_queue_size: 100
+                        worker_queue_size: 100
 
                 "#,
             );
@@ -277,6 +286,10 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50052
+                    dispatcher:
+                        num_worker_threads: 4
+                        dispatcher_queue_size: 100
+                        worker_queue_size: 100
                 "#,
             );
             let config = RootConfig::load();
@@ -321,6 +334,10 @@ mod tests {
                         Grpc:
                             host: "localhost"
                             port: 50052
+                    dispatcher:
+                        num_worker_threads: 4
+                        dispatcher_queue_size: 100
+                        worker_queue_size: 100
                 "#,
             );
             let config = RootConfig::load();

--- a/rust/worker/src/errors.rs
+++ b/rust/worker/src/errors.rs
@@ -42,6 +42,6 @@ pub(crate) enum ErrorCodes {
     DataLoss = 15,
 }
 
-pub(crate) trait ChromaError: Error {
+pub(crate) trait ChromaError: Error + Send {
     fn code(&self) -> ErrorCodes;
 }

--- a/rust/worker/src/execution/config.rs
+++ b/rust/worker/src/execution/config.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(crate) struct DispatcherConfig {
+    pub(crate) num_worker_threads: usize,
+    pub(crate) dispatcher_queue_size: usize,
+    pub(crate) worker_queue_size: usize,
+}

--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -46,7 +46,7 @@ use std::fmt::Debug;
   coarser work-stealing, and other optimizations.
 */
 #[derive(Debug)]
-struct Dispatcher {
+pub(crate) struct Dispatcher {
     task_queue: Vec<TaskMessage>,
     waiters: Vec<TaskRequestMessage>,
     n_worker_threads: usize,

--- a/rust/worker/src/execution/mod.rs
+++ b/rust/worker/src/execution/mod.rs
@@ -1,5 +1,5 @@
-mod dispatcher;
-mod operator;
+pub(crate) mod dispatcher;
+pub(crate) mod operator;
 mod operators;
-mod orchestration;
+pub(crate) mod orchestration;
 mod worker_thread;

--- a/rust/worker/src/execution/mod.rs
+++ b/rust/worker/src/execution/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod config;
 pub(crate) mod dispatcher;
 pub(crate) mod operator;
 mod operators;

--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -27,12 +27,12 @@ where
 }
 
 /// A message type used by the dispatcher to send tasks to worker threads.
-pub(super) type TaskMessage = Box<dyn TaskWrapper>;
+pub(crate) type TaskMessage = Box<dyn TaskWrapper>;
 
 /// A task wrapper is a trait that can be used to run a task. We use it to
 /// erase the I, O types from the Task struct so that tasks.
 #[async_trait]
-pub(super) trait TaskWrapper: Send + Debug {
+pub(crate) trait TaskWrapper: Send + Debug {
     async fn run(&self);
 }
 

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -35,7 +35,7 @@ enum ExecutionState {
 }
 
 #[derive(Debug)]
-struct HnswQueryOrchestrator {
+pub(crate) struct HnswQueryOrchestrator {
     state: ExecutionState,
     // Query state
     query_vectors: Vec<Vec<f32>>,
@@ -49,7 +49,7 @@ struct HnswQueryOrchestrator {
 }
 
 impl HnswQueryOrchestrator {
-    pub fn new(
+    pub(crate) fn new(
         query_vectors: Vec<Vec<f32>>,
         k: i32,
         include_embeddings: bool,

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -156,6 +156,14 @@ impl Handler<PullLogsOutput> for HnswQueryOrchestrator {
         ctx: &crate::system::ComponentContext<HnswQueryOrchestrator>,
     ) {
         self.state = ExecutionState::Dedupe;
+        match self.result_channel.take() {
+            Some(tx) => {
+                let _ = tx.send("done".to_string());
+            }
+            None => {
+                // Log an error
+            }
+        }
         // TODO: implement the remaining state transitions and operators
         // The query orchestrator kills itself in the last state
     }

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,1 +1,3 @@
 mod hnsw;
+
+pub(crate) use hnsw::*;

--- a/rust/worker/src/execution/worker_thread.rs
+++ b/rust/worker/src/execution/worker_thread.rs
@@ -9,11 +9,18 @@ use std::fmt::{Debug, Formatter, Result};
 /// - The actor loop will block until work is available
 pub(super) struct WorkerThread {
     dispatcher: Box<dyn Receiver<TaskRequestMessage>>,
+    queue_size: usize,
 }
 
 impl WorkerThread {
-    pub(super) fn new(dispatcher: Box<dyn Receiver<TaskRequestMessage>>) -> Self {
-        WorkerThread { dispatcher }
+    pub(super) fn new(
+        dispatcher: Box<dyn Receiver<TaskRequestMessage>>,
+        queue_size: usize,
+    ) -> WorkerThread {
+        WorkerThread {
+            dispatcher,
+            queue_size,
+        }
     }
 }
 
@@ -26,7 +33,7 @@ impl Debug for WorkerThread {
 #[async_trait]
 impl Component for WorkerThread {
     fn queue_size(&self) -> usize {
-        1000 // TODO: make configurable
+        self.queue_size
     }
 
     fn runtime() -> ComponentRuntime {

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -15,13 +15,47 @@ mod sysdb;
 mod system;
 mod types;
 
+use crate::sysdb::sysdb::SysDb;
 use config::Configurable;
 use memberlist::MemberlistProvider;
 
-use crate::sysdb::sysdb::SysDb;
-
 mod chroma_proto {
     tonic::include_proto!("chroma");
+}
+
+pub async fn query_service_entrypoint() {
+    let config = config::RootConfig::load();
+
+    let segment_manager = match segment::SegmentManager::try_from_config(&config.worker).await {
+        Ok(segment_manager) => segment_manager,
+        Err(err) => {
+            println!("Failed to create segment manager component: {:?}", err);
+            return;
+        }
+    };
+
+    let mut system: system::System = system::System::new();
+
+    // TODO: configurable
+    let dispatcher =
+        execution::dispatcher::Dispatcher::new(config.worker.num_indexing_threads as usize);
+    let mut dispatcher_handle = system.start_component(dispatcher);
+
+    let mut worker_server = match server::WorkerServer::try_from_config(&config.worker).await {
+        Ok(worker_server) => worker_server,
+        Err(err) => {
+            println!("Failed to create worker server component: {:?}", err);
+            return;
+        }
+    };
+    worker_server.set_segment_manager(segment_manager.clone());
+    worker_server.set_dispatcher(dispatcher_handle.receiver());
+
+    let server_join_handle = tokio::spawn(async move {
+        crate::server::WorkerServer::run(worker_server).await;
+    });
+
+    let _ = tokio::join!(server_join_handle, dispatcher_handle.join());
 }
 
 pub async fn worker_entrypoint() {
@@ -103,5 +137,6 @@ pub async fn worker_entrypoint() {
         ingest_handle.join(),
         memberlist_handle.join(),
         scheduler_handler.join(),
+        server_join_handle,
     );
 }

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -34,7 +34,7 @@ pub async fn query_service_entrypoint() {
         }
     };
 
-    let mut system: system::System = system::System::new();
+    let system: system::System = system::System::new();
 
     // TODO: configurable
     let dispatcher =

--- a/rust/worker/src/log/mod.rs
+++ b/rust/worker/src/log/mod.rs
@@ -1,2 +1,17 @@
 pub(crate) mod config;
 pub(crate) mod log;
+
+use crate::{
+    config::{Configurable, WorkerConfig},
+    errors::ChromaError,
+};
+
+pub(crate) async fn from_config(
+    config: &WorkerConfig,
+) -> Result<Box<dyn log::Log>, Box<dyn ChromaError>> {
+    match &config.log {
+        crate::log::config::LogConfig::Grpc(_) => {
+            Ok(Box::new(log::GrpcLog::try_from_config(config).await?))
+        }
+    }
+}

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -178,23 +178,19 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
             }
         };
 
-        let orchestrator = HnswQueryOrchestrator::new(
-            query_vectors,
-            request.k,
-            request.include_embeddings,
-            segment_uuid,
-            self.log.clone(),
-            self.sysdb.clone(),
-            dispatcher.clone(),
-        );
-
         match self.system {
             Some(ref system) => {
-                let handle = system.start_component(orchestrator);
-                // TODO:
-                // - await for reply here
-                // - cancel orchestrator
-                // - return results
+                let orchestrator = HnswQueryOrchestrator::new(
+                    system.clone(),
+                    query_vectors,
+                    request.k,
+                    request.include_embeddings,
+                    segment_uuid,
+                    self.log.clone(),
+                    self.sysdb.clone(),
+                    dispatcher.clone(),
+                );
+                let result: String = orchestrator.run().await;
             }
             None => {
                 return Err(Status::internal("No system found"));

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -1,28 +1,53 @@
-use std::f32::consts::E;
-
 use crate::chroma_proto;
 use crate::chroma_proto::{
     GetVectorsRequest, GetVectorsResponse, QueryVectorsRequest, QueryVectorsResponse,
 };
 use crate::config::{Configurable, WorkerConfig};
 use crate::errors::ChromaError;
+use crate::execution::operator::TaskMessage;
+use crate::execution::orchestration::HnswQueryOrchestrator;
+use crate::log::log::Log;
 use crate::segment::SegmentManager;
+use crate::sysdb::sysdb::SysDb;
+use crate::system::{Receiver, System};
 use crate::types::ScalarEncoding;
 use async_trait::async_trait;
-use kube::core::request;
 use tonic::{transport::Server, Request, Response, Status};
 use uuid::Uuid;
 
 pub struct WorkerServer {
+    // System
+    system: Option<System>,
+    // Component dependencies
     segment_manager: Option<SegmentManager>,
+    dispatcher: Option<Box<dyn Receiver<TaskMessage>>>,
+    // Service dependencies
+    log: Box<dyn Log>,
+    sysdb: Box<dyn SysDb>,
     port: u16,
 }
 
 #[async_trait]
 impl Configurable for WorkerServer {
     async fn try_from_config(config: &WorkerConfig) -> Result<Self, Box<dyn ChromaError>> {
+        let sysdb = match crate::sysdb::from_config(&config).await {
+            Ok(sysdb) => sysdb,
+            Err(err) => {
+                return Err(err);
+            }
+        };
+        let log = match crate::log::from_config(&config).await {
+            Ok(log) => log,
+            Err(err) => {
+                return Err(err);
+            }
+        };
         Ok(WorkerServer {
             segment_manager: None,
+            dispatcher: None,
+            system: None,
+            sysdb,
+            log,
             port: config.my_port,
         })
     }
@@ -45,6 +70,14 @@ impl WorkerServer {
 
     pub(crate) fn set_segment_manager(&mut self, segment_manager: SegmentManager) {
         self.segment_manager = Some(segment_manager);
+    }
+
+    pub(crate) fn set_dispatcher(&mut self, dispatcher: Box<dyn Receiver<TaskMessage>>) {
+        self.dispatcher = Some(dispatcher);
+    }
+
+    pub(crate) fn set_system(&mut self, system: System) {
+        self.system = Some(system);
     }
 }
 
@@ -126,6 +159,8 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
         };
 
         let mut proto_results_for_all = Vec::new();
+
+        let mut query_vectors = Vec::new();
         for proto_query_vector in request.vectors {
             let (query_vector, encoding) = match proto_query_vector.try_into() {
                 Ok((vector, encoding)) => (vector, encoding),
@@ -133,51 +168,91 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
                     return Err(Status::internal(format!("Error converting vector: {}", e)));
                 }
             };
-
-            let results = match segment_manager
-                .query_vector(
-                    &segment_uuid,
-                    &query_vector,
-                    request.k as usize,
-                    request.include_embeddings,
-                )
-                .await
-            {
-                Ok(results) => results,
-                Err(e) => {
-                    return Err(Status::internal(format!("Error querying segment: {}", e)));
-                }
-            };
-
-            let mut proto_results = Vec::new();
-            for query_result in results {
-                let proto_result = chroma_proto::VectorQueryResult {
-                    id: query_result.id,
-                    seq_id: query_result.seq_id.to_bytes_le().1,
-                    distance: query_result.distance,
-                    vector: match query_result.vector {
-                        Some(vector) => {
-                            match (vector, ScalarEncoding::FLOAT32, query_vector.len()).try_into() {
-                                Ok(proto_vector) => Some(proto_vector),
-                                Err(e) => {
-                                    return Err(Status::internal(format!(
-                                        "Error converting vector: {}",
-                                        e
-                                    )));
-                                }
-                            }
-                        }
-                        None => None,
-                    },
-                };
-                proto_results.push(proto_result);
-            }
-
-            let vector_query_results = chroma_proto::VectorQueryResults {
-                results: proto_results,
-            };
-            proto_results_for_all.push(vector_query_results);
+            query_vectors.push(query_vector);
         }
+
+        let dispatcher = match self.dispatcher {
+            Some(ref dispatcher) => dispatcher,
+            None => {
+                return Err(Status::internal("No dispatcher found"));
+            }
+        };
+
+        let orchestrator = HnswQueryOrchestrator::new(
+            query_vectors,
+            request.k,
+            request.include_embeddings,
+            segment_uuid,
+            self.log.clone(),
+            self.sysdb.clone(),
+            dispatcher.clone(),
+        );
+
+        match self.system {
+            Some(ref system) => {
+                let handle = system.start_component(orchestrator);
+                // TODO:
+                // - await for reply here
+                // - cancel orchestrator
+                // - return results
+            }
+            None => {
+                return Err(Status::internal("No system found"));
+            }
+        }
+
+        // for proto_query_vector in request.vectors {
+        //     let (query_vector, encoding) = match proto_query_vector.try_into() {
+        //         Ok((vector, encoding)) => (vector, encoding),
+        //         Err(e) => {
+        //             return Err(Status::internal(format!("Error converting vector: {}", e)));
+        //         }
+        //     };
+
+        //     let results = match segment_manager
+        //         .query_vector(
+        //             &segment_uuid,
+        //             &query_vector,
+        //             request.k as usize,
+        //             request.include_embeddings,
+        //         )
+        //         .await
+        //     {
+        //         Ok(results) => results,
+        //         Err(e) => {
+        //             return Err(Status::internal(format!("Error querying segment: {}", e)));
+        //         }
+        //     };
+
+        //     let mut proto_results = Vec::new();
+        //     for query_result in results {
+        //         let proto_result = chroma_proto::VectorQueryResult {
+        //             id: query_result.id,
+        //             seq_id: query_result.seq_id.to_bytes_le().1,
+        //             distance: query_result.distance,
+        //             vector: match query_result.vector {
+        //                 Some(vector) => {
+        //                     match (vector, ScalarEncoding::FLOAT32, query_vector.len()).try_into() {
+        //                         Ok(proto_vector) => Some(proto_vector),
+        //                         Err(e) => {
+        //                             return Err(Status::internal(format!(
+        //                                 "Error converting vector: {}",
+        //                                 e
+        //                             )));
+        //                         }
+        //                     }
+        //                 }
+        //                 None => None,
+        //             },
+        //         };
+        //         proto_results.push(proto_result);
+        //     }
+
+        //     let vector_query_results = chroma_proto::VectorQueryResults {
+        //         results: proto_results,
+        //     };
+        //     proto_results_for_all.push(vector_query_results);
+        // }
 
         let resp = chroma_proto::QueryVectorsResponse {
             results: proto_results_for_all,

--- a/rust/worker/src/sysdb/mod.rs
+++ b/rust/worker/src/sysdb/mod.rs
@@ -1,2 +1,17 @@
 pub(crate) mod config;
 pub(crate) mod sysdb;
+
+use crate::{
+    config::{Configurable, WorkerConfig},
+    errors::ChromaError,
+};
+
+pub(crate) async fn from_config(
+    config: &WorkerConfig,
+) -> Result<Box<dyn sysdb::SysDb>, Box<dyn ChromaError>> {
+    match &config.sysdb {
+        crate::sysdb::config::SysDbConfig::Grpc(_) => {
+            Ok(Box::new(sysdb::GrpcSysDb::try_from_config(config).await?))
+        }
+    }
+}

--- a/rust/worker/src/sysdb/sysdb.rs
+++ b/rust/worker/src/sysdb/sysdb.rs
@@ -1,3 +1,4 @@
+use super::config::SysDbConfig;
 use crate::chroma_proto;
 use crate::config::{Configurable, WorkerConfig};
 use crate::types::{CollectionConversionError, SegmentConversionError};
@@ -10,8 +11,6 @@ use async_trait::async_trait;
 use std::fmt::Debug;
 use thiserror::Error;
 use uuid::Uuid;
-
-use super::config::SysDbConfig;
 
 const DEFAULT_DATBASE: &str = "default_database";
 const DEFAULT_TENANT: &str = "default_tenant";

--- a/rust/worker/src/system/scheduler.rs
+++ b/rust/worker/src/system/scheduler.rs
@@ -1,6 +1,5 @@
 use parking_lot::RwLock;
 use std::fmt::Debug;
-use std::num;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::select;
@@ -10,12 +9,13 @@ use super::{
     executor::ComponentExecutor, sender::Sender, system::System, Receiver, ReceiverImpl, Wrapper,
 };
 
+#[derive(Debug)]
 pub(crate) struct SchedulerTaskHandle {
     join_handle: Option<tokio::task::JoinHandle<()>>,
     cancel: tokio_util::sync::CancellationToken,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Scheduler {
     handles: Arc<RwLock<Vec<SchedulerTaskHandle>>>,
 }

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -28,7 +28,7 @@ impl System {
         }
     }
 
-    pub(crate) fn start_component<C>(&mut self, component: C) -> ComponentHandle<C>
+    pub(crate) fn start_component<C>(&self, component: C) -> ComponentHandle<C>
     where
         C: Component + Send + 'static,
     {

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -10,11 +10,12 @@ use std::sync::Arc;
 use tokio::runtime::Builder;
 use tokio::{pin, select};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct System {
     inner: Arc<Inner>,
 }
 
+#[derive(Debug)]
 struct Inner {
     scheduler: Scheduler,
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Add a new entrypoint for query-service. Delete the old worker entrypoint that did not have read/write decoupling.
	 - Make dispatcher configurable
	 - Wrapped hnsw orchestrator logic into run() so server is unaware of it
	 - Make server struct {} have the resources it needs
 - New functionality
	  - Add dynamic creation for log
	 - Add dynamic creation for sysdb
	 - Make server respond to query by using orchestrator 


## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None