### PR TITLE
[BUG] GRPC Metadata segment should return results

### DIFF
--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -89,7 +89,7 @@ class GrpcMetadataSegment(MetadataReader):
             result = self._from_proto(record)
             results.append(result)
 
-        return []
+        return results
 
     def _where_to_proto(self, where: Optional[Where]) -> pb.Where:
         response = pb.Where()


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixes a bug where the segment was returning an empty [] despite constructing the correct result
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
We should have a test for this! For now I am getting the bug fix up and we can discuss how to test.
- [!!!!] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
