### PR TITLE
[ENH] Add rust metadata gprc reader

### DIFF
--- a/chromadb/segment/__init__.py
+++ b/chromadb/segment/__init__.py
@@ -23,7 +23,9 @@ class SegmentType(Enum):
     HNSW_LOCAL_MEMORY = "urn:chroma:segment/vector/hnsw-local-memory"
     HNSW_LOCAL_PERSISTED = "urn:chroma:segment/vector/hnsw-local-persisted"
     HNSW_DISTRIBUTED = "urn:chroma:segment/vector/hnsw-distributed"
+    # TODO: rename record to blockfile record
     RECORD = "urn:chroma:segment/record"
+    BLOCKFILE_METADATA = "urn:chroma:segment/metadata/blockfile"
 
 
 class SegmentImplementation(Component):

--- a/chromadb/segment/impl/manager/distributed.py
+++ b/chromadb/segment/impl/manager/distributed.py
@@ -30,6 +30,7 @@ from collections import defaultdict
 SEGMENT_TYPE_IMPLS = {
     SegmentType.SQLITE: "chromadb.segment.impl.metadata.sqlite.SqliteMetadataSegment",
     SegmentType.HNSW_DISTRIBUTED: "chromadb.segment.impl.vector.grpc_segment.GrpcVectorSegment",
+    SegmentType.BLOCKFILE_METADATA: "chromadb.segment.impl.metadata.grpc_segment.GrpcMetadataSegment",
 }
 
 
@@ -64,11 +65,11 @@ class DistributedSegmentManager(SegmentManager):
         vector_segment = _segment(
             SegmentType.HNSW_DISTRIBUTED, SegmentScope.VECTOR, collection
         )
-        # metadata_segment = _segment(
-        #     SegmentType.SQLITE, SegmentScope.METADATA, collection
-        # )
+        metadata_segment = _segment(
+            SegmentType.BLOCKFILE_METADATA, SegmentScope.METADATA, collection
+        )
         record_segment = _segment(SegmentType.RECORD, SegmentScope.RECORD, collection)
-        return [vector_segment, record_segment]
+        return [vector_segment, record_segment, metadata_segment]
 
     @override
     def delete_segments(self, collection_id: UUID) -> Sequence[UUID]:

--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -65,12 +65,12 @@ class GrpcMetadataSegment(MetadataReader):
     ) -> Sequence[MetadataEmbeddingRecord]:
         """Query for embedding metadata."""
 
