### PR TITLE
[CLN] Make sysdb use enum not dyn

### DIFF
--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -45,7 +45,7 @@ pub struct RegisterInput {
     log_position: i64,
     collection_version: i32,
     segment_flush_info: Arc<[SegmentFlushInfo]>,
-    sysdb: Box<dyn SysDb>,
+    sysdb: Box<SysDb>,
     log: Box<dyn Log>,
 }
 
@@ -57,7 +57,7 @@ impl RegisterInput {
         log_position: i64,
         collection_version: i32,
         segment_flush_info: Arc<[SegmentFlushInfo]>,
-        sysdb: Box<dyn SysDb>,
+        sysdb: Box<SysDb>,
         log: Box<dyn Log>,
     ) -> Self {
         RegisterInput {
@@ -150,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_operator() {
-        let mut sysdb = Box::new(TestSysDb::new());
+        let mut sysdb = Box::new(SysDb::Test(TestSysDb::new()));
         let mut log = Box::new(InMemoryLog::new());
         let collection_version = 0;
         let collection_uuid_1 = Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap();
@@ -178,8 +178,14 @@ mod tests {
             log_position: 0,
             version: collection_version,
         };
-        sysdb.add_collection(collection_1);
-        sysdb.add_collection(collection_2);
+
+        match *sysdb {
+            SysDb::Test(ref mut sysdb) => {
+                sysdb.add_collection(collection_1);
+                sysdb.add_collection(collection_2);
+            }
+            _ => panic!("Invalid sysdb type"),
+        }
 
         let mut file_path_1 = HashMap::new();
         file_path_1.insert("hnsw".to_string(), vec!["path_1".to_string()]);
@@ -205,8 +211,13 @@ mod tests {
             metadata: None,
             file_path: file_path_2.clone(),
         };
-        sysdb.add_segment(segment_1);
-        sysdb.add_segment(segment_2);
+        match *sysdb {
+            SysDb::Test(ref mut sysdb) => {
+                sysdb.add_segment(segment_1);
+                sysdb.add_segment(segment_2);
+            }
+            _ => panic!("Invalid sysdb type"),
+        }
 
         let mut file_path_3 = HashMap::new();
         file_path_3.insert("hnsw".to_string(), vec!["path_3".to_string()]);

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -85,7 +85,7 @@ pub struct CompactOrchestrator {
     collection_id: Uuid,
     // Dependencies
     log: Box<dyn Log>,
-    sysdb: Box<dyn SysDb>,
+    sysdb: Box<SysDb>,
     blockfile_provider: BlockfileProvider,
     hnsw_index_provider: HnswIndexProvider,
     // State we hold across the execution
@@ -146,7 +146,7 @@ impl CompactOrchestrator {
         system: System,
         collection_id: Uuid,
         log: Box<dyn Log>,
-        sysdb: Box<dyn SysDb>,
+        sysdb: Box<SysDb>,
         blockfile_provider: BlockfileProvider,
         hnsw_index_provider: HnswIndexProvider,
         dispatcher: Box<dyn Receiver<TaskMessage>>,

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -130,7 +130,7 @@ pub(crate) struct HnswQueryOrchestrator {
     finish_dependency_count: u32,
     // Services
     log: Box<dyn Log>,
-    sysdb: Box<dyn SysDb>,
+    sysdb: Box<SysDb>,
     dispatcher: Box<dyn Receiver<TaskMessage>>,
     hnsw_index_provider: HnswIndexProvider,
     blockfile_provider: BlockfileProvider,
@@ -149,7 +149,7 @@ impl HnswQueryOrchestrator {
         include_embeddings: bool,
         segment_id: Uuid,
         log: Box<dyn Log>,
-        sysdb: Box<dyn SysDb>,
+        sysdb: Box<SysDb>,
         hnsw_index_provider: HnswIndexProvider,
         blockfile_provider: BlockfileProvider,
         dispatcher: Box<dyn Receiver<TaskMessage>>,
@@ -419,7 +419,7 @@ impl HnswQueryOrchestrator {
 
     async fn get_hnsw_segment_from_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         hnsw_segment_id: &Uuid,
     ) -> Result<Segment, Box<dyn ChromaError>> {
         let segments = sysdb
@@ -449,7 +449,7 @@ impl HnswQueryOrchestrator {
 
     async fn get_collection(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         collection_id: &Uuid,
     ) -> Result<Collection, Box<dyn ChromaError>> {
         let child_span: tracing::Span =
@@ -475,7 +475,7 @@ impl HnswQueryOrchestrator {
 
     async fn get_record_segment_for_collection(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         collection_id: &Uuid,
     ) -> Result<Segment, Box<dyn ChromaError>> {
         let segments = sysdb

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -63,7 +63,7 @@ pub(crate) struct MetadataQueryOrchestrator {
     merge_dependency_count: u32,
     // Services
     log: Box<dyn Log>,
-    sysdb: Box<dyn SysDb>,
+    sysdb: Box<SysDb>,
     dispatcher: Box<dyn Receiver<TaskMessage>>,
     blockfile_provider: BlockfileProvider,
     // Query params
@@ -84,7 +84,7 @@ pub(crate) struct CountQueryOrchestrator {
     collection: Option<Collection>,
     // Services
     log: Box<dyn Log>,
-    sysdb: Box<dyn SysDb>,
+    sysdb: Box<SysDb>,
     dispatcher: Box<dyn Receiver<TaskMessage>>,
     blockfile_provider: BlockfileProvider,
     // Result channel
@@ -130,7 +130,7 @@ impl CountQueryOrchestrator {
         system: System,
         metadata_segment_id: &Uuid,
         log: Box<dyn Log>,
-        sysdb: Box<dyn SysDb>,
+        sysdb: Box<SysDb>,
         dispatcher: Box<dyn Receiver<TaskMessage>>,
         blockfile_provider: BlockfileProvider,
     ) -> Self {
@@ -247,7 +247,7 @@ impl CountQueryOrchestrator {
 
     async fn get_metadata_segment_from_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         metadata_segment_id: &Uuid,
     ) -> Result<Segment, Box<dyn ChromaError>> {
         let segments = sysdb
@@ -279,7 +279,7 @@ impl CountQueryOrchestrator {
 
     async fn get_record_segment_from_collection_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         collection_id: &Uuid,
     ) -> Result<Segment, Box<dyn ChromaError>> {
         let segments = sysdb
@@ -310,7 +310,7 @@ impl CountQueryOrchestrator {
 
     async fn get_collection_from_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         collection_id: &Uuid,
         ctx: &ComponentContext<Self>,
     ) -> Result<Collection, Box<dyn ChromaError>> {
@@ -451,7 +451,7 @@ impl MetadataQueryOrchestrator {
         metadata_segment_id: &Uuid,
         query_ids: Option<Vec<String>>,
         log: Box<dyn Log>,
-        sysdb: Box<dyn SysDb>,
+        sysdb: Box<SysDb>,
         dispatcher: Box<dyn Receiver<TaskMessage>>,
         blockfile_provider: BlockfileProvider,
         where_clause: Option<Where>,
@@ -605,7 +605,7 @@ impl MetadataQueryOrchestrator {
 
     async fn get_metadata_segment_from_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         metadata_segment_id: &Uuid,
     ) -> Result<Segment, Box<dyn ChromaError>> {
         let segments = sysdb
@@ -637,7 +637,7 @@ impl MetadataQueryOrchestrator {
 
     async fn get_record_segment_from_collection_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         collection_id: &Uuid,
     ) -> Result<Segment, Box<dyn ChromaError>> {
         let segments = sysdb
@@ -668,7 +668,7 @@ impl MetadataQueryOrchestrator {
 
     async fn get_collection_from_id(
         &self,
-        mut sysdb: Box<dyn SysDb>,
+        mut sysdb: Box<SysDb>,
         collection_id: &Uuid,
         ctx: &ComponentContext<Self>,
     ) -> Result<Collection, Box<dyn ChromaError>> {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -35,7 +35,7 @@ pub struct WorkerServer {
     dispatcher: Option<Box<dyn Receiver<TaskMessage>>>,
     // Service dependencies
     log: Box<dyn Log>,
-    sysdb: Box<dyn SysDb>,
+    sysdb: Box<SysDb>,
     hnsw_index_provider: HnswIndexProvider,
     blockfile_provider: BlockfileProvider,
     port: u16,

--- a/rust/worker/src/sysdb/mod.rs
+++ b/rust/worker/src/sysdb/mod.rs
@@ -8,10 +8,10 @@ use crate::errors::ChromaError;
 
 pub(crate) async fn from_config(
     config: &SysDbConfig,
-) -> Result<Box<dyn sysdb::SysDb>, Box<dyn ChromaError>> {
+) -> Result<Box<sysdb::SysDb>, Box<dyn ChromaError>> {
     match &config {
-        crate::sysdb::config::SysDbConfig::Grpc(_) => {
-            Ok(Box::new(sysdb::GrpcSysDb::try_from_config(config).await?))
-        }
+        crate::sysdb::config::SysDbConfig::Grpc(_) => Ok(Box::new(sysdb::SysDb::Grpc(
+            sysdb::GrpcSysDb::try_from_config(config).await?,
+        ))),
     }
 }

--- a/rust/worker/src/sysdb/test_sysdb.rs
+++ b/rust/worker/src/sysdb/test_sysdb.rs
@@ -1,7 +1,3 @@
-use crate::sysdb::sysdb::FlushCompactionError;
-use crate::sysdb::sysdb::GetCollectionsError;
-use crate::sysdb::sysdb::GetSegmentsError;
-use crate::sysdb::sysdb::SysDb;
 use crate::types::Collection;
 use crate::types::FlushCompactionResponse;
 use crate::types::Segment;
@@ -9,13 +5,15 @@ use crate::types::SegmentFlushInfo;
 use crate::types::SegmentScope;
 use crate::types::SegmentType;
 use crate::types::Tenant;
-use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use super::sysdb::FlushCompactionError;
+use super::sysdb::GetCollectionsError;
 use super::sysdb::GetLastCompactionTimeError;
+use super::sysdb::GetSegmentsError;
 
 #[derive(Clone, Debug)]
 pub(crate) struct TestSysDb {
@@ -115,9 +113,8 @@ impl TestSysDb {
     }
 }
 
-#[async_trait]
-impl SysDb for TestSysDb {
-    async fn get_collections(
+impl TestSysDb {
+    pub(crate) async fn get_collections(
         &mut self,
         collection_id: Option<Uuid>,
         name: Option<String>,
@@ -141,7 +138,7 @@ impl SysDb for TestSysDb {
         Ok(collections)
     }
 
-    async fn get_segments(
+    pub(crate) async fn get_segments(
         &mut self,
         id: Option<Uuid>,
         r#type: Option<String>,
@@ -160,7 +157,7 @@ impl SysDb for TestSysDb {
         Ok(segments)
     }
 
-    async fn get_last_compaction_time(
+    pub(crate) async fn get_last_compaction_time(
         &mut self,
         tenant_ids: Vec<String>,
     ) -> Result<Vec<Tenant>, GetLastCompactionTimeError> {
@@ -182,7 +179,7 @@ impl SysDb for TestSysDb {
         Ok(tenants)
     }
 
-    async fn flush_compaction(
+    pub(crate) async fn flush_compaction(
         &mut self,
         tenant_id: String,
         collection_id: Uuid,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Makes sysdb an enum not dyn. We perfer an enum to dyn where the number of impls is fairly bounded - in this case 2 - the real one and a mock.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Existing tests - this is a non-functional refactor.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
