### PR TITLE
[ENH] Cross-Version Collection Migration

### DIFF
--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -240,13 +240,37 @@ class HNSWConfiguration(Configuration):
             is_static=True,
             default_value=1000,
         ),
-        "sync_threashold": ConfigurationDefinition(
-            name="sync_threashold",
+        "sync_threshold": ConfigurationDefinition(
+            name="sync_threshold",
             validator=lambda value: isinstance(value, int) and value >= 1,
             is_static=True,
             default_value=100,
         ),
     }
+
+    @classmethod
+    def from_legacy_params(cls, params: Dict[str, Any]) -> Self:
+        """Returns an HNSWConfiguration from a metadata dict containing legacy HNSW parameters. Used for migration."""
+
+        # We maintain this map to avoid a circular import with HnswParams, and because then names won't change
+        old_to_new = {
+            "hnsw:space": "space",
+            "hnsw:construction_ef": "ef_construction",
+            "hnsw:search_ef": "ef_search",
+            "hnsw:M": "M",
+            "hnsw:num_threads": "num_threads",
+            "hnsw:resize_factor": "resize_factor",
+            "hnsw:batch_size": "batch_size",
+            "hnsw:sync_threshold": "sync_threshold",
+        }
+
+        parameters = []
+        for name, value in params.items():
+            if name not in old_to_new:
+                raise ValueError(f"Invalid legacy HNSW parameter name: {name}")
+            new_name = old_to_new[name]
+            parameters.append(ConfigurationParameter(name=new_name, value=value))
+        return cls(parameters=parameters)
 
 
 class CollectionConfiguration(Configuration):

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -251,7 +251,7 @@ def persist_generated_data_with_old_version(
 
 
 # Since we can't pickle the embedding function, we always generate record sets with embeddings
-collection_st: st.SearchStrategy[strategies.Collection] = st.shared(  # type: ignore[type-arg]
+collection_st: st.SearchStrategy[strategies.Collection] = st.shared(
     strategies.collections(with_hnsw_params=True, has_embeddings=True), key="coll"
 )
 


### PR DESCRIPTION
## Description of changes

This PR creates a path to migrating from previous versions of Chroma to the new version where we have collection configuration storage. The migration is idempotent and non-destructive. 

Since all collections now must have a configuration, old collections would error when loading them - this was reflected in cross-version persistence failures. 

With this approach, that doesn't happen. This is a first step to providing user-facing migration tooling. For now it's just this one script, but later as we add more of these, they can be composed in a more intelligent way. 

This PR includes a new CLI application as part of the `chroma` CLI,  `chroma migrate` which will migrate all collections in a specified `path` (and optional tenant, and database), with ./chroma being the default. 

## Test plan
**Manual Test**:
- Create a collection using an old version of chroma with a persisted client
- Load the database with a persistent client from this version. `list_collections()` should fail with a JSON parsing error (since configurations don't exist)
- Run the migration function over the client from the new version. 
- `list_collections()` should work as expected. 

**Automated**:
`test_cross_version_persist` passes locally and in CI. 

**ALL TESTS** Should pass by this point in the stack. 

## Documentation Changes
The migration and migration tool is documented at https://docs.trychroma.com/deployment/migration

Additionally, when a collection tries and fails to load a CollectionConfiguration from JSON, the error points the user to the same migration documentation. 

## TODO:

- [x] Documentation of migration
- [x] Migration tool in CLI 