### PR TITLE
[ENH] Add log materializer v2 taking care of updates/deletes/upserts + wire compactor to use it + clean up old abstraction

### DIFF
--- a/rust/worker/src/blockstore/arrow/block/data_record_value.rs
+++ b/rust/worker/src/blockstore/arrow/block/data_record_value.rs
@@ -70,11 +70,21 @@ impl ArrowWriteableValue for &DataRecord<'_> {
             BlockStorage::DataRecord(builder) => {
                 let mut id_storage = builder.id_storage.write();
                 let mut embedding_storage = builder.embedding_storage.write();
+                let mut metadata_storage = builder.metadata_storage.write();
+                let mut document_storage = builder.document_storage.write();
                 id_storage.remove(&CompositeKey {
                     prefix: prefix.to_string(),
                     key: key.clone(),
                 });
                 embedding_storage.remove(&CompositeKey {
+                    prefix: prefix.to_string(),
+                    key: key.clone(),
+                });
+                metadata_storage.remove(&CompositeKey {
+                    prefix: prefix.to_string(),
+                    key: key.clone(),
+                });
+                document_storage.remove(&CompositeKey {
                     prefix: prefix.to_string(),
                     key,
                 });

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -109,6 +109,7 @@ impl CompactionManager {
                     self.hnsw_index_provider.clone(),
                     dispatcher.clone(),
                     None,
+                    None,
                 );
 
                 match orchestrator.run().await {

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -187,7 +187,9 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
 
 #[cfg(test)]
 mod tests {
+    use crate::segment::record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError};
     use crate::segment::types::SegmentFlusher;
+    use crate::segment::LogMaterializer;
     use crate::{
         blockstore::provider::BlockfileProvider,
         execution::{
@@ -195,9 +197,11 @@ mod tests {
             operator::Operator,
             operators::count_records::{CountRecordsInput, CountRecordsOperator},
         },
-        segment::{record_segment::RecordSegmentWriter, LogMaterializer, SegmentWriter},
+        segment::{record_segment::RecordSegmentWriter, SegmentWriter},
         types::{LogRecord, Operation, OperationRecord},
     };
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
     use std::{collections::HashMap, str::FromStr};
     use uuid::Uuid;
 
@@ -255,7 +259,38 @@ mod tests {
                 },
             ];
             let data: Chunk<LogRecord> = Chunk::new(data.into());
-            segment_writer.materialize(&data).await;
+            let mut record_segment_reader: Option<RecordSegmentReader> = None;
+            match RecordSegmentReader::from_segment(&record_segment, &in_memory_provider).await {
+                Ok(reader) => {
+                    record_segment_reader = Some(reader);
+                }
+                Err(e) => {
+                    match *e {
+                        // Uninitialized segment is fine and means that the record
+                        // segment is not yet initialized in storage.
+                        RecordSegmentReaderCreationError::UninitializedSegment => {
+                            record_segment_reader = None;
+                        }
+                        RecordSegmentReaderCreationError::BlockfileOpenError(_) => {
+                            assert!(1 == 1, "Error creating record segment reader");
+                        }
+                        RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                            assert!(1 == 1, "Error creating record segment reader");
+                        }
+                    };
+                }
+            };
+            let curr_max_offset_id = Arc::new(AtomicU32::new(1));
+            let materializer =
+                LogMaterializer::new(record_segment_reader, data, curr_max_offset_id);
+            let mat_records = materializer
+                .materialize()
+                .await
+                .expect("Log materialization failed");
+            segment_writer
+                .apply_materialized_log_chunk(mat_records)
+                .await
+                .expect("Apply materializated log failed");
             let flusher = segment_writer
                 .commit()
                 .expect("Commit for segment writer failed");

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -272,10 +272,12 @@ mod tests {
                             record_segment_reader = None;
                         }
                         RecordSegmentReaderCreationError::BlockfileOpenError(_) => {
-                            assert!(1 == 1, "Error creating record segment reader");
+                            panic!("Error creating record segment reader. Blockfile open error.");
                         }
                         RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
-                            assert!(1 == 1, "Error creating record segment reader");
+                            panic!(
+                                "Error creating record segment reader. Invalid number of files."
+                            );
                         }
                     };
                 }

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -130,7 +130,6 @@ impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator
                 return Err(WriteSegmentsOperatorError::LogMaterializationError(e));
             }
         };
-        tracing::trace!("Materialized records {:?}", res);
         // Apply materialized records.
         match input
             .record_segment_writer

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -1,5 +1,12 @@
+use crate::blockstore::provider::BlockfileProvider;
+use crate::errors::ChromaError;
+use crate::segment::record_segment::ApplyMaterializedLogError;
+use crate::segment::record_segment::RecordSegmentReader;
+use crate::segment::record_segment::RecordSegmentReaderCreationError;
 use crate::segment::LogMaterializer;
+use crate::segment::LogMaterializerError;
 use crate::segment::SegmentWriter;
