### PR TITLE
[ENH] Only update memberlist when their is a change

### DIFF
--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -190,6 +190,31 @@ func TestMemberlistManager(t *testing.T) {
 	}, 10, 1*time.Second)
 }
 
+func TestMemberlistSame(t *testing.T) {
+	memberlist := Memberlist{""}
+	assert.True(t, memberlistSame(memberlist, memberlist))
+
+	newMemberlist := Memberlist{"10.0.0.1"}
+	assert.False(t, memberlistSame(memberlist, newMemberlist))
+	assert.False(t, memberlistSame(newMemberlist, memberlist))
+	assert.True(t, memberlistSame(newMemberlist, newMemberlist))
+
+	memberlist = Memberlist{"10.0.0.2"}
+	assert.False(t, memberlistSame(newMemberlist, memberlist))
+	assert.False(t, memberlistSame(memberlist, newMemberlist))
+	assert.True(t, memberlistSame(memberlist, memberlist))
+
+	memberlist = Memberlist{"10.0.0.1", "10.0.0.2"}
+	newMemberlist = Memberlist{"10.0.0.1", "10.0.0.2"}
+	assert.True(t, memberlistSame(memberlist, newMemberlist))
+	assert.True(t, memberlistSame(newMemberlist, memberlist))
+
+	memberlist = Memberlist{"10.0.0.1", "10.0.0.2"}
+	newMemberlist = Memberlist{"10.0.0.2", "10.0.0.1"}
+	assert.True(t, memberlistSame(memberlist, newMemberlist))
+	assert.True(t, memberlistSame(newMemberlist, memberlist))
+}
+
 func retryUntilCondition(t *testing.T, f func() bool, retry_count int, retry_interval time.Duration) {
 	for i := 0; i < retry_count; i++ {
 		if f() {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR improves the memberlist updates to downstream. Only memberlist change will  be updated Kubernetes and thus reduces the unnecessary updates.  
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
