### PR TITLE
[BUG] Log service incorrectly doesn't hydrate collection id

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -10,6 +10,10 @@
     - postgres=# `create role chroma with login password 'chroma';`
     - postgres=# `alter role chroma with superuser;`
     - postgres=# `create database chroma;`
+- Set postgres ENV Vars
+    Several tests (such as record_log_service_test.go) require the following environment variables to be set:
+    - `export POSTGRES_HOST=localhost`
+    - `export POSTGRES_PORT=5432`
 - Atlas schema migration
     - [~/chroma/go]: `atlas migrate diff --env dev`
     - [~/chroma/go]: `atlas --env dev migrate apply --url "postgres://chroma:chroma@localhost:5432/chroma?sslmode=disable"`

--- a/go/pkg/logservice/grpc/record_log_service.go
+++ b/go/pkg/logservice/grpc/record_log_service.go
@@ -28,6 +28,8 @@ func (s *Server) PushLogs(ctx context.Context, req *logservicepb.PushLogsRequest
 	}
 	var recordsContent [][]byte
 	for _, record := range req.Records {
+		// We remove the collection id for space reasons, as its double stored in the wrapping database RecordLog object.
+		// PullLogs will rehydrate the collection id from the database.
 		record.CollectionId = ""
 		data, err := proto.Marshal(record)
 		if err != nil {
@@ -73,6 +75,8 @@ func (s *Server) PullLogs(ctx context.Context, req *logservicepb.PullLogsRequest
 			}
 			return nil, grpcError
 		}
+		// Here we rehydrate the collection id from the database since in PushLogs we removed it for space reasons.
+		record.CollectionId = *recordLogs[index].CollectionID
 		recordLog := &logservicepb.RecordLog{
 			LogId:  recordLogs[index].ID,
 			Record: record,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Log service incorrectly did not return the collection ID of the record. I suspect that we meant to strip the collection id and rehydrate it into the proto for space reasons. I honored this intent and rehydrate the colleciton id.
	 - Add some readme for running tests locally with PG
	 - Fixed a bug in the log_service test where the input is mutated, which makes the source of truth have no collection id. This was passing when we incorrectly returned no collection id but was correctly failing now. I patched the test by cloning the records for a SOT.
	 - For the test I fixed, the expected vs actual order was incorrect.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
