### PR TITLE
[ENH] Refactor metadata indices to reader/writer

### DIFF
--- a/rust/worker/src/blockstore/arrow/block/bool_key.rs
+++ b/rust/worker/src/blockstore/arrow/block/bool_key.rs
@@ -1,0 +1,40 @@
+use super::delta_storage::BlockKeyArrowBuilder;
+use crate::blockstore::arrow::types::{ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey};
+use arrow::array::{Array, BooleanArray, BooleanBuilder, StringBuilder};
+use std::sync::Arc;
+
+impl ArrowWriteableKey for bool {
+    type ReadableKey<'referred_data> = bool;
+
+    fn offset_size(_: usize) -> usize {
+        0
+    }
+    fn get_arrow_builder(
+        item_count: usize,
+        prefix_capacity: usize,
+        _: usize,
+    ) -> BlockKeyArrowBuilder {
+        let prefix_builder = StringBuilder::with_capacity(item_count, prefix_capacity);
+        let key_builder: BooleanBuilder = BooleanBuilder::with_capacity(item_count);
+        BlockKeyArrowBuilder::Boolean((prefix_builder, key_builder))
+    }
+}
+
+impl ArrowReadableKey<'_> for bool {
+    fn get(array: &Arc<dyn Array>, index: usize) -> Self {
+        array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap()
+            .value(index)
+    }
+
+    fn add_to_delta<'external, V: ArrowReadableValue<'external>>(
+        prefix: &str,
+        key: Self,
+        value: V,
+        delta: &mut super::delta::BlockDelta,
+    ) {
+        V::add_to_delta(prefix, key, value, delta);
+    }
+}

--- a/rust/worker/src/blockstore/arrow/block/mod.rs
+++ b/rust/worker/src/blockstore/arrow/block/mod.rs
@@ -1,3 +1,4 @@
+mod bool_key;
 mod data_record_value;
 pub(in crate::blockstore::arrow) mod delta;
 pub(in crate::blockstore::arrow) mod delta_storage;

--- a/rust/worker/src/blockstore/memory/mod.rs
+++ b/rust/worker/src/blockstore/memory/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod provider;
 pub(super) mod reader_writer;
-pub(super) mod storage;
+pub(crate) mod storage;

--- a/rust/worker/src/blockstore/memory/storage.rs
+++ b/rust/worker/src/blockstore/memory/storage.rs
@@ -384,6 +384,110 @@ impl<'referred_data> Readable<'referred_data> for RoaringBitmap {
     }
 }
 
+impl Writeable for f32 {
+    fn write_to_storage(prefix: &str, key: KeyWrapper, value: Self, storage: &StorageBuilder) {
+        storage.f32_storage.write().as_mut().unwrap().insert(
+            CompositeKey {
+                prefix: prefix.to_string(),
+                key: key.clone(),
+            },
+            value,
+        );
+    }
+
+    fn remove_from_storage(prefix: &str, key: KeyWrapper, storage: &StorageBuilder) {
+        storage
+            .f32_storage
+            .write()
+            .as_mut()
+            .unwrap()
+            .remove(&CompositeKey {
+                prefix: prefix.to_string(),
+                key,
+            });
+    }
+}
+
+impl<'referred_data> Readable<'referred_data> for f32 {
+    fn read_from_storage(prefix: &str, key: KeyWrapper, storage: &Storage) -> Option<Self> {
+        storage
+            .f32_storage
+            .get(&CompositeKey {
+                prefix: prefix.to_string(),
+                key,
+            })
+            .map(|a| *a)
+    }
+
+    fn get_by_prefix_from_storage(
+        prefix: &str,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .f32_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn read_gt_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .f32_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key > key)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn read_gte_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .f32_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key >= key)
+            .map(|(k, v)| (k, v.clone()))
+            .collect()
+    }
+
+    fn read_lt_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .f32_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key < key)
+            .map(|(k, v)| (k, v.clone()))
+            .collect()
+    }
+
+    fn read_lte_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .f32_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key <= key)
+            .map(|(k, v)| (k, v.clone()))
+            .collect()
+    }
+
+    fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
+        Ok(storage.f32_storage.iter().len())
+    }
+}
+
 impl Writeable for u32 {
     fn write_to_storage(prefix: &str, key: KeyWrapper, value: Self, storage: &StorageBuilder) {
         storage.u32_storage.write().as_mut().unwrap().insert(
@@ -485,6 +589,114 @@ impl<'referred_data> Readable<'referred_data> for u32 {
 
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
         Ok(storage.u32_storage.iter().len())
+    }
+}
+
+impl Writeable for bool {
+    fn write_to_storage(prefix: &str, key: KeyWrapper, value: Self, storage: &StorageBuilder) {
+        storage.bool_storage.write().as_mut().unwrap().insert(
+            CompositeKey {
+                prefix: prefix.to_string(),
+                key: key.clone(),
+            },
+            value,
+        );
+    }
+
+    fn remove_from_storage(prefix: &str, key: KeyWrapper, storage: &StorageBuilder) {
+        storage
+            .bool_storage
+            .write()
+            .as_mut()
+            .unwrap()
+            .remove(&CompositeKey {
+                prefix: prefix.to_string(),
+                key,
+            });
+    }
+}
+
+impl<'referred_data> Readable<'referred_data> for bool {
+    fn read_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Option<Self> {
+        storage
+            .bool_storage
+            .get(&CompositeKey {
+                prefix: prefix.to_string(),
+                key,
+            })
+            .map(|a| *a)
+    }
+
+    fn get_by_prefix_from_storage(
+        prefix: &str,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .bool_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn read_gt_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .bool_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key > key)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn read_gte_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .bool_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key >= key)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn read_lt_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .bool_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key < key)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn read_lte_from_storage(
+        prefix: &str,
+        key: KeyWrapper,
+        storage: &'referred_data Storage,
+    ) -> Vec<(&'referred_data CompositeKey, Self)> {
+        storage
+            .bool_storage
+            .iter()
+            .filter(|(k, _)| k.prefix == prefix && k.key <= key)
+            .map(|(k, v)| (k, *v))
+            .collect()
+    }
+
+    fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
+        Ok(storage.bool_storage.iter().len())
     }
 }
 
