### PR TITLE
[ENH] Add task id to dispatcher/worker

### DIFF
--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -201,14 +201,20 @@ impl Handler<TaskRequestMessage> for Dispatcher {
 
 #[cfg(test)]
 mod tests {
+    use parking_lot::Mutex;
+    use uuid::Uuid;
+
     use super::*;
     use crate::{
-        execution::operator::{wrap, Operator},
+        execution::operator::{wrap, Operator, TaskResult},
         system::System,
     };
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
+    use std::{
+        collections::HashSet,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
     };
 
     // Create a component that will schedule DISPATCH_COUNT invocations of the MockOperator
@@ -239,6 +245,8 @@ mod tests {
     struct MockDispatchUser {
         pub dispatcher: Box<dyn Receiver<TaskMessage>>,
         counter: Arc<AtomicUsize>, // We expect to recieve DISPATCH_COUNT messages
+        sent_tasks: Arc<Mutex<HashSet<Uuid>>>,
+        received_tasks: Arc<Mutex<HashSet<Uuid>>>,
     }
     #[async_trait]
     impl Component for MockDispatchUser {
@@ -263,10 +271,10 @@ mod tests {
         }
     }
     #[async_trait]
-    impl Handler<Result<String, ()>> for MockDispatchUser {
+    impl Handler<TaskResult<String, ()>> for MockDispatchUser {
         async fn handle(
             &mut self,
-            _message: Result<String, ()>,
+            _message: TaskResult<String, ()>,
             ctx: &ComponentContext<MockDispatchUser>,
         ) {
             self.counter.fetch_add(1, Ordering::SeqCst);
@@ -275,6 +283,7 @@ mod tests {
             if curr_count == DISPATCH_COUNT {
                 ctx.cancellation_token.cancel();
             }
+            self.received_tasks.lock().insert(_message.id());
         }
     }
 
@@ -282,6 +291,8 @@ mod tests {
     impl Handler<()> for MockDispatchUser {
         async fn handle(&mut self, _message: (), ctx: &ComponentContext<MockDispatchUser>) {
             let task = wrap(Box::new(MockOperator {}), 42.0, ctx.sender.as_receiver());
+            let task_id = task.id();
+            self.sent_tasks.lock().insert(task_id);
             let res = self.dispatcher.send(task, None).await;
         }
     }
@@ -292,9 +303,13 @@ mod tests {
         let dispatcher = Dispatcher::new(THREAD_COUNT, 1000, 1000);
         let dispatcher_handle = system.start_component(dispatcher);
         let counter = Arc::new(AtomicUsize::new(0));
+        let sent_tasks = Arc::new(Mutex::new(HashSet::new()));
+        let received_tasks = Arc::new(Mutex::new(HashSet::new()));
         let dispatch_user = MockDispatchUser {
             dispatcher: dispatcher_handle.receiver(),
             counter: counter.clone(),
+            sent_tasks: sent_tasks.clone(),
+            received_tasks: received_tasks.clone(),
         };
         let mut dispatch_user_handle = system.start_component(dispatch_user);
         // yield to allow the component to process the messages
@@ -303,5 +318,10 @@ mod tests {
         dispatch_user_handle.join().await;
         // We should have received DISPATCH_COUNT messages
         assert_eq!(counter.load(Ordering::SeqCst), DISPATCH_COUNT);
+        // The sent tasks should be equal to the received tasks
+        assert_eq!(*sent_tasks.lock(), *received_tasks.lock());
+        // The length of the sent/recieved tasks should be equal to the number of dispatched tasks
+        assert_eq!(sent_tasks.lock().len(), DISPATCH_COUNT);
+        assert_eq!(received_tasks.lock().len(), DISPATCH_COUNT);
     }
 }

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -42,8 +42,6 @@ pub struct BruteForceKnnOperatorOutput {
     pub distances: Vec<f32>,
 }
 
-pub type BruteForceKnnOperatorResult = Result<BruteForceKnnOperatorOutput, ()>;
-
 #[derive(Debug)]
 struct Entry {
     index: usize,
@@ -82,7 +80,10 @@ impl Eq for Entry {}
 impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for BruteForceKnnOperator {
     type Error = ();
 
-    async fn run(&self, input: &BruteForceKnnOperatorInput) -> BruteForceKnnOperatorResult {
+    async fn run(
+        &self,
+        input: &BruteForceKnnOperatorInput,
+    ) -> Result<BruteForceKnnOperatorOutput, Self::Error> {
         let mut heap = BinaryHeap::with_capacity(input.k);
         let data_chunk = &input.data;
         for data in data_chunk.iter() {

--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -44,13 +44,11 @@ pub struct FlushS3Output {
     pub(crate) segment_flush_info: Arc<[SegmentFlushInfo]>,
 }
 
-pub type FlushS3Result = Result<FlushS3Output, Box<dyn ChromaError>>;
-
 #[async_trait]
 impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
     type Error = Box<dyn ChromaError>;
 
-    async fn run(&self, input: &FlushS3Input) -> FlushS3Result {
+    async fn run(&self, input: &FlushS3Input) -> Result<FlushS3Output, Self::Error> {
         let record_segment_flusher = input.record_segment_writer.clone().commit();
         let record_segment_flush_info = match record_segment_flusher {
             Ok(flusher) => {

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -53,8 +53,6 @@ impl ChromaError for HnswKnnOperatorError {
     }
 }
 
-pub type HnswKnnOperatorResult = Result<HnswKnnOperatorOutput, Box<dyn ChromaError>>;
-
 impl HnswKnnOperator {
     async fn get_disallowed_ids(
         &self,
@@ -103,7 +101,10 @@ impl HnswKnnOperator {
 impl Operator<HnswKnnOperatorInput, HnswKnnOperatorOutput> for HnswKnnOperator {
     type Error = Box<dyn ChromaError>;
 
-    async fn run(&self, input: &HnswKnnOperatorInput) -> HnswKnnOperatorResult {
+    async fn run(
+        &self,
+        input: &HnswKnnOperatorInput,
+    ) -> Result<HnswKnnOperatorOutput, Self::Error> {
         let record_segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment,
             &input.blockfile_provider,

--- a/rust/worker/src/execution/operators/merge_knn_results.rs
+++ b/rust/worker/src/execution/operators/merge_knn_results.rs
@@ -66,16 +66,16 @@ impl ChromaError for MergeKnnResultsOperatorError {
     }
 }
 
-pub type MergeKnnResultsOperatorResult =
-    Result<MergeKnnResultsOperatorOutput, Box<dyn ChromaError>>;
-
 #[async_trait]
 impl Operator<MergeKnnResultsOperatorInput, MergeKnnResultsOperatorOutput>
     for MergeKnnResultsOperator
 {
     type Error = Box<dyn ChromaError>;
 
-    async fn run(&self, input: &MergeKnnResultsOperatorInput) -> MergeKnnResultsOperatorResult {
+    async fn run(
+        &self,
+        input: &MergeKnnResultsOperatorInput,
+    ) -> Result<MergeKnnResultsOperatorOutput, Self::Error> {
         let (result_user_ids, result_distances, result_vectors) =
             match RecordSegmentReader::from_segment(
                 &input.record_segment_definition,

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -78,9 +78,6 @@ impl ChromaError for MergeMetadataResultsOperatorError {
     }
 }
 
-pub type MergeMetadataResultsOperatorResult =
-    Result<MergeMetadataResultsOperatorOutput, MergeMetadataResultsOperatorError>;
-
 #[async_trait]
 impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOutput>
     for MergeMetadataResultsOperator
@@ -90,7 +87,7 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
     async fn run(
         &self,
         input: &MergeMetadataResultsOperatorInput,
-    ) -> MergeMetadataResultsOperatorResult {
+    ) -> Result<MergeMetadataResultsOperatorOutput, Self::Error> {
         trace!(
             "[MergeMetadataResultsOperator] segment id: {}",
             input.record_segment_definition.id.to_string()

--- a/rust/worker/src/execution/operators/partition.rs
+++ b/rust/worker/src/execution/operators/partition.rs
@@ -60,8 +60,6 @@ impl ChromaError for PartitionError {
     }
 }
 
-pub type PartitionResult = Result<PartitionOutput, PartitionError>;
-
 impl PartitionOperator {
     pub fn new() -> Box<Self> {
         Box::new(PartitionOperator {})
@@ -126,7 +124,7 @@ impl PartitionOperator {
 impl Operator<PartitionInput, PartitionOutput> for PartitionOperator {
     type Error = PartitionError;
 
-    async fn run(&self, input: &PartitionInput) -> PartitionResult {
+    async fn run(&self, input: &PartitionInput) -> Result<PartitionOutput, PartitionError> {
         let records = &input.records;
         let partition_size = self.determine_partition_size(records.len(), input.max_partition_size);
         let deduped_records = self.partition(records, partition_size);

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -85,13 +85,11 @@ impl PullLogsOutput {
     }
 }
 
-pub type PullLogsResult = Result<PullLogsOutput, PullLogsError>;
-
 #[async_trait]
 impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
     type Error = PullLogsError;
 
-    async fn run(&self, input: &PullLogsInput) -> PullLogsResult {
+    async fn run(&self, input: &PullLogsInput) -> Result<PullLogsOutput, PullLogsError> {
         // We expect the log to be cheaply cloneable, we need to clone it since we need
         // a mutable reference to it. Not necessarily the best, but it works for our needs.
         let mut client_clone = self.client.clone();

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -97,13 +97,11 @@ impl ChromaError for RegisterError {
     }
 }
 
-pub type RegisterResult = Result<RegisterOutput, RegisterError>;
-
 #[async_trait]
 impl Operator<RegisterInput, RegisterOutput> for RegisterOperator {
     type Error = RegisterError;
 
-    async fn run(&self, input: &RegisterInput) -> RegisterResult {
+    async fn run(&self, input: &RegisterInput) -> Result<RegisterOutput, RegisterError> {
         let mut sysdb = input.sysdb.clone();
         let mut log = input.log.clone();
         let result = sysdb

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -45,13 +45,11 @@ pub struct WriteSegmentsOutput {
     pub(crate) hnsw_segment_writer: Box<DistributedHNSWSegmentWriter>,
 }
 
-pub type WriteSegmentsResult = Result<WriteSegmentsOutput, ()>;
-
 #[async_trait]
 impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator {
     type Error = ();
 
-    async fn run(&self, input: &WriteSegmentsInput) -> WriteSegmentsResult {
+    async fn run(&self, input: &WriteSegmentsInput) -> Result<WriteSegmentsOutput, Self::Error> {
         println!("Materializing N Records: {:?}", input.chunk.len());
         let res = input.record_segment_writer.materialize(&input.chunk).await;
         println!("Materialized N Records: {:?}", res.len());


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Cleans up Result aliases in the operator since they are clunky and not enforced to follow. Verbose TaskResult<> is preferred.
 - New functionality
	 - This adds a task id to tasks sent to the dispatcher. The task id is sent back in a new TaskResult<> which wraps a Result<> and an id

## Test plan
*How are these changes tested?*
A test was modified in dispatcher.rs to ensure the ids are sent and received.  
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None