### PR TITLE
[ENH] Integrate e2e tracing for query vectors endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4111,6 +4111,8 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -24,7 +24,7 @@ frontendService:
   authCredentialsProvider: 'value: ""'
   authzProvider: 'value: ""'
   authzConfigProvider: 'value: ""'
-  memberlistProviderImpl: 'value: "chromadb.segment.impl.distributed.segment_directory.MockMemberlistProvider"'
+  memberlistProviderImpl: 'value: "chromadb.segment.impl.distributed.segment_directory.CustomResourceMemberlistProvider"'
   logServiceHost: 'value: "logservice.chroma"'
   logServicePort: 'value: "50051"'
   otherEnvConfig: ''

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -24,7 +24,7 @@ frontendService:
   authCredentialsProvider: 'value: ""'
   authzProvider: 'value: ""'
   authzConfigProvider: 'value: ""'
-  memberlistProviderImpl: 'value: "chromadb.segment.impl.distributed.segment_directory.CustomResourceMemberlistProvider"'
+  memberlistProviderImpl: 'value: "chromadb.segment.impl.distributed.segment_directory.MockMemberlistProvider"'
   logServiceHost: 'value: "logservice.chroma"'
   logServicePort: 'value: "50051"'
   otherEnvConfig: ''

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -39,6 +39,8 @@ aws-config = { version = "1.1.2", features = ["behavior-version-latest"] }
 arrow = "50.0.0"
 roaring = "0.10.3"
 tantivy = "0.21.1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -3,7 +3,7 @@ use worker::query_service_entrypoint;
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_max_level(tracing::Level::INFO)
         .init();
     query_service_entrypoint().await;
 }

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -2,5 +2,8 @@ use worker::query_service_entrypoint;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
     query_service_entrypoint().await;
 }

--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::fmt::Debug;
+use tracing::{debug_span, instrument, Instrument, Span};
 
 /// The dispatcher is responsible for distributing tasks to worker threads.
 /// It is a component that receives tasks and distributes them to worker threads.