@@ -692,10 +904,13 @@ impl<'referred_data> Readable<'referred_data> for DataRecord<'referred_data> {
 
 #[derive(Clone)]
 pub(crate) struct StorageBuilder {
+    bool_storage: Arc<RwLock<Option<HashMap<CompositeKey, bool>>>>,
     // String Value
     string_value_storage: Arc<RwLock<Option<HashMap<CompositeKey, String>>>>,
     // u32 Value
     u32_storage: Arc<RwLock<Option<HashMap<CompositeKey, u32>>>>,
+    // f32 value
+    f32_storage: Arc<RwLock<Option<HashMap<CompositeKey, f32>>>>,
     // Roaring Bitmap Value
     roaring_bitmap_storage: Arc<RwLock<Option<HashMap<CompositeKey, RoaringBitmap>>>>,
     // Int32 Array Value
@@ -708,13 +923,16 @@ pub(crate) struct StorageBuilder {
 
 #[derive(Clone)]
 pub(crate) struct Storage {
+    bool_storage: Arc<HashMap<CompositeKey, bool>>,
     // String Value
     string_value_storage: Arc<HashMap<CompositeKey, String>>,
-    // // u32 Value
+    // u32 Value
     u32_storage: Arc<HashMap<CompositeKey, u32>>,
-    // // Roaring Bitmap Value
+    // f32 value
+    f32_storage: Arc<HashMap<CompositeKey, f32>>,
+    // Roaring Bitmap Value
     roaring_bitmap_storage: Arc<HashMap<CompositeKey, RoaringBitmap>>,
-    // // Int32 Array Value
+    // Int32 Array Value
     int32_array_storage: Arc<HashMap<CompositeKey, Int32Array>>,
     // Data Record Fields
     data_record_id_storage: Arc<HashMap<CompositeKey, String>>,
@@ -745,8 +963,10 @@ impl StorageManager {
     pub(super) fn create(&self) -> StorageBuilder {
         let id = uuid::Uuid::new_v4();
         let builder = StorageBuilder {
+            bool_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
             string_value_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
             u32_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
+            f32_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
             roaring_bitmap_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
             int32_array_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
             data_record_id_storage: Arc::new(RwLock::new(Some(HashMap::new()))),
@@ -762,6 +982,7 @@ impl StorageManager {
         let mut write_cache_guard = self.write_cache.write();
         let builder = write_cache_guard.remove(&id).unwrap();
         let storage = Storage {
+            bool_storage: builder.bool_storage.write().take().unwrap().into(),
             string_value_storage: builder.string_value_storage.write().take().unwrap().into(),
             int32_array_storage: builder.int32_array_storage.write().take().unwrap().into(),
             roaring_bitmap_storage: builder
@@ -771,6 +992,7 @@ impl StorageManager {
                 .unwrap()
                 .into(),
             u32_storage: builder.u32_storage.write().take().unwrap().into(),
+            f32_storage: builder.f32_storage.write().take().unwrap().into(),
             data_record_id_storage: builder
                 .data_record_id_storage
                 .write()

--- a/rust/worker/src/blockstore/mod.rs
+++ b/rust/worker/src/blockstore/mod.rs
@@ -1,4 +1,4 @@
-mod positional_posting_list_value;
+pub mod positional_posting_list_value;
 mod types;
 
 pub mod arrow;

--- a/rust/worker/src/blockstore/mod.rs
+++ b/rust/worker/src/blockstore/mod.rs
@@ -1,8 +1,8 @@
-mod memory;
 mod positional_posting_list_value;
 mod types;
 
 pub mod arrow;
 pub mod key;
+pub mod memory;
 pub(crate) mod provider;
 pub(crate) use types::*;

--- a/rust/worker/src/blockstore/mod.rs
+++ b/rust/worker/src/blockstore/mod.rs
@@ -1,10 +1,8 @@
-mod arrow;
-mod key;
 mod memory;
 mod positional_posting_list_value;
 mod types;
 
+pub mod arrow;
+pub mod key;
 pub(crate) mod provider;
-
-pub(crate) use positional_posting_list_value::*;
 pub(crate) use types::*;

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -8,6 +8,7 @@ use super::memory::reader_writer::{
     MemoryBlockfileFlusher, MemoryBlockfileReader, MemoryBlockfileWriter,
 };
 use super::memory::storage::{Readable, Writeable};
+use crate::blockstore::positional_posting_list_value::PositionalPostingList;
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::segment::DataRecord;
 use arrow::array::{Array, Int32Array};

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -8,7 +8,6 @@ use super::memory::reader_writer::{
     MemoryBlockfileFlusher, MemoryBlockfileReader, MemoryBlockfileWriter,
 };
 use super::memory::storage::{Readable, Writeable};
-use super::PositionalPostingList;
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::segment::DataRecord;
 use arrow::array::{Array, Int32Array};

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -714,4 +714,3 @@ mod tests {
         assert_eq!(res, vec![3]);
     }
 }
-}

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -1,6 +1,5 @@
-use crate::blockstore::{
-    BlockfileFlusher, BlockfileReader, BlockfileWriter, PositionalPostingListBuilder,
-};
+use crate::blockstore::positional_posting_list_value::PositionalPostingListBuilder;
+use crate::blockstore::{BlockfileFlusher, BlockfileReader, BlockfileWriter};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::index::fulltext::tokenizer::ChromaTokenizer;
 use arrow::array::Int32Array;

--- a/rust/worker/src/index/metadata/types.rs
+++ b/rust/worker/src/index/metadata/types.rs
@@ -1,158 +1,109 @@
+use crate::blockstore::arrow::types::{ArrowReadableKey, ArrowWriteableKey};
 use crate::blockstore::provider::BlockfileProvider;
-use crate::blockstore::{Blockfile, BlockfileKey, Key, Value};
+use crate::blockstore::{key::KeyWrapper, BlockfileReader, BlockfileWriter, Key, Value};
 use crate::errors::{ChromaError, ErrorCodes};
 
 use roaring::RoaringBitmap;
+use serde_json::value;
 use std::{collections::HashMap, marker::PhantomData};
 use thiserror::Error;
 
-#[derive(Debug, Error)]
-pub(crate) enum MetadataIndexError {
-    #[error("Key not found")]
-    NotFoundError,
-    #[error("This operation cannot be done in a transaction")]
-    InTransaction,
-    #[error("This operation can only be done in a transaction")]
-    NotInTransaction,
+pub(crate) struct MetadataIndexWriter<K: Into<KeyWrapper>> {
+    metadata_value_type: PhantomData<K>,
+    blockfile_writer: BlockfileWriter,
+    // We use a Vec<(KeyWrapper, RoaringBitmap)> instead of a HashMap because
+    // f32 doesn't implement Eq or Hash. Eq is trivial since we disallow
+    // about NaN values, but Hash is harder.
+    // Linear scanning is fine since we will only ever have 2^16 values
+    // and the expected case is much less than that.
+    uncommitted_rbms: HashMap<String, Vec<(KeyWrapper, RoaringBitmap)>>,
 }
 
-impl ChromaError for MetadataIndexError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            MetadataIndexError::NotFoundError => ErrorCodes::InvalidArgument,
-            MetadataIndexError::InTransaction => ErrorCodes::InvalidArgument,
-            MetadataIndexError::NotInTransaction => ErrorCodes::InvalidArgument,
-        }
-    }
-}
-
-pub(crate) trait MetadataIndexValue {
-    fn to_blockfile_key(&self) -> Key;
-}
-impl MetadataIndexValue for String {
-    fn to_blockfile_key(&self) -> Key {
-        Key::String(self.clone())
-    }
-}
-impl MetadataIndexValue for f32 {
-    fn to_blockfile_key(&self) -> Key {
-        Key::Float(*self)
-    }
-}
-impl MetadataIndexValue for bool {
-    fn to_blockfile_key(&self) -> Key {
-        Key::Bool(*self)
-    }
-}
-
-pub(crate) trait MetadataIndex<T: MetadataIndexValue> {
-    fn begin_transaction(&mut self) -> Result<(), Box<dyn ChromaError>>;
-    fn commit_transaction(&mut self) -> Result<(), Box<dyn ChromaError>>;
-    fn in_transaction(&self) -> bool;
-
-    // Must be in a transaction to put or delete.
-    fn set(&mut self, key: &str, value: T, offset_id: u32) -> Result<(), Box<dyn ChromaError>>;
-    // Can delete anything -- if it's not in committed state the delete will be silently discarded.
-    fn delete(&mut self, key: &str, value: T, offset_id: u32) -> Result<(), Box<dyn ChromaError>>;
-
-    // Always reads from committed state.
-    fn get(&self, key: &str, value: T) -> Result<RoaringBitmap, Box<dyn ChromaError>>;
-}
-
-struct BlockfileMetadataIndex<T> {
-    metadata_value_type: PhantomData<T>,
-    blockfile: Box<dyn Blockfile>,
-    in_transaction: bool,
-    uncommitted_rbms: HashMap<BlockfileKey, RoaringBitmap>,
-}
-
-impl<T> BlockfileMetadataIndex<T> {
-    pub fn new(init_blockfile: Box<dyn Blockfile>) -> Self {
-        BlockfileMetadataIndex {
+impl<K: Into<KeyWrapper> + ArrowWriteableKey> MetadataIndexWriter<K> {
+    pub fn new(init_blockfile_writer: BlockfileWriter) -> Self {
+        MetadataIndexWriter {
             metadata_value_type: PhantomData,
-            blockfile: init_blockfile,
-            in_transaction: false,
+            blockfile_writer: init_blockfile_writer,
             uncommitted_rbms: HashMap::new(),
         }
     }
 
     fn look_up_key_and_populate_uncommitted_rbms(
         &mut self,
-        key: &BlockfileKey,
+        prefix: &str,
+        key: &KeyWrapper,
     ) -> Result<(), Box<dyn ChromaError>> {
-        if !self.uncommitted_rbms.contains_key(&key) {
-            match self.blockfile.get(key.clone()) {
-                Ok(Value::RoaringBitmapValue(rbm)) => {
-                    self.uncommitted_rbms.insert(key.clone(), rbm);
-                }
-                _ => {
-                    let rbm = RoaringBitmap::new();
-                    self.uncommitted_rbms.insert(key.clone(), rbm);
-                }
-            };
+        if !self.uncommitted_rbms.contains_key(prefix) {
+            self.uncommitted_rbms.insert(prefix.to_string(), vec![]);
+        }
+        let rbms = self.uncommitted_rbms.get_mut(prefix).unwrap();
+        if !rbms.iter().any(|(k, _)| k == key) {
+            rbms.push((key.clone(), RoaringBitmap::new()));
         }
         Ok(())
     }
-}
 
-impl<T: MetadataIndexValue> MetadataIndex<T> for BlockfileMetadataIndex<T> {
-    fn begin_transaction(&mut self) -> Result<(), Box<dyn ChromaError>> {
-        if self.in_transaction {
-            return Err(Box::new(MetadataIndexError::InTransaction));
-        }
-        self.blockfile.begin_transaction()?;
-        self.in_transaction = true;
-        Ok(())
-    }
-
-    fn commit_transaction(&mut self) -> Result<(), Box<dyn ChromaError>> {
-        if !self.in_transaction {
-            return Err(Box::new(MetadataIndexError::NotInTransaction));
-        }
-        for (key, rbm) in self.uncommitted_rbms.drain() {
-            self.blockfile
-                .set(key.clone(), &Value::RoaringBitmapValue(rbm.clone()));
-        }
-        self.blockfile.commit_transaction()?;
-        self.in_transaction = false;
-        self.uncommitted_rbms.clear();
-        Ok(())
-    }
-
-    fn in_transaction(&self) -> bool {
-        self.in_transaction
-    }
-
-    fn set(&mut self, key: &str, value: T, offset_id: u32) -> Result<(), Box<dyn ChromaError>> {
-        if !self.in_transaction {
-            return Err(Box::new(MetadataIndexError::NotInTransaction));
-        }
-        let blockfilekey = BlockfileKey::new(key.to_string(), value.to_blockfile_key());
-        self.look_up_key_and_populate_uncommitted_rbms(&blockfilekey)?;
-        let rbm = self.uncommitted_rbms.get_mut(&blockfilekey).unwrap();
+    pub fn set(&mut self, key: &str, value: K, offset_id: u32) -> Result<(), Box<dyn ChromaError>> {
+        let value = K::into(value);
+        self.look_up_key_and_populate_uncommitted_rbms(key, &value)?;
+        let rbms = self.uncommitted_rbms.get_mut(key).unwrap();
+        let (_, rbm) = rbms.iter_mut().find(|(k, _)| k == &value).unwrap();
         rbm.insert(offset_id);
         Ok(())
     }
 
-    fn delete(&mut self, key: &str, value: T, offset_id: u32) -> Result<(), Box<dyn ChromaError>> {
-        if !self.in_transaction {
-            return Err(Box::new(MetadataIndexError::NotInTransaction));
-        }
-        let blockfilekey = BlockfileKey::new(key.to_string(), value.to_blockfile_key());
-        self.look_up_key_and_populate_uncommitted_rbms(&blockfilekey)?;
-        let rbm = self.uncommitted_rbms.get_mut(&blockfilekey).unwrap();
+    pub fn delete(
+        &mut self,
+        key: &str,
+        value: K,
+        offset_id: u32,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        let value = K::into(value);
+        self.look_up_key_and_populate_uncommitted_rbms(key, &value)?;
+        let rbms = self.uncommitted_rbms.get_mut(key).unwrap();
+        let (_, rbm) = rbms.iter_mut().find(|(k, _)| k == &value).unwrap();
         rbm.remove(offset_id);
         Ok(())
     }
 
-    fn get(&self, key: &str, value: T) -> Result<RoaringBitmap, Box<dyn ChromaError>> {
-        if self.in_transaction {
-            return Err(Box::new(MetadataIndexError::InTransaction));
+    pub async fn write_to_blockfile(&mut self) -> Result<(), Box<dyn ChromaError>> {
+        for (key, rbms) in self.uncommitted_rbms.iter() {
+            for (value, rbm) in rbms.iter() {
+                self.blockfile_writer.set(key, value, rbm).await?;
+            }
         }
-        let blockfilekey = BlockfileKey::new(key.to_string(), value.to_blockfile_key());
-        match self.blockfile.get(blockfilekey) {
-            Ok(Value::RoaringBitmapValue(rbm)) => Ok(rbm),
-            _ => Ok(RoaringBitmap::new()),
+        self.uncommitted_rbms.clear();
+        Ok(())
+    }
+}
+
+pub(crate) struct MetadataIndexReader<
+    'me,
+    K: Into<KeyWrapper> + From<&'me KeyWrapper> + ArrowReadableKey<'me> + Clone,
+> {
+    metadata_value_type: PhantomData<K>,
+    blockfile_reader: BlockfileReader<'me, K, RoaringBitmap>,
+}
+
+impl<'me, K: Into<KeyWrapper> + From<&'me KeyWrapper> + ArrowReadableKey<'me> + Clone>
+    MetadataIndexReader<'me, K>
+{
+    pub fn new(init_blockfile_reader: BlockfileReader<'me, K, RoaringBitmap>) -> Self {
+        MetadataIndexReader {
+            metadata_value_type: PhantomData,
+            blockfile_reader: init_blockfile_reader,
+        }
+    }
+
+    pub async fn get(
+        &'me self,
+        key: &str,
+        value: K,
+    ) -> Result<RoaringBitmap, Box<dyn ChromaError>> {
+        let rbm = self.blockfile_reader.get(key, value).await;
+        match rbm {
+            Ok(rbm) => Ok(rbm),
+            Err(e) => Err(e),
         }
     }
 }
@@ -160,603 +111,597 @@ impl<T: MetadataIndexValue> MetadataIndex<T> for BlockfileMetadataIndex<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::blockstore::provider::HashMapBlockfileProvider;
-    use crate::blockstore::{KeyType, ValueType};
 
     #[test]
-    fn test_string_value_metadata_index_error_when_not_in_transaction() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
+    fn test_new_writer() {
+        let provider = BlockfileProvider::new_memory();
+        let blockfile_writer = provider.create::<&str, &str>().unwrap();
+        let _writer = MetadataIndexWriter::<&str>::new(blockfile_writer);
+    }
+
+    #[tokio::test]
+    async fn test_new_writer_then_reader() {
+        let provider = BlockfileProvider::new_memory();
+        let blockfile_writer = provider.create::<&str, &str>().unwrap();
+        let writer_id = blockfile_writer.id();
+        let md_writer = MetadataIndexWriter::<&str>::new(blockfile_writer);
+
+        let blockfile_reader = provider
+            .open::<&str, RoaringBitmap>(&writer_id)
+            .await
             .unwrap();
-        let mut index = BlockfileMetadataIndex::new(blockfile);
-        let result = index.set("key", "value".to_string(), 1);
-        assert_eq!(result.is_err(), true);
-        let result = index.delete("key", "value".to_string(), 1);
-        assert_eq!(result.is_err(), true);
-        let result = index.commit_transaction();
-        assert_eq!(result.is_err(), true);
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_empty_transaction() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.commit_transaction().unwrap();
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_set_get() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", "value".to_string(), 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", "value".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(1), true);
-    }
-
-    #[test]
-    fn test_float_value_metadata_index_set_get() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<f32>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", 1.0, 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", 1.0).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(1), true);
-    }
-
-    #[test]
-    fn test_bool_value_metadata_index_set_get() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<bool>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", true, 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", true).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(1), true);
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_set_delete_get() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", "value".to_string(), 1).unwrap();
-        index.delete("key", "value".to_string(), 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", "value".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 0);
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_set_delete_set_get() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", "value".to_string(), 1).unwrap();
-        index.delete("key", "value".to_string(), 1).unwrap();
-        index.set("key", "value".to_string(), 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", "value".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(1), true);
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_multiple_keys() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key1", "value".to_string(), 1).unwrap();
-        index.set("key2", "value".to_string(), 2).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key1", "value".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(1), true);
-
-        let bitmap = index.get("key2", "value".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(2), true);
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_multiple_values() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", "value1".to_string(), 1).unwrap();
-        index.set("key", "value2".to_string(), 2).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", "value1".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(1), true);
-
-        let bitmap = index.get("key", "value2".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 1);
-        assert_eq!(bitmap.contains(2), true);
-    }
-
-    #[test]
-    fn test_string_value_metadata_index_delete_in_standalone_transaction() {
-        let mut provider = HashMapBlockfileProvider::new();
-        let blockfile = provider
-            .create("test", KeyType::String, ValueType::RoaringBitmap)
-            .unwrap();
-        let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-        index.begin_transaction().unwrap();
-        index.set("key", "value".to_string(), 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        index.begin_transaction().unwrap();
-        index.delete("key", "value".to_string(), 1).unwrap();
-        index.commit_transaction().unwrap();
-
-        let bitmap = index.get("key", "value".to_string()).unwrap();
-        assert_eq!(bitmap.len(), 0);
-    }
-
-    use proptest::prelude::*;
-    use proptest::test_runner::Config;
-    use proptest_state_machine::{prop_state_machine, ReferenceStateMachine, StateMachineTest};
-    use std::rc::Rc;
-
-    // Utility function to check if a Vec<u32> and RoaringBitmap contain equivalent
-    // sets.
-    fn vec_rbm_eq(a: &Vec<u32>, b: &RoaringBitmap) -> bool {
-        if a.len() != b.len() as usize {
-            return false;
-        }
-        for offset in a {
-            if !b.contains(*offset) {
-                return false;
-            }
-        }
-        for offset in b {
-            if !a.contains(&offset) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    pub(crate) trait PropTestValue:
-        MetadataIndexValue + PartialEq + Eq + Clone + std::hash::Hash + std::fmt::Debug
-    {
-        fn strategy() -> BoxedStrategy<Self>;
-    }
-
-    impl PropTestValue for String {
-        fn strategy() -> BoxedStrategy<Self> {
-            ".{0,10}".prop_map(|x| x.to_string()).boxed()
-        }
-    }
-
-    impl PropTestValue for bool {
-        fn strategy() -> BoxedStrategy<Self> {
-            prop_oneof![Just(true), Just(false)].boxed()
-        }
-    }
-
-    // f32 doesn't implement Hash or Eq so we need to wrap it to use
-    // in our reference state machine's HashMap. This is a bit of a hack
-    // but only used in tests.
-    #[derive(Clone, Debug, PartialEq)]
-    struct FloatWrapper(f32);
-
-    impl std::hash::Hash for FloatWrapper {
-        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-            self.0.to_bits().hash(state);
-        }
-    }
-
-    impl Eq for FloatWrapper {}
-
-    impl MetadataIndexValue for FloatWrapper {
-        fn to_blockfile_key(&self) -> Key {
-            self.0.to_blockfile_key()
-        }
-    }
-
-    impl PropTestValue for FloatWrapper {
-        fn strategy() -> BoxedStrategy<Self> {
-            (0..1000).prop_map(|x| FloatWrapper(x as f32)).boxed()
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub(crate) enum Transition<T: PropTestValue> {
-        BeginTransaction,
-        CommitTransaction,
-        Set(String, T, u32),
-        Delete(String, T, u32),
-        Get(String, T),
-    }
-
-    #[derive(Clone, Debug)]
-    pub(crate) struct ReferenceState<T: PropTestValue> {
-        // Are we in a transaction?
-        in_transaction: bool,
-        // {metadata key: {metadata value: offset ids}}
-        data: HashMap<String, HashMap<T, Vec<u32>>>,
-    }
-
-    impl<T: PropTestValue> ReferenceState<T> {
-        fn new() -> Self {
-            ReferenceState {
-                in_transaction: false,
-                data: HashMap::new(),
-            }
-        }
-
-        fn key_from_random_number(self: &Self, r1: usize) -> Option<String> {
-            let keys = self.data.keys().collect::<Vec<&String>>();
-            if keys.len() == 0 {
-                return None;
-            }
-            Some(keys[r1 % keys.len()].clone())
-        }
-
-        fn key_and_value_from_random_numbers(
-            self: &Self,
-            r1: usize,
-            r2: usize,
-        ) -> Option<(String, T)> {
-            let k = self.key_from_random_number(r1)?;
-
-            let values = self.data.get(&k)?.keys().collect::<Vec<&T>>();
-            if values.len() == 0 {
-                return None;
-            }
-            let v = values[r2 % values.len()];
-            Some((k.clone(), v.clone()))
-        }
-
-        fn key_and_value_and_entry_from_random_numbers(
-            self: &Self,
-            r1: usize,
-            r2: usize,
-            r3: usize,
-        ) -> Option<(String, T, u32)> {
-            let (k, v) = self.key_and_value_from_random_numbers(r1, r2)?;
-
-            let offsets = self.data.get(&k)?.get(&v)?;
-            if offsets.len() == 0 {
-                return None;
-            }
-            let oid = offsets[r3 % offsets.len()];
-            Some((k.clone(), v.clone(), oid))
-        }
-
-        fn kv_rbm_eq(self: &Self, rbm: &RoaringBitmap, k: &str, v: &T) -> bool {
-            match self.data.get(k) {
-                Some(vv) => match vv.get(v) {
-                    Some(rbm2) => vec_rbm_eq(rbm2, rbm),
-                    None => rbm.is_empty(),
-                },
-                None => rbm.is_empty(),
-            }
-        }
-    }
-
-    pub(crate) struct ReferenceStateMachineImpl<T: PropTestValue> {
-        value_type: PhantomData<T>,
-    }
-
-    impl<T: PropTestValue + 'static> ReferenceStateMachine for ReferenceStateMachineImpl<T> {
-        type State = ReferenceState<T>;
-        type Transition = Transition<T>;
-
-        fn init_state() -> BoxedStrategy<Self::State> {
-            return Just(ReferenceState::<T>::new()).boxed();
-        }
-
-        fn transitions(state: &ReferenceState<T>) -> BoxedStrategy<Transition<T>> {
-            let r = state.key_and_value_and_entry_from_random_numbers(0, 0, 0);
-            if r.is_none() {
-                // Nothing in the reference state yet.
-                return prop_oneof![
-                    Just(Transition::BeginTransaction),
-                    Just(Transition::CommitTransaction),
-                    // Set, get, delete random values
-                    (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-                        Transition::Set(k.to_string(), v, oid as u32)
-                    }),
-                    (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-                        Transition::Delete(k.to_string(), v, oid as u32)
-                    }),
-                    (".{0,10}", T::strategy())
-                        .prop_map(move |(k, v)| { Transition::Get(k.to_string(), v) }),
-                ]
-                .boxed();
-            }
-
-            let state = Rc::new(state.clone());
-            return prop_oneof![
-                Just(Transition::BeginTransaction),
-                Just(Transition::CommitTransaction),
-                // Set, get, delete random values
-                (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-                    Transition::Set(k.to_string(), v, oid as u32)
-                }),
-                (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-                    Transition::Delete(k.to_string(), v, oid as u32)
-                }),
-                (".{0,10}", T::strategy()).prop_map(move |(k, v)| {
-                    Transition::Get(k.to_string(), v)
-                }),
-
-                // Sets on values in the reference state
-                (0..usize::MAX, T::strategy(), 1..1000).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, v, oid)| {
-                        match state.key_from_random_number(r1) {
-                            Some(k) => Transition::Set(k, v, oid as u32),
-                            None => panic!("Error in the test harness: Setting on key from ref state")
-                        }
-                    }
-                }),
-                (0..usize::MAX, 0..usize::MAX, 1..1000).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, r2, oid)| {
-                        match state.key_and_value_from_random_numbers(r1, r2) {
-                            Some((k, v)) => Transition::Set(k, v, oid as u32),
-                            None => panic!("Error in the test harness: Setting on key and value from ref state")
-                        }
-                    }
-                }),
-                (0..usize::MAX, 0..usize::MAX, 0..usize::MAX).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, r2, r3)| {
-                        match state.key_and_value_and_entry_from_random_numbers(r1, r2, r3) {
-                            Some((k, v, oid)) => Transition::Set(k, v, oid),
-                            None => panic!("Error in the test harness: Setting on key, value, and entry from ref state")
-                        }
-                    }
-                }),
-
-                // Gets on values in the reference state
-                (0..usize::MAX, T::strategy()).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, v)| {
-                        match state.key_from_random_number(r1) {
-                            Some(k) => Transition::Get(k, v),
-                            None => panic!("Error in the test harness: Getting on key from ref state")
-                        }
-                    }
-                }),
-                (0..usize::MAX, 0..usize::MAX).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, r2)| {
-                        match state.key_and_value_from_random_numbers(r1, r2) {
-                            Some((k, v)) => Transition::Get(k, v),
-                            None => panic!("Error in the test harness: Getting on key and value from ref state")
-                        }
-                    }
-                }),
-
-                // Deletes on values in the reference state
-                (0..usize::MAX, T::strategy(), 1..1000).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, v, oid)| {
-                        match state.key_from_random_number(r1) {
-                            Some(k) => Transition::Delete(k, v, oid as u32),
-                            None => panic!("Error in the test harness: Deleting on key from ref state")
-                        }
-                    }
-                }),
-                (0..usize::MAX, 0..usize::MAX, 1..1000).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, r2, oid)| {
-                        match state.key_and_value_from_random_numbers(r1, r2) {
-                            Some((k, v)) => Transition::Delete(k, v, oid as u32),
-                            None => panic!("Error in the test harness: Deleting on key and value from ref state")
-                        }
-                    }
-                }),
-                (0..usize::MAX, 0..usize::MAX, 0..usize::MAX).prop_map({
-                    let state = Rc::clone(&state);
-                    move |(r1, r2, r3)| {
-                        match state.key_and_value_and_entry_from_random_numbers(r1, r2, r3) {
-                            Some((k, v, oid)) => Transition::Delete(k, v, oid as u32),
-                            None => panic!("Error in the test harness: Deleting on key, value, and entry from ref state")
-                        }
-                    }
-                }),
-            ].boxed();
-        }
-
-        fn apply(mut state: ReferenceState<T>, transition: &Transition<T>) -> Self::State {
-            match transition {
-                Transition::BeginTransaction => {
-                    state.in_transaction = true;
-                }
-                Transition::CommitTransaction => {
-                    state.in_transaction = false;
-                }
-                Transition::Set(k, v, oid) => {
-                    if !state.in_transaction {
-                        return state;
-                    }
-                    let entry = state.data.entry(k.clone()).or_insert(HashMap::new());
-                    let entry = entry.entry(v.clone()).or_insert(Vec::new());
-                    if !entry.contains(oid) {
-                        entry.push(*oid);
-                    }
-                }
-                Transition::Delete(k, v, oid) => {
-                    if !state.in_transaction {
-                        return state;
-                    }
-                    if !state.data.contains_key(k) {
-                        return state;
-                    }
-                    let entry = state.data.get_mut(k).unwrap();
-                    if let Some(offsets) = entry.get_mut(v) {
-                        offsets.retain(|x| *x != *oid);
-                    }
-
-                    // Remove the offset ID list if it's empty.
-                    let offsets_count = entry.get(v).map(|x| x.len()).unwrap_or(0);
-                    if offsets_count == 0 {
-                        entry.remove(v);
-                    }
-
-                    // Remove the entire hashmap for the key if it's empty.
-                    if entry.is_empty() {
-                        state.data.remove(k);
-                    }
-                }
-                Transition::Get(_, _) => {
-                    // No-op
-                }
-            }
-            state
-        }
-    }
-
-    impl<T: PropTestValue + 'static> StateMachineTest for BlockfileMetadataIndex<T> {
-        type SystemUnderTest = Self;
-        type Reference = ReferenceStateMachineImpl<T>;
-
-        fn init_test(_ref_state: &ReferenceState<T>) -> Self::SystemUnderTest {
-            // We don't need to set up on _ref_state since we always initialize
-            // ref_state to empty.
-            let mut provider = HashMapBlockfileProvider::new();
-            let blockfile = provider
-                .create("test", KeyType::String, ValueType::RoaringBitmap)
-                .unwrap();
-            return BlockfileMetadataIndex::<T>::new(blockfile);
-        }
-
-        fn apply(
-            mut state: Self::SystemUnderTest,
-            ref_state: &ReferenceState<T>,
-            transition: Transition<T>,
-        ) -> Self::SystemUnderTest {
-            match transition {
-                Transition::BeginTransaction => {
-                    let already_in_transaction = state.in_transaction();
-                    let res = state.begin_transaction();
-                    assert!(state.in_transaction());
-                    if already_in_transaction {
-                        assert!(res.is_err());
-                    } else {
-                        assert!(res.is_ok());
-                    }
-                }
-                Transition::CommitTransaction => {
-                    let in_transaction = state.in_transaction();
-                    let res = state.commit_transaction();
-                    assert_eq!(state.in_transaction(), false);
-                    if !in_transaction {
-                        assert!(res.is_err());
-                    } else {
-                        assert!(res.is_ok());
-                    }
-                }
-                Transition::Set(k, v, oid) => {
-                    let in_transaction = state.in_transaction();
-                    let res = state.set(&k, v.clone(), oid);
-                    if !in_transaction {
-                        assert!(res.is_err());
-                    } else {
-                        assert!(res.is_ok());
-                    }
-                }
-                Transition::Delete(k, v, oid) => {
-                    let in_transaction = state.in_transaction();
-                    let res = state.delete(&k, v, oid);
-                    if !in_transaction {
-                        assert!(res.is_err());
-                    } else {
-                        assert!(res.is_ok());
-                    }
-                }
-                Transition::Get(k, v) => {
-                    let in_transaction = state.in_transaction();
-                    let res = state.get(&k, v.clone());
-                    if in_transaction {
-                        assert!(res.is_err());
-                        return state;
-                    }
-                    let rbm = res.unwrap();
-                    assert!(ref_state.kv_rbm_eq(&rbm, &k, &v));
-                }
-            }
-            state
-        }
-
-        fn check_invariants(state: &Self::SystemUnderTest, ref_state: &ReferenceState<T>) {
-            assert_eq!(state.in_transaction(), ref_state.in_transaction);
-            if state.in_transaction() {
-                return;
-            }
-            for (metadata_key, metadata_values_hm) in &ref_state.data {
-                for (metadata_value, ref_offset_ids) in metadata_values_hm {
-                    assert!(vec_rbm_eq(
-                        ref_offset_ids,
-                        &state.get(metadata_key, metadata_value.clone()).unwrap()
-                    ));
-                }
-            }
-            // TODO once we have a way to iterate over all state in the blockfile,
-            // add a similar check here to make sure that blockfile data is a
-            // subset of reference state data.
-        }
-    }
-
-    prop_state_machine! {
-        #![proptest_config(Config {
-            // Enable verbose mode to make the state machine test print the
-            // transitions for each case.
-            verbose: 0,
-            cases: 100,
-            .. Config::default()
-        })]
-        #[test]
-        fn proptest_string_metadata_index(sequential 1..100 => BlockfileMetadataIndex<String>);
-
-        #[test]
-        fn proptest_boolean_metadata_index(sequential 1..100 => BlockfileMetadataIndex<bool>);
-
-        #[test]
-        fn proptest_numeric_metadata_index(sequential 1..100 => BlockfileMetadataIndex<FloatWrapper>);
+        let _reader = MetadataIndexReader::<&str>::new(blockfile_reader);
     }
 }
