### PR TITLE
[ENH]: use pgpool for log services

### DIFF
--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	log "github.com/chroma-core/chroma/go/database/log/db"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"time"
 )
 
 type LogRepository struct {
-	conn    *pgx.Conn
+	conn    *pgxpool.Pool
 	queries *log.Queries
 }
 
@@ -95,7 +96,7 @@ func (r *LogRepository) PurgeRecords(ctx context.Context) (err error) {
 	return
 }
 
-func NewLogRepository(conn *pgx.Conn) *LogRepository {
+func NewLogRepository(conn *pgxpool.Pool) *LogRepository {
 	return &LogRepository{
 		conn:    conn,
 		queries: log.New(conn),

--- a/go/pkg/log/server/property_test.go
+++ b/go/pkg/log/server/property_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/proto/logservicepb"
 	"github.com/chroma-core/chroma/go/pkg/types"
 	libs2 "github.com/chroma-core/chroma/go/shared/libs"
-	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"pgregory.net/rapid"
@@ -37,7 +37,7 @@ func (suite *LogServerTestSuite) SetupSuite() {
 	connectionString, err := libs2.StartPgContainer(ctx)
 	config.DATABASE_URL = connectionString
 	assert.NoError(suite.t, err, "Failed to start pg container")
-	var conn *pgx.Conn
+	var conn *pgxpool.Pool
 	conn, err = libs2.NewPgConnection(ctx, config)
 	assert.NoError(suite.t, err, "Failed to create new pg connection")
 	err = libs2.RunMigration(ctx, connectionString)

--- a/go/shared/libs/db_utils.go
+++ b/go/shared/libs/db_utils.go
@@ -3,10 +3,10 @@ package libs
 import (
 	"context"
 	"github.com/chroma-core/chroma/go/pkg/log/configuration"
-	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func NewPgConnection(ctx context.Context, config *configuration.LogServiceConfiguration) (conn *pgx.Conn, err error) {
-	conn, err = pgx.Connect(ctx, config.DATABASE_URL)
+func NewPgConnection(ctx context.Context, config *configuration.LogServiceConfiguration) (conn *pgxpool.Pool, err error) {
+	conn, err = pgxpool.New(ctx, config.DATABASE_URL)
 	return
 }


### PR DESCRIPTION
## Description of changes
pg.Connect is returning only one connection, which is not thread safe and cause an error. When running in grpc, each request run on a different go routine, and in parallel. pgpool will create and manage a set of connection.
*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Use pg pool to use threadsafe connection.