-        where_pb = self._where_to_proto(where)
-        where_document_pb = self._where_document_to_proto(where_document)
         request: pb.QueryMetadataRequest = pb.QueryMetadataRequest(
             segment_id=self._segment["id"].hex,
-            where=where_pb,
-            where_document=where_document_pb,
+            where=self._where_to_proto(where) if where is not None else None,
+            where_document=self._where_document_to_proto(where_document)
+            if where_document is not None
+            else None,
             ids=ids,
             limit=limit,
             offset=offset,
@@ -89,7 +89,7 @@ class GrpcMetadataSegment(MetadataReader):
             result = self._from_proto(record)
             results.append(result)
 
-        return []
+        return results
 
     def _where_to_proto(self, where: Optional[Where]) -> pb.Where:
         response = pb.Where()
@@ -263,7 +263,7 @@ class GrpcMetadataSegment(MetadataReader):
                             sfc = pb.SingleDoubleComparison()
                             sfc.value = operand
                             sfc.generic_comparator = pb.GenericComparator.EQ
-                            dc.double_list_operand.CopyFrom(sfc)
+                            dc.single_double_operand.CopyFrom(sfc)
 
             response.direct_comparison.CopyFrom(dc)
         return response

--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -54,7 +54,7 @@ func init() {
 	// Query service memberlist
 	Cmd.Flags().StringVar(&conf.QueryServiceMemberlistName, "query-memberlist-name", "query-service-memberlist", "Query service memberlist name")
 	Cmd.Flags().StringVar(&conf.QueryServicePodLabel, "query-pod-label", "query-service", "Query pod label")
-	Cmd.Flags().DurationVar(&conf.WatchInterval, "watch-interval", 60*time.Second, "Watch interval")
+	Cmd.Flags().DurationVar(&conf.WatchInterval, "watch-interval", 5*time.Second, "Watch interval")
 
 	// Compaction service Memberlist
 	Cmd.Flags().StringVar(&conf.CompactionServiceMemberlistName, "compaction-memberlist-name", "compaction-service-memberlist", "Compaction memberlist name")

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -30,7 +30,7 @@ pub struct BruteForceKnnOperatorInput {
 /// The output of the brute force k-nearest neighbors operator.
 /// # Parameters
 /// * `data` - The vectors to query against. Only the vectors that are nearest neighbors are visible.
-/// * `indices` - The indices of the nearest neighbors. This is a mask against the `query_vecs` input.
+/// * `indices` - The indices of the nearest neighbors. This is a mask against the `data` input.
 /// One row for each query vector.
 /// * `distances` - The distances of the nearest neighbors.
 /// One row for each query vector.
@@ -91,6 +91,7 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
             let embedding = match &log_record.record.embedding {
                 Some(embedding) => embedding,
                 None => {
+                    // Implies that the record is a delete or update of irrelevant field
                     continue;
                 }
             };

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -1,0 +1,204 @@
+use std::f64::consts::E;
+
+use crate::{
+    blockstore::provider::BlockfileProvider,
+    errors::{ChromaError, ErrorCodes},
+    execution::{data::data_chunk::Chunk, operator::Operator},
+    segment::record_segment::RecordSegmentReader,
+    types::{
+        update_metdata_to_metdata, LogRecord, Metadata, MetadataValueConversionError, Segment,
+    },
+};
+use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct MergeMetadataResultsOperator {}
+
+impl MergeMetadataResultsOperator {
+    pub fn new() -> Box<Self> {
+        Box::new(MergeMetadataResultsOperator {})
+    }
+}
+
+#[derive(Debug)]
+pub struct MergeMetadataResultsOperatorInput {
+    // The records that were found in the log based on the filter conditions
+    // TODO: Once we support update/delete this should be MaterializedLogRecord
+    filtered_log: Chunk<LogRecord>,
+    // The query ids that were not found in the log, that we need to pull from the record segment
+    remaining_query_ids: Vec<String>,
+    // The offset ids that were found in the log, from where/where_document results
+    filtered_index_offset_ids: Vec<u32>,
+    record_segment_definition: Segment,
+    blockfile_provider: BlockfileProvider,
+}
+
+impl MergeMetadataResultsOperatorInput {
+    pub fn new(
+        filtered_log: Chunk<LogRecord>,
+        remaining_query_ids: Vec<String>,
+        filtered_index_offset_ids: Vec<u32>,
+        record_segment_definition: Segment,
+        blockfile_provider: BlockfileProvider,
+    ) -> Self {
+        Self {
+            filtered_log: filtered_log,
+            remaining_query_ids: remaining_query_ids,
+            filtered_index_offset_ids: filtered_index_offset_ids,
+            record_segment_definition,
+            blockfile_provider: blockfile_provider,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MergeMetadataResultsOperatorOutput {
+    pub ids: Vec<String>,
+    pub metadata: Vec<Option<Metadata>>,
+    pub documents: Vec<Option<String>>,
+}
+
+#[derive(Error, Debug)]
+pub enum MergeMetadataResultsOperatorError {
+    #[error("Error creating Record Segment")]
+    RecordSegmentError,
+    #[error("Error reading Record Segment")]
+    RecordSegmentReadError,
+    #[error("Error converting metadata")]
+    MetadataConversionError(#[from] MetadataValueConversionError),
+}
+
+impl ChromaError for MergeMetadataResultsOperatorError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            MergeMetadataResultsOperatorError::RecordSegmentError => ErrorCodes::Internal,
+            MergeMetadataResultsOperatorError::RecordSegmentReadError => ErrorCodes::Internal,
+            MergeMetadataResultsOperatorError::MetadataConversionError(e) => e.code(),
+        }
+    }
+}
+
+pub type MergeMetadataResultsOperatorResult =
+    Result<MergeMetadataResultsOperatorOutput, MergeMetadataResultsOperatorError>;
+
+#[async_trait]
+impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOutput>
+    for MergeMetadataResultsOperator
+{
+    type Error = MergeMetadataResultsOperatorError;
+
+    async fn run(
+        &self,
+        input: &MergeMetadataResultsOperatorInput,
+    ) -> MergeMetadataResultsOperatorResult {
+        let record_segment_reader = match RecordSegmentReader::from_segment(
+            &input.record_segment_definition,
+            &input.blockfile_provider,
+        )
+        .await
+        {
+            Ok(reader) => reader,
+            Err(e) => {
+                return Err(MergeMetadataResultsOperatorError::RecordSegmentError);
+            }
+        };
+
+        let mut ids: Vec<String> = Vec::new();
+        let mut metadata = Vec::new();
+        let mut documents = Vec::new();
+
+        // Hydrate the data from the record segment for filtered data
+        for index_offset_id in input.filtered_index_offset_ids.iter() {
+            let record = match record_segment_reader
+                .get_data_for_offset_id(*index_offset_id as u32)
+                .await
+            {
+                Ok(record) => record,
+                Err(e) => {
+                    println!("Error reading Record Segment: {:?}", e);
+                    return Err(MergeMetadataResultsOperatorError::RecordSegmentReadError);
+                }
+            };
+
+            let user_id = match record_segment_reader
+                .get_user_id_for_offset_id(*index_offset_id as u32)
+                .await
+            {
+                Ok(user_id) => user_id,
+                Err(e) => {
+                    println!("Error reading Record Segment: {:?}", e);
+                    return Err(MergeMetadataResultsOperatorError::RecordSegmentReadError);
+                }
+            };
+
+            ids.push(user_id.to_string());
+            metadata.push(record.metadata.clone());
+            match record.document {
+                Some(document) => documents.push(Some(document.to_string())),
+                None => documents.push(None),
+            }
+        }
+
+        // Hydrate the data from the record segment for the remaining data
+        for query_id in input.remaining_query_ids.iter() {
+            let offset_id = match record_segment_reader
+                .get_offset_id_for_user_id(query_id)
+                .await
+            {
+                Ok(offset_id) => offset_id,
+                Err(e) => {
+                    println!("Error reading Record Segment: {:?}", e);
+                    return Err(MergeMetadataResultsOperatorError::RecordSegmentReadError);
+                }
+            };
+
+            let record = match record_segment_reader
+                .get_data_for_offset_id(offset_id)
+                .await
+            {
+                Ok(record) => record,
+                Err(e) => {
+                    println!("Error reading Record Segment: {:?}", e);
+                    return Err(MergeMetadataResultsOperatorError::RecordSegmentReadError);
+                }
+            };
+
+            ids.push(record.id.to_string());
+            metadata.push(record.metadata.clone());
+            match record.document {
+                Some(document) => documents.push(Some(document.to_string())),
+                None => documents.push(None),
+            }
+        }
+
+        // Merge the data from the brute force results
+        for (log_entry, index) in input.filtered_log.iter() {
+            ids.push(log_entry.record.id.to_string());
+            let output_metadata = match &log_entry.record.metadata {
+                Some(log_metadata) => match update_metdata_to_metdata(log_metadata) {
+                    Ok(metadata) => Some(metadata),
+                    Err(e) => {
+                        println!("Error converting log metadata: {:?}", e);
+                        return Err(MergeMetadataResultsOperatorError::MetadataConversionError(
+                            e,
+                        ));
+                    }
+                },
+                None => {
+                    println!("No metadata found for log entry");
+                    None
+                }
+            };
+            metadata.push(output_metadata);
+            // TODO: document
+            documents.push(Some("log_placeholder".to_string()));
+        }
+
+        Ok(MergeMetadataResultsOperatorOutput {
+            ids,
+            metadata,
+            documents,
+        })
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -2,6 +2,7 @@ pub(super) mod brute_force_knn;
 pub(super) mod flush_s3;
 pub(super) mod hnsw_knn;
 pub(super) mod merge_knn_results;
+pub(super) mod merge_metadata_results;
 pub(super) mod normalize_vectors;
 pub(super) mod partition;
 pub(super) mod pull_log;

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -382,10 +382,6 @@ impl HnswQueryOrchestrator {
         let segment = match segments {
             Ok(mut segments) => {
                 if segments.is_empty() {
-                    println!(
-                        "1. Record segment not found for collection: {:?}",
-                        collection_id
-                    );
                     return Err(Box::new(HnswSegmentQueryError::RecordSegmentNotFound(
                         *collection_id,
                     )));
@@ -398,10 +394,6 @@ impl HnswQueryOrchestrator {
         };
 
         if segment.r#type != SegmentType::Record {
-            println!(
-                "2. Record segment not found for collection: {:?}",
-                collection_id
-            );
             return Err(Box::new(HnswSegmentQueryError::RecordSegmentNotFound(
                 *collection_id,
             )));

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -1,0 +1,465 @@
+use crate::errors::{ChromaError, ErrorCodes};
+use crate::execution::data::data_chunk::Chunk;
+use crate::execution::operator::wrap;
+use crate::execution::operators::merge_metadata_results::{
+    MergeMetadataResultsOperator, MergeMetadataResultsOperatorInput,
+    MergeMetadataResultsOperatorResult,
+};
+use crate::execution::operators::pull_log::{PullLogsInput, PullLogsOperator, PullLogsResult};
+use crate::sysdb::sysdb::{GetCollectionsError, GetSegmentsError};
+use crate::system::{Component, ComponentContext, Handler};
+use crate::types::{Collection, LogRecord, Metadata, SegmentType};
+use crate::{
+    blockstore::provider::BlockfileProvider,
+    execution::operator::TaskMessage,
+    log::log::Log,
+    sysdb::sysdb::SysDb,
+    system::{Receiver, System},
+    types::Segment,
+};
+use async_trait::async_trait;
+use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use tracing::Span;
+use uuid::Uuid;
+
+#[derive(Debug)]
+enum ExecutionState {
+    Pending,
+    PullLogs,
+    Filter, // Filter logs and search metadata segment
+    MergeResults,
+}
+
+// Returns the ids, metadata, and documents
+type MetadataQueryOrchestratorResult =
+    Result<(Vec<String>, Vec<Option<Metadata>>, Vec<Option<String>>), Box<dyn ChromaError>>;
+
+#[derive(Debug)]
+pub(crate) struct MetadataQueryOrchestrator {
+    state: ExecutionState,
+    // Component Execution
+    system: System,
+    // Query state
+    metadata_segment_id: Uuid,
+    query_ids: Vec<String>,
+    // TODO
+    // State fetched or created for query execution
+    metadata_segment: Option<Segment>,
+    record_segment: Option<Segment>,
+    collection: Option<Collection>,
+    // State machine management
+    merge_dependency_count: u32,
+    // Services
+    log: Box<dyn Log>,
+    sysdb: Box<dyn SysDb>,
+    dispatcher: Box<dyn Receiver<TaskMessage>>,
+    blockfile_provider: BlockfileProvider,
+    // Result channel
+    result_channel: Option<tokio::sync::oneshot::Sender<MetadataQueryOrchestratorResult>>,
+}
+
+#[derive(Error, Debug)]
+enum MetadataSegmentQueryError {
+    #[error("Blockfile metadata segment with id: {0} not found")]
+    BlockfileMetadataSegmentNotFound(Uuid),
+    #[error("Get segments error")]
+    GetSegmentsError(#[from] GetSegmentsError),
+    #[error("Record segment not found for collection: {0}")]
+    RecordSegmentNotFound(Uuid),
+    #[error("Metadata segment has no collection")]
+    MetadataSegmentHasNoCollection,
+    #[error("System Time Error")]
+    SystemTimeError(#[from] std::time::SystemTimeError),
+    #[error("Collection not found for id: {0}")]
+    CollectionNotFound(Uuid),
+    #[error("Get collection error")]
+    GetCollectionError(#[from] GetCollectionsError),
+}
+
+impl ChromaError for MetadataSegmentQueryError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            MetadataSegmentQueryError::BlockfileMetadataSegmentNotFound(_) => ErrorCodes::NotFound,
+            MetadataSegmentQueryError::GetSegmentsError(e) => e.code(),
+            MetadataSegmentQueryError::RecordSegmentNotFound(_) => ErrorCodes::NotFound,
+            MetadataSegmentQueryError::MetadataSegmentHasNoCollection => {
+                ErrorCodes::InvalidArgument
+            }
+            MetadataSegmentQueryError::SystemTimeError(_) => ErrorCodes::Internal,
+            MetadataSegmentQueryError::CollectionNotFound(_) => ErrorCodes::NotFound,
+            MetadataSegmentQueryError::GetCollectionError(e) => e.code(),
+        }
+    }
+}
+
+impl MetadataQueryOrchestrator {
+    pub(crate) fn new(
+        system: System,
+        metadata_segment_id: &Uuid,
+        query_ids: Vec<String>,
+        log: Box<dyn Log>,
+        sysdb: Box<dyn SysDb>,
+        dispatcher: Box<dyn Receiver<TaskMessage>>,
+        blockfile_provider: BlockfileProvider,
+    ) -> Self {
+        Self {
+            state: ExecutionState::Pending,
+            system,
+            metadata_segment_id: *metadata_segment_id,
+            query_ids,
+            metadata_segment: None,
+            record_segment: None,
+            collection: None,
+            merge_dependency_count: 2,
+            log,
+            sysdb,
+            dispatcher,
+            blockfile_provider,
+            result_channel: None,
+        }
+    }
+
+    async fn start(&mut self, ctx: &ComponentContext<Self>) {
+        println!("Starting Metadata Query Orchestrator");
+        // Populate the orchestrator with the initial state - The Metadata Segment, The Record Segment and the Collection
+        let metdata_segment = self
+            .get_metadata_segment_from_id(self.sysdb.clone(), &self.metadata_segment_id)
+            .await;
+
+        let metadata_segment = match metdata_segment {
+            Ok(segment) => segment,
+            Err(e) => {
+                self.terminate_with_error(e, ctx);
+                return;
+            }
+        };
+
+        let collection_id = match metadata_segment.collection {
+            Some(collection_id) => collection_id,
+            None => {
+                self.terminate_with_error(
+                    Box::new(MetadataSegmentQueryError::MetadataSegmentHasNoCollection),
+                    ctx,
+                );
+                return;
+            }
+        };
+
+        let record_segment = self
+            .get_record_segment_from_collection_id(self.sysdb.clone(), &collection_id)
+            .await;
+
+        let record_segment = match record_segment {
+            Ok(segment) => segment,
+            Err(e) => {
+                self.terminate_with_error(e, ctx);
+                return;
+            }
+        };
+
+        let collection = match self
+            .get_collection_from_id(self.sysdb.clone(), &collection_id, ctx)
+            .await
+        {
+            Ok(collection) => collection,
+            Err(e) => {
+                self.terminate_with_error(e, ctx);
+                return;
+            }
+        };
+
+        self.metadata_segment = Some(metadata_segment);
+        self.record_segment = Some(record_segment);
+        self.collection = Some(collection);
+    }
+
+    async fn pull_logs(&mut self, ctx: &ComponentContext<Self>) {
+        println!("Pulling logs");
+        self.state = ExecutionState::PullLogs;
+
+        let operator = PullLogsOperator::new(self.log.clone());
+        let end_timestamp = SystemTime::now().duration_since(UNIX_EPOCH);
+        let end_timestamp = match end_timestamp {
+            Ok(end_timestamp) => end_timestamp.as_nanos() as i64,
+            Err(e) => {
+                self.terminate_with_error(
+                    Box::new(MetadataSegmentQueryError::SystemTimeError(e)),
+                    ctx,
+                );
+                return;
+            }
+        };
+
+        let collection = self
+            .collection
+            .as_ref()
+            .expect("Invariant violation. Collection is not set before pull logs state.");
+        let input = PullLogsInput::new(
+            collection.id,
+            collection.log_position,
+            100,
+            None,
+            Some(end_timestamp),
+        );
+
+        let task = wrap(operator, input, ctx.sender.as_receiver());
+        match self.dispatcher.send(task, Some(Span::current())).await {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implies the dispatcher was dropped somehow
+                // and is likely fatal
+                println!("Error sending Metadata Query task: {:?}", e);
+            }
+        }
+    }
+
+    async fn filter(&mut self, mut logs: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
+        println!("Filtering logs and searching metadata segment");
+        self.state = ExecutionState::Filter;
+
+        // TODO: Implement filtering and searching metadata segment
+        // for now we just proxy the items through on the request thread
+        // since in the server we disallow where/where document.
+        // When we implement this we can move it to an operator
+
+        // Build a query_id set
+        let query_id_set: HashSet<String> = self.query_ids.iter().cloned().collect();
+        // The query ids that are not present in the log
+        let mut remaining_query_ids = query_id_set.clone();
+
+        // Build the list of ids in the log to indices in the chunk
+        let mut new_visibility = Vec::new();
+        for (log_entry, _) in logs.iter() {
+            if query_id_set.contains(&log_entry.record.id) {
+                println!("Query id: {} found in log", log_entry.record.id);
+                new_visibility.push(true);
+                remaining_query_ids.remove(&log_entry.record.id);
+            } else {
+                new_visibility.push(false);
+            }
+        }
+        logs.set_visibility(new_visibility);
+
+        // TODO: If we were to search the metadata segment we would do it here
+        let filtered_index_offset_ids: Vec<u32> = Vec::new();
+        let remaining_query_ids = remaining_query_ids.into_iter().collect();
+        self.merge_results(logs, remaining_query_ids, filtered_index_offset_ids, ctx)
+            .await;
+    }
+
+    async fn merge_results(
+        &mut self,
+        logs: Chunk<LogRecord>,
+        remaining_query_ids: Vec<String>,
+        filtered_index_offset_ids: Vec<u32>,
+        ctx: &ComponentContext<Self>,
+    ) {
+        println!("Merging metadata results");
+        self.state = ExecutionState::MergeResults;
+
+        let operator = MergeMetadataResultsOperator::new();
+        let input = MergeMetadataResultsOperatorInput::new(
+            logs,
+            remaining_query_ids,
+            filtered_index_offset_ids,
+            self.record_segment
+                .as_ref()
+                .expect("Invariant violation. Record segment is not set.")
+                .clone(),
+            self.blockfile_provider.clone(),
+        );
+
+        let task = wrap(operator, input, ctx.sender.as_receiver());
+        match self.dispatcher.send(task, Some(Span::current())).await {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implies the dispatcher was dropped somehow
+                // and is likely fatal
+                println!("Error sending Metadata Query task: {:?}", e);
+            }
+        }
+    }
+
+    async fn get_metadata_segment_from_id(
+        &self,
+        mut sysdb: Box<dyn SysDb>,
+        metadata_segment_id: &Uuid,
+    ) -> Result<Segment, Box<dyn ChromaError>> {
+        let segments = sysdb
+            .get_segments(Some(*metadata_segment_id), None, None, None)
+            .await;
+        let segment = match segments {
+            Ok(segments) => {
+                if segments.is_empty() {
+                    return Err(Box::new(
+                        MetadataSegmentQueryError::BlockfileMetadataSegmentNotFound(
+                            *metadata_segment_id,
+                        ),
+                    ));
+                }
+                segments[0].clone()
+            }
+            Err(e) => {
+                return Err(Box::new(MetadataSegmentQueryError::GetSegmentsError(e)));
+            }
+        };
+
+        if segment.r#type != SegmentType::BlockfileMetadata {
+            return Err(Box::new(
+                MetadataSegmentQueryError::BlockfileMetadataSegmentNotFound(*metadata_segment_id),
+            ));
+        }
+        Ok(segment)
+    }
+
+    async fn get_record_segment_from_collection_id(
+        &self,
+        mut sysdb: Box<dyn SysDb>,
+        collection_id: &Uuid,
+    ) -> Result<Segment, Box<dyn ChromaError>> {
+        let segments = sysdb
+            .get_segments(
+                None,
+                Some(SegmentType::Record.into()),
+                None,
+                Some(*collection_id),
+            )
+            .await;
+
+        match segments {
+            Ok(segments) => {
+                if segments.is_empty() {
+                    return Err(Box::new(MetadataSegmentQueryError::RecordSegmentNotFound(
+                        *collection_id,
+                    )));
+                }
+                // Unwrap is safe as we know at least one segment exists from
+                // the check above
+                return Ok(segments.into_iter().next().unwrap());
+            }
+            Err(e) => {
+                return Err(Box::new(MetadataSegmentQueryError::GetSegmentsError(e)));
+            }
+        };
+    }
+
+    async fn get_collection_from_id(
+        &self,
+        mut sysdb: Box<dyn SysDb>,
+        collection_id: &Uuid,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<Collection, Box<dyn ChromaError>> {
+        let collections = sysdb
+            .get_collections(Some(*collection_id), None, None, None)
+            .await;
+
+        match collections {
+            Ok(collections) => {
+                if collections.is_empty() {
+                    return Err(Box::new(MetadataSegmentQueryError::CollectionNotFound(
+                        *collection_id,
+                    )));
+                }
+                // Unwrap is safe as we know at least one collection exists from
+                // the check above
+                return Ok(collections.into_iter().next().unwrap());
+            }
+            Err(e) => {
+                return Err(Box::new(MetadataSegmentQueryError::GetCollectionError(e)));
+            }
+        };
+    }
+
+    fn terminate_with_error(&mut self, error: Box<dyn ChromaError>, ctx: &ComponentContext<Self>) {
+        let result_channel = self
+            .result_channel
+            .take()
+            .expect("Invariant violation. Result channel is not set.");
+        match result_channel.send(Err(error)) {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implied the listener was dropped
+                println!("[MetadataQueryOrchestrator] Result channel dropped before sending error");
+            }
+        }
+        // Cancel the orchestrator so it stops processing
+        ctx.cancellation_token.cancel();
+    }
+
+    ///  Run the orchestrator and return the result.
+    ///  # Note
+    ///  Use this over spawning the component directly. This method will start the component and
+    ///  wait for it to finish before returning the result.
+    pub(crate) async fn run(mut self) -> MetadataQueryOrchestratorResult {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.result_channel = Some(tx);
+        let mut handle = self.system.clone().start_component(self);
+        let result = rx.await;
+        handle.stop();
+        result.unwrap()
+    }
+}
+
+#[async_trait]
+impl Component for MetadataQueryOrchestrator {
+    fn queue_size(&self) -> usize {
+        1000 // TODO: make this configurable
+    }
+
+    async fn on_start(&mut self, ctx: &crate::system::ComponentContext<Self>) -> () {
+        self.start(ctx).await;
+        self.pull_logs(ctx).await;
+    }
+}
+
+#[async_trait]
+impl Handler<PullLogsResult> for MetadataQueryOrchestrator {
+    async fn handle(&mut self, message: PullLogsResult, ctx: &ComponentContext<Self>) {
+        match message {
+            Ok(logs) => {
+                let logs = logs.logs();
+                println!("Logs pulled: {:?}", logs);
+                self.filter(logs, ctx).await;
+            }
+            Err(e) => {
+                self.terminate_with_error(Box::new(e), ctx);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<MergeMetadataResultsOperatorResult> for MetadataQueryOrchestrator {
+    async fn handle(
+        &mut self,
+        message: MergeMetadataResultsOperatorResult,
+        ctx: &ComponentContext<Self>,
+    ) {
+        let output = match message {
+            Ok(output) => output,
+            Err(e) => {
+                return self.terminate_with_error(Box::new(e), ctx);
+            }
+        };
+
+        let result_channel = self
+            .result_channel
+            .take()
+            .expect("Invariant violation. Result channel is not set.");
+
+        let output = (output.ids, output.metadata, output.documents);
+        println!("Merged metadata results: {:?}", output);
+
+        match result_channel.send(Ok(output)) {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implied the listener was dropped
+                println!(
+                    "[MetadataQueryOrchestrator] Result channel dropped before sending result"
+                );
+            }
+        }
+    }
+}

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,4 +1,6 @@
 mod compact;
 mod hnsw;
+mod metadata;
 pub(crate) use compact::*;
 pub(crate) use hnsw::*;
+pub(crate) use metadata::*;

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -427,4 +427,18 @@ impl RecordSegmentReader<'_> {
     ) -> Result<&str, Box<dyn ChromaError>> {
         self.id_to_user_id.get("", offset_id).await
     }
+
+    pub(crate) async fn get_offset_id_for_user_id(
+        &self,
+        user_id: &str,
+    ) -> Result<u32, Box<dyn ChromaError>> {
+        self.user_id_to_id.get("", user_id).await
+    }
+
+    pub(crate) async fn get_data_for_offset_id(
+        &self,
+        offset_id: u32,
+    ) -> Result<DataRecord, Box<dyn ChromaError>> {
+        self.id_to_data.get("", offset_id).await
+    }
 }

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -1,24 +1,27 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::blockstore::provider::BlockfileProvider;
-use crate::chroma_proto;
+use crate::chroma_proto::{self, QueryMetadataRequest, QueryMetadataResponse};
 use crate::chroma_proto::{
     GetVectorsRequest, GetVectorsResponse, QueryVectorsRequest, QueryVectorsResponse,
 };
 use crate::config::{Configurable, QueryServiceConfig};
 use crate::errors::ChromaError;
 use crate::execution::operator::TaskMessage;
-use crate::execution::orchestration::HnswQueryOrchestrator;
+use crate::execution::orchestration::{HnswQueryOrchestrator, MetadataQueryOrchestrator};
 use crate::index::hnsw_provider::HnswIndexProvider;
 use crate::log::log::Log;
 use crate::sysdb::sysdb::SysDb;
-use crate::system::{Receiver, System};
-use crate::types::ScalarEncoding;
+use crate::system::{self, Receiver, System};
+use crate::types::{MetadataEmbeddingRecord, MetadataValue, ScalarEncoding};
+use crate::{log, segment};
 use async_trait::async_trait;
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::{debug, trace, trace_span};
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct WorkerServer {
     // System
     system: Option<System>,
@@ -77,8 +80,9 @@ impl WorkerServer {
         println!("Worker listening on {}", addr);
         let _server = Server::builder()
             .add_service(chroma_proto::vector_reader_server::VectorReaderServer::new(
-                worker,
+                worker.clone(),
             ))
+            .add_service(chroma_proto::metadata_reader_server::MetadataReaderServer::new(worker))
             .serve(addr)
             .await?;
         println!("Worker shutting down");
@@ -216,5 +220,102 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
         };
 
         return Ok(Response::new(resp));
+    }
+}
+
+#[tonic::async_trait]
+impl chroma_proto::metadata_reader_server::MetadataReader for WorkerServer {
+    async fn query_metadata(
+        &self,
+        request: Request<QueryMetadataRequest>,
+    ) -> Result<Response<QueryMetadataResponse>, Status> {
+        let request = request.into_inner();
+        let segment_uuid = match Uuid::parse_str(&request.segment_id) {
+            Ok(uuid) => uuid,
+            Err(_) => {
+                return Err(Status::invalid_argument("Invalid Segment UUID"));
+            }
+        };
+
+        println!("Querying metadata for segment {}", segment_uuid);
+
+        let dispatcher = match self.dispatcher {
+            Some(ref dispatcher) => dispatcher,
+            None => {
+                return Err(Status::internal("No dispatcher found"));
+            }
+        };
+
+        let system = match self.system {
+            Some(ref system) => system,
+            None => {
+                return Err(Status::internal("No system found"));
+            }
+        };
+
+        // For now we don't support limit/offset/where/where document
+        if request.limit.is_some() || request.offset.is_some() {
+            return Err(Status::unimplemented("Limit and offset not supported"));
+        }
+        if request.where_document.is_some() {
+            return Err(Status::unimplemented("Where document not supported"));
+        }
+        if request.r#where.is_some() {
+            return Err(Status::unimplemented("Where not supported"));
+        }
+
+        let query_ids = request.ids;
+
+        let orchestrator = MetadataQueryOrchestrator::new(
+            system.clone(),
+            &segment_uuid,
+            query_ids,
+            self.log.clone(),
+            self.sysdb.clone(),
+            dispatcher.clone(),
+            self.blockfile_provider.clone(),
+        );
+
+        let result = orchestrator.run().await;
+        let result = match result {
+            Ok(result) => result,
+            Err(e) => {
+                return Err(Status::internal(format!(
+                    "Error running orchestrator: {}",
+                    e
+                )))
+            }
+        };
+
+        let mut output = Vec::new();
+        let (ids, metadatas, documents) = result;
+        for ((id, metadata), document) in ids
+            .into_iter()
+            .zip(metadatas.into_iter())
+            .zip(documents.into_iter())
+        {
+            // The transport layer assumes the document exists in the metadata
+            // with the special key "chroma:document"
+            let mut output_metadata = match metadata {
+                Some(metadata) => metadata,
+                None => HashMap::new(),
+            };
+            match document {
+                Some(document) => {
+                    output_metadata
+                        .insert("chroma:document".to_string(), MetadataValue::Str(document));
+                }
+                None => {}
+            }
+            let record = chroma_proto::MetadataEmbeddingRecord {
+                id,
+                metadata: Some(chroma_proto::UpdateMetadata::from(output_metadata)),
+            };
+            output.push(record);
+        }
+
+        // This is an implementation stub
+        let response = chroma_proto::QueryMetadataResponse { records: output };
+        Ok(Response::new(response))
     }
 }

--- a/rust/worker/src/types/record.rs
+++ b/rust/worker/src/types/record.rs
@@ -223,6 +223,27 @@ pub(crate) struct VectorQueryResult {
     pub(crate) vector: Option<Vec<f32>>,
 }
 
+/*
+===========================================
+Metadata Embedding Record
+===========================================
+*/
+
+#[derive(Debug)]
+pub(crate) struct MetadataEmbeddingRecord {
+    pub(crate) id: String,
+    pub(crate) metadata: UpdateMetadata,
+}
+
+impl From<MetadataEmbeddingRecord> for chroma_proto::MetadataEmbeddingRecord {
+    fn from(record: MetadataEmbeddingRecord) -> Self {
+        chroma_proto::MetadataEmbeddingRecord {
+            id: record.id,
+            metadata: Some(record.metadata.into()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/worker/src/types/segment.rs
+++ b/rust/worker/src/types/segment.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum SegmentType {
     HnswDistributed,
+    BlockfileMetadata,
     Record,
     Sqlite,
 }
@@ -22,6 +23,7 @@ impl From<SegmentType> for String {
             }
             SegmentType::Record => "urn:chroma:segment/record".to_string(),
             SegmentType::Sqlite => "urn:chroma:segment/metadata/sqlite".to_string(),
+            SegmentType::BlockfileMetadata => "urn:chroma:segment/metadata/blockfile".to_string(),
         }
     }
 }
@@ -93,6 +95,7 @@ impl TryFrom<chroma_proto::Segment> for Segment {
             "urn:chroma:segment/vector/hnsw-distributed" => SegmentType::HnswDistributed,
             "urn:chroma:segment/record" => SegmentType::Record,
             "urn:chroma:segment/metadata/sqlite" => SegmentType::Sqlite,
+            "urn:chroma:segment/metadata/blockfile" => SegmentType::BlockfileMetadata,
             _ => {
                 println!("Invalid segment type: {}", proto_segment.r#type);
                 return Err(SegmentConversionError::InvalidSegmentType);


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Fixes a bug in grpc metadata stub that does not pass None for where/where_document
 - New functionality
	 - Adds the rust server bindings for metadata reader
	 - Adds the metadata query orchestrator. For now this only handles get by ids (query_ids) it does not handle where/where_document and will error if requested.

Todo before we merge this
- [ ] document handling in record segment 
- [ ] document handling of read logs - i'd like to pull the special magic keys "chroma:document" out and make them first class fields everywhere except transport in rust.

Todo after
- [ ] updates/deletes

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None