### PR TITLE
[ENH] Emulate sqlite fts in brute force metadata filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4650,6 +4650,7 @@ dependencies = [
  "prost-types",
  "rand",
  "rayon",
+ "regex",
  "roaring",
  "schemars",
  "serde",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 opentelemetry = { version = "0.19.0", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = "0.12.0"
 shuttle = "0.7.1"
-
+regex = "1.10.5"
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use core::panic;
 use futures::stream::Count;
+use regex::Regex;
 use roaring::RoaringBitmap;
 use std::{
     collections::{HashMap, HashSet},
@@ -522,7 +523,10 @@ impl Operator<MetadataFilteringInput, MetadataFilteringOutput> for MetadataFilte
                         }
                         match record.merged_document_ref() {
                             Some(doc) => {
-                                if doc.contains(query) {
+                                // Emulate sqlite behavior. _ and % match to any character in sqlite.
+                                let normalized_query = query.replace("_", ".").replace("%", ".");
+                                let re = Regex::new(normalized_query.as_str()).unwrap();
+                                if re.is_match(doc) {
                                     matching_contains.push(record.offset_id as i32);
                                 }
                             }

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -517,15 +517,15 @@ impl Operator<MetadataFilteringInput, MetadataFilteringOutput> for MetadataFilte
                     let mut matching_contains = vec![];
                     // Upstream sorts materialized records by offset id so matching_contains
                     // will be sorted.
+                    // Emulate sqlite behavior. _ and % match to any character in sqlite.
+                    let normalized_query = query.replace("_", ".").replace("%", ".");
+                    let re = Regex::new(normalized_query.as_str()).unwrap();
                     for (record, _) in mat_records.iter() {
                         if record.final_operation == Operation::Delete {
                             continue;
                         }
                         match record.merged_document_ref() {
                             Some(doc) => {
-                                // Emulate sqlite behavior. _ and % match to any character in sqlite.
-                                let normalized_query = query.replace("_", ".").replace("%", ".");
-                                let re = Regex::new(normalized_query.as_str()).unwrap();
                                 if re.is_match(doc) {
                                     matching_contains.push(record.offset_id as i32);
                                 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
    Rust Brute force metadata filtering does not account for % and _ in full text search. In single node, sqlite matches any character for these two. Fix replaces % and _ with . and performs a regex search now.

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
