### PR TITLE
[BUG] QuotaEnforcer fails to check out the corner cases.

### DIFF
--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -70,7 +70,7 @@ class QuotaEnforcer(Component):
                                                                          subject=collection_id)
         metadata_value_length_quota = self._quota_provider.get_for_subject(resource=Resource.METADATA_VALUE_LENGTH,
                                                                            subject=collection_id)
-        if metadatas and (metadata_key_length_quota or metadata_key_length_quota):
+        if metadatas and (metadata_key_length_quota or metadata_value_length_quota):
             for metadata in metadatas:
                 for key in metadata:
                     if metadata_key_length_quota and len(key) > metadata_key_length_quota:

--- a/chromadb/test/quota/test_static_quota_enforcer.py
+++ b/chromadb/test/quota/test_static_quota_enforcer.py
@@ -16,6 +16,29 @@ def mock_get_for_subject(self, resource: Resource, subject: Optional[str] = "", 
     """Mock function to simulate quota retrieval."""
     return 10
 
+def mock_get_for_subject_none_key_length(self, resource: Resource, subject: Optional[str] = "", tier: Optional[str] = "") -> Optional[
+    int]:
+    """Mock function to simulate quota retrieval."""
+    if resource==Resource.METADATA_KEY_LENGTH:
+        return None
+    else:
+        return 10
+
+def mock_get_for_subject_none_value_length(self, resource: Resource, subject: Optional[str] = "", tier: Optional[str] = "") -> Optional[
+    int]:
+    """Mock function to simulate quota retrieval."""
+    if resource==Resource.METADATA_VALUE_LENGTH:
+        return None
+    else:
+        return 10
+
+def mock_get_for_subject_none_key_value_length(self, resource: Resource, subject: Optional[str] = "", tier: Optional[str] = "") -> Optional[
+    int]:
+    """Mock function to simulate quota retrieval."""
+    if resource==Resource.METADATA_KEY_LENGTH or resource==Resource.METADATA_VALUE_LENGTH:
+        return None
+    else:
+        return 10
 
 def run_static_checks(enforcer: QuotaEnforcer, test_cases: List[Tuple[Any, Optional[str]]], data_key: str):
     """Generalized function to run static checks on different types of data."""
@@ -49,6 +72,35 @@ def test_static_enforcer_metadata(enforcer):
     ]
     run_static_checks(enforcer, test_cases, 'metadatas')
 
+@patch('chromadb.quota.test_provider.QuotaProviderForTest.get_for_subject', mock_get_for_subject_none_key_length)
+def test_static_enforcer_metadata_none_key_length(enforcer):
+    test_cases = [
+        ({generate_random_string(20): generate_random_string(5)}, None),
+        ({generate_random_string(5): generate_random_string(5)}, None),
+        ({generate_random_string(5): generate_random_string(20)}, "METADATA_VALUE_LENGTH"),
+        ({generate_random_string(5): generate_random_string(5)}, None)
+    ]
+    run_static_checks(enforcer, test_cases, 'metadatas')
+
+@patch('chromadb.quota.test_provider.QuotaProviderForTest.get_for_subject', mock_get_for_subject_none_value_length)
+def test_static_enforcer_metadata_none_value_length(enforcer):
+    test_cases = [
+        ({generate_random_string(20): generate_random_string(5)}, "METADATA_KEY_LENGTH"),
+        ({generate_random_string(5): generate_random_string(5)}, None),
+        ({generate_random_string(5): generate_random_string(20)}, None),
+        ({generate_random_string(5): generate_random_string(5)}, None)
+    ]
+    run_static_checks(enforcer, test_cases, 'metadatas')
+
+@patch('chromadb.quota.test_provider.QuotaProviderForTest.get_for_subject', mock_get_for_subject_none_key_value_length)
+def test_static_enforcer_metadata_none_key_value_length(enforcer):
+    test_cases = [
+        ({generate_random_string(20): generate_random_string(5)}, None),
+        ({generate_random_string(5): generate_random_string(5)}, None),
+        ({generate_random_string(5): generate_random_string(20)}, None),
+        ({generate_random_string(5): generate_random_string(5)}, None)
+    ]
+    run_static_checks(enforcer, test_cases, 'metadatas')
 
 @patch('chromadb.quota.test_provider.QuotaProviderForTest.get_for_subject', mock_get_for_subject)
 def test_static_enforcer_documents(enforcer):


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Add more test cases in [test_static_quota_enforcer.py](https://github.com/chroma-core/chroma/blob/main/chromadb/test/quota/test_static_quota_enforcer.py) to find the buggy corner cases.
	 - Fix the bug in [QuotaEnforcer](https://github.com/chroma-core/chroma/blob/main/chromadb/quota/__init__.py) and pass the above corner cases.
 - New functionality
	 - None.

## Test plan

*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python.

## Documentation Changes
- No change is required for documentation.
