### PR TITLE
[ENH][SEC]: Add warning if cors is a wild card

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -137,6 +137,14 @@ class Settings(BaseSettings):  # type: ignore
     # eg ["http://localhost:3000"]
     chroma_server_cors_allow_origins: List[str] = []
 
+    @validator(
+        "chroma_server_cors_allow_origins", pre=True, always=True, allow_reuse=True
+    )
+    def validate_safe_cors_origin(cls, v: List[str]) -> List[str]:
+        if len(v) > 0 and any([origin == "*" for origin in v]):
+            logger.warning("CORS origin '*' is not recommended for production use")
+        return v
+
     @validator("chroma_server_nofile", pre=True, always=True, allow_reuse=True)
     def empty_str_to_none(cls, v: str) -> Optional[str]:
         if type(v) is str and v.strip() == "":

--- a/chromadb/test/test_config.py
+++ b/chromadb/test/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from chromadb.config import Component, System, Settings
 from overrides import overrides
 from threading import local
@@ -189,3 +191,18 @@ def test_runtime_dependencies() -> None:
     assert data.starts == ["D", "C"]
     system.stop()
     assert data.stops == ["C", "D"]
+
+
+def test_warn_cors(caplog: pytest.LogCaptureFixture) -> None:
+    Settings(chroma_server_cors_allow_origins=["*"])
+    assert "CORS origin '*' is not recommended for production use" in caplog.text
+
+    Settings(chroma_server_cors_allow_origins=["localhost:3000", "*", "localhost:3001"])
+    assert "CORS origin '*' is not recommended for production use" in caplog.text
+
+
+def test_no_warn(caplog: pytest.LogCaptureFixture) -> None:
+    Settings(chroma_server_cors_allow_origins=["localhost:3000"])
+    assert "CORS origin '*' is not recommended for production use" not in caplog.text
+    Settings()
+    assert "CORS origin '*' is not recommended for production use" not in caplog.text


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Chroma will issue a warning at startup in server mode when a wild card is found the the chroma_server_cors_allow_origins

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
TBD

Refs: #1841
