### PR TITLE
[ENH] max_batch_size -> get_max_batch_size()

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -434,8 +434,7 @@ class BaseAPI(ABC):
 
     @abstractmethod
     def get_max_batch_size(self) -> int:
-        """Return the maximum number of records that can be submitted in a single call
-        to submit_embeddings."""
+        """Return the maximum number of records that can be created or mutated in a single call."""
         pass
 
 

--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -432,9 +432,8 @@ class BaseAPI(ABC):
         """
         pass
 
-    @property
     @abstractmethod
-    def max_batch_size(self) -> int:
+    def get_max_batch_size(self) -> int:
         """Return the maximum number of records that can be submitted in a single call
         to submit_embeddings."""
         pass

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -413,10 +413,9 @@ class Client(SharedSystemClient, ClientAPI):
     def get_settings(self) -> Settings:
         return self._server.get_settings()
 
-    @property
     @override
-    def max_batch_size(self) -> int:
-        return self._server.max_batch_size
+    def get_max_batch_size(self) -> int:
+        return self._server.get_max_batch_size()
 
     # endregion
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -518,7 +518,7 @@ class FastAPI(ServerAPI):
         - pass in column oriented data lists
         """
         batch = (ids, embeddings, metadatas, documents, uris)
-        validate_batch(batch, {"max_batch_size": self.max_batch_size})
+        validate_batch(batch, {"max_batch_size": self.get_max_batch_size()})
         resp = self._submit_batch(batch, "/collections/" + str(collection_id) + "/add")
         raise_chroma_error(resp)
         return True
@@ -539,7 +539,7 @@ class FastAPI(ServerAPI):
         - pass in column oriented data lists
         """
         batch = (ids, embeddings, metadatas, documents, uris)
-        validate_batch(batch, {"max_batch_size": self.max_batch_size})
+        validate_batch(batch, {"max_batch_size": self.get_max_batch_size()})
         resp = self._submit_batch(
             batch, "/collections/" + str(collection_id) + "/update"
         )
@@ -562,7 +562,7 @@ class FastAPI(ServerAPI):
         - pass in column oriented data lists
         """
         batch = (ids, embeddings, metadatas, documents, uris)
-        validate_batch(batch, {"max_batch_size": self.max_batch_size})
+        validate_batch(batch, {"max_batch_size": self.get_max_batch_size()})
         resp = self._submit_batch(
             batch, "/collections/" + str(collection_id) + "/upsert"
         )
@@ -629,10 +629,9 @@ class FastAPI(ServerAPI):
         """Returns the settings of the client"""
         return self._settings
 
-    @property
-    @trace_method("FastAPI.max_batch_size", OpenTelemetryGranularity.OPERATION)
+    @trace_method("FastAPI.get_max_batch_size", OpenTelemetryGranularity.OPERATION)
     @override
-    def max_batch_size(self) -> int:
+    async def get_max_batch_size(self) -> int:
         if self._max_batch_size == -1:
             resp = self._session.get(self._api_url + "/pre-flight-checks")
             raise_chroma_error(resp)

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -631,7 +631,7 @@ class FastAPI(ServerAPI):
 
     @trace_method("FastAPI.get_max_batch_size", OpenTelemetryGranularity.OPERATION)
     @override
