### PR TITLE
[ENH] Connect spans of rust worker services with FE

### DIFF
--- a/chromadb/segment/impl/vector/grpc_segment.py
+++ b/chromadb/segment/impl/vector/grpc_segment.py
@@ -12,6 +12,7 @@ from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
 )
+from chromadb.telemetry.opentelemetry.grpc import OtelInterceptor
 from chromadb.types import (
     Metadata,
     ScalarEncoding,
@@ -41,6 +42,8 @@ class GrpcVectorSegment(VectorReader, EnforceOverrides):
             raise Exception("Missing grpc_url in segment metadata")
 
         channel = grpc.insecure_channel(segment["metadata"]["grpc_url"])
+        interceptors = [OtelInterceptor()]
+        channel = grpc.intercept_channel(channel, *interceptors)
         self._vector_reader_stub = VectorReaderStub(channel)  # type: ignore
         self._segment = segment
 

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -236,6 +236,10 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
 // ============== Component Implementation ==============
 #[async_trait]
 impl Component for CompactionManager {
+    fn get_name() -> &'static str {
+        "Compaction manager"
+    }
+
     fn queue_size(&self) -> usize {
         self.compaction_manager_queue_size
     }

--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -171,6 +171,10 @@ impl TaskRequestMessage {
 
 #[async_trait]
 impl Component for Dispatcher {
+    fn get_name() -> &'static str {
+        "Dispatcher"
+    }
+
     fn queue_size(&self) -> usize {
         self.queue_size
     }
@@ -238,6 +242,10 @@ mod tests {
     }
     #[async_trait]
     impl Component for MockDispatchUser {
+        fn get_name() -> &'static str {
+            "Mock dispatcher"
+        }
+
         fn queue_size(&self) -> usize {
             1000
         }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -409,6 +409,10 @@ impl CompactOrchestrator {
 
 #[async_trait]
 impl Component for CompactOrchestrator {
+    fn get_name() -> &'static str {
+        "Compaction orchestrator"
+    }
+
     fn queue_size(&self) -> usize {
         1000 // TODO: make configurable
     }

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -356,7 +356,7 @@ impl HnswQueryOrchestrator {
         collection_id: &Uuid,
     ) -> Result<Collection, Box<dyn ChromaError>> {
         let child_span: tracing::Span =
-            trace_span!(parent: Span::current(), "get collection id for segment id");
+            trace_span!(parent: Span::current(), "get collection for collection id");
         let collections = sysdb
             .get_collections(Some(*collection_id), None, None, None)
             .instrument(child_span.clone())
@@ -454,6 +454,10 @@ impl HnswQueryOrchestrator {
 
 #[async_trait]
 impl Component for HnswQueryOrchestrator {
+    fn get_name() -> &'static str {
+        "HNSW Query orchestrator"
+    }
+
     fn queue_size(&self) -> usize {
         1000 // TODO: make configurable
     }

--- a/rust/worker/src/execution/worker_thread.rs
+++ b/rust/worker/src/execution/worker_thread.rs
@@ -32,6 +32,10 @@ impl Debug for WorkerThread {
 
 #[async_trait]
 impl Component for WorkerThread {
+    fn get_name() -> &'static str {
+        "Worker thread"
+    }
+
     fn queue_size(&self) -> usize {
         self.queue_size
     }

--- a/rust/worker/src/log/log.rs
+++ b/rust/worker/src/log/log.rs
@@ -7,9 +7,19 @@ use crate::log::config::LogConfig;
 use crate::types::LogRecord;
 use crate::types::RecordConversionError;
 use async_trait::async_trait;
+use opentelemetry::trace::SpanContext;
+use opentelemetry::trace::TraceContextExt;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::str::FromStr;
 use thiserror::Error;
+use tonic::metadata::MetadataMap;
+use tonic::metadata::MetadataValue;
+use tonic::service::interceptor;
+use tonic::transport::Endpoint;
+use tonic::{Request, Status};
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 /// CollectionInfo is a struct that contains information about a collection for the
@@ -81,6 +91,36 @@ pub(crate) struct GrpcLog {
 }
 
 impl GrpcLog {
+    pub(crate) fn try_wrap_request_with_trace_context<T>(
+        &self,
+        request: &mut Request<T>,
+        spn: &tracing::Span,
+    ) {
+        // If span is disabled then nothing to append in the header.
+        if spn.is_disabled() {
+            return;
+        }
+        let metadata: &mut MetadataMap = request.metadata_mut();
+        let span_id = spn.context().span().span_context().span_id().to_string();
+        let trace_id = spn.context().span().span_context().trace_id().to_string();
+        println!("Span id {}, trace id {}", span_id, trace_id);
+        let ascii_traceid = MetadataValue::from_str(trace_id.as_str());
+        let ascii_spanid = MetadataValue::from_str(span_id.as_str());
+        // Errors are not fatal.
+        match ascii_traceid {
+            Ok(id) => {
+                metadata.append("chroma-traceid", id);
+            }
+            Err(_) => (),
+        }
+        match ascii_spanid {
+            Ok(ascii_id) => {
+                metadata.append("chroma-spanid", ascii_id);
+            }
+            Err(_) => (),
+        }
+    }
+
     pub(crate) fn new(client: LogServiceClient<tonic::transport::Channel>) -> Self {
         Self { client }
     }
@@ -137,12 +177,16 @@ impl Log for GrpcLog {
             Some(end_timestamp) => end_timestamp,
             None => -1,
         };
-        let request = self.client.pull_logs(chroma_proto::PullLogsRequest {
+        let tonic_request = tonic::Request::new(chroma_proto::PullLogsRequest {
             collection_id: collection_id.to_string(),
             start_from_offset: offset,
             batch_size,
             end_timestamp,
         });
+        let mut mut_tonic_request = tonic_request;
+        self.try_wrap_request_with_trace_context(&mut mut_tonic_request, &Span::current());
+        println!("Request {:?}", mut_tonic_request);
+        let request = self.client.pull_logs(mut_tonic_request);
         let response = request.await;
         match response {
             Ok(response) => {

--- a/rust/worker/src/log/log.rs
+++ b/rust/worker/src/log/log.rs
@@ -126,10 +126,13 @@ impl Configurable<LogConfig> for GrpcLog {
                 // TODO: switch to logging when logging is implemented
                 println!("Connecting to log service at {}:{}", host, port);
                 let connection_string = format!("http://{}:{}", host, port);
-                let client = Endpoint::from_shared(connection_string)
-                    .expect("Connection string parsing failed")
-                    .connect()
-                    .await;
+                let endpoint_res = Endpoint::from_shared(connection_string);
+                if endpoint_res.is_err() {
+                    return Err(Box::new(GrpcLogError::FailedToConnect(
+                        endpoint_res.err().unwrap(),
+                    )));
+                }
+                let client = endpoint_res.ok().unwrap().connect().await;
                 match client {
                     Ok(client) => {
                         let channel: LogServiceClient<

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -182,6 +182,10 @@ impl CustomResourceMemberlistProvider {
 
 #[async_trait]
 impl Component for CustomResourceMemberlistProvider {
+    fn get_name() -> &'static str {
+        "Custom resource member list provider"
+    }
+
     fn queue_size(&self) -> usize {
         self.queue_size
     }

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -15,8 +15,13 @@ use crate::sysdb::sysdb::SysDb;
 use crate::system::{Receiver, System};
 use crate::types::ScalarEncoding;
 use async_trait::async_trait;
-use tonic::{transport::Server, Request, Response, Status};
-use tracing::{debug, trace, trace_span};
+use opentelemetry::trace::{
+    FutureExt, SpanContext, SpanId, SpanRef, TraceContextExt, TraceFlags, TraceId, TraceState,
+};
+use opentelemetry::Context;
+use tonic::{metadata::MetadataMap, transport::Server, Request, Response, Status};
+use tracing::{debug, trace, trace_span, Instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 pub struct WorkerServer {
@@ -96,27 +101,45 @@ impl WorkerServer {
     pub(crate) fn set_system(&mut self, system: System) {
         self.system = Some(system);
     }
-}
 
-#[tonic::async_trait]
-impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
-    async fn get_vectors(
+    pub(crate) fn try_parse_tracecontext(
         &self,
-        request: Request<GetVectorsRequest>,
-    ) -> Result<Response<GetVectorsResponse>, Status> {
-        let request = request.into_inner();
-        let _segment_uuid = match Uuid::parse_str(&request.segment_id) {
-            Ok(uuid) => uuid,
-            Err(_) => {
-                return Err(Status::invalid_argument("Invalid UUID"));
+        metadata: &MetadataMap,
+    ) -> (Option<TraceId>, Option<SpanId>) {
+        let mut traceid: Option<TraceId> = None;
+        let mut spanid: Option<SpanId> = None;
+        if metadata.contains_key("chroma-traceid") {
+            let id_res = metadata.get("chroma-traceid").unwrap().to_str();
+            // Failure is not fatal.
+            match id_res {
+                Ok(id) => {
+                    let trace_id = TraceId::from_hex(id);
+                    match trace_id {
+                        Ok(id) => traceid = Some(id),
+                        Err(_) => traceid = None,
+                    }
+                }
+                Err(_) => traceid = None,
             }
-        };
-
-        Err(Status::unimplemented("Not yet implemented"))
+        }
+        if metadata.contains_key("chroma-spanid") {
+            let id_res = metadata.get("chroma-spanid").unwrap().to_str();
+            // Failure is not fatal.
+            match id_res {
+                Ok(id) => {
+                    let span_id = SpanId::from_hex(id);
+                    match span_id {
+                        Ok(id) => spanid = Some(id),
+                        Err(_) => spanid = None,
+                    }
+                }
+                Err(_) => spanid = None,
+            }
+        }
+        (traceid, spanid)
     }
 
-    #[tracing::instrument(skip(self, request), fields(request_metadata = ?request.metadata(), k = request.get_ref().k, segment_id = request.get_ref().segment_id, include_embeddings = request.get_ref().include_embeddings, allowed_ids = ?request.get_ref().allowed_ids))]
-    async fn query_vectors(
+    pub(crate) async fn query_vectors_instrumented(
         &self,
         request: Request<QueryVectorsRequest>,
     ) -> Result<Response<QueryVectorsResponse>, Status> {
@@ -130,8 +153,9 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
 
         let mut proto_results_for_all = Vec::new();
 
+        let parse_vectors_span = trace_span!("Input vectors parsing");
         let mut query_vectors = Vec::new();
-        trace_span!("Input vectors parsing").in_scope(|| {
+        let _ = parse_vectors_span.in_scope(|| {
             for proto_query_vector in request.vectors {
                 let (query_vector, _encoding) = match proto_query_vector.try_into() {
                     Ok((vector, encoding)) => (vector, encoding),
@@ -219,5 +243,55 @@ impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
         };
 
         return Ok(Response::new(resp));
+    }
+}
+
+#[tonic::async_trait]
+impl chroma_proto::vector_reader_server::VectorReader for WorkerServer {
+    async fn get_vectors(
+        &self,
+        request: Request<GetVectorsRequest>,
+    ) -> Result<Response<GetVectorsResponse>, Status> {
+        let request = request.into_inner();
+        let _segment_uuid = match Uuid::parse_str(&request.segment_id) {
+            Ok(uuid) => uuid,
+            Err(_) => {
+                return Err(Status::invalid_argument("Invalid UUID"));
+            }
+        };
+
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    async fn query_vectors(
+        &self,
+        request: Request<QueryVectorsRequest>,
+    ) -> Result<Response<QueryVectorsResponse>, Status> {
+        let (traceid, spanid) = self.try_parse_tracecontext(request.metadata());
+        let query_span = trace_span!(
+            "Query vectors",
+            k = request.get_ref().k,
+            segment_id = request.get_ref().segment_id,
+            include_embeddings = request.get_ref().include_embeddings,
+            allowed_ids = ?request.get_ref().allowed_ids
+        );
+        // Attach context passed by FE as parent.
+        if traceid.is_some() && spanid.is_some() {
+            let span_context = SpanContext::new(
+                traceid.unwrap(),
+                spanid.unwrap(),
+                TraceFlags::new(1),
+                true,
+                TraceState::default(),
+            );
+            let context = query_span
+                .context()
+                .with_remote_span_context(span_context)
+                .clone();
+            query_span.set_parent(context);
+        }
+        self.query_vectors_instrumented(request)
+            .instrument(query_span)
+            .await
     }
 }

--- a/rust/worker/src/system/scheduler.rs
+++ b/rust/worker/src/system/scheduler.rs
@@ -176,6 +176,10 @@ mod tests {
 
     #[async_trait]
     impl Component for TestComponent {
+        fn get_name() -> &'static str {
+            "Test component"
+        }
+
         fn queue_size(&self) -> usize {
             self.queue_size
         }

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -47,7 +47,8 @@ impl System {
 
         match C::runtime() {
             ComponentRuntime::Inherit => {
-                let child_span = trace_span!(parent: Span::current(), "component spawn");
+                let child_span =
+                    trace_span!(parent: Span::current(), "component spawn", "name" = C::get_name());
                 let task_future = async move { executor.run(rx).await };
                 let join_handle = tokio::spawn(task_future.instrument(child_span));
                 return ComponentHandle::new(cancel_token, Some(join_handle), sender);

--- a/rust/worker/src/system/types.rs
+++ b/rust/worker/src/system/types.rs
@@ -32,6 +32,7 @@ pub(crate) enum ComponentRuntime {
 /// - on_start: Called when the component is started
 #[async_trait]
 pub(crate) trait Component: Send + Sized + Debug + 'static {
+    fn get_name() -> &'static str;
     fn queue_size(&self) -> usize;
     fn runtime() -> ComponentRuntime {
         ComponentRuntime::Inherit
@@ -173,6 +174,10 @@ mod tests {
 
     #[async_trait]
     impl Component for TestComponent {
+        fn get_name() -> &'static str {
+            "Test component"
+        }
+
         fn queue_size(&self) -> usize {
             self.queue_size
         }

--- a/rust/worker/src/tracing/mod.rs
+++ b/rust/worker/src/tracing/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod opentelemetry_config;
+pub(crate) mod util;

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -37,8 +37,9 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     let stdout_layer =
         BunyanFormattingLayer::new(service_name.clone().to_string(), std::io::stdout)
             .with_filter(tracing_subscriber::filter::LevelFilter::INFO);
-    // global filter layer. Don't filter anything at global layer.
-    let global_layer = EnvFilter::new("TRACE");
+    // global filter layer. Don't filter anything at global layer for this crate. And disable
+    // for every other library.
+    let global_layer = EnvFilter::new("none,worker=trace");
     // Create subscriber.
     let subscriber = tracing_subscriber::registry()
         .with(global_layer)

--- a/rust/worker/src/tracing/util.rs
+++ b/rust/worker/src/tracing/util.rs
@@ -1,0 +1,107 @@
+use std::str::FromStr;
+
+use opentelemetry::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState};
+use tonic::{
+    metadata::{MetadataMap, MetadataValue},
+    Request, Status,
+};
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+pub(crate) fn client_interceptor(request: Request<()>) -> Result<Request<()>, Status> {
+    // If span is disabled then nothing to append in the header.
+    if Span::current().is_disabled() {
+        return Ok(request);
+    }
+    let mut mut_request = request;
+    let metadata = mut_request.metadata_mut();
+    let trace_id = MetadataValue::from_str(
+        Span::current()
+            .context()
+            .span()
+            .span_context()
+            .trace_id()
+            .to_string()
+            .as_str(),
+    );
+    let span_id = MetadataValue::from_str(
+        Span::current()
+            .context()
+            .span()
+            .span_context()
+            .span_id()
+            .to_string()
+            .as_str(),
+    );
+    // Errors are not fatal.
+    match trace_id {
+        Ok(id) => {
+            metadata.append("chroma-traceid", id);
+        }
+        Err(_) => (),
+    }
+    match span_id {
+        Ok(id) => {
+            metadata.append("chroma-spanid", id);
+        }
+        Err(_) => (),
+    }
+    Ok(mut_request)
+}
+
+pub(crate) fn try_parse_tracecontext(metadata: &MetadataMap) -> (Option<TraceId>, Option<SpanId>) {
+    let mut traceid: Option<TraceId> = None;
+    let mut spanid: Option<SpanId> = None;
+    if metadata.contains_key("chroma-traceid") {
+        let id_res = metadata.get("chroma-traceid").unwrap().to_str();
+        // Failure is not fatal.
+        match id_res {
+            Ok(id) => {
+                let trace_id = TraceId::from_hex(id);
+                match trace_id {
+                    Ok(id) => traceid = Some(id),
+                    Err(_) => traceid = None,
+                }
+            }
+            Err(_) => traceid = None,
+        }
+    }
+    if metadata.contains_key("chroma-spanid") {
+        let id_res = metadata.get("chroma-spanid").unwrap().to_str();
+        // Failure is not fatal.
+        match id_res {
+            Ok(id) => {
+                let span_id = SpanId::from_hex(id);
+                match span_id {
+                    Ok(id) => spanid = Some(id),
+                    Err(_) => spanid = None,
+                }
+            }
+            Err(_) => spanid = None,
+        }
+    }
+    (traceid, spanid)
+}
+
+pub(crate) fn wrap_span_with_parent_context(
+    request_span: tracing::Span,
+    metadata: &MetadataMap,
+) -> tracing::Span {
+    let (traceid, spanid) = try_parse_tracecontext(metadata);
+    // Attach context passed by FE as parent.
+    if traceid.is_some() && spanid.is_some() {
+        let span_context = SpanContext::new(
+            traceid.unwrap(),
+            spanid.unwrap(),
+            TraceFlags::new(1),
+            true,
+            TraceState::default(),
+        );
+        let context = request_span
+            .context()
+            .with_remote_span_context(span_context)
+            .clone();
+        request_span.set_parent(context);
+    }
+    request_span
+}


### PR DESCRIPTION
## Description of changes
FE passed span and trace id are used as parent for the first span of query service (or compaction service). Rust services also propagate the span and trace id to the sysdb and log service whenever they communicate with it. 

## Test plan
[+ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
NA
