### PR TITLE
Use existing model instance in SentenceTransformerEmbeddingFunction

### DIFF
--- a/chromadb/utils/embedding_functions.py
+++ b/chromadb/utils/embedding_functions.py
@@ -62,9 +62,9 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         self,
         model_name: str = "all-MiniLM-L6-v2",
         device: str = "cpu",
+        normalize_embeddings: bool = False,
         # Since we do dynamic imports we have to type this as Any
         model: Any = None,
-        normalize_embeddings: bool = False,
         **kwargs: Any,
     ):
         """Initialize SentenceTransformerEmbeddingFunction.
@@ -72,8 +72,8 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         Args:
             model_name (str, optional): Identifier of the SentenceTransformer model, defaults to "all-MiniLM-L6-v2"
             device (str, optional): Device used for computation, defaults to "cpu"
-            model (SentenceTransformer, optional): SentenceTransformer model
             normalize_embeddings (bool, optional): Whether to normalize returned vectors, defaults to False
+            model (SentenceTransformer, optional): SentenceTransformer model
             **kwargs: Additional arguments to pass to the SentenceTransformer model.
         """
         if model is not None or model_name not in self.models:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - ~~Improvements & Bug fixes~~
 - New functionality
	 - Add model argument to SentenceTransformerEmbeddingFunction: Initialize instance with existing loaded model.
	 - Useful for modifying a model parameter or its structure before usage.

## Test plan
*How are these changes tested?*

- [ ] ~~Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust~~
- [x] Updated class has been tested in a private project as a drop-in replacement.
  - Swapped the Chroma import for a local import.
  - Standard usage of the class in a Chroma collection.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

- Yes, docstrings for user-facing APIs has been updated. 
  - One argument has been added, a docstring has been added for it.
- Yes, the documentation could be changed to describe this new usage.
  - Relevant documentation page: [docs.trychroma.com/guides/embeddings#sentence-transformers](https://docs.trychroma.com/guides/embeddings#sentence-transformers)