### PR TITLE
[ENH] Operator/Executor error handling

### DIFF
--- a/rust/worker/src/errors.rs
+++ b/rust/worker/src/errors.rs
@@ -1,7 +1,6 @@
 // Defines 17 standard error codes based on the error codes defined in the
 // gRPC spec. https://grpc.github.io/grpc/core/md_doc_statuscodes.html
 // Custom errors can use these codes in order to allow for generic handling
-
 use std::error::Error;
 
 #[derive(PartialEq, Debug)]


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Allows errors to be propagated from operators back to the original caller of the task. 
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Compile checks show that the error propagates as expected. 
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None