-    async def get_max_batch_size(self) -> int:
+    def get_max_batch_size(self) -> int:
         if self._max_batch_size == -1:
             resp = self._session.get(self._api_url + "/pre-flight-checks")
             raise_chroma_error(resp)

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from chromadb.api import ServerAPI
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
 from chromadb.db.system import SysDB

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -364,7 +364,7 @@ class SegmentAPI(ServerAPI):
         self._manager.hint_use_collection(collection_id, t.Operation.ADD)
         validate_batch(
             (ids, embeddings, metadatas, documents, uris),
-            {"max_batch_size": self.max_batch_size},
+            {"max_batch_size": self.get_max_batch_size()},
         )
         records_to_submit = []
         for r in _records(
@@ -406,7 +406,7 @@ class SegmentAPI(ServerAPI):
         self._manager.hint_use_collection(collection_id, t.Operation.UPDATE)
         validate_batch(
             (ids, embeddings, metadatas, documents, uris),
-            {"max_batch_size": self.max_batch_size},
+            {"max_batch_size": self.get_max_batch_size()},
         )
         records_to_submit = []
         for r in _records(
@@ -450,7 +450,7 @@ class SegmentAPI(ServerAPI):
         self._manager.hint_use_collection(collection_id, t.Operation.UPSERT)
         validate_batch(
             (ids, embeddings, metadatas, documents, uris),
-            {"max_batch_size": self.max_batch_size},
+            {"max_batch_size": self.get_max_batch_size()},
         )
         records_to_submit = []
         for r in _records(
@@ -790,9 +790,8 @@ class SegmentAPI(ServerAPI):
     def get_settings(self) -> Settings:
         return self._settings
 
-    @cached_property
     @override
-    def max_batch_size(self) -> int:
+    def get_max_batch_size(self) -> int:
         return self._producer.max_batch_size
 
     # TODO: This could potentially cause race conditions in a distributed version of the

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -934,7 +934,7 @@ class FastAPI(Server):
     async def pre_flight_checks(self) -> Dict[str, Any]:
         def process_pre_flight_checks() -> Dict[str, Any]:
             return {
-                "max_batch_size": self._api.max_batch_size,
+                "max_batch_size": self._api.get_max_batch_size(),
             }
 
         return cast(

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -81,8 +81,9 @@ def test_add_large(api: ServerAPI, collection: strategies.Collection) -> None:
     reset(api)
 
     record_set = create_large_recordset(
-        min_size=api.max_batch_size,
-        max_size=api.max_batch_size + int(api.max_batch_size * random.random()),
+        min_size=api.get_max_batch_size(),
+        max_size=api.get_max_batch_size()
+        + int(api.get_max_batch_size() * random.random()),
     )
     coll = api.create_collection(
         name=collection.name,
@@ -112,8 +113,9 @@ def test_add_large_exceeding(api: ServerAPI, collection: strategies.Collection) 
     reset(api)
 
     record_set = create_large_recordset(
-        min_size=api.max_batch_size,
-        max_size=api.max_batch_size + int(api.max_batch_size * random.random()),
+        min_size=api.get_max_batch_size(),
+        max_size=api.get_max_batch_size()
+        + int(api.get_max_batch_size() * random.random()),
     )
     coll = api.create_collection(
         name=collection.name,

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -195,7 +195,7 @@ def test_heartbeat(api):
 
 def test_max_batch_size(api):
     print(api)
-    batch_size = api.max_batch_size
+    batch_size = api.get_max_batch_size()
     assert batch_size > 0
 
 

--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -18,15 +18,17 @@ def create_batches(
     _batches: List[
         Tuple[IDs, Embeddings, Optional[Metadatas], Optional[Documents]]
     ] = []
-    if len(ids) > api.max_batch_size:
+    if len(ids) > api.get_max_batch_size():
         # create split batches
-        for i in range(0, len(ids), api.max_batch_size):
+        for i in range(0, len(ids), api.get_max_batch_size()):
             _batches.append(
                 (  # type: ignore
-                    ids[i : i + api.max_batch_size],
-                    embeddings[i : i + api.max_batch_size] if embeddings else None,
-                    metadatas[i : i + api.max_batch_size] if metadatas else None,
-                    documents[i : i + api.max_batch_size] if documents else None,
+                    ids[i : i + api.get_max_batch_size()],
+                    embeddings[i : i + api.get_max_batch_size()]
+                    if embeddings
+                    else None,
+                    metadatas[i : i + api.get_max_batch_size()] if metadatas else None,
+                    documents[i : i + api.get_max_batch_size()] if documents else None,
                 )
             )
     else:

--- a/docs/docs.trychroma.com/pages/deployment/migration.md
+++ b/docs/docs.trychroma.com/pages/deployment/migration.md
@@ -20,9 +20,9 @@ We will aim to provide:
 
 ## Migration Log
 
-### Unreleased
+### v0.5.1
 
-It wasn't previously documented, but if you were reading `.max_batch_size` on the Python client, you should now use `.get_max_batch_size()`.
+On the Python client, the `max_batch_size` property was removed. It wasn't previously documented, but if you were reading it, you should now use `get_max_batch_size()`.
 
 The first time this is run, it makes a HTTP request. We made this a method to make it more clear that it's potentially a blocking operation.
 

--- a/docs/docs.trychroma.com/pages/deployment/migration.md
+++ b/docs/docs.trychroma.com/pages/deployment/migration.md
@@ -20,6 +20,12 @@ We will aim to provide:
 
 ## Migration Log
 
+### Unreleased
+
+It wasn't previously documented, but if you were reading `.max_batch_size` on the Python client, you should now use `.get_max_batch_size()`.
+
+The first time this is run, it makes a HTTP request. We made this a method to make it more clear that it's potentially a blocking operation.
+
 ### Auth overhaul - April 20, 2024
 
 **If you are not using Chroma's [built-in auth system](https://docs.trychroma.com/deployment/auth), you do not need to take any action.**

--- a/docs/docs.trychroma.com/pages/reference/py-client.md
+++ b/docs/docs.trychroma.com/pages/reference/py-client.md
@@ -285,3 +285,15 @@ Get the settings used to initialize the client.
 **Returns**:
 
 - `Settings` - The settings used to initialize the client.
+
+## get_max_batch_size
+
+```python
+def get_max_batch_size() -> int
+```
+
+Get the maximum batch size.
+
+**Returns**:
+
+- `int` - The maximum number of records that can be created or mutated in a single call.


### PR DESCRIPTION
This is needed for https://github.com/chroma-core/chroma/pull/2297 as there doesn't seem to be a good way to automatically detect async properties (when converting a set of async class methods to a synchronous version). Having a property that makes a HTTP request is kinda an antipattern regardless.

This is a breaking change. I will prepare a PR for the docs as well.