### PR TITLE
[ENH] Rust types for metadata queries

### DIFF
--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -74,6 +74,7 @@ message UpdateMetadataValue {
         string string_value = 1;
         int64 int_value = 2;
         double float_value = 3;
+        bool boolean_value = 4;
     }
 }
 
@@ -176,6 +177,8 @@ message DirectComparison {
         IntListComparison int_list_operand = 5;
         SingleDoubleComparison single_double_operand = 6;
         DoubleListComparison double_list_operand = 7;
+        SingleBooleanComparison single_boolean_operand = 8;
+        BooleanListComparison boolean_list_operand = 9;
     }
 }
 
@@ -258,6 +261,19 @@ message SingleDoubleComparison {
         GenericComparator generic_comparator = 2;
         NumberComparator number_comparator = 3;
     }
+}
+
+// Used when a leaf-node `Where` clause compares a boolean to a list of booleans.
+// `ListOperator` specifies whether values in the list are allowed or disallowed.
+message BooleanListComparison {
+    repeated bool values = 1;
+    ListOperator list_operator = 2;
+}
+
+// Used when a leaf-node `Where` clause compares a boolean to a single boolean.
+message SingleBooleanComparison {
+    bool value = 1;
+    GenericComparator comparator = 2;
 }
 
 /* Vector Reader Interface */

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -74,7 +74,6 @@ message UpdateMetadataValue {
         string string_value = 1;
         int64 int_value = 2;
         double float_value = 3;
-        bool boolean_value = 4;
     }
 }
 
@@ -177,8 +176,6 @@ message DirectComparison {
         IntListComparison int_list_operand = 5;
         SingleDoubleComparison single_double_operand = 6;
         DoubleListComparison double_list_operand = 7;
-        SingleBooleanComparison single_boolean_operand = 8;
-        BooleanListComparison boolean_list_operand = 9;
     }
 }
 
@@ -261,19 +258,6 @@ message SingleDoubleComparison {
         GenericComparator generic_comparator = 2;
         NumberComparator number_comparator = 3;
     }
-}
-
-// Used when a leaf-node `Where` clause compares a boolean to a list of booleans.
-// `ListOperator` specifies whether values in the list are allowed or disallowed.
-message BooleanListComparison {
-    repeated bool values = 1;
-    ListOperator list_operator = 2;
-}
-
-// Used when a leaf-node `Where` clause compares a boolean to a single boolean.
-message SingleBooleanComparison {
-    bool value = 1;
-    GenericComparator comparator = 2;
 }
 
 /* Vector Reader Interface */

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -280,6 +280,75 @@ pub(crate) fn update_metdata_to_metdata(
     Ok(metadata)
 }
 
