### PR TITLE
[TST] Property Test Generation Fixes

### DIFF
--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -163,12 +163,6 @@ def _exact_distances(
     return np.argsort(distances).tolist(), distances.tolist()
 
 
-def is_metadata_valid(normalized_record_set: NormalizedRecordSet) -> bool:
-    if normalized_record_set["metadatas"] is None:
-        return True
-    return not any([len(m) == 0 for m in normalized_record_set["metadatas"]])
-
-
 def ann_accuracy(
     collection: Collection,
     record_set: RecordSet,

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -10,16 +10,13 @@ import chromadb.api.types as types
 import re
 from hypothesis.strategies._internal.strategies import SearchStrategy
 from chromadb.test.conftest import NOT_CLUSTER_ONLY
-
 from dataclasses import dataclass
-
 from chromadb.api.types import (
     Documents,
     Embeddable,
     EmbeddingFunction,
     Embeddings,
     Metadata,
-    OneOrMany,
 )
 from chromadb.types import LiteralValue, WhereOperator, LogicalOperator
 
@@ -423,7 +420,9 @@ def recordsets(
     num_metadata = num_unique_metadata if num_unique_metadata is not None else len(ids)
     generated_metadatas = draw(
         st.lists(
-            metadata(collection, min_size=min_size, max_size=max_size),
+            metadata(
+                collection, min_size=min_metadata_size, max_size=max_metadata_size
+            ),
             min_size=num_metadata,
             max_size=num_metadata,
         )

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -60,7 +60,7 @@ class RecordSet(TypedDict):
 
     ids: Union[types.ID, List[types.ID]]
     embeddings: Optional[Union[types.Embeddings, types.Embedding]]
-    metadatas: Optional[Union[List[Optional[types.Metadata]], Optional[types.Metadata]]]
+    metadatas: Optional[Union[List[Optional[types.Metadata]], types.Metadata]]
     documents: Optional[Union[List[types.Document], types.Document]]
 
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -19,7 +19,6 @@ from chromadb.api.types import (
     EmbeddingFunction,
     Embeddings,
     Metadata,
-    OneOrMany,
 )
 from chromadb.types import LiteralValue, WhereOperator, LogicalOperator
 
@@ -61,7 +60,7 @@ class RecordSet(TypedDict):
 
     ids: Union[types.ID, List[types.ID]]
     embeddings: Optional[Union[types.Embeddings, types.Embedding]]
-    metadatas: OneOrMany[Optional[Metadata]] | None
+    metadatas: Optional[Union[List[Optional[types.Metadata]], Optional[types.Metadata]]]
     documents: Optional[Union[List[types.Document], types.Document]]
 
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -61,11 +61,7 @@ class RecordSet(TypedDict):
 
     ids: Union[types.ID, List[types.ID]]
     embeddings: Optional[Union[types.Embeddings, types.Embedding]]
-<<<<<<< HEAD
     metadatas: Optional[Union[List[Optional[types.Metadata]], types.Metadata]]
-=======
-    metadatas: OneOrMany[Optional[Metadata]] | None
->>>>>>> d0a7570a ([TST] Make metadata strategy return valid metadata and remove invariant in favor of point test)
     documents: Optional[Union[List[types.Document], types.Document]]
 
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -19,6 +19,7 @@ from chromadb.api.types import (
     EmbeddingFunction,
     Embeddings,
     Metadata,
+    OneOrMany,
 )
 from chromadb.types import LiteralValue, WhereOperator, LogicalOperator
 
@@ -60,7 +61,11 @@ class RecordSet(TypedDict):
 
     ids: Union[types.ID, List[types.ID]]
     embeddings: Optional[Union[types.Embeddings, types.Embedding]]
+<<<<<<< HEAD
     metadatas: Optional[Union[List[Optional[types.Metadata]], types.Metadata]]
+=======
+    metadatas: OneOrMany[Optional[Metadata]] | None
+>>>>>>> d0a7570a ([TST] Make metadata strategy return valid metadata and remove invariant in favor of point test)
     documents: Optional[Union[List[types.Document], types.Document]]
 
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -61,13 +61,15 @@ def test_add_small(
 @settings(
     deadline=None,
     parent=override_hypothesis_profile(
-        normal=hypothesis.settings(
-            max_examples=10, suppress_health_check=[hypothesis.HealthCheck.too_slow]
-        ),
-        fast=hypothesis.settings(
-            max_examples=5, suppress_health_check=[hypothesis.HealthCheck.too_slow]
-        ),
+        normal=hypothesis.settings(max_examples=10),
+        fast=hypothesis.settings(max_examples=5),
     ),
+    suppress_health_check=[
+        hypothesis.HealthCheck.too_slow,
+        hypothesis.HealthCheck.data_too_large,
+        hypothesis.HealthCheck.large_base_example,
+        hypothesis.HealthCheck.function_scoped_fixture,
+    ],
 )
 def test_add_medium(
     api: ServerAPI,

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -22,9 +22,12 @@ from chromadb.utils.batch_utils import create_batches
 collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="coll")
 
 
+# Hypothesis tends to generate smaller values so we explicitly segregate the
+# the tests into tiers, Small, Medium. Hypothesis struggles to generate large
+# record sets so we explicitly create a large record set without using Hypothesis
 @given(
     collection=collection_st,
-    record_set=strategies.recordsets(collection_st),
+    record_set=strategies.recordsets(collection_st, min_size=1, max_size=500),
     should_compact=st.booleans(),
 )
 @settings(
@@ -34,7 +37,44 @@ collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="co
         fast=hypothesis.settings(max_examples=200),
     ),
 )
-def test_add(
+def test_add_small(
+    api: ServerAPI,
+    collection: strategies.Collection,
+    record_set: strategies.RecordSet,
+    should_compact: bool,
+) -> None:
+    _test_add(api, collection, record_set, should_compact)
+
+
+@given(
+    collection=collection_st,
+    record_set=strategies.recordsets(
+        collection_st, min_size=250, max_size=500, num_unique_metadata=5
+    ),
+    should_compact=st.booleans(),
+)
+@settings(
+    deadline=None,
+    parent=override_hypothesis_profile(
+        normal=hypothesis.settings(max_examples=5),
+        fast=hypothesis.settings(max_examples=5),
+    ),
+    suppress_health_check=[
+        hypothesis.HealthCheck.data_too_large,
+        hypothesis.HealthCheck.too_slow,
+        hypothesis.HealthCheck.function_scoped_fixture,
+    ],
+)
+def test_add_medium(
+    api: ServerAPI,
+    collection: strategies.Collection,
+    record_set: strategies.RecordSet,
+    should_compact: bool,
+) -> None:
+    _test_add(api, collection, record_set, should_compact)
+
+
+def _test_add(
     api: ServerAPI,
     collection: strategies.Collection,
     record_set: strategies.RecordSet,
@@ -54,18 +94,22 @@ def test_add(
         print("WRAPPING")
         normalized_record_set = invariants.wrap_all(record_set)
         print("WRAPPED")
+        print("LEN OF RECORD SET", len(normalized_record_set["ids"]))
 
         # TODO: The type of add() is incorrect as it does not allow for metadatas
         # like [{"a": 1}, None, {"a": 3}]
         coll.add(**record_set)  # type: ignore
         print("ADDED")
-        if not NOT_CLUSTER_ONLY:
+        if (
+            not NOT_CLUSTER_ONLY
+            and should_compact
+            and len(normalized_record_set["ids"]) > 10
+        ):
             # Only wait for compaction if the size of the collection is
             # some minimal size
-            if should_compact and len(normalized_record_set["ids"]) > 10:
-                initial_version = coll.get_model()["version"]
-                # Wait for the model to be updated
-                wait_for_version_increase(api, collection.name, initial_version)
+            initial_version = coll.get_model()["version"]
+            # Wait for the model to be updated
+            wait_for_version_increase(api, collection.name, initial_version)
 
         print("INVAR CHECK")
         invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
@@ -88,6 +132,8 @@ def test_add(
     print("PASSED")
 
 
+# Hypothesis struggles to generate large record sets so we explicitly create
+# a large record set
 def create_large_recordset(
     min_size: int = 45000,
     max_size: int = 50000,
@@ -107,9 +153,12 @@ def create_large_recordset(
     return cast(strategies.RecordSet, record_set)
 
 
-@given(collection=collection_st)
-@settings(deadline=None, max_examples=1)
-def test_add_large(api: ServerAPI, collection: strategies.Collection) -> None:
+@given(collection=collection_st, should_compact=st.booleans())
+@settings(deadline=None, max_examples=5)
+def test_add_large(
+    api: ServerAPI, collection: strategies.Collection, should_compact: bool
+) -> None:
+    print("LARGE SHOULD COMPACT", should_compact)
     reset(api)
 
     record_set = create_large_recordset(
@@ -132,6 +181,12 @@ def test_add_large(api: ServerAPI, collection: strategies.Collection) -> None:
         documents=cast(List[str], record_set["documents"]),
     ):
         coll.add(*batch)
+
+    if not NOT_CLUSTER_ONLY and should_compact:
+        initial_version = coll.get_model()["version"]
+        # Wait for the model to be updated
+        wait_for_version_increase(api, collection.name, initial_version)
+
     invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
 
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -61,8 +61,12 @@ def test_add_small(
 @settings(
     deadline=None,
     parent=override_hypothesis_profile(
-        normal=hypothesis.settings(max_examples=5),
-        fast=hypothesis.settings(max_examples=5),
+        normal=hypothesis.settings(
+            max_examples=10, suppress_health_check=[hypothesis.HealthCheck.too_slow]
+        ),
+        fast=hypothesis.settings(
+            max_examples=5, suppress_health_check=[hypothesis.HealthCheck.too_slow]
+        ),
     ),
 )
 def test_add_medium(

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -171,8 +171,10 @@ def test_add_large(
 
     if not NOT_CLUSTER_ONLY and should_compact:
         initial_version = coll.get_model()["version"]
-        # Wait for the model to be updated
-        wait_for_version_increase(api, collection.name, initial_version)
+        # Wait for the model to be updated, since the record set is larger, add some additional time
+        wait_for_version_increase(
+            api, collection.name, initial_version, additional_time=240
+        )
 
     invariants.count(coll, cast(strategies.RecordSet, normalized_record_set))
 

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -28,6 +28,7 @@ from collections import defaultdict
 import chromadb.test.property.invariants as invariants
 from chromadb.test.conftest import reset
 import numpy as np
+import uuid
 
 
 traces: DefaultDict[str, int] = defaultdict(lambda: 0)
@@ -231,14 +232,16 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
                             Dict[str, Union[str, int, float]], record_set_state
                         )
                         if normalized_record_set["metadatas"][idx] is not None:
-                            record_set_state.update(normalized_record_set["metadatas"][idx])
+                            record_set_state.update(
+                                normalized_record_set["metadatas"][idx]
+                            )
                         else:
                             # None in the update metadata is a no-op
                             pass
                     else:
-                        self.record_set_state["metadatas"][target_idx] = (
-                            normalized_record_set["metadatas"][idx]
-                        )
+                        self.record_set_state["metadatas"][
+                            target_idx
+                        ] = normalized_record_set["metadatas"][idx]
                 if normalized_record_set["documents"] is not None:
                     self.record_set_state["documents"][
                         target_idx
@@ -295,17 +298,54 @@ def test_embeddings_state(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> N
 
 def test_update_none(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> None:
     state = EmbeddingStateMachine(api)
-    state.initialize(collection=strategies.Collection(name='A00', metadata={'hnsw:construction_ef': 128, 'hnsw:search_ef': 128, 'hnsw:M': 128}, embedding_function=None, id=uuid.UUID('2fb0c945-b877-42ab-9417-bfe0f6b172af'), dimension=2, dtype=numpy.float16, known_metadata_keys={}, known_document_keywords=[], has_documents=False, has_embeddings=True))
+    state.initialize(
+        collection=strategies.Collection(
+            name="A00",
+            metadata={
+                "hnsw:construction_ef": 128,
+                "hnsw:search_ef": 128,
+                "hnsw:M": 128,
+            },
+            embedding_function=None,
+            id=uuid.UUID("2fb0c945-b877-42ab-9417-bfe0f6b172af"),
+            dimension=2,
+            dtype=np.float16,
+            known_metadata_keys={},
+            known_document_keywords=[],
+            has_documents=False,
+            has_embeddings=True,
+        )
+    )
     state.ann_accuracy()
     state.count()
     state.fields_match()
     state.no_duplicates()
-    v1, v2, v3, v4, v5 = state.add_embeddings(record_set={'ids': ['0', '1', '2', '3', '4'], 'embeddings': [[0.09765625, 0.430419921875],[0.20556640625, 0.08978271484375],[-0.1527099609375, 0.291748046875],[-0.12481689453125, 0.78369140625],[0.92724609375, -0.233154296875]],'metadatas': [None, None, None, None, None],'documents': None})
+    v1, v2, v3, v4, v5 = state.add_embeddings(
+        record_set={
+            "ids": ["0", "1", "2", "3", "4"],
+            "embeddings": [
+                [0.09765625, 0.430419921875],
+                [0.20556640625, 0.08978271484375],
+                [-0.1527099609375, 0.291748046875],
+                [-0.12481689453125, 0.78369140625],
+                [0.92724609375, -0.233154296875],
+            ],
+            "metadatas": [None, None, None, None, None],
+            "documents": None,
+        }
+    )
     state.ann_accuracy()
     state.count()
     state.fields_match()
     state.no_duplicates()
-    state.update_embeddings(record_set={'ids': [v5],'embeddings': [[0.58349609375, 0.05780029296875]],'metadatas': [{v1: v1}],'documents': None})
+    state.update_embeddings(
+        record_set={
+            "ids": [v5],
+            "embeddings": [[0.58349609375, 0.05780029296875]],
+            "metadatas": [{v1: v1}],
+            "documents": None,
+        }
+    )
     state.ann_accuracy()
     state.teardown()
 

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -230,7 +230,15 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
                         record_set_state = cast(
                             Dict[str, Union[str, int, float]], record_set_state
                         )
-                        record_set_state.update(normalized_record_set["metadatas"][idx])
+                        if normalized_record_set["metadatas"][idx] is not None:
+                            record_set_state.update(normalized_record_set["metadatas"][idx])
+                        else:
+                            # None in the update metadata is a no-op
+                            pass
+                    else:
+                        self.record_set_state["metadatas"][target_idx] = (
+                            normalized_record_set["metadatas"][idx]
+                        )
                 if normalized_record_set["documents"] is not None:
                     self.record_set_state["documents"][
                         target_idx
@@ -283,6 +291,23 @@ def test_embeddings_state(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> N
         lambda: EmbeddingStateMachine(api),
     )  # type: ignore
     print_traces()
+
+
+def test_update_none(caplog: pytest.LogCaptureFixture, api: ServerAPI) -> None:
+    state = EmbeddingStateMachine(api)
+    state.initialize(collection=strategies.Collection(name='A00', metadata={'hnsw:construction_ef': 128, 'hnsw:search_ef': 128, 'hnsw:M': 128}, embedding_function=None, id=uuid.UUID('2fb0c945-b877-42ab-9417-bfe0f6b172af'), dimension=2, dtype=numpy.float16, known_metadata_keys={}, known_document_keywords=[], has_documents=False, has_embeddings=True))
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.no_duplicates()
+    v1, v2, v3, v4, v5 = state.add_embeddings(record_set={'ids': ['0', '1', '2', '3', '4'], 'embeddings': [[0.09765625, 0.430419921875],[0.20556640625, 0.08978271484375],[-0.1527099609375, 0.291748046875],[-0.12481689453125, 0.78369140625],[0.92724609375, -0.233154296875]],'metadatas': [None, None, None, None, None],'documents': None})
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.no_duplicates()
+    state.update_embeddings(record_set={'ids': [v5],'embeddings': [[0.58349609375, 0.05780029296875]],'metadatas': [{v1: v1}],'documents': None})
+    state.ann_accuracy()
+    state.teardown()
 
 
 def test_multi_add(api: ServerAPI) -> None:

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -102,11 +102,6 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
         if len(normalized_record_set["ids"]) > 0:
             trace("add_more_embeddings")
 
-        if not invariants.is_metadata_valid(normalized_record_set):
-            with pytest.raises(Exception):
-                self.collection.add(**normalized_record_set)
-            return multiple()
-
         intersection = set(normalized_record_set["ids"]).intersection(
             self.record_set_state["ids"]
         )
@@ -159,14 +154,6 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
         trace("update embeddings")
         self.on_state_change(EmbeddingStateMachineStates.update_embeddings)
 
-        normalized_record_set: strategies.NormalizedRecordSet = invariants.wrap_all(
-            record_set
-        )
-        if not invariants.is_metadata_valid(normalized_record_set):
-            with pytest.raises(Exception):
-                self.collection.update(**normalized_record_set)
-            return
-
         self.collection.update(**record_set)
         self._upsert_embeddings(record_set)
 
@@ -183,14 +170,6 @@ class EmbeddingStateMachine(RuleBasedStateMachine):
     def upsert_embeddings(self, record_set: strategies.RecordSet) -> None:
         trace("upsert embeddings")
         self.on_state_change(EmbeddingStateMachineStates.upsert_embeddings)
-
-        normalized_record_set: strategies.NormalizedRecordSet = invariants.wrap_all(
-            record_set
-        )
-        if not invariants.is_metadata_valid(normalized_record_set):
-            with pytest.raises(Exception):
-                self.collection.upsert(**normalized_record_set)
-            return
 
         self.collection.upsert(**record_set)
         self._upsert_embeddings(record_set)

--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -190,11 +190,6 @@ def test_filterable_metadata_get(
         embedding_function=collection.embedding_function,
     )
 
-    if not invariants.is_metadata_valid(invariants.wrap_all(record_set)):
-        with pytest.raises(Exception):
-            coll.add(**record_set)
-        return
-
     coll.add(**record_set)
     for filter in filters:
         result_ids = coll.get(**filter)["ids"]
@@ -238,11 +233,6 @@ def test_filterable_metadata_get_limit_offset(
         embedding_function=collection.embedding_function,
     )
 
-    if not invariants.is_metadata_valid(invariants.wrap_all(record_set)):
-        with pytest.raises(Exception):
-            coll.add(**record_set)
-        return
-
     coll.add(**record_set)
     for filter in filters:
         # add limit and offset to filter
@@ -283,11 +273,6 @@ def test_filterable_metadata_query(
         embedding_function=collection.embedding_function,
     )
     normalized_record_set = invariants.wrap_all(record_set)
-
-    if not invariants.is_metadata_valid(normalized_record_set):
-        with pytest.raises(Exception):
-            coll.add(**record_set)
-        return
 
     coll.add(**record_set)
     total_count = len(normalized_record_set["ids"])

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -81,11 +81,6 @@ def test_persist(
         embedding_function=collection_strategy.embedding_function,
     )
 
-    if not invariants.is_metadata_valid(invariants.wrap_all(embeddings_strategy)):
-        with pytest.raises(Exception):
-            coll.add(**embeddings_strategy)
-        return
-
     coll.add(**embeddings_strategy)
 
     invariants.count(coll, embeddings_strategy)

--- a/chromadb/test/utils/wait_for_version_increase.py
+++ b/chromadb/test/utils/wait_for_version_increase.py
@@ -11,10 +11,10 @@ def get_collection_version(api: ServerAPI, collection_name: str) -> int:
 
 
 def wait_for_version_increase(
-    api: ServerAPI, collection_name: str, initial_version: int
+    api: ServerAPI, collection_name: str, initial_version: int, additional_time: int = 0
 ) -> None:
     timeout = COMPACTION_SLEEP
-    initial_time = time.time()
+    initial_time = time.time() + additional_time
 
     while get_collection_version(api, collection_name) == initial_version:
         time.sleep(TIMEOUT_INTERVAL)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
The primary intent of this PR is to remove the is_metadata_valid invariant which was a workaround for our metadata strategy generating faulty metadata and then us special casing all uses of the record set strategy to handle invalid generations. This PR patches the metadata generation to not generate invalid metadata.

- Adds modes in test_add to add a medium sized record set. This was initially timing out in hypothesis's generation. Hypothesis bounds the buffer size of the bytes it uses to do random generation, so generating larger metadata was resulting in examples being marked at OVERRUN by conjecture (gleaned from issues like https://github.com/HypothesisWorks/hypothesis/issues/3999 + reading hypothesis code + stepping through it). This PR adds the ability to generate N fixed metadata entries and uniformly distribute them over the record set, reducing the overall entropy. 

- Fixes a bug that test_embeddings was not handling None as a possible metadata state, since this state was never generated. Added an explicit test for this.

- Fixes a bug in the reference filtering implementation in test_filtering that did not handle None metadata since that state was never generated.


This PR is forced to touch types related to metadata, which are incorrect and cause typing errors. I ignored the errors to minimize the surface area of this change and defer those changes to the pass mentioned in https://github.com/chroma-core/chroma/issues/2292.

## Test plan
*How are these changes tested?*
These changes are covered by existing tests, and 
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
No external changes required.
