### PR TITLE
[BUG] Make the gracefulperiod to be 0 for pod deletion

### DIFF
--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -132,7 +132,10 @@ func createFakePod(ip string, clientset kubernetes.Interface) {
 }
 
 func deleteFakePod(ip string, clientset kubernetes.Interface) {
-	clientset.CoreV1().Pods("chroma").Delete(context.TODO(), ip, metav1.DeleteOptions{})
+	gracefulPeriodSeconds := int64(0)
+	clientset.CoreV1().Pods("chroma").Delete(context.TODO(), ip, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracefulPeriodSeconds,
+	})
 }
 
 func TestMemberlistManager(t *testing.T) {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Make the gracefulperiod to be 0 for pod deletion
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
