### PR TITLE
CLN: Replace let with const in JS embeddings client's OllamaEmbeddingFunction

### DIFF
--- a/clients/js/src/embeddings/OllamaEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/OllamaEmbeddingFunction.ts
@@ -12,8 +12,8 @@ export class OllamaEmbeddingFunction implements IEmbeddingFunction {
   }
 
   public async generate(texts: string[]) {
-    let embeddings: number[][] = [];
-    for (let text of texts) {
+    const embeddings: number[][] = [];
+    for (const text of texts) {
       const response = await fetch(this.url, {
         method: "POST",
         headers: {
@@ -27,7 +27,7 @@ export class OllamaEmbeddingFunction implements IEmbeddingFunction {
           `Failed to generate embeddings: ${response.status} (${response.statusText})`,
         );
       }
-      let finalResponse = await response.json();
+      const finalResponse = await response.json();
       embeddings.push(finalResponse["embedding"]);
     }
     return embeddings;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Replaced `let` with `const` in variable declarations where variables were not reassigned within the `OllamaEmbeddingFunction` of the JavaScript client for embeddings. This change enhances code quality by enforcing immutability where applicable.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `yarn test` for js
  - Ensure existing unit tests pass with the modified code to confirm that no unintended changes have occurred.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

- No changes to user-facing APIs or documentation are necessary for this internal code quality improvement.
