### PR TITLE
[ENH] Rust write segments and flush S3 operator skeleton

### DIFF
--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -1,0 +1,22 @@
+use crate::execution::operator::Operator;
+use async_trait::async_trait;
+
+#[derive(Debug)]
+pub struct FlushS3Operator {}
+
+#[derive(Debug)]
+pub struct FlushS3Input {}
+
+#[derive(Debug)]
+pub struct FlushS3Output {}
+
+pub type WriteSegmentsResult = Result<FlushS3Output, ()>;
+
+#[async_trait]
+impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
+    type Error = ();
+
+    async fn run(&self, input: &FlushS3Input) -> WriteSegmentsResult {
+        Ok(FlushS3Output {})
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -1,5 +1,7 @@
 pub(super) mod brute_force_knn;
+pub(super) mod flush_s3;
 pub(super) mod flush_sysdb;
 pub(super) mod normalize_vectors;
 pub(super) mod partition;
 pub(super) mod pull_log;
+pub(super) mod write_segments;

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -1,0 +1,22 @@
+use crate::execution::operator::Operator;
+use async_trait::async_trait;
+
+#[derive(Debug)]
+pub struct WriteSegmentsOperator {}
+
+#[derive(Debug)]
+pub struct WriteSegmentsInput {}
+
+#[derive(Debug)]
+pub struct WriteSegmentsOutput {}
+
+pub type WriteSegmentsResult = Result<WriteSegmentsOutput, ()>;
+
+#[async_trait]
+impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator {
+    type Error = ();
+
+    async fn run(&self, input: &WriteSegmentsInput) -> WriteSegmentsResult {
+        Ok(WriteSegmentsOutput {})
+    }
+}

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -11,6 +11,7 @@ use crate::execution::operators::partition::PartitionResult;
 use crate::execution::operators::pull_log::PullLogsInput;
 use crate::execution::operators::pull_log::PullLogsOperator;
 use crate::execution::operators::pull_log::PullLogsResult;
+use crate::execution::operators::write_segments::WriteSegmentsResult;
 use crate::log::log::Log;
 use crate::sysdb::sysdb::SysDb;
 use crate::system::Component;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR adds skeleton code for write segments and flush S3 operator to prepare for integration with Blockfile. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
