### PR TITLE
[ENH] Towards enabling test_filtering

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -508,7 +508,7 @@ class SegmentAPI(ServerAPI):
         where_document = (
             validate_where_document(where_document)
             if where_document is not None and len(where_document) > 0
-            else None
+            else where_document
         )
 
         metadata_segment = self._manager.get_segment(collection_id, MetadataReader)

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -685,7 +685,7 @@ class SegmentAPI(ServerAPI):
         where_document = (
             validate_where_document(where_document)
             if where_document is not None and len(where_document) > 0
-            else where_document
+            else None
         )
 
         allowed_ids = None
@@ -700,6 +700,20 @@ class SegmentAPI(ServerAPI):
                 where=where, where_document=where_document
             )
             allowed_ids = [r["id"] for r in records]
+
+        # If where conditions returned empty list then no need to proceed
+        # further and can simply return an empty result set here.
+        if allowed_ids is not None and allowed_ids == []:
+            return QueryResult(
+                ids=[],
+                distances=None,
+                metadatas=None,
+                embeddings=None,
+                documents=None,
+                uris=None,
+                data=None,
+                included=include,
+            )
 
         query = t.VectorQuery(
             vectors=query_embeddings,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -700,12 +700,11 @@ class SegmentAPI(ServerAPI):
                 where=where, where_document=where_document
             )
             allowed_ids = [r["id"] for r in records]
