### PR TITLE
Update fastapi.py

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -572,6 +572,11 @@ class FastAPI(ServerAPI):
         include: Include = ["metadatas", "documents", "distances"],
     ) -> QueryResult:
         """Gets the nearest neighbors of a single embedding"""
+
+        def cast_to_float(embedding):
+	        return [float(e) for e in embedding]
+        query_embeddings = [cast_to_float(embedding) for embedding in query_embeddings]
+        
         resp = self._session.post(
             self._api_url + "/collections/" + str(collection_id) + "/query",
             data=json.dumps(


### PR DESCRIPTION
fix https://github.com/chroma-core/chroma/issues/1800

## Description of changes

*Summarize the changes made by this PR.*
 - Bug fixes
	 HuggingFaceEmbedding usage may return array of [[numpy.float64]] as embeddings. Thats ok, but ChromaDB in case of docker + client deployment got error becouse of numpy.float64 are not json serializeble; as described in https://github.com/chroma-core/chroma/issues/1800. So dirty but fastest way to fix this issue - is to cast [[numpy.float64]] to [[float]] objects

I fix issue only in that one method, becouse had no chance to delete or update embeddings, but i believe that fix would work in other cases too.