### PR TITLE
[BLD] add hypothesis profiles

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -8,7 +8,10 @@ on:
         required: false
         default: '["3.8"]'
         type: string
-
+      property_testing_preset:
+        description: 'Property testing preset'
+        required: true
+        type: string
 
 jobs:
   test:
@@ -39,6 +42,8 @@ jobs:
       - name: Test
         run: python -m pytest ${{ matrix.parallelized && '-n auto' || '' }}  ${{ matrix.test-globs }}
         shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   # todo: break out stress integration tests
   test-single-node-integration:
@@ -64,6 +69,8 @@ jobs:
     - name: Integration Test
       run: bin/python-integration-test ${{ matrix.test-globs }}
       shell: bash
+      env:
+        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-cluster-integration:
     strategy:
@@ -88,6 +95,8 @@ jobs:
       - name: Test
         run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}"'
         shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-thin-client:
     strategy:
@@ -104,6 +113,8 @@ jobs:
       - name: Test
         run: clients/python/integration-test.sh
         shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-stress:
     timeout-minutes: 90
@@ -120,6 +131,8 @@ jobs:
       - name: Test
         run: python -m pytest chromadb/test/stress/
         shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-single-node-integration-stress:
     strategy:
@@ -135,3 +148,5 @@ jobs:
     - name: Integration Test
       run: bin/python-integration-test chromadb/test/stress/
       shell: bash
+      env:
+        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,8 @@ jobs:
     needs: paths-filter
     if: needs.paths-filter.outputs.outside-docs == 'true'
     uses: ./.github/workflows/_python-tests.yml
+    with:
+      property_testing_preset: 'fast'
 
   python-vulnerability-scan:
     name: Python vulnerability scan

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -51,6 +51,7 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     with:
       python_versions: '["3.8", "3.9", "3.10", "3.11", "3.12"]'
