### PR TITLE
[BUG] Rust server should wire up system

### DIFF
--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn query_service_entrypoint() {
         }
     };
     worker_server.set_segment_manager(segment_manager.clone());
+    worker_server.set_system(system);
     worker_server.set_dispatcher(dispatcher_handle.receiver());
 
     let server_join_handle = tokio::spawn(async move {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Rust server boot code should wire up the system.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
