### PR TITLE
[TST] Try to fix a sporadic test failure

### DIFF
--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -6,6 +6,7 @@ from typing import Generator, List, Callable, Dict, Union
 
 from chromadb.db.impl.grpc.client import GrpcSysDB
 from chromadb.db.impl.grpc.server import GrpcMockSysDB
+from chromadb.test.conftest import find_free_port
 from chromadb.types import Collection, Segment, SegmentScope
 from chromadb.db.impl.sqlite import SqliteDB
 from chromadb.config import (
@@ -88,10 +89,12 @@ def sqlite_persistent() -> Generator[SysDB, None, None]:
 def grpc_with_mock_server() -> Generator[SysDB, None, None]:
     """Fixture generator for sqlite DB that creates a mock grpc sysdb server
     and a grpc client that connects to it."""
+    port = find_free_port()
+
     system = System(
         Settings(
             allow_reset=True,
-            chroma_server_grpc_port=50051,
+            chroma_server_grpc_port=port,
         )
     )
     system.instance(GrpcMockSysDB)


### PR DESCRIPTION
The test_system.py tests fail sporadically with "Address already in use". This is an attempt for fix those sporadic test failures. Example failed build: https://github.com/chroma-core/chroma/actions/runs/8743308262/job/23994159391?pr=2027#logs