### PR TITLE
[ENH] BF KNN operator skip deleted records from the log data chunk

### DIFF
--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -1,5 +1,6 @@
 use crate::execution::data::data_chunk::Chunk;
 use crate::types::LogRecord;
+use crate::types::Operation;
 use crate::{distance::DistanceFunction, execution::operator::Operator};
 use async_trait::async_trait;
 use std::cmp::Ordering;
@@ -88,6 +89,10 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
             let log_record = data.0;
             let index = data.1;
 
+            if log_record.record.operation == Operation::Delete {
+                // Explicitly skip deleted records.
+                continue;
+            }
             let embedding = match &log_record.record.embedding {
                 Some(embedding) => embedding,
                 None => {
@@ -277,5 +282,57 @@ mod tests {
         assert_eq!(output.indices, vec![0]);
         assert_eq!(output.distances, vec![0.0]);
         assert_eq!(output.data.get_visibility(0), Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_skip_deleted_records() {
+        let operator = BruteForceKnnOperator {};
+        let data = vec![
+            LogRecord {
+                log_offset: 1,
+                record: OperationRecord {
+                    id: "embedding_id_1".to_string(),
+                    embedding: Some(vec![0.0, 0.0, 0.0]),
+                    encoding: None,
+                    metadata: None,
+                    operation: Operation::Add,
+                },
+            },
+            LogRecord {
+                log_offset: 2,
+                record: OperationRecord {
+                    id: "embedding_id_2".to_string(),
+                    embedding: None,
+                    encoding: None,
+                    metadata: None,
+                    operation: Operation::Add,
+                },
+            },
+            LogRecord {
+                log_offset: 3,
+                record: OperationRecord {
+                    id: "embedding_id_3".to_string(),
+                    embedding: Some(vec![7.0, 8.0, 9.0]),
+                    encoding: None,
+                    metadata: None,
+                    operation: Operation::Add,
+                },
+            },
+        ];
+        let data_chunk = Chunk::new(data.into());
+
+        let input = BruteForceKnnOperatorInput {
+            data: data_chunk,
+            query: vec![0.0, 0.0, 0.0],
+            k: 2,
+            distance_metric: DistanceFunction::Euclidean,
+        };
+        let output = operator.run(&input).await.unwrap();
+        assert_eq!(output.indices, vec![0, 2]);
+        let distance_1 = 7.0_f32.powi(2) + 8.0_f32.powi(2) + 9.0_f32.powi(2);
+        assert_eq!(output.distances, vec![0.0, distance_1]);
+        assert_eq!(output.data.get_visibility(0), Some(true));
+        assert_eq!(output.data.get_visibility(1), Some(false));
+        assert_eq!(output.data.get_visibility(2), Some(true));
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR explicitly skips deleted records from the log data chunk. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
