### PR TITLE
[BUG] Rename memberlist to match new memberlist name

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -112,7 +112,7 @@ class Settings(BaseSettings):  # type: ignore
     chroma_collection_assignment_policy_impl: str = (
         "chromadb.ingest.impl.simple_policy.SimpleAssignmentPolicy"
     )
-    worker_memberlist_name: str = "worker-memberlist"
+    worker_memberlist_name: str = "query-service-memberlist"
     chroma_coordinator_host = "localhost"
 
     chroma_logservice_host = "localhost"
@@ -331,11 +331,11 @@ class System(Component):
             and settings["chroma_segment_cache_policy"] != "LRU"
         ):
             logger.error(
-                f"Failed to set chroma_segment_cache_policy: Only LRU is available."
+                "Failed to set chroma_segment_cache_policy: Only LRU is available."
             )
             if settings["chroma_memory_limit_bytes"] == 0:
                 logger.error(
-                    f"Failed to set chroma_segment_cache_policy: chroma_memory_limit_bytes is require."
+                    "Failed to set chroma_segment_cache_policy: chroma_memory_limit_bytes is require."
                 )
 
         # Apply the nofile limit if set

--- a/chromadb/segment/impl/distributed/server.py
+++ b/chromadb/segment/impl/distributed/server.py
@@ -11,13 +11,8 @@ from chromadb.proto.chroma_pb2_grpc import (
 import chromadb.proto.chroma_pb2 as proto
 import grpc
 from concurrent import futures
-from chromadb.proto.convert import (
-    to_proto_vector_embedding_record
-)
 from chromadb.segment import SegmentImplementation, SegmentType
-from chromadb.telemetry.opentelemetry import (
-    OpenTelemetryClient
-)
+from chromadb.telemetry.opentelemetry import OpenTelemetryClient
 from chromadb.types import EmbeddingRecord
 from chromadb.segment.distributed import MemberlistProvider, Memberlist
 from chromadb.utils.rendezvous_hash import assign, murmur3hasher
@@ -54,7 +49,7 @@ class SegmentServer(VectorReaderServicer):
         self._opentelemetry_client = system.require(OpenTelemetryClient)
         # TODO: add term and epoch to segment server
         self._memberlist_provider = system.require(MemberlistProvider)
-        self._memberlist_provider.set_memberlist_name("worker-memberlist")
+        self._memberlist_provider.set_memberlist_name("query-service-memberlist")
         self._assignment_policy = system.require(CollectionAssignmentPolicy)
         self._create_pulsar_topics()
         self._consumer = system.require(Consumer)

--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/chroma-core/chroma/go/pkg/coordinator/grpc"
-	"github.com/chroma-core/chroma/go/pkg/grpcutils"
 	"io"
 	"time"
+
+	"github.com/chroma-core/chroma/go/pkg/coordinator/grpc"
+	"github.com/chroma-core/chroma/go/pkg/grpcutils"
 
 	"github.com/chroma-core/chroma/go/cmd/flag"
 	"github.com/chroma-core/chroma/go/pkg/utils"
@@ -53,7 +54,7 @@ func init() {
 
 	// Memberlist
 	Cmd.Flags().StringVar(&conf.KubernetesNamespace, "kubernetes-namespace", "chroma", "Kubernetes namespace")
-	Cmd.Flags().StringVar(&conf.WorkerMemberlistName, "worker-memberlist-name", "worker-memberlist", "Worker memberlist name")
+	Cmd.Flags().StringVar(&conf.WorkerMemberlistName, "worker-memberlist-name", "query-service-memberlist", "Worker memberlist name")
 	Cmd.Flags().StringVar(&conf.AssignmentPolicy, "assignment-policy", "rendezvous", "Assignment policy")
 	Cmd.Flags().DurationVar(&conf.WatchInterval, "watch-interval", 60*time.Second, "Watch interval")
 }

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -16,7 +16,7 @@ worker:
             hasher: Murmur3
     memberlist_provider:
         CustomResource:
-            memberlist_name: "worker-memberlist"
+            memberlist_name: "query-service-memberlist"
             queue_size: 100
     ingest:
         queue_size: 10000

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -258,7 +258,7 @@ mod tests {
         let kube_ns = "chroma".to_string();
         let kube_client = Client::try_default().await.unwrap();
         let memberlist_provider = CustomResourceMemberlistProvider::new(
-            "worker-memberlist".to_string(),
+            "query-service-memberlist".to_string(),
             kube_client.clone(),
             kube_ns.clone(),
             10,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - We renamed the memberlist to query-service-memberlist given the query/compactor split. 
	 - This aligns all the defaults with that name
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
