### PR TITLE
[PERF]: Improved server-side serialization with orjson + async

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from chromadb.api import ServerAPI
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
 from chromadb.db.system import SysDB
@@ -789,7 +791,7 @@ class SegmentAPI(ServerAPI):
     def get_settings(self) -> Settings:
         return self._settings
 
-    @property
+    @cached_property
     @override
     def max_batch_size(self) -> int:
         return self._producer.max_batch_size

--- a/chromadb/auth/fastapi.py
+++ b/chromadb/auth/fastapi.py
@@ -216,6 +216,7 @@ def authz_context(
                     )
 
                     if _provider:
+                        # TODO this will block the event loop if it takes too long - refactor for async
                         a_authz_responses.append(_provider.authorize(_context))
                 if not any(a_authz_responses):
                     raise AuthorizationError("Unauthorized")

--- a/chromadb/auth/fastapi.py
+++ b/chromadb/auth/fastapi.py
@@ -1,3 +1,6 @@
+import asyncio
+
+import chromadb
 from contextvars import ContextVar
 from functools import wraps
 import logging
@@ -173,7 +176,7 @@ def authz_context(
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(f)
-        def wrapped(*args: Any, **kwargs: Dict[Any, Any]) -> Any:
+        async def wrapped(*args: Any, **kwargs: Dict[Any, Any]) -> Any:
             _dynamic_kwargs = {
                 "api": args[0]._api,
                 "function": f,
@@ -239,6 +242,8 @@ def authz_context(
                         ):
                             kwargs["database"].name = desired_database
 
+            if asyncio.iscoroutinefunction(f):
+                return await f(*args, **kwargs)
             return f(*args, **kwargs)
 
         return wrapped

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -145,7 +145,7 @@ class Settings(BaseSettings):  # type: ignore
 
     chroma_server_nofile: Optional[int] = None
     # the number of maximum threads to handle synchronous tasks in the FastAPI server
-    chroma_server_thread_pool_size: Optional[int] = 40
+    chroma_server_thread_pool_size: int = 40
 
     chroma_server_auth_provider: Optional[str] = None
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -144,6 +144,8 @@ class Settings(BaseSettings):  # type: ignore
         return v
 
     chroma_server_nofile: Optional[int] = None
+    # the number of maximum threads to handle synchronous tasks in the FastAPI server
+    chroma_server_thread_pool_size: Optional[int] = 40
 
     chroma_server_auth_provider: Optional[str] = None
 

--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -34,6 +34,7 @@ class TxWrapper(base.TxWrapper):
     @override
     def __enter__(self) -> base.Cursor:
         if len(self._tx_stack.stack) == 0:
+            self._conn.execute("PRAGMA case_sensitive_like = ON")
             self._conn.execute("BEGIN;")
         self._tx_stack.stack.append(self)
         return self._conn.cursor()  # type: ignore

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -776,7 +776,7 @@ class FastAPI(chromadb.server.Server):
         return nnresult
 
     async def pre_flight_checks(self) -> Dict[str, Any]:
-        def process_pre_flight_checks(_: Any) -> Dict[str, Any]:
+        def process_pre_flight_checks() -> Dict[str, Any]:
             return {
                 "max_batch_size": self._api.max_batch_size,
             }

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -592,7 +592,7 @@ class FastAPI(chromadb.server.Server):
             attributes=attr_from_collection_lookup(collection_id_arg="collection_id"),
         ),
     )
-    async def add(self, request: Request, collection_id: str) -> None:
+    async def add(self, request: Request, collection_id: str) -> bool:
         try:
 
             def process_add(raw_body: bytes) -> bool:
@@ -606,10 +606,13 @@ class FastAPI(chromadb.server.Server):
                     uris=add.uris,  # type: ignore
                 )
 
-            await to_thread.run_sync(
-                process_add,
-                await request.body(),
-                limiter=self._capacity_limiter,
+            return cast(
+                bool,
+                await to_thread.run_sync(
+                    process_add,
+                    await request.body(),
+                    limiter=self._capacity_limiter,
+                ),
             )
         except InvalidDimensionException as e:
             raise HTTPException(status_code=500, detail=str(e))

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -1,6 +1,8 @@
 from typing import Any, Callable, Dict, List, Sequence, Optional, cast
 import fastapi
 import orjson
+
+# https://anyio.readthedocs.io/en/stable/threads.html#adjusting-the-default-maximum-worker-thread-count
 from anyio import (
     to_thread,
 )  # this is used to transform sync code to async. By default, AnyIO uses 40 threads pool

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -1,7 +1,9 @@
 from typing import Any, Callable, Dict, List, Sequence, Optional, cast
 import fastapi
 import orjson
-from anyio import to_thread
+from anyio import (
+    to_thread,
+)  # this is used to transform sync code to async. By default, AnyIO uses 40 threads pool
 from fastapi import FastAPI as _FastAPI, Response, Request
 from fastapi.responses import JSONResponse
 
@@ -50,8 +52,6 @@ from chromadb.server.fastapi.types import (
     UpdateCollection,
     UpdateEmbedding,
 )
-
-# from starlette.requests import Request
 
 import logging
 
@@ -532,7 +532,7 @@ class FastAPI(chromadb.server.Server):
             attributes=attr_from_collection_lookup(collection_id_arg="collection_id"),
         ),
     )
