### PR TITLE
[ENH] Use statefulset for query and compaction services

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -111,7 +111,6 @@ k8s_resource(
     'query-service-memberlist-readerwriter:ClusterRole',
     'query-service-query-service-memberlist-binding:clusterrolebinding',
     'query-service-memberlist-readerwriter-binding:clusterrolebinding',
-    'query-service:service',
 
     'compaction-service-memberlist-readerwriter:ClusterRole',
     'compaction-service-compaction-service-memberlist-binding:clusterrolebinding',

--- a/chromadb/segment/impl/distributed/segment_directory.py
+++ b/chromadb/segment/impl/distributed/segment_directory.py
@@ -23,6 +23,7 @@ from chromadb.utils.rendezvous_hash import assign, murmur3hasher
 WATCH_TIMEOUT_SECONDS = 60
 KUBERNETES_NAMESPACE = "chroma"
 KUBERNETES_GROUP = "chroma.cluster"
+HEADLESS_SERVICE = "svc.cluster.local"
 
 
 class MockMemberlistProvider(MemberlistProvider, EnforceOverrides):
@@ -222,7 +223,8 @@ class RendezvousHashSegmentDirectory(SegmentDirectory, EnforceOverrides):
         if self._curr_memberlist is None or len(self._curr_memberlist) == 0:
             raise ValueError("Memberlist is not initialized")
         assignment = assign(segment["id"].hex, self._curr_memberlist, murmur3hasher)
-        assignment = f"{assignment}.query-service.chroma.svc.cluster.local:50051"  # TODO: make port configurable
+        service_name = self.extract_service_name(assignment)
+        assignment = f"{assignment}.{service_name}.{KUBERNETES_NAMESPACE}.{HEADLESS_SERVICE}:50051"  # TODO: make port configurable
         return assignment
 
     @override
@@ -239,3 +241,11 @@ class RendezvousHashSegmentDirectory(SegmentDirectory, EnforceOverrides):
         with self._curr_memberlist_mutex:
             add_attributes_to_current_span({"new_memberlist": memberlist})
             self._curr_memberlist = memberlist
+
+    def extract_service_name(self, pod_name: str) -> Optional[str]:
+        # Split the pod name by the hyphen
+        parts = pod_name.split("-")
+        # The service name is expected to be the prefix before the last hyphen
+        if len(parts) > 1:
+            return "-".join(parts[:-1])
+        return None

--- a/chromadb/segment/impl/distributed/segment_directory.py
+++ b/chromadb/segment/impl/distributed/segment_directory.py
@@ -181,7 +181,7 @@ class CustomResourceMemberlistProvider(MemberlistProvider, EnforceOverrides):
     ) -> Memberlist:
         if "members" not in api_response_spec:
             return []
-        return [m["url"] for m in api_response_spec["members"]]
+        return [m["member_id"] for m in api_response_spec["members"]]
 
     def _notify(self, memberlist: Memberlist) -> None:
         for callback in self.callbacks:
@@ -222,7 +222,7 @@ class RendezvousHashSegmentDirectory(SegmentDirectory, EnforceOverrides):
         if self._curr_memberlist is None or len(self._curr_memberlist) == 0:
             raise ValueError("Memberlist is not initialized")
         assignment = assign(segment["id"].hex, self._curr_memberlist, murmur3hasher)
-        assignment = f"{assignment}:50051"  # TODO: make port configurable
+        assignment = f"{assignment}.query-service.chroma.svc.cluster.local:50051"  # TODO: make port configurable
         return assignment
 
     @override

--- a/chromadb/test/segment/distributed/test_memberlist_provider.py
+++ b/chromadb/test/segment/distributed/test_memberlist_provider.py
@@ -17,7 +17,7 @@ def update_memberlist(n: int, memberlist_name: str = "test-memberlist") -> Membe
     config.load_config()
     api_instance = client.CustomObjectsApi()
 
-    members = [{"url": f"10.0.0.{i}"} for i in range(1, n + 1)]
+    members = [{"member_id": f"test-{i}"} for i in range(1, n + 1)]
 
     body = {
         "kind": "MemberList",
@@ -34,7 +34,7 @@ def update_memberlist(n: int, memberlist_name: str = "test-memberlist") -> Membe
         body=body,
     )
 
