### PR TITLE
[ENH] Enable test_embeddings

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -93,6 +93,7 @@ jobs:
                    "chromadb/test/property/test_collections.py",
                    "chromadb/test/property/test_add.py",
                    "chromadb/test/property/test_filtering.py",
+                   "chromadb/test/property/test_embeddings.py",
                    "chromadb/test/property/test_collections_with_database_tenant.py",
                    "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
                    "chromadb/test/ingest/test_producer_consumer.py",

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -214,7 +214,7 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
             i += 1;
         }
 
-        trace!("Brute force Knn result. distances: {:?}", sorted_distances);
+        tracing::info!("Brute force Knn result. distances: {:?}", sorted_distances);
         Ok(BruteForceKnnOperatorOutput {
             user_ids: sorted_user_ids,
             embeddings: sorted_embeddings,

--- a/rust/worker/src/execution/orchestration/get_vectors.rs
+++ b/rust/worker/src/execution/orchestration/get_vectors.rs
@@ -156,6 +156,7 @@ impl GetVectorsOrchestrator {
             .expect("Invariant violation. Record segment is not set.");
         let blockfile_provider = self.blockfile_provider.clone();
         let operator = GetVectorsOperator::new();
+        tracing::info!("get_vectors with search ids {:?}", self.search_user_ids);
         let input = GetVectorsOperatorInput::new(
             record_segment.clone(),
             blockfile_provider,

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -166,6 +166,12 @@ impl HnswQueryOrchestrator {
         let finish_dependency_count = query_vectors.len() as u32;
         // pre-allocate the result vectors
         let results = Some(Vec::with_capacity(query_vectors.len()));
+        tracing::info!(
+            "Performing KNN for k = {}, allowed_ids = {:?}, num query vectors = {:?}",
+            k,
+            allowed_ids,
+            query_vectors.len()
+        );
 
         HnswQueryOrchestrator {
             state: ExecutionState::Pending,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
    - Fixes get_vectors brute force add and update logic to account for uninitialized segment
    - Fixes get_vectors brute force update logic to also account for adds that happened in the log and not in the segment
    - Fixes get_vectors to return ids and embeddings in the same order as the input search ids. This is necessary since the FE relies on this
    - Fixes get_vectors to also get triggered on updates/deletes of records that were added in the log itself
    - Enables test_embeddings for cluster integration tests

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
