### PR TITLE
[CLN] ServerAPI to use Collection model

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional
+from typing import Generic, Sequence, Optional, TypeVar
 from uuid import UUID
 
 from overrides import override
@@ -26,7 +26,9 @@ from chromadb.api.types import (
 from chromadb.config import Component, Settings
 from chromadb.types import Database, Tenant, Collection as CollectionModel
 import chromadb.utils.embedding_functions as ef
-from chromadb.types import Collection as CollectionModel
+from chromadb.api.models.Collection import Collection
+
+T = TypeVar("T", CollectionModel, Collection)
 
 # Re-export the async version
 from chromadb.api.async_api import (  # noqa: F401
@@ -37,7 +39,7 @@ from chromadb.api.async_api import (  # noqa: F401
 )
 
 
-class BaseAPI(ABC):
+class BaseAPI(ABC, Generic[T]):
     @abstractmethod
     def heartbeat(self) -> int:
         """Get the current time in nanoseconds since epoch.
@@ -58,7 +60,7 @@ class BaseAPI(ABC):
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> Sequence[CollectionModel]:
+    ) -> Sequence[T]:
         """List all collections.
         Args:
             limit: The maximum number of entries to return. Defaults to None.
@@ -100,7 +102,7 @@ class BaseAPI(ABC):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
-    ) -> CollectionModel:
+    ) -> T:
         """Create a new collection with the given name and metadata.
         Args:
             name: The name of the collection to create.
@@ -137,7 +139,7 @@ class BaseAPI(ABC):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
-    ) -> CollectionModel:
+    ) -> T:
         """Get a collection with the given name.
         Args:
             id: The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
@@ -169,7 +171,7 @@ class BaseAPI(ABC):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
-    ) -> CollectionModel:
+    ) -> T:
         """Get or create a collection with the given name and metadata.
         Args:
             name: The name of the collection to get or create
@@ -448,7 +450,7 @@ class BaseAPI(ABC):
         pass
 
 
-class ClientAPI(BaseAPI, ABC):
+class ClientAPI(BaseAPI[Collection], ABC):
     tenant: str
     database: str
 
@@ -525,7 +527,7 @@ class AdminAPI(ABC):
         pass
 
 
-class ServerAPI(BaseAPI, AdminAPI, Component):
+class ServerAPI(BaseAPI[CollectionModel], AdminAPI, Component):
     """An API instance that extends the relevant Base API methods by passing
     in a tenant and database. This is the root component of the Chroma System"""
 

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from overrides import override
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
-from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
     CollectionMetadata,
     Documents,
@@ -25,7 +24,7 @@ from chromadb.api.types import (
     WhereDocument,
 )
 from chromadb.config import Component, Settings
-from chromadb.types import Database, Tenant
+from chromadb.types import Database, Tenant, Collection as CollectionModel
 import chromadb.utils.embedding_functions as ef
 from chromadb.types import Collection as CollectionModel
 
@@ -59,7 +58,7 @@ class BaseAPI(ABC):
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> Sequence[Collection]:
+    ) -> Sequence[CollectionModel]:
         """List all collections.
         Args:
             limit: The maximum number of entries to return. Defaults to None.
@@ -101,7 +100,7 @@ class BaseAPI(ABC):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
-    ) -> Collection:
+    ) -> CollectionModel:
         """Create a new collection with the given name and metadata.
         Args:
             name: The name of the collection to create.
@@ -138,7 +137,7 @@ class BaseAPI(ABC):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
-    ) -> Collection:
+    ) -> CollectionModel:
         """Get a collection with the given name.
         Args:
             id: The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
@@ -170,7 +169,7 @@ class BaseAPI(ABC):
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
-    ) -> Collection:
+    ) -> CollectionModel:
         """Get or create a collection with the given name and metadata.
         Args:
             name: The name of the collection to get or create
@@ -538,7 +537,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> Sequence[Collection]:
+    ) -> Sequence[CollectionModel]:
         pass
 
     @abstractmethod
@@ -561,7 +560,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         get_or_create: bool = False,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> Collection:
+    ) -> CollectionModel:
         pass
 
     @abstractmethod
@@ -576,7 +575,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> Collection:
+    ) -> CollectionModel:
         pass
 
     @abstractmethod
@@ -591,7 +590,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> Collection:
+    ) -> CollectionModel:
         pass
 
     @abstractmethod

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -23,7 +23,7 @@ from chromadb.api.types import (
     WhereDocument,
 )
 from chromadb.config import Component, Settings
-from chromadb.types import Database, Tenant
+from chromadb.types import Database, Tenant, Collection as CollectionModel
 import chromadb.utils.embedding_functions as ef
 
 
@@ -44,28 +44,6 @@ class AsyncBaseAPI(ABC):
     #
 
     @abstractmethod
-    async def list_collections(
-        self,
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
-    ) -> Sequence[AsyncCollection]:
-        """List all collections.
-        Args:
-            limit: The maximum number of entries to return. Defaults to None.
-            offset: The number of entries to skip before returning. Defaults to None.
-
-        Returns:
-            Sequence[Collection]: A list of collections
-
-        Examples:
-            ```python
-            await client.list_collections()
-            # [collection(name="my_collection", metadata={})]
-            ```
-        """
-        pass
-
-    @abstractmethod
     async def count_collections(self) -> int:
         """Count the number of collections.
 
@@ -76,107 +54,6 @@ class AsyncBaseAPI(ABC):
             ```python
             await client.count_collections()
             # 1
-            ```
-        """
-        pass
-
-    @abstractmethod
-    async def create_collection(
-        self,
-        name: str,
-        metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
-        get_or_create: bool = False,
-    ) -> AsyncCollection:
-        """Create a new collection with the given name and metadata.
-        Args:
-            name: The name of the collection to create.
-            metadata: Optional metadata to associate with the collection.
-            embedding_function: Optional function to use to embed documents.
-                                Uses the default embedding function if not provided.
-            get_or_create: If True, return the existing collection if it exists.
-            data_loader: Optional function to use to load records (documents, images, etc.)
-
-        Returns:
-            Collection: The newly created collection.
-
-        Raises:
-            ValueError: If the collection already exists and get_or_create is False.
-            ValueError: If the collection name is invalid.
-
-        Examples:
-            ```python
-            await client.create_collection("my_collection")
-            # collection(name="my_collection", metadata={})
-
-            await client.create_collection("my_collection", metadata={"foo": "bar"})
-            # collection(name="my_collection", metadata={"foo": "bar"})
-            ```
-        """
-        pass
-
-    @abstractmethod
-    async def get_collection(
-        self,
-        name: str,
-        id: Optional[UUID] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
-    ) -> AsyncCollection:
-        """Get a collection with the given name.
-        Args:
-            id: The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
-            name: The name of the collection to get
-            embedding_function: Optional function to use to embed documents.
-                                Uses the default embedding function if not provided.
-            data_loader: Optional function to use to load records (documents, images, etc.)
-
-        Returns:
-            Collection: The collection
-
-        Raises:
-            ValueError: If the collection does not exist
-
-        Examples:
-            ```python
-            await client.get_collection("my_collection")
-            # collection(name="my_collection", metadata={})
-            ```
-        """
-        pass
-
-    @abstractmethod
-    async def get_or_create_collection(
-        self,
-        name: str,
-        metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
-    ) -> AsyncCollection:
-        """Get or create a collection with the given name and metadata.
-        Args:
-            name: The name of the collection to get or create
-            metadata: Optional metadata to associate with the collection. If
-            the collection alredy exists, the metadata will be updated if
-            provided and not None. If the collection does not exist, the
-            new collection will be created with the provided metadata.
-            embedding_function: Optional function to use to embed documents
-            data_loader: Optional function to use to load records (documents, images, etc.)
-
-        Returns:
-            The collection
-
-        Examples:
-            ```python
-            await client.get_or_create_collection("my_collection")
-            # collection(name="my_collection", metadata={})
             ```
         """
         pass
@@ -444,6 +321,129 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
     database: str
 
     @abstractmethod
+    async def list_collections(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Sequence[AsyncCollection]:
+        """List all collections.
+        Args:
+            limit: The maximum number of entries to return. Defaults to None.
+            offset: The number of entries to skip before returning. Defaults to None.
+
+        Returns:
+            Sequence[Collection]: A list of collections
+
+        Examples:
+            ```python
+            await client.list_collections()
+            # [collection(name="my_collection", metadata={})]
+            ```
+        """
+        pass
+
+    @abstractmethod
+    async def create_collection(
+        self,
+        name: str,
+        metadata: Optional[CollectionMetadata] = None,
+        embedding_function: Optional[
+            EmbeddingFunction[Embeddable]
+        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        data_loader: Optional[DataLoader[Loadable]] = None,
+        get_or_create: bool = False,
+    ) -> AsyncCollection:
+        """Create a new collection with the given name and metadata.
+        Args:
+            name: The name of the collection to create.
+            metadata: Optional metadata to associate with the collection.
+            embedding_function: Optional function to use to embed documents.
+                                Uses the default embedding function if not provided.
+            get_or_create: If True, return the existing collection if it exists.
+            data_loader: Optional function to use to load records (documents, images, etc.)
+
+        Returns:
+            Collection: The newly created collection.
+
+        Raises:
+            ValueError: If the collection already exists and get_or_create is False.
+            ValueError: If the collection name is invalid.
+
+        Examples:
+            ```python
+            await client.create_collection("my_collection")
+            # collection(name="my_collection", metadata={})
+
+            await client.create_collection("my_collection", metadata={"foo": "bar"})
+            # collection(name="my_collection", metadata={"foo": "bar"})
+            ```
+        """
+        pass
+
+    @abstractmethod
+    async def get_collection(
+        self,
+        name: str,
+        id: Optional[UUID] = None,
+        embedding_function: Optional[
+            EmbeddingFunction[Embeddable]
+        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        data_loader: Optional[DataLoader[Loadable]] = None,
+    ) -> AsyncCollection:
+        """Get a collection with the given name.
+        Args:
+            id: The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
+            name: The name of the collection to get
+            embedding_function: Optional function to use to embed documents.
+                                Uses the default embedding function if not provided.
+            data_loader: Optional function to use to load records (documents, images, etc.)
+
+        Returns:
+            Collection: The collection
+
+        Raises:
+            ValueError: If the collection does not exist
+
+        Examples:
+            ```python
+            await client.get_collection("my_collection")
+            # collection(name="my_collection", metadata={})
+            ```
+        """
+        pass
+
+    @abstractmethod
+    async def get_or_create_collection(
+        self,
+        name: str,
+        metadata: Optional[CollectionMetadata] = None,
+        embedding_function: Optional[
+            EmbeddingFunction[Embeddable]
+        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        data_loader: Optional[DataLoader[Loadable]] = None,
+    ) -> AsyncCollection:
+        """Get or create a collection with the given name and metadata.
+        Args:
+            name: The name of the collection to get or create
+            metadata: Optional metadata to associate with the collection. If
+            the collection alredy exists, the metadata will be updated if
+            provided and not None. If the collection does not exist, the
+            new collection will be created with the provided metadata.
+            embedding_function: Optional function to use to embed documents
+            data_loader: Optional function to use to load records (documents, images, etc.)
+
+        Returns:
+            The collection
+
+        Examples:
+            ```python
+            await client.get_or_create_collection("my_collection")
+            # collection(name="my_collection", metadata={})
+            ```
+        """
+        pass
+
+    @abstractmethod
     async def set_tenant(self, tenant: str, database: str = DEFAULT_DATABASE) -> None:
         """Set the tenant and database for the client. Raises an error if the tenant or
         database does not exist.
