### PR TITLE
[ENH] Use specifc error for allow id set and disallow id set overlap

### DIFF
--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -48,7 +48,7 @@ impl ChromaError for HnswKnnOperatorError {
         match self {
             HnswKnnOperatorError::RecordSegmentError => ErrorCodes::Internal,
             HnswKnnOperatorError::RecordSegmentReadError => ErrorCodes::Internal,
-            HnswKnnOperatorError::InvalidAllowedAndDisallowedIds => ErrorCodes::Internal,
+            HnswKnnOperatorError::InvalidAllowedAndDisallowedIds => ErrorCodes::InvalidArgument,
         }
     }
 }

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -39,6 +39,8 @@ pub enum HnswKnnOperatorError {
     RecordSegmentError,
     #[error("Error reading Record Segment")]
     RecordSegmentReadError,
+    #[error("Invalid allowed and disallowed ids")]
+    InvalidAllowedAndDisallowedIds,
 }
 
 impl ChromaError for HnswKnnOperatorError {
@@ -46,6 +48,7 @@ impl ChromaError for HnswKnnOperatorError {
         match self {
             HnswKnnOperatorError::RecordSegmentError => ErrorCodes::Internal,
             HnswKnnOperatorError::RecordSegmentReadError => ErrorCodes::Internal,
+            HnswKnnOperatorError::InvalidAllowedAndDisallowedIds => ErrorCodes::Internal,
         }
     }
 }
@@ -87,7 +90,9 @@ impl HnswKnnOperator {
     ) -> Result<(), Box<dyn ChromaError>> {
         for allowed_id in allowed_ids {
             if disallowed_ids.contains(allowed_id) {
-                return Err(Box::new(HnswKnnOperatorError::RecordSegmentError));
+                return Err(Box::new(
+                    HnswKnnOperatorError::InvalidAllowedAndDisallowedIds,
+                ));
             }
         }
         Ok(())


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR adds specific error for allow id set and disallow id set overlap. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
