### PR TITLE
[ENH] Prefix, LT, LTE, GT, GTE queries in hashmap blockfile

### DIFF
--- a/rust/worker/src/blockstore/key.rs
+++ b/rust/worker/src/blockstore/key.rs
@@ -28,9 +28,27 @@ impl Into<KeyWrapper> for &str {
     }
 }
 
+impl<'referred_data> From<&'referred_data KeyWrapper> for &'referred_data str {
+    fn from(key: &'referred_data KeyWrapper) -> Self {
+        match key {
+            KeyWrapper::String(s) => s,
+            _ => panic!("Invalid conversion"),
+        }
+    }
+}
+
 impl Into<KeyWrapper> for f32 {
     fn into(self) -> KeyWrapper {
         KeyWrapper::Float32(self)
+    }
+}
+
+impl From<&KeyWrapper> for f32 {
+    fn from(key: &KeyWrapper) -> Self {
+        match key {
+            KeyWrapper::Float32(f) => f.clone(),
+            _ => panic!("Invalid conversion"),
+        }
     }
 }
 
@@ -40,14 +58,32 @@ impl Into<KeyWrapper> for bool {
     }
 }
 
+impl From<&KeyWrapper> for bool {
+    fn from(key: &KeyWrapper) -> Self {
+        match key {
+            KeyWrapper::Bool(b) => b.clone(),
+            _ => panic!("Invalid conversion"),
+        }
+    }
+}
+
 impl Into<KeyWrapper> for u32 {
     fn into(self) -> KeyWrapper {
         KeyWrapper::Uint32(self)
     }
 }
 
