### PR TITLE
[DOC] fix: add github link and update discord invite link

### DIFF
--- a/docs/docs.trychroma.com/pages/deployment/migration.md
+++ b/docs/docs.trychroma.com/pages/deployment/migration.md
@@ -9,7 +9,7 @@ Chroma's commitment is whenever schema or data format change, we will provide a 
 Specifically we will announce schema changes on:
 
 - Discord ([#migrations channel](https://discord.com/channels/1073293645303795742/1129286514845691975))
-- Github (here)
+- Github ([here](https://github.com/chroma-core/chroma/issues))
 - Email listserv [Sign up](https://airtable.com/shrHaErIs1j9F97BE)
 
 We will aim to provide:

--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -285,7 +285,7 @@ console.log(results)
 <!-- - Check out [💡 Examples](/examples) of what you can build with Chroma -->
 - Read the [🧪 Usage Guide](/guides) to learn more about the API
 - Learn how to [☁️ Deploy Chroma](/deployment) to a server
-- Join Chroma's [Discord Community](https://discord.gg/Fk2pH7k6) to ask questions and get help
+- Join Chroma's [Discord Community](https://discord.com/invite/MMeYNTmh3x) to ask questions and get help
 - Follow Chroma on [Twitter (@trychroma)](https://twitter.com/trychroma) for updates
 
 {% hint style="info" %}


### PR DESCRIPTION
## Description of changes

Updates docs to:
* adds a link Github issues on the migrations page
* updates the discord invite link (seems the other one expired)

## Test plan
previewed the markdown locally and links worked.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a didn't update these
