### PR TITLE
[ENH]: clarify non-included fields in .get() and .query() responses

### DIFF
--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -13,6 +13,7 @@ from chromadb.api.types import (
     Metadatas,
     Where,
     WhereDocument,
+    Omitted,
 )
 import chromadb.test.property.strategies as strategies
 import hypothesis.strategies as st
@@ -345,7 +346,7 @@ def test_empty_filter(api: ServerAPI) -> None:
         n_results=3,
     )
     assert res["ids"] == [[], []]
-    assert res["embeddings"] is None
+    assert isinstance(res["embeddings"], Omitted)
     assert res["distances"] == [[], []]
     assert res["metadatas"] == [[], []]
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -5,7 +5,7 @@ from urllib3.connectionpool import InsecureRequestWarning
 
 import chromadb
 from chromadb.api.fastapi import FastAPI
-from chromadb.api.types import QueryResult, EmbeddingFunction, Document
+from chromadb.api.types import QueryResult, EmbeddingFunction, Document, Omitted
 from chromadb.config import Settings
 import chromadb.server.fastapi
 import pytest
@@ -92,7 +92,7 @@ def test_persist_index_loading(api_fixture, request):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
 
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
@@ -119,7 +119,7 @@ def test_persist_index_loading_embedding_function(api_fixture, request):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
 
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
@@ -147,7 +147,7 @@ def test_persist_index_get_or_create_embedding_function(api_fixture, request):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
     assert nn["ids"] == [["id1"]]
     assert nn["embeddings"] == [[[1, 2, 3]]]
@@ -261,7 +261,7 @@ def test_get_from_db(api):
         if (key in includes) or (key == "ids"):
             assert len(records[key]) == 2
         else:
-            assert records[key] is None
+            assert isinstance(records[key], Omitted)
 
 
 def test_reset_db(api):
@@ -291,7 +291,7 @@ def test_get_nearest_neighbors(api):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
     nn = collection.query(
         query_embeddings=[[1.1, 2.3, 3.2]],
@@ -303,7 +303,7 @@ def test_get_nearest_neighbors(api):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
     nn = collection.query(
         query_embeddings=[[1.1, 2.3, 3.2], [0.1, 2.3, 4.5]],
@@ -315,7 +315,7 @@ def test_get_nearest_neighbors(api):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 2
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
 
 def test_delete(api):
@@ -438,7 +438,7 @@ def test_increment_index_on(api):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
 
 def test_add_a_collection(api):
@@ -999,7 +999,7 @@ def test_query_include(api):
         include=["metadatas", "documents", "distances"],
         n_results=1,
     )
-    assert items["embeddings"] is None
+    assert isinstance(items["embeddings"], Omitted)
     assert items["ids"][0][0] == "id1"
     assert items["metadatas"][0][0]["int_value"] == 1
 
@@ -1008,7 +1008,7 @@ def test_query_include(api):
         include=["embeddings", "documents", "distances"],
         n_results=1,
     )
-    assert items["metadatas"] is None
+    assert isinstance(items["metadatas"], Omitted)
     assert items["ids"][0][0] == "id1"
 
     items = collection.query(
@@ -1016,10 +1016,10 @@ def test_query_include(api):
         include=[],
         n_results=2,
     )
-    assert items["documents"] is None
-    assert items["metadatas"] is None
-    assert items["embeddings"] is None
-    assert items["distances"] is None
+    assert isinstance(items["documents"], Omitted)
+    assert isinstance(items["metadatas"], Omitted)
+    assert isinstance(items["embeddings"], Omitted)
+    assert isinstance(items["distances"], Omitted)
     assert items["ids"][0][0] == "id1"
     assert items["ids"][0][1] == "id2"
 
@@ -1030,20 +1030,20 @@ def test_get_include(api):
     collection.add(**records)
 
     items = collection.get(include=["metadatas", "documents"], where={"int_value": 1})
-    assert items["embeddings"] is None
+    assert isinstance(items["embeddings"], Omitted)
     assert items["ids"][0] == "id1"
     assert items["metadatas"][0]["int_value"] == 1
     assert items["documents"][0] == "this document is first"
 
     items = collection.get(include=["embeddings", "documents"])
-    assert items["metadatas"] is None
+    assert isinstance(items["metadatas"], Omitted)
     assert items["ids"][0] == "id1"
     assert approx_equal(items["embeddings"][1][0], 1.2)
 
     items = collection.get(include=[])
-    assert items["documents"] is None
-    assert items["metadatas"] is None
-    assert items["embeddings"] is None
+    assert isinstance(items["documents"], Omitted)
+    assert isinstance(items["metadatas"], Omitted)
+    assert isinstance(items["embeddings"], Omitted)
     assert items["ids"][0] == "id1"
 
     with pytest.raises(ValueError, match="include"):
@@ -1173,7 +1173,7 @@ def test_persist_index_loading_params(api, request):
         if (key in includes) or (key == "ids"):
             assert len(nn[key]) == 1
         else:
-            assert nn[key] is None
+            assert isinstance(nn[key], Omitted)
 
 
 def test_add_large(api):
@@ -1291,7 +1291,7 @@ def test_get_nearest_neighbors_where_n_results_more_than_element(api):
         if key in includes or key == "ids":
             assert len(results[key][0]) == 2
         else:
-            assert results[key] is None
+            assert isinstance(results[key], Omitted)
 
 
 def test_invalid_n_results_param(api):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1499,3 +1499,28 @@ def test_ssl_self_signed_with_verify_false(client_ssl):
         client.heartbeat()
     client_ssl.clear_system_cache()
     assert "Unverified HTTPS request" in str(record[0].message)
+
+
+def test_omitted_field_messages(api):
+    api.reset()
+    collection = api.create_collection("testspace")
+    collection.add(**records)
+
+    # Test .get()
+    document = collection.get(ids="id1")
+
+    assert "Add 'embeddings' to `include` to return this field" in str(document)
+
+    assert "Add 'embeddings' to `include` to return this field" in str(
+        document["embeddings"]
+    )
+
+    with pytest.raises(ValueError) as exc:
+        document["embeddings"][0]
+    assert "Add 'embeddings' to `include` to return this field" in str(exc.value)
+    assert exc.type == ValueError
+
+    # Test .query()
+    documents = collection.query(query_embeddings=[0, 0, 0], n_results=1)
+
+    assert "Add 'embeddings' to `include` to return this field" in str(documents)


### PR DESCRIPTION
## Description of changes

Closes https://github.com/chroma-core/chroma/issues/300.

`print(collection.get(...))` now looks like this:

<img width="1086" alt="Screenshot 2024-04-19 at 10 10 03 AM" src="https://github.com/chroma-core/chroma/assets/7410405/e721c52a-66d9-4eb9-b5df-91553a01f8a8">

Could use some opinions on this--is it too verbose? I figured it would be better to be consistent across all fields affected by `include`, but we could scope this to just `embeddings` for now as well.

This can probably be rolled into 0.5 as a potentially breaking change (`embeddings is None` will no longer work).

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

Existing docs don't really give much details on how the response shape changes depending on `include`, so not necessary to update but might be nice to give additional details.