### PR TITLE
[ENH] Add flush sysdb to compactor

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -12,6 +12,7 @@ use crate::execution::orchestration::CompactOrchestrator;
 use crate::execution::orchestration::CompactionResponse;
 use crate::log::log::Log;
 use crate::memberlist::Memberlist;
+use crate::sysdb::sysdb::SysDb;
 use crate::system::Component;
 use crate::system::ComponentContext;
 use crate::system::Handler;
@@ -32,6 +33,7 @@ pub(crate) struct CompactionManager {
     scheduler: Scheduler,
     // Dependencies
     log: Box<dyn Log>,
+    sysdb: Box<dyn SysDb>,
     // Dispatcher
     dispatcher: Option<Box<dyn Receiver<TaskMessage>>>,
     // Config
@@ -57,6 +59,7 @@ impl CompactionManager {
     pub(crate) fn new(
         scheduler: Scheduler,
         log: Box<dyn Log>,
+        sysdb: Box<dyn SysDb>,
         compaction_manager_queue_size: usize,
         compaction_interval: Duration,
     ) -> Self {
@@ -64,6 +67,7 @@ impl CompactionManager {
             system: None,
             scheduler,
             log,
+            sysdb,
             dispatcher: None,
             compaction_manager_queue_size,
             compaction_interval,
@@ -96,6 +100,7 @@ impl CompactionManager {
                     system.clone(),
                     collection_uuid.unwrap(),
                     self.log.clone(),
+                    self.sysdb.clone(),
                     dispatcher.clone(),
                     None,
                 );
@@ -196,6 +201,7 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
         Ok(CompactionManager::new(
             scheduler,
             log,
+            sysdb,
             compaction_manager_queue_size,
             Duration::from_secs(compaction_interval_sec),
         ))
@@ -257,8 +263,6 @@ mod tests {
     use crate::types::LogRecord;
     use crate::types::Operation;
     use crate::types::OperationRecord;
-    use std::str::FromStr;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_compaction_manager() {
@@ -362,6 +366,7 @@ mod tests {
         let mut manager = CompactionManager::new(
             scheduler,
             log,
+            sysdb,
             compaction_manager_queue_size,
             compaction_interval,
         );

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -102,6 +102,7 @@ impl Scheduler {
                         last_compaction_time,
                         first_record_time: collection_info.first_log_ts,
                         offset: collection_info.first_log_offset,
+                        collection_version: collection[0].version,
                     });
                 }
                 Err(e) => {
@@ -185,7 +186,6 @@ mod tests {
     use crate::types::Operation;
     use crate::types::OperationRecord;
     use std::str::FromStr;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_scheduler() {

--- a/rust/worker/src/compactor/scheduler_policy.rs
+++ b/rust/worker/src/compactor/scheduler_policy.rs
@@ -47,6 +47,7 @@ impl SchedulerPolicy for LasCompactionTimeSchedulerPolicy {
                 collection_id: collection.id.clone(),
                 tenant_id: collection.tenant_id.clone(),
                 offset: collection.offset,
+                collection_version: collection.collection_version,
             });
         }
         tasks
@@ -67,6 +68,7 @@ mod tests {
                 last_compaction_time: 1,
                 first_record_time: 1,
                 offset: 0,
+                collection_version: 0,
             },
             CollectionRecord {
                 id: "test2".to_string(),
@@ -74,6 +76,7 @@ mod tests {
                 last_compaction_time: 0,
                 first_record_time: 0,
                 offset: 0,
+                collection_version: 0,
             },
         ];
         let jobs = scheduler_policy.determine(collections.clone(), 1);

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -3,6 +3,7 @@ pub(crate) struct CompactionJob {
     pub(crate) collection_id: String,
     pub(crate) tenant_id: String,
     pub(crate) offset: i64,
+    pub(crate) collection_version: i32,
 }
 
 #[derive(Clone, Debug)]

--- a/rust/worker/src/execution/data/data_chunk.rs
+++ b/rust/worker/src/execution/data/data_chunk.rs
@@ -108,7 +108,6 @@ impl<'a> Iterator for DataChunkIteraror<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::LogRecord;
     use crate::types::Operation;
     use crate::types::OperationRecord;
 

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -1,9 +1,7 @@
 use crate::execution::data::data_chunk::DataChunk;
 use crate::{distance::DistanceFunction, execution::operator::Operator};
 use async_trait::async_trait;
-use std::cmp::Ord;
 use std::cmp::Ordering;
-use std::cmp::PartialOrd;
 use std::collections::BinaryHeap;
 
 /// The brute force k-nearest neighbors operator is responsible for computing the k-nearest neighbors

--- a/rust/worker/src/execution/operators/flush_sysdb.rs
+++ b/rust/worker/src/execution/operators/flush_sysdb.rs
@@ -1,0 +1,200 @@
+use crate::execution::operator::Operator;
+use crate::sysdb::sysdb::FlushCompactionError;
+use crate::sysdb::sysdb::SysDb;
+use crate::types::FlushCompactionResponse;
+use crate::types::SegmentFlushInfo;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// The flush sysdb operator is responsible for flushing compaction data to the sysdb.
+#[derive(Debug)]
+pub struct FlushSysDbOperator {}
+
+impl FlushSysDbOperator {
+    /// Create a new flush sysdb operator.
+    pub fn new() -> Box<Self> {
+        Box::new(FlushSysDbOperator {})
+    }
+}
+
+#[derive(Debug)]
+/// The input for the flush sysdb operator.
+/// This input is used to flush compaction data to the sysdb.
+/// # Parameters
+/// * `tenant` - The tenant id.
+/// * `collection_id` - The collection id.
+/// * `log_position` - The log position. Note that this is the log position for the last record that
+/// was flushed to S3.
+/// * `collection_version` - The collection version. This is the current collection version before
+/// the flush operation. This version will be incremented by 1 after the flush operation. If the
+/// collection version in sysdb is not the same as the current collection version, the flush operation
+/// will fail.
+/// * `segment_flush_info` - The segment flush info.
+pub struct FlushSysDbInput {
+    tenant: String,
+    collection_id: String,
+    log_position: i64,
+    collection_version: i32,
+    segment_flush_info: Arc<[SegmentFlushInfo]>,
+    sysdb: Box<dyn SysDb>,
+}
+
+impl FlushSysDbInput {
+    /// Create a new flush sysdb input.
+    pub fn new(
+        tenant: String,
+        collection_id: String,
+        log_position: i64,
+        collection_version: i32,
+        segment_flush_info: Arc<[SegmentFlushInfo]>,
+        sysdb: Box<dyn SysDb>,
+    ) -> Self {
+        FlushSysDbInput {
+            tenant,
+            collection_id,
+            log_position,
+            collection_version,
+            segment_flush_info,
+            sysdb,
+        }
+    }
+}
+
+/// The output for the flush sysdb operator.
+/// # Parameters
+/// * `result` - The result of the flush compaction operation.
+#[derive(Debug)]
+pub struct FlushSysDbOutput {
+    result: FlushCompactionResponse,
+}
+
+pub type FlushSysDbResult = Result<FlushSysDbOutput, FlushCompactionError>;
+
+#[async_trait]
+impl Operator<FlushSysDbInput, FlushSysDbOutput> for FlushSysDbOperator {
+    type Error = FlushCompactionError;
+
+    async fn run(&self, input: &FlushSysDbInput) -> FlushSysDbResult {
+        let mut sysdb = input.sysdb.clone();
+        let result = sysdb
+            .flush_compaction(
+                input.tenant.clone(),
+                input.collection_id.clone(),
+                input.log_position,
+                input.collection_version,
+                input.segment_flush_info.clone(),
+            )
+            .await;
+        match result {
+            Ok(response) => Ok(FlushSysDbOutput { result: response }),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sysdb::test_sysdb::TestSysDb;
+    use crate::types::Collection;
+    use crate::types::Segment;
+    use crate::types::SegmentScope;
+    use crate::types::SegmentType;
+    use std::collections::HashMap;
+    use std::str::FromStr;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn test_flush_sysdb_operator() {
+        let mut sysdb = Box::new(TestSysDb::new());
+        let collection_version = 0;
+        let collection_uuid_1 = Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let tenant_1 = "tenant_1".to_string();
+        let collection_1 = Collection {
+            id: collection_uuid_1,
+            name: "collection_1".to_string(),
+            metadata: None,
+            dimension: Some(1),
+            tenant: tenant_1.clone(),
+            database: "database_1".to_string(),
+            log_position: 0,
+            version: collection_version,
+        };
+
+        let collection_uuid_2 = Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let tenant_2 = "tenant_2".to_string();
+        let collection_2 = Collection {
+            id: collection_uuid_2,
+            name: "collection_2".to_string(),
+            metadata: None,
+            dimension: Some(1),
+            tenant: tenant_2.clone(),
+            database: "database_2".to_string(),
+            log_position: 0,
+            version: collection_version,
+        };
+        sysdb.add_collection(collection_1);
+        sysdb.add_collection(collection_2);
+
+        let mut file_path_1 = HashMap::new();
+        file_path_1.insert("hnsw".to_string(), vec!["path_1".to_string()]);
+        let segment_id_1 = Uuid::from_str("00000000-0000-0000-0000-000000000003").unwrap();
+
+        let segment_1 = Segment {
+            id: segment_id_1.clone(),
+            r#type: SegmentType::HnswDistributed,
+            scope: SegmentScope::VECTOR,
+            collection: Some(collection_uuid_1),
+            metadata: None,
+            file_path: file_path_1.clone(),
+        };
+
+        let mut file_path_2 = HashMap::new();
+        file_path_2.insert("hnsw".to_string(), vec!["path_2".to_string()]);
+        let segment_id_2 = Uuid::from_str("00000000-0000-0000-0000-000000000004").unwrap();
+        let segment_2 = Segment {
+            id: segment_id_2.clone(),
+            r#type: SegmentType::HnswDistributed,
+            scope: SegmentScope::VECTOR,
+            collection: Some(collection_uuid_2),
+            metadata: None,
+            file_path: file_path_2.clone(),
+        };
+        sysdb.add_segment(segment_1);
+        sysdb.add_segment(segment_2);
+
+        let mut file_path_3 = HashMap::new();
+        file_path_3.insert("hnsw".to_string(), vec!["path_3".to_string()]);
+
+        let mut file_path_4 = HashMap::new();
+        file_path_4.insert("hnsw".to_string(), vec!["path_4".to_string()]);
+        let segment_flush_info = vec![
+            SegmentFlushInfo {
+                segment_id: segment_id_1.clone(),
+                file_paths: file_path_3.clone(),
+            },
+            SegmentFlushInfo {
+                segment_id: segment_id_2.clone(),
+                file_paths: file_path_4.clone(),
+            },
+        ];
+
+        let log_position = 100;
+        let operator = FlushSysDbOperator::new();
+        let input = FlushSysDbInput::new(
+            tenant_1.clone(),
+            collection_uuid_1.to_string(),
+            log_position,
+            collection_version,
+            segment_flush_info.into(),
+            sysdb,
+        );
+
+        let result = operator.run(&input).await;
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.result.collection_id, collection_uuid_1.to_string());
+        assert_eq!(result.result.collection_version, collection_version + 1);
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod brute_force_knn;
+pub(super) mod flush_sysdb;
 pub(super) mod normalize_vectors;
 pub(super) mod partition;
 pub(super) mod pull_log;

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -148,7 +148,6 @@ mod tests {
     use crate::types::Operation;
     use crate::types::OperationRecord;
     use std::str::FromStr;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_pull_logs() {

--- a/rust/worker/src/log/log.rs
+++ b/rust/worker/src/log/log.rs
@@ -31,6 +31,7 @@ pub(crate) struct CollectionRecord {
     pub(crate) last_compaction_time: i64,
     pub(crate) first_record_time: i64,
     pub(crate) offset: i64,
+    pub(crate) collection_version: i32,
 }
 
 #[async_trait]

--- a/rust/worker/src/sysdb/sysdb.rs
+++ b/rust/worker/src/sysdb/sysdb.rs
@@ -6,11 +6,17 @@ use crate::errors::ChromaError;
 use crate::errors::ErrorCodes;
 use crate::types::Collection;
 use crate::types::CollectionConversionError;
+use crate::types::FlushCompactionResponse;
+use crate::types::FlushCompactionResponseConversionError;
 use crate::types::Segment;
 use crate::types::SegmentConversionError;
+use crate::types::SegmentFlushInfo;
+use crate::types::SegmentFlushInfoConversionError;
 use crate::types::SegmentScope;
 use crate::types::Tenant;
 use async_trait::async_trait;
+use std::sync::Arc;
+
 use std::fmt::Debug;
 use thiserror::Error;
 use uuid::Uuid;
@@ -40,6 +46,15 @@ pub(crate) trait SysDb: Send + Sync + SysDbClone + Debug {
         &mut self,
         tanant_ids: Vec<String>,
     ) -> Result<Vec<Tenant>, GetLastCompactionTimeError>;
+
+    async fn flush_compaction(
+        &mut self,
+        tenant_id: String,
+        collection_id: String,
+        log_position: i64,
+        collection_version: i32,
+        segment_flush_info: Arc<[SegmentFlushInfo]>,
+    ) -> Result<FlushCompactionResponse, FlushCompactionError>;
 }
 
 // We'd like to be able to clone the trait object, so we need to use the
@@ -248,6 +263,58 @@ impl SysDb for GrpcSysDb {
             }
         }
     }
+
+    async fn flush_compaction(
+        &mut self,
+        tenant_id: String,
+        collection_id: String,
+        log_position: i64,
+        collection_version: i32,
+        segment_flush_info: Arc<[SegmentFlushInfo]>,
+    ) -> Result<FlushCompactionResponse, FlushCompactionError> {
+        let segment_compaction_info =
+            segment_flush_info
+                .iter()
+                .map(|segment_flush_info| segment_flush_info.try_into())
+                .collect::<Result<
+                    Vec<chroma_proto::FlushSegmentCompactionInfo>,
+                    SegmentFlushInfoConversionError,
+                >>();
+
+        let segment_compaction_info = match segment_compaction_info {
+            Ok(segment_compaction_info) => segment_compaction_info,
+            Err(e) => {
+                return Err(FlushCompactionError::SegmentFlushInfoConversionError(e));
+            }
+        };
+
+        let req = chroma_proto::FlushCollectionCompactionRequest {
+            tenant_id,
+            collection_id,
+            log_position,
+            collection_version,
+            segment_compaction_info,
+        };
+
+        let res = self.client.flush_collection_compaction(req).await;
+        match res {
+            Ok(res) => {
+                let res = res.into_inner();
+                let res = match res.try_into() {
+                    Ok(res) => res,
+                    Err(e) => {
+                        return Err(
+                            FlushCompactionError::FlushCompactionResponseConversionError(e),
+                        );
+                    }
+                };
+                return Ok(res);
+            }
+            Err(e) => {
+                return Err(FlushCompactionError::FailedToFlushCompaction(e));
+            }
+        }
+    }
 }
 
 #[derive(Error, Debug)]
@@ -302,6 +369,32 @@ impl ChromaError for GetLastCompactionTimeError {
         match self {
             GetLastCompactionTimeError::FailedToGetLastCompactionTime(_) => ErrorCodes::Internal,
             GetLastCompactionTimeError::TenantNotFound => ErrorCodes::Internal,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum FlushCompactionError {
+    #[error("Failed to flush compaction")]
+    FailedToFlushCompaction(#[from] tonic::Status),
+    #[error("Failed to convert segment flush info")]
+    SegmentFlushInfoConversionError(#[from] SegmentFlushInfoConversionError),
+    #[error("Failed to convert flush compaction response")]
+    FlushCompactionResponseConversionError(#[from] FlushCompactionResponseConversionError),
+    #[error("Collection not found in sysdb")]
+    CollectionNotFound,
+    #[error("Segment not found in sysdb")]
+    SegmentNotFound,
+}
+
+impl ChromaError for FlushCompactionError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            FlushCompactionError::FailedToFlushCompaction(_) => ErrorCodes::Internal,
+            FlushCompactionError::SegmentFlushInfoConversionError(_) => ErrorCodes::Internal,
+            FlushCompactionError::FlushCompactionResponseConversionError(_) => ErrorCodes::Internal,
+            FlushCompactionError::CollectionNotFound => ErrorCodes::Internal,
+            FlushCompactionError::SegmentNotFound => ErrorCodes::Internal,
         }
     }
 }

--- a/rust/worker/src/sysdb/test_sysdb.rs
+++ b/rust/worker/src/sysdb/test_sysdb.rs
@@ -1,12 +1,17 @@
+use crate::sysdb::sysdb::FlushCompactionError;
 use crate::sysdb::sysdb::GetCollectionsError;
 use crate::sysdb::sysdb::GetSegmentsError;
 use crate::sysdb::sysdb::SysDb;
 use crate::types::Collection;
+use crate::types::FlushCompactionResponse;
 use crate::types::Segment;
+use crate::types::SegmentFlushInfo;
 use crate::types::SegmentScope;
+use crate::types::SegmentType;
 use crate::types::Tenant;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use super::sysdb::GetLastCompactionTimeError;
@@ -14,6 +19,7 @@ use super::sysdb::GetLastCompactionTimeError;
 #[derive(Clone, Debug)]
 pub(crate) struct TestSysDb {
     collections: HashMap<Uuid, Collection>,
+    segments: HashMap<Uuid, Segment>,
     tenant_last_compaction_time: HashMap<String, i64>,
 }
 
@@ -21,12 +27,17 @@ impl TestSysDb {
     pub(crate) fn new() -> Self {
         TestSysDb {
             collections: HashMap::new(),
+            segments: HashMap::new(),
             tenant_last_compaction_time: HashMap::new(),
         }
     }
 
     pub(crate) fn add_collection(&mut self, collection: Collection) {
         self.collections.insert(collection.id, collection);
+    }
+
+    pub(crate) fn add_segment(&mut self, segment: Segment) {
+        self.segments.insert(segment.id, segment);
     }
 
     pub(crate) fn add_tenant_last_compaction_time(
@@ -55,6 +66,37 @@ impl TestSysDb {
             return false;
         }
         if database.is_some() && database.unwrap() != collection.database {
+            return false;
+        }
+        true
+    }
+
+    fn filter_segments(
+        segment: &Segment,
+        id: Option<Uuid>,
+        r#type: Option<String>,
+        scope: Option<SegmentScope>,
+        collection: Option<Uuid>,
+    ) -> bool {
+        if id.is_some() && id.unwrap() != segment.id {
+            return false;
+        }
+        if r#type.is_some() {
+            match r#type.unwrap().as_str() {
+                "hnsw" => {
+                    if segment.r#type != SegmentType::HnswDistributed {
+                        return false;
+                    }
+                }
+                _ => return false,
+            }
+        }
+        if scope.is_some() && scope.unwrap() != segment.scope {
+            return false;
+        }
+        if collection.is_some()
+            && (segment.collection.is_none() || collection.unwrap() != segment.collection.unwrap())
+        {
             return false;
         }
         true
@@ -88,12 +130,20 @@ impl SysDb for TestSysDb {
 
     async fn get_segments(
         &mut self,
-        _id: Option<Uuid>,
-        _type: Option<String>,
-        _scope: Option<SegmentScope>,
-        _collection: Option<Uuid>,
+        id: Option<Uuid>,
+        r#type: Option<String>,
+        scope: Option<SegmentScope>,
+        collection: Option<Uuid>,
     ) -> Result<Vec<Segment>, GetSegmentsError> {
-        Ok(Vec::new())
+        let mut segments = Vec::new();
+        for segment in self.segments.values() {
+            if !TestSysDb::filter_segments(&segment, id, r#type.clone(), scope.clone(), collection)
+            {
+                continue;
+            }
+            segments.push(segment.clone());
+        }
+        Ok(segments)
     }
 
     async fn get_last_compaction_time(
@@ -115,5 +165,49 @@ impl SysDb for TestSysDb {
             });
         }
         Ok(tenants)
+    }
+
+    async fn flush_compaction(
+        &mut self,
+        tenant_id: String,
+        collection_id: String,
+        log_position: i64,
+        collection_version: i32,
+        segment_flush_info: Arc<[SegmentFlushInfo]>,
+    ) -> Result<FlushCompactionResponse, FlushCompactionError> {
+        let collection = self
+            .collections
+            .get(&Uuid::parse_str(&collection_id).unwrap());
+        if collection.is_none() {
+            return Err(FlushCompactionError::CollectionNotFound);
+        }
+        let collection = collection.unwrap();
+        let mut collection = collection.clone();
+        collection.log_position = log_position;
+        let new_collection_version = collection_version + 1;
+        collection.version = new_collection_version;
+        self.collections.insert(collection.id, collection);
+        let mut last_compaction_time = match self.tenant_last_compaction_time.get(&tenant_id) {
+            Some(last_compaction_time) => *last_compaction_time,
+            None => 0,
+        };
+        last_compaction_time += 1;
+
+        // update segments
+        for segment_flush_info in segment_flush_info.iter() {
+            let segment = self.segments.get(&segment_flush_info.segment_id);
+            if segment.is_none() {
+                return Err(FlushCompactionError::SegmentNotFound);
+            }
+            let mut segment = segment.unwrap().clone();
+            segment.file_path = segment_flush_info.file_paths.clone();
+            self.segments.insert(segment.id, segment);
+        }
+
+        Ok(FlushCompactionResponse::new(
+            collection_id,
+            new_collection_version,
+            last_compaction_time,
+        ))
     }
 }

--- a/rust/worker/src/types/flush.rs
+++ b/rust/worker/src/types/flush.rs
@@ -1,0 +1,76 @@
+use super::ConversionError;
+use crate::chroma_proto::FilePaths;
+use crate::chroma_proto::FlushCollectionCompactionResponse;
+use crate::chroma_proto::FlushSegmentCompactionInfo;
+use std::collections::HashMap;
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(crate) struct SegmentFlushInfo {
+    pub(crate) segment_id: Uuid,
+    pub(crate) file_paths: HashMap<String, Vec<String>>,
+}
+
+impl TryInto<FlushSegmentCompactionInfo> for &SegmentFlushInfo {
+    type Error = SegmentFlushInfoConversionError;
+
+    fn try_into(self) -> Result<FlushSegmentCompactionInfo, Self::Error> {
+        let mut file_paths = HashMap::new();
+        for (key, value) in self.file_paths.clone() {
+            file_paths.insert(key, FilePaths { paths: value });
+        }
+
+        Ok(FlushSegmentCompactionInfo {
+            segment_id: self.segment_id.to_string(),
+            file_paths,
+        })
+    }
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum SegmentFlushInfoConversionError {
+    #[error("Invalid segment id, valid UUID required")]
+    InvalidSegmentId,
+    #[error(transparent)]
+    DecodeError(#[from] ConversionError),
+}
+
+#[derive(Debug)]
+pub(crate) struct FlushCompactionResponse {
+    pub(crate) collection_id: String,
+    pub(crate) collection_version: i32,
+    pub(crate) last_compaction_time: i64,
+}
+
+impl FlushCompactionResponse {
+    pub(crate) fn new(
+        collection_id: String,
+        collection_version: i32,
+        last_compaction_time: i64,
+    ) -> Self {
+        FlushCompactionResponse {
+            collection_id,
+            collection_version,
+            last_compaction_time,
+        }
+    }
+}
+
+impl TryFrom<FlushCollectionCompactionResponse> for FlushCompactionResponse {
+    type Error = FlushCompactionResponseConversionError;
+
+    fn try_from(value: FlushCollectionCompactionResponse) -> Result<Self, Self::Error> {
+        Ok(FlushCompactionResponse {
+            collection_id: value.collection_id,
+            collection_version: value.collection_version,
+            last_compaction_time: value.last_compaction_time,
+        })
+    }
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum FlushCompactionResponseConversionError {
+    #[error(transparent)]
+    DecodeError(#[from] ConversionError),
+}

--- a/rust/worker/src/types/mod.rs
+++ b/rust/worker/src/types/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod types;
 mod collection;
+mod flush;
 mod metadata;
 mod operation;
 mod record;
@@ -11,6 +12,7 @@ mod tenant;
 
 // Re-export the types module, so that we can use it as a single import in other modules.
 pub(crate) use collection::*;
+pub(crate) use flush::*;
 pub(crate) use metadata::*;
 pub(crate) use operation::*;
 pub(crate) use record::*;

--- a/rust/worker/src/types/segment.rs
+++ b/rust/worker/src/types/segment.rs
@@ -101,7 +101,6 @@ impl TryFrom<chroma_proto::Segment> for Segment {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use super::*;
     use crate::types::MetadataValue;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR adds flush sysdb operator to compaction orchestrator. 
	 - Changes include
	   - A new sysdb API to write to the sysdb on the new compaction metadata.
	   - A flush_sysdb operator which will be used by the compaction orchestrator to register the compaction result to sysdb. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
