### PR TITLE
[TST] Don't fail fast when we matrix over tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -30,6 +30,7 @@ jobs:
                    "chromadb/test/property/test_embeddings.py",
                    "chromadb/test/property/test_filtering.py",
                    "chromadb/test/property/test_persist.py"]
+        fail-fast: false
         include:
           - test-globs: "chromadb/test/property/test_embeddings.py"
             parallelized: true
@@ -68,6 +69,7 @@ jobs:
             env-file: compose-env.linux
           - platform: windows-latest
             env-file: compose-env.windows
+      fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
@@ -95,6 +97,7 @@ jobs:
                    "chromadb/test/segment/distributed/test_memberlist_provider.py",
                    "chromadb/test/test_logservice.py",
                    "chromadb/test/distributed/test_sanity.py"]
+    fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
         platform: [ubuntu-latest, windows-latest]
@@ -30,7 +31,6 @@ jobs:
                    "chromadb/test/property/test_embeddings.py",
                    "chromadb/test/property/test_filtering.py",
                    "chromadb/test/property/test_persist.py"]
-        fail-fast: false
         include:
           - test-globs: "chromadb/test/property/test_embeddings.py"
             parallelized: true
@@ -51,6 +51,7 @@ jobs:
   # todo: break out stress integration tests
   test-single-node-integration:
     strategy:
+      fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
         platform: [ubuntu-latest, windows-latest]
@@ -69,7 +70,6 @@ jobs:
             env-file: compose-env.linux
           - platform: windows-latest
             env-file: compose-env.windows
-      fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
@@ -85,6 +85,7 @@ jobs:
 
   test-cluster-integration:
     strategy:
+      fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
         platform: ["16core-64gb-ubuntu-latest"]
@@ -97,7 +98,6 @@ jobs:
                    "chromadb/test/segment/distributed/test_memberlist_provider.py",
                    "chromadb/test/test_logservice.py",
                    "chromadb/test/distributed/test_sanity.py"]
-    fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - For workflows that matrix over multiple tests, we want to not fail fast since it reduces information / time for developers in their CI loop.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
These are tests
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None