### PR TITLE
[ENH] Handle metadata deletes + fix bugs related to Updates/deletes in the metadata writer

### DIFF
--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -189,6 +189,7 @@ def to_proto_metadata_update_value(
         return proto.UpdateMetadataValue(int_value=value)
     elif isinstance(value, float):
         return proto.UpdateMetadataValue(float_value=value)
+    # None is used to delete the metadata key.
     elif value is None:
         return proto.UpdateMetadataValue()
     else:

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -26,6 +26,7 @@ from hypothesis.stateful import (
 )
 from collections import defaultdict
 import chromadb.test.property.invariants as invariants
+from chromadb.test.conftest import reset
 import numpy as np
 
 
@@ -75,7 +76,7 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
 
     @initialize(collection=collection_st)  # type: ignore
     def initialize(self, collection: strategies.Collection):
-        self.api.reset()
+        reset(self.api)
         self.collection = self.api.create_collection(
             name=collection.name,
             metadata=collection.metadata,
@@ -306,7 +307,7 @@ def test_embeddings_state(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> N
 
 
 def test_multi_add(api: ServerAPI) -> None:
-    api.reset()
+    reset(api)
     coll = api.create_collection(name="foo")
     coll.add(ids=["a"], embeddings=[[0.0]])
     assert coll.count() == 1
@@ -325,7 +326,7 @@ def test_multi_add(api: ServerAPI) -> None:
 
 
 def test_dup_add(api: ServerAPI) -> None:
-    api.reset()
+    reset(api)
     coll = api.create_collection(name="foo")
     with pytest.raises(errors.DuplicateIDError):
         coll.add(ids=["a", "a"], embeddings=[[0.0], [1.1]])
@@ -334,7 +335,7 @@ def test_dup_add(api: ServerAPI) -> None:
 
 
 def test_query_without_add(api: ServerAPI) -> None:
-    api.reset()
+    reset(api)
     coll = api.create_collection(name="foo")
     fields: Include = ["documents", "metadatas", "embeddings", "distances"]
     N = np.random.randint(1, 2000)
@@ -349,7 +350,7 @@ def test_query_without_add(api: ServerAPI) -> None:
 
 
 def test_get_non_existent(api: ServerAPI) -> None:
-    api.reset()
+    reset(api)
     coll = api.create_collection(name="foo")
     result = coll.get(ids=["a"], include=["documents", "metadatas", "embeddings"])
     assert len(result["ids"]) == 0
@@ -361,7 +362,7 @@ def test_get_non_existent(api: ServerAPI) -> None:
 # TODO: Use SQL escaping correctly internally
 @pytest.mark.xfail(reason="We don't properly escape SQL internally, causing problems")
 def test_escape_chars_in_ids(api: ServerAPI) -> None:
-    api.reset()
+    reset(api)
     id = "\x1f"
     coll = api.create_collection(name="foo")
     coll.add(ids=[id], embeddings=[[0.0]])
@@ -381,7 +382,7 @@ def test_escape_chars_in_ids(api: ServerAPI) -> None:
     ],
 )
 def test_delete_empty_fails(api: ServerAPI, kwargs: dict):
-    api.reset()
+    reset(api)
     coll = api.create_collection(name="foo")
     with pytest.raises(Exception) as e:
         coll.delete(**kwargs)
@@ -404,7 +405,7 @@ def test_delete_empty_fails(api: ServerAPI, kwargs: dict):
     ],
 )
 def test_delete_success(api: ServerAPI, kwargs: dict):
-    api.reset()
+    reset(api)
     coll = api.create_collection(name="foo")
     # Should not raise
     coll.delete(**kwargs)

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -523,7 +523,7 @@ mod tests {
         log::config::{self, GrpcLogConfig},
         segment::DataRecord,
         storage::{local::LocalStorage, Storage},
-        types::{update_metdata_to_metdata, MetadataValue},
+        types::MetadataValue,
     };
     use arrow::array::Int32Array;
     use proptest::prelude::*;

--- a/rust/worker/src/blockstore/positional_posting_list_value.rs
+++ b/rust/worker/src/blockstore/positional_posting_list_value.rs
@@ -113,6 +113,8 @@ impl PositionalPostingListBuilder {
             return Err(PositionalPostingListBuilderError::DocIdDoesNotExist);
         }
 
+        // Safe to unwrap here since this is called for >= 2nd time a token
+        // exists in the document.
         self.positions.get_mut(&doc_id).unwrap().extend(positions);
         Ok(())
     }

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -6,11 +6,8 @@ use crate::{
         record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
         LogMaterializer, LogMaterializerError,
     },
