### PR TITLE
[BUG] LogService return empty records when endtimestamp is None

### DIFF
--- a/rust/worker/src/log/log.rs
+++ b/rust/worker/src/log/log.rs
@@ -163,7 +163,7 @@ impl Log for GrpcLog {
     ) -> Result<Vec<LogRecord>, PullLogsError> {
         let end_timestamp = match end_timestamp {
             Some(end_timestamp) => end_timestamp,
-            None => -1,
+            None => i64::MAX,
         };
         let request = self.client.pull_logs(chroma_proto::PullLogsRequest {
             collection_id: collection_id.to_string(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR fixes the issue when the endtimestamp is not set, the log service returns empty records. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
