### PR TITLE
[DOC]: Fix a typo in comment section in chromadb/db/system.py

### DIFF
--- a/chromadb/db/system.py
+++ b/chromadb/db/system.py
@@ -88,11 +88,11 @@ class SysDB(Component):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Tuple[Collection, bool]:
-        """Create a new collection any associated resources
+        """Create a new collection and associated resources
         in the SysDB. If get_or_create is True, the
         collection will be created if one with the same name does not exist.
         The metadata will be updated using the same protocol as update_collection. If get_or_create
-        is False and the collection already exists, a error will be raised.
+        is False and the collection already exists, an error will be raised.
 
         Returns a tuple of the created collection and a boolean indicating whether the
         collection was created or not.


### PR DESCRIPTION
## Description of changes

Fix a typo in comment section in chromadb/db/system.py

```

"""
Create a new collection any (-> and) associated resources
        in the SysDB.

"""
```

## Test plan

Do not need test

## Documentation Change

Not public facing API documentation change.