-    return [m["url"] for m in members]
+    return [m["member_id"] for m in members]
 
 
 def compare_memberlists(m1: Memberlist, m2: Memberlist) -> bool:

--- a/go/pkg/memberlist_manager/memberlist_manager.go
+++ b/go/pkg/memberlist_manager/memberlist_manager.go
@@ -132,10 +132,10 @@ func memberlistSame(oldMemberlist Memberlist, newMemberlist Memberlist) bool {
 	// use a map to check if the new memberlist contains all the old members
 	newMemberlistMap := make(map[string]bool)
 	for _, member := range newMemberlist {
-		newMemberlistMap[member] = true
+		newMemberlistMap[member.id] = true
 	}
 	for _, member := range oldMemberlist {
-		if _, ok := newMemberlistMap[member]; !ok {
+		if _, ok := newMemberlistMap[member.id]; !ok {
 			return false
 		}
 	}

--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -52,7 +52,7 @@ func TestNodeWatcher(t *testing.T) {
 			t.Fatalf("Error getting node status: %v", err)
 		}
 
-		return reflect.DeepEqual(memberlist, Memberlist{"test-pod-0"})
+		return reflect.DeepEqual(memberlist, Memberlist{Member{id: "test-pod-0"}})
 	}, 10, 1*time.Second)
 	if !ok {
 		t.Fatalf("Node status did not update after adding a pod")
@@ -83,7 +83,7 @@ func TestNodeWatcher(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error getting node status: %v", err)
 		}
-		return reflect.DeepEqual(memberlist, Memberlist{"test-pod-0"})
+		return reflect.DeepEqual(memberlist, Memberlist{Member{id: "test-pod-0"}})
 	}, 10, 1*time.Second)
 	if !ok {
 		t.Fatalf("Node status did not update after adding a not ready pod")
@@ -108,12 +108,12 @@ func TestMemberlistStore(t *testing.T) {
 	assert.Equal(t, Memberlist{}, *memberlist)
 
 	// Add a member to the memberlist
-	memberlist_store.UpdateMemberlist(context.Background(), &Memberlist{"test-pod-0", "test-pod-1"}, "0")
+	memberlist_store.UpdateMemberlist(context.Background(), &Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}, "0")
 	memberlist, _, err = memberlist_store.GetMemberlist(context.Background())
 	if err != nil {
 		t.Fatalf("Error getting memberlist: %v", err)
 	}
-	assert.Equal(t, Memberlist{"test-pod-0", "test-pod-1"}, *memberlist)
+	assert.Equal(t, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}, *memberlist)
 }
 
 func createFakePod(memberId string, podIp string, clientset kubernetes.Interface) {
@@ -181,7 +181,7 @@ func TestMemberlistManager(t *testing.T) {
 
 	// Get the memberlist
 	ok := retryUntilCondition(func() bool {
-		return getMemberlistAndCompare(t, memberlistStore, Memberlist{"test-pod-0"})
+		return getMemberlistAndCompare(t, memberlistStore, Memberlist{Member{id: "test-pod-0"}})
 	}, 10, 1*time.Second)
 	if !ok {
 		t.Fatalf("Memberlist did not update after adding a pod")
@@ -192,7 +192,7 @@ func TestMemberlistManager(t *testing.T) {
 
 	// Get the memberlist
 	ok = retryUntilCondition(func() bool {
-		return getMemberlistAndCompare(t, memberlistStore, Memberlist{"test-pod-0", "test-pod-1"})
+		return getMemberlistAndCompare(t, memberlistStore, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}})
 	}, 10, 1*time.Second)
 	if !ok {
 		t.Fatalf("Memberlist did not update after adding a pod")
@@ -203,7 +203,7 @@ func TestMemberlistManager(t *testing.T) {
 
 	// Get the memberlist
 	ok = retryUntilCondition(func() bool {
-		return getMemberlistAndCompare(t, memberlistStore, Memberlist{"test-pod-1"})
+		return getMemberlistAndCompare(t, memberlistStore, Memberlist{Member{id: "test-pod-1"}})
 	}, 10, 1*time.Second)
 	if !ok {
 		t.Fatalf("Memberlist did not update after deleting a pod")
@@ -211,26 +211,26 @@ func TestMemberlistManager(t *testing.T) {
 }
 
 func TestMemberlistSame(t *testing.T) {
-	memberlist := Memberlist{""}
+	memberlist := Memberlist{}
 	assert.True(t, memberlistSame(memberlist, memberlist))
 
-	newMemberlist := Memberlist{"test-pod-0"}
+	newMemberlist := Memberlist{Member{id: "test-pod-0"}}
 	assert.False(t, memberlistSame(memberlist, newMemberlist))
 	assert.False(t, memberlistSame(newMemberlist, memberlist))
 	assert.True(t, memberlistSame(newMemberlist, newMemberlist))
 
-	memberlist = Memberlist{"test-pod-1"}
+	memberlist = Memberlist{Member{id: "test-pod-1"}}
 	assert.False(t, memberlistSame(newMemberlist, memberlist))
 	assert.False(t, memberlistSame(memberlist, newMemberlist))
 	assert.True(t, memberlistSame(memberlist, memberlist))
 
-	memberlist = Memberlist{"test-pod-0", "test-pod-1"}
-	newMemberlist = Memberlist{"test-pod-0", "test-pod-1"}
+	memberlist = Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}
+	newMemberlist = Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}
 	assert.True(t, memberlistSame(memberlist, newMemberlist))
 	assert.True(t, memberlistSame(newMemberlist, memberlist))
 
-	memberlist = Memberlist{"test-pod-0", "test-pod-1"}
-	newMemberlist = Memberlist{"test-pod-1", "test-pod-0"}
+	memberlist = Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}
+	newMemberlist = Memberlist{Member{id: "test-pod-1"}, Member{id: "test-pod-0"}}
 	assert.True(t, memberlistSame(memberlist, newMemberlist))
 	assert.True(t, memberlistSame(newMemberlist, memberlist))
 }

--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -113,7 +113,10 @@ func TestMemberlistStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting memberlist: %v", err)
 	}
-	assert.Equal(t, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}, *memberlist)
+	// assert the memberlist has the correct members
+	if !memberlistSame(*memberlist, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}) {
+		t.Fatalf("Memberlist did not update after adding a member")
+	}
 }
 
 func createFakePod(memberId string, podIp string, clientset kubernetes.Interface) {
@@ -250,5 +253,5 @@ func getMemberlistAndCompare(t *testing.T, memberlistStore IMemberlistStore, exp
 	if err != nil {
 		t.Fatalf("Error getting memberlist: %v", err)
 	}
-	return reflect.DeepEqual(expected_memberlist, *memberlist)
+	return memberlistSame(*memberlist, expected_memberlist)
 }

--- a/go/pkg/memberlist_manager/node_watcher.go
+++ b/go/pkg/memberlist_manager/node_watcher.go
@@ -75,9 +75,9 @@ func (w *KubernetesWatcher) Start() error {
 				log.Error("Error while asserting object to pod")
 			}
 			if err == nil {
-				log.Info("Kubernetes Pod Added", zap.String("key", key), zap.String("ip", objPod.Status.PodIP))
-				ip := objPod.Status.PodIP
-				w.notify(ip)
+				log.Info("Kubernetes Pod Added", zap.String("key", key), zap.Any("pod name", objPod.Name))
+				name := objPod.Name
+				w.notify(name)
 			} else {
 				log.Error("Error while getting key from object", zap.Error(err))
 			}
@@ -89,9 +89,9 @@ func (w *KubernetesWatcher) Start() error {
 				log.Error("Error while asserting object to pod")
 			}
 			if err == nil {
-				log.Info("Kubernetes Pod Updated", zap.String("key", key), zap.String("ip", objPod.Status.PodIP))
-				ip := objPod.Status.PodIP
-				w.notify(ip)
+				log.Info("Kubernetes Pod Updated", zap.String("key", key), zap.String("pod name", objPod.Name))
+				name := objPod.Name
+				w.notify(name)
 			} else {
 				log.Error("Error while getting key from object", zap.Error(err))
 			}
@@ -103,10 +103,10 @@ func (w *KubernetesWatcher) Start() error {
 				log.Error("Error while asserting object to pod")
 			}
 			if err == nil {
-				log.Info("Kubernetes Pod Deleted", zap.String("ip", objPod.Status.PodIP))
-				ip := objPod.Status.PodIP
+				log.Info("Kubernetes Pod Deleted", zap.String("pod name", objPod.Name))
+				name := objPod.Name
 				// The contract for GetStatus is that if the ip is not in this map, then it returns NotReady
-				w.notify(ip)
+				w.notify(name)
 			} else {
 				log.Error("Error while getting key from object", zap.Error(err))
 			}
@@ -165,7 +165,7 @@ func (w *KubernetesWatcher) ListReadyMembers() (Memberlist, error) {
 		conditions := pod.Status.Conditions
 		for _, condition := range conditions {
 			if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
-				memberlist = append(memberlist, pod.Status.PodIP)
+				memberlist = append(memberlist, pod.Name)
 			}
 		}
 	}

