### PR TITLE
[ENH] Memory blockfile delete

### DIFF
--- a/rust/worker/src/blockstore/memory/provider.rs
+++ b/rust/worker/src/blockstore/memory/provider.rs
@@ -1,5 +1,5 @@
 use super::{
-    reader_writer::{HashMapBlockfileReader, MemoryBlockfileWriter},
+    reader_writer::{MemoryBlockfileReader, MemoryBlockfileWriter},
     storage::{Readable, StorageManager, Writeable},
 };
 use crate::blockstore::{
@@ -33,7 +33,7 @@ impl HashMapBlockfileProvider {
         &self,
         id: &uuid::Uuid,
     ) -> Result<BlockfileReader<'new, K, V>, Box<OpenError>> {
-        let reader = HashMapBlockfileReader::open(*id, self.storage_manager.clone());
+        let reader = MemoryBlockfileReader::open(*id, self.storage_manager.clone());
         Ok(BlockfileReader::<K, V>::MemoryBlockfileReader(reader))
     }
 

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -4,7 +4,7 @@ use super::arrow::types::{
     ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue,
 };
 use super::key::KeyWrapper;
-use super::memory::reader_writer::{HashMapBlockfileReader, MemoryBlockfileWriter};
+use super::memory::reader_writer::{MemoryBlockfileReader, MemoryBlockfileWriter};
 use super::memory::storage::{Readable, Writeable};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::segment::DataRecord;
@@ -214,6 +214,20 @@ impl BlockfileWriter {
         }
     }
 
+    pub(crate) async fn delete<
+        K: Key + Into<KeyWrapper> + ArrowWriteableKey,
+        V: Value + Writeable + ArrowWriteableValue,
+    >(
+        &self,
+        prefix: &str,
+        key: K,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        match self {
+            BlockfileWriter::MemoryBlockfileWriter(writer) => todo!(),
+            BlockfileWriter::ArrowBlockfileWriter(writer) => todo!(),
+        }
+    }
+
     pub(crate) fn id(&self) -> uuid::Uuid {
         match self {
             BlockfileWriter::MemoryBlockfileWriter(writer) => writer.id(),
@@ -254,7 +268,7 @@ pub(crate) enum BlockfileReader<
     K: Key + ArrowReadableKey<'me>,
     V: Value + ArrowReadableValue<'me>,
 > {
-    MemoryBlockfileReader(HashMapBlockfileReader<K, V>),
+    MemoryBlockfileReader(MemoryBlockfileReader<K, V>),
     ArrowBlockfileReader(ArrowBlockfileReader<'me, K, V>),
 }
 

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -223,7 +223,7 @@ impl BlockfileWriter {
         key: K,
     ) -> Result<(), Box<dyn ChromaError>> {
         match self {
-            BlockfileWriter::MemoryBlockfileWriter(writer) => todo!(),
+            BlockfileWriter::MemoryBlockfileWriter(writer) => writer.delete::<K, V>(prefix, key),
             BlockfileWriter::ArrowBlockfileWriter(writer) => todo!(),
         }
     }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Renamed HashMapBlockfileWriter to "Memory" to align with writer
 - New functionality
	 - Adds delete() in memory blockfiles

## Test plan
*How are these changes tested?*
A new basic test was added for delete for one type
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
