### PR TITLE
[CLN] Remove redundant sysdb initialization in compactor manager

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -171,13 +171,6 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
     async fn try_from_config(
         config: &crate::config::CompactionServiceConfig,
     ) -> Result<Self, Box<dyn ChromaError>> {
-        let sysdb_config = &config.sysdb;
-        let sysdb = match crate::sysdb::from_config(sysdb_config).await {
-            Ok(sysdb) => sysdb,
-            Err(err) => {
-                return Err(err);
-            }
-        };
         let log_config = &config.log;
         let log = match crate::log::from_config(log_config).await {
             Ok(log) => log,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 -  This PR cleans up the redundant sysdb initialization in compactor manager. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
