### PR TITLE
[BUG] Log service N+1 query

### DIFF
--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -123,6 +123,12 @@ impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
             offset += batch_size as i64;
             result.append(&mut logs);
 
+            // We used a a timestamp and we didn't get a full batch, so we are done
+            if input.end_timestamp.is_some() && logs.len() < batch_size as usize {
+                break;
+            }
+
+            // We have read all the records up to the size we wanted
             if input.num_records.is_some()
                 && num_records_read >= input.num_records.unwrap() as usize
             {

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -123,8 +123,9 @@ impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
             offset += batch_size as i64;
             result.append(&mut logs);
 
-            // We used a a timestamp and we didn't get a full batch, so we are done
-            if input.end_timestamp.is_some() && logs.len() < batch_size as usize {
+            // We used a a timestamp and we didn't get a full batch, so we have retrieved
+            // the last batch of logs relevant to our query
+            if input.end_timestamp.is_some() && num_records_read < batch_size as usize {
                 break;
             }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - The rust log service makes an additional query when it doesn't need to if the timestamp is provided and we read less than a batch size. This means that we are done reading the log and don't need to fetch again.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None