### PR TITLE
[CLN] Make collection api object wrap model.

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -3,7 +3,6 @@ import logging
 from typing import Optional, cast, Tuple
 from typing import Sequence
 from uuid import UUID
-
 import requests
 from overrides import override
 
@@ -41,6 +40,7 @@ from chromadb.telemetry.opentelemetry import (
 )
 from chromadb.telemetry.product import ProductTelemetryClient
 from urllib.parse import urlparse, urlunparse, quote
+from chromadb.types import Collection as CollectionModel
 
 logger = logging.getLogger(__name__)
 
@@ -254,13 +254,20 @@ class FastAPI(ServerAPI):
         )
         raise_chroma_error(resp)
         resp_json = json.loads(resp.text)
-        return Collection(
-            client=self,
+        model = CollectionModel(
             id=resp_json["id"],
             name=resp_json["name"],
+            metadata=resp_json["metadata"],
+            dimension=resp_json["dimension"],
+            tenant=resp_json["tenant"],
+            database=resp_json["database"],
+            version=resp_json["version"],
+        )
+        return Collection(
+            client=self,
+            model=model,
             embedding_function=embedding_function,
             data_loader=data_loader,
-            metadata=resp_json["metadata"],
         )
 
     @trace_method("FastAPI.get_collection", OpenTelemetryGranularity.OPERATION)
@@ -288,13 +295,20 @@ class FastAPI(ServerAPI):
         )
         raise_chroma_error(resp)
         resp_json = json.loads(resp.text)
+        model = CollectionModel(
+            id=resp_json["id"],
+            name=resp_json["name"],
+            metadata=resp_json["metadata"],
+            dimension=resp_json["dimension"],
+            tenant=resp_json["tenant"],
+            database=resp_json["database"],
+            version=resp_json["version"],
+        )
         return Collection(
             client=self,
-            name=resp_json["name"],
-            id=resp_json["id"],
+            model=model,
             embedding_function=embedding_function,
             data_loader=data_loader,
-            metadata=resp_json["metadata"],
         )
 
     @trace_method(

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -209,7 +209,16 @@ class FastAPI(ServerAPI):
         json_collections = json.loads(resp.text)
         collections = []
         for json_collection in json_collections:
-            collections.append(Collection(self, **json_collection))
+            model = CollectionModel(
+                id=json_collection["id"],
+                name=json_collection["name"],
+                metadata=json_collection["metadata"],
+                dimension=json_collection["dimension"],
+                tenant=json_collection["tenant"],
+                database=json_collection["database"],
+                version=json_collection["version"],
+            )
+            collections.append(Collection(self, model=model))
 
         return collections
 

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Tuple, Any, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Any, Union, cast
 import numpy as np
 from uuid import UUID
 import chromadb.utils.embedding_functions as ef
@@ -90,6 +90,10 @@ class Collection:
     @property
     def name(self) -> str:
         return self._model["name"]
+
+    @property
+    def metadata(self) -> CollectionMetadata:
+        return cast(CollectionMetadata, self._model["metadata"])
 
     @property
     def tenant(self) -> str:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -42,6 +42,11 @@ from chromadb.api.types import (
     validate_embeddings,
     validate_embedding_function,
 )
+
+# TODO: We should rename the types in chromadb.types to be Models where
+# appropriate. This will help to distinguish between manipulation objects
+# which are essentially API views. And the actual data models which are
+# stored / retrieved / transmitted.
 from chromadb.types import Collection as CollectionModel
 import logging
 
@@ -421,6 +426,7 @@ class Collection:
 
         # Note there is a race condition here where the metadata can be updated
         # but another thread sees the cached local metadata.
+        # TODO: fixme
         self._client._modify(id=self.id, new_name=name, new_metadata=metadata)
         if name:
             self._model["name"] = name

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -103,6 +103,26 @@ class Collection:
     def database(self) -> str:
         return self._model["database"]
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Collection):
+            return False
+        id_match = self.id == other.id
+        name_match = self.name == other.name
+        metadata_match = self.metadata == other.metadata
+        tenant_match = self.tenant == other.tenant
+        database_match = self.database == other.database
+        embedding_function_match = self._embedding_function == other._embedding_function
+        data_loader_match = self._data_loader == other._data_loader
+        return (
+            id_match
+            and name_match
+            and metadata_match
+            and tenant_match
+            and database_match
+            and embedding_function_match
+            and data_loader_match
+        )
+
     def get_model(self) -> CollectionModel:
         return self._model
 

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -201,13 +201,9 @@ class SegmentAPI(ServerAPI):
 
         return Collection(
             client=self,
-            id=coll["id"],
-            name=name,
-            metadata=coll["metadata"],  # type: ignore
+            model=coll,
             embedding_function=embedding_function,
             data_loader=data_loader,
-            tenant=tenant,
-            database=database,
         )
 
     @trace_method(
@@ -260,13 +256,9 @@ class SegmentAPI(ServerAPI):
         if existing:
             return Collection(
                 client=self,
-                id=existing[0]["id"],
-                name=existing[0]["name"],
-                metadata=existing[0]["metadata"],  # type: ignore
+                model=existing[0],
                 embedding_function=embedding_function,
                 data_loader=data_loader,
-                tenant=existing[0]["tenant"],
-                database=existing[0]["database"],
             )
         else:
             raise ValueError(f"Collection {name} does not exist.")
@@ -288,11 +280,7 @@ class SegmentAPI(ServerAPI):
             collections.append(
                 Collection(
                     client=self,
-                    id=db_collection["id"],
-                    name=db_collection["name"],
-                    metadata=db_collection["metadata"],  # type: ignore
-                    tenant=db_collection["tenant"],
-                    database=db_collection["database"],
+                    model=db_collection,
                 )
             )
         return collections

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -57,6 +57,8 @@ test("it should create a collection", async () => {
       id: collection2.id,
       database: "default_database",
       tenant: "default_tenant",
+      dimenion: null,
+      version: 0,
     },
   ]).toEqual(expect.arrayContaining(collections2));
 });

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -30,6 +30,7 @@ test("it should create a collection", async () => {
       database: "default_database",
       tenant: "default_tenant",
       version: 0,
+      dimension: null,
     },
   ]).toEqual(expect.arrayContaining(collections));
   expect([{ name: "test2", metadata: null }]).not.toEqual(

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -57,7 +57,7 @@ test("it should create a collection", async () => {
       id: collection2.id,
       database: "default_database",
       tenant: "default_tenant",
-      dimenion: null,
+      dimension: null,
       version: 0,
     },
   ]).toEqual(expect.arrayContaining(collections2));

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -29,6 +29,7 @@ test("it should create a collection", async () => {
       id: collection.id,
       database: "default_database",
       tenant: "default_tenant",
+      version: 0,
     },
   ]).toEqual(expect.arrayContaining(collections));
   expect([{ name: "test2", metadata: null }]).not.toEqual(


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This is cleanup borrowed from #1491. It makes Collection.py wrap a model instead of duplicating data into collection.py and implictly treating it as a serializable model. This is a cleaner seperation of concerns. We have the model object, and an API wrapper used to manipulate it via the api. 
 - New functionality
	 - None

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
