### PR TITLE
[BUG] Update release-javascript-client.yml with registry URL

### DIFF
--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: "16.x"
+        registry-url: "https://registry.npmjs.org"
     - name: Install dependencies
       run: npm install
       working-directory: ./clients/js/


### PR DESCRIPTION
https://github.com/npm/cli/issues/6184

This was removed in #2092. Needs to be added back
