### PR TITLE
[BUG] Modify attributes of `openai` only when using `openai 0.x`

### DIFF
--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -46,26 +46,12 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 "The openai python package is not installed. Please install it with `pip install openai`"
             )
 
-        if api_key is not None:
-            openai.api_key = api_key
-        # If the api key is still not set, raise an error
-        elif openai.api_key is None:
+        if api_key is None and openai.api_key is None:
             raise ValueError(
                 "Please provide an OpenAI API key. You can get one at https://platform.openai.com/account/api-keys"
             )
 
-        if api_base is not None:
-            openai.api_base = api_base
-
-        if api_version is not None:
-            openai.api_version = api_version
-
         self._api_type = api_type
-        if api_type is not None:
-            openai.api_type = api_type
-
-        if organization_id is not None:
-            openai.organization = organization_id
 
         self._v1 = openai.__version__.startswith("1.")
         if self._v1:
@@ -81,6 +67,21 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                     api_key=api_key, base_url=api_base, default_headers=default_headers
                 ).embeddings
         else:
+            if api_key is not None:
+                openai.api_key = api_key
+
+            if api_base is not None:
+                openai.api_base = api_base
+
+            if api_version is not None:
+                openai.api_version = api_version
+
+            if api_type is not None:
+                openai.api_type = api_type
+
+            if organization_id is not None:
+                openai.organization = organization_id
+
             self._client = openai.Embedding
         self._model_name = model_name
         self._deployment_id = deployment_id


### PR DESCRIPTION
## Description of changes

Updated `OpenAIEmbeddingFunction.__init__()`, now it will modify attributes of openai only when using `openai 0.x`. This is a better behavior:

* For most cases, people would use `openai 1.x`, which supports constructing client instances with config information stored as the instance attributes instead of global static attributes. This is very helpful to make it's possible to have multiple clients configured with different params in applications and all the constructing new client instances and reconfiguring will not affect other instances, for example: using OpenAI hosted LMs with different api keys while using Azure hosted embedding functions in one single app. So we should follow this new design to take full advantage.
* For minor cases, people would use `openai 0.x`, which only supports config all client instances with one param set, then we keep it compatible.

## Test plan
As it needs OpenAI API key to test `OpenAIEmbeddingFunction` and it seems there's no existing unit test for this class, I tested manually:

1. Install `openai==1.33.0`, construct an instance `azure_ef` of `OpenAIEmbeddingFunction` with config set of our dedicated Azure deployment and use the `azure_ef` generating embeddings of some text.
2. Keep the former `azure_ef` in context, then construct a new LM client instance `openai_lm` with config set of OpenAI hosted API. Both `azure_ef` and `openai_lm` works. *This wouldn't work without my new modification.*
3. Uninstall `openai==1.33.0` and install `openai==0.28.1`. Repeat step 1, working. Repeat step 2, not working, but this is expected because `openai==0.28.1` does not supports this use case and the only way to support is upgrading to `openai 1.x`.

If you think it's necessary to add a unit test for `OpenAIEmbeddingFunction`, I would like to do so later.

## Documentation Changes
No need to update documentation.