@@ -521,14 +521,13 @@ class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
     in a tenant and database. This is the root component of the Chroma System"""
 
     @abstractmethod
-    @override
     async def list_collections(
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> Sequence[AsyncCollection]:
+    ) -> Sequence[CollectionModel]:
         pass
 
     @abstractmethod
@@ -539,49 +538,34 @@ class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
         pass
 
     @abstractmethod
-    @override
     async def create_collection(
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> AsyncCollection:
+    ) -> CollectionModel:
         pass
 
     @abstractmethod
-    @override
     async def get_collection(
         self,
         name: str,
         id: Optional[UUID] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> AsyncCollection:
+    ) -> CollectionModel:
         pass
 
     @abstractmethod
-    @override
     async def get_or_create_collection(
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> AsyncCollection:
+    ) -> CollectionModel:
         pass
 
     @abstractmethod

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -136,9 +136,16 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     async def list_collections(
         self, limit: Optional[int] = None, offset: Optional[int] = None
     ) -> Sequence[AsyncCollection]:
-        return await self._server.list_collections(
+        models = await self._server.list_collections(
             limit, offset, tenant=self.tenant, database=self.database
         )
+        return [
+            AsyncCollection(
+                client=self._server,
+                model=model,
+            )
+            for model in models
+        ]
 
     @override
     async def count_collections(self) -> int:
@@ -157,14 +164,18 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
     ) -> AsyncCollection:
-        return await self._server.create_collection(
+        model = await self._server.create_collection(
             name=name,
             metadata=metadata,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
             get_or_create=get_or_create,
+        )
+        return AsyncCollection(
+            client=self._server,
+            model=model,
+            embedding_function=embedding_function,
+            data_loader=data_loader,
         )
 
     @override
@@ -177,13 +188,17 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
-        return await self._server.get_collection(
+        model = await self._server.get_collection(
             id=id,
             name=name,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
+        )
+        return AsyncCollection(
+            client=self._server,
+            model=model,
+            embedding_function=embedding_function,
+            data_loader=data_loader,
         )
 
     @override
@@ -196,13 +211,17 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
-        return await self._server.get_or_create_collection(
+        model = await self._server.get_or_create_collection(
             name=name,
             metadata=metadata,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
+        )
+        return AsyncCollection(
+            client=self._server,
+            model=model,
+            embedding_function=embedding_function,
+            data_loader=data_loader,
         )
 
     @override

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -16,20 +16,14 @@ from chromadb.telemetry.opentelemetry import (
 )
 from chromadb.telemetry.product import ProductTelemetryClient
 from chromadb.utils.async_to_sync import async_to_sync
-import chromadb.utils.embedding_functions as ef
 
-from chromadb.types import Database, Tenant
+from chromadb.types import Database, Tenant, Collection as CollectionModel
 
-from chromadb.api.models.AsyncCollection import AsyncCollection
 from chromadb.api.types import (
-    DataLoader,
     Documents,
-    Embeddable,
     Embeddings,
-    EmbeddingFunction,
     IDs,
     Include,
-    Loadable,
     Metadatas,
     URIs,
     Where,
@@ -194,7 +188,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> Sequence[AsyncCollection]:
+    ) -> Sequence[CollectionModel]:
         resp_json = await self._make_request(
             "get",
             "/collections",
@@ -208,13 +202,10 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             ),
         )
 
-        collections = []
-        for json_collection in resp_json:
-            model = json_to_collection_model(json_collection)
-
-            collections.append(AsyncCollection(client=self, model=model))
-
-        return collections
+        models = [
+            json_to_collection_model(json_collection) for json_collection in resp_json
+        ]
+        return models
 
     @trace_method("AsyncFastAPI.count_collections", OpenTelemetryGranularity.OPERATION)
     @override
@@ -235,14 +226,10 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> AsyncCollection:
+    ) -> CollectionModel:
         """Creates a collection"""
         resp_json = await self._make_request(
             "post",
@@ -257,12 +244,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
 
         model = json_to_collection_model(resp_json)
 
-        return AsyncCollection(
-            client=self,
-            model=model,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
-        )
+        return model
 
     @trace_method("AsyncFastAPI.get_collection", OpenTelemetryGranularity.OPERATION)
     @override
@@ -270,13 +252,9 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         self,
         name: str,
         id: Optional[UUID] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> AsyncCollection:
+    ) -> CollectionModel:
         if (name is None and id is None) or (name is not None and id is not None):
             raise ValueError("Name or id must be specified, but not both")
 
@@ -292,12 +270,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
 
         model = json_to_collection_model(resp_json)
 
-        return AsyncCollection(
-            client=self,
-            model=model,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
-        )
+        return model
 
     @trace_method(
         "AsyncFastAPI.get_or_create_collection", OpenTelemetryGranularity.OPERATION
@@ -307,18 +280,12 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> AsyncCollection:
+    ) -> CollectionModel:
         return await self.create_collection(
             name=name,
             metadata=metadata,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             get_or_create=True,
             tenant=tenant,
             database=database,

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -115,8 +115,6 @@ class Client(SharedSystemClient, ClientAPI):
         model = self._server.create_collection(
             name=name,
             metadata=metadata,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
             get_or_create=get_or_create,
@@ -141,8 +139,6 @@ class Client(SharedSystemClient, ClientAPI):
         model = self._server.get_collection(
             id=id,
             name=name,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
         )
@@ -166,8 +162,6 @@ class Client(SharedSystemClient, ClientAPI):
         model = self._server.get_or_create_collection(
             name=name,
             metadata=metadata,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
         )

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -88,9 +88,12 @@ class Client(SharedSystemClient, ClientAPI):
     def list_collections(
         self, limit: Optional[int] = None, offset: Optional[int] = None
     ) -> Sequence[Collection]:
-        return self._server.list_collections(
-            limit, offset, tenant=self.tenant, database=self.database
-        )
+        return [
+            Collection(client=self._server, model=model)
+            for model in self._server.list_collections(
+                limit, offset, tenant=self.tenant, database=self.database
+            )
+        ]
 
     @override
     def count_collections(self) -> int:
@@ -109,7 +112,7 @@ class Client(SharedSystemClient, ClientAPI):
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
     ) -> Collection:
-        return self._server.create_collection(
+        model = self._server.create_collection(
             name=name,
             metadata=metadata,
             embedding_function=embedding_function,
@@ -117,6 +120,12 @@ class Client(SharedSystemClient, ClientAPI):
             tenant=self.tenant,
             database=self.database,
             get_or_create=get_or_create,
+        )
+        return Collection(
+            client=self._server,
+            model=model,
+            embedding_function=embedding_function,
+            data_loader=data_loader,
         )
 
     @override
@@ -129,13 +138,19 @@ class Client(SharedSystemClient, ClientAPI):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
-        return self._server.get_collection(
+        model = self._server.get_collection(
             id=id,
             name=name,
             embedding_function=embedding_function,
             data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
+        )
+        return Collection(
+            client=self._server,
+            model=model,
+            embedding_function=embedding_function,
+            data_loader=data_loader,
         )
 
     @override
@@ -148,13 +163,19 @@ class Client(SharedSystemClient, ClientAPI):
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
-        return self._server.get_or_create_collection(
+        model = self._server.get_or_create_collection(
             name=name,
             metadata=metadata,
             embedding_function=embedding_function,
             data_loader=data_loader,
             tenant=self.tenant,
             database=self.database,
+        )
+        return Collection(
+            client=self._server,
+            model=model,
+            embedding_function=embedding_function,
+            data_loader=data_loader,
         )
 
     @override

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -8,19 +8,14 @@ import urllib.parse
 from overrides import override
 
 from chromadb.api.base_http_client import BaseHTTPClient
-from chromadb.types import Database, Tenant
-import chromadb.utils.embedding_functions as ef
+from chromadb.types import Database, Tenant, Collection as CollectionModel
 from chromadb.api import ServerAPI
 
 from chromadb.api.types import (
-    DataLoader,
     Documents,
-    Embeddable,
     Embeddings,
-    EmbeddingFunction,
     IDs,
     Include,
-    Loadable,
     Metadatas,
     URIs,
     Where,
@@ -230,10 +225,6 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         self,
         name: str,
         id: Optional[UUID] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
@@ -273,15 +264,12 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
-        return cast(
-            CollectionModel,
-            self.create_collection(
-                name=name,
-                metadata=metadata,
-                get_or_create=True,
-                tenant=tenant,
-                database=database,
-            ),
+        return self.create_collection(
+            name=name,
+            metadata=metadata,
+            get_or_create=True,
+            tenant=tenant,
+            database=database,
         )
 
     @trace_method("FastAPI._modify", OpenTelemetryGranularity.OPERATION)
@@ -339,7 +327,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             self._get(
                 collection_id,
                 limit=n,
-                include=["embeddings", "documents", "metadatas"],
+                include=["embeddings", "documents", "metadatas"],  # type: ignore[list-item]
             ),
         )
 
@@ -356,7 +344,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         page: Optional[int] = None,
         page_size: Optional[int] = None,
         where_document: Optional[WhereDocument] = {},
-        include: Include = ["metadatas", "documents"],
+        include: Include = ["metadatas", "documents"],  # type: ignore[list-item]
     ) -> GetResult:
         if page and page_size:
             offset = (page - 1) * page_size
@@ -503,7 +491,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         n_results: int = 10,
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-        include: Include = ["metadatas", "documents", "distances"],
+        include: Include = ["metadatas", "documents", "distances"],  # type: ignore[list-item]
     ) -> QueryResult:
         """Gets the nearest neighbors of a single embedding"""
         resp_json = self._make_request(

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -197,10 +197,6 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
@@ -274,10 +270,6 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
@@ -286,8 +278,6 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             self.create_collection(
                 name=name,
                 metadata=metadata,
-                embedding_function=embedding_function,
-                data_loader=data_loader,
                 get_or_create=True,
                 tenant=tenant,
                 database=database,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -15,19 +15,14 @@ from chromadb.ingest import Producer
 from chromadb.types import Collection as CollectionModel
 from chromadb import __version__
 from chromadb.errors import InvalidDimensionException, InvalidCollectionException
-import chromadb.utils.embedding_functions as ef
 
 from chromadb.api.types import (
     URI,
     CollectionMetadata,
-    Embeddable,
     Document,
-    EmbeddingFunction,
-    DataLoader,
     IDs,
     Embeddings,
     Embedding,
-    Loadable,
     Metadatas,
     Documents,
     URIs,
@@ -52,7 +47,7 @@ from chromadb.telemetry.product.events import (
 )
 
 import chromadb.types as t
-from typing import Any, Optional, Sequence, Generator, List, cast, Set, Dict
+from typing import Optional, Sequence, Generator, List, cast, Set, Dict
 from overrides import override
 from uuid import UUID, uuid4
 import time
@@ -152,10 +147,6 @@ class SegmentAPI(ServerAPI):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Any]
-        ] = ef.DefaultEmbeddingFunction(),
-        data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
@@ -189,10 +180,11 @@ class SegmentAPI(ServerAPI):
             )
 
         # TODO: This event doesn't capture the get_or_create case appropriately
+        # TODO: Re-enable embedding function tracking in create_collection
         self._product_telemetry_client.capture(
             ClientCreateCollectionEvent(
                 collection_uuid=str(id),
-                embedding_function=embedding_function.__class__.__name__,
+                # embedding_function=embedding_function.__class__.__name__,
             )
         )
         add_attributes_to_current_span({"collection_uuid": str(id)})
@@ -207,18 +199,12 @@ class SegmentAPI(ServerAPI):
         self,
         name: str,
         metadata: Optional[CollectionMetadata] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
         return self.create_collection(  # type: ignore
             name=name,
             metadata=metadata,
-            embedding_function=embedding_function,
-            data_loader=data_loader,
             get_or_create=True,
             tenant=tenant,
             database=database,
@@ -233,10 +219,6 @@ class SegmentAPI(ServerAPI):
         self,
         name: Optional[str] = None,
         id: Optional[UUID] = None,
-        embedding_function: Optional[
-            EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
-        data_loader: Optional[DataLoader[Loadable]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -11,7 +11,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
-from chromadb.api.models.Collection import Collection
+
+# from chromadb.api.models.Collection import Collection
 from chromadb.api.types import GetResult, QueryResult
 from chromadb.auth import (
     AuthzAction,
@@ -509,8 +510,8 @@ class FastAPI(Server):
         if maybe_database:
             database = maybe_database
 
-        api_collections = cast(
-            Sequence[Collection],
+        api_collection_models = cast(
+            Sequence[CollectionModel],
             await to_thread.run_sync(
                 self._api.list_collections,
                 limit,
@@ -521,7 +522,7 @@ class FastAPI(Server):
             ),
         )
 
-        return [c.get_model() for c in api_collections]
+        return api_collection_models
 
     @trace_method("FastAPI.count_collections", OpenTelemetryGranularity.OPERATION)
     async def count_collections(
@@ -565,7 +566,7 @@ class FastAPI(Server):
     ) -> CollectionModel:
         def process_create_collection(
             request: Request, tenant: str, database: str, raw_body: bytes
-        ) -> Collection:
+        ) -> CollectionModel:
             create = CreateCollection.model_validate(orjson.loads(raw_body))
 
             (
@@ -591,8 +592,8 @@ class FastAPI(Server):
                 database=database,
             )
 
-        api_collection = cast(
-            Collection,
+        api_collection_model = cast(
+            CollectionModel,
             await to_thread.run_sync(
                 process_create_collection,
                 request,
@@ -602,7 +603,7 @@ class FastAPI(Server):
                 limiter=self._capacity_limiter,
             ),
         )
-        return api_collection.get_model()
+        return api_collection_model
 
     @trace_method("FastAPI.get_collection", OpenTelemetryGranularity.OPERATION)
     async def get_collection(
@@ -627,8 +628,8 @@ class FastAPI(Server):
         if maybe_database:
             database = maybe_database
 
-        api_collection = cast(
-            Collection,
+        api_collection_model = cast(
+            CollectionModel,
             await to_thread.run_sync(
                 self._api.get_collection,
                 collection_name,
@@ -640,7 +641,7 @@ class FastAPI(Server):
                 limiter=self._capacity_limiter,
             ),
         )
-        return api_collection.get_model()
+        return api_collection_model
 
     @trace_method("FastAPI.update_collection", OpenTelemetryGranularity.OPERATION)
     async def update_collection(

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -12,7 +12,6 @@ from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
 from uuid import UUID
 
-# from chromadb.api.models.Collection import Collection
 from chromadb.api.types import GetResult, QueryResult
 from chromadb.auth import (
     AuthzAction,
@@ -633,9 +632,7 @@ class FastAPI(Server):
             await to_thread.run_sync(
                 self._api.get_collection,
                 collection_name,
-                None,
-                None,
-                None,
+                None,  # id
                 tenant,
                 database,
                 limiter=self._capacity_limiter,

--- a/chromadb/telemetry/product/events.py
+++ b/chromadb/telemetry/product/events.py
@@ -1,7 +1,6 @@
 import os
 from typing import cast, ClassVar
 from chromadb.telemetry.product import ProductTelemetryEvent
-from chromadb.utils.embedding_functions import get_builtins
 
 
 class ClientStartEvent(ProductTelemetryEvent):
@@ -21,21 +20,22 @@ class ServerStartEvent(ProductTelemetryEvent):
         self.is_cli = os.environ.get("CHROMA_CLI", "False") == "True"
 
 
+# TODO: Re-enable embedding function tracking in create_collection
 class ClientCreateCollectionEvent(ProductTelemetryEvent):
     collection_uuid: str
-    embedding_function: str
+    # embedding_function: str
 
-    def __init__(self, collection_uuid: str, embedding_function: str):
+    def __init__(self, collection_uuid: str):  # , embedding_function: str):
         super().__init__()
         self.collection_uuid = collection_uuid
 
-        embedding_function_names = get_builtins()
+        # embedding_function_names = get_builtins()
 
-        self.embedding_function = (
-            embedding_function
-            if embedding_function in embedding_function_names
-            else "custom"
-        )
+        # self.embedding_function = (
+        #     embedding_function
+        #     if embedding_function in embedding_function_names
+        #     else "custom"
+        # )
 
 
 class CollectionAddEvent(ProductTelemetryEvent):

--- a/chromadb/test/auth/rbac_test_executors.py
+++ b/chromadb/test/auth/rbac_test_executors.py
@@ -7,6 +7,30 @@ from chromadb.test.property.strategies import (
     collection_name,
     tenant_database_name,
 )
+from chromadb.api.models.Collection import Collection
+from chromadb.types import Collection as CollectionModel
+
+
+def wrap_model(api: ServerAPI, model: CollectionModel) -> Collection:
+    return Collection(client=api, model=model)
+
+
+def add_to_root_and_get_collection(
+    api: ServerAPI, root_api: ServerAPI, draw: st.DrawFn
+) -> Collection:
+    collection = draw(collection_name())
+    root_col = None
+    try:
+        root_col = root_api.create_collection(collection)
+    except Exception:
+        root_col = root_api.get_collection(collection)
+    if not root_col:
+        raise Exception("Failed to create collection")
+    root_col = wrap_model(api=root_api, model=root_col)
+    root_col.add(ids=["1"], documents=["test document"])
+    col = wrap_model(api=api, model=api.get_collection(collection))
+    return col
+
 
 # Each of these accepts two clients:
 # 1. A data plane client with credentials of the user under test.
@@ -118,12 +142,7 @@ def _delete_collection_executor(
 def _update_collection_executor(
     api: ServerAPI, root_api: ServerAPI, draw: st.DrawFn
 ) -> None:
-    collection = draw(collection_name())
-    try:
-        root_api.create_collection(collection)
-    except Exception:
-        pass
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.modify(metadata={"foo": "bar"})
 
 
@@ -132,12 +151,7 @@ def _add_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    try:
-        root_api.create_collection(collection)
-    except Exception:
-        pass
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.add(ids=["1"], documents=["test document"])
 
 
@@ -146,16 +160,7 @@ def _delete_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.delete(ids=["1"])
 
 
@@ -164,16 +169,7 @@ def _get_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.get(ids=["1"])
 
 
@@ -182,16 +178,7 @@ def _query_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.query(query_texts=["test query text"])
 
 
@@ -200,16 +187,7 @@ def _peek_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.peek()
 
 
@@ -218,16 +196,7 @@ def _count_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.count()
 
 
@@ -236,16 +205,7 @@ def _update_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.update(ids=["1"], documents=["different test document"])
 
 
@@ -254,16 +214,7 @@ def _upsert_executor(
     root_api: ServerAPI,
     draw: st.DrawFn,
 ) -> None:
-    collection = draw(collection_name())
-    root_col = None
-    try:
-        root_col = root_api.create_collection(collection)
-    except Exception:
-        root_col = root_api.get_collection(collection)
-    if not root_col:
-        raise Exception("Failed to create collection")
-    root_col.add(ids=["1"], documents=["test document"])
-    col = api.get_collection(collection)
+    col = add_to_root_and_get_collection(api, root_api, draw)
     col.upsert(ids=["1"], documents=["different test document"])
 
 

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -26,7 +26,7 @@ from typing_extensions import Protocol
 from chromadb.api.async_fastapi import AsyncFastAPI
 from chromadb.api.fastapi import FastAPI
 import chromadb.server.fastapi
-from chromadb.api import ClientAPI, ServerAPI
+from chromadb.api import ClientAPI, ServerAPI, BaseAPI
 from chromadb.config import Settings, System
 from chromadb.db.mixins import embeddings_queue
 from chromadb.ingest import Producer
@@ -70,7 +70,7 @@ hypothesis.settings.register_profile(
 hypothesis.settings.load_profile(CURRENT_PRESET)
 
 
-def reset(api: ServerAPI) -> None:
+def reset(api: BaseAPI) -> None:
     api.reset()
 
 
@@ -114,7 +114,7 @@ def override_hypothesis_profile(
 
         return hypothesis.settings(hypothesis.settings.default, **overridden_settings)
 
-    return hypothesis.settings.default
+    return cast(hypothesis.settings, hypothesis.settings.default)
 
 
 NOT_CLUSTER_ONLY = os.getenv("CHROMA_CLUSTER_TEST_ONLY") != "1"
@@ -285,7 +285,7 @@ def _fastapi_fixture(
         chroma_overwrite_singleton_tenant_database_access_from_auth,
     )
 
-    def run(args):
+    def run(args: Any) -> Generator[System, None, None]:
         proc = ctx.Process(target=_run_server, args=args, daemon=True)
         proc.start()
         settings = Settings(

--- a/chromadb/test/data_loader/test_data_loader.py
+++ b/chromadb/test/data_loader/test_data_loader.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 import pytest
 import chromadb
 from chromadb.api.types import URI, DataLoader, Documents, IDs, Image, URIs
-from chromadb.api import ServerAPI
+from chromadb.api import ClientAPI
 from chromadb.test.ef.test_multimodal_ef import hashing_multimodal_ef
 
 
@@ -29,27 +29,27 @@ def record_set_with_uris(n: int = 3) -> Dict[str, Union[IDs, Documents, URIs]]:
 
 @pytest.fixture()
 def collection_with_data_loader(
-    api: ServerAPI,
+    client: ClientAPI,
 ) -> Generator[chromadb.Collection, None, None]:
-    collection = api.create_collection(
+    collection = client.create_collection(
         name="collection_with_data_loader",
         data_loader=DefaultDataLoader(),
         embedding_function=hashing_multimodal_ef(),
     )
     yield collection
-    api.delete_collection(collection.name)
+    client.delete_collection(collection.name)
 
 
 @pytest.fixture
 def collection_without_data_loader(
-    api: ServerAPI,
+    client: ClientAPI,
 ) -> Generator[chromadb.Collection, None, None]:
-    collection = api.create_collection(
+    collection = client.create_collection(
         name="collection_without_data_loader",
         embedding_function=hashing_multimodal_ef(),
     )
     yield collection
-    api.delete_collection(collection.name)
+    client.delete_collection(collection.name)
 
 
 def test_without_data_loader(

--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -3,25 +3,28 @@
 # test working and then enable
 import random
 from typing import List
-from chromadb.api import ServerAPI
+
+import numpy as np
+from chromadb.api import ClientAPI
 import time
 
 from chromadb.api.types import QueryResult
 from chromadb.test.conftest import (
     COMPACTION_SLEEP,
+    reset,
     skip_if_not_cluster,
 )
+from chromadb.utils.distance_functions import l2
 
 EPS = 1e-6
 
 
 @skip_if_not_cluster()
 def test_add(
-    api: ServerAPI,
+    client: ClientAPI,
 ) -> None:
-    api.reset()
-
-    collection = api.create_collection(
+    reset(client)
+    collection = client.create_collection(
         name="test",
     )
 
@@ -48,8 +51,7 @@ def test_add(
 
     # Check that the distances are correct in l2
     ground_truth_distances = [
-        sum((a - b) ** 2 for a, b in zip(embedding, random_query))
-        for embedding in embeddings
+        l2(np.array(random_query), np.array(embedding)) for embedding in embeddings
     ]
     ground_truth_distances.sort()
     retrieved_distances = results["distances"][0]  # type: ignore
@@ -59,14 +61,13 @@ def test_add(
         assert retrieved_distances[i - 1] <= retrieved_distances[i]
 
     for i in range(len(retrieved_distances)):
-        assert abs(ground_truth_distances[i] - retrieved_distances[i]) < EPS
+        assert np.allclose(ground_truth_distances[i], retrieved_distances[i], atol=EPS)
 
 
 @skip_if_not_cluster()
-def test_add_include_all_with_compaction_delay(api: ServerAPI) -> None:
-    api.reset()
-
-    collection = api.create_collection(
+def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
+    reset(client)
+    collection = client.create_collection(
         name="test_add_include_all_with_compaction_delay"
     )
 

--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -46,7 +46,7 @@ def test_add(
     results = collection.query(
         query_embeddings=[random_query],  # type: ignore
         n_results=10,
-        include=["distances"],
+        include=["distances"],  # type: ignore[list-item]
     )
 
     # Check that the distances are correct in l2
@@ -91,7 +91,7 @@ def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
     results = collection.query(
         query_embeddings=[random_query_1, random_query_2],  # type: ignore
         n_results=10,
-        include=["metadatas", "documents", "distances", "embeddings"],
+        include=["metadatas", "documents", "distances", "embeddings"],  # type: ignore[list-item]
     )
 
     ids_and_embeddings = list(zip(ids, embeddings))

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -6,7 +6,7 @@ import hypothesis
 import pytest
 import hypothesis.strategies as st
 from hypothesis import given, settings
-from chromadb.api import ServerAPI
+from chromadb.api import ClientAPI
 from chromadb.api.types import Embeddings, Metadatas
 from chromadb.test.conftest import (
     reset,
@@ -38,12 +38,12 @@ collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="co
     ),
 )
 def test_add_small(
-    api: ServerAPI,
+    client: ClientAPI,
     collection: strategies.Collection,
     record_set: strategies.RecordSet,
     should_compact: bool,
 ) -> None:
-    _test_add(api, collection, record_set, should_compact)
+    _test_add(client, collection, record_set, should_compact)
 
 
 @given(
@@ -72,7 +72,7 @@ def test_add_small(
     ],
 )
 def test_add_medium(
-    api: ServerAPI,
+    client: ClientAPI,
     collection: strategies.Collection,
     record_set: strategies.RecordSet,
     should_compact: bool,
@@ -81,20 +81,20 @@ def test_add_medium(
     # This breaks the ann_accuracy invariant by default, since
     # the vector reader returns a payload of dataset size. So we need to batch
     # the queries in the ann_accuracy invariant
-    _test_add(api, collection, record_set, should_compact, batch_ann_accuracy=True)
+    _test_add(client, collection, record_set, should_compact, batch_ann_accuracy=True)
 
 
 def _test_add(
-    api: ServerAPI,
+    client: ClientAPI,
     collection: strategies.Collection,
     record_set: strategies.RecordSet,
     should_compact: bool,
     batch_ann_accuracy: bool = False,
 ) -> None:
-    reset(api)
+    client.reset()
 
     # TODO: Generative embedding functions
-    coll = api.create_collection(
+    coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
         embedding_function=collection.embedding_function,
@@ -164,16 +164,16 @@ def create_large_recordset(
 @given(collection=collection_st, should_compact=st.booleans())
 @settings(deadline=None, max_examples=5)
 def test_add_large(
-    api: ServerAPI, collection: strategies.Collection, should_compact: bool
+    client: ClientAPI, collection: strategies.Collection, should_compact: bool
 ) -> None:
-    reset(api)
+    client.reset()
 
     record_set = create_large_recordset(
-        min_size=api.get_max_batch_size(),
-        max_size=api.get_max_batch_size()
-        + int(api.get_max_batch_size() * random.random()),
+        min_size=client.get_max_batch_size(),
+        max_size=client.get_max_batch_size()
+        + int(client.get_max_batch_size() * random.random()),
     )
-    coll = api.create_collection(
+    coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
         embedding_function=collection.embedding_function,
@@ -182,7 +182,7 @@ def test_add_large(
     initial_version = coll.get_model()["version"]
 
     for batch in create_batches(
-        api=api,
+        api=client,
         ids=cast(List[str], record_set["ids"]),
         embeddings=cast(Embeddings, record_set["embeddings"]),
         metadatas=cast(Metadatas, record_set["metadatas"]),
@@ -205,15 +205,17 @@ def test_add_large(
 
 @given(collection=collection_st)
 @settings(deadline=None, max_examples=1)
-def test_add_large_exceeding(api: ServerAPI, collection: strategies.Collection) -> None:
-    reset(api)
+def test_add_large_exceeding(
+    client: ClientAPI, collection: strategies.Collection
+) -> None:
+    reset(client)
 
     record_set = create_large_recordset(
-        min_size=api.get_max_batch_size(),
-        max_size=api.get_max_batch_size()
-        + int(api.get_max_batch_size() * random.random()),
+        min_size=client.get_max_batch_size(),
+        max_size=client.get_max_batch_size()
+        + int(client.get_max_batch_size() * random.random()),
     )
-    coll = api.create_collection(
+    coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
         embedding_function=collection.embedding_function,
@@ -229,8 +231,8 @@ def test_add_large_exceeding(api: ServerAPI, collection: strategies.Collection) 
     reason="This is expected to fail right now. We should change the API to sort the \
     ids by input order."
 )
-def test_out_of_order_ids(api: ServerAPI) -> None:
-    reset(api)
+def test_out_of_order_ids(client: ClientAPI) -> None:
+    reset(client)
     ooo_ids = [
         "40",
         "05",
@@ -259,7 +261,7 @@ def test_out_of_order_ids(api: ServerAPI) -> None:
         "1",
     ]
 
-    coll = api.create_collection(
+    coll = client.create_collection(
         "test", embedding_function=lambda input: [[1, 2, 3] for _ in input]  # type: ignore
     )
     embeddings: Embeddings = [[1, 2, 3] for _ in ooo_ids]
@@ -268,11 +270,11 @@ def test_out_of_order_ids(api: ServerAPI) -> None:
     assert get_ids == ooo_ids
 
 
-def test_add_partial(api: ServerAPI) -> None:
+def test_add_partial(client: ClientAPI) -> None:
     """Tests adding a record set with some of the fields set to None."""
-    reset(api)
+    reset(client)
 
-    coll = api.create_collection("test")
+    coll = client.create_collection("test")
     # TODO: We need to clean up the api types to support this typing
     coll.add(
         ids=["1", "2", "3"],

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -91,7 +91,7 @@ def _test_add(
     should_compact: bool,
     batch_ann_accuracy: bool = False,
 ) -> None:
-    client.reset()
+    reset(client)
 
     # TODO: Generative embedding functions
     coll = client.create_collection(
@@ -114,7 +114,7 @@ def _test_add(
         and len(normalized_record_set["ids"]) > 10
     ):
         # Wait for the model to be updated
-        wait_for_version_increase(api, collection.name, initial_version)
+        wait_for_version_increase(client, collection.name, initial_version)
 
     invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
     n_results = max(1, (len(normalized_record_set["ids"]) // 10))
@@ -166,7 +166,7 @@ def create_large_recordset(
 def test_add_large(
     client: ClientAPI, collection: strategies.Collection, should_compact: bool
 ) -> None:
-    client.reset()
+    reset(client)
 
     record_set = create_large_recordset(
         min_size=client.get_max_batch_size(),
@@ -197,7 +197,7 @@ def test_add_large(
     ):
         # Wait for the model to be updated, since the record set is larger, add some additional time
         wait_for_version_increase(
-            api, collection.name, initial_version, additional_time=240
+            client, collection.name, initial_version, additional_time=240
         )
 
     invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
@@ -222,7 +222,7 @@ def test_add_large_exceeding(
     )
 
     with pytest.raises(Exception) as e:
-        coll.add(**record_set)
+        coll.add(**record_set)  # type: ignore[arg-type]
     assert "exceeds maximum batch size" in str(e.value)
 
 

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -246,9 +246,9 @@ class CollectionStateMachine(RuleBasedStateMachine):
         return self._model
 
 
-def test_collections(caplog: pytest.LogCaptureFixture, api: ClientAPI) -> None:
+def test_collections(caplog: pytest.LogCaptureFixture, client: ClientAPI) -> None:
     caplog.set_level(logging.ERROR)
-    run_state_machine_as_test(lambda: CollectionStateMachine(api))  # type: ignore
+    run_state_machine_as_test(lambda: CollectionStateMachine(client))  # type: ignore
 
 
 # Below are tests that have failed in the past. If your test fails, please add
@@ -256,8 +256,8 @@ def test_collections(caplog: pytest.LogCaptureFixture, api: ClientAPI) -> None:
 # help doing so, talk to ben.
 
 
-def test_previously_failing_one(api: ClientAPI) -> None:
-    state = CollectionStateMachine(api)
+def test_previously_failing_one(client: ClientAPI) -> None:
+    state = CollectionStateMachine(client)
     state.initialize()
     # I don't know why the typechecker is red here. This code is correct and is
     # pulled from the logs.
@@ -284,8 +284,8 @@ def test_previously_failing_one(api: ClientAPI) -> None:
 
 
 # https://github.com/chroma-core/chroma/commit/cf476d70f0cebb7c87cb30c7172ba74d6ea175cd#diff-e81868b665d149bb315d86890dea6fc6a9fc9fc9ea3089aa7728142b54f622c5R210
-def test_previously_failing_two(api: ClientAPI) -> None:
-    state = CollectionStateMachine(api)
+def test_previously_failing_two(client: ClientAPI) -> None:
+    state = CollectionStateMachine(client)
     state.initialize()
     (v13,) = state.get_or_create_coll(
         coll=strategies.ExternalCollection(

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -253,7 +253,7 @@ def test_collections(caplog: pytest.LogCaptureFixture, client: ClientAPI) -> Non
 
 # Below are tests that have failed in the past. If your test fails, please add
 # it to protect against regressions in the test harness itself. If you need
-# help doing so, talk to ben.
+# help doing so, talk to anton.
 
 
 def test_previously_failing_one(client: ClientAPI) -> None:

--- a/chromadb/test/property/test_collections_with_database_tenant.py
+++ b/chromadb/test/property/test_collections_with_database_tenant.py
@@ -36,16 +36,16 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
     def __init__(self, client_factories: ClientFactories):
         client = client_factories.create_client()
         super().__init__(client)
-        self.api = client
+        self.client = client
         self.admin_client = client_factories.create_admin_client_from_system()
 
     @initialize()
     def initialize(self) -> None:
-        self.api.reset()
+        self.client.reset()
         self.tenant_to_database_to_model = {}
         self.curr_tenant = DEFAULT_TENANT
         self.curr_database = DEFAULT_DATABASE
-        self.api.set_tenant(DEFAULT_TENANT, DEFAULT_DATABASE)
+        self.client.set_tenant(DEFAULT_TENANT, DEFAULT_DATABASE)
         self.set_tenant_model(self.curr_tenant, {})
         self.set_database_model_for_tenant(self.curr_tenant, self.curr_database, {})
 
@@ -103,7 +103,7 @@ class TenantDatabaseCollectionStateMachine(CollectionStateMachine):
     # without needing to do a bunch of pythonic cleverness to fake a dict which
     # preteds to have every key.
     def set_api_tenant_database(self, tenant: str, database: str) -> None:
-        self.api.set_tenant(tenant, database)
+        self.client.set_tenant(tenant, database)
 
     # For calls to create_database, and create_tenant we may want to override the tenant and database
     # This is a leaky abstraction that exists soley for the purpose of

--- a/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
+++ b/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
@@ -54,7 +54,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
     def initialize(self) -> None:
         # Make sure we're back to the root client and admin client before
         # doing reset/initialize things.
-        self.api = self.root_client
+        self.client = self.root_client
         self.admin_client = self.root_admin_client
 
         super().initialize()
@@ -67,18 +67,18 @@ class SingletonTenantDatabaseCollectionStateMachine(
 
     @invariant()
     def check_api_and_admin_client_are_in_sync(self) -> None:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             assert self.admin_client == self.singleton_admin_client
         else:
             assert self.admin_client == self.root_admin_client
 
     @rule()
     def change_clients(self) -> None:
-        if self.api == self.singleton_client:
-            self.api = self.root_client
+        if self.client == self.singleton_client:
+            self.client = self.root_client
             self.admin_client = self.root_admin_client
         else:
-            self.api = self.singleton_client
+            self.client = self.singleton_client
             self.admin_client = self.singleton_admin_client
 
     @overrides
@@ -89,7 +89,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
     def get_tenant_model(
         self, tenant: str
     ) -> Dict[str, Dict[str, Optional[types.CollectionMetadata]]]:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             tenant = SINGLETON_TENANT
         return self.tenant_to_database_to_model[tenant]
 
@@ -99,7 +99,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
         tenant: str,
         model: Dict[str, Dict[str, Optional[types.CollectionMetadata]]],
     ) -> None:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             # This never happens because we never actually issue a
             # create_tenant call on singleton_tenant:
             # thanks to the above overriding of get_tenant_model(),
@@ -115,7 +115,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
         database: str,
         database_model: Dict[str, Optional[types.CollectionMetadata]],
     ) -> None:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             # This never happens because we never actually issue a
             # create_database call on (singleton_tenant, singleton_database):
             # thanks to the above overriding of has_database_for_tenant(),
@@ -126,19 +126,19 @@ class SingletonTenantDatabaseCollectionStateMachine(
 
     @overrides
     def overwrite_database(self, database: str) -> str:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             return SINGLETON_DATABASE
         return database
 
     @overrides
     def overwrite_tenant(self, tenant: str) -> str:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             return SINGLETON_TENANT
         return tenant
 
     @property
     def model(self) -> Dict[str, Optional[types.CollectionMetadata]]:
-        if self.api == self.singleton_client:
+        if self.client == self.singleton_client:
             return self.tenant_to_database_to_model[SINGLETON_TENANT][
                 SINGLETON_DATABASE
             ]
@@ -200,7 +200,7 @@ def test_repeat_failure(
             name="A00",
             metadata=None,
             embedding_function=strategies.hashing_embedding_function(
-                dim=2, dtype=numpy.float16
+                dim=2, dtype=numpy.float16  # type: ignore
             ),
             id=uuid.UUID("c9bcb72f-92b1-4604-a8cb-084162dfe98b"),
             dimension=2,

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -74,15 +74,15 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
     collection: Collection
     embedding_ids: Bundle[ID] = Bundle("embedding_ids")
 
-    def __init__(self, api: ClientAPI):
+    def __init__(self, client: ClientAPI):
         super().__init__()
-        self.api = api
+        self.client = client
         self._rules_strategy = hypothesis.stateful.RuleStrategy(self)  # type: ignore
 
     @initialize(collection=collection_st)  # type: ignore
     def initialize(self, collection: strategies.Collection):
-        reset(self.api)
-        self.collection = self.api.create_collection(
+        self.client.reset()
+        self.collection = self.client.create_collection(
             name=collection.name,
             metadata=collection.metadata,
             embedding_function=collection.embedding_function,

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -7,7 +7,7 @@ import hypothesis.strategies as st
 from hypothesis import given, settings, HealthCheck
 from typing import Dict, Set, cast, Union, DefaultDict, Any, List
 from dataclasses import dataclass
-from chromadb.api.types import ID, Include, IDs, validate_embeddings
+from chromadb.api.types import ID, Embeddings, Include, IDs, validate_embeddings
 import chromadb.errors as errors
 from chromadb.api import ClientAPI
 from chromadb.api.models.Collection import Collection
@@ -49,11 +49,11 @@ def print_traces() -> None:
         print(f"{key}: {value}")
 
 
-dtype_shared_st: st.SearchStrategy[
+dtype_shared_st: st.SearchStrategy[  # type: ignore[type-arg]
     Union[np.float16, np.float32, np.float64]
 ] = st.shared(st.sampled_from(strategies.float_types), key="dtype")
 
-dimension_shared_st: st.SearchStrategy[int] = st.shared(
+dimension_shared_st: st.SearchStrategy[int] = st.shared(  # type: ignore[type-arg]
     st.integers(min_value=2, max_value=2048), key="dimension"
 )
 
@@ -72,7 +72,7 @@ collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="co
 
 class EmbeddingStateMachineBase(RuleBasedStateMachine):
     collection: Collection
-    embedding_ids: Bundle[ID] = Bundle("embedding_ids")
+    embedding_ids: Bundle[ID] = Bundle("embedding_ids")  # type: ignore[type-arg]
 
     def __init__(self, client: ClientAPI):
         super().__init__()
@@ -81,10 +81,10 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
 
     @initialize(collection=collection_st)  # type: ignore
     def initialize(self, collection: strategies.Collection):
-        self.client.reset()
+        reset(self.client)
         self.collection = self.client.create_collection(
             name=collection.name,
-            metadata=collection.metadata,
+            metadata=collection.metadata,  # type: ignore[arg-type]
             embedding_function=collection.embedding_function,
         )
         self.embedding_function = collection.embedding_function
@@ -99,7 +99,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
         target=embedding_ids,
         record_set=strategies.recordsets(collection_st),
     )
-    def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:
+    def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:  # type: ignore[type-arg]
         trace("add_embeddings")
         self.on_state_change(EmbeddingStateMachineStates.add_embeddings)
 
@@ -129,12 +129,12 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
                 if normalized_record_set["embeddings"]
                 else None,
             }
-            self.collection.add(**normalized_record_set)
+            self.collection.add(**normalized_record_set)  # type: ignore[arg-type]
             self._upsert_embeddings(cast(strategies.RecordSet, filtered_record_set))
             return multiple(*filtered_record_set["ids"])
 
         else:
-            self.collection.add(**normalized_record_set)
+            self.collection.add(**normalized_record_set)  # type: ignore[arg-type]
             self._upsert_embeddings(cast(strategies.RecordSet, normalized_record_set))
             return multiple(*normalized_record_set["ids"])
 
@@ -162,7 +162,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
         trace("update embeddings")
         self.on_state_change(EmbeddingStateMachineStates.update_embeddings)
 
-        self.collection.update(**record_set)
+        self.collection.update(**record_set)  # type: ignore[arg-type]
         self._upsert_embeddings(record_set)
 
     # Using a value < 3 causes more retries and lowers the number of valid samples
@@ -179,7 +179,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
         trace("upsert embeddings")
         self.on_state_change(EmbeddingStateMachineStates.upsert_embeddings)
 
-        self.collection.upsert(**record_set)
+        self.collection.upsert(**record_set)  # type: ignore[arg-type]
         self._upsert_embeddings(record_set)
 
     @invariant()
@@ -203,10 +203,10 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
 
     @invariant()
     def fields_match(self) -> None:
-        self.record_set_state = cast(strategies.RecordSet, self.record_set_state)
-        invariants.embeddings_match(self.collection, self.record_set_state)
-        invariants.metadatas_match(self.collection, self.record_set_state)
-        invariants.documents_match(self.collection, self.record_set_state)
+        self.record_set_state = cast(strategies.RecordSet, self.record_set_state)  # type: ignore[assignment]
+        invariants.embeddings_match(self.collection, self.record_set_state)  # type: ignore[arg-type]
+        invariants.metadatas_match(self.collection, self.record_set_state)  # type: ignore[arg-type]
+        invariants.documents_match(self.collection, self.record_set_state)  # type: ignore[arg-type]
 
     def _upsert_embeddings(self, record_set: strategies.RecordSet) -> None:
         normalized_record_set: strategies.NormalizedRecordSet = invariants.wrap_all(
@@ -240,7 +240,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
                         )
                         if normalized_record_set["metadatas"][idx] is not None:
                             record_set_state.update(
-                                normalized_record_set["metadatas"][idx]
+                                normalized_record_set["metadatas"][idx]  # type: ignore[arg-type]
                             )
                         else:
                             # None in the update metadata is a no-op
@@ -296,17 +296,17 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
 
 
 class EmbeddingStateMachine(EmbeddingStateMachineBase):
-    embedding_ids: Bundle[ID] = Bundle("embedding_ids")
+    embedding_ids: Bundle[ID] = Bundle("embedding_ids")  # type: ignore[type-arg]
 
-    def __init__(self, api: ServerAPI):
-        super().__init__(api)
+    def __init__(self, client: ClientAPI):
+        super().__init__(client)
 
     @initialize(collection=collection_st)  # type: ignore
     def initialize(self, collection: strategies.Collection):
         super().initialize(collection)
         print("[test_embeddings] Reset")
         self.log_operation_count = 0
-        self.unique_ids_in_log = set()
+        self.unique_ids_in_log: Set[ID] = set()
         self.collection_version = self.collection.get_model()["version"]
 
     @precondition(
@@ -316,7 +316,7 @@ class EmbeddingStateMachine(EmbeddingStateMachineBase):
     )
     @rule()
     def wait_for_compaction(self) -> None:
-        current_version = get_collection_version(self.api, self.collection.name)
+        current_version = get_collection_version(self.client, self.collection.name)
         assert current_version >= self.collection_version
         # This means that there was a compaction from the last time this was
         # invoked. Ok to start all over again.
@@ -331,7 +331,7 @@ class EmbeddingStateMachine(EmbeddingStateMachineBase):
         else:
             print("[test_embeddings][wait_for_compaction] wait for version to increase")
             new_version = wait_for_version_increase(
-                self.api, self.collection.name, current_version, additional_time=240
+                self.client, self.collection.name, current_version, additional_time=240
             )
             # Everything got compacted.
             self.log_operation_count = 0
@@ -342,125 +342,7 @@ class EmbeddingStateMachine(EmbeddingStateMachineBase):
         target=embedding_ids,
         record_set=strategies.recordsets(collection_st),
     )
-    def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:
-        res = super().add_embeddings(record_set)
-        normalized_record_set: strategies.NormalizedRecordSet = invariants.wrap_all(
-            record_set
-        )
-        print(
-            "[test_embeddings][add] Non Intersection ids ",
-            normalized_record_set["ids"],
-            " len ",
-            len(normalized_record_set["ids"]),
-        )
-        self.log_operation_count += len(normalized_record_set["ids"])
-        for id in normalized_record_set["ids"]:
-            if id not in self.unique_ids_in_log:
-                self.unique_ids_in_log.add(id)
-        return res
-
-    @rule(ids=st.lists(consumes(embedding_ids), min_size=1))
-    def delete_by_ids(self, ids: IDs) -> None:
-        super().delete_by_ids(ids)
-        print("[test_embeddings][delete] ids ", ids, " len ", len(ids))
-        self.log_operation_count += len(ids)
-        for id in ids:
-            if id in self.unique_ids_in_log:
-                self.unique_ids_in_log.remove(id)
-
-    # Removing the precondition causes the tests to frequently fail as "unsatisfiable"
-    # Using a value < 5 causes retries and lowers the number of valid samples
-    @precondition(lambda self: len(self.record_set_state["ids"]) >= 5)
-    @rule(
-        record_set=strategies.recordsets(
-            collection_strategy=collection_st,
-            id_strategy=embedding_ids,
-            min_size=1,
-            max_size=5,
-        ),
-    )
-    def update_embeddings(self, record_set: strategies.RecordSet) -> None:
-        super().update_embeddings(record_set)
-        print(
-            "[test_embeddings][update] ids ",
-            record_set["ids"],
-            " len ",
-            len(invariants.wrap(record_set["ids"])),
-        )
-        self.log_operation_count += len(invariants.wrap(record_set["ids"]))
-
-    # Using a value < 3 causes more retries and lowers the number of valid samples
-    @precondition(lambda self: len(self.record_set_state["ids"]) >= 3)
-    @rule(
-        record_set=strategies.recordsets(
-            collection_strategy=collection_st,
-            id_strategy=st.one_of(embedding_ids, strategies.safe_text),
-            min_size=1,
-            max_size=5,
-        )
-    )
-    def upsert_embeddings(self, record_set: strategies.RecordSet) -> None:
-        super().upsert_embeddings(record_set)
-        print(
-            "[test_embeddings][upsert] ids ",
-            record_set["ids"],
-            " len ",
-            len(invariants.wrap(record_set["ids"])),
-        )
-        self.log_operation_count += len(invariants.wrap(record_set["ids"]))
-        for id in invariants.wrap(record_set["ids"]):
-            if id not in self.unique_ids_in_log:
-                self.unique_ids_in_log.add(id)
-
-
-class EmbeddingStateMachine(EmbeddingStateMachineBase):
-    embedding_ids: Bundle[ID] = Bundle("embedding_ids")
-
-    def __init__(self, api: ClientAPI):
-        super().__init__(api)
-
-    @initialize(collection=collection_st)  # type: ignore
-    def initialize(self, collection: strategies.Collection):
-        super().initialize(collection)
-        print("[test_embeddings] Reset")
-        self.log_operation_count = 0
-        self.unique_ids_in_log = set()
-        self.collection_version = self.collection.get_model()["version"]
-
-    @precondition(
-        lambda self: not NOT_CLUSTER_ONLY
-        and self.log_operation_count > 10
-        and len(self.unique_ids_in_log) > 3
-    )
-    @rule()
-    def wait_for_compaction(self) -> None:
-        current_version = get_collection_version(self.api, self.collection.name)
-        assert current_version >= self.collection_version
-        # This means that there was a compaction from the last time this was
-        # invoked. Ok to start all over again.
-        if current_version > self.collection_version:
-            print(
-                "[test_embeddings][wait_for_compaction] collection version has changed, so reset to 0"
-            )
-            self.collection_version = current_version
-            # This is fine even if the log has some records right now
-            self.log_operation_count = 0
-            self.unique_ids_in_log = set()
-        else:
-            print("[test_embeddings][wait_for_compaction] wait for version to increase")
-            new_version = wait_for_version_increase(
-                self.api, self.collection.name, current_version, additional_time=240
-            )
-            # Everything got compacted.
-            self.log_operation_count = 0
-            self.unique_ids_in_log = set()
-            self.collection_version = new_version
-
-    @rule(
-        target=embedding_ids,
-        record_set=strategies.recordsets(collection_st),
-    )
-    def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:
+    def add_embeddings(self, record_set: strategies.RecordSet) -> MultipleResults[ID]:  # type: ignore[type-arg]
         res = super().add_embeddings(record_set)
         normalized_record_set: strategies.NormalizedRecordSet = invariants.wrap_all(
             record_set
@@ -542,8 +424,8 @@ def test_embeddings_state(caplog: pytest.LogCaptureFixture, client: ClientAPI) -
     print_traces()
 
 
-def test_add_then_delete_n_minus_1(api: ServerAPI) -> None:
-    state = EmbeddingStateMachine(api)
+def test_add_then_delete_n_minus_1(client: ClientAPI) -> None:
+    state = EmbeddingStateMachine(client)
     state.initialize(
         collection=strategies.Collection(
             name="A00",
@@ -592,61 +474,7 @@ def test_add_then_delete_n_minus_1(api: ServerAPI) -> None:
     state.count()
     state.fields_match()
     state.no_duplicates()
-    state.teardown()
-
-
-def test_update_none(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> None:
-    state = EmbeddingStateMachine(api)
-    state.initialize(
-        collection=strategies.Collection(
-            name="A00",
-            metadata={
-                "hnsw:construction_ef": 128,
-                "hnsw:search_ef": 128,
-                "hnsw:M": 128,
-            },
-            embedding_function=None,
-            id=uuid.UUID("2fb0c945-b877-42ab-9417-bfe0f6b172af"),
-            dimension=2,
-            dtype=np.float16,
-            known_metadata_keys={},
-            known_document_keywords=[],
-            has_documents=False,
-            has_embeddings=True,
-        )
-    )
-    state.ann_accuracy()
-    state.count()
-    state.fields_match()
-    state.no_duplicates()
-    v1, v2, v3, v4, v5 = state.add_embeddings(
-        record_set={
-            "ids": ["0", "1", "2", "3", "4"],
-            "embeddings": [
-                [0.09765625, 0.430419921875],
-                [0.20556640625, 0.08978271484375],
-                [-0.1527099609375, 0.291748046875],
-                [-0.12481689453125, 0.78369140625],
-                [0.92724609375, -0.233154296875],
-            ],
-            "metadatas": [None, None, None, None, None],
-            "documents": None,
-        }
-    )
-    state.ann_accuracy()
-    state.count()
-    state.fields_match()
-    state.no_duplicates()
-    state.update_embeddings(
-        record_set={
-            "ids": [v5],
-            "embeddings": [[0.58349609375, 0.05780029296875]],
-            "metadatas": [{v1: v1}],
-            "documents": None,
-        }
-    )
-    state.ann_accuracy()
-    state.teardown()
+    state.teardown()  # type: ignore[no-untyped-call]
 
 
 def test_update_none(caplog: pytest.LogCaptureFixture, client: ClientAPI) -> None:
@@ -700,18 +528,18 @@ def test_update_none(caplog: pytest.LogCaptureFixture, client: ClientAPI) -> Non
         }
     )
     state.ann_accuracy()
-    state.teardown()
+    state.teardown()  # type: ignore[no-untyped-call]
 
 
 def test_multi_add(client: ClientAPI) -> None:
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="foo")
-    coll.add(ids=["a"], embeddings=[[0.0]])
+    coll.add(ids=["a"], embeddings=[[0.0]])  # type: ignore[arg-type]
     assert coll.count() == 1
 
     # after the sqlite refactor - add silently ignores duplicates, no exception is raised
     # partial adds are supported - i.e we will add whatever we can in the request
-    coll.add(ids=["a"], embeddings=[[0.0]])
+    coll.add(ids=["a"], embeddings=[[0.0]])  # type: ignore[arg-type]
 
     assert coll.count() == 1
 
@@ -723,46 +551,46 @@ def test_multi_add(client: ClientAPI) -> None:
 
 
 def test_dup_add(client: ClientAPI) -> None:
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="foo")
     with pytest.raises(errors.DuplicateIDError):
-        coll.add(ids=["a", "a"], embeddings=[[0.0], [1.1]])
+        coll.add(ids=["a", "a"], embeddings=[[0.0], [1.1]])  # type: ignore[arg-type]
     with pytest.raises(errors.DuplicateIDError):
-        coll.upsert(ids=["a", "a"], embeddings=[[0.0], [1.1]])
+        coll.upsert(ids=["a", "a"], embeddings=[[0.0], [1.1]])  # type: ignore[arg-type]
 
 
 def test_query_without_add(client: ClientAPI) -> None:
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="foo")
-    fields: Include = ["documents", "metadatas", "embeddings", "distances"]
+    fields: Include = ["documents", "metadatas", "embeddings", "distances"]  # type: ignore[list-item]
     N = np.random.randint(1, 2000)
     K = np.random.randint(1, 100)
     results = coll.query(
         query_embeddings=np.random.random((N, K)).tolist(), include=fields
     )
     for field in fields:
-        field_results = results[field]
+        field_results = results[field]  # type: ignore[literal-required]
         assert field_results is not None
         assert all([len(result) == 0 for result in field_results])
 
 
 def test_get_non_existent(client: ClientAPI) -> None:
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="foo")
-    result = coll.get(ids=["a"], include=["documents", "metadatas", "embeddings"])
+    result = coll.get(ids=["a"], include=["documents", "metadatas", "embeddings"])  # type: ignore[list-item]
     assert len(result["ids"]) == 0
-    assert len(result["metadatas"]) == 0
-    assert len(result["documents"]) == 0
-    assert len(result["embeddings"]) == 0
+    assert len(result["metadatas"]) == 0  # type: ignore[arg-type]
+    assert len(result["documents"]) == 0  # type: ignore[arg-type]
+    assert len(result["embeddings"]) == 0  # type: ignore[arg-type]
 
 
 # TODO: Use SQL escaping correctly internally
 @pytest.mark.xfail(reason="We don't properly escape SQL internally, causing problems")
 def test_escape_chars_in_ids(client: ClientAPI) -> None:
-    client.reset()
+    reset(client)
     id = "\x1f"
     coll = client.create_collection(name="foo")
-    coll.add(ids=[id], embeddings=[[0.0]])
+    coll.add(ids=[id], embeddings=[[0.0]])  # type: ignore[arg-type]
     assert coll.count() == 1
     coll.delete(ids=[id])
     assert coll.count() == 0
@@ -778,8 +606,8 @@ def test_escape_chars_in_ids(client: ClientAPI) -> None:
         {"where_document": {}, "where": {}},
     ],
 )
-def test_delete_empty_fails(client: ClientAPI, kwargs: dict):
-    client.reset()
+def test_delete_empty_fails(client: ClientAPI, kwargs: Any) -> None:
+    reset(client)
     coll = client.create_collection(name="foo")
     with pytest.raises(Exception) as e:
         coll.delete(**kwargs)
@@ -801,8 +629,8 @@ def test_delete_empty_fails(client: ClientAPI, kwargs: dict):
         },
     ],
 )
-def test_delete_success(client: ClientAPI, kwargs: dict):
-    client.reset()
+def test_delete_success(client: ClientAPI, kwargs: Any) -> None:
+    reset(client)
     coll = client.create_collection(name="foo")
     # Should not raise
     coll.delete(**kwargs)
@@ -860,7 +688,7 @@ def test_autocasting_validate_embeddings_incompatible_types(
 
 
 def test_0dim_embedding_validation() -> None:
-    embds = [[]]
+    embds: Embeddings = [[]]
     with pytest.raises(ValueError) as e:
         validate_embeddings(embds)
     assert "Expected each embedding in the embeddings to be a non-empty list" in str(e)

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, cast
 from hypothesis import given, settings, HealthCheck
 import pytest
-from chromadb.api import ServerAPI
+from chromadb.api import ClientAPI
 from chromadb.test.property import invariants
 from chromadb.api.types import (
     Document,
@@ -191,7 +191,7 @@ recordset_st = st.shared(
 )
 def test_filterable_metadata_get(
     caplog,
-    api: ServerAPI,
+    client: ClientAPI,
     collection: strategies.Collection,
     record_set,
     filters,
@@ -199,8 +199,8 @@ def test_filterable_metadata_get(
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    reset(api)
-    coll = api.create_collection(
+    client.reset()
+    coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
         embedding_function=collection.embedding_function,
@@ -241,7 +241,7 @@ def test_filterable_metadata_get(
 )
 def test_filterable_metadata_get_limit_offset(
     caplog,
-    api: ServerAPI,
+    client: ClientAPI,
     collection: strategies.Collection,
     record_set,
     filters,
@@ -256,8 +256,8 @@ def test_filterable_metadata_get_limit_offset(
     if not NOT_CLUSTER_ONLY:
         pytest.skip("Distributed system does not support limit/offset yet")
 
-    reset(api)
-    coll = api.create_collection(
+    client.reset()
+    coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
         embedding_function=collection.embedding_function,
@@ -302,7 +302,7 @@ def test_filterable_metadata_get_limit_offset(
 )
 def test_filterable_metadata_query(
     caplog: pytest.LogCaptureFixture,
-    api: ServerAPI,
+    client: ClientAPI,
     collection: strategies.Collection,
     record_set: strategies.RecordSet,
     filters: List[strategies.Filter],
@@ -310,8 +310,8 @@ def test_filterable_metadata_query(
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    reset(api)
-    coll = api.create_collection(
+    client.reset()
+    coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
         embedding_function=collection.embedding_function,
@@ -360,10 +360,10 @@ def test_filterable_metadata_query(
         assert len(result_ids.intersection(expected_ids)) == len(result_ids)
 
 
-def test_empty_filter(api: ServerAPI) -> None:
+def test_empty_filter(client: ClientAPI) -> None:
     """Test that a filter where no document matches returns an empty result"""
-    reset(api)
-    coll = api.create_collection(name="test")
+    client.reset()
+    coll = client.create_collection(name="test")
 
     test_ids: IDs = ["1", "2", "3"]
     test_embeddings: Embeddings = [[1, 1], [2, 2], [3, 3]]
@@ -396,10 +396,10 @@ def test_empty_filter(api: ServerAPI) -> None:
     assert set(res["included"]) == set(["metadatas", "documents", "distances"])
 
 
-def test_boolean_metadata(api: ServerAPI) -> None:
+def test_boolean_metadata(client: ClientAPI) -> None:
     """Test that metadata with boolean values is correctly filtered"""
-    reset(api)
-    coll = api.create_collection(name="test")
+    client.reset()
+    coll = client.create_collection(name="test")
 
     test_ids: IDs = ["1", "2", "3"]
     test_embeddings: Embeddings = [[1, 1], [2, 2], [3, 3]]
@@ -412,11 +412,11 @@ def test_boolean_metadata(api: ServerAPI) -> None:
     assert res["ids"] == ["1", "3"]
 
 
-def test_get_empty(api: ServerAPI) -> None:
+def test_get_empty(client: ClientAPI) -> None:
     """Tests that calling get() with empty filters returns nothing"""
 
-    reset(api)
-    coll = api.create_collection(name="test")
+    client.reset()
+    coll = client.create_collection(name="test")
 
     test_ids: IDs = ["1", "2", "3"]
     test_embeddings: Embeddings = [[1, 1], [2, 2], [3, 3]]

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -42,7 +42,7 @@ def _filter_where_clause(clause: Where, metadata: Optional[Metadata]) -> bool:
         or isinstance(expr, int)
         or isinstance(expr, float)
     ):
-        return _filter_where_clause({key: {"$eq": expr}}, metadata)
+        return _filter_where_clause({key: {"$eq": expr}}, metadata)  # type: ignore[dict-item]
 
     # expr is a list of clauses
     if key == "$and":
@@ -54,10 +54,10 @@ def _filter_where_clause(clause: Where, metadata: Optional[Metadata]) -> bool:
         return any(_filter_where_clause(clause, metadata) for clause in expr)
     if key == "$in":
         assert isinstance(expr, list)
-        return metadata[key] in expr if key in metadata else False
+        return metadata[key] in expr if key in metadata else False  # type: ignore[comparison-overlap]
     if key == "$nin":
         assert isinstance(expr, list)
-        return metadata[key] not in expr
+        return metadata[key] not in expr  # type: ignore[comparison-overlap]
 
     # expr is an operator expression
     assert isinstance(expr, dict)
@@ -71,9 +71,9 @@ def _filter_where_clause(clause: Where, metadata: Optional[Metadata]) -> bool:
     elif op == "$ne":
         return key in metadata and metadata_key != val
     elif op == "$in":
-        return key in metadata and metadata_key in val
+        return key in metadata and metadata_key in val  # type: ignore[operator]
     elif op == "$nin":
-        return key in metadata and metadata_key not in val
+        return key in metadata and metadata_key not in val  # type: ignore[operator]
 
     # The following conditions only make sense for numeric values
     assert isinstance(metadata_key, int) or isinstance(metadata_key, float)
@@ -149,7 +149,7 @@ def _filter_embedding_set(
         if filter["where"]:
             metadatas: Metadatas
             if isinstance(normalized_record_set["metadatas"], list):
-                metadatas = normalized_record_set["metadatas"]
+                metadatas = normalized_record_set["metadatas"]  # type: ignore[assignment]
             else:
                 metadatas = [EMPTY_DICT] * len(normalized_record_set["ids"])
             filter_where: Where = filter["where"]
@@ -199,7 +199,7 @@ def test_filterable_metadata_get(
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    client.reset()
+    reset(client)
     coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
@@ -215,7 +215,7 @@ def test_filterable_metadata_get(
         # some minimal size
         if should_compact and len(invariants.wrap(record_set["ids"])) > 10:
             # Wait for the model to be updated
-            wait_for_version_increase(api, collection.name, initial_version)
+            wait_for_version_increase(client, collection.name, initial_version)
 
     for filter in filters:
         result_ids = coll.get(**filter)["ids"]
@@ -256,7 +256,7 @@ def test_filterable_metadata_get_limit_offset(
     if not NOT_CLUSTER_ONLY:
         pytest.skip("Distributed system does not support limit/offset yet")
 
-    client.reset()
+    reset(client)
     coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
@@ -272,7 +272,7 @@ def test_filterable_metadata_get_limit_offset(
         # some minimal size
         if should_compact and len(invariants.wrap(record_set["ids"])) > 10:
             # Wait for the model to be updated
-            wait_for_version_increase(api, collection.name, initial_version)
+            wait_for_version_increase(client, collection.name, initial_version)
 
     for filter in filters:
         # add limit and offset to filter
@@ -310,7 +310,7 @@ def test_filterable_metadata_query(
 ) -> None:
     caplog.set_level(logging.ERROR)
 
-    client.reset()
+    reset(client)
     coll = client.create_collection(
         name=collection.name,
         metadata=collection.metadata,  # type: ignore
@@ -319,14 +319,14 @@ def test_filterable_metadata_query(
     initial_version = coll.get_model()["version"]
     normalized_record_set = invariants.wrap_all(record_set)
 
-    coll.add(**record_set)
+    coll.add(**record_set)  # type: ignore[arg-type]
 
     if not NOT_CLUSTER_ONLY:
         # Only wait for compaction if the size of the collection is
         # some minimal size
         if should_compact and len(invariants.wrap(record_set["ids"])) > 10:
             # Wait for the model to be updated
-            wait_for_version_increase(api, collection.name, initial_version)
+            wait_for_version_increase(client, collection.name, initial_version)
 
     total_count = len(normalized_record_set["ids"])
     # Pick a random vector
@@ -362,7 +362,7 @@ def test_filterable_metadata_query(
 
 def test_empty_filter(client: ClientAPI) -> None:
     """Test that a filter where no document matches returns an empty result"""
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="test")
 
     test_ids: IDs = ["1", "2", "3"]
@@ -374,9 +374,9 @@ def test_empty_filter(client: ClientAPI) -> None:
 
     res = coll.query(
         query_embeddings=test_query_embedding,
-        where={"q": {"$eq": 4}},
+        where={"q": {"$eq": 4}},  # type: ignore[dict-item]
         n_results=3,
-        include=["embeddings", "distances", "metadatas"],
+        include=["embeddings", "distances", "metadatas"],  # type: ignore[list-item]
     )
     assert res["ids"] == [[]]
     assert res["embeddings"] == [[]]
@@ -398,7 +398,7 @@ def test_empty_filter(client: ClientAPI) -> None:
 
 def test_boolean_metadata(client: ClientAPI) -> None:
     """Test that metadata with boolean values is correctly filtered"""
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="test")
 
     test_ids: IDs = ["1", "2", "3"]
@@ -415,7 +415,7 @@ def test_boolean_metadata(client: ClientAPI) -> None:
 def test_get_empty(client: ClientAPI) -> None:
     """Tests that calling get() with empty filters returns nothing"""
 
-    client.reset()
+    reset(client)
     coll = client.create_collection(name="test")
 
     test_ids: IDs = ["1", "2", "3"]
@@ -432,9 +432,9 @@ def test_get_empty(client: ClientAPI) -> None:
 
     coll.add(ids=test_ids, embeddings=test_embeddings, metadatas=test_metadatas)
 
-    res = coll.get(ids=["nope"], include=["embeddings", "metadatas", "documents"])
+    res = coll.get(ids=["nope"], include=["embeddings", "metadatas", "documents"])  # type: ignore[list-item]
     check_empty_res(res)
     res = coll.get(
-        include=["embeddings", "metadatas", "documents"], where={"test": 100}
+        include=["embeddings", "metadatas", "documents"], where={"test": 100}  # type: ignore[list-item]
     )
     check_empty_res(res)

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -129,10 +129,10 @@ def load_and_check(
 ) -> None:
     try:
         system = System(settings)
-        api = system.instance(ServerAPI)
         system.start()
+        client = ClientCreator.from_system(system)
 
-        coll = api.get_collection(
+        coll = client.get_collection(
             name=collection_name,
             embedding_function=strategies.not_implemented_embedding_function(),
         )

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -25,6 +25,7 @@ from hypothesis.stateful import (
 import os
 import shutil
 import tempfile
+from chromadb.api.client import Client as ClientCreator
 
 CreatePersistAPI = Callable[[], ServerAPI]
 
@@ -71,11 +72,11 @@ def test_persist(
     embeddings_strategy: strategies.RecordSet,
 ) -> None:
     system_1 = System(settings)
-    api_1 = system_1.instance(ServerAPI)
     system_1.start()
+    client_1 = ClientCreator.from_system(system_1)
 
-    api_1.reset()
-    coll = api_1.create_collection(
+    client_1.reset()
+    coll = client_1.create_collection(
         name=collection_strategy.name,
         metadata=collection_strategy.metadata,
         embedding_function=collection_strategy.embedding_function,
@@ -94,14 +95,14 @@ def test_persist(
     )
 
     system_1.stop()
-    del api_1
+    del client_1
     del system_1
 
     system_2 = System(settings)
-    api_2 = system_2.instance(ServerAPI)
     system_2.start()
+    client_2 = ClientCreator.from_system(system_2)
 
-    coll = api_2.get_collection(
+    coll = client_2.get_collection(
         name=collection_strategy.name,
         embedding_function=collection_strategy.embedding_function,
     )
@@ -116,7 +117,7 @@ def test_persist(
     )
 
     system_2.stop()
-    del api_2
+    del client_2
     del system_2
 
 
@@ -169,19 +170,19 @@ MIN_STATE_CHANGES_BEFORE_PERSIST = 5
 
 
 class PersistEmbeddingsStateMachine(EmbeddingStateMachineBase):
-    def __init__(self, api: ClientAPI, settings: Settings):
-        self.api = api
+    def __init__(self, client: ClientAPI, settings: Settings):
+        self.client = client
         self.settings = settings
         self.min_state_changes_left_before_persisting = MIN_STATE_CHANGES_BEFORE_PERSIST
-        self.api.reset()
-        super().__init__(self.api)
+        self.client.reset()
+        super().__init__(self.client)
 
     @initialize(collection=embedding_collection_st, batch_size=st.integers(min_value=3, max_value=2000), sync_threshold=st.integers(min_value=3, max_value=2000))  # type: ignore
     def initialize(
         self, collection: strategies.Collection, batch_size: int, sync_threshold: int
     ):
-        self.api.reset()
-        self.collection = self.api.create_collection(
+        self.client.reset()
+        self.collection = self.client.create_collection(
             name=collection.name,
             metadata=collection.metadata,
             embedding_function=collection.embedding_function,
@@ -226,14 +227,18 @@ class PersistEmbeddingsStateMachine(EmbeddingStateMachineBase):
             self.min_state_changes_left_before_persisting -= 1
 
     def teardown(self) -> None:
-        self.api.reset()
+        self.client.reset()
 
 
 def test_persist_embeddings_state(
     caplog: pytest.LogCaptureFixture, settings: Settings
 ) -> None:
     caplog.set_level(logging.ERROR)
-    api = chromadb.Client(settings)
+    client = chromadb.Client(settings)
     run_state_machine_as_test(
-        lambda: PersistEmbeddingsStateMachine(settings=settings, api=api),
+        lambda: PersistEmbeddingsStateMachine(settings=settings, client=client),
+        # For small max_example values, the test may not generate any examples that pass the precondition for persist().
+        # This value makes it much more likely that the precondition will be satisfied and thus the rule will be exercised.
+        _min_steps=10,
+        settings=override_hypothesis_profile(fast=hypothesis.settings(max_examples=10)),
     )  # type: ignore

--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -5,16 +5,16 @@ from chromadb.api import ServerAPI
 from chromadb.api.models.Collection import Collection
 
 
-def test_many_collections(api: ServerAPI) -> None:
+def test_many_collections(client: ServerAPI) -> None:
     """Test that we can create a large number of collections and that the system
     # remains responsive."""
