### PR TITLE
[BUG] remove query service build cache - breaks staging

### DIFF
--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /
 RUN git clone https://github.com/chroma-core/hnswlib.git
 
 WORKDIR /chroma/
+COPY . .
 
 ENV PROTOC_ZIP=protoc-25.1-linux-x86_64.zip
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/$PROTOC_ZIP \
@@ -14,10 +15,7 @@ RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1
     && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
     && rm -f $PROTOC_ZIP
 
-COPY . .
-
-ENV CARGO_TARGET_DIR=/root/.cache/cargo
-RUN --mount=type=cache,target=/root/.cache/cargo if [ "$RELEASE_MODE" = "1" ]; then cargo build --release; else cargo build; fi
+RUN if [ "$RELEASE_MODE" = "1" ]; then cargo build --release; else cargo build; fi
 
 WORKDIR /chroma/rust/worker
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Remove the build cache for the query service. Right now it makes the stagnig query node recompile the binary.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
