### PR TITLE
[BUG] Metadata query orchestrators were pulling logs including the last compacted offset

### DIFF
--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -212,7 +212,8 @@ impl CountQueryOrchestrator {
             .expect("Invariant violation. Collection is not set before pull logs state.");
         let input = PullLogsInput::new(
             collection.id,
-            collection.log_position,
+            // The collection log position is inclusive, and we want to start from the next log.
+            collection.log_position + 1,
             100,
             None,
             Some(end_timestamp),
@@ -527,7 +528,8 @@ impl MetadataQueryOrchestrator {
             .expect("Invariant violation. Collection is not set before pull logs state.");
         let input = PullLogsInput::new(
             collection.id,
-            collection.log_position,
+            // The collection log position is inclusive, and we want to start from the next log.
+            collection.log_position + 1,
             100,
             None,
             Some(end_timestamp),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	Metadata query orchestrators were pulling logs including the last compacted offset. PR fixes that
 - New functionality
        None

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
