### PR TITLE
[ENH] Nomic Text Embed function

### DIFF
--- a/chromadb/test/ef/test_nomic_ef.py
+++ b/chromadb/test/ef/test_nomic_ef.py
@@ -2,26 +2,31 @@ import os
 
 import pytest
 
-# import requests
-# from requests import HTTPError
-# from requests.exceptions import ConnectionError
+import requests
+from requests import HTTPError
+from requests.exceptions import ConnectionError
+from pytest_httpserver import HTTPServer
+import json
+from unittest.mock import patch
 
 from chromadb.utils.embedding_functions import NomicEmbeddingFunction
 
 
+@pytest.mark.skipif(
+    "NOMIC_API_KEY" not in os.environ,
+    reason="NOMIC_API_KEY environment variable not set, skipping test.",
+)
 def test_nomic() -> None:
     """
     To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
     Export the NOMIC_API_KEY and optionally the NOMIC_MODEL environment variables.
     """
-    if os.environ.get("NOMIC_API_KEY") is None:
-        pytest.skip("NOMIC_API_KEY environment variable not set. Skipping test.")
-    # try:
-    #     response = requests.get(os.environ.get(???, ""))
-    #     # If the response was successful, no Exception will be raised
-    #     response.raise_for_status()
-    # except (HTTPError, ConnectionError):
-    #     pytest.skip("Nomic API server can't be reached. Skipping test.")
+    try:
+        response = requests.get("https://api-atlas.nomic.ai/v1/health", timeout=10)
+        # If the response was successful, no Exception will be raised
+        response.raise_for_status()
+    except (HTTPError, ConnectionError):
+        pytest.skip("Nomic API server can't be reached. Skipping test.")
     ef = NomicEmbeddingFunction(
         api_key=os.environ.get("NOMIC_API_KEY") or "",
         model_name=os.environ.get("NOMIC_MODEL") or "nomic-embed-text-v1.5",
@@ -30,3 +35,59 @@ def test_nomic() -> None:
         ["Henceforth, it is the map that precedes the territory", "nom nom Nomic"]
     )
     assert len(embeddings) == 2
+
+
+def test_nomic_no_api_key() -> None:
+    """
+    To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
+    Test intentionaly excludes the NOMIC_API_KEY.
+    """
+    with pytest.raises(ValueError, match="No Nomic API key provided"):
+        NomicEmbeddingFunction(
+            api_key="",
+            model_name=os.environ.get("NOMIC_MODEL") or "nomic-embed-text-v1.5",
+        )
+
+
+@pytest.mark.skipif(
+    "NOMIC_API_KEY" not in os.environ,
+    reason="NOMIC_API_KEY environment variable not set, skipping test.",
+)
+def test_nomic_no_model() -> None:
+    """
+    To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
+    Test intentionaly excludes the NOMIC_MODEL.
+    """
+    with pytest.raises(ValueError, match="No Nomic embedding model provided"):
+        NomicEmbeddingFunction(
+            api_key=os.environ.get("NOMIC_API_KEY") or "",
+            model_name="",
+        )
+
+
+@pytest.mark.skipif(
+    "NOMIC_API_KEY" not in os.environ,
+    reason="NOMIC_API_KEY environment variable not set, skipping test.",
+)
+def test_handle_nomic_api_returns_error() -> None:
+    """
+    To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
+    """
+    with HTTPServer() as httpserver:
+        httpserver.expect_oneshot_request(
+            "/embedding/text", method="POST"
+        ).respond_with_data(
+            json.dumps({"detail": "error"}),
+            status=400,
+        )
+        nomic_ef = NomicEmbeddingFunction(
+            api_key=os.environ.get("NOMIC_API_KEY") or "",
+            model_name=os.environ.get("NOMIC_MODEL") or "nomic-embed-text-v1.5",
+        )
+        with patch.object(
+            nomic_ef,
+            "_api_url",
+            f"http://{httpserver.host}:{httpserver.port}/embedding/text",
+        ):
+            with pytest.raises(Exception):
+                nomic_ef(["test text"])

--- a/chromadb/test/ef/test_nomic_ef.py
+++ b/chromadb/test/ef/test_nomic_ef.py
@@ -1,14 +1,11 @@
 import os
-
 import pytest
-
 import requests
 from requests import HTTPError
 from requests.exceptions import ConnectionError
 from pytest_httpserver import HTTPServer
 import json
 from unittest.mock import patch
-
 from chromadb.utils.embedding_functions import NomicEmbeddingFunction
 
 
@@ -49,29 +46,22 @@ def test_nomic_no_api_key() -> None:
         )
 
 
-@pytest.mark.skipif(
-    "NOMIC_API_KEY" not in os.environ,
-    reason="NOMIC_API_KEY environment variable not set, skipping test.",
-)
 def test_nomic_no_model() -> None:
     """
     To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
-    Test intentionaly excludes the NOMIC_MODEL.
+    Test intentionally excludes the NOMIC_MODEL. api_key does not matter since we expect an error before hitting API.
     """
     with pytest.raises(ValueError, match="No Nomic embedding model provided"):
         NomicEmbeddingFunction(
-            api_key=os.environ.get("NOMIC_API_KEY") or "",
+            api_key="does-not-matter",
             model_name="",
         )
 
 