+/*
+===========================================
+Metadata queries
+===========================================
+*/
+
+pub(crate) enum Where {
+    DirectWhereComparison(DirectComparison),
+    WhereChildren(WhereChildren),
+}
+
+pub(crate) struct DirectComparison {
+    pub key: String,
+    pub comparison: WhereComparison,
+}
+
+pub(crate) enum WhereComparison {
+    SingleStringComparison(String, WhereClauseComparator),
+    SingleIntComparison(i32, WhereClauseComparator),
+    SingleFloatComparison(f64, WhereClauseComparator),
+    StringListComparison(Vec<String>, WhereClauseListOperator),
+    IntListComparison(Vec<i32>, WhereClauseListOperator),
+    FloatListComparison(Vec<f64>, WhereClauseListOperator),
+}
+
+pub(crate) enum WhereClauseComparator {
+    Equal,
+    NotEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}
+
+pub(crate) enum WhereClauseListOperator {
+    In,
+    NotIn,
+}
+
+pub(crate) struct WhereChildren {
+    pub children: Vec<Where>,
+    pub operator: WhereChildrenOperator,
+}
+
+pub(crate) enum WhereChildrenOperator {
+    And,
+    Or,
+}
+
+pub(crate) enum WhereDocument {
+    DirectWhereDocumentComparison(DirectDocumentComparison),
+    WhereDocumentChildren(WhereDocumentChildren),
+}
+
+pub(crate) struct DirectDocumentComparison {
+    pub key: String,
+    pub operator: WhereDocumentOperator,
+}
+
+pub(crate) enum WhereDocumentOperator {
+    Contains,
+    NotContains,
+}
+
+pub(crate) struct WhereDocumentChildren {
+    pub children: Vec<WhereDocument>,
+    pub operator: WhereChildrenOperator,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -299,10 +299,10 @@ pub(crate) struct DirectComparison {
 pub(crate) enum WhereComparison {
     SingleStringComparison(String, WhereClauseComparator),
     SingleIntComparison(i32, WhereClauseComparator),
-    SingleFloatComparison(f64, WhereClauseComparator),
+    SingleDoubleComparison(f64, WhereClauseComparator),
     StringListComparison(Vec<String>, WhereClauseListOperator),
     IntListComparison(Vec<i32>, WhereClauseListOperator),
-    FloatListComparison(Vec<f64>, WhereClauseListOperator),
+    DoubleListComparison(Vec<f64>, WhereClauseListOperator),
 }
 
 pub(crate) enum WhereClauseComparator {
@@ -321,10 +321,10 @@ pub(crate) enum WhereClauseListOperator {
 
 pub(crate) struct WhereChildren {
     pub children: Vec<Where>,
-    pub operator: WhereChildrenOperator,
+    pub operator: BooleanOperator,
 }
 
-pub(crate) enum WhereChildrenOperator {
+pub(crate) enum BooleanOperator {
     And,
     Or,
 }
@@ -335,7 +335,7 @@ pub(crate) enum WhereDocument {
 }
 
 pub(crate) struct DirectDocumentComparison {
-    pub key: String,
+    pub document: String,
     pub operator: WhereDocumentOperator,
 }
 
@@ -346,7 +346,288 @@ pub(crate) enum WhereDocumentOperator {
 
 pub(crate) struct WhereDocumentChildren {
     pub children: Vec<WhereDocument>,
-    pub operator: WhereChildrenOperator,
+    pub operator: BooleanOperator,
+}
+
+pub(crate) enum WhereConversionError {
+    InvalidWhere,
+    InvalidWhereComparison,
+    InvalidWhereChildren,
+}
+
+impl TryFrom<chroma_proto::Where> for Where {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_where: chroma_proto::Where) -> Result<Self, Self::Error> {
+        match proto_where.r#where {
+            Some(chroma_proto::r#where::Where::DirectComparison(proto_comparison)) => {
+                let comparison = DirectComparison {
+                    key: proto_comparison.key.clone(),
+                    comparison: proto_comparison.try_into()?,
+                };
+                Ok(Where::DirectWhereComparison(comparison))
+            }
+            Some(chroma_proto::r#where::Where::Children(proto_children)) => {
+                let operator = match TryInto::<chroma_proto::BooleanOperator>::try_into(
+                    proto_children.operator,
+                ) {
+                    Ok(operator) => operator,
+                    Err(_) => return Err(WhereConversionError::InvalidWhereChildren),
+                };
+                let children = WhereChildren {
+                    children: proto_children
+                        .children
+                        .into_iter()
+                        .map(|child| child.try_into())
+                        .collect::<Result<Vec<Where>, WhereConversionError>>()?,
+                    operator: operator.try_into()?,
+                };
+                Ok(Where::WhereChildren(children))
+            }
+            None => Err(WhereConversionError::InvalidWhere),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::DirectComparison> for WhereComparison {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_comparison: chroma_proto::DirectComparison) -> Result<Self, Self::Error> {
+        match proto_comparison.r#comparison {
+            Some(chroma_proto::direct_comparison::Comparison::SingleStringOperand(
+                proto_string,
+            )) => {
+                let comparator = match TryInto::<chroma_proto::GenericComparator>::try_into(
+                    proto_string.comparator,
+                ) {
+                    Ok(comparator) => comparator,
+                    Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                };
+                Ok(WhereComparison::SingleStringComparison(
+                    proto_string.value,
+                    comparator.try_into()?,
+                ))
+            }
+            Some(chroma_proto::direct_comparison::Comparison::SingleIntOperand(proto_int)) => {
+                let comparator: WhereClauseComparator = match proto_int.comparator {
+                    Some(comparator) => match comparator {
+                        chroma_proto::single_int_comparison::Comparator::NumberComparator(
+                            proto_comparator,
+                        ) => {
+                            match TryInto::<chroma_proto::NumberComparator>::try_into(
+                                proto_comparator,
+                            ) {
+                                Ok(comparator) => comparator.try_into()?,
+                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                            }
+                        }
+                        chroma_proto::single_int_comparison::Comparator::GenericComparator(
+                            proto_comparator,
+                        ) => {
+                            match TryInto::<chroma_proto::GenericComparator>::try_into(
+                                proto_comparator,
+                            ) {
+                                Ok(comparator) => comparator.try_into()?,
+                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                            }
+                        }
+                    },
+                    None => WhereClauseComparator::Equal,
+                };
+                Ok(WhereComparison::SingleIntComparison(
+                    proto_int.value as i32,
+                    comparator,
+                ))
+            }
+            Some(chroma_proto::direct_comparison::Comparison::SingleDoubleOperand(
+                proto_double,
+            )) => {
+                let comparator: WhereClauseComparator = match proto_double.comparator {
+                    Some(comparator) => match comparator {
+                        chroma_proto::single_double_comparison::Comparator::NumberComparator(
+                            proto_comparator,
+                        ) => {
+                            match TryInto::<chroma_proto::NumberComparator>::try_into(
+                                proto_comparator,
+                            ) {
+                                Ok(comparator) => comparator.try_into()?,
+                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                            }
+                        }
+                        chroma_proto::single_double_comparison::Comparator::GenericComparator(
+                            proto_comparator,
+                        ) => {
+                            match TryInto::<chroma_proto::GenericComparator>::try_into(
+                                proto_comparator,
+                            ) {
+                                Ok(comparator) => comparator.try_into()?,
+                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                            }
+                        }
+                    },
+                    None => WhereClauseComparator::Equal,
+                };
+                Ok(WhereComparison::SingleDoubleComparison(
+                    proto_double.value,
+                    comparator,
+                ))
+            }
+            Some(chroma_proto::direct_comparison::Comparison::StringListOperand(proto_list)) => {
+                let list_operator =
+                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
+                    {
+                        Ok(list_operator) => list_operator,
+                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                    };
+                Ok(WhereComparison::StringListComparison(
+                    proto_list.values,
+                    list_operator.try_into()?,
+                ))
+            }
+            Some(chroma_proto::direct_comparison::Comparison::IntListOperand(proto_list)) => {
+                let list_operator =
+                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
+                    {
+                        Ok(list_operator) => list_operator,
+                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                    };
+                Ok(WhereComparison::IntListComparison(
+                    proto_list.values.into_iter().map(|v| v as i32).collect(),
+                    list_operator.try_into()?,
+                ))
+            }
+            Some(chroma_proto::direct_comparison::Comparison::DoubleListOperand(proto_list)) => {
+                let list_operator =
+                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
+                    {
+                        Ok(list_operator) => list_operator,
+                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                    };
+                Ok(WhereComparison::DoubleListComparison(
+                    proto_list.values,
+                    list_operator.try_into()?,
+                ))
+            }
+            None => Err(WhereConversionError::InvalidWhereComparison),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::NumberComparator> for WhereClauseComparator {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_comparator: chroma_proto::NumberComparator) -> Result<Self, Self::Error> {
+        match proto_comparator {
+            chroma_proto::NumberComparator::Gt => Ok(WhereClauseComparator::GreaterThan),
+            chroma_proto::NumberComparator::Gte => Ok(WhereClauseComparator::GreaterThanOrEqual),
+            chroma_proto::NumberComparator::Lt => Ok(WhereClauseComparator::LessThan),
+            chroma_proto::NumberComparator::Lte => Ok(WhereClauseComparator::LessThanOrEqual),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::GenericComparator> for WhereClauseComparator {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_comparator: chroma_proto::GenericComparator) -> Result<Self, Self::Error> {
+        match proto_comparator {
+            chroma_proto::GenericComparator::Eq => Ok(WhereClauseComparator::Equal),
+            chroma_proto::GenericComparator::Ne => Ok(WhereClauseComparator::NotEqual),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::ListOperator> for WhereClauseListOperator {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_operator: chroma_proto::ListOperator) -> Result<Self, Self::Error> {
+        match proto_operator {
+            chroma_proto::ListOperator::In => Ok(WhereClauseListOperator::In),
+            chroma_proto::ListOperator::Nin => Ok(WhereClauseListOperator::NotIn),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::WhereChildren> for WhereChildren {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_children: chroma_proto::WhereChildren) -> Result<Self, Self::Error> {
+        let children = proto_children
+            .children
+            .into_iter()
+            .map(|child| child.try_into())
+            .collect::<Result<Vec<Where>, WhereConversionError>>()?;
+        let operator: BooleanOperator =
+            match TryInto::<chroma_proto::BooleanOperator>::try_into(proto_children.operator) {
+                Ok(operator) => operator.try_into()?,
+                Err(_) => return Err(WhereConversionError::InvalidWhereChildren),
+            };
+        Ok(WhereChildren { children, operator })
+    }
+}
+
+impl TryFrom<chroma_proto::BooleanOperator> for BooleanOperator {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_operator: chroma_proto::BooleanOperator) -> Result<Self, Self::Error> {
+        match proto_operator {
+            chroma_proto::BooleanOperator::And => Ok(BooleanOperator::And),
+            chroma_proto::BooleanOperator::Or => Ok(BooleanOperator::Or),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::WhereDocument> for WhereDocument {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_document: chroma_proto::WhereDocument) -> Result<Self, Self::Error> {
+        match proto_document.r#where_document {
+            Some(chroma_proto::where_document::WhereDocument::Direct(proto_comparison)) => {
+                let operator = match TryInto::<chroma_proto::WhereDocumentOperator>::try_into(
+                    proto_comparison.operator,
+                ) {
+                    Ok(operator) => operator,
+                    Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
+                };
+                let comparison = DirectDocumentComparison {
+                    document: proto_comparison.document,
+                    operator: operator.try_into()?,
+                };
+                Ok(WhereDocument::DirectWhereDocumentComparison(comparison))
+            }
+            Some(chroma_proto::where_document::WhereDocument::Children(proto_children)) => {
+                let operator = match TryInto::<chroma_proto::BooleanOperator>::try_into(
+                    proto_children.operator,
+                ) {
+                    Ok(operator) => operator,
+                    Err(_) => return Err(WhereConversionError::InvalidWhereChildren),
+                };
+                let children = WhereDocumentChildren {
+                    children: proto_children
+                        .children
+                        .into_iter()
+                        .map(|child| child.try_into())
+                        .collect::<Result<Vec<WhereDocument>, WhereConversionError>>()?,
+                    operator: operator.try_into()?,
+                };
+                Ok(WhereDocument::WhereDocumentChildren(children))
+            }
+            None => Err(WhereConversionError::InvalidWhere),
+        }
+    }
+}
+
+impl TryFrom<chroma_proto::WhereDocumentOperator> for WhereDocumentOperator {
+    type Error = WhereConversionError;
+
+    fn try_from(proto_operator: chroma_proto::WhereDocumentOperator) -> Result<Self, Self::Error> {
+        match proto_operator {
+            chroma_proto::WhereDocumentOperator::Contains => Ok(WhereDocumentOperator::Contains),
+            chroma_proto::WhereDocumentOperator::NotContains => {
+                Ok(WhereDocumentOperator::NotContains)
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Rust types for Where and WhereDocument queries.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