-
         # If where conditions returned empty list then no need to proceed
         # further and can simply return an empty result set here.
         if allowed_ids is not None and allowed_ids == []:
             return QueryResult(
-                ids=[],
+                ids=[[]],
                 distances=None,
                 metadatas=None,
                 embeddings=None,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -508,7 +508,7 @@ class SegmentAPI(ServerAPI):
         where_document = (
             validate_where_document(where_document)
             if where_document is not None and len(where_document) > 0
-            else where_document
+            else None
         )
 
         metadata_segment = self._manager.get_segment(collection_id, MetadataReader)
@@ -701,7 +701,7 @@ class SegmentAPI(ServerAPI):
         where_document = (
             validate_where_document(where_document)
             if where_document is not None and len(where_document) > 0
-            else None
+            else where_document
         )
 
         allowed_ids = None

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -721,7 +721,7 @@ class SegmentAPI(ServerAPI):
                     empty_metadatas.append([])
                 if "uris" in include:
                     empty_uris.append([])
-                
+
             return QueryResult(
                 ids=empty_ids,
                 distances=empty_distances if empty_distances else None,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -703,13 +703,32 @@ class SegmentAPI(ServerAPI):
         # If where conditions returned empty list then no need to proceed
         # further and can simply return an empty result set here.
         if allowed_ids is not None and allowed_ids == []:
+            empty_ids: List[List[str]] = []
+            empty_distances: List[List[float]] = []
+            empty_embeddings: List[List[Embedding]] = []
+            empty_documents: List[List[Document]] = []
+            empty_uris: List[List[URI]] = []
+            empty_metadatas: List[List[t.Metadata]] = []
+            for em in range(len(query_embeddings)):
+                empty_ids.append([])
+                if "distances" in include:
+                    empty_distances.append([])
+                if "embeddings" in include:
+                    empty_embeddings.append([])
+                if "documents" in include:
+                    empty_documents.append([])
+                if "metadatas" in include:
+                    empty_metadatas.append([])
+                if "uris" in include:
+                    empty_uris.append([])
+                
             return QueryResult(
-                ids=[[]],
-                distances=None,
-                metadatas=None,
-                embeddings=None,
-                documents=None,
-                uris=None,
+                ids=empty_ids,
+                distances=empty_distances if empty_distances else None,
+                metadatas=empty_metadatas if empty_metadatas else None,
+                embeddings=empty_embeddings if empty_embeddings else None,
+                documents=empty_documents if empty_documents else None,
+                uris=empty_uris if empty_uris else None,
                 data=None,
                 included=include,
             )

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -261,6 +261,7 @@ def test_filterable_metadata_get_limit_offset(
         min_size=1,
     ),
 )
+
 def test_filterable_metadata_query(
     caplog: pytest.LogCaptureFixture,
     api: ServerAPI,

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -261,7 +261,6 @@ def test_filterable_metadata_get_limit_offset(
         min_size=1,
     ),
 )
-
 def test_filterable_metadata_query(
     caplog: pytest.LogCaptureFixture,
     api: ServerAPI,

--- a/rust/worker/src/blockstore/arrow/block/types.rs
+++ b/rust/worker/src/blockstore/arrow/block/types.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 /// A Block holds BlockData via its Inner. Conceptually, the BlockData being loaded into memory is an optimization. The Block interface
 /// could also support out of core operations where the BlockData is loaded from disk on demand. Currently we force operations to be in-core
 /// but could expand to out-of-core in the future.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Block {
     // The data is stored in an Arrow record batch with the column schema (prefix, key, value).
     // These are stored in sorted order by prefix and key for efficient lookups.

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -258,6 +258,7 @@ impl ArrowBlockfileWriter {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct ArrowBlockfileReader<
     'me,
     K: ArrowReadableKey<'me> + Into<KeyWrapper>,
@@ -265,7 +266,7 @@ pub(crate) struct ArrowBlockfileReader<
 > {
     block_manager: BlockManager,
     pub(super) sparse_index: SparseIndex,
-    loaded_blocks: Mutex<HashMap<Uuid, Box<Block>>>,
+    loaded_blocks: Arc<Mutex<HashMap<Uuid, Box<Block>>>>,
     marker: std::marker::PhantomData<(K, V, &'me ())>,
     id: Uuid,
 }
@@ -277,7 +278,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         Self {
             block_manager,
             sparse_index,
-            loaded_blocks: Mutex::new(HashMap::new()),
+            loaded_blocks: Arc::new(Mutex::new(HashMap::new())),
             marker: std::marker::PhantomData,
             id,
         }

--- a/rust/worker/src/blockstore/memory/reader_writer.rs
+++ b/rust/worker/src/blockstore/memory/reader_writer.rs
@@ -63,6 +63,7 @@ impl MemoryBlockfileWriter {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct MemoryBlockfileReader<K: Key, V: Value> {
     storage_manager: StorageManager,
     storage: Storage,

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -227,6 +227,7 @@ impl BlockfileFlusher {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum BlockfileReader<
     'me,
     K: Key + Into<KeyWrapper> + ArrowReadableKey<'me>,

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -422,10 +422,30 @@ mod tests {
             file_path: HashMap::new(),
         };
 
+        let collection_1_metadata_segment = Segment {
+            id: Uuid::new_v4(),
+            r#type: crate::types::SegmentType::BlockfileMetadata,
+            scope: crate::types::SegmentScope::METADATA,
+            collection: Some(collection_uuid_1),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+
+        let collection_2_metadata_segment = Segment {
+            id: Uuid::new_v4(),
+            r#type: crate::types::SegmentType::BlockfileMetadata,
+            scope: crate::types::SegmentScope::METADATA,
+            collection: Some(collection_uuid_2),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+
         sysdb.add_segment(collection_1_record_segment);
         sysdb.add_segment(collection_2_record_segment);
         sysdb.add_segment(collection_1_hnsw_segment);
         sysdb.add_segment(collection_2_hnsw_segment);
+        sysdb.add_segment(collection_1_metadata_segment);
+        sysdb.add_segment(collection_2_metadata_segment);
 
         let last_compaction_time_1 = 2;
         sysdb.add_tenant_last_compaction_time(tenant_1, last_compaction_time_1);

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -29,6 +29,8 @@ pub struct BruteForceKnnOperatorInput {
     pub k: usize,
     pub distance_metric: DistanceFunction,
     pub allowed_ids: Arc<[String]>,
+    // This is just a subset of allowed_ids containing
+    // only the ids that are allowed and present in the log.
     pub allowed_ids_brute_force: Arc<[String]>,
 }
 

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -6,6 +6,7 @@ use crate::{distance::DistanceFunction, execution::operator::Operator};
 use async_trait::async_trait;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
+use std::sync::Arc;
 use tracing::trace;
 
 /// The brute force k-nearest neighbors operator is responsible for computing the k-nearest neighbors
@@ -27,6 +28,8 @@ pub struct BruteForceKnnOperatorInput {
     pub query: Vec<f32>,
     pub k: usize,
     pub distance_metric: DistanceFunction,
+    pub allowed_ids: Arc<[String]>,
+    pub allowed_ids_brute_force: Arc<[String]>,
 }
 
 /// The output of the brute force k-nearest neighbors operator.
@@ -103,6 +106,17 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
 
             if log_record.record.operation == Operation::Delete {
                 // Explicitly skip deleted records.
+                continue;
+            }
+
+            // Skip records that are disallowed. If allowed list is empty then
+            // don't exclude anything.
+            // Empty allowed list is passed when where filtering is absent.
+            if !input.allowed_ids.is_empty()
+                && !input
+                    .allowed_ids_brute_force
+                    .contains(&log_record.record.id)
+            {
                 continue;
             }
             let embedding = match &log_record.record.embedding {
@@ -210,6 +224,8 @@ mod tests {
             query: vec![0.0, 0.0, 0.0],
             k: 2,
             distance_metric: DistanceFunction::Euclidean,
+            allowed_ids: Arc::new([]),
+            allowed_ids_brute_force: Arc::new([]),
         };
         let output = operator.run(&input).await.unwrap();
         assert_eq!(output.indices, vec![0, 1]);
@@ -271,6 +287,8 @@ mod tests {
             query: vec![0.0, 1.0, 0.0],
             k: 2,
             distance_metric: DistanceFunction::InnerProduct,
+            allowed_ids: Arc::new([]),
+            allowed_ids_brute_force: Arc::new([]),
         };
         let output = operator.run(&input).await.unwrap();
 
@@ -306,6 +324,8 @@ mod tests {
             query: vec![0.0, 0.0, 0.0],
             k: 2,
             distance_metric: DistanceFunction::Euclidean,
+            allowed_ids: Arc::new([]),
+            allowed_ids_brute_force: Arc::new([]),
         };
         let output = operator.run(&input).await.unwrap();
         assert_eq!(output.indices, vec![0]);
@@ -358,6 +378,8 @@ mod tests {
             query: vec![0.0, 0.0, 0.0],
             k: 2,
             distance_metric: DistanceFunction::Euclidean,
+            allowed_ids: Arc::new([]),
+            allowed_ids_brute_force: Arc::new([]),
         };
         let output = operator.run(&input).await.unwrap();
         assert_eq!(output.indices, vec![0, 2]);

--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::errors::ChromaError;
+use crate::segment::metadata_segment::MetadataSegmentWriter;
 use crate::segment::SegmentFlusher;
 use crate::types::SegmentFlushInfo;
 use crate::{
@@ -25,16 +26,19 @@ impl FlushS3Operator {
 pub struct FlushS3Input {
     record_segment_writer: RecordSegmentWriter,
     hnsw_segment_writer: Box<DistributedHNSWSegmentWriter>,
+    metadata_segment_writer: MetadataSegmentWriter<'static>,
 }
 
 impl FlushS3Input {
     pub fn new(
         record_segment_writer: RecordSegmentWriter,
         hnsw_segment_writer: Box<DistributedHNSWSegmentWriter>,
+        metadata_segment_writer: MetadataSegmentWriter<'static>,
     ) -> Self {
         Self {
             record_segment_writer,
             hnsw_segment_writer,
+            metadata_segment_writer,
         }
     }
 }
@@ -56,18 +60,20 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
                 let res = flusher.flush().await;
                 match res {
                     Ok(res) => {
-                        println!("Record Segment Flushed");
+                        tracing::info!("Record Segment Flushed");
                         SegmentFlushInfo {
                             segment_id,
                             file_paths: res,
                         }
                     }
                     Err(e) => {
+                        tracing::error!("Error flushing metadata Segment: {:?}", e);
                         return Err(e);
                     }
                 }
             }
             Err(e) => {
+                tracing::error!("Error Commiting record Segment: {:?}", e);
                 return Err(e);
             }
         };
@@ -86,23 +92,49 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
                         }
                     }
                     Err(e) => {
-                        // TODO: use logging
-                        println!("Error Flushing HNSW Segment: {:?}", e);
+                        tracing::error!("Error Flushing HNSW Segment: {:?}", e);
                         return Err(e);
                     }
                 }
             }
             Err(e) => {
-                // TODO: use logging;
-                println!("Error Commiting HNSW Segment: {:?}", e);
+                tracing::error!("Error Commiting HNSW Segment: {:?}", e);
                 return Err(e);
             }
         };
 
-        // TODO: use logging
-        println!("Flush to S3 complete");
+        let metadata_segment_flusher = input.metadata_segment_writer.clone().commit();
+        let metadata_segment_flush_info = match metadata_segment_flusher {
+            Ok(flusher) => {
+                let segment_id = input.metadata_segment_writer.id;
+                let res = flusher.flush().await;
+                match res {
+                    Ok(res) => {
+                        tracing::info!("Metadata Segment Flushed");
+                        SegmentFlushInfo {
+                            segment_id,
+                            file_paths: res,
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Error Flushing metadata Segment: {:?}", e);
+                        return Err(e);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Error Commiting metadata Segment: {:?}", e);
+                return Err(e);
+            }
+        };
+
+        tracing::info!("Flush to S3 complete");
         Ok(FlushS3Output {
-            segment_flush_info: Arc::new([record_segment_flush_info, hnsw_segment_flush_info]),
+            segment_flush_info: Arc::new([
+                record_segment_flush_info,
+                hnsw_segment_flush_info,
+                metadata_segment_flush_info,
+            ]),
         })
     }
 }

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -106,7 +106,7 @@ impl Operator<HnswKnnOperatorInput, HnswKnnOperatorOutput> for HnswKnnOperator {
         &self,
         input: &HnswKnnOperatorInput,
     ) -> Result<HnswKnnOperatorOutput, Self::Error> {
-        // If a filter list is supplied but it does not have anything for the segment
+        // If a filter list is supplied but it does not have anything for the segment, as it implies the data is all in the log
         // then return an empty response.
         if !input.allowed_ids.is_empty() && input.allowed_ids_hnsw.is_empty() {
             return Ok(HnswKnnOperatorOutput {

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -24,6 +24,9 @@ pub struct HnswKnnOperatorInput {
     pub record_segment: Segment,
     pub blockfile_provider: BlockfileProvider,
     pub allowed_ids: Arc<[String]>,
+    // This is just a subset of allowed_ids containing
+    // ids that are allowed but not present in the log
+    // thus present in the segment.
     pub allowed_ids_hnsw: Arc<[String]>,
     pub logs: Chunk<LogRecord>,
 }

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -346,7 +346,7 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
                 let data = match record_segment_reader.get_all_data().await {
                     Ok(data) => data,
                     Err(e) => {
-                        tracing::info!("Error reading Record Segment: {:?}", e);
+                        tracing::error!("[Mergemetadata]: Error reading Record Segment: {:?}", e);
                         return Err(MergeMetadataResultsOperatorError::RecordSegmentReadError);
                     }
                 };

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -572,7 +572,7 @@ impl MetadataQueryOrchestrator {
     }
 
     async fn filter(&mut self, mut logs: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
-        println!("Filtering logs and searching metadata segment");
+        tracing::debug!("Filtering logs and searching metadata segment");
         self.state = ExecutionState::Filter;
 
         let input = MetadataFilteringInput::new(
@@ -778,7 +778,6 @@ impl Handler<TaskResult<MetadataFilteringOutput, MetadataFilteringError>>
             }
         };
 
-        tracing::info!("MetadataFiltering output {:?}", output);
         self.state = ExecutionState::MergeResults;
 
         let operator = MergeMetadataResultsOperator::new();
@@ -829,7 +828,7 @@ impl Handler<TaskResult<MergeMetadataResultsOperatorOutput, MergeMetadataResults
             .expect("Invariant violation. Result channel is not set.");
 
         let output = (output.ids, output.metadata, output.documents);
-        println!("Merged metadata results: {:?}", output);
+        tracing::trace!("Merged metadata results: {:?}", output);
 
         match result_channel.send(Ok(output)) {
             Ok(_) => (),

--- a/rust/worker/src/index/fulltext/tokenizer.rs
+++ b/rust/worker/src/index/fulltext/tokenizer.rs
@@ -2,7 +2,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use tantivy::tokenizer::{NgramTokenizer, Token, TokenStream, Tokenizer};
 
-pub(crate) trait ChromaTokenStream {
+pub(crate) trait ChromaTokenStream: Send {
     fn process(&mut self, sink: &mut dyn FnMut(&Token));
     fn get_tokens(&self) -> &Vec<Token>;
 }

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
+use super::tokenizer::ChromaTokenStream;
+
 #[derive(Error, Debug)]
 pub enum FullTextIndexError {
     #[error("Multiple tokens found in frequencies blockfile")]
@@ -35,6 +37,7 @@ impl ChromaError for FullTextIndexError {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct FullTextIndexWriter<'me> {
     // We use this to implement updates which require read-then-write semantics.
     full_text_index_reader: Option<FullTextIndexReader<'me>>,
@@ -43,8 +46,8 @@ pub(crate) struct FullTextIndexWriter<'me> {
     tokenizer: Arc<Mutex<Box<dyn ChromaTokenizer>>>,
 
     // term -> positional posting list builder for that term
-    uncommitted: Arc<Mutex<HashMap<String, PositionalPostingListBuilder>>>,
-    uncommitted_frequencies: Arc<Mutex<HashMap<String, i32>>>,
+    uncommitted: Arc<tokio::sync::Mutex<HashMap<String, PositionalPostingListBuilder>>>,
+    uncommitted_frequencies: Arc<tokio::sync::Mutex<HashMap<String, i32>>>,
 }
 
 impl<'me> FullTextIndexWriter<'me> {
@@ -59,8 +62,8 @@ impl<'me> FullTextIndexWriter<'me> {
             posting_lists_blockfile_writer,
             frequencies_blockfile_writer,
             tokenizer: Arc::new(Mutex::new(tokenizer)),
-            uncommitted: Arc::new(Mutex::new(HashMap::new())),
-            uncommitted_frequencies: Arc::new(Mutex::new(HashMap::new())),
+            uncommitted: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            uncommitted_frequencies: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -68,7 +71,7 @@ impl<'me> FullTextIndexWriter<'me> {
         &self,
         token: &str,
     ) -> Result<(), FullTextIndexError> {
-        let mut uncommitted_frequencies = self.uncommitted_frequencies.lock();
+        let mut uncommitted_frequencies = self.uncommitted_frequencies.lock().await;
         match uncommitted_frequencies.get(token) {
             Some(_) => return Ok(()),
             None => {
@@ -82,7 +85,7 @@ impl<'me> FullTextIndexWriter<'me> {
                 uncommitted_frequencies.insert(token.to_string(), frequency as i32);
             }
         }
-        let mut uncommitted = self.uncommitted.lock();
+        let mut uncommitted = self.uncommitted.lock().await;
         match uncommitted.get(token) {
             Some(_) => {
                 // This should never happen -- if uncommitted has the token, then
@@ -116,21 +119,28 @@ impl<'me> FullTextIndexWriter<'me> {
         Ok(())
     }
 
+    pub fn encode_tokens(&self, document: &str) -> Box<dyn ChromaTokenStream> {
+        let tokenizer = self.tokenizer.lock();
+        let tokens = tokenizer.encode(document);
+        tokens
+    }
+
     pub async fn add_document(
         &self,
         document: &str,
         offset_id: i32,
     ) -> Result<(), FullTextIndexError> {
-        let tokenizer = self.tokenizer.lock();
-        let tokens = tokenizer.encode(document);
+        let tokens = self.encode_tokens(document);
+        // let tokenizer = self.tokenizer.lock();
+        // let tokens = tokenizer.encode(document);
         for token in tokens.get_tokens() {
             self.populate_frequencies_and_posting_lists_from_previous_version(token.text.as_str())
                 .await?;
-            let mut uncommitted_frequencies = self.uncommitted_frequencies.lock();
+            let mut uncommitted_frequencies = self.uncommitted_frequencies.lock().await;
             uncommitted_frequencies
                 .entry(token.text.to_string())
                 .and_modify(|e| *e += 1);
-            let mut uncommitted = self.uncommitted.lock();
+            let mut uncommitted = self.uncommitted.lock().await;
             let builder = uncommitted
                 .entry(token.text.to_string())
                 .or_insert(PositionalPostingListBuilder::new());
@@ -165,12 +175,13 @@ impl<'me> FullTextIndexWriter<'me> {
         document: &str,
         offset_id: u32,
     ) -> Result<(), FullTextIndexError> {
-        let tokenizer = self.tokenizer.lock();
-        let tokens = tokenizer.encode(document);
+        let tokens = self.encode_tokens(document);
+        // let tokenizer = self.tokenizer.lock();
+        // let tokens = tokenizer.encode(document);
         for token in tokens.get_tokens() {
             self.populate_frequencies_and_posting_lists_from_previous_version(token.text.as_str())
                 .await?;
-            let mut uncommitted_frequencies = self.uncommitted_frequencies.lock();
+            let mut uncommitted_frequencies = self.uncommitted_frequencies.lock().await;
             match uncommitted_frequencies.get_mut(token.text.as_str()) {
                 Some(frequency) => {
                     *frequency -= 1;
@@ -181,7 +192,7 @@ impl<'me> FullTextIndexWriter<'me> {
                     return Err(FullTextIndexError::InvariantViolation);
                 }
             }
-            let mut uncommitted = self.uncommitted.lock();
+            let mut uncommitted = self.uncommitted.lock().await;
             match uncommitted.get_mut(token.text.as_str()) {
                 Some(builder) => match builder.delete_doc_id(offset_id as i32) {
                     Ok(_) => {}
@@ -218,7 +229,7 @@ impl<'me> FullTextIndexWriter<'me> {
     }
 
     pub async fn write_to_blockfiles(&mut self) -> Result<(), FullTextIndexError> {
-        let mut uncommitted = self.uncommitted.lock();
+        let mut uncommitted = self.uncommitted.lock().await;
         for (key, mut value) in uncommitted.drain() {
             let built_list = value.build();
             for doc_id in built_list.doc_ids.iter() {
@@ -243,7 +254,7 @@ impl<'me> FullTextIndexWriter<'me> {
                 }
             }
         }
-        let mut uncommitted_frequencies = self.uncommitted_frequencies.lock();
+        let mut uncommitted_frequencies = self.uncommitted_frequencies.lock().await;
         for (key, value) in uncommitted_frequencies.drain() {
             // TODO we just have token -> frequency here. Should frequency be the key or should we use an empty key and make it the value?
             match self
@@ -313,6 +324,7 @@ impl FullTextIndexFlusher {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct FullTextIndexReader<'me> {
     posting_lists_blockfile_reader: BlockfileReader<'me, u32, Int32Array>,
     frequencies_blockfile_reader: BlockfileReader<'me, u32, u32>,
@@ -332,9 +344,16 @@ impl<'me> FullTextIndexReader<'me> {
         }
     }
 
-    pub async fn search(&self, query: &str) -> Result<Vec<i32>, FullTextIndexError> {
+    pub fn encode_tokens(&self, document: &str) -> Box<dyn ChromaTokenStream> {
         let tokenizer = self.tokenizer.lock();
-        let binding = tokenizer.encode(query);
+        let tokens = tokenizer.encode(document);
+        tokens
+    }
+
+    pub async fn search(&self, query: &str) -> Result<Vec<i32>, FullTextIndexError> {
+        let binding = self.encode_tokens(query);
+        // let tokenizer = self.tokenizer.lock();
+        // let binding = tokenizer.encode(query);
         let tokens = binding.get_tokens();
 
         // Get query tokens sorted by frequency.

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -37,6 +37,7 @@ const BOOL_METADATA: &str = "bool_metadata";
 const F32_METADATA: &str = "f32_metadata";
 const U32_METADATA: &str = "u32_metadata";
 
+#[derive(Clone)]
 pub(crate) struct MetadataSegmentWriter<'me> {
     pub(crate) full_text_index_writer: Option<FullTextIndexWriter<'me>>,
     pub(crate) string_metadata_index_writer: Option<MetadataIndexWriter<'me>>,

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -9,7 +9,6 @@ use std::fmt::{self, Debug, Formatter};
 use std::u32;
 use tantivy::tokenizer::NgramTokenizer;
 use thiserror::Error;
-use tokio::runtime::{Handle, Runtime};
 use uuid::Uuid;
 
 use super::record_segment::ApplyMaterializedLogError;
@@ -1249,8 +1248,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1303,8 +1303,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1340,8 +1341,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1374,8 +1376,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1408,8 +1411,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1442,8 +1446,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1480,8 +1485,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1517,8 +1523,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1551,8 +1558,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1585,8 +1593,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1619,8 +1628,9 @@ impl MetadataSegmentReader<'_> {
                                                                 .map(|x| x as usize)
                                                                 .collect();
                                                         }
-                                                        // TODO: Convert to error here.
-                                                        Err(_) => (),
+                                                        Err(e) => {
+                                                            return Err(e);
+                                                        }
                                                     }
                                                 }
                                                 // This is expected. Before the first ever compaction
@@ -1648,7 +1658,6 @@ impl MetadataSegmentReader<'_> {
                     }
                 }
                 Where::WhereChildren(where_children) => {
-                    // This feels like a crime.
                     let mut first_iteration = true;
                     for child in where_children.children.iter() {
                         let child_results: Vec<usize> =
@@ -1697,8 +1706,9 @@ impl MetadataSegmentReader<'_> {
                                         Ok(r) => {
                                             results = r.iter().map(|x| *x as usize).collect();
                                         }
-                                        // TODO: Convert to error here.
-                                        Err(_) => (),
+                                        Err(e) => {
+                                            return Err(MetadataIndexError::FullTextError(e));
+                                        }
                                     }
                                 }
                                 // This is expected. Before the first ever compaction

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -1,17 +1,21 @@
 use arrow::array::Int32Array;
 use async_trait::async_trait;
 use core::panic;
+use futures::future::BoxFuture;
+use futures::FutureExt;
 use roaring::RoaringBitmap;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::u32;
 use tantivy::tokenizer::NgramTokenizer;
 use thiserror::Error;
+use tokio::runtime::{Handle, Runtime};
 use uuid::Uuid;
 
 use super::record_segment::ApplyMaterializedLogError;
 use super::types::{MaterializedLogRecord, SegmentWriter};
 use super::SegmentFlusher;
+use crate::blockstore::key::KeyWrapper;
 use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::index::fulltext::tokenizer::TantivyChromaTokenizer;
@@ -23,12 +27,12 @@ use crate::index::metadata::types::{
     process_where_clause_with_callback, MetadataIndexError, MetadataIndexFlusher,
     MetadataIndexReader, MetadataIndexWriter,
 };
-use crate::types::SegmentType;
 use crate::types::{
-    MetadataValue, Operation, Segment, Where, WhereClauseComparator, WhereDocument,
-    WhereDocumentOperator,
+    BooleanOperator, MetadataValue, Operation, Segment, Where, WhereClauseComparator,
+    WhereDocument, WhereDocumentOperator,
 };
-use crate::utils::merge_sorted_vecs_conjunction;
+use crate::types::{SegmentType, WhereComparison};
+use crate::utils::{merge_sorted_vecs_conjunction, merge_sorted_vecs_disjunction};
 
 const FULL_TEXT_PLS: &str = "full_text_pls";
 const FULL_TEXT_FREQS: &str = "full_text_freqs";
@@ -44,6 +48,7 @@ pub(crate) struct MetadataSegmentWriter<'me> {
     pub(crate) bool_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) f32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) u32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
+    pub(crate) id: Uuid,
 }
 
 impl Debug for MetadataSegmentWriter<'_> {
@@ -99,7 +104,6 @@ impl<'me> MetadataSegmentWriter<'me> {
         segment: &Segment,
         blockfile_provider: &BlockfileProvider,
     ) -> Result<MetadataSegmentWriter<'me>, MetadataSegmentError> {
-        println!("Creating MetadataSegmentWriter from Segment");
         if segment.r#type != SegmentType::BlockfileMetadata {
             return Err(MetadataSegmentError::InvalidSegmentType);
         }
@@ -178,7 +182,7 @@ impl<'me> MetadataSegmentWriter<'me> {
         let full_text_index_reader = match (pls_reader, freqs_reader) {
             (Some(pls_reader), Some(freqs_reader)) => {
                 let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
-                    NgramTokenizer::new(1, 3, false).unwrap(),
+                    NgramTokenizer::new(3, 3, false).unwrap(),
                 )));
                 Some(FullTextIndexReader::new(
                     pls_reader,
@@ -191,7 +195,7 @@ impl<'me> MetadataSegmentWriter<'me> {
         };
 
         let full_text_writer_tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
-            NgramTokenizer::new(1, 3, false).unwrap(),
+            NgramTokenizer::new(3, 3, false).unwrap(),
         )));
         let full_text_index_writer = FullTextIndexWriter::new(
             full_text_index_reader,
@@ -358,6 +362,7 @@ impl<'me> MetadataSegmentWriter<'me> {
             bool_metadata_index_writer: Some(bool_metadata_index_writer),
             f32_metadata_index_writer: Some(f32_metadata_index_writer),
             u32_metadata_index_writer: Some(u32_metadata_index_writer),
+            id: segment.id,
         })
     }
 
@@ -979,7 +984,7 @@ impl MetadataSegmentReader<'_> {
         let full_text_index_reader = match (pls_reader, freqs_reader) {
             (Some(pls_reader), Some(freqs_reader)) => {
                 let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
-                    NgramTokenizer::new(1, 3, false).unwrap(),
+                    NgramTokenizer::new(3, 3, false).unwrap(),
                 )));
                 Some(FullTextIndexReader::new(
                     pls_reader,
@@ -1131,11 +1136,28 @@ impl MetadataSegmentReader<'_> {
         // TODO we can do lots of clever query planning here. For now, just
         // run through the Where and WhereDocument clauses sequentially.
         let where_results = match where_clause {
-            Some(where_clause) => match self.process_where_clause(where_clause).map_err(|e| e) {
-                Ok(results) => Some(results),
-                Err(e) => return Err(MetadataSegmentError::MetadataIndexQueryError(e)),
-            },
-            None => None,
+            Some(where_clause) => {
+                match self.process_where_clause(where_clause).await.map_err(|e| e) {
+                    Ok(results) => {
+                        tracing::info!(
+                            "Filtered {} records from metadata segment based on where clause",
+                            results.len()
+                        );
+                        Some(results)
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Error fetching results from metadata segment based on where clause {:?}",
+                            e
+                        );
+                        return Err(MetadataSegmentError::MetadataIndexQueryError(e));
+                    }
+                }
+            }
+            None => {
+                tracing::info!("No where clause to filter anything from metadata segment");
+                None
+            }
         };
         // Where and WhereDocument are implicitly ANDed, so if we have nothing
         // for the Where query we can just return.
@@ -1149,12 +1171,30 @@ impl MetadataSegmentReader<'_> {
         };
         let where_document_results = match where_document_clause {
             Some(where_document_clause) => {
-                match self.process_where_document_clause(where_document_clause) {
-                    Ok(results) => Some(results),
-                    Err(e) => return Err(MetadataSegmentError::MetadataIndexQueryError(e)),
+                match self
+                    .process_where_document_clause(where_document_clause)
+                    .await
+                {
+                    Ok(results) => {
+                        tracing::info!(
+                            "Filtered {} records from metadata segment based on where document",
+                            results.len()
+                        );
+                        Some(results)
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Error fetching results from metadata segment based on where clause {:?}",
+                            e
+                        );
+                        return Err(MetadataSegmentError::MetadataIndexQueryError(e));
+                    }
                 }
             }
-            None => None,
+            None => {
+                tracing::info!("No where document to filter anything from metadata segment");
+                None
+            }
         };
         match &where_document_results {
             Some(results) => {
@@ -1179,253 +1219,528 @@ impl MetadataSegmentReader<'_> {
         }
     }
 
-    fn process_where_clause(&self, where_clause: &Where) -> Result<Vec<usize>, MetadataIndexError> {
-        let clo = |metadata_key: &str,
-                   metadata_value: &crate::blockstore::key::KeyWrapper,
-                   metadata_type: crate::types::MetadataType,
-                   comparator: WhereClauseComparator| {
-            match metadata_type {
-                crate::types::MetadataType::StringType => match comparator {
-                    WhereClauseComparator::Equal => {
-                        let result = match &self.string_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.get(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                    WhereClauseComparator::NotEqual => {
-                        todo!();
-                    }
-                    // We don't allow these comparators for strings.
-                    WhereClauseComparator::LessThan => {
-                        unimplemented!();
-                    }
-                    WhereClauseComparator::LessThanOrEqual => {
-                        unimplemented!();
-                    }
-                    WhereClauseComparator::GreaterThan => {
-                        unimplemented!();
-                    }
-                    WhereClauseComparator::GreaterThanOrEqual => {
-                        unimplemented!();
-                    }
-                },
-                crate::types::MetadataType::IntType => match comparator {
-                    WhereClauseComparator::Equal => {
-                        let result = match &self.u32_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.get(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                    WhereClauseComparator::NotEqual => {
-                        todo!();
-                    }
-                    WhereClauseComparator::LessThan => {
-                        let result = match &self.u32_metadata_index_reader {
-                            Some(reader) => {
-                                futures::executor::block_on(reader.lt(metadata_key, metadata_value))
-                            }
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
+    fn process_where_clause<'me>(
+        &'me self,
+        where_clause: &'me Where,
+    ) -> BoxFuture<Result<Vec<usize>, MetadataIndexError>> {
+        async move {
+            let mut results = vec![];
+            match where_clause {
+                Where::DirectWhereComparison(direct_where_comparison) => {
+                    match &direct_where_comparison.comparison {
+                        WhereComparison::SingleStringComparison(operand, comparator) => {
+                            match comparator {
+                                WhereClauseComparator::Equal => {
+                                    let metadata_value_keywrapper = operand.as_str().try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.string_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .get(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting string to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::NotEqual => {
+                                    todo!();
+                                }
+                                // We don't allow these comparators for strings.
+                                WhereClauseComparator::LessThan => {
+                                    unimplemented!();
+                                }
+                                WhereClauseComparator::LessThanOrEqual => {
+                                    unimplemented!();
+                                }
+                                WhereClauseComparator::GreaterThan => {
+                                    unimplemented!();
+                                }
+                                WhereClauseComparator::GreaterThanOrEqual => {
+                                    unimplemented!();
+                                }
                             }
                         }
-                    }
-                    WhereClauseComparator::LessThanOrEqual => {
-                        let result = match &self.u32_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.lte(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
+                        WhereComparison::SingleIntComparison(operand, comparator) => {
+                            match comparator {
+                                WhereClauseComparator::Equal => {
+                                    let metadata_value_keywrapper = (*operand).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.u32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .get(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting int to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::NotEqual => {
+                                    todo!();
+                                }
+                                WhereClauseComparator::LessThan => {
+                                    let metadata_value_keywrapper = (*operand).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.u32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .lt(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting int to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::LessThanOrEqual => {
+                                    let metadata_value_keywrapper = (*operand).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.u32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .lte(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting int to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::GreaterThan => {
+                                    let metadata_value_keywrapper = (*operand).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.u32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .gt(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting int to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::GreaterThanOrEqual => {
+                                    let metadata_value_keywrapper = (*operand).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.u32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .gte(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting int to keywrapper")
+                                        }
+                                    }
+                                }
                             }
                         }
-                    }
-                    WhereClauseComparator::GreaterThan => {
-                        let result = match &self.u32_metadata_index_reader {
-                            Some(reader) => {
-                                futures::executor::block_on(reader.gt(metadata_key, metadata_value))
-                            }
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
+                        WhereComparison::SingleDoubleComparison(operand, comparator) => {
+                            match comparator {
+                                WhereClauseComparator::Equal => {
+                                    let metadata_value_keywrapper = (*operand as f32).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.f32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .get(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting double to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::NotEqual => {
+                                    todo!();
+                                }
+                                WhereClauseComparator::LessThan => {
+                                    let metadata_value_keywrapper = (*operand as f32).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.f32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .lt(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting double to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::LessThanOrEqual => {
+                                    let metadata_value_keywrapper = (*operand as f32).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.f32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .lte(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting double to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::GreaterThan => {
+                                    let metadata_value_keywrapper = (*operand as f32).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.f32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .gt(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting double to keywrapper")
+                                        }
+                                    }
+                                }
+                                WhereClauseComparator::GreaterThanOrEqual => {
+                                    let metadata_value_keywrapper = (*operand as f32).try_into();
+                                    match metadata_value_keywrapper {
+                                        Ok(keywrapper) => {
+                                            match &self.f32_metadata_index_reader {
+                                                Some(reader) => {
+                                                    let result = reader
+                                                        .gte(
+                                                            &direct_where_comparison.key,
+                                                            &keywrapper,
+                                                        )
+                                                        .await;
+                                                    match result {
+                                                        Ok(r) => {
+                                                            results = r
+                                                                .iter()
+                                                                .map(|x| x as usize)
+                                                                .collect();
+                                                        }
+                                                        // TODO: Convert to error here.
+                                                        Err(_) => (),
+                                                    }
+                                                }
+                                                // This is expected. Before the first ever compaction
+                                                // the reader will be uninitialized, hence an empty vector
+                                                // here since nothing has been written to storage yet.
+                                                None => results = vec![],
+                                            }
+                                        }
+                                        Err(_) => {
+                                            panic!("Error converting double to keywrapper")
+                                        }
+                                    }
+                                }
                             }
                         }
-                    }
-                    WhereClauseComparator::GreaterThanOrEqual => {
-                        let result = match &self.u32_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.gte(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
+                        WhereComparison::StringListComparison(operand, list_operator) => {
+                            todo!();
+                        }
+                        WhereComparison::IntListComparison(..) => {
+                            todo!();
+                        }
+                        WhereComparison::DoubleListComparison(..) => {
+                            todo!();
                         }
                     }
-                },
-                crate::types::MetadataType::DoubleType => match comparator {
-                    WhereClauseComparator::Equal => {
-                        let result = match &self.f32_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.get(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                    WhereClauseComparator::NotEqual => {
-                        todo!();
-                    }
-                    WhereClauseComparator::LessThan => {
-                        let result = match &self.f32_metadata_index_reader {
-                            Some(reader) => {
-                                futures::executor::block_on(reader.lt(metadata_key, metadata_value))
-                            }
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                    WhereClauseComparator::LessThanOrEqual => {
-                        let result = match &self.f32_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.lte(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                    WhereClauseComparator::GreaterThan => {
-                        let result = match &self.f32_metadata_index_reader {
-                            Some(reader) => {
-                                futures::executor::block_on(reader.gt(metadata_key, metadata_value))
-                            }
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                    WhereClauseComparator::GreaterThanOrEqual => {
-                        let result = match &self.f32_metadata_index_reader {
-                            Some(reader) => futures::executor::block_on(
-                                reader.gte(metadata_key, metadata_value),
-                            ),
-                            None => Ok(RoaringBitmap::new()),
-                        };
-                        match result {
-                            Ok(result) => {
-                                return result;
-                            }
-                            Err(_) => {
-                                panic!("Error querying metadata index")
-                            }
-                        }
-                    }
-                },
-                crate::types::MetadataType::StringListType => {
-                    todo!();
                 }
-                crate::types::MetadataType::IntListType => {
-                    todo!();
-                }
-                crate::types::MetadataType::DoubleListType => {
-                    todo!();
+                Where::WhereChildren(where_children) => {
+                    // This feels like a crime.
+                    let mut first_iteration = true;
+                    for child in where_children.children.iter() {
+                        let child_results: Vec<usize> =
+                            match self.process_where_clause(&child).await {
+                                Ok(result) => result,
+                                Err(_) => vec![],
+                            };
+                        if first_iteration {
+                            results = child_results;
+                            first_iteration = false;
+                        } else {
+                            match where_children.operator {
+                                BooleanOperator::And => {
+                                    results =
+                                        merge_sorted_vecs_conjunction(&results, &child_results);
+                                }
+                                BooleanOperator::Or => {
+                                    results =
+                                        merge_sorted_vecs_disjunction(&results, &child_results);
+                                }
+                            }
+                        }
+                    }
                 }
             }
-        };
-        return process_where_clause_with_callback(where_clause, &clo);
+            return Ok(results);
+        }
+        .boxed()
     }
 
-    fn process_where_document_clause(
-        &self,
-        where_document_clause: &WhereDocument,
-    ) -> Result<Vec<usize>, MetadataIndexError> {
-        let cb = |doc: &str, comparison: WhereDocumentOperator| match comparison {
-            WhereDocumentOperator::Contains => {
-                let result = match &self.full_text_index_reader {
-                    Some(reader) => futures::executor::block_on(reader.search(doc)),
-                    None => Ok(vec![]),
-                };
-                match result {
-                    Ok(result) => {
-                        return result;
+    fn process_where_document_clause<'me>(
+        &'me self,
+        where_document_clause: &'me WhereDocument,
+    ) -> BoxFuture<Result<Vec<usize>, MetadataIndexError>> {
+        async move {
+            let mut results = vec![];
+            match where_document_clause {
+                WhereDocument::DirectWhereDocumentComparison(direct_document_comparison) => {
+                    match &direct_document_comparison.operator {
+                        WhereDocumentOperator::Contains => {
+                            match &self.full_text_index_reader {
+                                Some(reader) => {
+                                    let result =
+                                        reader.search(&direct_document_comparison.document).await;
+                                    match result {
+                                        Ok(r) => {
+                                            results = r.iter().map(|x| *x as usize).collect();
+                                        }
+                                        // TODO: Convert to error here.
+                                        Err(_) => (),
+                                    }
+                                }
+                                // This is expected. Before the first ever compaction
+                                // the reader will be uninitialized, hence an empty vector
+                                // here since nothing has been written to storage yet.
+                                None => results = vec![],
+                            }
+                        }
+                        WhereDocumentOperator::NotContains => {
+                            todo!();
+                        }
                     }
-                    Err(_) => {
-                        panic!("Error querying metadata index")
+                }
+                WhereDocument::WhereDocumentChildren(where_document_children) => {
+                    let mut first_iteration = true;
+                    for child in where_document_children.children.iter() {
+                        let child_results: Vec<usize> =
+                            match self.process_where_document_clause(&child).await {
+                                Ok(result) => result,
+                                Err(_) => vec![],
+                            };
+                        if first_iteration {
+                            results = child_results;
+                            first_iteration = false;
+                        } else {
+                            match where_document_children.operator {
+                                BooleanOperator::And => {
+                                    results =
+                                        merge_sorted_vecs_conjunction(&results, &child_results);
+                                }
+                                BooleanOperator::Or => {
+                                    results =
+                                        merge_sorted_vecs_disjunction(&results, &child_results);
+                                }
+                            }
+                        }
                     }
                 }
             }
-            WhereDocumentOperator::NotContains => {
-                todo!()
-            }
-        };
-        process_where_document_clause_with_callback(where_document_clause, &cb)
+            results.sort();
+            return Ok(results);
+        }
+        .boxed()
     }
 }

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -102,7 +102,7 @@ impl RecordSegmentWriter {
         segment: &Segment,
         blockfile_provider: &BlockfileProvider,
     ) -> Result<Self, RecordSegmentWriterCreationError> {
-        println!("Creating RecordSegmentWriter from Segment");
+        tracing::debug!("Creating RecordSegmentWriter from Segment");
         if segment.r#type != SegmentType::BlockfileRecord {
             return Err(RecordSegmentWriterCreationError::InvalidSegmentType);
         }
@@ -110,7 +110,7 @@ impl RecordSegmentWriter {
         let (user_id_to_id, id_to_user_id, id_to_data, max_offset_id) =
             match segment.file_path.len() {
                 0 => {
-                    println!("No files found, creating new blockfiles for record segment");
+                    tracing::debug!("No files found, creating new blockfiles for record segment");
                     let user_id_to_id = match blockfile_provider.create::<&str, u32>() {
                         Ok(user_id_to_id) => user_id_to_id,
                         Err(e) => {
@@ -139,7 +139,7 @@ impl RecordSegmentWriter {
                     (user_id_to_id, id_to_user_id, id_to_data, max_offset_id)
                 }
                 4 => {
-                    println!("Found files, loading blockfiles for record segment");
+                    tracing::debug!("Found files, loading blockfiles for record segment");
                     let user_id_to_id_bf_id = match segment.file_path.get(USER_ID_TO_OFFSET_ID) {
                         Some(user_id_to_id_bf_id) => match user_id_to_id_bf_id.get(0) {
                             Some(user_id_to_id_bf_id) => user_id_to_id_bf_id,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
  This PR has a bunch of fixes and improvements to make queries and gets with metadata and full text filtering work. Among these are:
  1. Wire in the compactor to also write to metadata segment. This was non trivial and involved changes like making the lifetime of the metadata segment writer in WriteSegmentsOutput and FlushS3Input 'static, introduce tokio::sync::mutex for holding mutexes even when yielding due to an async call, etc
  2. Make where clause parsing async - it was incorrectly using futures::executor::block_on. There is no need to keep it sync, I made the recursive function async.
  3. Full text search creates n gram tokenizer with wrong parameters - The min and max were incorrectly set. Due to this the search result was always empty
  4. Frequencies list incorrect logic when adding documents - Since frequency is a part of the key in the frequencies_list blockfile, whenever we write the updated frequency (aka key with updated frequency), we also need to delete the old frequency i.e. the key containing the old frequency.
  5. Brute force KNN does not respect allowed_ids list - Passing allow list to brute force KNN and filter taking into account this list
  6. HNSW segment reader tries to read allowed_ids not present in segment but only present in the log - allow list should be divided into two parts - 1) allow list for the log, 2) allow list for the segment
  7. FE should distinguish between no where clause and no results matching where clause - If where filtering returns an empty list (i.e. no documents match user supplied where conditions) then FE was incorrectly returning everything.
  8. FE does not support only where clause and no where document clause - Only supplying where_clause and no where_document_clause results in an error today.

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
