### PR TITLE
[CLN] Improve JS client async errors tests

### DIFF
--- a/clients/js/test/admin.test.ts
+++ b/clients/js/test/admin.test.ts
@@ -67,11 +67,9 @@ test("it should set the tenant and database", async () => {
 });
 
 test("it should throw well-formatted errors", async () => {
-  try {
-    await adminClient.createDatabase({ name: "test", tenantName: "foo" });
-    expect(false).toBe(true);
-  } catch (error) {
-    expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(ChromaError);
-  }
+  await expect(
+    adminClient.createDatabase({ name: "test", tenantName: "foo" }),
+  ).rejects.toThrow(
+    new ChromaError("", "Database test already exists for tenant foo"),
+  );
 });

--- a/clients/js/test/client.test.ts
+++ b/clients/js/test/client.test.ts
@@ -192,16 +192,15 @@ test("wrong code returns an error", async () => {
   ];
   const metadatas = [{ test: "test1" }, { test: "test2" }, { test: "test3" }];
   await collection.add({ ids, embeddings, metadatas });
-  try {
-    await collection.get({
+
+  await expect(
+    collection.get({
       // @ts-ignore - supposed to fail
       where: { test: { $contains: "hello" } },
-    });
-  } catch (e: any) {
-    expect(e).toBeDefined();
-    expect(e).toBeInstanceOf(ChromaValueError);
-    expect(e.message).toMatchInlineSnapshot(
-      `"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, got $contains"`,
-    );
-  }
+    }),
+  ).rejects.toThrow(
+    new ChromaValueError(
+      "Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, got $contains",
+    ),
+  );
 });

--- a/clients/js/test/delete.collection.test.ts
+++ b/clients/js/test/delete.collection.test.ts
@@ -27,7 +27,7 @@ test("should error on non existing collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
-  expect(async () => {
-    await collection.delete({ where: { test: "test1" } });
-  }).rejects.toThrow(InvalidCollectionError);
+  await expect(collection.delete({ where: { test: "test1" } })).rejects.toThrow(
+    InvalidCollectionError,
+  );
 });

--- a/clients/js/test/get.collection.test.ts
+++ b/clients/js/test/get.collection.test.ts
@@ -36,20 +36,19 @@ test("wrong code returns an error", async () => {
     embeddings: EMBEDDINGS,
     metadatas: METADATAS,
   });
-  try {
-    await collection.get({
+
+  await expect(
+    collection.get({
       where: {
         //@ts-ignore supposed to fail
         test: { $contains: "hello" },
       },
-    });
-  } catch (error: any) {
-    expect(error).toBeDefined();
-    expect(error).toBeInstanceOf(ChromaValueError);
-    expect(error.message).toMatchInlineSnapshot(
-      `"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, got $contains"`,
-    );
-  }
+    }),
+  ).rejects.toThrow(
+    new ChromaValueError(
+      "Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, got $contains",
+    ),
+  );
 });
 
 test("it should get embedding with matching documents", async () => {
@@ -105,9 +104,9 @@ test("should error on non existing collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
-  expect(async () => {
-    await collection.get({ ids: IDS });
-  }).rejects.toThrow(InvalidCollectionError);
+  await expect(collection.get({ ids: IDS })).rejects.toThrow(
+    InvalidCollectionError,
+  );
 });
 
 test("it should throw an error if the collection does not exist", async () => {

--- a/clients/js/test/offline.test.ts
+++ b/clients/js/test/offline.test.ts
@@ -1,15 +1,13 @@
 import { expect, test } from "@jest/globals";
 import { ChromaClient } from "../src/ChromaClient";
+import { ChromaConnectionError } from "../src/Errors";
 
 test("it fails with a nice error", async () => {
   const chroma = new ChromaClient({ path: "http://example.invalid" });
-  try {
-    await chroma.createCollection({ name: "test" });
-    throw new Error("Should have thrown an error.");
-  } catch (e) {
-    expect(e instanceof Error).toBe(true);
-    expect((e as Error).message).toMatchInlineSnapshot(
-      `"Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable."`,
-    );
-  }
+
+  await expect(chroma.createCollection({ name: "test" })).rejects.toThrow(
+    new ChromaConnectionError(
+      "Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable.",
+    ),
+  );
 });

--- a/clients/js/test/peek.collection.test.ts
+++ b/clients/js/test/peek.collection.test.ts
@@ -18,7 +18,5 @@ test("should error on non existing collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
-  expect(async () => {
-    await collection.peek();
-  }).rejects.toThrow(InvalidCollectionError);
+  await expect(collection.peek()).rejects.toThrow(InvalidCollectionError);
 });

--- a/clients/js/test/query.collection.test.ts
+++ b/clients/js/test/query.collection.test.ts
@@ -223,7 +223,7 @@ test("should error on non existing collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
-  expect(async () => {
-    await collection.query({ queryEmbeddings: [1, 2, 3] });
-  }).rejects.toThrow(InvalidCollectionError);
+  await expect(
+    collection.query({ queryEmbeddings: [1, 2, 3] }),
+  ).rejects.toThrow(InvalidCollectionError);
 });

--- a/clients/js/test/update.collection.test.ts
+++ b/clients/js/test/update.collection.test.ts
@@ -52,14 +52,14 @@ test("should error on non existing collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
-  expect(async () => {
-    await collection.update({
+  await expect(
+    collection.update({
       ids: ["test1"],
       embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
       metadatas: [{ test: "meta1" }],
       documents: ["doc1"],
-    });
-  }).rejects.toThrow(InvalidCollectionError);
+    }),
+  ).rejects.toThrow(InvalidCollectionError);
 });
 
 // this currently fails

--- a/clients/js/test/upsert.collections.test.ts
+++ b/clients/js/test/upsert.collections.test.ts
@@ -30,12 +30,12 @@ test("should error on non existing collection", async () => {
   await chroma.reset();
   const collection = await chroma.createCollection({ name: "test" });
   await chroma.deleteCollection({ name: "test" });
-  expect(async () => {
-    await collection.upsert({
+  await expect(
+    collection.upsert({
       ids: ["test1"],
       embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
       metadatas: [{ test: "meta1" }],
       documents: ["doc1"],
-    });
-  }).rejects.toThrow(InvalidCollectionError);
+    }),
+  ).rejects.toThrow(InvalidCollectionError);
 });


### PR DESCRIPTION
Use the jest standard Jest way for testing for rejected promises: `await expect(...).rejects.throw(new Error("expected message"));`.

Before, some of the tests were not failing if an error is thrown -> the tests did not really test what was expected. Skipped one such test ("collection.get should error on empty embedding"). I will fix it in a next PR.