### PR TITLE
[ENH] Metadata and full-text updates and deletes

### DIFF
--- a/rust/worker/src/blockstore/positional_posting_list_value.rs
+++ b/rust/worker/src/blockstore/positional_posting_list_value.rs
@@ -89,6 +89,18 @@ impl PositionalPostingListBuilder {
         Ok(())
     }
 
+    pub(crate) fn delete_doc_id(&mut self, doc_id: i32) -> Result<(), Box<dyn ChromaError>> {
+        if !self.doc_ids.contains(&doc_id) {
+            return Err(Box::new(
+                PositionalPostingListBuilderError::DocIdDoesNotExist,
+            ));
+        }
+
+        self.doc_ids.remove(&doc_id);
+        self.positions.remove(&doc_id);
+        Ok(())
+    }
+
     pub(crate) fn contains_doc_id(&self, doc_id: i32) -> bool {
         self.doc_ids.contains(&doc_id)
     }
@@ -215,6 +227,22 @@ mod tests {
         assert_eq!(
             list.get_positions_for_doc_id(1).unwrap(),
             Int32Array::from(vec![1, 2, 3, 4, 5, 6])
+        );
+    }
+
+    #[test]
+    fn test_positional_posting_list_delete_doc_id() {
+        let mut builder = PositionalPostingListBuilder::new();
+
+        let _res = builder.add_doc_id_and_positions(1, vec![1, 2, 3]);
+        let _res = builder.add_doc_id_and_positions(2, vec![4, 5, 6]);
+        let _res = builder.delete_doc_id(1);
+
+        let list = builder.build();
+        assert_eq!(list.get_doc_ids().values()[0], 2);
+        assert_eq!(
+            list.get_positions_for_doc_id(2).unwrap(),
+            Int32Array::from(vec![4, 5, 6])
         );
     }
 

--- a/rust/worker/src/blockstore/positional_posting_list_value.rs
+++ b/rust/worker/src/blockstore/positional_posting_list_value.rs
@@ -4,6 +4,8 @@ use arrow::{
 };
 use thiserror::Error;
 
