### PR TITLE
[ENH] Pass in allow ids and disallow ids to HNSW KNN operator

### DIFF
--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -1,9 +1,17 @@
+use crate::execution::data::data_chunk::Chunk;
+use crate::types::{LogRecord, Operation};
 use crate::{
-    errors::ChromaError, execution::operator::Operator,
-    segment::distributed_hnsw_segment::DistributedHNSWSegmentReader,
+    blockstore::provider::BlockfileProvider,
+    errors::{ChromaError, ErrorCodes},
+    execution::operator::Operator,
+    segment::{
+        distributed_hnsw_segment::DistributedHNSWSegmentReader, record_segment::RecordSegmentReader,
+    },
+    types::Segment,
 };
 use async_trait::async_trait;
 use std::sync::Arc;
+use thiserror::Error;
 
 #[derive(Debug)]
 pub struct HnswKnnOperator {}
@@ -13,8 +21,10 @@ pub struct HnswKnnOperatorInput {
     pub segment: Box<DistributedHNSWSegmentReader>,
     pub query: Vec<f32>,
     pub k: usize,
-    pub allowed_offset_ids: Arc<[u32]>,
-    pub disallowed_offset_ids: Arc<[u32]>,
+    pub record_segment: Segment,
+    pub blockfile_provider: BlockfileProvider,
+    pub allowed_ids: Arc<[String]>,
+    pub logs: Chunk<LogRecord>,
 }
 
 #[derive(Debug)]
@@ -23,13 +33,91 @@ pub struct HnswKnnOperatorOutput {
     pub distances: Vec<f32>,
 }
 
+#[derive(Error, Debug)]
+pub enum HnswKnnOperatorError {
+    #[error("Error creating Record Segment")]
+    RecordSegmentError,
+    #[error("Error reading Record Segment")]
+    RecordSegmentReadError,
+}
+
+impl ChromaError for HnswKnnOperatorError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            HnswKnnOperatorError::RecordSegmentError => ErrorCodes::Internal,
+            HnswKnnOperatorError::RecordSegmentReadError => ErrorCodes::Internal,
+        }
+    }
+}
+
 pub type HnswKnnOperatorResult = Result<HnswKnnOperatorOutput, Box<dyn ChromaError>>;
