### PR TITLE
[ENH] Add support for delete in blockfile

### DIFF
--- a/rust/worker/src/blockstore/arrow_blockfile/block/iterator.rs
+++ b/rust/worker/src/blockstore/arrow_blockfile/block/iterator.rs
@@ -8,15 +8,18 @@ use arrow::array::{Array, BooleanArray, Int32Array, ListArray, StringArray, UInt
 pub(super) struct BlockIterator {
     block: Block,
     index: usize,
+    length: usize,
     key_type: KeyType,
     value_type: ValueType,
 }
 
 impl BlockIterator {
     pub fn new(block: Block, key_type: KeyType, value_type: ValueType) -> Self {
+        let len = block.len();
         Self {
             block,
             index: 0,
+            length: len,
             key_type,
             value_type,
         }
@@ -29,6 +32,9 @@ impl Iterator for BlockIterator {
     fn next(&mut self) -> Option<Self::Item> {
         let data = &self.block.inner.read().data;
         if data.is_none() {
+            return None;
+        }
+        if self.index >= self.length {
             return None;
         }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Add a Into_Result type for casing to Box<dyn ChromaError> for results with concrete ChromaErrors as their err type.
	 - Add an explicit length check in BlockIterator
 - New functionality
	 - Adds support for deletes in blockfiles 

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
