### PR TITLE
[BUG] Metadata should be handle uninit'ed record segment.

### DIFF
--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -7,6 +7,7 @@ from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
 )
+from chromadb.telemetry.opentelemetry.grpc import OtelInterceptor
 from chromadb.types import (
     Where,
     WhereDocument,
@@ -36,6 +37,8 @@ class GrpcMetadataSegment(MetadataReader):
             raise Exception("Missing grpc_url in segment metadata")
 
         channel = grpc.insecure_channel(self._segment["metadata"]["grpc_url"])
+        interceptors = [OtelInterceptor()]
+        channel = grpc.intercept_channel(channel, *interceptors)
         self._metadata_reader_stub = MetadataReaderStub(channel)  # type: ignore
 
     @override

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -1,14 +1,12 @@
-use thiserror::Error;
-
-use tonic::async_trait;
-
 use crate::{
-    blockstore::provider::BlockfileProvider,
+    blockstore::provider::{BlockfileProvider, OpenError},
     errors::{ChromaError, ErrorCodes},
     execution::operator::Operator,
     segment::record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
     types::Segment,
 };
+use thiserror::Error;
+use tonic::async_trait;
 
 #[derive(Debug)]
 pub(crate) struct CountRecordsOperator {}
@@ -45,16 +43,19 @@ pub(crate) struct CountRecordsOutput {
 #[derive(Error, Debug)]
 pub(crate) enum CountRecordsError {
     #[error("Error reading record segment reader")]
-    RecordSegmentReadError,
+    RecordSegmentOpenError(#[from] OpenError),
     #[error("Error creating record segment reader")]
     RecordSegmentError(#[from] RecordSegmentReaderCreationError),
+    #[error("Error reading record segment")]
+    RecordSegmentReadError(#[from] Box<dyn ChromaError>),
 }
 
 impl ChromaError for CountRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
             CountRecordsError::RecordSegmentError(_) => ErrorCodes::Internal,
-            CountRecordsError::RecordSegmentReadError => ErrorCodes::Internal,
+            CountRecordsError::RecordSegmentReadError(e) => e.code(),
+            CountRecordsError::RecordSegmentOpenError(e) => e.code(),
         }
     }
 }
@@ -66,25 +67,36 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
         &self,
         input: &CountRecordsInput,
     ) -> Result<CountRecordsOutput, CountRecordsError> {
-        let segment_reader = RecordSegmentReader::from_segment(
+        let segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment_definition,
             &input.blockfile_provider,
         )
-        .await;
-        match segment_reader {
-            Ok(reader) => match reader.count().await {
-                Ok(val) => {
-                    return Ok(CountRecordsOutput { count: val });
-                }
-                Err(_) => {
-                    println!("Error reading record segment");
-                    return Err(CountRecordsError::RecordSegmentReadError);
-                }
-            },
+        .await
+        {
+            Ok(reader) => reader,
             Err(e) => {
-                println!("Error opening record segment");
-                return Err(CountRecordsError::RecordSegmentError(*e));
+                match *e {
+                    RecordSegmentReaderCreationError::UninitializedSegment => {
+                        // This means no compaction has occured.
+                        return Ok(CountRecordsOutput { count: 0 });
+                    }
+                    RecordSegmentReaderCreationError::BlockfileOpenError(e) => {
+                        return Err(CountRecordsError::RecordSegmentOpenError(*e));
+                    }
+                    RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                        return Err(CountRecordsError::RecordSegmentError(*e));
+                    }
+                }
             }
-        }
+        };
+
+        let count = match segment_reader.count().await {
+            Ok(val) => val,
+            Err(e) => {
+                return Err(CountRecordsError::RecordSegmentReadError(e));
+            }
+        };
+
+        Ok(CountRecordsOutput { count })
     }
 }

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -2,14 +2,14 @@ use crate::{
     blockstore::provider::BlockfileProvider,
     errors::{ChromaError, ErrorCodes},
     execution::{data::data_chunk::Chunk, operator::Operator},
-    segment::record_segment::RecordSegmentReader,
+    segment::record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
     types::{
         update_metdata_to_metdata, LogRecord, Metadata, MetadataValueConversionError, Segment,
     },
 };
 use async_trait::async_trait;
-use std::f64::consts::E;
 use thiserror::Error;
+use tracing::{error, trace};
 
 #[derive(Debug)]
 pub struct MergeMetadataResultsOperator {}
