### PR TITLE
[ENH] Brute force metadata filtering operator

### DIFF
--- a/rust/worker/src/execution/operators/brute_force_metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/brute_force_metadata_filtering.rs
@@ -1,0 +1,625 @@
+use core::panic;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU16, AtomicU32},
+        Arc,
+    },
+};
+
+use futures::stream::Count;
+use roaring::RoaringBitmap;
+use tonic::async_trait;
+
+use crate::{
+    blockstore::{key::KeyWrapper, provider::BlockfileProvider},
+    chroma_proto::r#where,
+    execution::{
+        data::data_chunk::Chunk, operator::Operator,
+        operators::write_segments::WriteSegmentsOperatorError,
+    },
+    index::metadata::types::process_where_clause,
+    segment::{
+        record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
+        LogMaterializer, MaterializedLogRecord,
+    },
+    types::{LogRecord, Metadata, MetadataValue, Operation, Segment, Where, WhereClauseComparator},
+};
+
+use super::count_records::CountRecordsError;
+
+#[derive(Debug)]
+pub(crate) struct BruteForceMetadataFilteringOperator {}
+
+impl BruteForceMetadataFilteringOperator {
+    pub(crate) fn new() -> Box<Self> {
+        Box::new(BruteForceMetadataFilteringOperator {})
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BruteForceMetadataFilteringInput {
+    log_record: Chunk<LogRecord>,
+    record_segment: Segment,
+    blockfile_provider: BlockfileProvider,
+    curr_max_offset_id: Arc<AtomicU32>,
+    where_clause: Where,
+    // TODO(Sanket): Add Where document.
+}
+
+impl BruteForceMetadataFilteringInput {
+    pub(crate) fn new(
+        log_record: Chunk<LogRecord>,
+        record_segment: Segment,
+        blockfile_provider: BlockfileProvider,
+        where_clause: Where,
+        curr_max_offset_id: Arc<AtomicU32>,
+    ) -> Self {
+        Self {
+            log_record,
+            record_segment,
+            blockfile_provider,
+            where_clause,
+            curr_max_offset_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BruteForceMetadataFilteringOutput {
+    // Offset Ids.
+    filtered_documents: Vec<usize>,
+}
+
+#[async_trait]
+impl Operator<BruteForceMetadataFilteringInput, BruteForceMetadataFilteringOutput>
+    for BruteForceMetadataFilteringOperator
+{
+    type Error = CountRecordsError;
+    async fn run(
+        &self,
+        input: &BruteForceMetadataFilteringInput,
+    ) -> Result<BruteForceMetadataFilteringOutput, CountRecordsError> {
+        let record_segment_reader: Option<RecordSegmentReader>;
+        match RecordSegmentReader::from_segment(&input.record_segment, &input.blockfile_provider)
+            .await
+        {
+            Ok(reader) => {
+                record_segment_reader = Some(reader);
+            }
+            Err(e) => {
+                match *e {
+                    // Uninitialized segment is fine and means that the record
+                    // segment is not yet initialized in storage.
+                    RecordSegmentReaderCreationError::UninitializedSegment => {
+                        record_segment_reader = None;
+                    }
+                    RecordSegmentReaderCreationError::BlockfileOpenError(e) => {
+                        tracing::error!("Error creating record segment reader {}", e);
+                        return Err(CountRecordsError::RecordSegmentCreateError(
+                            RecordSegmentReaderCreationError::BlockfileOpenError(e),
+                        ));
+                    }
+                    RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                        tracing::error!("Error creating record segment reader {}", e);
+                        return Err(CountRecordsError::RecordSegmentCreateError(
+                            RecordSegmentReaderCreationError::InvalidNumberOfFiles,
+                        ));
+                    }
+                };
+            }
+        };
+        let materializer = LogMaterializer::new(
+            record_segment_reader,
+            input.log_record.clone(),
+            input.curr_max_offset_id.clone(),
+        );
+        let mat_records = match materializer.materialize().await {
+            Ok(records) => records,
+            Err(e) => {
+                return Err(CountRecordsError::RecordSegmentReadError(Box::new(e)));
+            }
+        };
+        let mut ids_to_metadata: HashMap<u32, HashMap<&String, &MetadataValue>> = HashMap::new();
+        for (records, _) in mat_records.iter() {
+            if records.final_operation == Operation::Delete {
+                continue;
+            }
+            if !ids_to_metadata.contains_key(&records.offset_id) {
+                ids_to_metadata.insert(records.offset_id, HashMap::new());
+            }
+            let map_pointer = ids_to_metadata
+                .get_mut(&records.offset_id)
+                .expect("Not possible.");
+            match &records.data_record {
+                Some(data_record) => match &data_record.metadata {
+                    Some(meta) => {
+                        for (meta_key, meta_val) in meta {
+                            map_pointer.insert(&meta_key, &meta_val);
+                        }
+                    }
+                    None => (),
+                },
+                None => (),
+            };
+            match &records.metadata_to_be_merged {
+                Some(meta) => {
+                    for (meta_key, meta_val) in meta {
+                        map_pointer.insert(meta_key, meta_val);
+                    }
+                }
+                None => (),
+            };
+        }
+        // Time now to perform a metadata search based on where clause.
+        let clo = |metadata_key: &str,
+                   metadata_value: &crate::blockstore::key::KeyWrapper,
+                   metadata_type: crate::types::MetadataType,
+                   comparator: WhereClauseComparator| {
+            match metadata_type {
+                crate::types::MetadataType::StringType => match comparator {
+                    WhereClauseComparator::Equal => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Str(string_value) => {
+                                        if let KeyWrapper::String(where_value) = metadata_value {
+                                            if *string_value == *where_value {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::NotEqual => {
+                        todo!();
+                    }
+                    // We don't allow these comparators for strings.
+                    WhereClauseComparator::LessThan => {
+                        unimplemented!();
+                    }
+                    WhereClauseComparator::LessThanOrEqual => {
+                        unimplemented!();
+                    }
+                    WhereClauseComparator::GreaterThan => {
+                        unimplemented!();
+                    }
+                    WhereClauseComparator::GreaterThanOrEqual => {
+                        unimplemented!();
+                    }
+                },
+                crate::types::MetadataType::IntType => match comparator {
+                    WhereClauseComparator::Equal => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Int(int_value) => {
+                                        if let KeyWrapper::Uint32(where_value) = metadata_value {
+                                            if *int_value as u32 == *where_value {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::NotEqual => {
+                        todo!();
+                    }
+                    WhereClauseComparator::LessThan => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Int(int_value) => {
+                                        if let KeyWrapper::Uint32(where_value) = metadata_value {
+                                            if ((*int_value) as u32) < (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::LessThanOrEqual => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Int(int_value) => {
+                                        if let KeyWrapper::Uint32(where_value) = metadata_value {
+                                            if ((*int_value) as u32) <= (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::GreaterThan => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Int(int_value) => {
+                                        if let KeyWrapper::Uint32(where_value) = metadata_value {
+                                            if ((*int_value) as u32) > (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::GreaterThanOrEqual => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Int(int_value) => {
+                                        if let KeyWrapper::Uint32(where_value) = metadata_value {
+                                            if ((*int_value) as u32) >= (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                },
+                crate::types::MetadataType::DoubleType => match comparator {
+                    WhereClauseComparator::Equal => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Float(float_value) => {
+                                        if let KeyWrapper::Float32(where_value) = metadata_value {
+                                            if ((*float_value) as f32) == (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::NotEqual => {
+                        todo!();
+                    }
+                    WhereClauseComparator::LessThan => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Float(float_value) => {
+                                        if let KeyWrapper::Float32(where_value) = metadata_value {
+                                            if ((*float_value) as f32) < (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::LessThanOrEqual => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Float(float_value) => {
+                                        if let KeyWrapper::Float32(where_value) = metadata_value {
+                                            if ((*float_value) as f32) <= (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::GreaterThan => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Float(float_value) => {
+                                        if let KeyWrapper::Float32(where_value) = metadata_value {
+                                            if ((*float_value) as f32) > (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                    WhereClauseComparator::GreaterThanOrEqual => {
+                        let mut result = RoaringBitmap::new();
+                        // Construct a bitmap consisting of all offset ids
+                        // that have this key equal to this value.
+                        for (offset_id, meta_map) in &ids_to_metadata {
+                            if let Some(val) = meta_map.get(&metadata_key.to_string()) {
+                                match *val {
+                                    MetadataValue::Float(float_value) => {
+                                        if let KeyWrapper::Float32(where_value) = metadata_value {
+                                            if ((*float_value) as f32) >= (*where_value) {
+                                                result.insert(*offset_id);
+                                            }
+                                        }
+                                    }
+                                    _ => (),
+                                }
+                            }
+                        }
+                        return result;
+                    }
+                },
+                crate::types::MetadataType::StringListType => {
+                    todo!();
+                }
+                crate::types::MetadataType::IntListType => {
+                    todo!();
+                }
+                crate::types::MetadataType::DoubleListType => {
+                    todo!();
+                }
+            }
+        };
+        let res = match process_where_clause(&input.where_clause, &clo) {
+            Ok(r) => r,
+            Err(e) => panic!("Failed parsing where clause"),
+        };
+        return Ok(BruteForceMetadataFilteringOutput {
+            filtered_documents: res,
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::HashMap,
+        str::FromStr,
+        sync::{atomic::AtomicU32, Arc},
+    };
+
+    use uuid::Uuid;
+
+    use crate::{
+        blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
+        execution::{
+            data::data_chunk::Chunk,
+            operator::Operator,
+            operators::brute_force_metadata_filtering::{
+                BruteForceMetadataFilteringInput, BruteForceMetadataFilteringOperator,
+            },
+        },
+        segment::{
+            record_segment::{
+                RecordSegmentReader, RecordSegmentReaderCreationError, RecordSegmentWriter,
+            },
+            types::SegmentFlusher,
+            LogMaterializer, SegmentWriter,
+        },
+        storage::{local::LocalStorage, Storage},
+        types::{
+            DirectComparison, LogRecord, Operation, OperationRecord, UpdateMetadataValue, Where,
+            WhereComparison,
+        },
+    };
+
+    #[tokio::test]
+    async fn test_where_clause() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let arrow_blockfile_provider = ArrowBlockfileProvider::new(storage);
+        let blockfile_provider =
+            BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
+        let mut record_segment = crate::types::Segment {
+            id: Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
+            r#type: crate::types::SegmentType::Record,
+            scope: crate::types::SegmentScope::RECORD,
+            collection: Some(
+                Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
+            ),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        {
+            let segment_writer =
+                RecordSegmentWriter::from_segment(&record_segment, &blockfile_provider)
+                    .await
+                    .expect("Error creating segment writer");
+            let mut update_metadata = HashMap::new();
+            update_metadata.insert(
+                String::from("hello"),
+                UpdateMetadataValue::Str(String::from("world")),
+            );
+            update_metadata.insert(
+                String::from("bye"),
+                UpdateMetadataValue::Str(String::from("world")),
+            );
+            let data = vec![
+                LogRecord {
+                    log_offset: 1,
+                    record: OperationRecord {
+                        id: "embedding_id_1".to_string(),
+                        embedding: Some(vec![1.0, 2.0, 3.0]),
+                        encoding: None,
+                        metadata: Some(update_metadata.clone()),
+                        document: Some(String::from("doc1")),
+                        operation: Operation::Add,
+                    },
+                },
+                LogRecord {
+                    log_offset: 2,
+                    record: OperationRecord {
+                        id: "embedding_id_2".to_string(),
+                        embedding: Some(vec![4.0, 5.0, 6.0]),
+                        encoding: None,
+                        metadata: Some(update_metadata),
+                        document: Some(String::from("doc2")),
+                        operation: Operation::Add,
+                    },
+                },
+            ];
+            let data: Chunk<LogRecord> = Chunk::new(data.into());
+            let mut record_segment_reader: Option<RecordSegmentReader> = None;
+            match RecordSegmentReader::from_segment(&record_segment, &blockfile_provider).await {
+                Ok(reader) => {
+                    record_segment_reader = Some(reader);
+                }
+                Err(e) => {
+                    match *e {
+                        // Uninitialized segment is fine and means that the record
+                        // segment is not yet initialized in storage.
+                        RecordSegmentReaderCreationError::UninitializedSegment => {
+                            record_segment_reader = None;
+                        }
+                        RecordSegmentReaderCreationError::BlockfileOpenError(_) => {
+                            assert!(1 == 1, "Error creating record segment reader");
+                        }
+                        RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                            assert!(1 == 1, "Error creating record segment reader");
+                        }
+                    };
+                }
+            };
+            let curr_max_offset_id = Arc::new(AtomicU32::new(1));
+            let materializer =
+                LogMaterializer::new(record_segment_reader, data, curr_max_offset_id);
+            let mat_records = materializer
+                .materialize()
+                .await
+                .expect("Log materialization failed");
+            segment_writer
+                .apply_materialized_log_chunk(mat_records)
+                .await
+                .expect("Apply materialized log failed");
+            let flusher = segment_writer
+                .commit()
+                .expect("Commit for segment writer failed");
+            record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
+        }
+        let mut update_metadata = HashMap::new();
+        update_metadata.insert(
+            String::from("hello"),
+            UpdateMetadataValue::Str(String::from("new_world")),
+        );
+        update_metadata.insert(
+            String::from("hello_again"),
+            UpdateMetadataValue::Str(String::from("new_world")),
+        );
+        let data = vec![
+            LogRecord {
+                log_offset: 3,
+                record: OperationRecord {
+                    id: "embedding_id_1".to_string(),
+                    embedding: None,
+                    encoding: None,
+                    metadata: Some(update_metadata.clone()),
+                    document: None,
+                    operation: Operation::Update,
+                },
+            },
+            LogRecord {
+                log_offset: 4,
+                record: OperationRecord {
+                    id: "embedding_id_3".to_string(),
+                    embedding: Some(vec![7.0, 8.0, 9.0]),
+                    encoding: None,
+                    metadata: Some(update_metadata),
+                    document: Some(String::from("doc3")),
+                    operation: Operation::Add,
+                },
+            },
+            LogRecord {
+                log_offset: 5,
+                record: OperationRecord {
+                    id: "embedding_id_2".to_string(),
+                    embedding: Some(vec![10.0, 11.0, 12.0]),
+                    encoding: None,
+                    metadata: None,
+                    document: None,
+                    operation: Operation::Update,
+                },
+            },
+        ];
+        let data: Chunk<LogRecord> = Chunk::new(data.into());
+        let operator = BruteForceMetadataFilteringOperator::new();
+        let curr_max_offset_id = Arc::new(AtomicU32::new(3));
+        let where_clause: Where = Where::DirectWhereComparison(DirectComparison {
+            key: String::from("hello"),
+            comparison: WhereComparison::SingleStringComparison(
+                String::from("new_world"),
+                crate::types::WhereClauseComparator::Equal,
+            ),
+        });
+        let input = BruteForceMetadataFilteringInput::new(
+            data,
+            record_segment,
+            blockfile_provider,
+            where_clause,
+            curr_max_offset_id,
+        );
+        let mut res = operator
+            .run(&input)
+            .await
+            .expect("Error during running of operator");
+        assert_eq!(2, res.filtered_documents.len());
+        res.filtered_documents.sort();
+        assert_eq!(1, *res.filtered_documents.get(0).expect("Expect not none"));
+        assert_eq!(3, *res.filtered_documents.get(1).expect("Expect not none"));
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod brute_force_knn;
+pub(super) mod brute_force_metadata_filtering;
 pub(super) mod count_records;
 pub(super) mod flush_s3;
 pub(super) mod hnsw_knn;

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -306,7 +306,7 @@ impl<'me> FullTextIndexReader<'me> {
     }
 }
 
-pub(crate) fn process_where_document_clause<F: Fn(&str, WhereDocumentOperator) -> Vec<i32>>(
+pub(crate) fn process_where_document_clause_with_callback<F: Fn(&str, WhereDocumentOperator) -> Vec<i32>>(
     where_document_clause: &WhereDocument,
     callback: &F,
 ) -> Result<Vec<usize>, MetadataIndexError> {
@@ -330,7 +330,7 @@ pub(crate) fn process_where_document_clause<F: Fn(&str, WhereDocumentOperator) -
             let mut first_iteration = true;
             for child in where_document_children.children.iter() {
                 let child_results: Vec<usize> =
-                    match process_where_document_clause(&child, callback) {
+                    match process_where_document_clause_with_callback(&child, callback) {
                         Ok(result) => result,
                         Err(_) => vec![],
                     };

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -306,7 +306,9 @@ impl<'me> FullTextIndexReader<'me> {
     }
 }
 
-pub(crate) fn process_where_document_clause_with_callback<F: Fn(&str, WhereDocumentOperator) -> Vec<i32>>(
+pub(crate) fn process_where_document_clause_with_callback<
+    F: Fn(&str, WhereDocumentOperator) -> Vec<i32>,
+>(
     where_document_clause: &WhereDocument,
     callback: &F,
 ) -> Result<Vec<usize>, MetadataIndexError> {

--- a/rust/worker/src/index/metadata/types.rs
+++ b/rust/worker/src/index/metadata/types.rs
@@ -59,7 +59,7 @@ pub(crate) enum MetadataIndexWriter {
     ),
 }
 
-pub(crate) fn process_where_clause<
+pub(crate) fn process_where_clause_with_callback<
     F: Fn(&str, &KeyWrapper, MetadataType, WhereClauseComparator) -> RoaringBitmap,
 >(
     where_clause: &Where,
@@ -301,7 +301,7 @@ pub(crate) fn process_where_clause<
             // This feels like a crime.
             let mut first_iteration = true;
             for child in where_children.children.iter() {
-                let child_results: Vec<usize> = match process_where_clause(&child, callback) {
+                let child_results: Vec<usize> = match process_where_clause_with_callback(&child, callback) {
                     Ok(result) => result,
                     Err(_) => vec![],
                 };

--- a/rust/worker/src/index/metadata/types.rs
+++ b/rust/worker/src/index/metadata/types.rs
@@ -1,5 +1,7 @@
 use crate::blockstore::{key::KeyWrapper, BlockfileFlusher, BlockfileReader, BlockfileWriter};
 use crate::errors::{ChromaError, ErrorCodes};
+use crate::types::{BooleanOperator, MetadataType, Where, WhereClauseComparator, WhereComparison};
+use crate::utils::{merge_sorted_vecs_conjunction, merge_sorted_vecs_disjunction};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -55,6 +57,272 @@ pub(crate) enum MetadataIndexWriter {
         BlockfileWriter,
         Arc<Mutex<HashMap<String, HashMap<bool, RoaringBitmap>>>>,
     ),
+}
+
+pub(crate) fn process_where_clause<
+    F: Fn(&str, &KeyWrapper, MetadataType, WhereClauseComparator) -> RoaringBitmap,
+>(
+    where_clause: &Where,
+    callback: &F,
+) -> Result<Vec<usize>, MetadataIndexError> {
+    let mut results = vec![];
+    match where_clause {
+        Where::DirectWhereComparison(direct_where_comparison) => {
+            match &direct_where_comparison.comparison {
+                WhereComparison::SingleStringComparison(operand, comparator) => {
+                    match comparator {
+                        WhereClauseComparator::Equal => {
+                            let metadata_value_keywrapper = operand.as_str().try_into();
+                            match metadata_value_keywrapper {
+                                Ok(keywrapper) => {
+                                    let result = callback(
+                                        &direct_where_comparison.key,
+                                        &keywrapper,
+                                        MetadataType::StringType,
+                                        WhereClauseComparator::Equal,
+                                    );
+                                    results = result.iter().map(|x| x as usize).collect();
+                                }
+                                Err(_) => {
+                                    panic!("Error converting string to keywrapper")
+                                }
+                            }
+                        }
+                        WhereClauseComparator::NotEqual => {
+                            todo!();
+                        }
+                        // We don't allow these comparators for strings.
+                        WhereClauseComparator::LessThan => {
+                            unimplemented!();
+                        }
+                        WhereClauseComparator::LessThanOrEqual => {
+                            unimplemented!();
+                        }
+                        WhereClauseComparator::GreaterThan => {
+                            unimplemented!();
+                        }
+                        WhereClauseComparator::GreaterThanOrEqual => {
+                            unimplemented!();
+                        }
+                    }
+                }
+                WhereComparison::SingleIntComparison(operand, comparator) => match comparator {
+                    WhereClauseComparator::Equal => {
+                        let metadata_value_keywrapper = (*operand).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::IntType,
+                                    WhereClauseComparator::Equal,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting int to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::NotEqual => {
+                        todo!();
+                    }
+                    WhereClauseComparator::LessThan => {
+                        let metadata_value_keywrapper = (*operand).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::IntType,
+                                    WhereClauseComparator::LessThan,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting int to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::LessThanOrEqual => {
+                        let metadata_value_keywrapper = (*operand).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::IntType,
+                                    WhereClauseComparator::LessThanOrEqual,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting int to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::GreaterThan => {
+                        let metadata_value_keywrapper = (*operand).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::IntType,
+                                    WhereClauseComparator::GreaterThan,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting int to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::GreaterThanOrEqual => {
+                        let metadata_value_keywrapper = (*operand).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::IntType,
+                                    WhereClauseComparator::GreaterThanOrEqual,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting int to keywrapper")
+                            }
+                        }
+                    }
+                },
+                WhereComparison::SingleDoubleComparison(operand, comparator) => match comparator {
+                    WhereClauseComparator::Equal => {
+                        let metadata_value_keywrapper = (*operand as f32).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::DoubleType,
+                                    WhereClauseComparator::Equal,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting double to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::NotEqual => {
+                        todo!();
+                    }
+                    WhereClauseComparator::LessThan => {
+                        let metadata_value_keywrapper = (*operand as f32).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::DoubleType,
+                                    WhereClauseComparator::LessThan,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting double to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::LessThanOrEqual => {
+                        let metadata_value_keywrapper = (*operand as f32).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::DoubleType,
+                                    WhereClauseComparator::LessThanOrEqual,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting double to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::GreaterThan => {
+                        let metadata_value_keywrapper = (*operand as f32).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::DoubleType,
+                                    WhereClauseComparator::GreaterThan,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting double to keywrapper")
+                            }
+                        }
+                    }
+                    WhereClauseComparator::GreaterThanOrEqual => {
+                        let metadata_value_keywrapper = (*operand as f32).try_into();
+                        match metadata_value_keywrapper {
+                            Ok(keywrapper) => {
+                                let result = callback(
+                                    &direct_where_comparison.key,
+                                    &keywrapper,
+                                    MetadataType::DoubleType,
+                                    WhereClauseComparator::GreaterThanOrEqual,
+                                );
+                                results = result.iter().map(|x| x as usize).collect();
+                            }
+                            Err(_) => {
+                                panic!("Error converting double to keywrapper")
+                            }
+                        }
+                    }
+                },
+                WhereComparison::StringListComparison(operand, list_operator) => {
+                    todo!();
+                }
+                WhereComparison::IntListComparison(..) => {
+                    todo!();
+                }
+                WhereComparison::DoubleListComparison(..) => {
+                    todo!();
+                }
+            }
+        }
+        Where::WhereChildren(where_children) => {
+            // This feels like a crime.
+            let mut first_iteration = true;
+            for child in where_children.children.iter() {
+                let child_results: Vec<usize> = match process_where_clause(&child, callback) {
+                    Ok(result) => result,
+                    Err(_) => vec![],
+                };
+                if first_iteration {
+                    results = child_results;
+                    first_iteration = false;
+                } else {
+                    match where_children.operator {
+                        BooleanOperator::And => {
+                            results = merge_sorted_vecs_conjunction(results, child_results);
+                        }
+                        BooleanOperator::Or => {
+                            results = merge_sorted_vecs_disjunction(results, child_results);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    results.sort();
+    return Ok(results);
 }
 
 impl MetadataIndexWriter {

--- a/rust/worker/src/index/metadata/types.rs
+++ b/rust/worker/src/index/metadata/types.rs
@@ -301,10 +301,11 @@ pub(crate) fn process_where_clause_with_callback<
             // This feels like a crime.
             let mut first_iteration = true;
             for child in where_children.children.iter() {
-                let child_results: Vec<usize> = match process_where_clause_with_callback(&child, callback) {
-                    Ok(result) => result,
-                    Err(_) => vec![],
-                };
+                let child_results: Vec<usize> =
+                    match process_where_clause_with_callback(&child, callback) {
+                        Ok(result) => result,
+                        Err(_) => vec![],
+                    };
                 if first_iteration {
                     results = child_results;
                     first_iteration = false;

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -17,11 +17,11 @@ use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::index::fulltext::tokenizer::TantivyChromaTokenizer;
 use crate::index::fulltext::types::{
-    process_where_document_clause, FullTextIndexError, FullTextIndexFlusher, FullTextIndexReader,
+    process_where_document_clause_with_callback, FullTextIndexError, FullTextIndexFlusher, FullTextIndexReader,
     FullTextIndexWriter,
 };
 use crate::index::metadata::types::{
-    process_where_clause, MetadataIndexError, MetadataIndexFlusher, MetadataIndexReader,
+    process_where_clause_with_callback, MetadataIndexError, MetadataIndexFlusher, MetadataIndexReader,
     MetadataIndexWriter,
 };
 use crate::types::SegmentType;
@@ -1011,7 +1011,7 @@ impl MetadataSegmentReader<'_> {
                 }
             }
         };
-        return process_where_clause(where_clause, &clo);
+        return process_where_clause_with_callback(where_clause, &clo);
     }
 
     fn process_where_document_clause(
@@ -1037,6 +1037,6 @@ impl MetadataSegmentReader<'_> {
                 todo!()
             }
         };
-        process_where_document_clause(where_document_clause, &cb)
+        process_where_document_clause_with_callback(where_document_clause, &cb)
     }
 }

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -17,12 +17,12 @@ use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::index::fulltext::tokenizer::TantivyChromaTokenizer;
 use crate::index::fulltext::types::{
-    process_where_document_clause_with_callback, FullTextIndexError, FullTextIndexFlusher, FullTextIndexReader,
-    FullTextIndexWriter,
+    process_where_document_clause_with_callback, FullTextIndexError, FullTextIndexFlusher,
+    FullTextIndexReader, FullTextIndexWriter,
 };
 use crate::index::metadata::types::{
-    process_where_clause_with_callback, MetadataIndexError, MetadataIndexFlusher, MetadataIndexReader,
-    MetadataIndexWriter,
+    process_where_clause_with_callback, MetadataIndexError, MetadataIndexFlusher,
+    MetadataIndexReader, MetadataIndexWriter,
 };
 use crate::types::SegmentType;
 use crate::types::{

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -308,6 +308,16 @@ pub(crate) enum WhereComparison {
     DoubleListComparison(Vec<f64>, WhereClauseListOperator),
 }
 
+#[derive(Debug)]
+pub(crate) enum MetadataType {
+    StringType,
+    IntType,
+    DoubleType,
+    StringListType,
+    IntListType,
+    DoubleListType,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum WhereClauseComparator {
     Equal,


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
Introduces an operator that takes the where and where_document clauses and returns a list of offset ids of the log that match the conditions. Note wiring it into the orchestrator is a bit more work and will be a separate PR

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