--- a/go/pkg/memberlist_manager/node_watcher.go
+++ b/go/pkg/memberlist_manager/node_watcher.go
@@ -165,7 +165,10 @@ func (w *KubernetesWatcher) ListReadyMembers() (Memberlist, error) {
 		conditions := pod.Status.Conditions
 		for _, condition := range conditions {
 			if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
-				memberlist = append(memberlist, pod.Name)
+				member := Member{
+					id: pod.Name,
+				}
+				memberlist = append(memberlist, member)
 			}
 		}
 	}

--- a/k8s/distributed-chroma/crds/memberlist_crd.yaml
+++ b/k8s/distributed-chroma/crds/memberlist_crd.yaml
@@ -25,7 +25,7 @@ spec:
                   items:
                     type: object
                     properties:
-                      url: # Rename to ip
+                      member_id:
                         type: string
   scope: Namespaced
   names:

--- a/k8s/distributed-chroma/crds/memberlist_crd.yaml
+++ b/k8s/distributed-chroma/crds/memberlist_crd.yaml
@@ -27,7 +27,6 @@ spec:
                     properties:
                       url: # Rename to ip
                         type: string
-                        pattern: '^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$'
   scope: Namespaced
   names:
     plural: memberlists

--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -13,7 +13,7 @@ data:
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: compaction-service
   namespace: {{ .Values.namespace }}
