### PR TITLE
[ENH] support multiple queries in rust vectorreader

### DIFF
--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -2,6 +2,7 @@
 # instead of a property based test. We can use the delta to get the property
 # test working and then enable
 import random
+from typing import List
 from chromadb.api import ServerAPI
 import time
 
@@ -97,7 +98,7 @@ def test_add_include_all_with_compaction_delay(api: ServerAPI) -> None:
 
     ids_and_embeddings = list(zip(ids, embeddings))
 
-    def validate(results: QueryResult, query: list[float], result_index: int) -> None:
+    def validate(results: QueryResult, query: List[float], result_index: int) -> None:
         # Check that the distances are correct in l2
         gt_ids_distances_embeddings = [
             (id, sum((a - b) ** 2 for a, b in zip(embedding, query)), embedding)

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -770,15 +770,7 @@ impl Handler<TaskResult<MergeKnnResultsOperatorOutput, Box<dyn ChromaError>>>
             .expect("Invariant violation. Results are not set")
             .spare_capacity_mut();
         results_slice[query_index].write(query_results);
-        println!(
-            "Finish dependency count before: {}",
-            self.finish_dependency_count
-        );
         self.finish_dependency_count -= 1;
-        println!(
-            "Finish dependency count after: {}",
-            self.finish_dependency_count
-        );
 
         if self.finish_dependency_count == 0 {
             let result_channel = match self.result_channel.take() {

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -155,7 +155,7 @@ impl HnswQueryOrchestrator {
         // Set the finish dependency count to the number of query vectors
         // since each query vector will have a merge task
         let finish_dependency_count = query_vectors.len() as u32;
-        // pre-allcoate the result vectors
+        // pre-allocate the result vectors
         let results = Some(Vec::with_capacity(query_vectors.len()));
 
         HnswQueryOrchestrator {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Update test_sanity to excercise n > 1 queries.
 - New functionality
	 - This makes the hsnw query orchestrator able to respond to multiple queries, as the contract for it expects.

## Test plan
*How are these changes tested?*
Updated test_sanity
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
