### PR TITLE
[TST] Increase the number of retry to 30 to reduce memberlist test flakyness

### DIFF
--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -185,7 +185,7 @@ func TestMemberlistManager(t *testing.T) {
 	// Get the memberlist
 	ok := retryUntilCondition(func() bool {
 		return getMemberlistAndCompare(t, memberlistStore, Memberlist{Member{id: "test-pod-0"}})
-	}, 10, 1*time.Second)
+	}, 30, 1*time.Second)
 	if !ok {
 		t.Fatalf("Memberlist did not update after adding a pod")
 	}
@@ -196,7 +196,7 @@ func TestMemberlistManager(t *testing.T) {
 	// Get the memberlist
 	ok = retryUntilCondition(func() bool {
 		return getMemberlistAndCompare(t, memberlistStore, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}})
-	}, 10, 1*time.Second)
+	}, 30, 1*time.Second)
 	if !ok {
 		t.Fatalf("Memberlist did not update after adding a pod")
 	}
@@ -207,7 +207,7 @@ func TestMemberlistManager(t *testing.T) {
 	// Get the memberlist
 	ok = retryUntilCondition(func() bool {
 		return getMemberlistAndCompare(t, memberlistStore, Memberlist{Member{id: "test-pod-1"}})
-	}, 10, 1*time.Second)
+	}, 30, 1*time.Second)
 	if !ok {
 		t.Fatalf("Memberlist did not update after deleting a pod")
 	}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 -  This PR increases the number of retry to 30 to reduce memberlist test flakyness.
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
