### PR TITLE
[BLD] Py release WF now returns tag_matches=false instead of failure

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -25,7 +25,7 @@ jobs:
               echo "tag_matches=true" >> $GITHUB_OUTPUT
           else
             echo "Tag does not match the release tag pattern ([0-9]+\.[0-9]+\.[0-9]+), exiting workflow"
-            exit 1
+            echo "tag_matches=false" >> $GITHUB_OUTPUT
           fi
 
   get-version:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - now we allow tests and dev builds to continue even if tag is not a release one

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