@@ -56,10 +56,10 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
-            - name: CHROMA_COMPACTION_SERVICE__MY_IP
+            - name: CHROMA_COMPACTION_SERVICE__MY_MEMBER_ID
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP
+                  fieldPath: metadata.name
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -30,7 +30,7 @@ spec:
 ---
 
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: query-service
   namespace: {{ .Values.namespace }}
@@ -73,10 +73,10 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
-            - name: CHROMA_QUERY_SERVICE__MY_IP
+            - name: CHROMA_QUERY_SERVICE__MY_MEMBER_ID
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP
+                  fieldPath: metadata.name
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -23,8 +23,9 @@ spec:
     - name: query-service-server-port
       port: 50051
       targetPort: 50051
+  clusterIP: None
   selector:
-    app: query-service-server
+    app: query-service
   type: ClusterIP
 
 ---
@@ -35,6 +36,7 @@ metadata:
   name: query-service
   namespace: {{ .Values.namespace }}
 spec:
+  serviceName: query-service
   replicas: 2
   selector:
     matchLabels:

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -6,7 +6,7 @@
 query_service:
     service_name: "query-service"
     otel_endpoint: "http://jaeger:4317"
-    my_ip: "10.244.0.9"
+    my_member_id: "query-service-0"
     my_port: 50051
     assignment_policy:
         RendezvousHashing:
@@ -36,7 +36,7 @@ query_service:
 compaction_service:
     service_name: "compaction-service"
     otel_endpoint: "http://jaeger:4317"
-    my_ip: "10.244.0.9"
+    my_member_id: "compaction-service-0"
     my_port: 50051
     assignment_policy:
         RendezvousHashing:

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -193,7 +193,7 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
             }
         };
 
