### PR TITLE
[CLN] Rename blockfile record segment appropriately

### DIFF
--- a/chromadb/segment/__init__.py
+++ b/chromadb/segment/__init__.py
@@ -23,7 +23,7 @@ class SegmentType(Enum):
     HNSW_LOCAL_MEMORY = "urn:chroma:segment/vector/hnsw-local-memory"
     HNSW_LOCAL_PERSISTED = "urn:chroma:segment/vector/hnsw-local-persisted"
     HNSW_DISTRIBUTED = "urn:chroma:segment/vector/hnsw-distributed"
-    RECORD = "urn:chroma:segment/record"
+    BLOCKFILE_RECORD = "urn:chroma:segment/record/blockfile"
     BLOCKFILE_METADATA = "urn:chroma:segment/metadata/blockfile"
 
 

--- a/chromadb/segment/impl/manager/distributed.py
+++ b/chromadb/segment/impl/manager/distributed.py
@@ -68,7 +68,9 @@ class DistributedSegmentManager(SegmentManager):
         metadata_segment = _segment(
             SegmentType.BLOCKFILE_METADATA, SegmentScope.METADATA, collection
         )
-        record_segment = _segment(SegmentType.RECORD, SegmentScope.RECORD, collection)
+        record_segment = _segment(
+            SegmentType.BLOCKFILE_RECORD, SegmentScope.RECORD, collection
+        )
         return [vector_segment, record_segment, metadata_segment]
 
     @override

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -384,7 +384,7 @@ mod tests {
 
         let collection_1_record_segment = Segment {
             id: Uuid::new_v4(),
-            r#type: crate::types::SegmentType::Record,
+            r#type: crate::types::SegmentType::BlockfileRecord,
             scope: crate::types::SegmentScope::RECORD,
             collection: Some(collection_uuid_1),
             metadata: None,
@@ -393,7 +393,7 @@ mod tests {
 
         let collection_2_record_segment = Segment {
             id: Uuid::new_v4(),
-            r#type: crate::types::SegmentType::Record,
+            r#type: crate::types::SegmentType::BlockfileRecord,
             scope: crate::types::SegmentScope::RECORD,
             collection: Some(collection_uuid_2),
             metadata: None,

--- a/rust/worker/src/execution/operators/brute_force_metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/brute_force_metadata_filtering.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::{
     collections::HashMap,
     sync::{
@@ -6,11 +5,6 @@ use std::{
         Arc,
     },
 };
-
-use futures::stream::Count;
-use roaring::RoaringBitmap;
-use thiserror::Error;
-use tonic::async_trait;
 
 use crate::{
     blockstore::{key::KeyWrapper, provider::BlockfileProvider},
@@ -30,9 +24,9 @@ use crate::{
     },
     utils::merge_sorted_vecs_conjunction,
 };
-
-use super::count_records::CountRecordsError;
-
+use roaring::RoaringBitmap;
+use thiserror::Error;
+use tonic::async_trait;
 #[derive(Debug)]
 pub(crate) struct BruteForceMetadataFilteringOperator {}
 
@@ -555,7 +549,7 @@ mod test {
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let mut record_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
-            r#type: crate::types::SegmentType::Record,
+            r#type: crate::types::SegmentType::BlockfileRecord,
             scope: crate::types::SegmentScope::RECORD,
             collection: Some(
                 Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -210,7 +210,7 @@ mod tests {
         let in_memory_provider = BlockfileProvider::new_memory();
         let mut record_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
-            r#type: crate::types::SegmentType::Record,
+            r#type: crate::types::SegmentType::BlockfileRecord,
             scope: crate::types::SegmentScope::RECORD,
             collection: Some(
                 Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
@@ -352,7 +352,7 @@ mod tests {
         let in_memory_provider = BlockfileProvider::new_memory();
         let record_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
-            r#type: crate::types::SegmentType::Record,
+            r#type: crate::types::SegmentType::BlockfileRecord,
             scope: crate::types::SegmentScope::RECORD,
             collection: Some(
                 Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -342,7 +342,7 @@ impl CompactOrchestrator {
 
         let record_segment = segments
             .iter()
-            .find(|segment| segment.r#type == SegmentType::Record);
+            .find(|segment| segment.r#type == SegmentType::BlockfileRecord);
 
         tracing::debug!("Found Record Segment: {:?}", record_segment);
 

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -463,7 +463,7 @@ impl HnswQueryOrchestrator {
         let segments = sysdb
             .get_segments(
                 None,
-                Some(SegmentType::Record.into()),
+                Some(SegmentType::BlockfileRecord.into()),
                 None,
                 Some(*collection_id),
             )
@@ -483,7 +483,7 @@ impl HnswQueryOrchestrator {
             }
         };
 
-        if segment.r#type != SegmentType::Record {
+        if segment.r#type != SegmentType::BlockfileRecord {
             return Err(Box::new(HnswSegmentQueryError::RecordSegmentNotFound(
                 *collection_id,
             )));

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -280,7 +280,7 @@ impl CountQueryOrchestrator {
         let segments = sysdb
             .get_segments(
                 None,
-                Some(SegmentType::Record.into()),
+                Some(SegmentType::BlockfileRecord.into()),
                 None,
                 Some(*collection_id),
             )
@@ -720,7 +720,7 @@ impl MetadataQueryOrchestrator {
         let segments = sysdb
             .get_segments(
                 None,
-                Some(SegmentType::Record.into()),
+                Some(SegmentType::BlockfileRecord.into()),
                 None,
                 Some(*collection_id),
             )

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -131,7 +131,7 @@ impl RecordSegmentWriter {
         blockfile_provider: &BlockfileProvider,
     ) -> Result<Self, RecordSegmentWriterCreationError> {
         println!("Creating RecordSegmentWriter from Segment");
-        if segment.r#type != SegmentType::Record {
+        if segment.r#type != SegmentType::BlockfileRecord {
             return Err(RecordSegmentWriterCreationError::InvalidSegmentType);
         }
 

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -436,7 +436,7 @@ mod tests {
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let mut record_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
-            r#type: crate::types::SegmentType::Record,
+            r#type: crate::types::SegmentType::BlockfileRecord,
             scope: crate::types::SegmentScope::RECORD,
             collection: Some(
                 Uuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -75,7 +75,9 @@ pub(crate) struct MaterializedLogRecord<'referred_data> {
     pub(super) final_embedding: Option<&'referred_data [f32]>,
 }
 
-impl<'referred_data> From<(DataRecord<'referred_data>, u32)> for MaterializedLogRecord<'referred_data> {
+impl<'referred_data> From<(DataRecord<'referred_data>, u32)>
+    for MaterializedLogRecord<'referred_data>
+{
     fn from(data_record_info: (DataRecord<'referred_data>, u32)) -> Self {
         let data_record = data_record_info.0;
         let offset_id = data_record_info.1;
@@ -94,7 +96,9 @@ impl<'referred_data> From<(DataRecord<'referred_data>, u32)> for MaterializedLog
 // Creates a materialized log record from the corresponding entry
 // in the log (OperationRecord), offset id in storage where it will be stored (u32)
 // and user id (str).
-impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_data str)> for MaterializedLogRecord<'referred_data> {
+impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_data str)>
+    for MaterializedLogRecord<'referred_data>
+{
     type Error = LogMaterializerError;
 
     fn try_from(

--- a/rust/worker/src/types/segment.rs
+++ b/rust/worker/src/types/segment.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 pub(crate) enum SegmentType {
     HnswDistributed,
     BlockfileMetadata,
-    Record,
+    BlockfileRecord,
     Sqlite,
 }
 
@@ -21,7 +21,7 @@ impl From<SegmentType> for String {
             SegmentType::HnswDistributed => {
                 "urn:chroma:segment/vector/hnsw-distributed".to_string()
             }
-            SegmentType::Record => "urn:chroma:segment/record".to_string(),
+            SegmentType::BlockfileRecord => "urn:chroma:segment/record/blockfile".to_string(),
             SegmentType::Sqlite => "urn:chroma:segment/metadata/sqlite".to_string(),
             SegmentType::BlockfileMetadata => "urn:chroma:segment/metadata/blockfile".to_string(),
         }
@@ -93,7 +93,7 @@ impl TryFrom<chroma_proto::Segment> for Segment {
 
         let segment_type = match proto_segment.r#type.as_str() {
             "urn:chroma:segment/vector/hnsw-distributed" => SegmentType::HnswDistributed,
-            "urn:chroma:segment/record" => SegmentType::Record,
+            "urn:chroma:segment/record/blockfile" => SegmentType::BlockfileRecord,
             "urn:chroma:segment/metadata/sqlite" => SegmentType::Sqlite,
             "urn:chroma:segment/metadata/blockfile" => SegmentType::BlockfileMetadata,
             _ => {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Renames the blockfile record segment to be more specific. The current name doesn't allow for multiple types in the name path.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
None required