+
+//     #[test]
+//     fn test_string_value_metadata_index_set_get() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", "value".to_string(), 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", "value".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(1), true);
+//     }
+
+//     #[test]
+//     fn test_float_value_metadata_index_set_get() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<f32>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", 1.0, 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", 1.0).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(1), true);
+//     }
+
+//     #[test]
+//     fn test_bool_value_metadata_index_set_get() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<bool>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", true, 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", true).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(1), true);
+//     }
+
+//     #[test]
+//     fn test_string_value_metadata_index_set_delete_get() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", "value".to_string(), 1).unwrap();
+//         index.delete("key", "value".to_string(), 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", "value".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 0);
+//     }
+
+//     #[test]
+//     fn test_string_value_metadata_index_set_delete_set_get() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", "value".to_string(), 1).unwrap();
+//         index.delete("key", "value".to_string(), 1).unwrap();
+//         index.set("key", "value".to_string(), 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", "value".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(1), true);
+//     }
+
+//     #[test]
+//     fn test_string_value_metadata_index_multiple_keys() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key1", "value".to_string(), 1).unwrap();
+//         index.set("key2", "value".to_string(), 2).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key1", "value".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(1), true);
+
+//         let bitmap = index.get("key2", "value".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(2), true);
+//     }
+
+//     #[test]
+//     fn test_string_value_metadata_index_multiple_values() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", "value1".to_string(), 1).unwrap();
+//         index.set("key", "value2".to_string(), 2).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", "value1".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(1), true);
+
+//         let bitmap = index.get("key", "value2".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 1);
+//         assert_eq!(bitmap.contains(2), true);
+//     }
+
+//     #[test]
+//     fn test_string_value_metadata_index_delete_in_standalone_transaction() {
+//         let mut provider = HashMapBlockfileProvider::new();
+//         let blockfile = provider
+//             .create("test", KeyType::String, ValueType::RoaringBitmap)
+//             .unwrap();
+//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
+//         index.begin_transaction().unwrap();
+//         index.set("key", "value".to_string(), 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         index.begin_transaction().unwrap();
+//         index.delete("key", "value".to_string(), 1).unwrap();
+//         index.commit_transaction().unwrap();
+
+//         let bitmap = index.get("key", "value".to_string()).unwrap();
+//         assert_eq!(bitmap.len(), 0);
+//     }
+
+//     use proptest::prelude::*;
+//     use proptest::test_runner::Config;
+//     use proptest_state_machine::{prop_state_machine, ReferenceStateMachine, StateMachineTest};
+//     use std::rc::Rc;
+
+//     // Utility function to check if a Vec<u32> and RoaringBitmap contain equivalent
+//     // sets.
+//     fn vec_rbm_eq(a: &Vec<u32>, b: &RoaringBitmap) -> bool {
+//         if a.len() != b.len() as usize {
+//             return false;
+//         }
+//         for offset in a {
+//             if !b.contains(*offset) {
+//                 return false;
+//             }
+//         }
+//         for offset in b {
+//             if !a.contains(&offset) {
+//                 return false;
+//             }
+//         }
+//         return true;
+//     }
+
+//     pub(crate) trait PropTestValue:
+//         MetadataIndexValue + PartialEq + Eq + Clone + std::hash::Hash + std::fmt::Debug
+//     {
+//         fn strategy() -> BoxedStrategy<Self>;
+//     }
+
+//     impl PropTestValue for String {
+//         fn strategy() -> BoxedStrategy<Self> {
+//             ".{0,10}".prop_map(|x| x.to_string()).boxed()
+//         }
+//     }
+
+//     impl PropTestValue for bool {
+//         fn strategy() -> BoxedStrategy<Self> {
+//             prop_oneof![Just(true), Just(false)].boxed()
+//         }
+//     }
+
+//     // f32 doesn't implement Hash or Eq so we need to wrap it to use
+//     // in our reference state machine's HashMap. This is a bit of a hack
+//     // but only used in tests.
+//     #[derive(Clone, Debug, PartialEq)]
+//     struct FloatWrapper(f32);
+
+//     impl std::hash::Hash for FloatWrapper {
+//         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+//             self.0.to_bits().hash(state);
+//         }
+//     }
+
+//     impl Eq for FloatWrapper {}
+
+//     impl MetadataIndexValue for FloatWrapper {
+//         fn to_blockfile_key(&self) -> Key {
+//             self.0.to_blockfile_key()
+//         }
+//     }
+
+//     impl PropTestValue for FloatWrapper {
+//         fn strategy() -> BoxedStrategy<Self> {
+//             (0..1000).prop_map(|x| FloatWrapper(x as f32)).boxed()
+//         }
+//     }
+
+//     #[derive(Clone, Debug)]
+//     pub(crate) enum Transition<T: PropTestValue> {
+//         BeginTransaction,
+//         CommitTransaction,
+//         Set(String, T, u32),
+//         Delete(String, T, u32),
+//         Get(String, T),
+//     }
+
+//     #[derive(Clone, Debug)]
+//     pub(crate) struct ReferenceState<T: PropTestValue> {
+//         // Are we in a transaction?
+//         in_transaction: bool,
+//         // {metadata key: {metadata value: offset ids}}
+//         data: HashMap<String, HashMap<T, Vec<u32>>>,
+//     }
+
+//     impl<T: PropTestValue> ReferenceState<T> {
+//         fn new() -> Self {
+//             ReferenceState {
+//                 in_transaction: false,
+//                 data: HashMap::new(),
+//             }
+//         }
+
+//         fn key_from_random_number(self: &Self, r1: usize) -> Option<String> {
+//             let keys = self.data.keys().collect::<Vec<&String>>();
+//             if keys.len() == 0 {
+//                 return None;
+//             }
+//             Some(keys[r1 % keys.len()].clone())
+//         }
+
+//         fn key_and_value_from_random_numbers(
+//             self: &Self,
+//             r1: usize,
+//             r2: usize,
+//         ) -> Option<(String, T)> {
+//             let k = self.key_from_random_number(r1)?;
+
+//             let values = self.data.get(&k)?.keys().collect::<Vec<&T>>();
+//             if values.len() == 0 {
+//                 return None;
+//             }
+//             let v = values[r2 % values.len()];
+//             Some((k.clone(), v.clone()))
+//         }
+
+//         fn key_and_value_and_entry_from_random_numbers(
+//             self: &Self,
+//             r1: usize,
+//             r2: usize,
+//             r3: usize,
+//         ) -> Option<(String, T, u32)> {
+//             let (k, v) = self.key_and_value_from_random_numbers(r1, r2)?;
+
+//             let offsets = self.data.get(&k)?.get(&v)?;
+//             if offsets.len() == 0 {
+//                 return None;
+//             }
+//             let oid = offsets[r3 % offsets.len()];
+//             Some((k.clone(), v.clone(), oid))
+//         }
+
+//         fn kv_rbm_eq(self: &Self, rbm: &RoaringBitmap, k: &str, v: &T) -> bool {
+//             match self.data.get(k) {
+//                 Some(vv) => match vv.get(v) {
+//                     Some(rbm2) => vec_rbm_eq(rbm2, rbm),
+//                     None => rbm.is_empty(),
+//                 },
+//                 None => rbm.is_empty(),
+//             }
+//         }
+//     }
+
+//     pub(crate) struct ReferenceStateMachineImpl<T: PropTestValue> {
+//         value_type: PhantomData<T>,
+//     }
+
+//     impl<T: PropTestValue + 'static> ReferenceStateMachine for ReferenceStateMachineImpl<T> {
+//         type State = ReferenceState<T>;
+//         type Transition = Transition<T>;
+
+//         fn init_state() -> BoxedStrategy<Self::State> {
+//             return Just(ReferenceState::<T>::new()).boxed();
+//         }
+
+//         fn transitions(state: &ReferenceState<T>) -> BoxedStrategy<Transition<T>> {
+//             let r = state.key_and_value_and_entry_from_random_numbers(0, 0, 0);
+//             if r.is_none() {
+//                 // Nothing in the reference state yet.
+//                 return prop_oneof![
+//                     Just(Transition::BeginTransaction),
+//                     Just(Transition::CommitTransaction),
+//                     // Set, get, delete random values
+//                     (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
+//                         Transition::Set(k.to_string(), v, oid as u32)
+//                     }),
+//                     (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
+//                         Transition::Delete(k.to_string(), v, oid as u32)
+//                     }),
+//                     (".{0,10}", T::strategy())
+//                         .prop_map(move |(k, v)| { Transition::Get(k.to_string(), v) }),
+//                 ]
+//                 .boxed();
+//             }
+
+//             let state = Rc::new(state.clone());
+//             return prop_oneof![
+//                 Just(Transition::BeginTransaction),
+//                 Just(Transition::CommitTransaction),
+//                 // Set, get, delete random values
+//                 (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
+//                     Transition::Set(k.to_string(), v, oid as u32)
+//                 }),
+//                 (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
+//                     Transition::Delete(k.to_string(), v, oid as u32)
+//                 }),
+//                 (".{0,10}", T::strategy()).prop_map(move |(k, v)| {
+//                     Transition::Get(k.to_string(), v)
+//                 }),
+
+//                 // Sets on values in the reference state
+//                 (0..usize::MAX, T::strategy(), 1..1000).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, v, oid)| {
+//                         match state.key_from_random_number(r1) {
+//                             Some(k) => Transition::Set(k, v, oid as u32),
+//                             None => panic!("Error in the test harness: Setting on key from ref state")
+//                         }
+//                     }
+//                 }),
+//                 (0..usize::MAX, 0..usize::MAX, 1..1000).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, r2, oid)| {
+//                         match state.key_and_value_from_random_numbers(r1, r2) {
+//                             Some((k, v)) => Transition::Set(k, v, oid as u32),
+//                             None => panic!("Error in the test harness: Setting on key and value from ref state")
+//                         }
+//                     }
+//                 }),
+//                 (0..usize::MAX, 0..usize::MAX, 0..usize::MAX).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, r2, r3)| {
+//                         match state.key_and_value_and_entry_from_random_numbers(r1, r2, r3) {
+//                             Some((k, v, oid)) => Transition::Set(k, v, oid),
+//                             None => panic!("Error in the test harness: Setting on key, value, and entry from ref state")
+//                         }
+//                     }
+//                 }),
+
+//                 // Gets on values in the reference state
+//                 (0..usize::MAX, T::strategy()).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, v)| {
+//                         match state.key_from_random_number(r1) {
+//                             Some(k) => Transition::Get(k, v),
+//                             None => panic!("Error in the test harness: Getting on key from ref state")
+//                         }
+//                     }
+//                 }),
+//                 (0..usize::MAX, 0..usize::MAX).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, r2)| {
+//                         match state.key_and_value_from_random_numbers(r1, r2) {
+//                             Some((k, v)) => Transition::Get(k, v),
+//                             None => panic!("Error in the test harness: Getting on key and value from ref state")
+//                         }
+//                     }
+//                 }),
+
+//                 // Deletes on values in the reference state
+//                 (0..usize::MAX, T::strategy(), 1..1000).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, v, oid)| {
+//                         match state.key_from_random_number(r1) {
+//                             Some(k) => Transition::Delete(k, v, oid as u32),
+//                             None => panic!("Error in the test harness: Deleting on key from ref state")
+//                         }
+//                     }
+//                 }),
+//                 (0..usize::MAX, 0..usize::MAX, 1..1000).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, r2, oid)| {
+//                         match state.key_and_value_from_random_numbers(r1, r2) {
+//                             Some((k, v)) => Transition::Delete(k, v, oid as u32),
+//                             None => panic!("Error in the test harness: Deleting on key and value from ref state")
+//                         }
+//                     }
+//                 }),
+//                 (0..usize::MAX, 0..usize::MAX, 0..usize::MAX).prop_map({
+//                     let state = Rc::clone(&state);
+//                     move |(r1, r2, r3)| {
+//                         match state.key_and_value_and_entry_from_random_numbers(r1, r2, r3) {
+//                             Some((k, v, oid)) => Transition::Delete(k, v, oid as u32),
+//                             None => panic!("Error in the test harness: Deleting on key, value, and entry from ref state")
+//                         }
+//                     }
+//                 }),
+//             ].boxed();
+//         }
+
+//         fn apply(mut state: ReferenceState<T>, transition: &Transition<T>) -> Self::State {
+//             match transition {
+//                 Transition::BeginTransaction => {
+//                     state.in_transaction = true;
+//                 }
+//                 Transition::CommitTransaction => {
+//                     state.in_transaction = false;
+//                 }
+//                 Transition::Set(k, v, oid) => {
+//                     if !state.in_transaction {
+//                         return state;
+//                     }
+//                     let entry = state.data.entry(k.clone()).or_insert(HashMap::new());
+//                     let entry = entry.entry(v.clone()).or_insert(Vec::new());
+//                     if !entry.contains(oid) {
+//                         entry.push(*oid);
+//                     }
+//                 }
+//                 Transition::Delete(k, v, oid) => {
+//                     if !state.in_transaction {
+//                         return state;
+//                     }
+//                     if !state.data.contains_key(k) {
+//                         return state;
+//                     }
+//                     let entry = state.data.get_mut(k).unwrap();
+//                     if let Some(offsets) = entry.get_mut(v) {
+//                         offsets.retain(|x| *x != *oid);
+//                     }
+
+//                     // Remove the offset ID list if it's empty.
+//                     let offsets_count = entry.get(v).map(|x| x.len()).unwrap_or(0);
+//                     if offsets_count == 0 {
+//                         entry.remove(v);
+//                     }
+
+//                     // Remove the entire hashmap for the key if it's empty.
+//                     if entry.is_empty() {
+//                         state.data.remove(k);
+//                     }
+//                 }
+//                 Transition::Get(_, _) => {
+//                     // No-op
+//                 }
+//             }
+//             state
+//         }
+//     }
+
+//     impl<T: PropTestValue + 'static> StateMachineTest for BlockfileMetadataIndex<T> {
+//         type SystemUnderTest = Self;
+//         type Reference = ReferenceStateMachineImpl<T>;
+
+//         fn init_test(_ref_state: &ReferenceState<T>) -> Self::SystemUnderTest {
+//             // We don't need to set up on _ref_state since we always initialize
+//             // ref_state to empty.
+//             let mut provider = HashMapBlockfileProvider::new();
+//             let blockfile = provider
+//                 .create("test", KeyType::String, ValueType::RoaringBitmap)
+//                 .unwrap();
+//             return BlockfileMetadataIndex::<T>::new(blockfile);
+//         }
+
+//         fn apply(
+//             mut state: Self::SystemUnderTest,
+//             ref_state: &ReferenceState<T>,
+//             transition: Transition<T>,
+//         ) -> Self::SystemUnderTest {
+//             match transition {
+//                 Transition::BeginTransaction => {
+//                     let already_in_transaction = state.in_transaction();
+//                     let res = state.begin_transaction();
+//                     assert!(state.in_transaction());
+//                     if already_in_transaction {
+//                         assert!(res.is_err());
+//                     } else {
+//                         assert!(res.is_ok());
+//                     }
+//                 }
+//                 Transition::CommitTransaction => {
+//                     let in_transaction = state.in_transaction();
+//                     let res = state.commit_transaction();
+//                     assert_eq!(state.in_transaction(), false);
+//                     if !in_transaction {
+//                         assert!(res.is_err());
+//                     } else {
+//                         assert!(res.is_ok());
+//                     }
+//                 }
+//                 Transition::Set(k, v, oid) => {
+//                     let in_transaction = state.in_transaction();
+//                     let res = state.set(&k, v.clone(), oid);
+//                     if !in_transaction {
+//                         assert!(res.is_err());
+//                     } else {
+//                         assert!(res.is_ok());
+//                     }
+//                 }
+//                 Transition::Delete(k, v, oid) => {
+//                     let in_transaction = state.in_transaction();
+//                     let res = state.delete(&k, v, oid);
+//                     if !in_transaction {
+//                         assert!(res.is_err());
+//                     } else {
+//                         assert!(res.is_ok());
+//                     }
+//                 }
+//                 Transition::Get(k, v) => {
+//                     let in_transaction = state.in_transaction();
+//                     let res = state.get(&k, v.clone());
+//                     if in_transaction {
+//                         assert!(res.is_err());
+//                         return state;
+//                     }
+//                     let rbm = res.unwrap();
+//                     assert!(ref_state.kv_rbm_eq(&rbm, &k, &v));
+//                 }
+//             }
+//             state
+//         }
+
+//         fn check_invariants(state: &Self::SystemUnderTest, ref_state: &ReferenceState<T>) {
+//             assert_eq!(state.in_transaction(), ref_state.in_transaction);
+//             if state.in_transaction() {
+//                 return;
+//             }
+//             for (metadata_key, metadata_values_hm) in &ref_state.data {
+//                 for (metadata_value, ref_offset_ids) in metadata_values_hm {
+//                     assert!(vec_rbm_eq(
+//                         ref_offset_ids,
+//                         &state.get(metadata_key, metadata_value.clone()).unwrap()
+//                     ));
+//                 }
+//             }
+//             // TODO once we have a way to iterate over all state in the blockfile,
+//             // add a similar check here to make sure that blockfile data is a
+//             // subset of reference state data.
+//         }
+//     }
+
+//     prop_state_machine! {
+//         #![proptest_config(Config {
+//             // Enable verbose mode to make the state machine test print the
+//             // transitions for each case.
+//             verbose: 0,
+//             cases: 100,
+//             .. Config::default()
+//         })]
+//         #[test]
+//         fn proptest_string_metadata_index(sequential 1..100 => BlockfileMetadataIndex<String>);
+
+//         #[test]
+//         fn proptest_boolean_metadata_index(sequential 1..100 => BlockfileMetadataIndex<bool>);
+
+//         #[test]
+//         fn proptest_numeric_metadata_index(sequential 1..100 => BlockfileMetadataIndex<FloatWrapper>);
+//     }
+// }