-        let my_ip = config.my_ip.clone();
+        let my_ip = config.my_member_id.clone();
         let policy = Box::new(LasCompactionTimeSchedulerPolicy {});
         let compaction_interval_sec = config.compactor.compaction_interval_sec;
         let max_concurrent_jobs = config.compactor.max_concurrent_jobs;
@@ -424,17 +424,17 @@ mod tests {
         let last_compaction_time_2 = 1;
         sysdb.add_tenant_last_compaction_time(tenant_2, last_compaction_time_2);
 
-        let my_ip = "127.0.0.1".to_string();
+        let my_member_id = "1".to_string();
         let compaction_manager_queue_size = 1000;
         let max_concurrent_jobs = 10;
         let compaction_interval = Duration::from_secs(1);
 
         // Set assignment policy
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::new());
-        assignment_policy.set_members(vec![my_ip.clone()]);
+        assignment_policy.set_members(vec![my_member_id.clone()]);
 
         let mut scheduler = Scheduler::new(
-            my_ip.clone(),
+            my_member_id.clone(),
             log.clone(),
             sysdb.clone(),
             Box::new(LasCompactionTimeSchedulerPolicy {}),
@@ -442,7 +442,7 @@ mod tests {
             assignment_policy,
         );
         // Set memberlist
-        scheduler.set_memberlist(vec![my_ip.clone()]);
+        scheduler.set_memberlist(vec![my_member_id.clone()]);
 
         let mut manager = CompactionManager::new(
             scheduler,

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -277,16 +277,16 @@ mod tests {
         let last_compaction_time_1 = 2;
         sysdb.add_tenant_last_compaction_time(tenant_1, last_compaction_time_1);
 
-        let my_ip = "0.0.0.1".to_string();
+        let my_member_id = "1".to_string();
         let scheduler_policy = Box::new(LasCompactionTimeSchedulerPolicy {});
         let max_concurrent_jobs = 1000;
 
         // Set assignment policy
         let mut assignment_policy = Box::new(RendezvousHashingAssignmentPolicy::new());
-        assignment_policy.set_members(vec![my_ip.clone()]);
+        assignment_policy.set_members(vec![my_member_id.clone()]);
 
         let mut scheduler = Scheduler::new(
-            my_ip.clone(),
+            my_member_id.clone(),
             log,
             sysdb.clone(),
             scheduler_policy,
@@ -306,7 +306,7 @@ mod tests {
         assert_eq!(jobs.count(), 0);
 
         // Set memberlist
-        scheduler.set_memberlist(vec![my_ip.clone()]);
+        scheduler.set_memberlist(vec![my_member_id.clone()]);
         scheduler.schedule().await;
         let jobs = scheduler.get_jobs();
         let jobs = jobs.collect::<Vec<&CompactionJob>>();
@@ -325,8 +325,8 @@ mod tests {
         assert_eq!(jobs[1].collection_id, collection_uuid_1,);
 
         // Test filter_collections
-        let member_1 = "0.0.0.1".to_string();
-        let member_2 = "0.0.0.2".to_string();
+        let member_1 = "1".to_string();
+        let member_2 = "5".to_string();
         let members = vec![member_1.clone(), member_2.clone()];
         scheduler.set_memberlist(members.clone());
         scheduler.schedule().await;

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -45,7 +45,7 @@ pub(crate) struct MemberListCrd {
 // Define the structure for items in the members array
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub(crate) struct Member {
-    pub(crate) url: String,
+    pub(crate) member_id: String,
 }
 
 /* =========== CR Provider ============== */
@@ -218,7 +218,7 @@ impl Handler<Option<MemberListKubeResource>> for CustomResourceMemberlistProvide
                 let memberlist = memberlist.spec.members;
                 let memberlist = memberlist
                     .iter()
-                    .map(|member| member.url.clone())
+                    .map(|member| member.member_id.clone())
                     .collect::<Vec<String>>();
                 {
                     let curr_memberlist_handle = self.current_memberlist.write();


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR makes the following changes:
	   - The SysDb now publishes the pod name instead of the pod IP in the memberlist.
	   - The compaction and query services are using a Statefulset instead of Deployment to reduce assignment shuffle. 
	   - Removed the pattern check in the memberlist CRD that only allow valid IPs. 
	   - Change the compaction and query services configuration from my_ip to my_member_id. 
  - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