+impl From<&KeyWrapper> for u32 {
+    fn from(key: &KeyWrapper) -> Self {
+        match key {
+            KeyWrapper::Uint32(u) => u.clone(),
+            _ => panic!("Invalid conversion"),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
-pub(super) struct CompositeKey {
+pub(crate) struct CompositeKey {
     pub(super) prefix: String,
     pub(super) key: KeyWrapper,
 }

--- a/rust/worker/src/blockstore/memory/provider.rs
+++ b/rust/worker/src/blockstore/memory/provider.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::blockstore::{
     arrow::types::{ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue},
     key::KeyWrapper,
-    provider::{BlockfileProvider, CreateError, OpenError},
+    provider::{CreateError, OpenError},
     BlockfileReader, BlockfileWriter, Key, Value,
 };
 
@@ -27,7 +27,7 @@ impl HashMapBlockfileProvider {
 
     pub(crate) fn open<
         'new,
-        K: Key + Into<KeyWrapper> + ArrowReadableKey<'new> + 'new,
+        K: Key + Into<KeyWrapper> + From<&'new KeyWrapper> + ArrowReadableKey<'new> + 'new,
         V: Value + Readable<'new> + ArrowReadableValue<'new> + 'new,
     >(
         &self,

--- a/rust/worker/src/blockstore/memory/reader_writer.rs
+++ b/rust/worker/src/blockstore/memory/reader_writer.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn test_blockfile_string() {
         let storage_manager = StorageManager::new();
-        let mut writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
         let _ = writer.set("prefix", "key1", "value1");
         let _ = writer.commit();
 
@@ -183,10 +183,29 @@ mod tests {
     }
 
     #[test]
-    fn test_data_record() {
+    fn test_string_key_rbm_value() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let mut bitmap = roaring::RoaringBitmap::new();
+        bitmap.insert(1);
+        bitmap.insert(2);
+        bitmap.insert(3);
+        let _ = writer.set("prefix", "bitmap1", &bitmap);
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<&str, roaring::RoaringBitmap> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let value = reader.get("prefix", "bitmap1").unwrap();
+        assert!(value.contains(1));
+        assert!(value.contains(2));
+        assert!(value.contains(3));
+    }
+
+    #[test]
+    fn test_string_key_data_record_value() {
         // TODO: cleanup this test
         let storage_manager = StorageManager::new();
-        let mut writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
         let id = uuid::Uuid::new_v4().to_string();
         let embedding = vec![1.0, 2.0, 3.0];
         let record = DataRecord {
@@ -256,7 +275,7 @@ mod tests {
     #[test]
     fn test_bool_key() {
         let storage_manager = StorageManager::new();
-        let mut writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
         let _ = writer.set("prefix", true, "value1");
         let _ = writer.commit();
 
@@ -266,197 +285,530 @@ mod tests {
         assert_eq!(value, "value1");
     }
 
-    // #[test]
-    // fn test_blockfile_get_by_prefix() {
-    //     let mut blockfile = HashMapBlockfile::new();
-    //     let key1 = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("key1".to_string()),
-    //     };
-    //     let key2 = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("key2".to_string()),
-    //     };
-    //     let _res = blockfile
-    //         .set(
-    //             key1.clone(),
-    //             &Value::Int32ArrayValue(Int32Array::from(vec![1, 2, 3])),
-    //         )
-    //         .unwrap();
-    //     let _res = blockfile
-    //         .set(
-    //             key2.clone(),
-    //             &Value::Int32ArrayValue(Int32Array::from(vec![4, 5, 6])),
-    //         )
-    //         .unwrap();
-    //     let values = blockfile.get_by_prefix("text_prefix".to_string()).unwrap();
-    //     assert_eq!(values.len(), 2);
-    //     // May return values in any order
-    //     match &values[0].1 {
-    //         Value::Int32ArrayValue(arr) => assert!(
-    //             arr == &Int32Array::from(vec![1, 2, 3]) || arr == &Int32Array::from(vec![4, 5, 6])
-    //         ),
-    //         _ => panic!("Value is not a string"),
-    //     }
-    //     match &values[1].1 {
-    //         Value::Int32ArrayValue(arr) => assert!(
-    //             arr == &Int32Array::from(vec![1, 2, 3]) || arr == &Int32Array::from(vec![4, 5, 6])
-    //         ),
-    //         _ => panic!("Value is not a string"),
-    //     }
-    // }
+    #[test]
+    fn test_u32_key() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.commit();
 
-    // #[test]
-    // fn test_bool_key() {
-    //     let mut blockfile = HashMapBlockfileWriter::new();
-    //     let key = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: true,
-    //     };
-    //     let _res = blockfile.set(key.clone(), &Int32Array::from(vec![1]));
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let value = reader.get("prefix", 1).unwrap();
+        assert_eq!(value, "value1");
+    }
 
-    //     let blockfile = blockfile.to_reader();
-    //     let value = blockfile.get(key).unwrap();
-    //     assert_eq!(value, Int32Array::from(vec![1]));
-    // }
+    #[test]
+    fn test_float32_key() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.commit();
 
-    // #[test]
-    // fn test_string_value() {
-    //     let mut blockfile = HashMapBlockfileWriter::new();
-    //     let key = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: "key1".to_string(),
-    //     };
-    //     let _res = blockfile.set(key.clone(), &"value1".to_string());
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let value = reader.get("prefix", 1.0).unwrap();
+        assert_eq!(value, "value1");
+    }
 
-    //     let blockfile = blockfile.to_reader();
-    //     let value = blockfile.get(key).unwrap();
-    //     assert_eq!(value, "value1".to_string());
-    // }
+    #[test]
+    fn test_get_by_prefix() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", "key1", "value1");
+        let _ = writer.set("prefix", "key2", "value2");
+        let _ = writer.set("different_prefix", "key3", "value3");
+        let _ = writer.commit();
 
-    // #[test]
-    // fn test_storing_arrow_in_blockfile() {
-    //     let mut blockfile = HashMapBlockfile::new();
-    //     let key = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("key1".to_string()),
-    //     };
-    //     let array = Value::Int32ArrayValue(Int32Array::from(vec![1, 2, 3]));
-    //     let _res = blockfile.set(key.clone(), &array).unwrap();
-    //     let value = blockfile.get(key).unwrap();
-    //     match value {
-    //         Value::Int32ArrayValue(arr) => assert_eq!(arr, Int32Array::from(vec![1, 2, 3])),
-    //         _ => panic!("Value is not an arrow int32 array"),
-    //     }
-    // }
+        let reader: HashMapBlockfileReader<&str, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_by_prefix("prefix").unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values.iter().any(|(prefix, key, value)| *prefix == "prefix"
+            && *key == "key1"
+            && *value == "value1"));
+        assert!(values.iter().any(|(prefix, key, value)| *prefix == "prefix"
+            && *key == "key2"
+            && *value == "value2"));
+    }
 
-    // #[test]
-    // fn test_blockfile_get_gt() {
-    //     let mut blockfile = HashMapBlockfile::new();
-    //     let key1 = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("key1".to_string()),
-    //     };
-    //     let key2 = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("key2".to_string()),
-    //     };
-    //     let key3 = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("key3".to_string()),
-    //     };
-    //     let _res = blockfile.set(
-    //         key1.clone(),
-    //         &Value::Int32ArrayValue(Int32Array::from(vec![1])),
-    //     );
-    //     let _res = blockfile.set(
-    //         key2.clone(),
-    //         &Value::Int32ArrayValue(Int32Array::from(vec![2])),
-    //     );
-    //     let _res = blockfile.set(
-    //         key3.clone(),
-    //         &Value::Int32ArrayValue(Int32Array::from(vec![3])),
-    //     );
-    //     let values = blockfile
-    //         .get_gt("text_prefix".to_string(), Key::String("key1".to_string()))
-    //         .unwrap();
-    //     assert_eq!(values.len(), 2);
-    //     match &values[0].0.key {
-    //         Key::String(s) => assert!(s == "key2" || s == "key3"),
-    //         _ => panic!("Key is not a string"),
-    //     }
-    //     match &values[1].0.key {
-    //         Key::String(s) => assert!(s == "key2" || s == "key3"),
-    //         _ => panic!("Key is not a string"),
-    //     }
-    // }
+    #[test]
+    fn test_get_gt_int_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
 
-    // #[test]
-    // fn test_learning_arrow_struct() {
-    //     let mut builder = PositionalPostingListBuilder::new();
-    //     let _res = builder.add_doc_id_and_positions(1, vec![0]);
-    //     let _res = builder.add_doc_id_and_positions(2, vec![0, 1]);
-    //     let _res = builder.add_doc_id_and_positions(3, vec![0, 1, 2]);
-    //     let list_term_1 = builder.build();
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gt("prefix", 3);
+        assert!(values.is_err());
+    }
 
-    //     // Example of how to use the struct array, which is one value for a term
-    //     let mut blockfile = HashMapBlockfile::new();
-    //     let key = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: Key::String("term1".to_string()),
-    //     };
-    //     let _res = blockfile
-    //         .set(key.clone(), &Value::PositionalPostingListValue(list_term_1))
-    //         .unwrap();
-    //     let posting_list = blockfile.get(key).unwrap();
-    //     let posting_list = match posting_list {
-    //         Value::PositionalPostingListValue(arr) => arr,
-    //         _ => panic!("Value is not an arrow struct array"),
-    //     };
+    #[test]
+    fn test_get_gt_int_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
 
-    //     let ids = posting_list.get_doc_ids();
-    //     let ids = ids.as_any().downcast_ref::<Int32Array>().unwrap();
-    //     // find index of target id
-    //     let target_id = 2;
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gt("prefix", 0).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+    }
 
-    //     // imagine this is binary search instead of linear
-    //     for i in 0..ids.len() {
-    //         if ids.is_null(i) {
-    //             continue;
-    //         }
-    //         if ids.value(i) == target_id {
-    //             let pos_list = posting_list.get_positions_for_doc_id(target_id).unwrap();
-    //             let pos_list = pos_list.as_any().downcast_ref::<Int32Array>().unwrap();
-    //             assert_eq!(pos_list.len(), 2);
-    //             assert_eq!(pos_list.value(0), 0);
-    //             assert_eq!(pos_list.value(1), 1);
-    //             break;
-    //         }
-    //     }
-    // }
+    #[test]
+    fn test_get_gt_int_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
 
-    // #[test]
-    // fn test_roaring_bitmap_example() {
-    //     let mut bitmap = RoaringBitmap::new();
-    //     bitmap.insert(1);
-    //     bitmap.insert(2);
-    //     bitmap.insert(3);
-    //     let mut blockfile = HashMapBlockfile::new();
-    //     let key = BlockfileKey::new(
-    //         "text_prefix".to_string(),
-    //         Key::String("bitmap1".to_string()),
-    //     );
-    //     let _res = blockfile
-    //         .set(key.clone(), &Value::RoaringBitmapValue(bitmap))
-    //         .unwrap();
-    //     let value = blockfile.get(key).unwrap();
-    //     match value {
-    //         Value::RoaringBitmapValue(bitmap) => {
-    //             assert!(bitmap.contains(1));
-    //             assert!(bitmap.contains(2));
-    //             assert!(bitmap.contains(3));
-    //         }
-    //         _ => panic!("Value is not a roaring bitmap"),
-    //     }
-    // }
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gt("prefix", 1).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_gt_float_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gt("prefix", 3.0);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_gt_float_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gt("prefix", 0.0).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_gt_float_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gt("prefix", 1.0).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_gte_int_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gte("prefix", 4);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_gte_int_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gte("prefix", 1).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_gte_int_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gte("prefix", 2).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_gte_float_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gte("prefix", 3.5);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_gte_float_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gte("prefix", 0.5).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_gte_float_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_gte("prefix", 1.5).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_lt_int_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lt("prefix", 1);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_lt_int_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lt("prefix", 4).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_lt_int_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lt("prefix", 3).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+    }
+
+    #[test]
+    fn test_get_lt_float_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lt("prefix", 0.5);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_lt_float_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lt("prefix", 3.5).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_lt_float_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lt("prefix", 2.5).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+    }
+
+    #[test]
+    fn test_get_lte_int_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lte("prefix", 0);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_lte_int_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lte("prefix", 3).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_lte_int_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1, "value1");
+        let _ = writer.set("prefix", 2, "value2");
+        let _ = writer.set("prefix", 3, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<u32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lte("prefix", 2).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+    }
+
+    #[test]
+    fn test_get_lte_float_none_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lte("prefix", 0.5);
+        assert!(values.is_err());
+    }
+
+    #[test]
+    fn test_get_lte_float_all_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lte("prefix", 3.0).unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+    }
+
+    #[test]
+    fn test_get_lte_float_some_returned() {
+        let storage_manager = StorageManager::new();
+        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", 1.0, "value1");
+        let _ = writer.set("prefix", 2.0, "value2");
+        let _ = writer.set("prefix", 3.0, "value3");
+        let _ = writer.commit();
+
+        let reader: HashMapBlockfileReader<f32, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let values = reader.get_lte("prefix", 2.0).unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+    }
 }

