### PR TITLE
[ENH] add OpenAI env var attribution for opanai embedding function

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -116,7 +116,7 @@ class Text2VecEmbeddingFunction(EmbeddingFunction[Documents]):
 class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: Optional[str] = os.getenv("OPENAI_API_KEY"),
         model_name: str = "text-embedding-ada-002",
         organization_id: Optional[str] = None,
         api_base: Optional[str] = None,
@@ -152,7 +152,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
             raise ValueError(
                 "The openai python package is not installed. Please install it with `pip install openai`"
             )
-
+            
         if api_key is not None:
             openai.api_key = api_key
         # If the api key is still not set, raise an error


### PR DESCRIPTION
By default set the OpenAIEmbeddingFunction API key to what is in the corresponding environment variable. This mimics the openai lib's behavior.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - by default apply the OPENAI_API_KEY env var to the openai.api_key
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
