### PR TITLE
[BUG] Refactor memberlist reconciliation in MemberlistManager

### DIFF
--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -160,10 +160,12 @@ func TestMemberlistManager(t *testing.T) {
 	memberlistStore := NewCRMemberlistStore(dynamicClient, namespace, memberlist_name)
 
 	// Create a memberlist manager
-	memberlist_manager := NewMemberlistManager(nodeWatcher, memberlistStore)
+	memberlistManager := NewMemberlistManager(nodeWatcher, memberlistStore)
+	memberlistManager.SetReconcileInterval(5 * time.Second)
+	memberlistManager.SetReconcileCount(1)
 
 	// Start the memberlist manager
-	err = memberlist_manager.Start()
+	err = memberlistManager.Start()
 	if err != nil {
 		t.Fatalf("Error starting memberlist manager: %v", err)
 	}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR fixes the issue that the memberlist manager is not propagating the memberlist to downstream. The issue is that the Get function for the worker queue is blocking when the queue is empty. The end result is that if the number of events is not cumulated to the batch size, the memberlist may block waiting and not propagate the memberlist with timeout. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
