### PR TITLE
[ENH] Add orchestration for count

### DIFF
--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -282,7 +282,6 @@ impl<'me, K: ArrowReadableKey<'me>, V: ArrowReadableValue<'me>> ArrowBlockfileRe
             let lock_guard = self.sparse_index.forward.lock();
             let mut curr_iter = lock_guard.iter();
             while let Some((_, block_id)) = curr_iter.next() {
-                println!("Block id {}", block_id);
                 block_ids.push(block_id.clone());
             }
         }

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -277,11 +277,18 @@ impl<'me, K: ArrowReadableKey<'me>, V: ArrowReadableValue<'me>> ArrowBlockfileRe
 
     // Count the total number of records.
     pub(crate) async fn count(&self) -> Result<usize, Box<dyn ChromaError>> {
+        let mut block_ids: Vec<Uuid> = vec![];
+        {
+            let lock_guard = self.sparse_index.forward.lock();
+            let mut curr_iter = lock_guard.iter();
+            while let Some((_, block_id)) = curr_iter.next() {
+                println!("Block id {}", block_id);
+                block_ids.push(block_id.clone());
+            }
+        }
         let mut result: usize = 0;
-        let lock_guard = self.sparse_index.forward.lock();
-        let mut curr_iter = lock_guard.iter();
-        while let Some((_, block_id)) = curr_iter.next() {
-            let block = self.get_block(*block_id).await;
+        for block_id in block_ids {
+            let block = self.get_block(block_id).await;
             match block {
                 Some(b) => result = result + b.len(),
                 None => {

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -1,0 +1,68 @@
+use tonic::async_trait;
+
+use crate::{
+    blockstore::provider::BlockfileProvider, errors::ChromaError, execution::operator::Operator,
+    segment::record_segment::RecordSegmentReader, types::Segment,
+};
+
+use super::merge_metadata_results::MergeMetadataResultsOperatorError;
+
+#[derive(Debug)]
+pub(crate) struct CountRecordsOperator {}
+
+impl CountRecordsOperator {
+    pub(crate) fn new() -> Box<Self> {
+        Box::new(CountRecordsOperator {})
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CountRecordsInput {
+    record_segment_definition: Segment,
+    blockfile_provider: BlockfileProvider,
+}
+
+impl CountRecordsInput {
+    pub(crate) fn new(
+        record_segment_definition: Segment,
+        blockfile_provider: BlockfileProvider,
+    ) -> Self {
+        Self {
+            record_segment_definition,
+            blockfile_provider,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CountRecordsOutput {
+    pub(crate) count: usize,
+}
+
+#[async_trait]
+impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
+    type Error = MergeMetadataResultsOperatorError;
+    async fn run(
+        &self,
+        input: &CountRecordsInput,
+    ) -> Result<CountRecordsOutput, MergeMetadataResultsOperatorError> {
+        let segment_reader = RecordSegmentReader::from_segment(
+            &input.record_segment_definition,
+            &input.blockfile_provider,
+        )
+        .await;
+        match segment_reader {
+            Ok(reader) => match reader.count().await {
+                Ok(val) => {
+                    return Ok(CountRecordsOutput { count: val });
+                }
+                Err(_) => {
+                    return Err(MergeMetadataResultsOperatorError::RecordSegmentReadError);
+                }
+            },
+            Err(_) => {
+                return Err(MergeMetadataResultsOperatorError::RecordSegmentError);
+            }
+        }
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod brute_force_knn;
+pub(super) mod count_records;
 pub(super) mod flush_s3;
 pub(super) mod hnsw_knn;
 pub(super) mod merge_knn_results;

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -2,7 +2,7 @@ use crate::errors::{ChromaError, ErrorCodes};
 use crate::execution::data::data_chunk::Chunk;
 use crate::execution::operator::wrap;
 use crate::execution::operators::count_records::{
-    CountRecordsInput, CountRecordsOperator, CountRecordsOutput,
+    CountRecordsError, CountRecordsInput, CountRecordsOperator, CountRecordsOutput,
 };
 use crate::execution::operators::merge_metadata_results::{
     MergeMetadataResultsOperator, MergeMetadataResultsOperatorError,
@@ -374,8 +374,6 @@ impl Handler<PullLogsResult> for CountQueryOrchestrator {
         match message {
             Ok(logs) => {
                 let logs = logs.logs();
-                println!("Got logs {}", logs.total_len());
-                println!("Logs {:?}", logs);
                 self.log_record_count = logs.total_len();
                 // TODO: Add logic for merging logs with count from record segment.
                 let operator = CountRecordsOperator::new();
@@ -404,12 +402,10 @@ impl Handler<PullLogsResult> for CountQueryOrchestrator {
 }
 
 #[async_trait]
-impl Handler<Result<CountRecordsOutput, MergeMetadataResultsOperatorError>>
-    for CountQueryOrchestrator
-{
+impl Handler<Result<CountRecordsOutput, CountRecordsError>> for CountQueryOrchestrator {
     async fn handle(
         &mut self,
-        message: Result<CountRecordsOutput, MergeMetadataResultsOperatorError>,
+        message: Result<CountRecordsOutput, CountRecordsError>,
         ctx: &ComponentContext<Self>,
     ) {
         let msg = match message {

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -1,9 +1,12 @@
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::execution::data::data_chunk::Chunk;
 use crate::execution::operator::wrap;
+use crate::execution::operators::count_records::{
+    CountRecordsInput, CountRecordsOperator, CountRecordsOutput,
+};
 use crate::execution::operators::merge_metadata_results::{
-    MergeMetadataResultsOperator, MergeMetadataResultsOperatorInput,
-    MergeMetadataResultsOperatorResult,
+    MergeMetadataResultsOperator, MergeMetadataResultsOperatorError,
+    MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorResult,
 };
 use crate::execution::operators::pull_log::{PullLogsInput, PullLogsOperator, PullLogsResult};
 use crate::sysdb::sysdb::{GetCollectionsError, GetSegmentsError};
@@ -60,6 +63,26 @@ pub(crate) struct MetadataQueryOrchestrator {
     result_channel: Option<tokio::sync::oneshot::Sender<MetadataQueryOrchestratorResult>>,
 }
 
+#[derive(Debug)]
+pub(crate) struct CountQueryOrchestrator {
+    // Component Execution
+    system: System,
+    // Query state
+    metadata_segment_id: Uuid,
+    // State fetched or created for query execution
+    record_segment: Option<Segment>,
+    collection: Option<Collection>,
+    // Services
+    log: Box<dyn Log>,
+    sysdb: Box<dyn SysDb>,
+    dispatcher: Box<dyn Receiver<TaskMessage>>,
+    blockfile_provider: BlockfileProvider,
+    // Result channel
+    result_channel: Option<tokio::sync::oneshot::Sender<Result<usize, Box<dyn ChromaError>>>>,
+    // Count of records in the log
+    log_record_count: usize,
+}
+
 #[derive(Error, Debug)]
 enum MetadataSegmentQueryError {
     #[error("Blockfile metadata segment with id: {0} not found")]
@@ -90,6 +113,321 @@ impl ChromaError for MetadataSegmentQueryError {
             MetadataSegmentQueryError::SystemTimeError(_) => ErrorCodes::Internal,
             MetadataSegmentQueryError::CollectionNotFound(_) => ErrorCodes::NotFound,
             MetadataSegmentQueryError::GetCollectionError(e) => e.code(),
+        }
+    }
+}
+
+impl CountQueryOrchestrator {
+    pub(crate) fn new(
+        system: System,
+        metadata_segment_id: &Uuid,
+        log: Box<dyn Log>,
+        sysdb: Box<dyn SysDb>,
+        dispatcher: Box<dyn Receiver<TaskMessage>>,
+        blockfile_provider: BlockfileProvider,
+    ) -> Self {
+        Self {
+            system,
+            metadata_segment_id: *metadata_segment_id,
+            record_segment: None,
+            collection: None,
+            log,
+            sysdb,
+            dispatcher,
+            blockfile_provider,
+            result_channel: None,
+            log_record_count: 0,
+        }
+    }
+
+    async fn start(&mut self, ctx: &ComponentContext<Self>) {
+        println!("Starting Count Query Orchestrator");
+        // Populate the orchestrator with the initial state - The Record Segment and the Collection
+        let metdata_segment = self
+            .get_metadata_segment_from_id(self.sysdb.clone(), &self.metadata_segment_id)
+            .await;
+
+        let metadata_segment = match metdata_segment {
+            Ok(segment) => segment,
+            Err(e) => {
+                self.terminate_with_error(e, ctx);
+                return;
+            }
+        };
+
+        let collection_id = match metadata_segment.collection {
+            Some(collection_id) => collection_id,
+            None => {
+                self.terminate_with_error(
+                    Box::new(MetadataSegmentQueryError::MetadataSegmentHasNoCollection),
+                    ctx,
+                );
+                return;
+            }
+        };
+
+        let record_segment = self
+            .get_record_segment_from_collection_id(self.sysdb.clone(), &collection_id)
+            .await;
+
+        let record_segment = match record_segment {
+            Ok(segment) => segment,
+            Err(e) => {
+                self.terminate_with_error(e, ctx);
+                return;
+            }
+        };
+
+        let collection = match self
+            .get_collection_from_id(self.sysdb.clone(), &collection_id, ctx)
+            .await
+        {
+            Ok(collection) => collection,
+            Err(e) => {
+                self.terminate_with_error(e, ctx);
+                return;
+            }
+        };
+
+        self.record_segment = Some(record_segment);
+        self.collection = Some(collection);
+    }
+
+    async fn pull_logs(&mut self, ctx: &ComponentContext<Self>) {
+        println!("Count query orchestrator pulling logs");
+
+        let operator = PullLogsOperator::new(self.log.clone());
+        let end_timestamp = SystemTime::now().duration_since(UNIX_EPOCH);
+        let end_timestamp = match end_timestamp {
+            Ok(end_timestamp) => end_timestamp.as_nanos() as i64,
+            Err(e) => {
+                self.terminate_with_error(
+                    Box::new(MetadataSegmentQueryError::SystemTimeError(e)),
+                    ctx,
+                );
+                return;
+            }
+        };
+
+        let collection = self
+            .collection
+            .as_ref()
+            .expect("Invariant violation. Collection is not set before pull logs state.");
+        let input = PullLogsInput::new(
+            collection.id,
+            collection.log_position,
+            100,
+            None,
+            Some(end_timestamp),
+        );
+
+        let task = wrap(operator, input, ctx.sender.as_receiver());
+        match self.dispatcher.send(task, Some(Span::current())).await {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implies the dispatcher was dropped somehow
+                // and is likely fatal
+                println!("Error sending Metadata Query task: {:?}", e);
+            }
+        }
+    }
+
+    async fn get_metadata_segment_from_id(
+        &self,
+        mut sysdb: Box<dyn SysDb>,
+        metadata_segment_id: &Uuid,
+    ) -> Result<Segment, Box<dyn ChromaError>> {
+        let segments = sysdb
+            .get_segments(Some(*metadata_segment_id), None, None, None)
+            .await;
+        let segment = match segments {
+            Ok(segments) => {
+                if segments.is_empty() {
+                    return Err(Box::new(
+                        MetadataSegmentQueryError::BlockfileMetadataSegmentNotFound(
+                            *metadata_segment_id,
+                        ),
+                    ));
+                }
+                segments[0].clone()
+            }
+            Err(e) => {
+                return Err(Box::new(MetadataSegmentQueryError::GetSegmentsError(e)));
+            }
+        };
+
+        if segment.r#type != SegmentType::BlockfileMetadata {
+            return Err(Box::new(
+                MetadataSegmentQueryError::BlockfileMetadataSegmentNotFound(*metadata_segment_id),
+            ));
+        }
+        Ok(segment)
+    }
+
+    async fn get_record_segment_from_collection_id(
+        &self,
+        mut sysdb: Box<dyn SysDb>,
+        collection_id: &Uuid,
+    ) -> Result<Segment, Box<dyn ChromaError>> {
+        let segments = sysdb
+            .get_segments(
+                None,
+                Some(SegmentType::Record.into()),
+                None,
+                Some(*collection_id),
+            )
+            .await;
+
+        match segments {
+            Ok(segments) => {
+                if segments.is_empty() {
+                    return Err(Box::new(MetadataSegmentQueryError::RecordSegmentNotFound(
+                        *collection_id,
+                    )));
+                }
+                // Unwrap is safe as we know at least one segment exists from
+                // the check above
+                return Ok(segments.into_iter().next().unwrap());
+            }
+            Err(e) => {
+                return Err(Box::new(MetadataSegmentQueryError::GetSegmentsError(e)));
+            }
+        };
+    }
+
+    async fn get_collection_from_id(
+        &self,
+        mut sysdb: Box<dyn SysDb>,
+        collection_id: &Uuid,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<Collection, Box<dyn ChromaError>> {
+        let collections = sysdb
+            .get_collections(Some(*collection_id), None, None, None)
+            .await;
+
+        match collections {
+            Ok(collections) => {
+                if collections.is_empty() {
+                    return Err(Box::new(MetadataSegmentQueryError::CollectionNotFound(
+                        *collection_id,
+                    )));
+                }
+                // Unwrap is safe as we know at least one collection exists from
+                // the check above
+                return Ok(collections.into_iter().next().unwrap());
+            }
+            Err(e) => {
+                return Err(Box::new(MetadataSegmentQueryError::GetCollectionError(e)));
+            }
+        };
+    }
+
+    fn terminate_with_error(&mut self, error: Box<dyn ChromaError>, ctx: &ComponentContext<Self>) {
+        let result_channel = self
+            .result_channel
+            .take()
+            .expect("Invariant violation. Result channel is not set.");
+        match result_channel.send(Err(error)) {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implied the listener was dropped
+                println!("[CountQueryOrchestrator] Result channel dropped before sending error");
+            }
+        }
+        // Cancel the orchestrator so it stops processing
+        ctx.cancellation_token.cancel();
+    }
+
+    ///  Run the orchestrator and return the result.
+    ///  # Note
+    ///  Use this over spawning the component directly. This method will start the component and
+    ///  wait for it to finish before returning the result.
+    pub(crate) async fn run(mut self) -> Result<usize, Box<dyn ChromaError>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.result_channel = Some(tx);
+        let mut handle = self.system.clone().start_component(self);
+        let result = rx.await;
+        handle.stop();
+        result.unwrap()
+    }
+}
+
+#[async_trait]
+impl Component for CountQueryOrchestrator {
+    fn get_name() -> &'static str {
+        "Count Query Orchestrator"
+    }
+
+    fn queue_size(&self) -> usize {
+        1000 // TODO: make this configurable
+    }
+
+    async fn on_start(&mut self, ctx: &crate::system::ComponentContext<Self>) -> () {
+        self.start(ctx).await;
+        self.pull_logs(ctx).await;
+    }
+}
+
+#[async_trait]
+impl Handler<PullLogsResult> for CountQueryOrchestrator {
+    async fn handle(&mut self, message: PullLogsResult, ctx: &ComponentContext<Self>) {
+        match message {
+            Ok(logs) => {
+                let logs = logs.logs();
+                println!("Got logs {}", logs.total_len());
+                println!("Logs {:?}", logs);
+                self.log_record_count = logs.total_len();
+                // TODO: Add logic for merging logs with count from record segment.
+                let operator = CountRecordsOperator::new();
+                let input = CountRecordsInput::new(
+                    self.record_segment
+                        .as_ref()
+                        .expect("Expect segment")
+                        .clone(),
+                    self.blockfile_provider.clone(),
+                );
+                let msg = wrap(operator, input, ctx.sender.as_receiver());
+                match self.dispatcher.send(msg, None).await {
+                    Ok(_) => (),
+                    Err(e) => {
+                        // Log an error - this implies the dispatcher was dropped somehow
+                        // and is likely fatal
+                        println!("Error sending Count Query task: {:?}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                self.terminate_with_error(Box::new(e), ctx);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<Result<CountRecordsOutput, MergeMetadataResultsOperatorError>>
+    for CountQueryOrchestrator
+{
+    async fn handle(
+        &mut self,
+        message: Result<CountRecordsOutput, MergeMetadataResultsOperatorError>,
+        ctx: &ComponentContext<Self>,
+    ) {
+        let msg = match message {
+            Ok(m) => m,
+            Err(e) => {
+                return self.terminate_with_error(Box::new(e), ctx);
+            }
+        };
+        let channel = self
+            .result_channel
+            .take()
+            .expect("Expect channel to be present");
+        match channel.send(Ok(msg.count + self.log_record_count)) {
+            Ok(_) => (),
+            Err(e) => {
+                // Log an error - this implied the listener was dropped
+                println!("[CountQueryOrchestrator] Result channel dropped before sending result");
+            }
         }
     }
 }

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -291,11 +291,12 @@ impl chroma_proto::metadata_reader_server::MetadataReader for WorkerServer {
         let result = orchestrator.run().await;
         let c = match result {
             Ok(r) => {
-                println!("(Sanket-temp) Count value {}", r);
+                println!("Count value {}", r);
                 r
             }
-            Err(_) => {
-                println!("Error!");
+            Err(e) => {
+                println!("Error! {:?}", e);
+                // TODO: Return 0 for now but should return an error at some point.
                 0
             }
         };


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 Introduces the orchestrator for count and a basic counting logic where we simply add the number of log records with the number of records in the blockfile. More advanced merging like deduping adds and updates and removing deletes will be a different PR.

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
