### PR TITLE
[BUG] Lock numpy to < 2.0.0 across all reqs and pyproject.toml

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'numpy >= 1.22.5',
+  'numpy >= 1.22.5, < 2.0.0',
   'opentelemetry-api>=1.2.0',
   'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
   'opentelemetry-sdk>=1.2.0',

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.22.5
+numpy >= 1.22.5, < 2.0.0
 opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.2.0
 opentelemetry-sdk>=1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   'chroma-hnswlib==0.7.3',
   'fastapi >= 0.95.2',
   'uvicorn[standard] >= 0.18.3',
-  'numpy >= 1.22.5',
+  'numpy >= 1.22.5, < 2.0.0',
   'posthog >= 2.4.0',
   'typing_extensions >= 4.5.0',
   'onnxruntime >= 1.14.1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ httpx>=0.27.0
 importlib-resources
 kubernetes>=28.1.0
 mmh3>=4.0.1
-numpy>=1.22.5
+numpy>=1.22.5, <2.0.0
 onnxruntime>=1.14.1
 opentelemetry-api>=1.2.0
 opentelemetry-exporter-otlp-proto-grpc>=1.24.0


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Numpy 2.0 has some type changes which break our code. This was flagged by @itayB in #2352 (Thank you!). We need to extend that PR a bit to include other requirements for the thin client, as well as the pyproject.toml.
	 - Note: We could fix these type issues but Onnxruntime does not yet support python 2.0 - which we depend on (https://github.com/microsoft/onnxruntime/issues/21063)
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
We may want to update our docs? I am not sure what makes sense here - input solicited.
