### PR TITLE
[BUG] CHROMA_SERVER_NOFILE cannot be overriden with env var in container

### DIFF
--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 export IS_PERSISTENT=1
-export CHROMA_SERVER_NOFILE=65535
+export CHROMA_SERVER_NOFILE=${CHROMA_SERVER_NOFILE:-65536}
 args="$@"
 
 if [[ $args =~ ^uvicorn.* ]]; then


### PR DESCRIPTION
## Description of changes

Ref: #1404

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - CHROMA_SERVER_NOFILE is not correctly overriden by user env var provided in docker compose or .env file; defaults to 65536 otherwise. 

## Test plan
*How are these changes tested?*

Manually tested

## Documentation Changes
N/A
