### PR TITLE
[BUG]: Aligning Chroma-specific errors with Generic exceptions returned by FastAPI server

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -79,7 +79,9 @@ async def catch_exceptions_middleware(
         return fastapi_json_response(e)
     except Exception as e:
         logger.exception(e)
-        return JSONResponse(content={"error": repr(e)}, status_code=500)
+        return JSONResponse(
+            content={"error": str(type(e)), "message": f"{str(e)}"}, status_code=500
+        )
 
 
 async def check_http_version_middleware(


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - The error signature for ChromaError and any other generic exception will now be the same - this is a breakout from PR #1494

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
