### PR TITLE
[TST] Fix a flaky metastore collection test

### DIFF
--- a/go/pkg/metastore/db/dao/collection_test.go
+++ b/go/pkg/metastore/db/dao/collection_test.go
@@ -97,11 +97,19 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, nil)
 	suite.NoError(err)
 	suite.Len(collections, 1)
-	suite.Equal(collectionID, collections[0].Collection.ID)
+	if collectionID < collection2 {
+		suite.Equal(collectionID, collections[0].Collection.ID)
+	} else {
+		suite.Equal(collection2, collections[0].Collection.ID)
+	}
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset)
 	suite.NoError(err)
 	suite.Len(collections, 1)
-	suite.Equal(collection2, collections[0].Collection.ID)
+	if collectionID < collection2 {
+		suite.Equal(collection2, collections[0].Collection.ID)
+	} else {
+		suite.Equal(collectionID, collections[0].Collection.ID)
+	}
 	offset = int32(2)
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset)
 	suite.NoError(err)

--- a/go/pkg/metastore/db/dao/collection_test.go
+++ b/go/pkg/metastore/db/dao/collection_test.go
@@ -87,29 +87,25 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	suite.Equal(collectionID, collections[0].Collection.ID)
 
 	// Test limit and offset
-	collection2, err := CreateTestCollection(suite.db, "test_collection_get_collections2", 128, suite.databaseId)
+	_, err = CreateTestCollection(suite.db, "test_collection_get_collections2", 128, suite.databaseId)
 	suite.NoError(err)
-	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
+
+	allCollections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
 	suite.NoError(err)
-	suite.Len(collections, 2)
+	suite.Len(allCollections, 2)
+
 	limit := int32(1)
 	offset := int32(1)
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, nil)
 	suite.NoError(err)
 	suite.Len(collections, 1)
-	if collectionID < collection2 {
-		suite.Equal(collectionID, collections[0].Collection.ID)
-	} else {
-		suite.Equal(collection2, collections[0].Collection.ID)
-	}
+	suite.Equal(allCollections[0].Collection.ID, collections[0].Collection.ID)
+
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset)
 	suite.NoError(err)
 	suite.Len(collections, 1)
-	if collectionID < collection2 {
-		suite.Equal(collection2, collections[0].Collection.ID)
-	} else {
-		suite.Equal(collectionID, collections[0].Collection.ID)
-	}
+	suite.Equal(allCollections[1].Collection.ID, collections[0].Collection.ID)
+
 	offset = int32(2)
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset)
 	suite.NoError(err)


### PR DESCRIPTION
Issue:
A particular order for collections is expected. The collections are currently returned ordered by id which is UUID -> random. This makes the test flaky and fails ~ every second run.

Fix:
Fix the tests to expect the collections returned in the appropriate order.
