### PR TITLE
[BUG] Double comparison proto conversion

### DIFF
--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -263,7 +263,7 @@ class GrpcMetadataSegment(MetadataReader):
                             sfc = pb.SingleDoubleComparison()
                             sfc.value = operand
                             sfc.generic_comparator = pb.GenericComparator.EQ
-                            dc.double_list_operand.CopyFrom(sfc)
+                            dc.single_double_operand.CopyFrom(sfc)
 
             response.direct_comparison.CopyFrom(dc)
         return response


### PR DESCRIPTION
Not sure if this is correct but type checker was complaining so putting up for thoughts

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixes a (assumed) bug where we were converting the wrong type
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
We should to discuss the testing here / why this worked
- [!!!] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