--- a/rust/worker/src/index/metadata/types.rs
+++ b/rust/worker/src/index/metadata/types.rs
@@ -183,100 +183,50 @@ mod test {
         assert_eq!(bitmap.contains(1), true);
     }
 
-    // #[tokio::test]
-    // async fn test_float_metadata_index_set_get() {
-    //     let provider = BlockfileProvider::new_memory();
-    //     let blockfile_writer = provider.create::<f32, &str>().unwrap();
-    //     let writer_id = blockfile_writer.id();
+    #[tokio::test]
+    async fn test_float_metadata_index_set_get() {
+        let provider = BlockfileProvider::new_memory();
+        let blockfile_writer = provider.create::<f32, &str>().unwrap();
+        let writer_id = blockfile_writer.id();
 
-    //     let mut writer = MetadataIndexWriter::<f32>::new(blockfile_writer);
-    //     writer.set("key", 1.0, 1).unwrap();
-    //     writer.write_to_blockfile().await.unwrap();
-    //     let flusher = writer.commit().await.unwrap();
-    //     flusher.flush().await.unwrap();
+        let mut writer = MetadataIndexWriter::<f32>::new(blockfile_writer);
+        writer.set("key", 1.0, 1).unwrap();
+        writer.write_to_blockfile().await.unwrap();
+        let flusher = writer.commit().await.unwrap();
+        flusher.flush().await.unwrap();
 
-    //     let blockfile_reader = provider
-    //         .open::<f32, RoaringBitmap>(&writer_id)
-    //         .await
-    //         .unwrap();
-    //     let reader = MetadataIndexReader::<f32>::new(blockfile_reader);
-    //     let bitmap = reader.get("key", 1.0).await.unwrap();
-    //     assert_eq!(bitmap.len(), 1);
-    //     assert_eq!(bitmap.contains(1), true);
-    // }
+        let blockfile_reader = provider
+            .open::<f32, RoaringBitmap>(&writer_id)
+            .await
+            .unwrap();
+        let reader = MetadataIndexReader::<f32>::new(blockfile_reader);
+        let bitmap = reader.get("key", 1.0).await.unwrap();
+        assert_eq!(bitmap.len(), 1);
+        assert_eq!(bitmap.contains(1), true);
+    }
 