+
+impl HnswKnnOperator {
+    async fn get_disallowed_ids(
+        &self,
+        logs: Chunk<LogRecord>,
+        record_segment_reader: &RecordSegmentReader<'_>,
+    ) -> Result<Vec<u32>, Box<dyn ChromaError>> {
+        let mut disallowed_ids = Vec::new();
+        for item in logs.iter() {
+            let log = item.0;
+            let operation_record = &log.record;
+            if operation_record.operation == Operation::Delete
+                || operation_record.operation == Operation::Update
+            {
+                let offset_id = record_segment_reader
+                    .get_offset_id_for_user_id(&operation_record.id)
+                    .await;
+                match offset_id {
+                    Ok(offset_id) => disallowed_ids.push(offset_id),
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+        Ok(disallowed_ids)
+    }
+}
 
 #[async_trait]
 impl Operator<HnswKnnOperatorInput, HnswKnnOperatorOutput> for HnswKnnOperator {
     type Error = Box<dyn ChromaError>;
 
     async fn run(&self, input: &HnswKnnOperatorInput) -> HnswKnnOperatorResult {
+        let record_segment_reader = match RecordSegmentReader::from_segment(
+            &input.record_segment,
+            &input.blockfile_provider,
+        )
+        .await
+        {
+            Ok(reader) => reader,
+            Err(e) => {
+                return Err(Box::new(HnswKnnOperatorError::RecordSegmentError));
+            }
+        };
+        let mut allowed_offset_ids = Vec::new();
+        for user_id in input.allowed_ids.iter() {
+            let offset_id = record_segment_reader
+                .get_offset_id_for_user_id(user_id)
+                .await;
+            match offset_id {
+                Ok(offset_id) => allowed_offset_ids.push(offset_id),
+                Err(e) => {
+                    return Err(Box::new(HnswKnnOperatorError::RecordSegmentReadError));
+                }
+            }
+        }
+        let disallowed_offset_ids = match self
+            .get_disallowed_ids(input.logs.clone(), &record_segment_reader)
+            .await
+        {
+            Ok(disallowed_offset_ids) => disallowed_offset_ids,
+            Err(e) => {
+                return Err(Box::new(HnswKnnOperatorError::RecordSegmentReadError));
+            }
+        };
+
         // TODO: pass in the updated + deleted ids from log and the result from the metadata filtering
         let (offset_ids, distances) = input.segment.query(&input.query, input.k);
         Ok(HnswKnnOperatorOutput {

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -3,6 +3,7 @@ use crate::{
     segment::distributed_hnsw_segment::DistributedHNSWSegmentReader,
 };
 use async_trait::async_trait;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct HnswKnnOperator {}
@@ -12,6 +13,8 @@ pub struct HnswKnnOperatorInput {
     pub segment: Box<DistributedHNSWSegmentReader>,
     pub query: Vec<f32>,
     pub k: usize,
+    pub allowed_ids: Arc<[String]>,
+    pub disallowed_ids: Arc<[String]>,
 }
 
 #[derive(Debug)]
@@ -27,6 +30,7 @@ impl Operator<HnswKnnOperatorInput, HnswKnnOperatorOutput> for HnswKnnOperator {
     type Error = Box<dyn ChromaError>;
 
     async fn run(&self, input: &HnswKnnOperatorInput) -> HnswKnnOperatorResult {
+        // TODO: pass in the updated + deleted ids from log and the result from the metadata filtering
         let (offset_ids, distances) = input.segment.query(&input.query, input.k);
         Ok(HnswKnnOperatorOutput {
             offset_ids,

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -13,8 +13,8 @@ pub struct HnswKnnOperatorInput {
     pub segment: Box<DistributedHNSWSegmentReader>,
     pub query: Vec<f32>,
     pub k: usize,
-    pub allowed_ids: Arc<[String]>,
-    pub disallowed_ids: Arc<[String]>,
+    pub allowed_offset_ids: Arc<[u32]>,
+    pub disallowed_offset_ids: Arc<[u32]>,
 }
 
 #[derive(Debug)]

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -21,13 +21,14 @@ use crate::segment::distributed_hnsw_segment::{
 };
 use crate::sysdb::sysdb::{GetCollectionsError, GetSegmentsError, SysDb};
 use crate::system::{ComponentContext, System};
-use crate::types::{Collection, LogRecord, Segment, SegmentType, VectorQueryResult};
+use crate::types::{Collection, LogRecord, Operation, Segment, SegmentType, VectorQueryResult};
 use crate::{
     log::log::Log,
     system::{Component, Handler, Receiver},
 };
 use async_trait::async_trait;
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tracing::{trace, trace_span, Instrument, Span};
@@ -98,6 +99,7 @@ pub(crate) struct HnswQueryOrchestrator {
     // Query state
     query_vectors: Vec<Vec<f32>>,
     k: i32,
+    allowed_ids: Arc<[String]>,
     include_embeddings: bool,
     hnsw_segment_id: Uuid,
     // State fetched or created for query execution
@@ -127,6 +129,7 @@ impl HnswQueryOrchestrator {
         system: System,
         query_vectors: Vec<Vec<f32>>,
         k: i32,
+        allowed_ids: Vec<String>,
         include_embeddings: bool,
         segment_id: Uuid,
         log: Box<dyn Log>,
@@ -141,6 +144,7 @@ impl HnswQueryOrchestrator {
             merge_dependency_count: 2,
             query_vectors,
             k,
+            allowed_ids: allowed_ids.into(),
             include_embeddings,
             hnsw_segment_id: segment_id,
             hnsw_segment: None,
@@ -221,7 +225,21 @@ impl HnswQueryOrchestrator {
         }
     }
 
-    async fn hnsw_segment_query(&mut self, ctx: &ComponentContext<Self>) {
+    fn get_disallowed_ids(&self, logs: Chunk<LogRecord>) -> Vec<String> {
+        let mut disallowed_ids = Vec::new();
+        for item in logs.iter() {
+            let log = item.0;
+            let operation_record = &log.record;
+            if operation_record.operation == Operation::Delete
+                || operation_record.operation == Operation::Update
+            {
+                disallowed_ids.push(operation_record.id.clone());
+            }
+        }
+        disallowed_ids
+    }
+
+    async fn hnsw_segment_query(&mut self, logs: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
         self.state = ExecutionState::QueryKnn;
 
         let hnsw_segment = self
@@ -264,10 +282,13 @@ impl HnswQueryOrchestrator {
 
         // Dispatch a query task
         let operator = Box::new(HnswKnnOperator {});
+        let disallowed_ids = self.get_disallowed_ids(logs);
         let input = HnswKnnOperatorInput {
             segment: hnsw_segment_reader,
             query: self.query_vectors[0].clone(),
             k: self.k as usize,
+            allowed_ids: self.allowed_ids.clone(),
+            disallowed_ids: disallowed_ids.into(),
         };
         let task = wrap(operator, input, ctx.sender.as_receiver());
         match self.dispatcher.send(task, Some(Span::current())).await {
@@ -536,9 +557,10 @@ impl Handler<PullLogsResult> for HnswQueryOrchestrator {
 
         match message {
             Ok(pull_logs_output) => {
-                self.brute_force_query(pull_logs_output.logs(), ctx.sender.as_receiver())
+                let logs = pull_logs_output.logs();
+                self.brute_force_query(logs.clone(), ctx.sender.as_receiver())
                     .await;
-                self.hnsw_segment_query(ctx).await;
+                self.hnsw_segment_query(logs, ctx).await;
             }
             Err(e) => {
                 self.terminate_with_error(Box::new(e), ctx);

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -146,6 +146,7 @@ impl WorkerServer {
                     system.clone(),
                     query_vectors.clone(),
                     request.k,
+                    request.allowed_ids,
                     request.include_embeddings,
                     segment_uuid,
                     self.log.clone(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR pass the allowed ids and disallowed ids to HNSW KNN operator. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
