### PR TITLE
[BUG]: Cohere v5 support (Python-only)

### DIFF
--- a/chromadb/test/ef/test_cohere_ef.py
+++ b/chromadb/test/ef/test_cohere_ef.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+from chromadb.utils.embedding_functions.cohere_embedding_function import (
+    CohereEmbeddingFunction,
+)
+
+# Skip test if the 'fastembed' package is not installed is not installed
+cohere = pytest.importorskip("cohere", reason="cohere not installed")
+
+
+@pytest.mark.skipif(not os.getenv("COHERE_API_KEY"), reason="COHERE_API_KEY is not set")
+def test_cohere_embedding_function():
+    cohere_ef = CohereEmbeddingFunction(
+        api_key=os.getenv("COHERE_API_KEY"), model_name="embed-multilingual-v3.0"
+    )
+    embeddings = cohere_ef(["This is a test doc"])
+    assert len(embeddings) == 1

--- a/chromadb/utils/embedding_functions/cohere_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cohere_embedding_function.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
 
@@ -17,11 +18,22 @@ class CohereEmbeddingFunction(EmbeddingFunction[Documents]):
         self._client = cohere.Client(api_key)
         self._model_name = model_name
 
+    @staticmethod
+    def _convert_v5_embeddings(embeddings_response: Any) -> Embeddings:
+        try:
+            # works with v5 - does't work with typed returned e.g. int/uint etc.
+            from cohere.types.embed_response import (  # noqa: F401
+                EmbedResponse_EmbeddingsFloats,
+            )
+
+            return embeddings_response.embeddings
+        except ImportError:
+            # work with v4
+            return [embeddings for embeddings in embeddings_response]
+
     def __call__(self, input: Documents) -> Embeddings:
         # Call Cohere Embedding API for each document.
-        return [
-            embeddings
-            for embeddings in self._client.embed(
-                texts=input, model=self._model_name, input_type="search_document"
-            )
-        ]
+        embeddings_response = self._client.embed(
+            texts=input, model=self._model_name, input_type="search_document"
+        )
+        return self._convert_v5_embeddings(embeddings_response)


### PR DESCRIPTION
Closes #2258 

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Adds support for Cohere v5 client that introduced a new way to generate the client that breaks existing code

*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