-    // #[tokio::test]
-    // async fn test_bool_value_metadata_index_set_get() {
-    //     let provider = BlockfileProvider::new_memory();
-    //     let blockfile_writer = provider.create::<&str, &str>().unwrap();
-    //     let writer_id = blockfile_writer.id();
+    #[tokio::test]
+    async fn test_bool_value_metadata_index_set_get() {
+        let provider = BlockfileProvider::new_memory();
+        let blockfile_writer = provider.create::<&str, &str>().unwrap();
+        let writer_id = blockfile_writer.id();
 
-    //     let mut writer = MetadataIndexWriter::<bool>::new(blockfile_writer);
-    //     writer.set("key", true, 1).unwrap();
-    //     writer.write_to_blockfile().await.unwrap();
-    //     let flusher = writer.commit().await.unwrap();
-    //     flusher.flush().await.unwrap();
+        let mut writer = MetadataIndexWriter::<bool>::new(blockfile_writer);
+        writer.set("key", true, 1).unwrap();
+        writer.write_to_blockfile().await.unwrap();
+        let flusher = writer.commit().await.unwrap();
+        flusher.flush().await.unwrap();
 
-    //     let blockfile_reader = provider
-    //         .open::<&str, RoaringBitmap>(&writer_id)
-    //         .await
-    //         .unwrap();
-    //     let reader = MetadataIndexReader::<&str>::new(blockfile_reader);
-    //     let bitmap = reader.get("key", true).await.unwrap();
-    //     assert_eq!(bitmap.len(), 1);
-    //     assert_eq!(bitmap.contains(1), true);
-    // }
+        let blockfile_reader = provider
+            .open::<bool, RoaringBitmap>(&writer_id)
+            .await
+            .unwrap();
+        let reader = MetadataIndexReader::<bool>::new(blockfile_reader);
+        let bitmap = reader.get("key", true).await.unwrap();
+        assert_eq!(bitmap.len(), 1);
+        assert_eq!(bitmap.contains(1), true);
+    }
 }
