### PR TITLE
[CLN] Refactor log materializer to not need to pass in offset id explicitly for readers

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -112,7 +112,7 @@ impl CompactionManager {
                     dispatcher.clone(),
                     None,
                     None,
-                    Arc::new(AtomicU32::new(1)),
+                    Arc::new(AtomicU32::new(0)),
                 );
 
                 match orchestrator.run().await {

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -136,13 +136,7 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
                 }
             }
         };
-        // We use this really confusing pattern found in the rest of the code
-        // Where we create an effectively unused offset id for the read path
-        // This is very odd and confusing, and should be refactored, for now
-        // we just replicate the pattern here.
-        let offset_id = Arc::new(AtomicU32::new(1));
-        let log_materializer =
-            LogMaterializer::new(record_segment_reader, input.log.clone(), offset_id);
+        let log_materializer = LogMaterializer::new(record_segment_reader, input.log.clone(), None);
         let logs = match log_materializer.materialize().await {
             Ok(logs) => logs,
             Err(e) => {

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -282,9 +282,8 @@ mod tests {
                     };
                 }
             };
-            let curr_max_offset_id = Arc::new(AtomicU32::new(1));
             let materializer =
-                LogMaterializer::new(record_segment_reader, data, curr_max_offset_id);
+                LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -282,8 +282,7 @@ mod tests {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, None);
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -164,16 +164,8 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
         };
 
         // Step 1: Materialize the logs.
-        let mut offset_id = Arc::new(AtomicU32::new(1));
-        match record_segment_reader.as_ref() {
-            Some(reader) => {
-                offset_id = reader.get_current_max_offset_id();
-                offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            }
-            None => {}
-        };
         let materializer =
-            LogMaterializer::new(record_segment_reader, input.filtered_log.clone(), offset_id);
+            LogMaterializer::new(record_segment_reader, input.filtered_log.clone(), None);
         let mat_records = match materializer.materialize().await {
             Ok(records) => records,
             Err(e) => {
@@ -490,8 +482,7 @@ mod test {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, Arc::new(AtomicU32::new(1)));
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await
@@ -779,8 +770,7 @@ mod test {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, Arc::new(AtomicU32::new(1)));
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -152,16 +152,8 @@ impl Operator<MetadataFilteringInput, MetadataFilteringOutput> for MetadataFilte
             }
         };
         // Step 1: Materialize the logs.
-        let mut offset_id = Arc::new(AtomicU32::new(1));
-        match record_segment_reader.as_ref() {
-            Some(reader) => {
-                offset_id = reader.get_current_max_offset_id();
-                offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            }
-            None => {}
-        };
         let materializer =
-            LogMaterializer::new(record_segment_reader, input.log_record.clone(), offset_id);
+            LogMaterializer::new(record_segment_reader, input.log_record.clone(), None);
         let mat_records = match materializer.materialize().await {
             Ok(records) => records,
             Err(e) => {
@@ -851,8 +843,7 @@ mod test {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, Arc::new(AtomicU32::new(1)));
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await
@@ -1064,8 +1055,7 @@ mod test {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, Arc::new(AtomicU32::new(1)));
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await
@@ -1248,8 +1238,7 @@ mod test {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, Arc::new(AtomicU32::new(1)));
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -135,7 +135,7 @@ impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator
         let materializer = LogMaterializer::new(
             record_segment_reader,
             input.chunk.clone(),
-            input.offset_id.clone(),
+            Some(input.offset_id.clone()),
         );
         // Materialize the logs.
         let res = match materializer.materialize().await {

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -390,10 +390,10 @@ impl CompactOrchestrator {
         match RecordSegmentReader::from_segment(record_segment, &self.blockfile_provider).await {
             Ok(reader) => {
                 self.curr_max_offset_id = reader.get_current_max_offset_id();
-                self.curr_max_offset_id
-                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             }
-            Err(_) => {}
+            Err(_) => {
+                self.curr_max_offset_id = Arc::new(AtomicU32::new(0));
+            }
         };
         self.record_segment = Some(record_segment.clone()); // auto deref.
 

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -260,24 +260,48 @@ pub(crate) struct LogMaterializer<'me> {
     // Is None when record segment is uninitialized.
     pub(crate) record_segment_reader: Option<RecordSegmentReader<'me>>,
     pub(crate) logs: Chunk<LogRecord>,
-    pub(crate) offset_id: Arc<AtomicU32>,
+    // Is None for readers. In that case, the materializer reads
+    // the current maximum from the record segment and uses that
+    // for materializing. Writers pass this value to the materializer
+    // because they need to share this across all log partitions.
+    pub(crate) curr_offset_id: Option<Arc<AtomicU32>>,
 }
 
 impl<'me> LogMaterializer<'me> {
     pub(crate) fn new(
         record_segment_reader: Option<RecordSegmentReader<'me>>,
         logs: Chunk<LogRecord>,
-        offset_id: Arc<AtomicU32>,
+        curr_offset_id: Option<Arc<AtomicU32>>,
     ) -> Self {
         Self {
             record_segment_reader,
             logs,
-            offset_id,
+            curr_offset_id,
         }
     }
     pub(crate) async fn materialize(
         &'me self,
     ) -> Result<Chunk<MaterializedLogRecord<'me>>, LogMaterializerError> {
+        let next_offset_id;
+        match self.curr_offset_id.as_ref() {
+            Some(curr_offset_id) => {
+                next_offset_id = curr_offset_id.clone();
+                next_offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+            None => {
+                match self.record_segment_reader.as_ref() {
+                    Some(reader) => {
+                        next_offset_id = reader.get_current_max_offset_id();
+                        next_offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    // This means that the segment is uninitialized so counting starts
+                    // from 1.
+                    None => {
+                        next_offset_id = Arc::new(AtomicU32::new(1));
+                    }
+                };
+            }
+        }
         // Populate entries that are present in the record segment.
         let mut existing_id_to_materialized: HashMap<&str, MaterializedLogRecord> = HashMap::new();
         let mut new_id_to_materialized: HashMap<&str, MaterializedLogRecord> = HashMap::new();
@@ -327,9 +351,8 @@ impl<'me> LogMaterializer<'me> {
                     if !existing_id_to_materialized.contains_key(log_record.record.id.as_str())
                         && !new_id_to_materialized.contains_key(log_record.record.id.as_str())
                     {
-                        let next_offset_id = self
-                            .offset_id
-                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let next_offset_id =
+                            next_offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                         let materialized_record = match MaterializedLogRecord::try_from((
                             &log_record.record,
                             next_offset_id,
@@ -463,9 +486,8 @@ impl<'me> LogMaterializer<'me> {
                         record_from_map.final_operation = Operation::Add;
                     } else {
                         // Insert.
-                        let next_offset_id = self
-                            .offset_id
-                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let next_offset_id =
+                            next_offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                         let materialized_record = match MaterializedLogRecord::try_from((
                             &log_record.record,
                             next_offset_id,
@@ -619,8 +641,7 @@ mod tests {
                     };
                 }
             };
-            let materializer =
-                LogMaterializer::new(record_segment_reader, data, Arc::new(AtomicU32::new(1)));
+            let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
                 .await
@@ -685,7 +706,7 @@ mod tests {
         let materializer = LogMaterializer {
             record_segment_reader: Some(reader),
             logs: data,
-            offset_id: Arc::new(AtomicU32::new(3)),
+            curr_offset_id: None,
         };
         let res = materializer
             .materialize()


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 Readers can pass None for the current offset id when materializing and the materializer takes care of using the correct value by reading from the record segment. Writers still need to pass it in since it is shared by writers of different partitions.

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
