### PR TITLE
[ENH] Add graceful shutdown to tonic server

### DIFF
--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -80,11 +80,6 @@ pub async fn query_service_entrypoint() {
         // Kubernetes will send SIGTERM to stop the pod gracefully
         // TODO: add more signal handling
         _ = sigterm.recv() => {
-            server_join_handle.abort();
-            match server_join_handle.await {
-                Ok(_) => println!("Server stopped"),
-                Err(e) => println!("Server stopped with error {}", e),
-            }
             dispatcher_handle.stop();
             dispatcher_handle.join().await;
             system.stop().await;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - This PR adds a graceful shutdown to the tonic GRPC server with serve_with_shutdown method. We pass in a future that captures the sigterm and starts the graceful shutdown process. 
    - The behavior of the tonic server graceful shutdown process is as follows: upon receiving the shutdown signal, the server transitions from the "Running" state to the "Draining" state. In this state, the server stops accepting new requests or connections, effectively making it read-only concerning new external interactions. While in the "Draining" state, the server focuses on allowing existing connections and ongoing tasks to be completed gracefully. 
    - The above behavior has been verified by code reading and a simple prototype with an RPC with delays in request handling. 
    - The implementation relies on tonic's graceful shutdown and did not introduce a is_shut_down state to reject the request explicitly.  Relying on tonic's shut down approach will reduce the number of failed requests, however, it may make the shutdown process longer. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