-
-//     #[test]
-//     fn test_bool_value_metadata_index_set_get() {
-//         let mut provider = HashMapBlockfileProvider::new();
-//         let blockfile = provider
-//             .create("test", KeyType::String, ValueType::RoaringBitmap)
-//             .unwrap();
-//         let mut index = BlockfileMetadataIndex::<bool>::new(blockfile);
-//         index.begin_transaction().unwrap();
-//         index.set("key", true, 1).unwrap();
-//         index.commit_transaction().unwrap();
-
-//         let bitmap = index.get("key", true).unwrap();
-//         assert_eq!(bitmap.len(), 1);
-//         assert_eq!(bitmap.contains(1), true);
-//     }
-
-//     #[test]
-//     fn test_string_value_metadata_index_set_delete_get() {
-//         let mut provider = HashMapBlockfileProvider::new();
-//         let blockfile = provider
-//             .create("test", KeyType::String, ValueType::RoaringBitmap)
-//             .unwrap();
-//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-//         index.begin_transaction().unwrap();
-//         index.set("key", "value".to_string(), 1).unwrap();
-//         index.delete("key", "value".to_string(), 1).unwrap();
-//         index.commit_transaction().unwrap();
-
-//         let bitmap = index.get("key", "value".to_string()).unwrap();
-//         assert_eq!(bitmap.len(), 0);
-//     }
-
-//     #[test]
-//     fn test_string_value_metadata_index_set_delete_set_get() {
-//         let mut provider = HashMapBlockfileProvider::new();
-//         let blockfile = provider
-//             .create("test", KeyType::String, ValueType::RoaringBitmap)
-//             .unwrap();
-//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-//         index.begin_transaction().unwrap();
-//         index.set("key", "value".to_string(), 1).unwrap();
-//         index.delete("key", "value".to_string(), 1).unwrap();
-//         index.set("key", "value".to_string(), 1).unwrap();
-//         index.commit_transaction().unwrap();
-
-//         let bitmap = index.get("key", "value".to_string()).unwrap();
-//         assert_eq!(bitmap.len(), 1);
-//         assert_eq!(bitmap.contains(1), true);
-//     }
 
 //     #[test]
 //     fn test_string_value_metadata_index_multiple_keys() {

--- a/rust/worker/src/index/metadata/types.rs
+++ b/rust/worker/src/index/metadata/types.rs
@@ -1,28 +1,24 @@
 use crate::blockstore::arrow::types::{ArrowReadableKey, ArrowWriteableKey};
-use crate::blockstore::provider::BlockfileProvider;
-use crate::blockstore::{key::KeyWrapper, BlockfileReader, BlockfileWriter, Key, Value};
-use crate::errors::{ChromaError, ErrorCodes};
+use crate::blockstore::memory::storage::Writeable;
+use crate::blockstore::{key::KeyWrapper, BlockfileFlusher, BlockfileReader, BlockfileWriter};
+use crate::errors::ChromaError;
 
 use roaring::RoaringBitmap;
-use serde_json::value;
 use std::{collections::HashMap, marker::PhantomData};
-use thiserror::Error;
 