@@ -97,7 +98,11 @@ impl Dispatcher {
         // If a worker is waiting for a task, send it to the worker in FIFO order
         // Otherwise, add it to the task queue
         match self.waiters.pop() {
-            Some(channel) => match channel.reply_to.send(task).await {
+            Some(channel) => match channel
+                .reply_to
+                .send(task, Some(Span::current().clone()))
+                .await
+            {
                 Ok(_) => {}
                 Err(e) => {
                     println!("Error sending task to worker: {:?}", e);
@@ -116,7 +121,11 @@ impl Dispatcher {
     /// when one is available
     async fn handle_work_request(&mut self, request: TaskRequestMessage) {
         match self.task_queue.pop() {
-            Some(task) => match request.reply_to.send(task).await {
+            Some(task) => match request
+                .reply_to
+                .send(task, Some(Span::current().clone()))
+                .await
+            {
                 Ok(_) => {}
                 Err(e) => {
                     println!("Error sending task to worker: {:?}", e);
@@ -264,13 +273,8 @@ mod tests {
     #[async_trait]
     impl Handler<()> for MockDispatchUser {
         async fn handle(&mut self, _message: (), ctx: &ComponentContext<MockDispatchUser>) {
-            let task = wrap(
-                Box::new(MockOperator {}),
-                42.0,
-                ctx.sender.as_receiver(),
-                None,
-            );
-            let res = self.dispatcher.send(task).await;
+            let task = wrap(Box::new(MockOperator {}), 42.0, ctx.sender.as_receiver());
+            let res = self.dispatcher.send(task, None).await;
         }
     }
 

--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::fmt::Debug;
-use tracing::{debug_span, instrument, Instrument, Span};
+use tracing::Span;
 
 /// The dispatcher is responsible for distributing tasks to worker threads.
 /// It is a component that receives tasks and distributes them to worker threads.

--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -264,7 +264,12 @@ mod tests {
     #[async_trait]
     impl Handler<()> for MockDispatchUser {
         async fn handle(&mut self, _message: (), ctx: &ComponentContext<MockDispatchUser>) {
-            let task = wrap(Box::new(MockOperator {}), 42.0, ctx.sender.as_receiver());
+            let task = wrap(
+                Box::new(MockOperator {}),
+                42.0,
+                ctx.sender.as_receiver(),
+                None,
+            );
             let res = self.dispatcher.send(task).await;
         }
     }

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -3,6 +3,7 @@ use crate::{distance::DistanceFunction, execution::operator::Operator};
 use async_trait::async_trait;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
+use tracing::debug;
 
 /// The brute force k-nearest neighbors operator is responsible for computing the k-nearest neighbors
 /// of a given query vector against a set of vectors using brute force calculation.
@@ -114,6 +115,12 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
         }
         let mut data_chunk = data_chunk.clone();
         data_chunk.set_visibility(visibility);
+        debug!(
+            "Brute force Knn result. data: {:?}, indices: {:?}, distances: {:?}",
+            data_chunk,
+            sorted_indices,
+            sorted_distances
+        );
         Ok(BruteForceKnnOperatorOutput {
             data: data_chunk,
             indices: sorted_indices,

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -3,7 +3,7 @@ use crate::{distance::DistanceFunction, execution::operator::Operator};
 use async_trait::async_trait;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use tracing::debug;
+use tracing::{debug, trace};
 
 /// The brute force k-nearest neighbors operator is responsible for computing the k-nearest neighbors
 /// of a given query vector against a set of vectors using brute force calculation.
@@ -115,7 +115,7 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
         }
         let mut data_chunk = data_chunk.clone();
         data_chunk.set_visibility(visibility);
-        debug!(
+        trace!(
             "Brute force Knn result. data: {:?}, indices: {:?}, distances: {:?}",
             data_chunk,
             sorted_indices,

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -3,6 +3,7 @@ use crate::execution::operator::Operator;
 use crate::log::log::Log;
 use crate::log::log::PullLogsError;
 use async_trait::async_trait;
+use tracing::debug;
 use uuid::Uuid;
 
 /// The pull logs operator is responsible for reading logs from the log service.
@@ -130,8 +131,10 @@ impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
                 break;
             }
         }
+        debug!("Log records {:?}", result);
         if input.num_records.is_some() && result.len() > input.num_records.unwrap() as usize {
             result.truncate(input.num_records.unwrap() as usize);
+            debug!("Truncated log records {:?}", result);
         }
         // Convert to DataChunk
         let data_chunk = DataChunk::new(result.into());

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -4,6 +4,7 @@ use crate::log::log::Log;
 use crate::log::log::PullLogsError;
 use async_trait::async_trait;
 use tracing::debug;
+use tracing::trace;
 use uuid::Uuid;
 
 /// The pull logs operator is responsible for reading logs from the log service.
@@ -131,10 +132,10 @@ impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
                 break;
             }
         }
-        debug!("Log records {:?}", result);
+        trace!("Log records {:?}", result);
         if input.num_records.is_some() && result.len() > input.num_records.unwrap() as usize {
             result.truncate(input.num_records.unwrap() as usize);
-            debug!("Truncated log records {:?}", result);
+            trace!("Truncated log records {:?}", result);
         }
         // Convert to DataChunk
         let data_chunk = DataChunk::new(result.into());

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -179,7 +179,7 @@ impl CompactOrchestrator {
         );
 
         let task = wrap(operator, input, self_address);
-        match self.dispatcher.send(task).await {
+        match self.dispatcher.send(task, None).await {
             Ok(_) => (),
             Err(e) => {
                 // TODO: log an error and reply to caller

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -119,7 +119,7 @@ impl CompactOrchestrator {
             }
         };
         let input = PullLogsInput::new(collection_id, 0, 100, None, Some(end_timestamp));
-        let task = wrap(operator, input, self_address);
+        let task = wrap(operator, input, self_address, None);
         match self.dispatcher.send(task).await {
             Ok(_) => (),
             Err(e) => {
@@ -138,7 +138,7 @@ impl CompactOrchestrator {
         let max_partition_size = 100;
         let operator = PartitionOperator::new();
         let input = PartitionInput::new(records, max_partition_size);
-        let task = wrap(operator, input, self_address);
+        let task = wrap(operator, input, self_address, None);
         match self.dispatcher.send(task).await {
             Ok(_) => (),
             Err(e) => {

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -119,8 +119,8 @@ impl CompactOrchestrator {
             }
         };
         let input = PullLogsInput::new(collection_id, 0, 100, None, Some(end_timestamp));
-        let task = wrap(operator, input, self_address, None);
-        match self.dispatcher.send(task).await {
+        let task = wrap(operator, input, self_address);
+        match self.dispatcher.send(task, None).await {
             Ok(_) => (),
             Err(e) => {
                 // TODO: log an error and reply to caller
@@ -138,8 +138,8 @@ impl CompactOrchestrator {
         let max_partition_size = 100;
         let operator = PartitionOperator::new();
         let input = PartitionInput::new(records, max_partition_size);
-        let task = wrap(operator, input, self_address, None);
-        match self.dispatcher.send(task).await {
+        let task = wrap(operator, input, self_address);
+        match self.dispatcher.send(task, None).await {
             Ok(_) => (),
             Err(e) => {
                 // TODO: log an error and reply to caller

--- a/rust/worker/src/execution/worker_thread.rs
+++ b/rust/worker/src/execution/worker_thread.rs
@@ -2,6 +2,7 @@ use super::{dispatcher::TaskRequestMessage, operator::TaskMessage};
 use crate::system::{Component, ComponentContext, ComponentRuntime, Handler, Receiver};
 use async_trait::async_trait;
 use std::fmt::{Debug, Formatter, Result};
+use tracing::{debug_span, instrument, Instrument};
 
 /// A worker thread is responsible for executing tasks
 /// It sends requests to the dispatcher for new tasks.
@@ -50,7 +51,11 @@ impl Component for WorkerThread {
 #[async_trait]
 impl Handler<TaskMessage> for WorkerThread {
     async fn handle(&mut self, task: TaskMessage, ctx: &ComponentContext<WorkerThread>) {
-        task.run().await;
+        // Execute the task with the caller span
+        let parent_id = (*task).getTracingContext();
+        let child_span = debug_span!(parent: parent_id, "worker task execution");
+        let task_future = task.run();
+        task_future.instrument(child_span).await;
         let req: TaskRequestMessage = TaskRequestMessage::new(ctx.sender.as_receiver());
         let res = self.dispatcher.send(req).await;
         // TODO: task run should be able to error and we should send it as part of the result

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -175,7 +175,7 @@ impl CustomResourceMemberlistProvider {
         };
 
         for subscriber in self.subscribers.iter() {
-            let _ = subscriber.send(curr_memberlist.clone()).await;
+            let _ = subscriber.send(curr_memberlist.clone(), None).await;
         }
     }
 }

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -12,7 +12,7 @@ use crate::system::{Receiver, System};
 use crate::types::ScalarEncoding;
 use async_trait::async_trait;
 use tonic::{transport::Server, Request, Response, Status};
-use tracing::{debug, debug_span, instrument};
+use tracing::{debug, trace, trace_span};
 use uuid::Uuid;
 
 pub struct WorkerServer {
@@ -110,7 +110,7 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
         let mut proto_results_for_all = Vec::new();
 
         let mut query_vectors = Vec::new();
-        debug_span!("Input vectors parsing").in_scope(|| {
+        trace_span!("Input vectors parsing").in_scope(|| {
             for proto_query_vector in request.vectors {
                 let (query_vector, _encoding) = match proto_query_vector.try_into() {
                     Ok((vector, encoding)) => (vector, encoding),
@@ -120,7 +120,7 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
                 };
                 query_vectors.push(query_vector);
             }
-            debug!("Parsed vectors {:?}", query_vectors);
+            trace!("Parsed vectors {:?}", query_vectors);
             Ok(())
         });
 

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -12,6 +12,7 @@ use crate::system::{Receiver, System};
 use crate::types::ScalarEncoding;
 use async_trait::async_trait;
 use tonic::{transport::Server, Request, Response, Status};
+use tracing::{debug, debug_span, instrument};
 use uuid::Uuid;
 
 pub struct WorkerServer {
@@ -93,6 +94,7 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
         Err(Status::unimplemented("Not yet implemented"))
     }
 
+    #[tracing::instrument(skip(self, request), fields(request_metadata = ?request.metadata(), k = request.get_ref().k, segment_id = request.get_ref().segment_id, include_embeddings = request.get_ref().include_embeddings, allowed_ids = ?request.get_ref().allowed_ids))]
     async fn query_vectors(
         &self,
         request: Request<QueryVectorsRequest>,
@@ -108,15 +110,19 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
         let mut proto_results_for_all = Vec::new();
 
         let mut query_vectors = Vec::new();
-        for proto_query_vector in request.vectors {
-            let (query_vector, _encoding) = match proto_query_vector.try_into() {
-                Ok((vector, encoding)) => (vector, encoding),
-                Err(e) => {
-                    return Err(Status::internal(format!("Error converting vector: {}", e)));
-                }
-            };
-            query_vectors.push(query_vector);
-        }
+        debug_span!("Input vectors parsing").in_scope(|| {
+            for proto_query_vector in request.vectors {
+                let (query_vector, _encoding) = match proto_query_vector.try_into() {
+                    Ok((vector, encoding)) => (vector, encoding),
+                    Err(e) => {
+                        return Err(Status::internal(format!("Error converting vector: {}", e)));
+                    }
+                };
+                query_vectors.push(query_vector);
+            }
+            debug!("Parsed vectors {:?}", query_vectors);
+            Ok(())
+        });
 
         let dispatcher = match self.dispatcher {
             Some(ref dispatcher) => dispatcher,

--- a/rust/worker/src/system/executor.rs
+++ b/rust/worker/src/system/executor.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::system::ComponentContext;
 use std::sync::Arc;
 use tokio::select;
-use tracing::{debug_span, instrument, span, Id, Instrument, Span};
+use tracing::{trace_span, Instrument, Span};
 
 struct Inner<C>
 where
@@ -79,7 +79,7 @@ where
                                     parent_span = Span::current().clone();
                                 }
                             }
-                            let child_span = debug_span!(parent: parent_span, "task handler");
+                            let child_span = trace_span!(parent: parent_span, "task handler");
                             let component_context = ComponentContext {
                                     system: self.inner.system.clone(),
                                     sender: self.inner.sender.clone(),

--- a/rust/worker/src/system/scheduler.rs
+++ b/rust/worker/src/system/scheduler.rs
@@ -42,7 +42,7 @@ impl Scheduler {
                     return;
                 }
                 _ = tokio::time::sleep(duration) => {
-                    match sender.send(message).await {
+                    match sender.send(message, None).await {
                         Ok(_) => {
                             return;
                         },
@@ -83,7 +83,7 @@ impl Scheduler {
                         return;
                     }
                     _ = tokio::time::sleep(duration) => {
-                        match sender.send(message.clone()).await {
+                        match sender.send(message.clone(), None).await {
                             Ok(_) => {
                             },
                             Err(e) => {

--- a/rust/worker/src/system/sender.rs
+++ b/rust/worker/src/system/sender.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use super::{Component, ComponentContext, Handler};
 use async_trait::async_trait;
 use thiserror::Error;
+use tracing::Span;
 
 // Message Wrapper
 #[derive(Debug)]
@@ -11,11 +12,16 @@ where
     C: Component,
 {
     wrapper: Box<dyn WrapperTrait<C>>,
+    tracing_context: Option<tracing::Span>,
 }
 
 impl<C: Component> Wrapper<C> {
     pub(super) async fn handle(&mut self, component: &mut C, ctx: &ComponentContext<C>) -> () {
         self.wrapper.handle(component, ctx).await;
+    }
+
+    pub(super) fn get_tracing_context(&self) -> Option<tracing::Span> {
+        return self.tracing_context.clone();
     }
 }
 
@@ -40,13 +46,14 @@ where
     }
 }
 
-pub(crate) fn wrap<C, M>(message: M) -> Wrapper<C>
+pub(crate) fn wrap<C, M>(message: M, tracing_context: Option<tracing::Span>) -> Wrapper<C>
 where
     C: Component + Handler<M>,
     M: Debug + Send + 'static,
 {
     Wrapper {
         wrapper: Box::new(Some(message)),
+        tracing_context,
     }
 }
 
@@ -66,12 +73,16 @@ where
         Sender { sender }
     }
 
-    pub(crate) async fn send<M>(&self, message: M) -> Result<(), ChannelError>
+    pub(crate) async fn send<M>(
+        &self,
+        message: M,
+        tracing_context: Option<tracing::Span>,
+    ) -> Result<(), ChannelError>
     where
         C: Component + Handler<M>,
         M: Debug + Send + 'static,
     {
-        let res = self.sender.send(wrap(message)).await;
+        let res = self.sender.send(wrap(message, tracing_context)).await;
         match res {
             Ok(_) => Ok(()),
             Err(_) => Err(ChannelError::SendError),
@@ -102,7 +113,11 @@ where
 
 #[async_trait]
 pub(crate) trait Receiver<M>: Send + Sync + Debug + ReceiverClone<M> {
-    async fn send(&self, message: M) -> Result<(), ChannelError>;
+    async fn send(
+        &self,
+        message: M,
+        tracing_context: Option<tracing::Span>,
+    ) -> Result<(), ChannelError>;
 }
 
 trait ReceiverClone<M> {
@@ -159,8 +174,12 @@ where
     C: Component + Handler<M>,
     M: Send + Debug + 'static,
 {
-    async fn send(&self, message: M) -> Result<(), ChannelError> {
-        let res = self.sender.send(wrap(message)).await;
+    async fn send(
+        &self,
+        message: M,
+        tracing_context: Option<tracing::Span>,
+    ) -> Result<(), ChannelError> {
+        let res = self.sender.send(wrap(message, tracing_context)).await;
         match res {
             Ok(_) => Ok(()),
             Err(_) => Err(ChannelError::SendError),

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::runtime::Builder;
 use tokio::{pin, select};
-use tracing::{debug_span, instrument, Instrument, Span};
+use tracing::{trace_span, Instrument, Span};
 
 #[derive(Clone, Debug)]
 pub(crate) struct System {
@@ -47,7 +47,7 @@ impl System {
 
         match C::runtime() {
             ComponentRuntime::Inherit => {
-                let child_span = debug_span!(parent: Span::current(), "component spawn");
+                let child_span = trace_span!(parent: Span::current(), "component spawn");
                 let task_future = async move { executor.run(rx).await };
                 let join_handle = tokio::spawn(task_future.instrument(child_span));
                 return ComponentHandle::new(cancel_token, Some(join_handle), sender);

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -9,6 +9,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::runtime::Builder;
 use tokio::{pin, select};
+use tracing::{debug_span, instrument, Instrument, Span};
 
 #[derive(Clone, Debug)]
 pub(crate) struct System {
@@ -46,7 +47,9 @@ impl System {
 
         match C::runtime() {
             ComponentRuntime::Inherit => {
-                let join_handle = tokio::spawn(async move { executor.run(rx).await });
+                let child_span = debug_span!(parent: Span::current(), "component spawn");
+                let task_future = async move { executor.run(rx).await };
+                let join_handle = tokio::spawn(task_future.instrument(child_span));
                 return ComponentHandle::new(cancel_token, Some(join_handle), sender);
             }
             ComponentRuntime::Dedicated => {

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -104,7 +104,7 @@ where
             message = stream.next() => {
                 match message {
                     Some(message) => {
-                        let res = ctx.sender.send(message).await;
+                        let res = ctx.sender.send(message, None).await;
                         match res {
                             Ok(_) => {}
                             Err(e) => {

--- a/rust/worker/src/system/types.rs
+++ b/rust/worker/src/system/types.rs
@@ -185,9 +185,9 @@ mod tests {
         let counter = Arc::new(AtomicUsize::new(0));
         let component = TestComponent::new(10, counter.clone());
         let mut handle = system.start_component(component);
-        handle.sender.send(1).await.unwrap();
-        handle.sender.send(2).await.unwrap();
-        handle.sender.send(3).await.unwrap();
+        handle.sender.send(1, None).await.unwrap();
+        handle.sender.send(2, None).await.unwrap();
+        handle.sender.send(3, None).await.unwrap();
         // yield to allow the component to process the messages
         tokio::task::yield_now().await;
         // With the streaming data and the messages we should have 12
@@ -197,7 +197,7 @@ mod tests {
         tokio::task::yield_now().await;
         // Expect the component to be stopped
         assert_eq!(*handle.state(), ComponentState::Stopped);
-        let res = handle.sender.send(4).await;
+        let res = handle.sender.send(4, None).await;
         // Expect an error because the component is stopped
         assert!(res.is_err());
     }


### PR DESCRIPTION
## Description of changes

This PR integrates end-to-end tracing for the Query Service (specifically the `query_vectors()` RPC). The main highlights are:
- Span inheritance by component - whenever a component is started the executor executes the `run()` function inside a child span with the current span as the parent. This works even across threads now for e.g. if the component was spawned in `inherited` mode but it invoked the receive msg handler on a different thread, etc.
- Span propagation across components. For e.g. when the HNSW Query orchestrator submits the Pull logs request or brute force KNN request to the worker (via the dispatcher), the worker invokes the task handler inside a child span with parent span as the HNSW orchestrator. This is implemented by adding a new field to the `Task` struct - the span id of the parent and the worker then creates a child span with this id as the parent.

## Test plan

- [+] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Check https://gist.github.com/sanketkedia/96f3b00a2037a0fb2e99c16c3a379e69 for the exact logs for `query_vectors()` rpc

## Documentation Changes
None required
