### PR TITLE
[ENH] catch panics in tasks

### DIFF
--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -374,7 +374,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn panics_should_bubble() {
+    async fn panic_in_operator_should_be_caught() {
         let system = System::new();
         let dispatcher = Dispatcher::new(THREAD_COUNT, 1000, 1000);
         let dispatcher_handle = system.start_component(dispatcher);
@@ -391,6 +391,11 @@ mod tests {
         assert_eq!(received_messages.lock().len(), 1);
         let task_result = received_messages.lock().pop().unwrap().into_inner();
         assert!(task_result.is_err());
-        assert!(matches!(task_result.unwrap_err(), TaskError::Panic));
+
+        if let TaskError::Panic(panic_message) = task_result.unwrap_err() {
+            assert_eq!(panic_message, Some("Intentional panic".to_string()));
+        } else {
+            panic!("Expected panic error");
+        }
     }
 }

--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -1,6 +1,11 @@
-use crate::system::Receiver;
+use crate::{errors, system::Receiver};
 use async_trait::async_trait;
-use std::fmt::Debug;
+use futures::FutureExt;
+use std::{
+    fmt::Debug,
+    panic::{AssertUnwindSafe, PanicInfo},
+};
+use thiserror::Error;
 use uuid::Uuid;
 
 /// An operator takes a generic input and returns a generic output.
@@ -17,16 +22,48 @@ where
     async fn run(&self, input: &I) -> Result<O, Self::Error>;
 }
 
+#[derive(Debug, Error)]
+pub(super) enum TaskError<Error> {
+    #[error("Task error: {0}")]
+    Other(Error),
+    #[error("Task panicked")]
+    Panic,
+}
+
+impl<Error> errors::ChromaError for TaskError<Error>
+where
+    Error: std::error::Error + errors::ChromaError + Send,
+{
+    fn code(&self) -> errors::ErrorCodes {
+        match self {
+            TaskError::Other(error) => error.code(),
+            TaskError::Panic => errors::ErrorCodes::UNKNOWN,
+        }
+    }
+}
+
+impl errors::ChromaError for Box<dyn errors::ChromaError> {
+    fn code(&self) -> errors::ErrorCodes {
+        (**self).code()
+    }
+}
+
+impl From<TaskError<Box<dyn errors::ChromaError>>> for Box<dyn errors::ChromaError> {
+    fn from(error: TaskError<Box<dyn errors::ChromaError>>) -> Self {
+        Box::new(error)
+    }
+}
+
 /// A task result is a wrapper around the result of a task.
 /// It contains the task id for tracking purposes.
 #[derive(Debug)]
 pub(super) struct TaskResult<Output, Error> {
-    result: Result<Output, Error>,
+    result: Result<Output, TaskError<Error>>,
     task_id: Uuid,
 }
 
 impl<Output, Error> TaskResult<Output, Error> {
-    pub(super) fn into_inner(self) -> Result<Output, Error> {
+    pub(super) fn into_inner(self) -> Result<Output, TaskError<Error>> {
         self.result
     }
 
@@ -71,10 +108,18 @@ where
     Output: Send + Sync + Debug,
 {
     async fn run(&self) {
-        let result = self.operator.run(&self.input).await;
-        let task_result = TaskResult {
-            result,
-            task_id: self.task_id,
+        let task_result = match AssertUnwindSafe(self.operator.run(&self.input))
+            .catch_unwind()
+            .await
+        {
+            Ok(result) => TaskResult {
+                result: result.map_err(TaskError::Other),
+                task_id: self.task_id,
+            },
+            Err(_) => TaskResult {
+                result: Err(TaskError::Panic),
+                task_id: self.task_id,
+            },
         };
         let res = self.reply_channel.send(task_result, None).await;
         // TODO: if this errors, it means the caller was dropped

--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -21,7 +21,7 @@ where
 
 #[derive(Debug, Error)]
 pub(super) enum TaskError<Error> {
-    #[error("Task error: {0}")]
+    #[error("Error in task: {0}")]
     Other(Error),
     #[error("Task panicked")]
     Panic(Option<String>),

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -692,7 +692,7 @@ impl Handler<TaskResult<HnswKnnOperatorOutput, Box<dyn ChromaError>>> for HnswQu
                     .insert(query_index, output.distances);
             }
             Err(e) => {
-                self.terminate_with_error(e, ctx);
+                self.terminate_with_error(e.into(), ctx);
             }
         }
 
@@ -725,7 +725,7 @@ impl Handler<TaskResult<MergeKnnResultsOperatorOutput, Box<dyn ChromaError>>>
         let (mut output_ids, mut output_distances, output_vectors) = match message {
             Ok(output) => (output.user_ids, output.distances, output.vectors),
             Err(e) => {
-                self.terminate_with_error(e, ctx);
+                self.terminate_with_error(e.into(), ctx);
                 return;
             }
         };

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -528,6 +528,7 @@ impl chroma_proto::metadata_reader_server::MetadataReader for WorkerServer {
     }
 }
 
+#[cfg(debug_assertions)]
 #[tonic::async_trait]
 impl chroma_proto::debug_server::Debug for WorkerServer {
     async fn get_info(


### PR DESCRIPTION
This catches panics when they occur inside dispatched tasks, preventing the associated worker component from crashing. Depending on upstream handling this can still result in a component crashing--many places use `.unwrap()` instead of handling errors.

I originally started down the route of adding lifecycle events to components, but after talking with @Ishiihara we decided that the complexity tradeoff may not be worth it right now, and catching panics at the task level is quite a bit easier. (Unlike components, tasks have the concept of a request/response unit, so it's much easier to propagate the error.)

If something panics outside a task, e.g. logic in an orchestrator, the query node will survive as Tonic catches it. The only other place we have to worry about are panics in the `CompactionManager`/`CompactOrchestrator` which can be handled separately.

