### PR TITLE
[DOC]: Fix missing OpenLIT reference in Integration sidenav

### DIFF
--- a/docs/docs.trychroma.com/pages/integrations/_sidenav.js
+++ b/docs/docs.trychroma.com/pages/integrations/_sidenav.js
@@ -22,6 +22,7 @@ export const items = [
         { href: '/integrations/haystack', children: 'Haystack' },
         { href: '/integrations/openllmetry', children: 'OpenLLMetry' },
         { href: '/integrations/streamlit', children: 'Streamlit' },
+          { href: '/integrations/openlit', children: 'OpenLIT' },
       ]
     },
   ];


### PR DESCRIPTION
## Description of changes

OpenLIT integration reference was not added to the sidenav in the [previous PR](https://github.com/chroma-core/chroma/pull/2249). This fixes by adding the OpenLIT SDK to the sidenav