+use crate::types::Segment;
 use crate::{
     execution::{data::data_chunk::Chunk, operator::Operator},
     segment::{
@@ -8,6 +15,27 @@ use crate::{
     types::LogRecord,
 };
 use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WriteSegmentsOperatorError {
+    #[error("Preparation for log materialization failed {0}")]
+    LogMaterializationPreparationError(#[from] RecordSegmentReaderCreationError),
+    #[error("Log materialization failed {0}")]
+    LogMaterializationError(#[from] LogMaterializerError),
+    #[error("Materialized logs failed to apply {0}")]
+    ApplyMaterializatedLogsError(#[from] ApplyMaterializedLogError),
+}
+
+impl ChromaError for WriteSegmentsOperatorError {
+    fn code(&self) -> crate::errors::ErrorCodes {
+        match self {
+            WriteSegmentsOperatorError::LogMaterializationPreparationError(e) => e.code(),
+            WriteSegmentsOperatorError::LogMaterializationError(e) => e.code(),
+            WriteSegmentsOperatorError::ApplyMaterializatedLogsError(e) => e.code(),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct WriteSegmentsOperator {}
@@ -23,6 +51,8 @@ pub struct WriteSegmentsInput {
     record_segment_writer: RecordSegmentWriter,
     hnsw_segment_writer: Box<DistributedHNSWSegmentWriter>,
     chunk: Chunk<LogRecord>,
+    provider: BlockfileProvider,
+    record_segment: Segment,
 }
 
 impl<'me> WriteSegmentsInput {
@@ -30,11 +60,15 @@ impl<'me> WriteSegmentsInput {
         record_segment_writer: RecordSegmentWriter,
         hnsw_segment_writer: Box<DistributedHNSWSegmentWriter>,
         chunk: Chunk<LogRecord>,
+        provider: BlockfileProvider,
+        record_segment: Segment,
     ) -> Self {
         WriteSegmentsInput {
             record_segment_writer,
             hnsw_segment_writer,
             chunk,
+            provider,
+            record_segment,
         }
     }
 }
@@ -47,14 +81,79 @@ pub struct WriteSegmentsOutput {
 
 #[async_trait]
 impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator {
-    type Error = ();
+    type Error = WriteSegmentsOperatorError;
 
     async fn run(&self, input: &WriteSegmentsInput) -> Result<WriteSegmentsOutput, Self::Error> {
-        println!("Materializing N Records: {:?}", input.chunk.len());
-        let res = input.record_segment_writer.materialize(&input.chunk).await;
-        println!("Materialized N Records: {:?}", res.len());
-        input.hnsw_segment_writer.apply_materialized_log_chunk(res);
-        println!("Applied Materialized Records to HNSW Segment");
+        tracing::debug!("Materializing N Records: {:?}", input.chunk.len());
+        // Prepare for log materialization.
+        let record_segment_reader: Option<RecordSegmentReader>;
+        match RecordSegmentReader::from_segment(&input.record_segment, &input.provider).await {
+            Ok(reader) => {
+                record_segment_reader = Some(reader);
+            }
+            Err(e) => {
+                match *e {
+                    // Uninitialized segment is fine and means that the record
+                    // segment is not yet initialized in storage.
+                    RecordSegmentReaderCreationError::UninitializedSegment => {
+                        record_segment_reader = None;
+                    }
+                    RecordSegmentReaderCreationError::BlockfileOpenError(e) => {
+                        tracing::error!("Error creating record segment reader {}", e);
+                        return Err(
+                            WriteSegmentsOperatorError::LogMaterializationPreparationError(
+                                RecordSegmentReaderCreationError::BlockfileOpenError(e),
+                            ),
+                        );
+                    }
+                    RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                        tracing::error!("Error creating record segment reader {}", e);
+                        return Err(
+                            WriteSegmentsOperatorError::LogMaterializationPreparationError(
+                                RecordSegmentReaderCreationError::InvalidNumberOfFiles,
+                            ),
+                        );
+                    }
+                };
+            }
+        };
+        let materializer = LogMaterializer::new(
+            record_segment_reader,
+            input.chunk.clone(),
+            input.record_segment_writer.get_curr_max_offset_id(),
+        );
+        // Materialize the logs.
+        let res = match materializer.materialize().await {
+            Ok(records) => records,
+            Err(e) => {
+                tracing::error!("Error materializing records {}", e);
+                return Err(WriteSegmentsOperatorError::LogMaterializationError(e));
+            }
+        };
+        tracing::trace!("Materialized records {:?}", res);
+        // Apply materialized records.
+        match input
+            .record_segment_writer
+            .apply_materialized_log_chunk(res.clone())
+            .await
+        {
+            Ok(()) => (),
+            Err(e) => {
+                return Err(WriteSegmentsOperatorError::ApplyMaterializatedLogsError(e));
+            }
+        }
+        tracing::debug!("Applied materialized records to record segment");
+        match input
+            .hnsw_segment_writer
+            .apply_materialized_log_chunk(res)
+            .await
+        {
+            Ok(()) => (),
+            Err(e) => {
+                return Err(WriteSegmentsOperatorError::ApplyMaterializatedLogsError(e));
+            }
+        }
+        tracing::debug!("Applied Materialized Records to HNSW Segment");
         Ok(WriteSegmentsOutput {
             record_segment_writer: input.record_segment_writer.clone(),
             hnsw_segment_writer: input.hnsw_segment_writer.clone(),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -88,6 +88,7 @@ pub struct CompactOrchestrator {
     hnsw_index_provider: HnswIndexProvider,
     // State we hold across the execution
     pulled_log_offset: Option<i64>,
+    record_segment: Option<Segment>,
     // Dispatcher
     dispatcher: Box<dyn Receiver<TaskMessage>>,
     // number of write segments tasks
@@ -95,7 +96,6 @@ pub struct CompactOrchestrator {
     // Result Channel
     result_channel:
         Option<tokio::sync::oneshot::Sender<Result<CompactionResponse, Box<dyn ChromaError>>>>,
-    record_segment: Option<Segment>,
 }
 
 #[derive(Error, Debug)]
@@ -250,7 +250,7 @@ impl CompactOrchestrator {
                 self.blockfile_provider.clone(),
                 self.record_segment
                     .as_ref()
-                    .expect("Expect segment")
+                    .expect("WriteSegmentsInput: Record segment not set in the input")
                     .clone(),
             );
             let task = wrap(operator, input, self_address.clone());

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -216,6 +216,8 @@ impl<'a> SegmentWriter<'a> for DistributedHNSWSegmentWriter {
                             }
                         },
                     };
+                    // hnsw index behavior is to treat add() as upsert so this
+                    // will update the embedding if it exists.
                     self.index.read().add(record.offset_id as usize, embedding);
                 }
                 Operation::Delete => {

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -216,11 +216,18 @@ impl<'a> SegmentWriter<'a> for DistributedHNSWSegmentWriter {
                             }
                         },
                     };
-                    // hnsw index behavior is to treat add() as upsert so this
-                    // will update the embedding if it exists.
+                    // HNSW index behavior is to treat add() as upsert so this
+                    // will update the embedding if it exists. It does not
+                    // perform any validation on its own and assumes that the
+                    // offset ids are correct (i.e. pertaining to records that
+                    // are actually meant to be updated).
                     self.index.read().add(record.offset_id as usize, embedding);
                 }
                 Operation::Delete => {
+                    // HNSW segment does not perform validation of any sort. So,
+                    // the assumption here is that the materialized log records
+                    // contain the correct offset ids pertaining to records that
+                    // are actually meant to be deleted.
                     self.index.read().delete(record.offset_id as usize);
                 }
             }

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -1,3 +1,4 @@
+use super::record_segment::ApplyMaterializedLogError;
 use super::{SegmentFlusher, SegmentWriter};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::index::hnsw_provider::{
@@ -172,57 +173,57 @@ impl DistributedHNSWSegmentWriter {
     }
 }
 
-impl SegmentWriter for DistributedHNSWSegmentWriter {
-    fn apply_materialized_log_chunk(
+impl<'a> SegmentWriter<'a> for DistributedHNSWSegmentWriter {
+    async fn apply_materialized_log_chunk(
         &self,
-        records: crate::execution::data::data_chunk::Chunk<super::MaterializedLogRecord>,
-    ) {
-        for record in records.iter() {
-            match record.0.log_record.record.operation {
+        records: crate::execution::data::data_chunk::Chunk<super::MaterializedLogRecord<'a>>,
+    ) -> Result<(), ApplyMaterializedLogError> {
+        for (record, _) in records.iter() {
+            match record.final_operation {
+                // If embedding is not found in case of adds it means that user
+                // did not supply them and thus we should return an error as
+                // opposed to panic.
                 Operation::Add => {
-                    let segment_offset_id = record.0.segment_offset_id;
-                    let embedding = record.0.log_record.record.embedding.as_ref().unwrap();
-                    self.index
-                        .read()
-                        .add(segment_offset_id as usize, &embedding);
+                    let embedding = match record.final_embedding {
+                        Some(e) => e,
+                        None => match record.data_record.as_ref() {
+                            Some(record) => record.embedding,
+                            None => {
+                                tracing::error!("Embedding not set for record {:?}", record);
+                                return Err(ApplyMaterializedLogError::EmbeddingNotSet);
+                            }
+                        },
+                    };
+                    self.index.read().add(record.offset_id as usize, embedding);
                 }
+                // This shouldn't be reached since materialization always derefs
+                // upserts into either updates or inserts.
                 Operation::Upsert => {
-                    // hnsw index behavior is to treat add() as upsert
-                    let segment_offset_id = record.0.segment_offset_id;
-                    // Assumption: Upserts must have embedding set
-                    let embedding = record.0.log_record.record.embedding.as_ref().unwrap();
-                    self.index
-                        .read()
-                        .add(segment_offset_id as usize, &embedding);
+                    panic!(
+                        "Invariant violation. Upserts should not be present after materialization"
+                    );
                 }
                 Operation::Update => {
-                    // hnsw index behvaior is to treat add() as upsert so this
-                    // will update the embedding
-                    // The assumption is that materialized log records only contain
-                    // valid updates.
-                    let segment_offset_id = record.0.segment_offset_id;
-                    match record.0.log_record.record.embedding.as_ref() {
-                        Some(e) => {
-                            self.index.read().add(segment_offset_id as usize, &e);
-                        }
-                        None => {
-                            // An update may not necessarily update the embedding
-                            continue;
-                        }
+                    // Should panic here if embedding is not found because it likely
+                    // means that somehow our storage is corrupt as data record on
+                    // the record segment does not contain the embedding.
+                    let embedding = match record.final_embedding {
+                        Some(e) => e,
+                        None => match record.data_record.as_ref() {
+                            Some(record) => record.embedding,
+                            None => {
+                                panic!("Invariant violation. Embedding not found on storage");
+                            }
+                        },
                     };
+                    self.index.read().add(record.offset_id as usize, embedding);
                 }
                 Operation::Delete => {
-                    // The assumption is that materialized log records only contain
-                    // valid deletes
-                    let segment_offset_id = record.0.segment_offset_id;
-                    self.index.read().delete(segment_offset_id as usize);
+                    self.index.read().delete(record.offset_id as usize);
                 }
             }
         }
-    }
-
-    fn apply_log_chunk(&self, records: crate::execution::data::data_chunk::Chunk<LogRecord>) {
-        todo!()
+        Ok(())
     }
 
     fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -598,6 +598,22 @@ impl RecordSegmentReader<'_> {
         self.id_to_data.get("", offset_id).await
     }
 
+    pub(crate) async fn get_data_and_offset_id_for_user_id(
+        &self,
+        user_id: &str,
+    ) -> Result<(DataRecord, u32), Box<dyn ChromaError>> {
+        let offset_id = match self.user_id_to_id.get("", user_id).await {
+            Ok(id) => id,
+            Err(e) => {
+                return Err(e);
+            }
+        };
+        match self.id_to_data.get("", offset_id).await {
+            Ok(data_record) => Ok((data_record, offset_id)),
+            Err(e) => Err(e),
+        }
+    }
+
     pub(crate) async fn data_exists_for_user_id(
         &self,
         user_id: &str,

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -1,10 +1,13 @@
-use super::types::{LogMaterializer, MaterializedLogRecord, SegmentWriter};
+use super::types::{MaterializedLogRecord, SegmentWriter};
 use super::{DataRecord, SegmentFlusher};
 use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
 use crate::blockstore::{BlockfileFlusher, BlockfileReader, BlockfileWriter};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::execution::data::data_chunk::Chunk;
-use crate::types::{update_metdata_to_metdata, LogRecord, Operation, Segment, SegmentType};
+use crate::types::{
+    merge_update_metadata, update_metdata_to_metdata, LogRecord, Metadata, MetadataValue,
+    Operation, Segment, SegmentType,
+};
 use async_trait::async_trait;
 use futures::StreamExt;
 use std::collections::HashMap;
@@ -60,6 +63,69 @@ pub enum RecordSegmentWriterCreationError {
 }
 
 impl RecordSegmentWriter {
+    async fn construct_and_set_data_record<'a>(
+        &self,
+        mat_record: &MaterializedLogRecord<'a>,
+        user_id: &str,
+        offset_id: u32,
+    ) -> Result<(), ApplyMaterializedLogError> {
+        // Merge data record with updates.
+        let updated_document = match mat_record.final_document {
+            Some(doc) => Some(doc),
+            None => match mat_record.data_record.as_ref() {
+                Some(data_record) => data_record.document,
+                None => None,
+            },
+        };
+        let updated_embeddings = match mat_record.final_embedding {
+            Some(embed) => embed,
+            None => match mat_record.data_record.as_ref() {
+                Some(data_record) => data_record.embedding,
+                None => panic!("Expected at least one source of embedding"),
+            },
+        };
+        let mut final_metadata = match mat_record.data_record.as_ref() {
+            Some(data_record) => match data_record.metadata {
+                Some(ref map) => map.clone(), // auto deref here.
+                None => HashMap::new(),
+            },
+            None => HashMap::new(),
+        };
+        if mat_record.metadata_to_be_merged.as_ref().is_some() {
+            for (key, value) in mat_record.metadata_to_be_merged.as_ref().unwrap() {
+                final_metadata.insert(key.clone(), value.clone()); // auto deref here.
+            }
+        }
+        let mut final_metadata_opt = None;
+        if !final_metadata.is_empty() {
+            final_metadata_opt = Some(final_metadata);
+        }
+        // Time to create a data record now.
+        let data_record = DataRecord {
+            id: user_id,
+            embedding: updated_embeddings,
+            metadata: final_metadata_opt,
+            document: updated_document,
+        };
+        match self
+            .id_to_data
+            .as_ref()
+            .unwrap()
+            .set("", offset_id, &data_record)
+            .await
+        {
+            Ok(_) => (),
+            Err(_) => {
+                return Err(ApplyMaterializedLogError::BlockfileSetError);
+            }
+        };
+        Ok(())
+    }
+
+    pub(crate) fn get_curr_max_offset_id(&self) -> Arc<AtomicU32> {
+        self.curr_max_offset_id.clone()
+    }
+
     pub(crate) async fn from_segment(
         segment: &Segment,
         blockfile_provider: &BlockfileProvider,
@@ -268,13 +334,172 @@ impl RecordSegmentWriter {
     }
 }
 
-impl SegmentWriter for RecordSegmentWriter {
-    fn apply_materialized_log_chunk(&self, records: Chunk<MaterializedLogRecord>) {
-        todo!()
-    }
+#[derive(Error, Debug)]
+// TODO(Sanket): Should compose errors here but can't currently because
+// of Box<dyn ChromaError>.
+// Since blockfile does not support read then write semantics natively
+// all write operations to it are either set or delete.
+pub enum ApplyMaterializedLogError {
+    #[error("Error setting to blockfile")]
+    BlockfileSetError,
+    #[error("Error deleting from blockfile")]
+    BlockfileDeleteError,
+    #[error("Embedding not set in the user write")]
+    EmbeddingNotSet,
+}
 
-    fn apply_log_chunk(&self, records: Chunk<LogRecord>) {
-        todo!()
+impl ChromaError for ApplyMaterializedLogError {
+    fn code(&self) -> crate::errors::ErrorCodes {
+        match self {
+            ApplyMaterializedLogError::BlockfileSetError => ErrorCodes::Internal,
+            ApplyMaterializedLogError::BlockfileDeleteError => ErrorCodes::Internal,
+            ApplyMaterializedLogError::EmbeddingNotSet => ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
+impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
+    async fn apply_materialized_log_chunk(
+        &self,
+        records: Chunk<MaterializedLogRecord<'a>>,
+    ) -> Result<(), ApplyMaterializedLogError> {
+        for (log_record, _) in records.iter() {
+            match log_record.final_operation {
+                Operation::Add => {
+                    // Set all four.
+                    // Set user id to offset id.
+                    match self
+                        .user_id_to_id
+                        .as_ref()
+                        .unwrap()
+                        .set::<&str, u32>("", log_record.user_id.unwrap(), log_record.offset_id)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileSetError);
+                        }
+                    };
+                    // Set offset id to user id.
+                    match self
+                        .id_to_user_id
+                        .as_ref()
+                        .unwrap()
+                        .set::<u32, &str>("", log_record.offset_id, log_record.user_id.unwrap())
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileSetError);
+                        }
+                    };
+                    // Set data record.
+                    match self
+                        .construct_and_set_data_record(
+                            log_record,
+                            log_record.user_id.unwrap(),
+                            log_record.offset_id,
+                        )
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                    // Set max offset id.
+                    match self
+                        .max_offset_id
+                        .as_ref()
+                        .unwrap()
+                        .set("", MAX_OFFSET_ID, log_record.offset_id)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileSetError);
+                        }
+                    }
+                }
+                Operation::Update => {
+                    // Offset id and user id do not need to change. Only data
+                    // needs to change. Blockfile does not have Read then write
+                    // semantics so we'll delete and insert.
+                    match self
+                        .id_to_data
+                        .as_ref()
+                        .unwrap()
+                        .delete::<u32, &DataRecord>("", log_record.offset_id)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileDeleteError);
+                        }
+                    }
+                    match self
+                        .construct_and_set_data_record(
+                            log_record,
+                            log_record.data_record.as_ref().unwrap().id,
+                            log_record.offset_id,
+                        )
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                }
+                Operation::Upsert => {
+                    // MaterializedLogRecord already converts upserts into either updates or inserts
+                    // so here we expect to not have any records of this type.
+                    panic!("Invariant violation. After log materialization there shouldn't be any upserts.");
+                }
+                Operation::Delete => {
+                    // Delete user id to offset id.
+                    match self
+                        .user_id_to_id
+                        .as_ref()
+                        .unwrap()
+                        .delete::<&str, u32>("", log_record.data_record.as_ref().unwrap().id)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileDeleteError);
+                        }
+                    };
+                    // Delete offset id to user id.
+                    match self
+                        .id_to_user_id
+                        .as_ref()
+                        .unwrap()
+                        .delete::<u32, &str>("", log_record.offset_id)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileDeleteError);
+                        }
+                    };
+                    // Delete data record.
+                    match self
+                        .id_to_data
+                        .as_ref()
+                        .unwrap()
+                        .delete::<u32, &DataRecord>("", log_record.offset_id)
+                        .await
+                    {
+                        Ok(()) => (),
+                        Err(_) => {
+                            return Err(ApplyMaterializedLogError::BlockfileDeleteError);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     fn commit(mut self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
@@ -398,88 +623,6 @@ impl SegmentFlusher for RecordSegmentFlusher {
         }
 
         Ok(flushed_files)
-    }
-}
-
-// TODO: remove log materializer, its needless abstraction and complexity
-#[async_trait]
-impl LogMaterializer for RecordSegmentWriter {
-    async fn materialize<'chunk>(
-        &self,
-        log_records: &'chunk Chunk<LogRecord>,
-    ) -> Chunk<MaterializedLogRecord<'chunk>> {
-        let mut materialized_records = Vec::new();
-        for (log_entry, index) in log_records.iter() {
-            match log_entry.record.operation {
-                Operation::Add => {
-                    let next_offset_id = self
-                        .curr_max_offset_id
-                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-
-                    let metadata = match &log_entry.record.metadata {
-                        Some(metadata) => match update_metdata_to_metdata(&metadata) {
-                            Ok(metadata) => Some(metadata),
-                            Err(e) => {
-                                // TODO: this should error out and return an error
-                                panic!("Error converting metadata: {}", e);
-                            }
-                        },
-                        None => None,
-                    };
-
-                    let document = match &log_entry.record.document {
-                        Some(document) => Some(document.as_str()),
-                        None => None,
-                    };
-
-                    let data_record = DataRecord {
-                        id: &log_entry.record.id,
-                        // TODO: don't unwrap here, it should never happen as Adds always have embeddings
-                        // but we should handle this gracefully
-                        embedding: log_entry.record.embedding.as_ref().unwrap(),
-                        document,
-                        metadata,
-                    };
-                    let materialized =
-                        MaterializedLogRecord::new(next_offset_id, log_entry, data_record);
-                    println!("Writing to id_to_data");
-                    let res = self
-                        .id_to_data
-                        .as_ref()
-                        .unwrap()
-                        .set("", next_offset_id, &materialized.materialized_record)
-                        .await;
-                    println!("Writing to user_id_to_id");
-                    let res = self
-                        .user_id_to_id
-                        .as_ref()
-                        .unwrap()
-                        .set::<&str, u32>("", log_entry.record.id.as_str(), next_offset_id)
-                        .await;
-                    println!("Writing to id_to_user_id");
-                    let res = self
-                        .id_to_user_id
-                        .as_ref()
-                        .unwrap()
-                        .set("", next_offset_id, log_entry.record.id.as_str())
-                        .await;
-                    println!("Writing to max_offset_id: {}", next_offset_id);
-                    let res = self
-                        .max_offset_id
-                        .as_ref()
-                        .unwrap()
-                        .set("", MAX_OFFSET_ID, next_offset_id)
-                        .await;
-                    // TODO: use res
-                    materialized_records.push(materialized);
-                }
-                Operation::Delete => {}
-                Operation::Update => {}
-                Operation::Upsert => {}
-            }
-        }
-
-        Chunk::new(materialized_records.into())
     }
 }
 

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -672,17 +672,22 @@ mod tests {
             assert_ne!(data.id, "embedding_id_2");
             if data.id == "embedding_id_1" {
                 assert_eq!(
-                    data.metadata.clone()
+                    data.metadata
+                        .clone()
                         .expect("Metadata is empty")
                         .contains_key("hello"),
                     true
                 );
                 assert_eq!(
-                    data.metadata.clone().expect("Metadata is empty").get("hello"),
+                    data.metadata
+                        .clone()
+                        .expect("Metadata is empty")
+                        .get("hello"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
                 assert_eq!(
-                    data.metadata.clone()
+                    data.metadata
+                        .clone()
                         .expect("Metadata is empty")
                         .contains_key("bye"),
                     true
@@ -692,36 +697,48 @@ mod tests {
                     Some(&MetadataValue::Str(String::from("world")))
                 );
                 assert_eq!(
-                    data.metadata.clone()
+                    data.metadata
+                        .clone()
                         .expect("Metadata is empty")
                         .contains_key("hello_again"),
                     true
                 );
                 assert_eq!(
-                    data.metadata.clone().expect("Metadata is empty").get("hello_again"),
+                    data.metadata
+                        .clone()
+                        .expect("Metadata is empty")
+                        .get("hello_again"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
                 assert_eq!(data.document.expect("Non empty document"), "doc1");
                 assert_eq!(data.embedding, vec![1.0, 2.0, 3.0]);
             } else if data.id == "embedding_id_3" {
                 assert_eq!(
-                    data.metadata.clone()
+                    data.metadata
+                        .clone()
                         .expect("Metadata is empty")
                         .contains_key("hello"),
                     true
                 );
                 assert_eq!(
-                    data.metadata.clone().expect("Metadata is empty").get("hello"),
+                    data.metadata
+                        .clone()
+                        .expect("Metadata is empty")
+                        .get("hello"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
                 assert_eq!(
-                    data.metadata.clone()
+                    data.metadata
+                        .clone()
                         .expect("Metadata is empty")
                         .contains_key("hello_again"),
                     true
                 );
                 assert_eq!(
-                    data.metadata.clone().expect("Metadata is empty").get("hello_again"),
+                    data.metadata
+                        .clone()
+                        .expect("Metadata is empty")
+                        .get("hello_again"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
                 assert_eq!(data.document.expect("Non empty document"), "doc3");

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
 
 use crate::errors::ChromaError;
 use crate::execution::data::data_chunk::Chunk;
-use crate::types::{LogRecord, Metadata};
+use crate::types::{
+    merge_update_metadata, update_metdata_to_metdata, LogRecord, Metadata, Operation,
+    OperationRecord,
+};
 use async_trait::async_trait;
+
+use super::record_segment::RecordSegmentReader;
 
 #[derive(Debug)]
 pub(crate) struct MaterializedLogRecord<'a> {
@@ -23,6 +30,273 @@ impl<'a> MaterializedLogRecord<'a> {
             log_record,
             materialized_record,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MaterializedLogRecordV2<'a> {
+    // This is the data record read from the record segment for this id.
+    // None if the record exists only in the log.
+    data_record: Option<DataRecord<'a>>,
+    // If present in the record segment then it is the offset id
+    // in the record segment at which the record was found.
+    // If not present in the segment then it is the offset id
+    // at which it should be inserted.
+    offset_id: u32,
+    // Set only for the records that are being inserted for the first time
+    // in the log since data_record will be None in such cases.
+    user_id: Option<&'a str>,
+    // There can be several entries in the log for an id. This is the final
+    // operation that needs to be done on it. For e.g.
+    // If log has [Update, Update, Delete] then final operation is Delete.
+    // If log has [Insert, Update, Update, Delete] then final operation is Delete.
+    // If log has [Insert, Update, Update] then final operation is Insert.
+    // If log has [Update, Update] then final operation is Update.
+    final_operation: Operation,
+    // This is the metadata obtained by combining all the operations
+    // present in the log for this id.
+    // E.g. if has log has [Insert(a: h), Update(a: b, c: d), Update(a: e, f: g)] then this
+    // will contain (a: e, c: d, f: g). This is None if the final operation
+    // above is Delete.
+    metadata_to_be_merged: Option<Metadata>,
+    // This is the final document obtained from the last non null operation.
+    // E.g. if log has [Insert(str0), Update(str1), Update(str2), Update()] then this will contain
+    // str2. None if final operation is Delete.
+    final_document: Option<&'a str>,
+    // Similar to above, this is the final embedding obtained
+    // from the last non null operation.
+    // E.g. if log has [Insert(emb0), Update(emb1), Update(emb2), Update()]
+    // then this will contain emb2. None if final operation is Delete.
+    final_embedding: Option<&'a [f32]>,
+}
+
+impl<'a> MaterializedLogRecordV2<'a> {
+    pub(crate) fn from_data_record(data_record: DataRecord<'a>, offset_id: u32) -> Self {
+        Self {
+            data_record: Some(data_record),
+            offset_id,
+            user_id: None,
+            final_operation: Operation::Add,
+            metadata_to_be_merged: None,
+            final_document: None,
+            final_embedding: None,
+        }
+    }
+
+    pub(crate) fn from_operation_record(
+        log_record: &'a OperationRecord,
+        offset_id: u32,
+        user_id: &'a str,
+    ) -> Self {
+        let metadata = match &log_record.metadata {
+            Some(metadata) => match update_metdata_to_metdata(metadata) {
+                Ok(m) => Some(m),
+                Err(e) => panic!("Should not panic. TODO"),
+            },
+            None => None,
+        };
+
+        let document = match &log_record.document {
+            Some(doc) => Some(doc.as_str()),
+            // TODO(Sanket): Should this be an error since this is an insert operation.
+            None => None,
+        };
+
+        let embedding = match &log_record.embedding {
+            Some(embedding) => Some(embedding.as_slice()),
+            // TODO(Sanket): Should this be an error since this is an insert operation.
+            None => None,
+        };
+
+        Self {
+            data_record: None,
+            offset_id,
+            user_id: Some(user_id),
+            final_operation: Operation::Add,
+            metadata_to_be_merged: metadata,
+            final_document: document,
+            final_embedding: embedding,
+        }
+    }
+}
+
+pub(crate) struct LogMaterializerV2<'a> {
+    record_segment_reader: RecordSegmentReader<'a>,
+    logs: Chunk<LogRecord>,
+    curr_max_offset_id: Arc<AtomicU32>,
+}
+
+impl<'a> LogMaterializerV2<'a> {
+    pub(crate) async fn materializeV2(&'a self) -> Chunk<MaterializedLogRecordV2<'a>> {
+        // Find entries that can be skipped completely.
+        let mut existing_id_to_materialized: HashMap<&str, MaterializedLogRecordV2> =
+            HashMap::new();
+        let mut new_id_to_materialized: HashMap<&str, MaterializedLogRecordV2> = HashMap::new();
+        for (log_record, _) in self.logs.iter() {
+            let mut exists: bool = false;
+            match self
+                .record_segment_reader
+                .data_exists_for_user_id(log_record.record.id.as_str())
+                .await
+            {
+                Ok(res) => exists = res,
+                Err(e) => (),
+            };
+            if exists {
+                match self
+                    .record_segment_reader
+                    .get_data_and_offset_id_for_user_id(log_record.record.id.as_str())
+                    .await
+                {
+                    Ok((data_record, offset_id)) => {
+                        existing_id_to_materialized.insert(
+                            log_record.record.id.as_str(),
+                            MaterializedLogRecordV2::from_data_record(data_record, offset_id),
+                        );
+                    }
+                    // TODO(Sanket): Error handling here.
+                    Err(e) => (),
+                }
+            }
+        }
+        // Time to build the actual records.
+        for (log_record, _) in self.logs.iter() {
+            match log_record.record.operation {
+                Operation::Add => {
+                    // If user is trying to insert a key that already exists in
+                    // storage then ignore. Also if it already existed in the log
+                    // before then also ignore.
+                    if !existing_id_to_materialized.contains_key(log_record.record.id.as_str())
+                        && !new_id_to_materialized.contains_key(log_record.record.id.as_str())
+                    {
+                        let next_offset_id = self
+                            .curr_max_offset_id
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        new_id_to_materialized.insert(
+                            log_record.record.id.as_str(),
+                            MaterializedLogRecordV2::from_operation_record(
+                                &log_record.record,
+                                next_offset_id,
+                                log_record.record.id.as_str(),
+                            ),
+                        );
+                    }
+                }
+                Operation::Delete => {
+                    // If the delete is for a record that is currently not in the
+                    // record segment, then we can just not process these records
+                    // at all. On the other hand if it is for a record that is currently
+                    // in the record segment then we'll have to pass it as a delete
+                    // to the compactor so that it can be deleted.
+                    if new_id_to_materialized.contains_key(log_record.record.id.as_str()) {
+                        new_id_to_materialized.remove(log_record.record.id.as_str());
+                    } else if existing_id_to_materialized
+                        .contains_key(log_record.record.id.as_str())
+                    {
+                        // Mark state as deleted.
+                        existing_id_to_materialized
+                            .get_mut(log_record.record.id.as_str())
+                            .unwrap()
+                            .final_operation = Operation::Delete;
+                    }
+                }
+                Operation::Update => {
+                    let mut created_in_log = true;
+                    let record_from_map = match existing_id_to_materialized
+                        .get_mut(log_record.record.id.as_str())
+                    {
+                        Some(res) => {
+                            created_in_log = false;
+                            res
+                        }
+                        None => match new_id_to_materialized.get_mut(log_record.record.id.as_str())
+                        {
+                            Some(res) => res,
+                            None => {
+                                continue;
+                            }
+                        },
+                    };
+
+                    record_from_map.metadata_to_be_merged = merge_update_metadata(
+                        &record_from_map.metadata_to_be_merged,
+                        &log_record.record.metadata,
+                    );
+                    if log_record.record.document.is_some() {
+                        record_from_map.final_document =
+                            Some(log_record.record.document.as_ref().unwrap().as_str());
+                    }
+                    if log_record.record.embedding.is_some() {
+                        record_from_map.final_embedding =
+                            Some(log_record.record.embedding.as_ref().unwrap().as_slice());
+                    }
+                    // Only update the operation state for records that were not created
+                    // from the log.
+                    if !created_in_log {
+                        record_from_map.final_operation = Operation::Update;
+                    }
+                }
+                Operation::Upsert => {
+                    if existing_id_to_materialized.contains_key(log_record.record.id.as_str()) {
+                        // Just another update.
+                        let record_from_map = existing_id_to_materialized
+                            .get_mut(log_record.record.id.as_str())
+                            .unwrap();
+                        record_from_map.metadata_to_be_merged = merge_update_metadata(
+                            &record_from_map.metadata_to_be_merged,
+                            &log_record.record.metadata,
+                        );
+                        if log_record.record.document.is_some() {
+                            record_from_map.final_document =
+                                Some(log_record.record.document.as_ref().unwrap().as_str());
+                        }
+                        if log_record.record.embedding.is_some() {
+                            record_from_map.final_embedding =
+                                Some(log_record.record.embedding.as_ref().unwrap().as_slice());
+                        }
+                        record_from_map.final_operation = Operation::Upsert;
+                    } else if new_id_to_materialized.contains_key(log_record.record.id.as_str()) {
+                        // Just another update.
+                        let record_from_map = new_id_to_materialized
+                            .get_mut(log_record.record.id.as_str())
+                            .unwrap();
+                        record_from_map.metadata_to_be_merged = merge_update_metadata(
+                            &record_from_map.metadata_to_be_merged,
+                            &log_record.record.metadata,
+                        );
+                        if log_record.record.document.is_some() {
+                            record_from_map.final_document =
+                                Some(log_record.record.document.as_ref().unwrap().as_str());
+                        }
+                        if log_record.record.embedding.is_some() {
+                            record_from_map.final_embedding =
+                                Some(log_record.record.embedding.as_ref().unwrap().as_slice());
+                        }
+                    } else {
+                        // Insert.
+                        let next_offset_id = self
+                            .curr_max_offset_id
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        new_id_to_materialized.insert(
+                            log_record.record.id.as_str(),
+                            MaterializedLogRecordV2::from_operation_record(
+                                &log_record.record,
+                                next_offset_id,
+                                log_record.record.id.as_str(),
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+        let mut res = vec![];
+        for (_key, value) in existing_id_to_materialized {
+            res.push(value);
+        }
+        for (_key, value) in new_id_to_materialized {
+            res.push(value);
+        }
+        Chunk::new(res.into())
     }
 }
 
@@ -69,9 +343,163 @@ pub(crate) trait LogMaterializer: SegmentWriter {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
-    use crate::types::{MetadataValue, Operation, OperationRecord};
-    use std::collections::HashMap;
+    use crate::{
+        blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
+        segment::record_segment::RecordSegmentWriter,
+        storage::{local::LocalStorage, Storage},
+        types::{MetadataValue, Operation, OperationRecord, UpdateMetadataValue},
+    };
+    use std::{collections::HashMap, str::FromStr};
+
+    #[tokio::test]
+    async fn test_materializer_v2() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let arrow_blockfile_provider = ArrowBlockfileProvider::new(storage);
+        let blockfile_provider =
+            BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
+        // let in_memory_provider = BlockfileProvider::new_memory();
+        let mut record_segment = crate::types::Segment {
+            id: Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
+            r#type: crate::types::SegmentType::Record,
+            scope: crate::types::SegmentScope::RECORD,
+            collection: Some(
+                Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
+            ),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        {
+            let segment_writer =
+                RecordSegmentWriter::from_segment(&record_segment, &blockfile_provider)
+                    .await
+                    .expect("Error creating segment writer");
+            let mut update_metadata = HashMap::new();
+            update_metadata.insert(
+                String::from("hello"),
+                UpdateMetadataValue::Str(String::from("world")),
+            );
+            update_metadata.insert(
+                String::from("bye"),
+                UpdateMetadataValue::Str(String::from("world")),
+            );
+            let data = vec![
+                LogRecord {
+                    log_offset: 1,
+                    record: OperationRecord {
+                        id: "embedding_id_1".to_string(),
+                        embedding: Some(vec![1.0, 2.0, 3.0]),
+                        encoding: None,
+                        metadata: Some(update_metadata.clone()),
+                        document: Some(String::from("doc1")),
+                        operation: Operation::Add,
+                    },
+                },
+                LogRecord {
+                    log_offset: 2,
+                    record: OperationRecord {
+                        id: "embedding_id_2".to_string(),
+                        embedding: Some(vec![4.0, 5.0, 6.0]),
+                        encoding: None,
+                        metadata: Some(update_metadata),
+                        document: Some(String::from("doc2")),
+                        operation: Operation::Add,
+                    },
+                },
+            ];
+            let data: Chunk<LogRecord> = Chunk::new(data.into());
+            segment_writer.materialize(&data).await;
+            let flusher = segment_writer
+                .commit()
+                .expect("Commit for segment writer failed");
+            record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
+        }
+        let mut update_metadata = HashMap::new();
+        update_metadata.insert(
+            String::from("hello"),
+            UpdateMetadataValue::Str(String::from("new_world")),
+        );
+        update_metadata.insert(
+            String::from("hello_again"),
+            UpdateMetadataValue::Str(String::from("new_world")),
+        );
+        let data = vec![
+            LogRecord {
+                log_offset: 3,
+                record: OperationRecord {
+                    id: "embedding_id_1".to_string(),
+                    embedding: None,
+                    encoding: None,
+                    metadata: Some(update_metadata.clone()),
+                    document: None,
+                    operation: Operation::Update,
+                },
+            },
+            LogRecord {
+                log_offset: 4,
+                record: OperationRecord {
+                    id: "embedding_id_3".to_string(),
+                    embedding: Some(vec![7.0, 8.0, 9.0]),
+                    encoding: None,
+                    metadata: Some(update_metadata),
+                    document: Some(String::from("doc3")),
+                    operation: Operation::Add,
+                },
+            },
+            LogRecord {
+                log_offset: 5,
+                record: OperationRecord {
+                    id: "embedding_id_2".to_string(),
+                    embedding: None,
+                    encoding: None,
+                    metadata: None,
+                    document: None,
+                    operation: Operation::Delete,
+                },
+            },
+        ];
+        let data: Chunk<LogRecord> = Chunk::new(data.into());
+        let reader = RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
+            .await
+            .expect("Error creating segment reader");
+        let curr_max_offset_id = Arc::new(AtomicU32::new(2));
+        let materializer = LogMaterializerV2 {
+            record_segment_reader: reader,
+            logs: data,
+            curr_max_offset_id,
+        };
+        let res = materializer.materializeV2().await;
+        assert_eq!(3, res.len());
+        for (log, _) in res.iter() {
+            // Embedding 3.
+            if log.user_id.is_some() {
+                assert_eq!("embedding_id_3", log.user_id.unwrap());
+                assert_eq!(true, log.data_record.is_none());
+                assert_eq!("doc3", log.final_document.unwrap());
+                assert_eq!(vec![7.0, 8.0, 9.0], log.final_embedding.unwrap());
+                assert_eq!(3, log.offset_id);
+                assert_eq!(Operation::Add, log.final_operation);
+                let mut hello_found = 0;
+                let mut hello_again_found = 0;
+                for (key, value) in log.metadata_to_be_merged.as_ref().unwrap() {
+                    if key == "hello" {
+                        assert_eq!(MetadataValue::Str(String::from("new_world")), *value);
+                        hello_found += 1;
+                    } else if key == "hello_again" {
+                        assert_eq!(MetadataValue::Str(String::from("new_world")), *value);
+                        hello_again_found += 1;
+                    } else {
+                        assert!(1 == 1, "Not expecting any other key");
+                    }
+                }
+                assert_eq!(hello_found, 1);
+                assert_eq!(hello_again_found, 1);
+            }
+        }
+    }
 
     // This is just a POC test to show how the materialize method could be tested, we can
     // remove it later

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -642,6 +642,32 @@ impl TryFrom<chroma_proto::WhereDocumentOperator> for WhereDocumentOperator {
     }
 }
 
+pub(crate) fn merge_update_metadata(
+    base_metadata: &Option<Metadata>,
+    update_metadata: &Option<UpdateMetadata>,
+) -> Option<Metadata> {
+    let mut merged_metadata = HashMap::new();
+    if base_metadata.is_some() {
+        for (key, value) in base_metadata.as_ref().unwrap() {
+            merged_metadata.insert(key.clone(), value.clone());
+        }
+    }
+    if update_metadata.is_some() {
+        match update_metdata_to_metdata(update_metadata.as_ref().unwrap()) {
+            Ok(metadata) => {
+                for (key, value) in metadata {
+                    merged_metadata.insert(key, value);
+                }
+            }
+            Err(e) => panic!("Should not panic. TODO"),
+        };
+    }
+    if merged_metadata.is_empty() {
+        return None;
+    }
+    Some(merged_metadata)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -645,7 +645,7 @@ impl TryFrom<chroma_proto::WhereDocumentOperator> for WhereDocumentOperator {
 pub(crate) fn merge_update_metadata(
     base_metadata: &Option<Metadata>,
     update_metadata: &Option<UpdateMetadata>,
-) -> Option<Metadata> {
+) -> Result<Option<Metadata>, MetadataValueConversionError> {
     let mut merged_metadata = HashMap::new();
     if base_metadata.is_some() {
         for (key, value) in base_metadata.as_ref().unwrap() {
@@ -659,13 +659,15 @@ pub(crate) fn merge_update_metadata(
                     merged_metadata.insert(key, value);
                 }
             }
-            Err(e) => panic!("Should not panic. TODO"),
+            Err(e) => {
+                return Err(e);
+            }
         };
     }
     if merged_metadata.is_empty() {
-        return None;
+        return Ok(None);
     }
-    Some(merged_metadata)
+    Ok(Some(merged_metadata))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	Adds log materializer v2 taking care of updates/deletes/upserts.
        Wires the compactor (i.e. record segment writer and hnsw index writer) to use the new materialization
        Cleans up the old needless abstraction

## Test plan
Rust test
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