-    types::{
-        update_metdata_to_metdata, LogRecord, Metadata, MetadataValueConversionError, Operation,
-        Segment,
-    },
-    utils::{merge_sorted_vecs_conjunction, merge_sorted_vecs_disjunction},
+    types::{LogRecord, Metadata, MetadataValueConversionError, Operation, Segment},
+    utils::merge_sorted_vecs_conjunction,
 };
 use async_trait::async_trait;
 use std::{

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -435,7 +435,7 @@ impl HnswQueryOrchestrator {
             .take()
             .expect("Invariant violation. Result channel is not set.");
         let mut empty_resp = vec![];
-        for _ in 1..=self.query_vectors.len() {
+        for _ in 0..self.query_vectors.len() {
             empty_resp.push(vec![]);
         }
         match result_channel.send(Ok(empty_resp)) {

--- a/rust/worker/src/index/fulltext/types.rs
+++ b/rust/worker/src/index/fulltext/types.rs
@@ -19,10 +19,6 @@ use super::tokenizer::ChromaTokenStream;
 
 #[derive(Error, Debug)]
 pub enum FullTextIndexError {
-    #[error("Multiple tokens found in frequencies blockfile")]
-    MultipleTokenFrequencies,
-    #[error("Zero frequency token found")]
-    ZeroFrequencyToken,
     #[error("Empty value in positional posting list")]
     EmptyValueInPositionalPostingList,
     #[error("Invariant violation")]
@@ -443,11 +439,11 @@ impl<'me> FullTextIndexReader<'me> {
                 return Ok(vec![]);
             }
             if res.len() > 1 {
-                return Err(FullTextIndexError::MultipleTokenFrequencies);
+                panic!("Invariant violation. Multiple frequency values found for a token.");
             }
             let res = res[0];
             if res.1 <= 0 {
-                return Err(FullTextIndexError::ZeroFrequencyToken);
+                panic!("Invariant violation. Zero frequency token found.");
             }
             // Throw away the "value" since we store frequencies in the keys.
             token_frequencies.push((token.text.to_string(), res.1));
@@ -570,7 +566,7 @@ impl<'me> FullTextIndexReader<'me> {
             return Ok(0);
         }
         if res.len() > 1 {
-            return Err(FullTextIndexError::MultipleTokenFrequencies);
+            panic!("Invariant violation. Multiple frequency values found for a token.");
         }
         Ok(res[0].1)
     }

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -4,10 +4,7 @@ use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
 use crate::blockstore::{BlockfileFlusher, BlockfileReader, BlockfileWriter};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::execution::data::data_chunk::Chunk;
-use crate::types::{
-    merge_update_metadata, update_metdata_to_metdata, LogRecord, Metadata, MetadataValue,
-    Operation, Segment, SegmentType,
-};
+use crate::types::{Operation, Segment, SegmentType};
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
@@ -294,8 +291,12 @@ pub enum ApplyMaterializedLogError {
     BlockfileSetError,
     #[error("Error deleting from blockfile")]
     BlockfileDeleteError,
+    #[error("Error updating blockfile")]
+    BlockfileUpdateError,
     #[error("Embedding not set in the user write")]
     EmbeddingNotSet,
+    #[error("Metadata update not valid")]
+    MetadataUpdateNotValid,
 }
 
 impl ChromaError for ApplyMaterializedLogError {
@@ -303,6 +304,8 @@ impl ChromaError for ApplyMaterializedLogError {
         match self {
             ApplyMaterializedLogError::BlockfileSetError => ErrorCodes::Internal,
             ApplyMaterializedLogError::BlockfileDeleteError => ErrorCodes::Internal,
+            ApplyMaterializedLogError::BlockfileUpdateError => ErrorCodes::Internal,
+            ApplyMaterializedLogError::MetadataUpdateNotValid => ErrorCodes::Internal,
             ApplyMaterializedLogError::EmbeddingNotSet => ErrorCodes::InvalidArgument,
         }
     }

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -1,8 +1,8 @@
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::execution::data::data_chunk::Chunk;
 use crate::types::{
-    DeletedMetadata, LogRecord, Metadata, MetadataValue, MetadataValueConversionError, Operation,
-    OperationRecord, UpdateMetadata, UpdateMetadataValue,
+    DeletedMetadata, LogRecord, Metadata, MetadataDelta, MetadataValue,
+    MetadataValueConversionError, Operation, OperationRecord, UpdateMetadata, UpdateMetadataValue,
 };
 use async_trait::async_trait;
 use std::collections::{HashMap, HashSet};
@@ -166,25 +166,6 @@ pub(crate) struct MaterializedLogRecord<'referred_data> {
     // E.g. if log has [Insert(emb0), Update(emb1), Update(emb2), Update()]
     // then this will contain emb2. None if final operation is Delete.
     pub(crate) final_embedding: Option<&'referred_data [f32]>,
-}
-
-pub(crate) struct MetadataDelta<'referred_data> {
-    pub(crate) metadata_to_update: HashMap<
-        &'referred_data str,
-        (&'referred_data MetadataValue, &'referred_data MetadataValue),
-    >,
-    pub(crate) metadata_to_delete: HashMap<&'referred_data str, &'referred_data MetadataValue>,
-    pub(crate) metadata_to_insert: HashMap<&'referred_data str, &'referred_data MetadataValue>,
-}
-
-impl<'referred_data> MetadataDelta<'referred_data> {
-    pub(crate) fn new() -> Self {
-        Self {
-            metadata_to_update: HashMap::new(),
-            metadata_to_delete: HashMap::new(),
-            metadata_to_insert: HashMap::new(),
-        }
-    }
 }
 
 impl<'referred_data> MaterializedLogRecord<'referred_data> {

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -2,7 +2,7 @@ use crate::{
     chroma_proto,
     errors::{ChromaError, ErrorCodes},
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -271,6 +271,7 @@ Metadata
 */
 
 pub(crate) type Metadata = HashMap<String, MetadataValue>;
+pub(crate) type DeletedMetadata = HashSet<String>;
 
 impl TryFrom<chroma_proto::UpdateMetadata> for Metadata {
     type Error = MetadataValueConversionError;
@@ -287,24 +288,6 @@ impl TryFrom<chroma_proto::UpdateMetadata> for Metadata {
         }
         Ok(metadata)
     }
-}
-
-pub(crate) fn update_metdata_to_metdata(
-    update_metdata: &UpdateMetadata,
-) -> Result<Metadata, MetadataValueConversionError> {
-    let mut metadata = Metadata::new();
-    for (key, value) in update_metdata {
-        let res = value.try_into();
-        match res {
-            Ok(value) => {
-                metadata.insert(key.clone(), value);
-            }
-            Err(err) => {
-                return Err(err);
-            }
-        }
-    }
-    Ok(metadata)
 }
 
 /*
@@ -705,34 +688,6 @@ impl TryFrom<chroma_proto::WhereDocumentOperator> for WhereDocumentOperator {
             }
         }
     }
-}
-
-pub(crate) fn merge_update_metadata(
-    base_metadata: &Option<Metadata>,
-    update_metadata: &Option<UpdateMetadata>,
-) -> Result<Option<Metadata>, MetadataValueConversionError> {
-    let mut merged_metadata = HashMap::new();
-    if base_metadata.is_some() {
-        for (key, value) in base_metadata.as_ref().unwrap() {
-            merged_metadata.insert(key.clone(), value.clone());
-        }
-    }
-    if update_metadata.is_some() {
-        match update_metdata_to_metdata(update_metadata.as_ref().unwrap()) {
-            Ok(metadata) => {
-                for (key, value) in metadata {
-                    merged_metadata.insert(key, value);
-                }
-            }
-            Err(e) => {
-                return Err(e);
-            }
-        };
-    }
-    if merged_metadata.is_empty() {
-        return Ok(None);
-    }
-    Ok(Some(merged_metadata))
 }
 
 #[cfg(test)]

--- a/rust/worker/src/types/metadata.rs
+++ b/rust/worker/src/types/metadata.rs
@@ -290,6 +290,25 @@ impl TryFrom<chroma_proto::UpdateMetadata> for Metadata {
     }
 }
 
+pub(crate) struct MetadataDelta<'referred_data> {
+    pub(crate) metadata_to_update: HashMap<
+        &'referred_data str,
+        (&'referred_data MetadataValue, &'referred_data MetadataValue),
+    >,
+    pub(crate) metadata_to_delete: HashMap<&'referred_data str, &'referred_data MetadataValue>,
+    pub(crate) metadata_to_insert: HashMap<&'referred_data str, &'referred_data MetadataValue>,
+}
+
+impl<'referred_data> MetadataDelta<'referred_data> {
+    pub(crate) fn new() -> Self {
+        Self {
+            metadata_to_update: HashMap::new(),
+            metadata_to_delete: HashMap::new(),
+            metadata_to_insert: HashMap::new(),
+        }
+    }
+}
+
 /*
 ===========================================
 Metadata queries


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
    - Handles metadata deletes
    - Full text writer adds (token, freq) pair even if freq is 0. Fixes this.
    - Full text writer does not remove postings list of documents that have been deleted. Fixes this.
    - Fix for test_query_without_add

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
