### PR TITLE
[BUG] Fix bug with blockfile split

### DIFF
--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -33,15 +33,12 @@ pub(crate) struct ArrowBlockfileWriter {
 pub enum ArrowBlockfileError {
     #[error("Block not found")]
     BlockNotFound,
-    #[error("Split point not found")]
-    SplitPointNotFound,
 }
 
 impl ChromaError for ArrowBlockfileError {
     fn code(&self) -> ErrorCodes {
         match self {
             ArrowBlockfileError::BlockNotFound => ErrorCodes::Internal,
-            ArrowBlockfileError::SplitPointNotFound => ErrorCodes::Internal,
         }
     }
 }
@@ -145,7 +142,7 @@ impl ArrowBlockfileWriter {
                     }
                 }
                 None => {
-                    return Err(Box::new(ArrowBlockfileError::SplitPointNotFound));
+                    panic!("New block after split cannot be empty");
                 }
             }
             let mut deltas = self.block_deltas.lock();


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes

Consider the following scenario - 
1. Block has keys {4, 5, 6, 7} 
2. We want to insert key 2
3. Block is full so it needs to split
4. Split in the middle => block1: {4, 5}, block2: {6, 7}
5. [BUG] We insert the new key (i.e. 2) into the new block ALWAYS (i.e. here block2)
6. After insertion blocks are: block1: {4, 5}, block2: {2, 6, 7}
7. All the keys in Block1 are no longer < Keys in Block2 and we have an invariance violation thus a correctness issue!

Fix is to NOT ALWAYS insert the key into the new block but rather insert it into the block which fits in the range i.e. here in Block1.

## Test plan
Added a unit test
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