--- a/rust/worker/src/blockstore/memory/reader_writer.rs
+++ b/rust/worker/src/blockstore/memory/reader_writer.rs
@@ -76,7 +76,7 @@ impl<
 
     pub(crate) fn get_by_prefix(
         &'storage self,
-        prefix: &'storage str,
+        prefix: &str,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         let values = V::get_by_prefix_from_storage(prefix, &self.storage);
         if values.is_empty() {
@@ -84,14 +84,14 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| (prefix, K::from(&key.key), value.clone()))
+            .map(|(key, value)| (key.prefix.as_str(), K::from(&key.key), value.clone()))
             .collect();
         Ok(values)
     }
 
     pub(crate) fn get_gt(
         &'storage self,
-        prefix: &'storage str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
@@ -101,14 +101,14 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| (prefix, K::from(&key.key), value.clone()))
+            .map(|(key, value)| (key.prefix.as_str(), K::from(&key.key), value.clone()))
             .collect();
         Ok(values)
     }
 
     pub(crate) fn get_lt(
         &'storage self,
-        prefix: &'storage str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
@@ -118,14 +118,14 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| (prefix, K::from(&key.key), value.clone()))
+            .map(|(key, value)| (key.prefix.as_str(), K::from(&key.key), value.clone()))
             .collect();
         Ok(values)
     }
 
     pub(crate) fn get_gte(
         &'storage self,
-        prefix: &'storage str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
@@ -135,14 +135,14 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| (prefix, K::from(&key.key), value.clone()))
+            .map(|(key, value)| (key.prefix.as_str(), K::from(&key.key), value.clone()))
             .collect();
         Ok(values)
     }
 
     pub(crate) fn get_lte(
         &'storage self,
-        prefix: &'storage str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
@@ -152,7 +152,7 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| (prefix, K::from(&key.key), value.clone()))
+            .map(|(key, value)| (key.prefix.as_str(), K::from(&key.key), value.clone()))
             .collect();
         Ok(values)
     }
