### PR TITLE
[BUG] Chroma crash with the new numpy version - update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ httpx>=0.27.0
 importlib-resources
 kubernetes>=28.1.0
 mmh3>=4.0.1
-numpy<2.0.0
+numpy>=1.22.5,<2.0.0
 onnxruntime>=1.14.1
 opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ httpx>=0.27.0
 importlib-resources
 kubernetes>=28.1.0
 mmh3>=4.0.1
-numpy>=1.22.5
+numpy<2.0.0
 onnxruntime>=1.14.1
 opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.24.0


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - NumPy just released their next major version and chroma is crashing
```
    import chromadb
  File "/usr/local/lib/python3.12/site-packages/chromadb/__init__.py", line 3, in <module>
    from chromadb.api.client import Client as ClientCreator
  File "/usr/local/lib/python3.12/site-packages/chromadb/api/__init__.py", line 7, in <module>
    from chromadb.api.models.Collection import Collection
  File "/usr/local/lib/python3.12/site-packages/chromadb/api/models/Collection.py", line 7, in <module>
    import chromadb.utils.embedding_functions as ef
  File "/usr/local/lib/python3.12/site-packages/chromadb/utils/embedding_functions.py", line 7, in <module>
    from chromadb.api.types import (
  File "/usr/local/lib/python3.12/site-packages/chromadb/api/types.py", line 102, in <module>
    ImageDType = Union[np.uint, np.int_, np.float_]
                                         ^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```
Suggesting locking before version 2 as a first Aid
