### PR TITLE
[BLD] add lint workflow

### DIFF
--- a/.github/workflows/chroma-lint.yml
+++ b/.github/workflows/chroma-lint.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+      - name: Install pre-commit
+        run: python -m pip install -r requirements_dev.txt
       - name: Run pre-commit
         # todo: remove || true once lint issues are resolved
         run: pre-commit run --all-files || true


### PR DESCRIPTION
Currently, this will run in CI but never error. There's 80-90 files that need to be (automatically) updated, so I figured I'd do that in a separate PR to reduce noise.

See https://github.com/chroma-core/chroma/actions/runs/8805438845/job/24168001018?pr=2045 for an example workflow run.