@@ -253,53 +253,18 @@ mod tests {
         assert_eq!(record.embedding, vec![1.0, 2.0, 3.0]);
     }
 
-    // #[test]
-    // fn test_blockfile_set_get() {
-    //     let mut blockfile_writer = HashMapBlockfileWriter::new();
-    //     let key = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: "key1".to_string(),
-    //     };
-    //     let _res = blockfile_writer
-    //         .set(key.clone(), &Int32Array::from(vec![1, 2, 3]))
-    //         .unwrap();
+    #[test]
+    fn test_bool_key() {
+        let storage_manager = StorageManager::new();
+        let mut writer = MemoryBlockfileWriter::new(storage_manager.clone());
+        let _ = writer.set("prefix", true, "value1");
+        let _ = writer.commit();
 
-    //     let blockfile_reader = blockfile_writer.to_reader();
-    //     let value = blockfile_reader.get(key).unwrap();
-    //     assert_eq!(value, Int32Array::from(vec![1, 2, 3]));
-    // }
-
-    // #[test]
-    // fn test_data_record_key() {
-    //     let mut blockfile_writer = HashMapBlockfileWriter::new();
-    //     let key = BlockfileKey {
-    //         prefix: "text_prefix".to_string(),
-    //         key: "key1".to_string(),
-    //     };
-    //     let id = "id1".to_string();
-    //     let embedding = vec![1.0, 2.0, 3.0];
-    //     let mut metadata = HashMap::new();
-    //     metadata.insert("key".to_string(), MetadataValue::Str("value".to_string()));
-    //     let record = DataRecord {
-    //         id: &id,
-    //         embedding: &embedding,
-    //         metadata: &Some(metadata),
-    //         document: &None,
-    //         serialized_metadata: None,
-    //     };
-    //     let _res = blockfile_writer.set(key.clone(), &record).unwrap();
-
-    //     let blockfile_reader = blockfile_writer.to_reader();
-    //     let value = blockfile_reader.get(key).unwrap();
-    //     assert_eq!(value.id, "id1");
-    //     assert_eq!(value.embedding, vec![1.0, 2.0, 3.0]);
-    //     assert_eq!(value.metadata.as_ref().unwrap().len(), 1);
-    //     assert_eq!(
-    //         *value.metadata.as_ref().unwrap().get("key").unwrap(),
-    //         MetadataValue::Str("value".to_string())
-    //     );
-    //     assert!(value.document.is_none());
-    // }
+        let reader: HashMapBlockfileReader<bool, &str> =
+            HashMapBlockfileReader::open(writer.id, storage_manager);
+        let value = reader.get("prefix", true).unwrap();
+        assert_eq!(value, "value1");
+    }
 
     // #[test]
     // fn test_blockfile_get_by_prefix() {

