### PR TITLE
updated the ImageLoader data loader to work with local URIs and remote URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
             "numpy",
             "types-protobuf",
             "kubernetes",
+            "types-requests"
           ]
 
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/chromadb/utils/data_loaders.py
+++ b/chromadb/utils/data_loaders.py
@@ -1,4 +1,6 @@
 import importlib
+import requests
+from io import BytesIO
 import multiprocessing
 from typing import Optional, Sequence, List, Tuple
 import numpy as np
@@ -16,8 +18,19 @@ class ImageLoader(DataLoader[List[Optional[Image]]]):
                 "The PIL python package is not installed. Please install it with `pip install pillow`"
             )
 
+    #    def _load_image(self, uri: Optional[URI]) -> Optional[Image]:
+    #        return np.array(self._PILImage.open(uri)) if uri is not None else None
+
     def _load_image(self, uri: Optional[URI]) -> Optional[Image]:
-        return np.array(self._PILImage.open(uri)) if uri is not None else None
+        if uri is not None:
+            if uri[0:4] == "http":
+                return np.asarray(
+                    self._PILImage.open(BytesIO(requests.get(uri).content))
+                )
+            else:
+                return np.array(self._PILImage.open(uri))
+        else:
+            return None
 
     def __call__(self, uris: Sequence[Optional[URI]]) -> List[Optional[Image]]:
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:


### PR DESCRIPTION
Updated ImageLoader in data_loaders.py to accept images from both local URIs and remote URLs

## Description of changes

 - Improvements & Bug fixes
	 - No bug fixes. 1 improvement (new functionality, described below)  
 - New functionality
	 - Currently, the ImageLoader data loader only accepts local URIs. When working with multimodal embeddings, many users need to pass remote images as URLs. This PR makes a small update to `load_image` in class `ImageLoader` in `utils/data_loaders.py` to detect whether the passed URI is a remote URL. If it is, then it fetches the remote URL's data and then processes it. If it is not a remote URL, it works the same as before (currently). 

## Test plan
*How are these changes tested?*

- By running `pytest` locally.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
