### PR TITLE
[DOC] remove test labels from readme since we broke them out

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,6 @@
 </p>
 
 
-<p align="center">
-  <a href="https://github.com/chroma-core/chroma/actions/workflows/chroma-integration-test.yml" target="_blank">
-    <img src="https://github.com/chroma-core/chroma/actions/workflows/chroma-integration-test.yml/badge.svg?branch=main" alt="Integration Tests">
-  </a> |
-  <a href="https://github.com/chroma-core/chroma/actions/workflows/chroma-test.yml" target="_blank">
-    <img src="https://github.com/chroma-core/chroma/actions/workflows/chroma-test.yml/badge.svg?branch=main" alt="Tests">
-  </a>
-</p>
-
 ```bash
 pip install chromadb # python client
 # for javascript, npm install chromadb!


### PR DESCRIPTION
We broke our tests out and there isn't a good single workflow to pin them on

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
