### PR TITLE
[ENH] JS admin client should throw well-formatted errors rather than Responses

### DIFF
--- a/clients/js/src/AdminClient.ts
+++ b/clients/js/src/AdminClient.ts
@@ -6,6 +6,7 @@ import {
   authOptionsToAuthProvider,
   ClientAuthProvider,
 } from "./auth";
+import { chromaFetch } from "./ChromaFetch";
 
 const DEFAULT_TENANT = "default_tenant";
 const DEFAULT_DATABASE = "default_database";
@@ -64,7 +65,7 @@ export class AdminClient {
       basePath: path,
     });
 
-    this.api = new DefaultApi(apiConfig);
+    this.api = new DefaultApi(apiConfig, undefined, chromaFetch);
     this.api.options = fetchOptions ?? {};
 
     if (auth !== undefined) {

--- a/clients/js/test/admin.test.ts
+++ b/clients/js/test/admin.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@jest/globals";
 import { AdminClient } from "../src/AdminClient";
 import adminClient from "./initAdminClient";
+import { ChromaError } from "../src/Errors";
 
 test("it should create the admin client connection", async () => {
   expect(adminClient).toBeDefined();
@@ -63,4 +64,14 @@ test("it should set the tenant and database", async () => {
   await adminClient.setDatabase({ database: "testDatabase2" });
 
   expect(adminClient.database).toBe("testDatabase2");
+});
+
+test("it should throw well-formatted errors", async () => {
+  try {
+    await adminClient.createDatabase({ name: "test", tenantName: "foo" });
+    expect(false).toBe(true);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(ChromaError);
+  }
 });


### PR DESCRIPTION
Previously, the admin client was throwing `Response`s rather than Errors. It now uses the same helper as the data plane client to throw well-formatted errors.