-@pytest.mark.skipif(
-    "NOMIC_API_KEY" not in os.environ,
-    reason="NOMIC_API_KEY environment variable not set, skipping test.",
-)
 def test_handle_nomic_api_returns_error() -> None:
     """
     To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
+    Mocks an error from the Nomic API, so model and api key don't matter.
     """
     with HTTPServer() as httpserver:
         httpserver.expect_oneshot_request(
@@ -81,8 +71,8 @@ def test_handle_nomic_api_returns_error() -> None:
             status=400,
         )
         nomic_ef = NomicEmbeddingFunction(
-            api_key=os.environ.get("NOMIC_API_KEY") or "",
-            model_name=os.environ.get("NOMIC_MODEL") or "nomic-embed-text-v1.5",
+            api_key="does-not-matter",
+            model_name="does-not-matter",
         )
         with patch.object(
             nomic_ef,

--- a/chromadb/test/ef/test_nomic_ef.py
+++ b/chromadb/test/ef/test_nomic_ef.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+
+# import requests
+# from requests import HTTPError
+# from requests.exceptions import ConnectionError
+
+from chromadb.utils.embedding_functions import NomicEmbeddingFunction
+
+
+def test_nomic() -> None:
+    """
+    To learn more about the Nomic API: https://docs.nomic.ai/reference/endpoints/nomic-embed-text
+    Export the NOMIC_API_KEY and optionally the NOMIC_MODEL environment variables.
+    """
+    if os.environ.get("NOMIC_API_KEY") is None:
+        pytest.skip("NOMIC_API_KEY environment variable not set. Skipping test.")
+    # try:
+    #     response = requests.get(os.environ.get(???, ""))
+    #     # If the response was successful, no Exception will be raised
+    #     response.raise_for_status()
+    # except (HTTPError, ConnectionError):
+    #     pytest.skip("Nomic API server can't be reached. Skipping test.")
+    ef = NomicEmbeddingFunction(
+        api_key=os.environ.get("NOMIC_API_KEY") or "",
+        model_name=os.environ.get("NOMIC_MODEL") or "nomic-embed-text-v1.5",
+    )
+    embeddings = ef(
+        ["Henceforth, it is the map that precedes the territory", "nom nom Nomic"]
+    )
+    assert len(embeddings) == 2

--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -1017,6 +1017,58 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
         )
 
 
+class NomicEmbeddingFunction(EmbeddingFunction[Documents]):
+    """
+    This class is used to generate embeddings for a list of texts using the Nomic Embedding API (https://docs.nomic.ai/reference/endpoints/nomic-embed-text).
+    """
+
+    def __init__(self, api_key: str, model_name: str) -> None:
+        """
+        Initialize the Nomic Embedding Function.
+
+        Args:
+            model_name (str): The name of the model to use for text embeddings. E.g. "nomic-embed-text-v1.5" (see https://docs.nomic.ai/atlas/models/text-embedding for available models).
+        """
+        try:
+            import requests
+        except ImportError:
+            raise ValueError(
+                "The requests python package is not installed. Please install it with `pip install requests`"
+            )
+        self._api_url = "https://api-atlas.nomic.ai/v1/embedding/text"
+        self._api_key = api_key
+        self._model_name = model_name
+        self._session = requests.Session()
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """
+        Get the embeddings for a list of texts.
+
+        Args:
+            input (Documents): A list of texts to get embeddings for.
+
+        Returns:
+            Embeddings: The embeddings for the texts.
+
+        Example:
+            >>> nomic_ef = NomicEmbeddingFunction(model_name="nomic-embed-text-v1.5")
+            >>> texts = ["Hello, world!", "How are you?"]
+            >>> embeddings = nomic_ef(texts)
+        """
+        texts = input if isinstance(input, list) else [input]
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._api_key}",
+        }
+        embeddings = self._session.post(
+            self._api_url,
+            headers=headers,
+            json={"model": self._model_name, "texts": texts},
+        ).json()
+
+        return cast(Embeddings, embeddings["embeddings"])
+
+
 # List of all classes in this module
 _classes = [
     name

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ mypy-protobuf
 pre-commit
 pytest
 pytest-asyncio
+pytest_httpserver==1.0.10
 setuptools_scm
 types-protobuf
 types-requests==2.30.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,8 +8,8 @@ mypy-protobuf
 pre-commit
 pytest
 pytest-asyncio
-pytest_httpserver==1.0.10
 pytest-xdist
+pytest_httpserver==1.0.10
 setuptools_scm
 types-protobuf
 types-requests==2.30.0.0


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Embedding function that calls the Nomic Atlas API asked for by @tazarov in #2061 
	 - 
## Test plan
*How are these changes tested?*
Added a test that is similar to the existing test for Ollama. 

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