+use crate::errors::{ChromaError, ErrorCodes};
+
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
@@ -46,6 +48,16 @@ pub(crate) enum PositionalPostingListBuilderError {
     DocIdDoesNotExist,
     #[error("Incremental positions must be sorted")]
     UnsortedPosition,
+}
+
+impl ChromaError for PositionalPostingListBuilderError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            PositionalPostingListBuilderError::DocIdAlreadyExists => ErrorCodes::AlreadyExists,
+            PositionalPostingListBuilderError::DocIdDoesNotExist => ErrorCodes::InvalidArgument,
+            PositionalPostingListBuilderError::UnsortedPosition => ErrorCodes::InvalidArgument,
+        }
+    }
 }
 
 pub(crate) struct PositionalPostingListBuilder {

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -140,7 +140,11 @@ impl<'me> FullTextIndexWriter<'me> {
         Ok(())
     }
 
-    pub async fn delete(&self, document: &str, offset_id: u32) -> Result<(), Box<dyn ChromaError>> {
+    pub async fn delete_document(
+        &self,
+        document: &str,
+        offset_id: u32,
+    ) -> Result<(), Box<dyn ChromaError>> {
         let mut tokenizer = self.tokenizer.lock();
         let tokens = tokenizer.encode(document);
         for token in tokens.get_tokens() {
@@ -179,6 +183,17 @@ impl<'me> FullTextIndexWriter<'me> {
                 }
             }
         }
+        Ok(())
+    }
+
+    pub async fn update_document(
+        &self,
+        old_document: &str,
+        new_document: &str,
+        offset_id: u32,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.delete_document(old_document, offset_id).await?;
+        self.add_document(new_document, offset_id as i32).await?;
         Ok(())
     }
 
@@ -957,5 +972,88 @@ mod tests {
 
         let res = index_reader.get_all_results_for_token("l").await.unwrap();
         assert_eq!(res.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_update_document() {
+        let provider = BlockfileProvider::new_memory();
+        let pl_blockfile_writer = provider.create::<u32, &Int32Array>().unwrap();
+        let freq_blockfile_writer = provider.create::<u32, &str>().unwrap();
+        let pl_blockfile_id = pl_blockfile_writer.id();
+        let freq_blockfile_id = freq_blockfile_writer.id();
+
+        let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+            NgramTokenizer::new(1, 1, false).unwrap(),
+        )));
+        let mut index_writer =
+            FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
+
+        index_writer.add_document("hello world", 1).await.unwrap();
+        index_writer.add_document("hello", 2).await.unwrap();
+        index_writer.add_document("world", 3).await.unwrap();
+        index_writer
+            .update_document("world", "hello", 3)
+            .await
+            .unwrap();
+
+        index_writer.write_to_blockfiles().await.unwrap();
+        let flusher = index_writer.commit().unwrap();
+        flusher.flush().await.unwrap();
+
+        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let pl_blockfile_reader = provider
+            .open::<u32, Int32Array>(&pl_blockfile_id)
+            .await
+            .unwrap();
+        let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+            NgramTokenizer::new(1, 1, false).unwrap(),
+        )));
+        let index_reader =
+            FullTextIndexReader::new(pl_blockfile_reader, freq_blockfile_reader, tokenizer);
+
+        let mut res = index_reader.search("hello").await.unwrap();
+        res.sort();
+        assert_eq!(res, vec![1, 2, 3]);
+
+        let res = index_reader.search("world").await.unwrap();
+        assert_eq!(res, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_delete_document() {
+        let provider = BlockfileProvider::new_memory();
+        let pl_blockfile_writer = provider.create::<u32, &Int32Array>().unwrap();
+        let freq_blockfile_writer = provider.create::<u32, &str>().unwrap();
+        let pl_blockfile_id = pl_blockfile_writer.id();
+        let freq_blockfile_id = freq_blockfile_writer.id();
+
+        let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+            NgramTokenizer::new(1, 1, false).unwrap(),
+        )));
+        let mut index_writer =
+            FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
+
+        index_writer.add_document("hello world", 1).await.unwrap();
+        index_writer.add_document("hello", 2).await.unwrap();
+        index_writer.add_document("world", 3).await.unwrap();
+        index_writer.delete_document("world", 3).await.unwrap();
+
+        index_writer.write_to_blockfiles().await.unwrap();
+        let flusher = index_writer.commit().unwrap();
+        flusher.flush().await.unwrap();
+
+        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let pl_blockfile_reader = provider
+            .open::<u32, Int32Array>(&pl_blockfile_id)
+            .await
+            .unwrap();
+        let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+            NgramTokenizer::new(1, 1, false).unwrap(),
+        )));
+        let index_reader =
+            FullTextIndexReader::new(pl_blockfile_reader, freq_blockfile_reader, tokenizer);
+
+        let res = index_reader.search("world").await.unwrap();
+        assert_eq!(res, vec![1]);
     }
 }

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -38,8 +38,6 @@ const U32_METADATA: &str = "u32_metadata";
 
 pub(crate) struct MetadataSegmentWriter<'me> {
     pub(crate) full_text_index_writer: Option<FullTextIndexWriter>,
-    // TODO this needs a real lifetime. However doing it breaks the commit() method
-    // for some reason? This works for now.
     pub(crate) string_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) bool_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) f32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
@@ -194,7 +192,8 @@ impl<'me> MetadataSegmentWriter<'me> {
                 Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
             },
         };
-        let string_metadata_index_writer = MetadataIndexWriter::new_string(string_metadata_writer);
+        let string_metadata_index_writer =
+            MetadataIndexWriter::new_string(string_metadata_writer, None);
 
         let bool_metadata_writer = match segment.file_path.get(BOOL_METADATA) {
             Some(bool_metadata_path) => match bool_metadata_path.get(0) {
@@ -223,7 +222,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                 Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
             },
         };
-        let bool_metadata_index_writer = MetadataIndexWriter::new_bool(bool_metadata_writer);
+        let bool_metadata_index_writer = MetadataIndexWriter::new_bool(bool_metadata_writer, None);
 
         let f32_metadata_writer = match segment.file_path.get(F32_METADATA) {
             Some(f32_metadata_path) => match f32_metadata_path.get(0) {
@@ -252,7 +251,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                 Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
             },
         };
-        let f32_metadata_index_writer = MetadataIndexWriter::new_f32(f32_metadata_writer);
+        let f32_metadata_index_writer = MetadataIndexWriter::new_f32(f32_metadata_writer, None);
 
         let u32_metadata_writer = match segment.file_path.get(U32_METADATA) {
             Some(u32_metadata_path) => match u32_metadata_path.get(0) {
@@ -281,7 +280,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                 Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
             },
         };
