### PR TITLE
Allow using Azure for embedding with the JS client + fix docker-compose for running tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
       - ALLOW_RESET=True
       - IS_PERSISTENT=True
     ports:
-      - 8000:8000
+      - "${CHROMA_PORT:-8000}:8000"
     networks:
       - test_net
 

--- a/docs/docs.trychroma.com/pages/integrations/openai.md
+++ b/docs/docs.trychroma.com/pages/integrations/openai.md
@@ -74,5 +74,19 @@ const collection = await client.getCollection({
 })
 ```
 
+To use the OpenAI embedding models on other platforms such as Azure, you can use the `api_base` and `api_type` parameters:
+```javascript
+const {OpenAIEmbeddingFunction} = require('chromadb');
+const embeddingFunction = new OpenAIEmbeddingFunction({
+    openai_api_key: "apiKey",
+    api_type: "azure",
+    api_version: "apiVersion",
+    api_base: "apiBase",
+    deployment: "deployment",
+    model: "text-embedding-3-small"
+})
+```
+
+
 {% /tab %}
 {% /tabs %}


### PR DESCRIPTION
## Description of changes
Add the possibility to use Azure for embeddings with the JS client (same ability as the python client)

*Summarize the changes made by this PR.*
 - New functionality
	 - allow using Azure for embedding with the JS client (just like the Python client)
 - Small fix in docker-compose file for test : set the chromadb port with env var.

## Test plan
- [x] built and ran tests locally.

## Documentation Changes
Docs were updated (very similar to the existing python docs)
