### PR TITLE
[BUG]: Correct package name in Sentence Transformer installation error

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -78,7 +78,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
                 from sentence_transformers import SentenceTransformer
             except ImportError:
                 raise ValueError(
-                    "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+                    "The sentence_transformers python package is not installed. Please install it with `pip install sentence-transformers`"
                 )
             self.models[model_name] = SentenceTransformer(
                 model_name, device=device, **kwargs


### PR DESCRIPTION
The Python package for Sentence Transformer is sentence-transformers (kebab-case), not sentence_transformers (snake_case). Update the error message to use the correct package name.

See https://pypi.org/project/sentence-transformers

## Description of changes

Just the name of the package in the error message.