### PR TITLE
[TST] Add sanity test which includes defaults and delays for compaction

### DIFF
--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -6,7 +6,8 @@ from chromadb.api import ServerAPI
 import time
 
 EPS = 1e-6
-SLEEP = 5
+MEMBERLIST_SLEEP = 5
+COMPACTION_SLEEP = 120
 
 
 def test_add(
@@ -17,7 +18,7 @@ def test_add(
     # Once we reset, we have to wait for sometime to let the memberlist on the frontends
     # propagate, there isn't a clean way to do this so we sleep for a configured amount of time
     # to ensure that the memberlist has propagated
-    time.sleep(SLEEP)
+    time.sleep(MEMBERLIST_SLEEP)
 
     collection = api.create_collection(
         name="test",
@@ -58,3 +59,60 @@ def test_add(
 
     for i in range(len(retrieved_distances)):
         assert abs(ground_truth_distances[i] - retrieved_distances[i]) < EPS
+
+
+def test_add_include_default_with_compaction_delay(api: ServerAPI) -> None:
+    api.reset()
+
+    time.sleep(MEMBERLIST_SLEEP)
+
+    collection = api.create_collection(
+        name="test_add_include_default_with_compaction_delay"
+    )
+
+    ids = []
+    embeddings = []
+    for i in range(1000):
+        ids.append(str(i))
+        embeddings.append([random.random(), random.random(), random.random()])
+        collection.add(
+            ids=[str(i)],
+            embeddings=[embeddings[-1]],  # type: ignore
+            documents=f"document_{i}",
+        )
+
+    time.sleep(COMPACTION_SLEEP)  # Wait for the documents to be compacted
+
+    random_query = [random.random(), random.random(), random.random()]
+
+    # Query the collection with a random query
+    results = collection.query(
+        query_embeddings=[random_query],  # type: ignore
+        n_results=10,
+    )
+
+    ids_and_embeddings = list(zip(ids, embeddings))
+    # Check that the distances are correct in l2
+    gt_ids_and_distances = [
+        (id, sum((a - b) ** 2 for a, b in zip(embedding, random_query)))
+        for id, embedding in ids_and_embeddings
+    ]
+    gt_ids_and_distances.sort(key=lambda x: x[1])
+    retrieved_distances = results["distances"][0]  # type: ignore
+
+    # Check that the query results are sorted by distance
+    for i in range(1, len(retrieved_distances)):
+        assert retrieved_distances[i - 1] <= retrieved_distances[i]
+
+    for i in range(len(retrieved_distances)):
+        assert abs(gt_ids_and_distances[i][1] - retrieved_distances[i]) < EPS
+
+    # Check that the ids are correct
+    retrieved_ids = results["ids"][0]
+    for i in range(len(retrieved_ids)):
+        assert retrieved_ids[i] == gt_ids_and_distances[i][0]
+
+    # Check that the documents are correct
+    retrieved_documents = results["documents"][0]  # type: ignore
+    for i in range(len(retrieved_documents)):
+        assert retrieved_documents[i] == f"document_{gt_ids_and_distances[i][0]}"


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds a sanity test which includes=[] the defaults and delays for compaction. The hardcoding of the compaction delay isn't ideal since its implicit across services. This is fine for now but when we standardize config this service could introspect it.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