-    async def update(self, request: Request, collection_id:str) -> None:
+    async def update(self, request: Request, collection_id: str) -> None:
         raw_body = await request.body()
         add = UpdateEmbedding.model_validate(orjson.loads(raw_body))
         await to_thread.run_sync(
@@ -554,7 +554,7 @@ class FastAPI(chromadb.server.Server):
             attributes=attr_from_collection_lookup(collection_id_arg="collection_id"),
         ),
     )
-    async def upsert(self, request: Request, collection_id:str) -> None:
+    async def upsert(self, request: Request, collection_id: str) -> None:
         raw_body = await request.body()
         collection_id = request.path_params.get("collection_id")
         upsert = AddEmbedding.model_validate(orjson.loads(raw_body))

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -342,7 +342,7 @@ class FastAPI(chromadb.server.Server):
     async def create_database(
         self, request: Request, tenant: str = DEFAULT_TENANT
     ) -> None:
-        def process_create_tenant(raw_body: bytes) -> None:
+        def process_create_database(raw_body: bytes) -> None:
             create = CreateDatabase.model_validate(orjson.loads(raw_body))
             return self._api.create_database(create.name, tenant)
 

--- a/chromadb/test/client/test_multiple_clients_concurrency.py
+++ b/chromadb/test/client/test_multiple_clients_concurrency.py
@@ -1,4 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
+from time import sleep
+
 from chromadb.api.client import AdminClient, Client
 from chromadb.config import DEFAULT_TENANT
 
@@ -33,7 +35,7 @@ def test_multiple_clients_concurrently(client: Client) -> None:
 
     with ThreadPoolExecutor(max_workers=CLIENT_COUNT) as executor:
         executor.map(run_target, range(CLIENT_COUNT))
-
+    executor.shutdown(wait=True)
     # Create a final client, which will be used to verify the collections were created
     client = Client(settings=client._system.settings)
 

--- a/chromadb/test/client/test_multiple_clients_concurrency.py
+++ b/chromadb/test/client/test_multiple_clients_concurrency.py
@@ -1,5 +1,4 @@
 from concurrent.futures import ThreadPoolExecutor
-from time import sleep
 
 from chromadb.api.client import AdminClient, Client
 from chromadb.config import DEFAULT_TENANT


### PR DESCRIPTION
This is PR #1695 migrated to Chroma repo for stacking the outstanding changes.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Added orjson serialization improving serialization performance especially on large batches 100+ docs 2x faster (tested with locust)
         - Added async body serialization further improving performance (tested with locust)
         - ⚠️ Fixed an issue with SQLite lack of case_sensitive_like for FastAPI Server thread pool connections

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js
- [x] Locust performance tests

For performance tests, **5** concurrent clients were querying, and **1** was adding pre-computed OpenAI (ada-02) embeddings (runtime **~1m**)

**Batch size**: 100 (1000 also attached in a zip)


Tests with existing `main` codebase:

![Screenshot 2024-02-03 at 17 52 39](https://github.com/chroma-core/chroma/assets/1157440/5d87b4d5-4dae-48fe-908c-7c09db2a5abc)


Tests with orjson + async:

![Screenshot 2024-02-03 at 17 53 17](https://github.com/chroma-core/chroma/assets/1157440/d9818fdd-11c3-45c9-81dd-8baecbb638cf)

[1m-100batch-5concur.zip](https://github.com/chroma-core/chroma/files/14152062/1m-100batch-5concur.zip)
[1m-1000batch-5concur.zip](https://github.com/chroma-core/chroma/files/14152063/1m-1000batch-5concur.zip)


## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*


## Refs

- https://showmax.engineering/articles/json-python-libraries-overview
- https://github.com/ijl/orjson
- https://catnotfoundnear.github.io/finding-the-fastest-python-json-library-on-all-python-versions-8-compared.html