### PR TITLE
[ENH] Removing new line cleanup from OpenAI EF (python)

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -193,9 +193,6 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
         self._deployment_id = deployment_id
 
     def __call__(self, input: Documents) -> Embeddings:
-        # replace newlines, which can negatively affect performance.
-        input = [t.replace("\n", " ") for t in input]
-
         # Call the OpenAI Embedding API
         if self._v1:
             embeddings = self._client.create(


### PR DESCRIPTION
Closes #2129 

- Align with the JS OpenAI EF which doesn't remove new lines
- The statement that new lines negatively impact performance is no longer true - https://github.com/openai/openai-python/issues/418
- OpenAI client no longer removes new lines (embedding_utils.py was removed in v1)
- Align with what other ecosystem players (Langchain) where new lines are also not removed https://github.com/langchain-ai/langchain/blob/70bde154807cbe434dfa7c059a43db6796b6b3e7/libs/partners/openai/langchain_openai/embeddings/base.py#L461-L489
- Users in discord have reported similarity score of Chroma and direct OpenAI client embeddings of the same string as low as 98% (https://discord.com/channels/1073293645303795742/1074711816900456519/1235657579812880444)

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - New line removal from OpenAI inputs is not required

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
