### PR TITLE
[BLD] add workflow job for branch protection

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,3 +104,26 @@ jobs:
       - name: Cargo fmt check
         shell: bash
         run: cargo fmt -- --check
+
+  # This job exists for our branch protection rule.
+  # We want to require status checks to pass before merging, but the set of
+  # checks that run for any given PR is dynamic based on the files changed.
+  # When creating a branch protection rule, you have to specify a static list
+  # of checks.
+  # So since this job always runs, we can specify it in the branch protection rule.
+  check:
+    if: always()
+    needs:
+    - python-tests
+    - python-vulnerability-scan
+    - javascript-client-tests
+    - rust-tests
+    - go-tests
+    - check-title
+    - lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
E.x. https://github.com/chroma-core/chroma/pull/2314 only changed docs, so Python tests won't run. But current branch protection rules require Python tests to pass before merging, so merging is blocked.