--- a/rust/worker/src/blockstore/provider.rs
+++ b/rust/worker/src/blockstore/provider.rs
@@ -43,7 +43,7 @@ impl BlockfileProvider {
 
     pub(crate) async fn open<
         'new,
-        K: Key + Into<KeyWrapper> + ArrowReadableKey<'new> + 'new,
+        K: Key + Into<KeyWrapper> + From<&'new KeyWrapper> + ArrowReadableKey<'new> + 'new,
         V: Value + Readable<'new> + ArrowReadableValue<'new> + 'new,
     >(
         &self,

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -281,7 +281,7 @@ impl<
     // TODO: make prefix &str
     pub(crate) fn get_by_prefix(
         &'referred_data self,
-        prefix: &'referred_data str,
+        prefix: &str,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_by_prefix(prefix),
@@ -291,7 +291,7 @@ impl<
 
     pub(crate) fn get_gt(
         &'referred_data self,
-        prefix: &'referred_data str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
@@ -302,7 +302,7 @@ impl<
 
     pub(crate) fn get_lt(
         &'referred_data self,
-        prefix: &'referred_data str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
@@ -313,7 +313,7 @@ impl<
 
     pub(crate) fn get_gte(
         &'referred_data self,
-        prefix: &'referred_data str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
@@ -324,7 +324,7 @@ impl<
 
     pub(crate) fn get_lte(
         &'referred_data self,
-        prefix: &'referred_data str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -260,7 +260,10 @@ pub(crate) enum BlockfileReader<
 
 impl<
         'referred_data,
-        K: Key + Into<KeyWrapper> + ArrowReadableKey<'referred_data>,
+        K: Key
+            + Into<KeyWrapper>
+            + From<&'referred_data KeyWrapper>
+            + ArrowReadableKey<'referred_data>,
         V: Value + Readable<'referred_data> + ArrowReadableValue<'referred_data>,
     > BlockfileReader<'referred_data, K, V>
 {
@@ -277,9 +280,9 @@ impl<
 
     // TODO: make prefix &str
     pub(crate) fn get_by_prefix(
-        &self,
-        prefix: String,
-    ) -> Result<Vec<(&str, &K, &V)>, Box<dyn ChromaError>> {
+        &'referred_data self,
+        prefix: &'referred_data str,
+    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_by_prefix(prefix),
             BlockfileReader::ArrowBlockfileReader(reader) => todo!(),
@@ -287,10 +290,10 @@ impl<
     }
 
     pub(crate) fn get_gt(
-        &self,
-        prefix: String,
+        &'referred_data self,
+        prefix: &'referred_data str,
         key: K,
-    ) -> Result<Vec<(&str, &K, &V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_gt(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => todo!(),
@@ -298,10 +301,10 @@ impl<
     }
 
     pub(crate) fn get_lt(
-        &self,
-        prefix: String,
+        &'referred_data self,
+        prefix: &'referred_data str,
         key: K,
-    ) -> Result<Vec<(&str, &K, &V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_lt(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => todo!(),
@@ -309,10 +312,10 @@ impl<
     }
 
     pub(crate) fn get_gte(
-        &self,
-        prefix: String,
+        &'referred_data self,
+        prefix: &'referred_data str,
         key: K,
-    ) -> Result<Vec<(&str, &K, &V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_gte(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => todo!(),
@@ -320,10 +323,10 @@ impl<
     }
 
     pub(crate) fn get_lte(
-        &self,
-        prefix: String,
+        &'referred_data self,
+        prefix: &'referred_data str,
         key: K,
-    ) -> Result<Vec<(&str, &K, &V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_lte(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => todo!(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Add Prefix, LT, LTE, GT, and GTE queries to the hashmap blockfile. This required changing a couple of the blockfile API contracts as we discussed (removing references in favor of returning values directly)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
