### PR TITLE
[ENH]: Retry Strategy for HttpClient

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -12,6 +12,7 @@ from overrides import override
 from typing_extensions import Literal
 import platform
 
+from chromadb.utils.net import RetryStrategy
 
 in_pydantic_v2 = False
 try:
@@ -133,6 +134,8 @@ class Settings(BaseSettings):  # type: ignore
     chroma_server_api_default_path: Optional[APIVersion] = APIVersion.V2
     # eg ["http://localhost:3000"]
     chroma_server_cors_allow_origins: List[str] = []
+
+    chroma_client_retry_strategy: Optional[RetryStrategy] = None
 
     # ==================
     # Server config

--- a/chromadb/utils/net.py
+++ b/chromadb/utils/net.py
@@ -1,0 +1,68 @@
+from typing import Collection
+
+from pydantic import BaseModel, Field
+from urllib3.util.retry import Retry
+
+RETRY_AFTER_STATUS_CODES = frozenset([429, 503, 504])
+
+RETRY_METHODS = frozenset(["GET", "POST", "PUT", "DELETE", "OPTIONS"])
+
+
+class RetryStrategy(BaseModel):
+    total: int = Field(
+        default=3,
+        ge=0,
+        description="The total number of retries to allow. This overrides the value of the 'connect', "
+        "'read', and 'other' parameters.",
+    )
+    connect: int = Field(
+        default=3, ge=0, description="How many connection-related errors to retry on."
+    )
+    read: int = Field(
+        default=3, ge=0, description="How many times to retry on read errors."
+    )
+    other: int = Field(
+        default=3, ge=0, description="How many times to retry on other errors."
+    )
+    methods: Collection[str] = Field(
+        default_factory=lambda: RETRY_METHODS,
+        description="Which HTTP methods to retry on.",
+    )
+    status_codes: Collection[int] = Field(
+        default_factory=lambda: RETRY_AFTER_STATUS_CODES,
+        description="Which HTTP status codes to retry on.",
+    )
+    backoff_factor: float = Field(
+        default=1.1,
+        ge=0,
+        description="A backoff factor to apply between attempts after the "
+        "second try (most errors are resolved immediately by a "
+        "retry, so the default is 1.1, slightly above a linear "
+        "backoff).",
+    )
+    backoff_max: float = Field(
+        default=120, ge=0, description="The maximum back off time in seconds."
+    )
+    backoff_jitter: float = Field(
+        default=0, ge=0, description="A jitter factor to apply to the backoff time."
+    )
+    respect_retry_after_header: bool = Field(
+        default=True, description="Whether to respect the Retry-After header."
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def to_retry(self) -> Retry:
+        return Retry(
+            total=self.total,
+            connect=self.connect,
+            read=self.read,
+            other=self.other,
+            allowed_methods=self.methods,
+            status_forcelist=self.status_codes,
+            backoff_factor=self.backoff_factor,
+            backoff_max=self.backoff_max,
+            backoff_jitter=self.backoff_jitter,
+            respect_retry_after_header=self.respect_retry_after_header,
+        )

--- a/examples/basic_functionality/http_client_with_retries.ipynb
+++ b/examples/basic_functionality/http_client_with_retries.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "This example assumes you have a Chroma server running on localhost port 8000.\n",
+    "\n",
+    "To start a Chroma server you can run the following:\n",
+    "\n",
+    "```bash\n",
+    "docker run --it --rm -p 8000:8000 chromadb/chroma:latest\n",
+    "```\n"
+   ],
+   "id": "3774bc1ccb0d9f2f"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "import chromadb\n",
+    "\n",
+    "# we configure retry strategy that will retry 5 times with a backoff factor of 0.5\n",
+    "# for more details on RetryStrategy defaults see chromadb.utils.net.RetryStrategy\n",
+    "client = chromadb.HttpClient(host='localhost', port=8000, retry=chromadb.RetryStrategy(total=5, backoff_factor=0.5))"
+   ],
+   "id": "initial_id",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "",
+   "id": "35bb827819d168fb",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,6 @@ psutil
 pytest
 pytest-asyncio
 pytest-xdist
+pytest_httpserver>=1.0.10
 setuptools_scm
 types-protobuf


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	- Retry strategy configuration for HttpClient to give more control to users to deal with intermittent or retryable error codes (e.g. 429, 502,503,504)
	- Sensible defaults are configured for the HttpClient 

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
Example added

## Refs

- https://discord.com/channels/1073293645303795742/1238417639400017920
- https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
- https://requests.readthedocs.io/en/latest/api/#requests.adapters.HTTPAdapter

## Future work

The second-order effect of the Retryable strategy is that it is immediately usable/pluggable into the majority of EFs that rely on `requests` library