+      property_testing_preset: 'normal'
 
   javascript-client-tests:
     name: JavaScript client tests

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -63,10 +63,10 @@ hypothesis.settings.load_profile(CURRENT_PRESET)
 
 
 def override_hypothesis_profile(
-    fast: hypothesis.settings | None = None,
-    normal: hypothesis.settings | None = None,
-    slow: hypothesis.settings | None = None,
-) -> hypothesis.settings | None:
+    fast: Optional[hypothesis.settings] = None,
+    normal: Optional[hypothesis.settings] = None,
+    slow: Optional[hypothesis.settings] = None,
+) -> Optional[hypothesis.settings]:
     """Override Hypothesis settings for specific profiles.
 
     For example, to override max_examples only when the current profile is 'fast':

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -30,16 +30,80 @@ from chromadb.ingest import Producer
 from chromadb.types import SeqId, OperationRecord
 from chromadb.api.client import Client as ClientCreator
 
+VALID_PRESETS = ["fast", "normal", "slow"]
+CURRENT_PRESET = os.getenv("PROPERTY_TESTING_PRESET", "normal")
+
+if CURRENT_PRESET not in VALID_PRESETS:
+    raise ValueError(
+        f"Invalid property testing preset: {CURRENT_PRESET}. Must be one of {VALID_PRESETS}."
+    )
+
 hypothesis.settings.register_profile(
-    "dev",
+    "base",
     deadline=45000,
     suppress_health_check=[
-        # hypothesis.HealthCheck.data_too_large,
-        # hypothesis.HealthCheck.large_base_example,
+        hypothesis.HealthCheck.data_too_large,
+        hypothesis.HealthCheck.large_base_example,
         hypothesis.HealthCheck.function_scoped_fixture,
     ],
 )
-hypothesis.settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))
+
+hypothesis.settings.register_profile(
+    "fast", hypothesis.settings.get_profile("base"), max_examples=50
+)
+# Hypothesis's default max_examples is 100
+hypothesis.settings.register_profile(
+    "normal", hypothesis.settings.get_profile("base"), max_examples=100
+)
+hypothesis.settings.register_profile(
+    "slow", hypothesis.settings.get_profile("base"), max_examples=200
+)
+
+hypothesis.settings.load_profile(CURRENT_PRESET)
+
+
+def override_hypothesis_profile(
+    fast: hypothesis.settings | None = None,
+    normal: hypothesis.settings | None = None,
+    slow: hypothesis.settings | None = None,
+) -> hypothesis.settings | None:
+    """Override Hypothesis settings for specific profiles.
+
+    For example, to override max_examples only when the current profile is 'fast':
+
+    override_hypothesis_profile(
+        fast=hypothesis.settings(max_examples=50),
+    )
+
+    Settings will be merged with the default/active profile.
+    """
+
+    allowable_override_keys = [
+        "deadline",
+        "max_examples",
+        "stateful_step_count",
+        "suppress_health_check",
+    ]
+
+    override_profiles = {
+        "fast": fast,
+        "normal": normal,
+        "slow": slow,
+    }
+
+    overriding_profile = override_profiles.get(CURRENT_PRESET)
+
+    if overriding_profile is not None:
+        overridden_settings = {
+            key: value
+            for key, value in overriding_profile.__dict__.items()
+            if key in allowable_override_keys
+        }
+
+        return hypothesis.settings(hypothesis.settings.default, **overridden_settings)
+
+    return hypothesis.settings.default
+
 
 NOT_CLUSTER_ONLY = os.getenv("CHROMA_CLUSTER_TEST_ONLY") != "1"
 MEMBERLIST_SLEEP = 5

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -34,8 +34,8 @@ hypothesis.settings.register_profile(
     "dev",
     deadline=45000,
     suppress_health_check=[
-        hypothesis.HealthCheck.data_too_large,
-        hypothesis.HealthCheck.large_base_example,
+        # hypothesis.HealthCheck.data_too_large,
+        # hypothesis.HealthCheck.large_base_example,
         hypothesis.HealthCheck.function_scoped_fixture,
     ],
 )

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -31,7 +31,7 @@ from chromadb.types import SeqId, OperationRecord
 from chromadb.api.client import Client as ClientCreator
 
 VALID_PRESETS = ["fast", "normal", "slow"]
-CURRENT_PRESET = os.getenv("PROPERTY_TESTING_PRESET", "normal")
+CURRENT_PRESET = os.getenv("PROPERTY_TESTING_PRESET", "fast")
 
 if CURRENT_PRESET not in VALID_PRESETS:
     raise ValueError(

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+import hypothesis
 import hypothesis.strategies as st
 from hypothesis import given
 from typing import Dict, Set, cast, Union, DefaultDict, Any, List
@@ -23,6 +24,7 @@ from hypothesis.stateful import (
 )
 from collections import defaultdict
 import chromadb.test.property.invariants as invariants
+from chromadb.test.conftest import override_hypothesis_profile
 import numpy as np
 
 
@@ -297,7 +299,10 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
 
 def test_embeddings_state(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> None:
     caplog.set_level(logging.ERROR)
-    run_state_machine_as_test(lambda: EmbeddingStateMachine(api))  # type: ignore
+    run_state_machine_as_test(
+        lambda: EmbeddingStateMachine(api),
+        settings=override_hypothesis_profile(fast=hypothesis.settings(max_examples=10)),
+    )  # type: ignore
     print_traces()
 
 

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -86,7 +86,10 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
             ids=[], metadatas=[], documents=[], embeddings=[]
         )
 
-    @rule(target=embedding_ids, record_set=strategies.recordsets(collection_st))
+    @rule(
+        target=embedding_ids,
+        record_set=strategies.recordsets(collection_st, min_size=1),
+    )
     def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:
         trace("add_embeddings")
         self.on_state_change(EmbeddingStateMachineStates.add_embeddings)

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -86,10 +86,7 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
             ids=[], metadatas=[], documents=[], embeddings=[]
         )
 
-    @rule(
-        target=embedding_ids,
-        record_set=strategies.recordsets(collection_st, min_size=1),
-    )
+    @rule(target=embedding_ids, record_set=strategies.recordsets(collection_st))
     def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:
         trace("add_embeddings")
         self.on_state_change(EmbeddingStateMachineStates.add_embeddings)


### PR DESCRIPTION
Adds property testing "presets": fast, normal, slow (in order of increasing correctness guarantees).

PR checks run under the fast profile and checks before release run under the normal profile.

In the future, we could periodically run the slow profile against `main`.