-pub(crate) struct MetadataIndexWriter<K: Into<KeyWrapper>> {
-    metadata_value_type: PhantomData<K>,
+pub(crate) struct MetadataIndexWriter<K: ArrowWriteableKey + Writeable> {
     blockfile_writer: BlockfileWriter,
     // We use a Vec<(KeyWrapper, RoaringBitmap)> instead of a HashMap because
     // f32 doesn't implement Eq or Hash. Eq is trivial since we disallow
     // about NaN values, but Hash is harder.
     // Linear scanning is fine since we will only ever have 2^16 values
     // and the expected case is much less than that.
-    uncommitted_rbms: HashMap<String, Vec<(KeyWrapper, RoaringBitmap)>>,
+    uncommitted_rbms: HashMap<String, Vec<(K, RoaringBitmap)>>,
 }
 
-impl<K: Into<KeyWrapper> + ArrowWriteableKey> MetadataIndexWriter<K> {
+impl<K: ArrowWriteableKey + Writeable> MetadataIndexWriter<K> {
     pub fn new(init_blockfile_writer: BlockfileWriter) -> Self {
         MetadataIndexWriter {
-            metadata_value_type: PhantomData,
             blockfile_writer: init_blockfile_writer,
             uncommitted_rbms: HashMap::new(),
         }
@@ -31,7 +27,7 @@ impl<K: Into<KeyWrapper> + ArrowWriteableKey> MetadataIndexWriter<K> {
     fn look_up_key_and_populate_uncommitted_rbms(
         &mut self,
         prefix: &str,
-        key: &KeyWrapper,
+        key: &K,
     ) -> Result<(), Box<dyn ChromaError>> {
         if !self.uncommitted_rbms.contains_key(prefix) {
             self.uncommitted_rbms.insert(prefix.to_string(), vec![]);
@@ -44,7 +40,6 @@ impl<K: Into<KeyWrapper> + ArrowWriteableKey> MetadataIndexWriter<K> {
     }
 
     pub fn set(&mut self, key: &str, value: K, offset_id: u32) -> Result<(), Box<dyn ChromaError>> {
-        let value = K::into(value);
         self.look_up_key_and_populate_uncommitted_rbms(key, &value)?;
         let rbms = self.uncommitted_rbms.get_mut(key).unwrap();
         let (_, rbm) = rbms.iter_mut().find(|(k, _)| k == &value).unwrap();
@@ -52,28 +47,36 @@ impl<K: Into<KeyWrapper> + ArrowWriteableKey> MetadataIndexWriter<K> {
         Ok(())
     }
 
-    pub fn delete(
-        &mut self,
-        key: &str,
-        value: K,
-        offset_id: u32,
-    ) -> Result<(), Box<dyn ChromaError>> {
-        let value = K::into(value);
-        self.look_up_key_and_populate_uncommitted_rbms(key, &value)?;
-        let rbms = self.uncommitted_rbms.get_mut(key).unwrap();
-        let (_, rbm) = rbms.iter_mut().find(|(k, _)| k == &value).unwrap();
-        rbm.remove(offset_id);
-        Ok(())
-    }
-
     pub async fn write_to_blockfile(&mut self) -> Result<(), Box<dyn ChromaError>> {
-        for (key, rbms) in self.uncommitted_rbms.iter() {
-            for (value, rbm) in rbms.iter() {
-                self.blockfile_writer.set(key, value, rbm).await?;
+        for (key, mut rbms) in self.uncommitted_rbms.drain() {
+            for (value, rbm) in rbms.drain(..) {
+                self.blockfile_writer.set(key.as_str(), value, &rbm).await?;
             }
         }
         self.uncommitted_rbms.clear();
         Ok(())
+    }
+
+    pub async fn commit(self) -> Result<MetadataIndexFlusher<K>, Box<dyn ChromaError>> {
+        let f = match self.blockfile_writer.commit::<K, &RoaringBitmap>() {
+            Ok(f) => f,
+            Err(e) => return Err(e),
+        };
+        Ok(MetadataIndexFlusher {
+            phantom: PhantomData,
+            flusher: f,
+        })
+    }
+}
+
+pub(crate) struct MetadataIndexFlusher<K: ArrowWriteableKey + Writeable> {
+    phantom: PhantomData<K>,
+    flusher: BlockfileFlusher,
+}
+
+impl<K: ArrowWriteableKey + Writeable> MetadataIndexFlusher<K> {
+    pub async fn flush(self) -> Result<(), Box<dyn ChromaError>> {
+        self.flusher.flush::<K, &RoaringBitmap>().await
     }
 }
 
@@ -111,6 +114,7 @@ impl<'me, K: Into<KeyWrapper> + From<&'me KeyWrapper> + ArrowReadableKey<'me> + 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::blockstore::provider::BlockfileProvider;
 
     #[test]
     fn test_new_writer() {
@@ -125,6 +129,8 @@ mod test {
         let blockfile_writer = provider.create::<&str, &str>().unwrap();
         let writer_id = blockfile_writer.id();
         let md_writer = MetadataIndexWriter::<&str>::new(blockfile_writer);
+        let flusher = md_writer.commit().await.unwrap();
+        flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
             .open::<&str, RoaringBitmap>(&writer_id)
@@ -132,39 +138,95 @@ mod test {
             .unwrap();
         let _reader = MetadataIndexReader::<&str>::new(blockfile_reader);
     }
+
+    #[tokio::test]
+    async fn test_string_metadata_index_set_get() {
+        let provider = BlockfileProvider::new_memory();
+        let blockfile_writer = provider.create::<&str, &str>().unwrap();
+        let writer_id = blockfile_writer.id();
+
+        let mut writer = MetadataIndexWriter::<&str>::new(blockfile_writer);
+        writer.set("key", "value", 1).unwrap();
+        writer.write_to_blockfile().await.unwrap();
+        let flusher = writer.commit().await.unwrap();
+        flusher.flush().await.unwrap();
+
+        let blockfile_reader = provider
+            .open::<&str, RoaringBitmap>(&writer_id)
+            .await
+            .unwrap();
+        let reader = MetadataIndexReader::<&str>::new(blockfile_reader);
+        let bitmap = reader.get("key", "value").await.unwrap();
+        assert_eq!(bitmap.len(), 1);
+        assert_eq!(bitmap.contains(1), true);
+    }
+
+    #[tokio::test]
+    async fn test_u32_metadata_index_set_get() {
+        let provider = BlockfileProvider::new_memory();
+        let blockfile_writer = provider.create::<u32, &str>().unwrap();
+        let writer_id = blockfile_writer.id();
+
+        let mut writer = MetadataIndexWriter::<u32>::new(blockfile_writer);
+        writer.set("key", 1, 1).unwrap();
+        writer.write_to_blockfile().await.unwrap();
+        let flusher = writer.commit().await.unwrap();
+        flusher.flush().await.unwrap();
+
+        let blockfile_reader = provider
+            .open::<u32, RoaringBitmap>(&writer_id)
+            .await
+            .unwrap();
+        let reader = MetadataIndexReader::<u32>::new(blockfile_reader);
+        let bitmap = reader.get("key", 1).await.unwrap();
+        assert_eq!(bitmap.len(), 1);
+        assert_eq!(bitmap.contains(1), true);
+    }
+
+    // #[tokio::test]
+    // async fn test_float_metadata_index_set_get() {
+    //     let provider = BlockfileProvider::new_memory();
+    //     let blockfile_writer = provider.create::<f32, &str>().unwrap();
+    //     let writer_id = blockfile_writer.id();
+
+    //     let mut writer = MetadataIndexWriter::<f32>::new(blockfile_writer);
+    //     writer.set("key", 1.0, 1).unwrap();
+    //     writer.write_to_blockfile().await.unwrap();
+    //     let flusher = writer.commit().await.unwrap();
+    //     flusher.flush().await.unwrap();
+
+    //     let blockfile_reader = provider
+    //         .open::<f32, RoaringBitmap>(&writer_id)
+    //         .await
+    //         .unwrap();
+    //     let reader = MetadataIndexReader::<f32>::new(blockfile_reader);
+    //     let bitmap = reader.get("key", 1.0).await.unwrap();
+    //     assert_eq!(bitmap.len(), 1);
+    //     assert_eq!(bitmap.contains(1), true);
+    // }
+
+    // #[tokio::test]
+    // async fn test_bool_value_metadata_index_set_get() {
+    //     let provider = BlockfileProvider::new_memory();
+    //     let blockfile_writer = provider.create::<&str, &str>().unwrap();
+    //     let writer_id = blockfile_writer.id();
+
+    //     let mut writer = MetadataIndexWriter::<bool>::new(blockfile_writer);
+    //     writer.set("key", true, 1).unwrap();
+    //     writer.write_to_blockfile().await.unwrap();
+    //     let flusher = writer.commit().await.unwrap();
+    //     flusher.flush().await.unwrap();
+
+    //     let blockfile_reader = provider
+    //         .open::<&str, RoaringBitmap>(&writer_id)
+    //         .await
+    //         .unwrap();
+    //     let reader = MetadataIndexReader::<&str>::new(blockfile_reader);
+    //     let bitmap = reader.get("key", true).await.unwrap();
+    //     assert_eq!(bitmap.len(), 1);
+    //     assert_eq!(bitmap.contains(1), true);
+    // }
 }
-
-//     #[test]
-//     fn test_string_value_metadata_index_set_get() {
-//         let mut provider = HashMapBlockfileProvider::new();
-//         let blockfile = provider
-//             .create("test", KeyType::String, ValueType::RoaringBitmap)
-//             .unwrap();
-//         let mut index = BlockfileMetadataIndex::<String>::new(blockfile);
-//         index.begin_transaction().unwrap();
-//         index.set("key", "value".to_string(), 1).unwrap();
-//         index.commit_transaction().unwrap();
-
-//         let bitmap = index.get("key", "value".to_string()).unwrap();
-//         assert_eq!(bitmap.len(), 1);
-//         assert_eq!(bitmap.contains(1), true);
-//     }
-
-//     #[test]
-//     fn test_float_value_metadata_index_set_get() {
-//         let mut provider = HashMapBlockfileProvider::new();
-//         let blockfile = provider
-//             .create("test", KeyType::String, ValueType::RoaringBitmap)
-//             .unwrap();
-//         let mut index = BlockfileMetadataIndex::<f32>::new(blockfile);
-//         index.begin_transaction().unwrap();
-//         index.set("key", 1.0, 1).unwrap();
-//         index.commit_transaction().unwrap();
-
-//         let bitmap = index.get("key", 1.0).unwrap();
-//         assert_eq!(bitmap.len(), 1);
-//         assert_eq!(bitmap.contains(1), true);
-//     }
 
 //     #[test]
 //     fn test_bool_value_metadata_index_set_get() {
@@ -276,432 +338,3 @@ mod test {
 //         let bitmap = index.get("key", "value".to_string()).unwrap();
 //         assert_eq!(bitmap.len(), 0);
 //     }
-
-//     use proptest::prelude::*;
-//     use proptest::test_runner::Config;
-//     use proptest_state_machine::{prop_state_machine, ReferenceStateMachine, StateMachineTest};
-//     use std::rc::Rc;
-
-//     // Utility function to check if a Vec<u32> and RoaringBitmap contain equivalent
-//     // sets.
-//     fn vec_rbm_eq(a: &Vec<u32>, b: &RoaringBitmap) -> bool {
-//         if a.len() != b.len() as usize {
-//             return false;
-//         }
-//         for offset in a {
-//             if !b.contains(*offset) {
-//                 return false;
-//             }
-//         }
-//         for offset in b {
-//             if !a.contains(&offset) {
-//                 return false;
-//             }
-//         }
-//         return true;
-//     }
-
-//     pub(crate) trait PropTestValue:
-//         MetadataIndexValue + PartialEq + Eq + Clone + std::hash::Hash + std::fmt::Debug
-//     {
-//         fn strategy() -> BoxedStrategy<Self>;
-//     }
-
-//     impl PropTestValue for String {
-//         fn strategy() -> BoxedStrategy<Self> {
-//             ".{0,10}".prop_map(|x| x.to_string()).boxed()
-//         }
-//     }
-
-//     impl PropTestValue for bool {
-//         fn strategy() -> BoxedStrategy<Self> {
-//             prop_oneof![Just(true), Just(false)].boxed()
-//         }
-//     }
-
-//     // f32 doesn't implement Hash or Eq so we need to wrap it to use
-//     // in our reference state machine's HashMap. This is a bit of a hack
-//     // but only used in tests.
-//     #[derive(Clone, Debug, PartialEq)]
-//     struct FloatWrapper(f32);
-
-//     impl std::hash::Hash for FloatWrapper {
-//         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-//             self.0.to_bits().hash(state);
-//         }
-//     }
-
-//     impl Eq for FloatWrapper {}
-
-//     impl MetadataIndexValue for FloatWrapper {
-//         fn to_blockfile_key(&self) -> Key {
-//             self.0.to_blockfile_key()
-//         }
-//     }
-
-//     impl PropTestValue for FloatWrapper {
-//         fn strategy() -> BoxedStrategy<Self> {
-//             (0..1000).prop_map(|x| FloatWrapper(x as f32)).boxed()
-//         }
-//     }
-
-//     #[derive(Clone, Debug)]
-//     pub(crate) enum Transition<T: PropTestValue> {
-//         BeginTransaction,
-//         CommitTransaction,
-//         Set(String, T, u32),
-//         Delete(String, T, u32),
-//         Get(String, T),
-//     }
-
-//     #[derive(Clone, Debug)]
-//     pub(crate) struct ReferenceState<T: PropTestValue> {
-//         // Are we in a transaction?
-//         in_transaction: bool,
-//         // {metadata key: {metadata value: offset ids}}
-//         data: HashMap<String, HashMap<T, Vec<u32>>>,
-//     }
-
-//     impl<T: PropTestValue> ReferenceState<T> {
-//         fn new() -> Self {
-//             ReferenceState {
-//                 in_transaction: false,
-//                 data: HashMap::new(),
-//             }
-//         }
-
-//         fn key_from_random_number(self: &Self, r1: usize) -> Option<String> {
-//             let keys = self.data.keys().collect::<Vec<&String>>();
-//             if keys.len() == 0 {
-//                 return None;
-//             }
-//             Some(keys[r1 % keys.len()].clone())
-//         }
-
-//         fn key_and_value_from_random_numbers(
-//             self: &Self,
-//             r1: usize,
-//             r2: usize,
-//         ) -> Option<(String, T)> {
-//             let k = self.key_from_random_number(r1)?;
-
-//             let values = self.data.get(&k)?.keys().collect::<Vec<&T>>();
-//             if values.len() == 0 {
-//                 return None;
-//             }
-//             let v = values[r2 % values.len()];
-//             Some((k.clone(), v.clone()))
-//         }
-
-//         fn key_and_value_and_entry_from_random_numbers(
-//             self: &Self,
-//             r1: usize,
-//             r2: usize,
-//             r3: usize,
-//         ) -> Option<(String, T, u32)> {
-//             let (k, v) = self.key_and_value_from_random_numbers(r1, r2)?;
-
-//             let offsets = self.data.get(&k)?.get(&v)?;
-//             if offsets.len() == 0 {
-//                 return None;
-//             }
-//             let oid = offsets[r3 % offsets.len()];
-//             Some((k.clone(), v.clone(), oid))
-//         }
-
-//         fn kv_rbm_eq(self: &Self, rbm: &RoaringBitmap, k: &str, v: &T) -> bool {
-//             match self.data.get(k) {
-//                 Some(vv) => match vv.get(v) {
-//                     Some(rbm2) => vec_rbm_eq(rbm2, rbm),
-//                     None => rbm.is_empty(),
-//                 },
-//                 None => rbm.is_empty(),
-//             }
-//         }
-//     }
-
-//     pub(crate) struct ReferenceStateMachineImpl<T: PropTestValue> {
-//         value_type: PhantomData<T>,
-//     }
-
-//     impl<T: PropTestValue + 'static> ReferenceStateMachine for ReferenceStateMachineImpl<T> {
-//         type State = ReferenceState<T>;
-//         type Transition = Transition<T>;
-
-//         fn init_state() -> BoxedStrategy<Self::State> {
-//             return Just(ReferenceState::<T>::new()).boxed();
-//         }
-
-//         fn transitions(state: &ReferenceState<T>) -> BoxedStrategy<Transition<T>> {
-//             let r = state.key_and_value_and_entry_from_random_numbers(0, 0, 0);
-//             if r.is_none() {
-//                 // Nothing in the reference state yet.
-//                 return prop_oneof![
-//                     Just(Transition::BeginTransaction),
-//                     Just(Transition::CommitTransaction),
-//                     // Set, get, delete random values
-//                     (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-//                         Transition::Set(k.to_string(), v, oid as u32)
-//                     }),
-//                     (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-//                         Transition::Delete(k.to_string(), v, oid as u32)
-//                     }),
-//                     (".{0,10}", T::strategy())
-//                         .prop_map(move |(k, v)| { Transition::Get(k.to_string(), v) }),
-//                 ]
-//                 .boxed();
-//             }
-
-//             let state = Rc::new(state.clone());
-//             return prop_oneof![
-//                 Just(Transition::BeginTransaction),
-//                 Just(Transition::CommitTransaction),
-//                 // Set, get, delete random values
-//                 (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-//                     Transition::Set(k.to_string(), v, oid as u32)
-//                 }),
-//                 (".{0,10}", T::strategy(), 1..1000).prop_map(move |(k, v, oid)| {
-//                     Transition::Delete(k.to_string(), v, oid as u32)
-//                 }),
-//                 (".{0,10}", T::strategy()).prop_map(move |(k, v)| {
-//                     Transition::Get(k.to_string(), v)
-//                 }),
-
-//                 // Sets on values in the reference state
-//                 (0..usize::MAX, T::strategy(), 1..1000).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, v, oid)| {
-//                         match state.key_from_random_number(r1) {
-//                             Some(k) => Transition::Set(k, v, oid as u32),
-//                             None => panic!("Error in the test harness: Setting on key from ref state")
-//                         }
-//                     }
-//                 }),
-//                 (0..usize::MAX, 0..usize::MAX, 1..1000).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, r2, oid)| {
-//                         match state.key_and_value_from_random_numbers(r1, r2) {
-//                             Some((k, v)) => Transition::Set(k, v, oid as u32),
-//                             None => panic!("Error in the test harness: Setting on key and value from ref state")
-//                         }
-//                     }
-//                 }),
-//                 (0..usize::MAX, 0..usize::MAX, 0..usize::MAX).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, r2, r3)| {
-//                         match state.key_and_value_and_entry_from_random_numbers(r1, r2, r3) {
-//                             Some((k, v, oid)) => Transition::Set(k, v, oid),
-//                             None => panic!("Error in the test harness: Setting on key, value, and entry from ref state")
-//                         }
-//                     }
-//                 }),
-
-//                 // Gets on values in the reference state
-//                 (0..usize::MAX, T::strategy()).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, v)| {
-//                         match state.key_from_random_number(r1) {
-//                             Some(k) => Transition::Get(k, v),
-//                             None => panic!("Error in the test harness: Getting on key from ref state")
-//                         }
-//                     }
-//                 }),
-//                 (0..usize::MAX, 0..usize::MAX).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, r2)| {
-//                         match state.key_and_value_from_random_numbers(r1, r2) {
-//                             Some((k, v)) => Transition::Get(k, v),
-//                             None => panic!("Error in the test harness: Getting on key and value from ref state")
-//                         }
-//                     }
-//                 }),
-
-//                 // Deletes on values in the reference state
-//                 (0..usize::MAX, T::strategy(), 1..1000).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, v, oid)| {
-//                         match state.key_from_random_number(r1) {
-//                             Some(k) => Transition::Delete(k, v, oid as u32),
-//                             None => panic!("Error in the test harness: Deleting on key from ref state")
-//                         }
-//                     }
-//                 }),
-//                 (0..usize::MAX, 0..usize::MAX, 1..1000).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, r2, oid)| {
-//                         match state.key_and_value_from_random_numbers(r1, r2) {
-//                             Some((k, v)) => Transition::Delete(k, v, oid as u32),
-//                             None => panic!("Error in the test harness: Deleting on key and value from ref state")
-//                         }
-//                     }
-//                 }),
-//                 (0..usize::MAX, 0..usize::MAX, 0..usize::MAX).prop_map({
-//                     let state = Rc::clone(&state);
-//                     move |(r1, r2, r3)| {
-//                         match state.key_and_value_and_entry_from_random_numbers(r1, r2, r3) {
-//                             Some((k, v, oid)) => Transition::Delete(k, v, oid as u32),
-//                             None => panic!("Error in the test harness: Deleting on key, value, and entry from ref state")
-//                         }
-//                     }
-//                 }),
-//             ].boxed();
-//         }
-
-//         fn apply(mut state: ReferenceState<T>, transition: &Transition<T>) -> Self::State {
-//             match transition {
-//                 Transition::BeginTransaction => {
-//                     state.in_transaction = true;
-//                 }
-//                 Transition::CommitTransaction => {
-//                     state.in_transaction = false;
-//                 }
-//                 Transition::Set(k, v, oid) => {
-//                     if !state.in_transaction {
-//                         return state;
-//                     }
-//                     let entry = state.data.entry(k.clone()).or_insert(HashMap::new());
-//                     let entry = entry.entry(v.clone()).or_insert(Vec::new());
-//                     if !entry.contains(oid) {
-//                         entry.push(*oid);
-//                     }
-//                 }
-//                 Transition::Delete(k, v, oid) => {
-//                     if !state.in_transaction {
-//                         return state;
-//                     }
-//                     if !state.data.contains_key(k) {
-//                         return state;
-//                     }
-//                     let entry = state.data.get_mut(k).unwrap();
-//                     if let Some(offsets) = entry.get_mut(v) {
-//                         offsets.retain(|x| *x != *oid);
-//                     }
-
-//                     // Remove the offset ID list if it's empty.
-//                     let offsets_count = entry.get(v).map(|x| x.len()).unwrap_or(0);
-//                     if offsets_count == 0 {
-//                         entry.remove(v);
-//                     }
-
-//                     // Remove the entire hashmap for the key if it's empty.
-//                     if entry.is_empty() {
-//                         state.data.remove(k);
-//                     }
-//                 }
-//                 Transition::Get(_, _) => {
-//                     // No-op
-//                 }
-//             }
-//             state
-//         }
-//     }
-
-//     impl<T: PropTestValue + 'static> StateMachineTest for BlockfileMetadataIndex<T> {
-//         type SystemUnderTest = Self;
-//         type Reference = ReferenceStateMachineImpl<T>;
-
-//         fn init_test(_ref_state: &ReferenceState<T>) -> Self::SystemUnderTest {
-//             // We don't need to set up on _ref_state since we always initialize
-//             // ref_state to empty.
-//             let mut provider = HashMapBlockfileProvider::new();
-//             let blockfile = provider
-//                 .create("test", KeyType::String, ValueType::RoaringBitmap)
-//                 .unwrap();
-//             return BlockfileMetadataIndex::<T>::new(blockfile);
-//         }
-
-//         fn apply(
-//             mut state: Self::SystemUnderTest,
-//             ref_state: &ReferenceState<T>,
-//             transition: Transition<T>,
-//         ) -> Self::SystemUnderTest {
-//             match transition {
-//                 Transition::BeginTransaction => {
-//                     let already_in_transaction = state.in_transaction();
-//                     let res = state.begin_transaction();
-//                     assert!(state.in_transaction());
-//                     if already_in_transaction {
-//                         assert!(res.is_err());
-//                     } else {
-//                         assert!(res.is_ok());
-//                     }
-//                 }
-//                 Transition::CommitTransaction => {
-//                     let in_transaction = state.in_transaction();
-//                     let res = state.commit_transaction();
-//                     assert_eq!(state.in_transaction(), false);
-//                     if !in_transaction {
-//                         assert!(res.is_err());
-//                     } else {
-//                         assert!(res.is_ok());
-//                     }
-//                 }
-//                 Transition::Set(k, v, oid) => {
-//                     let in_transaction = state.in_transaction();
-//                     let res = state.set(&k, v.clone(), oid);
-//                     if !in_transaction {
-//                         assert!(res.is_err());
-//                     } else {
-//                         assert!(res.is_ok());
-//                     }
-//                 }
-//                 Transition::Delete(k, v, oid) => {
-//                     let in_transaction = state.in_transaction();
-//                     let res = state.delete(&k, v, oid);
-//                     if !in_transaction {
-//                         assert!(res.is_err());
-//                     } else {
-//                         assert!(res.is_ok());
-//                     }
-//                 }
-//                 Transition::Get(k, v) => {
-//                     let in_transaction = state.in_transaction();
-//                     let res = state.get(&k, v.clone());
-//                     if in_transaction {
-//                         assert!(res.is_err());
-//                         return state;
-//                     }
-//                     let rbm = res.unwrap();
-//                     assert!(ref_state.kv_rbm_eq(&rbm, &k, &v));
-//                 }
-//             }
-//             state
-//         }
-
-//         fn check_invariants(state: &Self::SystemUnderTest, ref_state: &ReferenceState<T>) {
-//             assert_eq!(state.in_transaction(), ref_state.in_transaction);
-//             if state.in_transaction() {
-//                 return;
-//             }
-//             for (metadata_key, metadata_values_hm) in &ref_state.data {
-//                 for (metadata_value, ref_offset_ids) in metadata_values_hm {
-//                     assert!(vec_rbm_eq(
-//                         ref_offset_ids,
-//                         &state.get(metadata_key, metadata_value.clone()).unwrap()
-//                     ));
-//                 }
-//             }
-//             // TODO once we have a way to iterate over all state in the blockfile,
-//             // add a similar check here to make sure that blockfile data is a
-//             // subset of reference state data.
-//         }
-//     }
-
-//     prop_state_machine! {
-//         #![proptest_config(Config {
-//             // Enable verbose mode to make the state machine test print the
-//             // transitions for each case.
-//             verbose: 0,
-//             cases: 100,
-//             .. Config::default()
-//         })]
-//         #[test]
-//         fn proptest_string_metadata_index(sequential 1..100 => BlockfileMetadataIndex<String>);
-
-//         #[test]
-//         fn proptest_boolean_metadata_index(sequential 1..100 => BlockfileMetadataIndex<bool>);
-
-//         #[test]
-//         fn proptest_numeric_metadata_index(sequential 1..100 => BlockfileMetadataIndex<FloatWrapper>);
-//     }
-// }

--- a/rust/worker/src/index/mod.rs
+++ b/rust/worker/src/index/mod.rs
@@ -1,7 +1,7 @@
 // mod fulltext;
 mod hnsw;
-// mod metadata;
 pub(crate) mod hnsw_provider;
+mod metadata;
 mod types;
 mod utils;
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Migrate metadata indices to reader/writer pattern.
	 - This required adding bool keys to the arrow blockfile, and bool+f32 keys to the memory blockfile

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
