### PR TITLE
[ENH] Get vectors orchestrator

### DIFF
--- a/rust/worker/src/execution/operators/get_vectors_operator.rs
+++ b/rust/worker/src/execution/operators/get_vectors_operator.rs
@@ -1,0 +1,108 @@
+use crate::{
+    blockstore::provider::BlockfileProvider,
+    execution::{data::data_chunk::Chunk, operator::Operator},
+    types::{LogRecord, Segment},
+};
+use async_trait::async_trait;
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct GetVectorsOperator {}
+
+impl GetVectorsOperator {
+    pub fn new() -> Box<Self> {
+        return Box::new(GetVectorsOperator {});
+    }
+}
+
+/// The input to the get vectors operator.
+/// # Parameters
+/// * `record_segment_definition` - The segment definition for the record segment.
+/// * `blockfile_provider` - The blockfile provider.
+/// * `log_records` - The log records.
+/// * `search_user_ids` - The user ids to search for.
+#[derive(Debug)]
+pub struct GetVectorsOperatorInput {
+    record_segment_definition: Segment,
+    blockfile_provider: BlockfileProvider,
+    log_records: Chunk<LogRecord>,
+    search_user_ids: Vec<String>,
+}
+
+impl GetVectorsOperatorInput {
+    pub fn new(
+        record_segment_definition: Segment,
+        blockfile_provider: BlockfileProvider,
+        log_records: Chunk<LogRecord>,
+        search_user_ids: Vec<String>,
+    ) -> Self {
+        return GetVectorsOperatorInput {
+            record_segment_definition,
+            blockfile_provider,
+            log_records,
+            search_user_ids,
+        };
+    }
+}
+
+/// The output of the get vectors operator.
+/// # Parameters
+/// * `ids` - The ids of the vectors.
+/// * `vectors` - The vectors.
+/// # Notes
+/// The vectors are in the same order as the ids.
+#[derive(Debug)]
+pub struct GetVectorsOperatorOutput {
+    pub(crate) ids: Vec<String>,
+    pub(crate) vectors: Vec<Vec<f32>>,
+}
+
+#[derive(Debug, Error)]
+pub enum GetVectorsOperatorError {}
+
+#[async_trait]
+impl Operator<GetVectorsOperatorInput, GetVectorsOperatorOutput> for GetVectorsOperator {
+    type Error = GetVectorsOperatorError;
+
+    async fn run(
+        &self,
+        input: &GetVectorsOperatorInput,
+    ) -> Result<GetVectorsOperatorOutput, Self::Error> {
+        unimplemented!()
+
+        // let logs = output.logs();
+        //         let mut log_user_ids_to_vectors = HashMap::new();
+        //         for (log, index) in logs.iter() {
+        //             match log.record.operation {
+        //                 crate::types::Operation::Add => {
+        //                     let user_id = log.record.id.clone();
+        //                     // If the user id is already present in the log set, skip it
+        //                     // We use the first log entry for a user id if a
+        //                     // user has multiple log entries
+        //                     if log_user_ids_to_vectors.contains_key(&user_id) {
+        //                         continue;
+        //                     }
+        //                     // Otherwise, Add the vector to the output
+        //                     let vector = log.record.embedding.expect("Invariant violation. The log record for an add does not have an embedding.");
+        //                     log_user_ids_to_vectors.insert(user_id, vector);
+        //                 }
+        //                 crate::types::Operation::Update => {
+        //                     // If the update touches the vector, we need to update the output
+        //                     if log_user_ids_to_vectors.contains_key(&log.record.id) {
+        //                         match log.record.embedding {
+        //                             Some(vector) => {
+        //                                 log_user_ids_to_vectors
+        //                                     .insert(log.record.id.clone(), vector);
+        //                             }
+        //                             None => {
+        //                                 // Nothing to do with this as the vector was not updated
+        //                             }
+        //                         }
+        //                     }
+        //                 }
+        //                 crate::types::Operation::Upsert => todo!(),
+        //                 crate::types::Operation::Delete => todo!(),
+        //             }
+        //         }
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -1,6 +1,7 @@
 pub(super) mod brute_force_knn;
 pub(super) mod count_records;
 pub(super) mod flush_s3;
+pub(super) mod get_vectors_operator;
 pub(super) mod hnsw_knn;
 pub(super) mod merge_knn_results;
 pub(super) mod merge_metadata_results;

--- a/rust/worker/src/execution/orchestration/common.rs
+++ b/rust/worker/src/execution/orchestration/common.rs
@@ -1,0 +1,53 @@
+use crate::{
+    errors::{ChromaError, ErrorCodes},
+    sysdb::sysdb::{GetSegmentsError, SysDb},
+    types::{Segment, SegmentType},
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Debug, Error)]
+pub(super) enum HnswSegmentQueryError {
+    #[error("Hnsw segment with id: {0} not found")]
+    HnswSegmentNotFound(Uuid),
+    #[error("Get segments error")]
+    GetSegmentsError(#[from] GetSegmentsError),
+}
+
+impl ChromaError for HnswSegmentQueryError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            HnswSegmentQueryError::HnswSegmentNotFound(_) => ErrorCodes::NotFound,
+            HnswSegmentQueryError::GetSegmentsError(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+pub(super) async fn get_hnsw_segment_from_id(
+    mut sysdb: Box<dyn SysDb>,
+    hnsw_segment_id: &Uuid,
+) -> Result<Segment, Box<dyn ChromaError>> {
+    let segments = sysdb
+        .get_segments(Some(*hnsw_segment_id), None, None, None)
+        .await;
+    let segment = match segments {
+        Ok(segments) => {
+            if segments.is_empty() {
+                return Err(Box::new(HnswSegmentQueryError::HnswSegmentNotFound(
+                    *hnsw_segment_id,
+                )));
+            }
+            segments[0].clone()
+        }
+        Err(e) => {
+            return Err(Box::new(HnswSegmentQueryError::GetSegmentsError(e)));
+        }
+    };
+
+    if segment.r#type != SegmentType::HnswDistributed {
+        return Err(Box::new(HnswSegmentQueryError::HnswSegmentNotFound(
+            *hnsw_segment_id,
+        )));
+    }
+    Ok(segment)
+}

--- a/rust/worker/src/execution/orchestration/get_vectors.rs
+++ b/rust/worker/src/execution/orchestration/get_vectors.rs
@@ -62,7 +62,7 @@ pub struct GetVectorsOrchestrator {
     record_segment: Option<Segment>,
     collection: Option<Collection>,
     // Services
-    log: Box<dyn Log>,
+    log: Box<Log>,
     sysdb: Box<SysDb>,
     dispatcher: Box<dyn Receiver<TaskMessage>>,
     blockfile_provider: BlockfileProvider,
@@ -76,7 +76,7 @@ impl GetVectorsOrchestrator {
         system: System,
         get_ids: Vec<String>,
         hnsw_segment_id: Uuid,
-        log: Box<dyn Log>,
+        log: Box<Log>,
         sysdb: Box<SysDb>,
         dispatcher: Box<dyn Receiver<TaskMessage>>,
         blockfile_provider: BlockfileProvider,

--- a/rust/worker/src/execution/orchestration/get_vectors.rs
+++ b/rust/worker/src/execution/orchestration/get_vectors.rs
@@ -48,7 +48,7 @@ pub struct GetVectorsOrchestrator {
     // blockfile_provider: BlockfileProvider,
     // Result channel
     result_channel:
-        Option<tokio::sync::oneshot::Sender<Result<Vec<GetVectorsResult>, Box<dyn ChromaError>>>>,
+        Option<tokio::sync::oneshot::Sender<Result<GetVectorsResult, Box<dyn ChromaError>>>>,
 }
 
 impl GetVectorsOrchestrator {
@@ -83,7 +83,7 @@ impl GetVectorsOrchestrator {
     ///  # Note
     ///  Use this over spawning the component directly. This method will start the component and
     ///  wait for it to finish before returning the result.
-    pub(crate) async fn run(mut self) -> Result<Vec<GetVectorsResult>, Box<dyn ChromaError>> {
+    pub(crate) async fn run(mut self) -> Result<GetVectorsResult, Box<dyn ChromaError>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.result_channel = Some(tx);
         let mut handle = self.system.clone().start_component(self);

--- a/rust/worker/src/execution/orchestration/get_vectors.rs
+++ b/rust/worker/src/execution/orchestration/get_vectors.rs
@@ -1,0 +1,72 @@
+#[derive(Debug)]
+enum ExecutionState {
+    Pending,
+    PullLogs,
+    // IMPL NOTE: read vectors should filter out the vectors that are not present in the index.
+    ReadVectors,
+    MergeResults,
+}
+
+#[derive(Debug)]
+pub struct GetVectorsOrchestrator {
+    state: ExecutionState,
+    // Component Execution
+    system: System,
+    // Query state
+    get_ids: Vec<String>,
+    hnsw_segment_id: Uuid,
+    // State fetched or created for query execution
+    record_segment: Option<Segment>,
+    // // query_vectors index to the result
+    // hnsw_result_offset_ids: HashMap<usize, Vec<usize>>,
+    // hnsw_result_distances: HashMap<usize, Vec<f32>>,
+    // brute_force_result_user_ids: HashMap<usize, Vec<String>>,
+    // brute_force_result_distances: HashMap<usize, Vec<f32>>,
+    // brute_force_result_embeddings: HashMap<usize, Vec<Vec<f32>>>,
+    // // Task id to query_vectors index
+    // hnsw_task_id_to_query_index: HashMap<Uuid, usize>,
+    // brute_force_task_id_to_query_index: HashMap<Uuid, usize>,
+    // merge_task_id_to_query_index: HashMap<Uuid, usize>,
+    // // Result state
+    // results: Option<Vec<Vec<VectorQueryResult>>>,
+    // // State machine management
+    // merge_dependency_count: u32,
+    // finish_dependency_count: u32,
+    // // Services
+    // log: Box<dyn Log>,
+    // sysdb: Box<dyn SysDb>,
+    // dispatcher: Box<dyn Receiver<TaskMessage>>,
+    // hnsw_index_provider: HnswIndexProvider,
+    // blockfile_provider: BlockfileProvider,
+    // Result channel
+    // result_channel: Option<
+    //     tokio::sync::oneshot::Sender<Result<Vec<Vec<VectorQueryResult>>, Box<dyn ChromaError>>>,
+    // >,
+}
+
+impl GetVectorsOrchestrator {
+    pub fn new(system: System, get_ids: Vec<String>, hnsw_segment_id: Uuid) -> Self {
+        Self {
+            state: ExecutionState::Pending,
+            system,
+            get_ids,
+            hnsw_segment_id,
+            record_segment: None,
+        }
+    }
+}
+
+// ============== Component Implementation ==============
+
+#[async_trait]
+impl Component for GetVectorOrchestrator {
+    fn get_name(&self) -> &'static str {
+        "GetVectorOrchestrator"
+    }
+
+    fn queue_size(&self) -> usize {
+        1000
+    }
+}
+
+// ============== Handlers ==============

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,6 +1,8 @@
 mod compact;
+mod get_vectors;
 mod hnsw;
 mod metadata;
 pub(crate) use compact::*;
+pub(crate) use get_vectors::*;
 pub(crate) use hnsw::*;
 pub(crate) use metadata::*;

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,3 +1,4 @@
+mod common;
 mod compact;
 mod get_vectors;
 mod hnsw;

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -252,7 +252,13 @@ impl WorkerServer {
             }
         };
 
-        let orchestrator = GetVectorsOrchestrator::new(system.clone(), request.ids, segment_uuid);
+        let orchestrator = GetVectorsOrchestrator::new(
+            system.clone(),
+            request.ids,
+            segment_uuid,
+            self.log.clone(),
+            self.sysdb.clone(),
+        );
         let result = orchestrator.run().await;
         let mut result = match result {
             Ok(result) => result,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -258,6 +258,8 @@ impl WorkerServer {
             segment_uuid,
             self.log.clone(),
             self.sysdb.clone(),
+            dispatcher.clone(),
+            self.blockfile_provider.clone(),
         );
         let result = orchestrator.run().await;
         let mut result = match result {

--- a/rust/worker/src/system/sender.rs
+++ b/rust/worker/src/system/sender.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use crate::errors::{ChromaError, ErrorCodes};
+
 use super::{Component, ComponentContext, Handler};
 use async_trait::async_trait;
 use thiserror::Error;
@@ -192,4 +194,10 @@ where
 pub enum ChannelError {
     #[error("Failed to send message")]
     SendError,
+}
+
+impl ChromaError for ChannelError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
 }

--- a/rust/worker/src/system/sender.rs
+++ b/rust/worker/src/system/sender.rs
@@ -5,7 +5,6 @@ use crate::errors::{ChromaError, ErrorCodes};
 use super::{Component, ComponentContext, Handler};
 use async_trait::async_trait;
 use thiserror::Error;
-use tracing::Span;
 
 // Message Wrapper
 #[derive(Debug)]

--- a/rust/worker/src/types/record.rs
+++ b/rust/worker/src/types/record.rs
@@ -239,6 +239,18 @@ pub(crate) struct VectorQueryResult {
 
 /*
 ===========================================
+Get Vector Results
+===========================================
+*/
+
+#[derive(Debug)]
+pub(crate) struct GetVectorsResult {
+    pub(crate) ids: Vec<String>,
+    pub(crate) vectors: Vec<Vec<f32>>,
+}
+
+/*
+===========================================
 Metadata Embedding Record
 ===========================================
 */


### PR DESCRIPTION
This PR adds the Get Vectors() RPC for query nodes.

1. Adds the GetVectors instrumented rpc call and associated types
2. Adds a GetVectorsOrchestrator for managing these queries
3. Adds the GetVectorsOperator for reading from the log and record segment to respond to get_vectors
4. Moves common orchestrator functions into a /common and refactors hnsw orchestrator to use this instead (DRY)
5. Adds the `ChromaError` Trait for ChannelError in Sender - needed to use that as Box<dyn ChromaError> elsewhere.

I explicitly make the choice to not have to materialize in this operator since it doesn't need to for any reason.

Tasks
- [x] Stub out
- [x] Types
- [x] Implement return
- [x] Server input parse
- [x] Server output parse
- [x] Init segments
- [x] Pull log + filter
- [x] Operator for reading
- [x] Add test (Will handle in separate PR) 
- [x] Validate that the get() semantics for missing ids is correct (I have validated that the semantics are the same - we just ignore invalid entries in the output)