### PR TITLE
fix: allow sentence transform to choose default device

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -59,7 +59,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
     def __init__(
         self,
         model_name: str = "all-MiniLM-L6-v2",
-        device: str = "cpu",
+        device: Optional[str] = None,
         normalize_embeddings: bool = False,
     ):
         if model_name not in self.models:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Given sentence_transformers, is able to automatically detect and choose the appropriate device, that is better.
	 - Secondly, for users with GPUs, they get a significant performance hit when CPU is used. 
	    Only after setting the device will they benefit. 
	    In my scenario when using the sentence transformer model directly I was getting about 11 seconds
	    to generate embeddings, but when using chroma_client I was getting 7 mins.
	    Digging a little bit deeper I noticed that chromdb overrides the default value for the device for
	    sentence_transformers.
	    This PR is a fix for this scenario.
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
