### PR TITLE
[TST] Enable test_add in distributed tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -72,6 +72,7 @@ jobs:
         platform: ["16core-64gb-ubuntu-latest"]
         test-globs: ["chromadb/test/db/test_system.py",
                    "chromadb/test/property/test_collections.py",
+                   "chromadb/test/property/test_add.py",
                    "chromadb/test/property/test_collections_with_database_tenant.py",
                    "chromadb/test/ingest/test_producer_consumer.py",
                    "chromadb/test/segment/distributed/test_memberlist_provider.py",

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -42,6 +42,8 @@ hypothesis.settings.register_profile(
 hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))
 
 NOT_CLUSTER_ONLY = os.getenv("CHROMA_CLUSTER_TEST_ONLY") != "1"
+MEMBERLIST_SLEEP = 5
+COMPACTION_SLEEP = 120
 
 
 def skip_if_not_cluster() -> pytest.MarkDecorator:

--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -7,10 +7,9 @@ from chromadb.api import ServerAPI
 import time
 
 from chromadb.api.types import QueryResult
+from chromadb.test.conftest import COMPACTION_SLEEP, MEMBERLIST_SLEEP
 
 EPS = 1e-6
-MEMBERLIST_SLEEP = 5
-COMPACTION_SLEEP = 120
 
 
 def test_add(


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Moves some distributed test consts into conftest so its shared across tests
	 - enables test_add
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
This enables tests
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