-        let u32_metadata_index_writer = MetadataIndexWriter::new_u32(u32_metadata_writer);
+        let u32_metadata_index_writer = MetadataIndexWriter::new_u32(u32_metadata_writer, None);
 
         Ok(MetadataSegmentWriter {
             full_text_index_writer: Some(full_text_index_writer),
@@ -352,7 +351,7 @@ impl<'me> MetadataSegmentWriter<'me> {
     }
 }
 
-impl SegmentWriter for MetadataSegmentWriter {
+impl SegmentWriter for MetadataSegmentWriter<'_> {
     fn apply_materialized_log_chunk(
         &self,
         records: crate::execution::data::data_chunk::Chunk<MaterializedLogRecord>,

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -82,6 +82,8 @@ pub enum MetadataSegmentError {
     LimitOffsetNotSupported,
     #[error("Could not query metadata index {0}")]
     MetadataIndexQueryError(#[from] MetadataIndexError),
+    #[error("Attempted to delete a document that does not exist")]
+    DocumentDoesNotExist,
 }
 
 impl ChromaError for MetadataSegmentError {
@@ -418,7 +420,6 @@ impl<'me> MetadataSegmentWriter<'me> {
     }
 }
 
-// TODO(Sanket): Implement this for updates/upserts/deletes.
 impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
     async fn apply_materialized_log_chunk(
         &self,

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -36,17 +36,17 @@ const BOOL_METADATA: &str = "bool_metadata";
 const F32_METADATA: &str = "f32_metadata";
 const U32_METADATA: &str = "u32_metadata";
 
-pub(crate) struct MetadataSegmentWriter {
+pub(crate) struct MetadataSegmentWriter<'me> {
     pub(crate) full_text_index_writer: Option<FullTextIndexWriter>,
     // TODO this needs a real lifetime. However doing it breaks the commit() method
     // for some reason? This works for now.
-    pub(crate) string_metadata_index_writer: Option<MetadataIndexWriter>,
-    pub(crate) bool_metadata_index_writer: Option<MetadataIndexWriter>,
-    pub(crate) f32_metadata_index_writer: Option<MetadataIndexWriter>,
-    pub(crate) u32_metadata_index_writer: Option<MetadataIndexWriter>,
+    pub(crate) string_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
+    pub(crate) bool_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
+    pub(crate) f32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
+    pub(crate) u32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
 }
 
-impl Debug for MetadataSegmentWriter {
+impl Debug for MetadataSegmentWriter<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "MetadataSegmentWriter")
     }
@@ -90,11 +90,11 @@ impl ChromaError for MetadataSegmentError {
     }
 }
 
-impl MetadataSegmentWriter {
+impl<'me> MetadataSegmentWriter<'me> {
     pub(crate) async fn from_segment(
         segment: &Segment,
         blockfile_provider: &BlockfileProvider,
-    ) -> Result<MetadataSegmentWriter, MetadataSegmentError> {
+    ) -> Result<MetadataSegmentWriter<'me>, MetadataSegmentError> {
         println!("Creating MetadataSegmentWriter from Segment");
         if segment.r#type != SegmentType::BlockfileMetadata {
             return Err(MetadataSegmentError::InvalidSegmentType);

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -75,7 +75,9 @@ pub(crate) struct MaterializedLogRecord<'referred_data> {
     pub(super) final_embedding: Option<&'referred_data [f32]>,
 }
 
-impl<'referred_data> From<(DataRecord<'referred_data>, u32)> for MaterializedLogRecord<'referred_data> {
+impl<'referred_data> From<(DataRecord<'referred_data>, u32)>
+    for MaterializedLogRecord<'referred_data>
+{
     fn from(data_record_info: (DataRecord<'referred_data>, u32)) -> Self {
         let data_record = data_record_info.0;
         let offset_id = data_record_info.1;
@@ -94,7 +96,9 @@ impl<'referred_data> From<(DataRecord<'referred_data>, u32)> for MaterializedLog
 // Creates a materialized log record from the corresponding entry
 // in the log (OperationRecord), offset id in storage where it will be stored (u32)
 // and user id (str).
-impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_data str)> for MaterializedLogRecord<'referred_data> {
+impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_data str)>
+    for MaterializedLogRecord<'referred_data>
+{
     type Error = LogMaterializerError;
 
     fn try_from(


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Updates and deletes for metadata and fulltext indices. This required plumbing readers into the indices so they could read old values -- as a side effect, this fixed a bug where we weren't correctly updating compacted values before.
	 - I would like to test this better but doing so requires the MemoryBlockfileProvider implementing `fork()`, which is a pretty nontrivial amount of work. It should be done as a fast-follow

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
