### PR TITLE
[BUG] Rust sysdb should send default string value

### DIFF
--- a/rust/worker/src/sysdb/sysdb.rs
+++ b/rust/worker/src/sysdb/sysdb.rs
@@ -153,12 +153,12 @@ impl SysDb for GrpcSysDb {
                 tenant: if tenant.is_some() {
                     tenant.unwrap()
                 } else {
-                    DEFAULT_TENANT.to_string()
+                    "".to_string()
                 },
                 database: if database.is_some() {
                     database.unwrap()
                 } else {
-                    DEFAULT_DATBASE.to_string()
+                    "".to_string()
                 },
             })
             .await;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - The go sysdb expects this if id is set
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
