### PR TITLE
[BUG] Point query service to the right logservice port

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -32,7 +32,7 @@ worker:
     log:
         Grpc:
             host: "logservice.chroma"
-            port: 50052
+            port: 50051
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -165,7 +165,7 @@ mod tests {
                     log:
                         Grpc:
                             host: "localhost"
-                            port: 50052
+                            port: 50051
                     dispatcher:
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
@@ -217,7 +217,7 @@ mod tests {
                     log:
                         Grpc:
                             host: "localhost"
-                            port: 50052
+                            port: 50051
                     dispatcher:
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
@@ -285,7 +285,7 @@ mod tests {
                     log:
                         Grpc:
                             host: "localhost"
-                            port: 50052
+                            port: 50051
                     dispatcher:
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
@@ -333,7 +333,7 @@ mod tests {
                     log:
                         Grpc:
                             host: "localhost"
-                            port: 50052
+                            port: 50051
                     dispatcher:
                         num_worker_threads: 4
                         dispatcher_queue_size: 100


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Point the query service to port 50051 on the log service, not 50052. We only use 50052 for the external-facing service during testing since it conflicts with the sysdb on 50051.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
