### PR TITLE
[ENH]: Async AuthN/AuthZ

### DIFF
--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -159,11 +159,11 @@ class ServerAuthenticationRequest(EnforceOverrides, ABC, Generic[T]):
 
 class ServerAuthenticationResponse(EnforceOverrides, ABC):
     @abstractmethod
-    def success(self) -> bool:
+    async def success(self) -> bool:
         ...
 
     @abstractmethod
-    def get_user_identity(self) -> Optional[UserIdentity]:
+    async def get_user_identity(self) -> Optional[UserIdentity]:
         ...
 
 
@@ -180,11 +180,11 @@ class SimpleServerAuthenticationResponse(ServerAuthenticationResponse):
         self._user_identity = user_identity
 
     @override
-    def success(self) -> bool:
+    async def success(self) -> bool:
         return self._auth_success
 
     @override
-    def get_user_identity(self) -> Optional[UserIdentity]:
+    async def get_user_identity(self) -> Optional[UserIdentity]:
         return self._user_identity
 
 
@@ -204,13 +204,13 @@ class ChromaAuthMiddleware(Component):
         super().__init__(system)
 
     @abstractmethod
-    def authenticate(
+    async def authenticate(
         self, request: ServerAuthenticationRequest[T]
     ) -> ServerAuthenticationResponse:
         ...
 
     @abstractmethod
-    def ignore_operation(self, verb: str, path: str) -> bool:
+    async def ignore_operation(self, verb: str, path: str) -> bool:
         ...
 
     @abstractmethod
@@ -414,6 +414,11 @@ class ServerAuthorizationProvider(Component):
 
     @abstractmethod
     def authorize(self, context: AuthorizationContext) -> bool:
+        pass
+
+    @abstractmethod
+    async def aauthorize(self, context: AuthorizationContext) -> bool:
+        """Asynchronous version of authorize"""
         pass
 
 

--- a/chromadb/auth/__init__.py
+++ b/chromadb/auth/__init__.py
@@ -193,7 +193,7 @@ class ServerAuthProvider(Component):
         super().__init__(system)
 
     @abstractmethod
-    def authenticate(
+    async def authenticate(
         self, request: ServerAuthenticationRequest[T]
     ) -> ServerAuthenticationResponse:
         pass
@@ -288,11 +288,11 @@ class ServerAuthCredentialsProvider(Component):
         super().__init__(system)
 
     @abstractmethod
-    def validate_credentials(self, credentials: AbstractCredentials[T]) -> bool:
+    async def validate_credentials(self, credentials: AbstractCredentials[T]) -> bool:
         ...
 
     @abstractmethod
-    def get_user_identity(
+    async def get_user_identity(
         self, credentials: AbstractCredentials[T]
     ) -> Optional[UserIdentity]:
         ...

--- a/chromadb/auth/authz/__init__.py
+++ b/chromadb/auth/authz/__init__.py
@@ -108,3 +108,8 @@ class SimpleRBACAuthorizationProvider(ServerAuthorizationProvider):
             f" on [{context.resource}]"
         )
         return policy_decision
+
+    @override
+    async def aauthorize(self, context: AuthorizationContext) -> bool:
+        # since we're doing hash lookups, we can reuse existing authorize sunc method
+        return self.authorize(context)  # type: ignore

--- a/chromadb/auth/basic/__init__.py
+++ b/chromadb/auth/basic/__init__.py
@@ -91,17 +91,17 @@ class BasicAuthServerProvider(ServerAuthProvider):
 
     @trace_method("BasicAuthServerProvider.authenticate", OpenTelemetryGranularity.ALL)
     @override
-    def authenticate(
+    async def authenticate(
         self, request: ServerAuthenticationRequest[Any]
     ) -> SimpleServerAuthenticationResponse:
         try:
             _auth_header = request.get_auth_info(AuthInfoType.HEADER, "Authorization")
-            _validation = self._credentials_provider.validate_credentials(
+            _validation = await self._credentials_provider.validate_credentials(
                 BasicAuthCredentials.from_header(_auth_header)
             )
             return SimpleServerAuthenticationResponse(
                 _validation,
-                self._credentials_provider.get_user_identity(
+                await self._credentials_provider.get_user_identity(
                     BasicAuthCredentials.from_header(_auth_header)
                 ),
             )

--- a/chromadb/auth/fastapi.py
+++ b/chromadb/auth/fastapi.py
@@ -98,7 +98,7 @@ class FastAPIChromaAuthMiddleware(ChromaAuthMiddleware):
     async def authenticate(
         self, request: ServerAuthenticationRequest[Any]
     ) -> ServerAuthenticationResponse:
-        return self._auth_provider.authenticate(request)
+        return await self._auth_provider.authenticate(request)
 
     @trace_method(
         "FastAPIChromaAuthMiddleware.ignore_operation", OpenTelemetryGranularity.ALL

--- a/chromadb/auth/providers.py
+++ b/chromadb/auth/providers.py
@@ -45,7 +45,7 @@ class HtpasswdServerAuthCredentialsProvider(ServerAuthCredentialsProvider):
         OpenTelemetryGranularity.ALL,
     )
     @override
-    def validate_credentials(self, credentials: AbstractCredentials[T]) -> bool:
+    async def validate_credentials(self, credentials: AbstractCredentials[T]) -> bool:
         _creds = cast(Dict[str, SecretStr], credentials.get_credentials())
         if len(_creds) != 2:
             logger.error(
@@ -54,8 +54,7 @@ class HtpasswdServerAuthCredentialsProvider(ServerAuthCredentialsProvider):
             )
             return False
         if "username" not in _creds or "password" not in _creds:
-            logger.error(
-                "Returned credentials do not contain username or password")
+            logger.error("Returned credentials do not contain username or password")
             return False
         _usr_check = bool(
             _creds["username"].get_secret_value()
@@ -67,7 +66,7 @@ class HtpasswdServerAuthCredentialsProvider(ServerAuthCredentialsProvider):
         )
 
     @override
-    def get_user_identity(
+    async def get_user_identity(
         self, credentials: AbstractCredentials[T]
     ) -> Optional[SimpleUserIdentity]:
         _creds = cast(Dict[str, SecretStr], credentials.get_credentials())
@@ -173,8 +172,7 @@ class RequestsClientAuthProtocolAdapter(
                 ].get_secret_value()
             else:
                 for header in _header_info:
-                    injection_context.headers[header[0]
-                                              ] = header[1].get_secret_value()
+                    injection_context.headers[header[0]] = header[1].get_secret_value()
         else:
             raise ValueError(
                 f"Unsupported auth type: {self._auth_header.get_auth_info_type()}"
@@ -189,8 +187,7 @@ class ConfigurationClientAuthCredentialsProvider(
     def __init__(self, system: System) -> None:
         super().__init__(system)
         system.settings.require("chroma_client_auth_credentials")
-        self._creds = SecretStr(
-            str(system.settings.chroma_client_auth_credentials))
+        self._creds = SecretStr(str(system.settings.chroma_client_auth_credentials))
 
     @override
     def get_credentials(self) -> SecretStr:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Making AuthN middleware async
         - Authorization now supports both sync and async - it is up to the implementer of the authorization provider to decide which to use (we should generally favour Async)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A