@@ -61,7 +61,7 @@ pub struct MergeMetadataResultsOperatorOutput {
 #[derive(Error, Debug)]
 pub enum MergeMetadataResultsOperatorError {
     #[error("Error creating Record Segment")]
-    RecordSegmentError,
+    RecordSegmentCreationError(#[from] RecordSegmentReaderCreationError),
     #[error("Error reading Record Segment")]
     RecordSegmentReadError,
     #[error("Error converting metadata")]
@@ -71,7 +71,7 @@ pub enum MergeMetadataResultsOperatorError {
 impl ChromaError for MergeMetadataResultsOperatorError {
     fn code(&self) -> ErrorCodes {
         match self {
-            MergeMetadataResultsOperatorError::RecordSegmentError => ErrorCodes::Internal,
+            MergeMetadataResultsOperatorError::RecordSegmentCreationError(e) => e.code(),
             MergeMetadataResultsOperatorError::RecordSegmentReadError => ErrorCodes::Internal,
             MergeMetadataResultsOperatorError::MetadataConversionError(e) => e.code(),
         }
@@ -91,6 +91,36 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
         &self,
         input: &MergeMetadataResultsOperatorInput,
     ) -> MergeMetadataResultsOperatorResult {
+        trace!(
+            "[MergeMetadataResultsOperator] segment id: {}",
+            input.record_segment_definition.id.to_string()
+        );
+
+        let mut ids: Vec<String> = Vec::new();
+        let mut metadata = Vec::new();
+        let mut documents = Vec::new();
+        // Add the data from the brute force results
+        for (log_entry, index) in input.filtered_log.iter() {
+            ids.push(log_entry.record.id.to_string());
+            let output_metadata = match &log_entry.record.metadata {
+                Some(log_metadata) => match update_metdata_to_metdata(log_metadata) {
+                    Ok(metadata) => Some(metadata),
+                    Err(e) => {
+                        println!("Error converting log metadata: {:?}", e);
+                        return Err(MergeMetadataResultsOperatorError::MetadataConversionError(
+                            e,
+                        ));
+                    }
+                },
+                None => {
+                    println!("No metadata found for log entry");
+                    None
+                }
+            };
+            metadata.push(output_metadata);
+            documents.push(log_entry.record.document.clone());
+        }
+
         let record_segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment_definition,
             &input.blockfile_provider,
@@ -99,13 +129,30 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
         {
             Ok(reader) => reader,
             Err(e) => {
-                return Err(MergeMetadataResultsOperatorError::RecordSegmentError);
+                match *e {
+                    RecordSegmentReaderCreationError::UninitializedSegment => {
+                        // This means no compaction has occured, so we can just return whats on the log.
+                        return Ok(MergeMetadataResultsOperatorOutput {
+                            ids,
+                            metadata,
+                            documents,
+                        });
+                    }
+                    RecordSegmentReaderCreationError::BlockfileOpenError(_) => {
+                        error!("Error creating Record Segment: {:?}", e);
+                        return Err(
+                            MergeMetadataResultsOperatorError::RecordSegmentCreationError(*e),
+                        );
+                    }
+                    RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                        error!("Error creating Record Segment: {:?}", e);
+                        return Err(
+                            MergeMetadataResultsOperatorError::RecordSegmentCreationError(*e),
+                        );
+                    }
+                }
             }
         };
-
-        let mut ids: Vec<String> = Vec::new();
-        let mut metadata = Vec::new();
-        let mut documents = Vec::new();
 
         // Hydrate the data from the record segment for filtered data
         for index_offset_id in input.filtered_index_offset_ids.iter() {
@@ -169,28 +216,6 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
                 Some(document) => documents.push(Some(document.to_string())),
                 None => documents.push(None),
             }
-        }
-
-        // Merge the data from the brute force results
-        for (log_entry, index) in input.filtered_log.iter() {
-            ids.push(log_entry.record.id.to_string());
-            let output_metadata = match &log_entry.record.metadata {
-                Some(log_metadata) => match update_metdata_to_metdata(log_metadata) {
-                    Ok(metadata) => Some(metadata),
-                    Err(e) => {
-                        println!("Error converting log metadata: {:?}", e);
-                        return Err(MergeMetadataResultsOperatorError::MetadataConversionError(
-                            e,
-                        ));
-                    }
-                },
-                None => {
-                    println!("No metadata found for log entry");
-                    None
-                }
-            };
-            metadata.push(output_metadata);
-            documents.push(log_entry.record.document.clone());
         }
 
         Ok(MergeMetadataResultsOperatorOutput {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Metadata merge should handle uninit'ed record segments by not reading the segment.
	 - Add tracing on demand for debugging in metadata reader
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