-    api.reset()
+    client.reset()
 
     N = 10
     D = 10
 
     metadata = None
-    if api.get_settings().is_persistent:
+    if client.get_settings().is_persistent:
         metadata = {"hnsw:batch_size": 3, "hnsw:sync_threshold": 3}
     else:
         # We only want to test persistent configurations in this way, since the main
@@ -24,7 +24,7 @@ def test_many_collections(api: ServerAPI) -> None:
     num_collections = 10000
     collections: List[Collection] = []
     for i in range(num_collections):
-        new_collection = api.create_collection(
+        new_collection = client.create_collection(
             f"test_collection_{i}",
             metadata=metadata,
         )

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -74,9 +74,9 @@ def vector_approx_equal(a, b, tolerance: float = 1e-6) -> bool:
 
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
 def test_persist_index_loading(api_fixture, request):
-    api = request.getfixturevalue("local_persist_api")
-    api.reset()
-    collection = api.create_collection("test")
+    client = request.getfixturevalue("local_persist_api")
+    client.reset()
+    collection = client.create_collection("test")
     collection.add(ids="id1", documents="hello")
 
     api2 = request.getfixturevalue("local_persist_api_cache_bust")
@@ -103,13 +103,13 @@ def test_persist_index_loading_embedding_function(api_fixture, request):
         def __call__(self, input):
             return [[1, 2, 3] for _ in range(len(input))]
 
-    api = request.getfixturevalue("local_persist_api")
-    api.reset()
-    collection = api.create_collection("test", embedding_function=TestEF())
+    client = request.getfixturevalue("local_persist_api")
+    client.reset()
+    collection = client.create_collection("test", embedding_function=TestEF())
     collection.add(ids="id1", documents="hello")
 
-    api2 = request.getfixturevalue("local_persist_api_cache_bust")
-    collection = api2.get_collection("test", embedding_function=TestEF())
+    client2 = request.getfixturevalue("local_persist_api_cache_bust")
+    collection = client2.get_collection("test", embedding_function=TestEF())
 
     includes = ["embeddings", "documents", "metadatas", "distances"]
     nn = collection.query(
@@ -163,24 +163,24 @@ def test_persist_index_get_or_create_embedding_function(api_fixture, request):
 
 @pytest.mark.parametrize("api_fixture", [local_persist_api])
 def test_persist(api_fixture, request):
-    api = request.getfixturevalue(api_fixture.__name__)
+    client = request.getfixturevalue(api_fixture.__name__)
 
-    api.reset()
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
 
     collection.add(**batch_records)
 
     assert collection.count() == 2
 
-    api = request.getfixturevalue(api_fixture.__name__)
-    collection = api.get_collection("testspace")
+    client = request.getfixturevalue(api_fixture.__name__)
+    collection = client.get_collection("testspace")
     assert collection.count() == 2
 
-    api.delete_collection("testspace")
+    client.delete_collection("testspace")
 
-    api = request.getfixturevalue(api_fixture.__name__)
-    assert api.list_collections() == []
+    client = request.getfixturevalue(api_fixture.__name__)
+    assert client.list_collections() == []
 
 
 def test_heartbeat(client):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -183,8 +183,8 @@ def test_persist(api_fixture, request):
     assert api.list_collections() == []
 
 
-def test_heartbeat(api):
-    heartbeat_ns = api.heartbeat()
+def test_heartbeat(client):
+    heartbeat_ns = client.heartbeat()
     assert isinstance(heartbeat_ns, int)
 
     heartbeat_s = heartbeat_ns // 10**9
@@ -192,17 +192,17 @@ def test_heartbeat(api):
     assert heartbeat > datetime.now() - timedelta(seconds=10)
 
 
-def test_max_batch_size(api):
-    print(api)
-    batch_size = api.get_max_batch_size()
+def test_max_batch_size(client):
+    print(client)
+    batch_size = client.get_max_batch_size()
     assert batch_size > 0
 
 
-def test_pre_flight_checks(api):
-    if not isinstance(api, FastAPI):
+def test_pre_flight_checks(client):
+    if not isinstance(client, FastAPI):
         pytest.skip("Not a FastAPI instance")
 
-    resp = httpx.get(f"{api._api_url}/pre-flight-checks")
+    resp = httpx.get(f"{client._api_url}/pre-flight-checks")
     assert resp.status_code == 200
     assert resp.json() is not None
     assert "max_batch_size" in resp.json().keys()
@@ -214,20 +214,20 @@ batch_records = {
 }
 
 
-def test_add(api):
-    api.reset()
+def test_add(client):
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
 
     collection.add(**batch_records)
 
     assert collection.count() == 2
 
 
-def test_collection_add_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_add_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -235,19 +235,19 @@ def test_collection_add_with_invalid_collection_throws(api):
         collection.add(**batch_records)
 
 
-def test_get_or_create(api):
-    api.reset()
+def test_get_or_create(client):
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
 
     collection.add(**batch_records)
 
     assert collection.count() == 2
 
     with pytest.raises(Exception):
-        collection = api.create_collection("testspace")
+        collection = client.create_collection("testspace")
 
-    collection = api.get_or_create_collection("testspace")
+    collection = client.get_or_create_collection("testspace")
 
     assert collection.count() == 2
 
@@ -258,19 +258,19 @@ minimal_records = {
 }
 
 
-def test_add_minimal(api):
-    api.reset()
+def test_add_minimal(client):
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
 
     collection.add(**minimal_records)
 
     assert collection.count() == 2
 
 
-def test_get_from_db(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_get_from_db(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
     includes = ["embeddings", "documents", "metadatas"]
     records = collection.get(include=includes)
@@ -283,10 +283,10 @@ def test_get_from_db(api):
             assert records[key] is None
 
 
-def test_collection_get_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_get_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -294,20 +294,20 @@ def test_collection_get_with_invalid_collection_throws(api):
         collection.get()
 
 
-def test_reset_db(api):
-    api.reset()
+def test_reset_db(client):
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
 
-    api.reset()
-    assert len(api.list_collections()) == 0
+    client.reset()
+    assert len(client.list_collections()) == 0
 
 
-def test_get_nearest_neighbors(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_get_nearest_neighbors(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
 
     includes = ["embeddings", "documents", "metadatas", "distances"]
@@ -354,9 +354,9 @@ def test_get_nearest_neighbors(api):
             assert nn[key] is None
 
 
-def test_delete(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_delete(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
 
@@ -364,18 +364,18 @@ def test_delete(api):
         collection.delete()
 
 
-def test_delete_with_index(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_delete_with_index(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
     collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
 
 
-def test_collection_delete_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_delete_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -383,18 +383,18 @@ def test_collection_delete_with_invalid_collection_throws(api):
         collection.delete(ids=["id1"])
 
 
-def test_count(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_count(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     assert collection.count() == 0
     collection.add(**batch_records)
     assert collection.count() == 2
 
 
-def test_collection_count_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_count_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -402,19 +402,19 @@ def test_collection_count_with_invalid_collection_throws(api):
         collection.count()
 
 
-def test_modify(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_modify(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.modify(name="testspace2")
 
     # collection name is modify
     assert collection.name == "testspace2"
 
 
-def test_collection_modify_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_modify_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -422,36 +422,36 @@ def test_collection_modify_with_invalid_collection_throws(api):
         collection.modify(name="test2")
 
 
-def test_modify_error_on_existing_name(api):
-    api.reset()
+def test_modify_error_on_existing_name(client):
+    client.reset()
 
-    api.create_collection("testspace")
-    c2 = api.create_collection("testspace2")
+    client.create_collection("testspace")
+    c2 = client.create_collection("testspace2")
 
     with pytest.raises(Exception):
         c2.modify(name="testspace")
 
 
-def test_modify_warn_on_DF_change(api, caplog):
-    api.reset()
+def test_modify_warn_on_DF_change(client, caplog):
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
 
     with pytest.raises(Exception, match="not supported"):
         collection.modify(metadata={"hnsw:space": "cosine"})
 
 
-def test_metadata_cru(api):
-    api.reset()
+def test_metadata_cru(client):
+    client.reset()
     metadata_a = {"a": 1, "b": 2}
     # Test create metatdata
-    collection = api.create_collection("testspace", metadata=metadata_a)
+    collection = client.create_collection("testspace", metadata=metadata_a)
     assert collection.metadata is not None
     assert collection.metadata["a"] == 1
     assert collection.metadata["b"] == 2
 
     # Test get metatdata
-    collection = api.get_collection("testspace")
+    collection = client.get_collection("testspace")
     assert collection.metadata is not None
     assert collection.metadata["a"] == 1
     assert collection.metadata["b"] == 2
@@ -463,24 +463,24 @@ def test_metadata_cru(api):
     assert "b" not in collection.metadata
 
     # Test get after modify metatdata
-    collection = api.get_collection("testspace")
+    collection = client.get_collection("testspace")
     assert collection.metadata is not None
     assert collection.metadata["a"] == 2
     assert collection.metadata["c"] == 3
     assert "b" not in collection.metadata
 
     # Test name exists get_or_create_metadata
-    collection = api.get_or_create_collection("testspace")
+    collection = client.get_or_create_collection("testspace")
     assert collection.metadata is not None
     assert collection.metadata["a"] == 2
     assert collection.metadata["c"] == 3
 
     # Test name exists create metadata
-    collection = api.get_or_create_collection("testspace2")
+    collection = client.get_or_create_collection("testspace2")
     assert collection.metadata is None
 
     # Test list collections
-    collections = api.list_collections()
+    collections = client.list_collections()
     for collection in collections:
         if collection.name == "testspace":
             assert collection.metadata is not None
@@ -490,9 +490,9 @@ def test_metadata_cru(api):
             assert collection.metadata is None
 
 
-def test_increment_index_on(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_increment_index_on(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
 
@@ -512,46 +512,46 @@ def test_increment_index_on(api):
             assert nn[key] is None
 
 
-def test_add_a_collection(api):
-    api.reset()
-    api.create_collection("testspace")
+def test_add_a_collection(client):
+    client.reset()
+    client.create_collection("testspace")
 
     # get collection does not throw an error
-    collection = api.get_collection("testspace")
+    collection = client.get_collection("testspace")
     assert collection.name == "testspace"
 
     # get collection should throw an error if collection does not exist
     with pytest.raises(Exception):
-        collection = api.get_collection("testspace2")
+        collection = client.get_collection("testspace2")
 
 
-def test_list_collections(api):
-    api.reset()
-    api.create_collection("testspace")
-    api.create_collection("testspace2")
+def test_list_collections(client):
+    client.reset()
+    client.create_collection("testspace")
+    client.create_collection("testspace2")
 
     # get collection does not throw an error
-    collections = api.list_collections()
+    collections = client.list_collections()
     assert len(collections) == 2
 
 
-def test_reset(api):
-    api.reset()
-    api.create_collection("testspace")
-    api.create_collection("testspace2")
+def test_reset(client):
+    client.reset()
+    client.create_collection("testspace")
+    client.create_collection("testspace2")
 
     # get collection does not throw an error
-    collections = api.list_collections()
+    collections = client.list_collections()
     assert len(collections) == 2
 
-    api.reset()
-    collections = api.list_collections()
+    client.reset()
+    collections = client.list_collections()
     assert len(collections) == 0
 
 
-def test_peek(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_peek(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
 
@@ -566,10 +566,10 @@ def test_peek(api):
             assert peek[key] is None
 
 
-def test_collection_peek_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_peek_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -577,10 +577,10 @@ def test_collection_peek_with_invalid_collection_throws(api):
         collection.peek()
 
 
-def test_collection_query_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_query_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -588,10 +588,10 @@ def test_collection_query_with_invalid_collection_throws(api):
         collection.query(query_texts=["test"])
 
 
-def test_collection_update_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_update_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -612,9 +612,9 @@ metadata_records = {
 }
 
 
-def test_metadata_add_get_int_float(api):
-    api.reset()
-    collection = api.create_collection("test_int")
+def test_metadata_add_get_int_float(client):
+    client.reset()
+    collection = client.create_collection("test_int")
     collection.add(**metadata_records)
 
     items = collection.get(ids=["id1", "id2"])
@@ -625,9 +625,9 @@ def test_metadata_add_get_int_float(api):
     assert isinstance(items["metadatas"][0]["float_value"], float)
 
 
-def test_metadata_add_query_int_float(api):
-    api.reset()
-    collection = api.create_collection("test_int")
+def test_metadata_add_query_int_float(client):
+    client.reset()
+    collection = client.create_collection("test_int")
     collection.add(**metadata_records)
 
     items: QueryResult = collection.query(
@@ -640,9 +640,9 @@ def test_metadata_add_query_int_float(api):
     assert isinstance(items["metadatas"][0][0]["float_value"], float)
 
 
-def test_metadata_get_where_string(api):
-    api.reset()
-    collection = api.create_collection("test_int")
+def test_metadata_get_where_string(client):
+    client.reset()
+    collection = client.create_collection("test_int")
     collection.add(**metadata_records)
 
     items = collection.get(where={"string_value": "one"})
@@ -650,9 +650,9 @@ def test_metadata_get_where_string(api):
     assert items["metadatas"][0]["string_value"] == "one"
 
 
-def test_metadata_get_where_int(api):
-    api.reset()
-    collection = api.create_collection("test_int")
+def test_metadata_get_where_int(client):
+    client.reset()
+    collection = client.create_collection("test_int")
     collection.add(**metadata_records)
 
     items = collection.get(where={"int_value": 1})
@@ -660,9 +660,9 @@ def test_metadata_get_where_int(api):
     assert items["metadatas"][0]["string_value"] == "one"
 
 
-def test_metadata_get_where_float(api):
-    api.reset()
-    collection = api.create_collection("test_int")
+def test_metadata_get_where_float(client):
+    client.reset()
+    collection = client.create_collection("test_int")
     collection.add(**metadata_records)
 
     items = collection.get(where={"float_value": 1.001})
@@ -671,9 +671,9 @@ def test_metadata_get_where_float(api):
     assert items["metadatas"][0]["float_value"] == 1.001
 
 
-def test_metadata_update_get_int_float(api):
-    api.reset()
-    collection = api.create_collection("test_int")
+def test_metadata_update_get_int_float(client):
+    client.reset()
+    collection = client.create_collection("test_int")
     collection.add(**metadata_records)
 
     collection.update(
@@ -693,31 +693,31 @@ bad_metadata_records = {
 }
 
 
-def test_metadata_validation_add(api):
-    api.reset()
-    collection = api.create_collection("test_metadata_validation")
+def test_metadata_validation_add(client):
+    client.reset()
+    collection = client.create_collection("test_metadata_validation")
     with pytest.raises(ValueError, match="metadata"):
         collection.add(**bad_metadata_records)
 
 
-def test_metadata_validation_update(api):
-    api.reset()
-    collection = api.create_collection("test_metadata_validation")
+def test_metadata_validation_update(client):
+    client.reset()
+    collection = client.create_collection("test_metadata_validation")
     collection.add(**metadata_records)
     with pytest.raises(ValueError, match="metadata"):
         collection.update(ids=["id1"], metadatas={"value": {"nested": "5"}})
 
 
-def test_where_validation_get(api):
-    api.reset()
-    collection = api.create_collection("test_where_validation")
+def test_where_validation_get(client):
+    client.reset()
+    collection = client.create_collection("test_where_validation")
     with pytest.raises(ValueError, match="where"):
         collection.get(where={"value": {"nested": "5"}})
 
 
-def test_where_validation_query(api):
-    api.reset()
-    collection = api.create_collection("test_where_validation")
+def test_where_validation_query(client):
+    client.reset()
+    collection = client.create_collection("test_where_validation")
     with pytest.raises(ValueError, match="where"):
         collection.query(query_embeddings=[0, 0, 0], where={"value": {"nested": "5"}})
 
@@ -732,49 +732,49 @@ operator_records = {
 }
 
 
-def test_where_lt(api):
-    api.reset()
-    collection = api.create_collection("test_where_lt")
+def test_where_lt(client):
+    client.reset()
+    collection = client.create_collection("test_where_lt")
     collection.add(**operator_records)
     items = collection.get(where={"int_value": {"$lt": 2}})
     assert len(items["metadatas"]) == 1
 
 
-def test_where_lte(api):
-    api.reset()
-    collection = api.create_collection("test_where_lte")
+def test_where_lte(client):
+    client.reset()
+    collection = client.create_collection("test_where_lte")
     collection.add(**operator_records)
     items = collection.get(where={"int_value": {"$lte": 2.0}})
     assert len(items["metadatas"]) == 2
 
 
-def test_where_gt(api):
-    api.reset()
-    collection = api.create_collection("test_where_lte")
+def test_where_gt(client):
+    client.reset()
+    collection = client.create_collection("test_where_lte")
     collection.add(**operator_records)
     items = collection.get(where={"float_value": {"$gt": -1.4}})
     assert len(items["metadatas"]) == 2
 
 
-def test_where_gte(api):
-    api.reset()
-    collection = api.create_collection("test_where_lte")
+def test_where_gte(client):
+    client.reset()
+    collection = client.create_collection("test_where_lte")
     collection.add(**operator_records)
     items = collection.get(where={"float_value": {"$gte": 2.002}})
     assert len(items["metadatas"]) == 1
 
 
-def test_where_ne_string(api):
-    api.reset()
-    collection = api.create_collection("test_where_lte")
+def test_where_ne_string(client):
+    client.reset()
+    collection = client.create_collection("test_where_lte")
     collection.add(**operator_records)
     items = collection.get(where={"string_value": {"$ne": "two"}})
     assert len(items["metadatas"]) == 1
 
 
-def test_where_ne_eq_number(api):
-    api.reset()
-    collection = api.create_collection("test_where_lte")
+def test_where_ne_eq_number(client):
+    client.reset()
+    collection = client.create_collection("test_where_lte")
     collection.add(**operator_records)
     items = collection.get(where={"int_value": {"$ne": 1}})
     assert len(items["metadatas"]) == 1
@@ -782,9 +782,9 @@ def test_where_ne_eq_number(api):
     assert len(items["metadatas"]) == 1
 
 
-def test_where_valid_operators(api):
-    api.reset()
-    collection = api.create_collection("test_where_valid_operators")
+def test_where_valid_operators(client):
+    client.reset()
+    collection = client.create_collection("test_where_valid_operators")
     collection.add(**operator_records)
     with pytest.raises(ValueError):
         collection.get(where={"int_value": {"$invalid": 2}})
@@ -845,9 +845,9 @@ bad_number_of_results_query = {
 }
 
 
-def test_dimensionality_validation_add(api):
-    api.reset()
-    collection = api.create_collection("test_dimensionality_validation")
+def test_dimensionality_validation_add(client):
+    client.reset()
+    collection = client.create_collection("test_dimensionality_validation")
     collection.add(**minimal_records)
 
     with pytest.raises(Exception) as e:
@@ -855,9 +855,9 @@ def test_dimensionality_validation_add(api):
     assert "dimensionality" in str(e.value)
 
 
-def test_dimensionality_validation_query(api):
-    api.reset()
-    collection = api.create_collection("test_dimensionality_validation_query")
+def test_dimensionality_validation_query(client):
+    client.reset()
+    collection = client.create_collection("test_dimensionality_validation_query")
     collection.add(**minimal_records)
 
     with pytest.raises(Exception) as e:
@@ -865,9 +865,9 @@ def test_dimensionality_validation_query(api):
     assert "dimensionality" in str(e.value)
 
 
-def test_query_document_valid_operators(api):
-    api.reset()
-    collection = api.create_collection("test_where_valid_operators")
+def test_query_document_valid_operators(client):
+    client.reset()
+    collection = client.create_collection("test_where_valid_operators")
     collection.add(**operator_records)
     with pytest.raises(ValueError, match="where document"):
         collection.get(where_document={"$lt": {"$nested": 2}})
@@ -912,9 +912,9 @@ contains_records = {
 }
 
 
-def test_get_where_document(api):
-    api.reset()
-    collection = api.create_collection("test_get_where_document")
+def test_get_where_document(client):
+    client.reset()
+    collection = client.create_collection("test_get_where_document")
     collection.add(**contains_records)
 
     items = collection.get(where_document={"$contains": "doc1"})
@@ -927,9 +927,9 @@ def test_get_where_document(api):
     assert len(items["metadatas"]) == 0
 
 
-def test_query_where_document(api):
-    api.reset()
-    collection = api.create_collection("test_query_where_document")
+def test_query_where_document(client):
+    client.reset()
+    collection = client.create_collection("test_query_where_document")
     collection.add(**contains_records)
 
     items = collection.query(
@@ -949,9 +949,9 @@ def test_query_where_document(api):
         assert "datapoints" in str(e.value)
 
 
-def test_delete_where_document(api):
-    api.reset()
-    collection = api.create_collection("test_delete_where_document")
+def test_delete_where_document(client):
+    client.reset()
+    collection = client.create_collection("test_delete_where_document")
     collection.add(**contains_records)
 
     collection.delete(where_document={"$contains": "doc1"})
@@ -987,9 +987,9 @@ logical_operator_records = {
 }
 
 
-def test_where_logical_operators(api):
-    api.reset()
-    collection = api.create_collection("test_logical_operators")
+def test_where_logical_operators(client):
+    client.reset()
+    collection = client.create_collection("test_logical_operators")
     collection.add(**logical_operator_records)
 
     items = collection.get(
@@ -1043,9 +1043,9 @@ def test_where_logical_operators(api):
     assert len(items["metadatas"]) == 2
 
 
-def test_where_document_logical_operators(api):
-    api.reset()
-    collection = api.create_collection("test_document_logical_operators")
+def test_where_document_logical_operators(client):
+    client.reset()
+    collection = client.create_collection("test_document_logical_operators")
     collection.add(**logical_operator_records)
 
     items = collection.get(
@@ -1095,9 +1095,9 @@ records = {
 }
 
 
-def test_query_include(api):
-    api.reset()
-    collection = api.create_collection("test_query_include")
+def test_query_include(client):
+    client.reset()
+    collection = client.create_collection("test_query_include")
     collection.add(**records)
 
     include = ["metadatas", "documents", "distances"]
@@ -1134,9 +1134,9 @@ def test_query_include(api):
     assert items["ids"][0][1] == "id2"
 
 
-def test_get_include(api):
-    api.reset()
-    collection = api.create_collection("test_get_include")
+def test_get_include(client):
+    client.reset()
+    collection = client.create_collection("test_get_include")
     collection.add(**records)
 
     include = ["metadatas", "documents"]
@@ -1171,9 +1171,9 @@ def test_get_include(api):
 # make sure query results are returned in the right order
 
 
-def test_query_order(api):
-    api.reset()
-    collection = api.create_collection("test_query_order")
+def test_query_order(client):
+    client.reset()
+    collection = client.create_collection("test_query_order")
     collection.add(**records)
 
     items = collection.query(
@@ -1189,9 +1189,9 @@ def test_query_order(api):
 # test to make sure add, get, delete error on invalid id input
 
 
-def test_invalid_id(api):
-    api.reset()
-    collection = api.create_collection("test_invalid_id")
+def test_invalid_id(client):
+    client.reset()
+    collection = client.create_collection("test_invalid_id")
     # Add with non-string id
     with pytest.raises(ValueError) as e:
         collection.add(embeddings=[0, 0, 0], ids=[1], metadatas=[{}])
@@ -1208,11 +1208,11 @@ def test_invalid_id(api):
     assert "ID" in str(e.value)
 
 
-def test_index_params(api):
+def test_index_params(client):
     EPS = 1e-12
     # first standard add
-    api.reset()
-    collection = api.create_collection(name="test_index_params")
+    client.reset()
+    collection = client.create_collection(name="test_index_params")
     collection.add(**records)
     items = collection.query(
         query_embeddings=[0.6, 1.12, 1.6],
@@ -1221,8 +1221,8 @@ def test_index_params(api):
     assert items["distances"][0][0] > 4
 
     # cosine
-    api.reset()
-    collection = api.create_collection(
+    client.reset()
+    collection = client.create_collection(
         name="test_index_params",
         metadata={"hnsw:space": "cosine", "hnsw:construction_ef": 20, "hnsw:M": 5},
     )
@@ -1235,8 +1235,8 @@ def test_index_params(api):
     assert items["distances"][0][0] < 1 + EPS
 
     # ip
-    api.reset()
-    collection = api.create_collection(
+    client.reset()
+    collection = client.create_collection(
         name="test_index_params", metadata={"hnsw:space": "ip"}
     )
     collection.add(**records)
@@ -1247,26 +1247,26 @@ def test_index_params(api):
     assert items["distances"][0][0] < -5
 
 
-def test_invalid_index_params(api):
-    api.reset()
+def test_invalid_index_params(client):
+    client.reset()
 
     with pytest.raises(Exception):
-        collection = api.create_collection(
+        collection = client.create_collection(
             name="test_index_params", metadata={"hnsw:foobar": "blarg"}
         )
         collection.add(**records)
 
     with pytest.raises(Exception):
-        collection = api.create_collection(
+        collection = client.create_collection(
             name="test_index_params", metadata={"hnsw:space": "foobar"}
         )
         collection.add(**records)
 
 
-def test_persist_index_loading_params(api, request):
-    api = request.getfixturevalue("local_persist_api")
-    api.reset()
-    collection = api.create_collection(
+def test_persist_index_loading_params(client, request):
+    client = request.getfixturevalue("local_persist_api")
+    client.reset()
+    collection = client.create_collection(
         "test",
         metadata={"hnsw:space": "ip"},
     )
@@ -1293,10 +1293,10 @@ def test_persist_index_loading_params(api, request):
             assert nn[key] is None
 
 
-def test_add_large(api):
-    api.reset()
+def test_add_large(client):
+    client.reset()
 
-    collection = api.create_collection("testspace")
+    collection = client.create_collection("testspace")
 
     # Test adding a large number of records
     large_records = np.random.rand(2000, 512).astype(np.float32).tolist()
@@ -1310,9 +1310,9 @@ def test_add_large(api):
 
 
 # test get_version
-def test_get_version(api):
-    api.reset()
-    version = api.get_version()
+def test_get_version(client):
+    client.reset()
+    version = client.get_version()
 
     # assert version matches the pattern x.y.z
     import re
@@ -1321,14 +1321,14 @@ def test_get_version(api):
 
 
 # test delete_collection
-def test_delete_collection(api):
-    api.reset()
-    collection = api.create_collection("test_delete_collection")
+def test_delete_collection(client):
+    client.reset()
+    collection = client.create_collection("test_delete_collection")
     collection.add(**records)
 
-    assert len(api.list_collections()) == 1
-    api.delete_collection("test_delete_collection")
-    assert len(api.list_collections()) == 0
+    assert len(client.list_collections()) == 1
+    client.delete_collection("test_delete_collection")
+    assert len(client.list_collections()) == 0
 
 
 # test default embedding function
@@ -1339,20 +1339,20 @@ def test_default_embedding():
     assert len(embeddings) == 64
 
 
-def test_multiple_collections(api):
+def test_multiple_collections(client):
     embeddings1 = np.random.rand(10, 512).astype(np.float32).tolist()
     embeddings2 = np.random.rand(10, 512).astype(np.float32).tolist()
     ids1 = [f"http://example.com/1/{i}" for i in range(len(embeddings1))]
     ids2 = [f"http://example.com/2/{i}" for i in range(len(embeddings2))]
 
-    api.reset()
-    coll1 = api.create_collection("coll1")
+    client.reset()
+    coll1 = client.create_collection("coll1")
     coll1.add(embeddings=embeddings1, ids=ids1)
 
-    coll2 = api.create_collection("coll2")
+    coll2 = client.create_collection("coll2")
     coll2.add(embeddings=embeddings2, ids=ids2)
 
-    assert len(api.list_collections()) == 2
+    assert len(client.list_collections()) == 2
     assert coll1.count() == len(embeddings1)
     assert coll2.count() == len(embeddings2)
 
@@ -1363,9 +1363,9 @@ def test_multiple_collections(api):
     assert results2["ids"][0][0] == ids2[0]
 
 
-def test_update_query(api):
-    api.reset()
-    collection = api.create_collection("test_update_query")
+def test_update_query(client):
+    client.reset()
+    collection = client.create_collection("test_update_query")
     collection.add(**records)
 
     updated_records = {
@@ -1392,9 +1392,9 @@ def test_update_query(api):
     )
 
 
-def test_get_nearest_neighbors_where_n_results_more_than_element(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_get_nearest_neighbors_where_n_results_more_than_element(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**records)
 
     includes = ["embeddings", "documents", "metadatas", "distances"]
@@ -1413,9 +1413,9 @@ def test_get_nearest_neighbors_where_n_results_more_than_element(api):
             assert results[key] is None
 
 
-def test_invalid_n_results_param(api):
-    api.reset()
-    collection = api.create_collection("testspace")
+def test_invalid_n_results_param(client):
+    client.reset()
+    collection = client.create_collection("testspace")
     collection.add(**records)
     with pytest.raises(TypeError) as exc:
         collection.query(
@@ -1469,9 +1469,9 @@ new_records = {
 }
 
 
-def test_upsert(api):
-    api.reset()
-    collection = api.create_collection("test")
+def test_upsert(client):
+    client.reset()
+    collection = client.create_collection("test")
 
     collection.add(**initial_records)
     assert collection.count() == 3
@@ -1515,10 +1515,10 @@ def test_upsert(api):
     assert get_result["documents"][0] is None
 
 
-def test_collection_upsert_with_invalid_collection_throws(api):
-    api.reset()
-    collection = api.create_collection("test")
-    api.delete_collection("test")
+def test_collection_upsert_with_invalid_collection_throws(client):
+    client.reset()
+    collection = client.create_collection("test")
+    client.delete_collection("test")
 
     with pytest.raises(
         InvalidCollectionException, match=r"Collection .* does not exist."
@@ -1529,9 +1529,9 @@ def test_collection_upsert_with_invalid_collection_throws(api):
 # test to make sure add, query, update, upsert error on invalid embeddings input
 
 
-def test_invalid_embeddings(api):
-    api.reset()
-    collection = api.create_collection("test_invalid_embeddings")
+def test_invalid_embeddings(client):
+    client.reset()
+    collection = client.create_collection("test_invalid_embeddings")
 
     # Add with string embeddings
     invalid_records = {
@@ -1572,9 +1572,9 @@ def test_invalid_embeddings(api):
 # test to make sure update shows exception for bad dimensionality
 
 
-def test_dimensionality_exception_update(api):
-    api.reset()
-    collection = api.create_collection("test_dimensionality_update_exception")
+def test_dimensionality_exception_update(client):
+    client.reset()
+    collection = client.create_collection("test_dimensionality_update_exception")
     collection.add(**minimal_records)
 
     with pytest.raises(Exception) as e:
@@ -1585,9 +1585,9 @@ def test_dimensionality_exception_update(api):
 # test to make sure upsert shows exception for bad dimensionality
 
 
-def test_dimensionality_exception_upsert(api):
-    api.reset()
-    collection = api.create_collection("test_dimensionality_upsert_exception")
+def test_dimensionality_exception_upsert(client):
+    client.reset()
+    collection = client.create_collection("test_dimensionality_upsert_exception")
     collection.add(**minimal_records)
 
     with pytest.raises(Exception) as e:

--- a/chromadb/test/test_logservice.py
+++ b/chromadb/test/test_logservice.py
@@ -7,6 +7,7 @@ from chromadb.test.conftest import skip_if_not_cluster
 from chromadb.test.test_api import records  # type: ignore
 from chromadb.api.models.Collection import Collection
 import time
+from chromadb.api.client import Client as ClientCreator
 
 batch_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
@@ -78,11 +79,12 @@ def verify_records(
 
 
 @skip_if_not_cluster()
-def test_add(api):  # type: ignore
+def test_add():  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
     system.start()
-    api.reset()
+    client = ClientCreator.from_system(system)
+    client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
     test_records_map = {
@@ -91,16 +93,17 @@ def test_add(api):  # type: ignore
         "contains_records": contains_records,
     }
 
-    collection = api.create_collection("testadd")
+    collection = client.create_collection("testadd")
     verify_records(logservice, collection, test_records_map, collection.add, 0)
 
 
 @skip_if_not_cluster()
-def test_update(api):  # type: ignore
+def test_update():  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
     system.start()
-    api.reset()
+    client = ClientCreator.from_system(system)
+    client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
     test_records_map = {
@@ -111,7 +114,7 @@ def test_update(api):  # type: ignore
         },
     }
 
-    collection = api.create_collection("testupdate")
+    collection = client.create_collection("testupdate")
     verify_records(logservice, collection, test_records_map, collection.update, 1)
 
 
@@ -120,10 +123,11 @@ def test_delete(api):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
     system.start()
-    api.reset()
+    client = ClientCreator.from_system(system)
+    client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
-    collection = api.create_collection("testdelete")
+    collection = client.create_collection("testdelete")
 
     # push 2 records
     collection.add(**contains_records)
@@ -137,10 +141,11 @@ def test_delete(api):  # type: ignore
 def test_delete_filter(api):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
-    system.start()
-    api.reset()
+    client = ClientCreator.from_system(system)
+    client.reset()
+    time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
-    collection = api.create_collection("testdelete_filter")
+    collection = client.create_collection("testdelete_filter")
 
     # delete by where
     collection.delete(where_document={"$contains": "doc1"})
@@ -162,8 +167,8 @@ def test_delete_filter(api):  # type: ignore
 def test_upsert(api):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
-    system.start()
-    api.reset()
+    client = ClientCreator.from_system(system)
+    client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
     test_records_map = {
@@ -172,5 +177,5 @@ def test_upsert(api):  # type: ignore
         "contains_records": contains_records,
     }
 
-    collection = api.create_collection("testupsert")
+    collection = client.create_collection("testupsert")
     verify_records(logservice, collection, test_records_map, collection.upsert, 2)

--- a/chromadb/test/test_logservice.py
+++ b/chromadb/test/test_logservice.py
@@ -7,7 +7,6 @@ from chromadb.test.conftest import skip_if_not_cluster
 from chromadb.test.test_api import records  # type: ignore
 from chromadb.api.models.Collection import Collection
 import time
-from chromadb.api.client import Client as ClientCreator
 
 batch_records = {
     "embeddings": [[1.1, 2.3, 3.2], [1.2, 2.24, 3.2]],
@@ -79,12 +78,12 @@ def verify_records(
 
 
 @skip_if_not_cluster()
-def test_add():  # type: ignore
+def test_add(client):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
     system.start()
-    client = ClientCreator.from_system(system)
     client.reset()
+
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
     test_records_map = {
@@ -98,11 +97,10 @@ def test_add():  # type: ignore
 
 
 @skip_if_not_cluster()
-def test_update():  # type: ignore
+def test_update(client):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
     system.start()
-    client = ClientCreator.from_system(system)
     client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
@@ -119,11 +117,10 @@ def test_update():  # type: ignore
 
 
 @skip_if_not_cluster()
-def test_delete(api):  # type: ignore
+def test_delete(client):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
     system.start()
-    client = ClientCreator.from_system(system)
     client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
@@ -138,10 +135,10 @@ def test_delete(api):  # type: ignore
 # TODO: These tests should be enabled when the distributed system has metadata segments
 @pytest.mark.xfail
 @skip_if_not_cluster()
-def test_delete_filter(api):  # type: ignore
+def test_delete_filter(client):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
-    client = ClientCreator.from_system(system)
+    system.start()
     client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 
@@ -164,10 +161,10 @@ def test_delete_filter(api):  # type: ignore
 
 
 @skip_if_not_cluster()
-def test_upsert(api):  # type: ignore
+def test_upsert(client):  # type: ignore
     system = System(Settings(allow_reset=True))
     logservice = system.instance(LogService)
-    client = ClientCreator.from_system(system)
+    system.start()
     client.reset()
     time.sleep(MEMBERLIST_DELAY_SLEEP_TIME)
 

--- a/chromadb/test/test_multithreaded.py
+++ b/chromadb/test/test_multithreaded.py
@@ -5,7 +5,7 @@ import threading
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
 import numpy as np
 
-from chromadb.api import ServerAPI
+from chromadb.api import ClientAPI
 import chromadb.test.property.invariants as invariants
 from chromadb.test.property.strategies import RecordSet
 from chromadb.test.property.strategies import test_hnsw_config
@@ -37,7 +37,9 @@ def generate_record_set(N: int, D: int) -> RecordSet:
 
 # Hypothesis is bad at generating large datasets so we manually generate data in
 # this test to test multithreaded add with larger datasets
-def _test_multithreaded_add(api: ServerAPI, N: int, D: int, num_workers: int) -> None:
+def _test_multithreaded_add(
+    client: ClientAPI, N: int, D: int, num_workers: int
+) -> None:
     records_set = generate_record_set(N, D)
     ids = records_set["ids"]
     embeddings = records_set["embeddings"]
@@ -47,8 +49,8 @@ def _test_multithreaded_add(api: ServerAPI, N: int, D: int, num_workers: int) ->
     print(f"Adding {N} records with {D} dimensions on {num_workers} workers")
 
     # TODO: batch_size and sync_threshold should be configurable
-    api.reset()
-    coll = api.create_collection(name="test", metadata=test_hnsw_config)
+    client.reset()
+    coll = client.create_collection(name="test", metadata=test_hnsw_config)
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures: List[Future[Any]] = []
         total_sent = -1
@@ -96,12 +98,12 @@ def _test_multithreaded_add(api: ServerAPI, N: int, D: int, num_workers: int) ->
 
 
 def _test_interleaved_add_query(
-    api: ServerAPI, N: int, D: int, num_workers: int
+    client: ClientAPI, N: int, D: int, num_workers: int
 ) -> None:
     """Test that will use multiple threads to interleave operations on the db and verify they work correctly"""
 
-    api.reset()
-    coll = api.create_collection(name="test", metadata=test_hnsw_config)
+    client.reset()
+    coll = client.create_collection(name="test", metadata=test_hnsw_config)
 
     records_set = generate_record_set(N, D)
     ids = cast(List[str], records_set["ids"])
@@ -209,15 +211,15 @@ def _test_interleaved_add_query(
     )
 
 
-def test_multithreaded_add(api: ServerAPI) -> None:
+def test_multithreaded_add(client: ClientAPI) -> None:
     for i in range(3):
         num_workers = random.randint(2, multiprocessing.cpu_count() * 2)
         N, D = generate_data_shape()
-        _test_multithreaded_add(api, N, D, num_workers)
+        _test_multithreaded_add(client, N, D, num_workers)
 
 
-def test_interleaved_add_query(api: ServerAPI) -> None:
+def test_interleaved_add_query(client: ClientAPI) -> None:
     for i in range(3):
         num_workers = random.randint(2, multiprocessing.cpu_count() * 2)
         N, D = generate_data_shape()
-        _test_interleaved_add_query(api, N, D, num_workers)
+        _test_interleaved_add_query(client, N, D, num_workers)

--- a/chromadb/test/utils/wait_for_version_increase.py
+++ b/chromadb/test/utils/wait_for_version_increase.py
@@ -1,26 +1,29 @@
 import time
-from chromadb.api import ServerAPI
+from chromadb.api import ClientAPI
 from chromadb.test.conftest import COMPACTION_SLEEP
 
 TIMEOUT_INTERVAL = 1
 
 
-def get_collection_version(api: ServerAPI, collection_name: str) -> int:
-    coll = api.get_collection(collection_name)
+def get_collection_version(client: ClientAPI, collection_name: str) -> int:
+    coll = client.get_collection(collection_name)
     return coll.get_model()["version"]
 
 
 def wait_for_version_increase(
-    api: ServerAPI, collection_name: str, initial_version: int, additional_time: int = 0
+    client: ClientAPI,
+    collection_name: str,
+    initial_version: int,
+    additional_time: int = 0,
 ) -> int:
     timeout = COMPACTION_SLEEP
     initial_time = time.time() + additional_time
 
-    curr_version = get_collection_version(api, collection_name)
+    curr_version = get_collection_version(client, collection_name)
     while curr_version == initial_version:
         time.sleep(TIMEOUT_INTERVAL)
         if time.time() - initial_time > timeout:
             raise TimeoutError("Model was not updated in time")
-        curr_version = get_collection_version(api, collection_name)
+        curr_version = get_collection_version(client, collection_name)
 
     return curr_version


### PR DESCRIPTION
## Description of changes

This PR refactors the `ServerAPI` classes so that their methods only return the `Collection` model, not the `Collection` object itself, i.e. the view on the data.

This is a much cleaner separation of concerns than we had before, and should enable faster iteration in parts. For example, the ServerAPI no longer needs to know about EmbeddingFunction or DataLoader etc - these only exist for Clients. 

We will probably re-add them when we start moving some of that functionality server-side for cloud, but for now this is a fine solution. 

Most the LoC in this PR are changing tests to use the ClientAPI and fixture instead of the ServerAPI and fixture. This does put the client in the line, but I think this is fine. 

## Test plan

Tests pass in CI. 

## Documentation Changes
N/A