### PR TITLE
update fastapi types to fix ts client codegen

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional
+from typing import List, Sequence, Optional
 from uuid import UUID
 
 from overrides import override
+from pydantic import Field
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
 from chromadb.api.models.Collection import Collection
 from chromadb.api.types import (
@@ -13,7 +14,6 @@ from chromadb.api.types import (
     DataLoader,
     Embeddings,
     IDs,
-    Include,
     Loadable,
     Metadatas,
     URIs,
@@ -23,6 +23,7 @@ from chromadb.api.types import (
     WhereDocument,
 )
 from chromadb.config import Component, Settings
+from chromadb.server.fastapi.types import IncludeEnum
 from chromadb.types import Database, Tenant
 import chromadb.utils.embedding_functions as ef
 from chromadb.types import Collection as CollectionModel
@@ -344,7 +345,9 @@ class BaseAPI(ABC):
         page: Optional[int] = None,
         page_size: Optional[int] = None,
         where_document: Optional[WhereDocument] = {},
-        include: Include = ["embeddings", "metadatas", "documents"],
+        include: List[IncludeEnum] = Field(
+            default=["embeddings", "metadatas", "documents"]
+        ),
     ) -> GetResult:
         """[Internal] Returns entries from a collection specified by UUID.
 
@@ -394,7 +397,9 @@ class BaseAPI(ABC):
         n_results: int = 10,
         where: Where = {},
         where_document: WhereDocument = {},
-        include: Include = ["embeddings", "metadatas", "documents", "distances"],
+        include: List[IncludeEnum] = Field(
+            default=["embeddings", "metadatas", "documents"]
+        ),
     ) -> QueryResult:
         """[Internal] Performs a nearest neighbors query on a collection specified by UUID.
 
@@ -603,7 +608,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         pass
 
 
-def json_to_collection_model(json_collection: dict) -> CollectionModel:
+def json_to_collection_model(json_collection: dict) -> CollectionModel:  # type: ignore
     return CollectionModel(
         id=json_collection["id"],
         name=json_collection["name"],

--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -58,6 +58,7 @@ def run(
 
     # set ENV variable for PERSIST_DIRECTORY to path
     os.environ["IS_PERSISTENT"] = "True"
+    os.environ["ALLOW_RESET"] = "True"
     os.environ["PERSIST_DIRECTORY"] = path
     os.environ["CHROMA_SERVER_NOFILE"] = "65535"
     os.environ["CHROMA_CLI"] = "True"

--- a/chromadb/server/fastapi/types.py
+++ b/chromadb/server/fastapi/types.py
@@ -1,9 +1,18 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Optional
 from chromadb.api.types import (
     CollectionMetadata,
-    Include,
 )
+from enum import Enum
+
+
+class IncludeEnum(str, Enum):
+    documents = "documents"
+    embeddings = "embeddings"
+    metadatas = "metadatas"
+    distances = "distances"
+    uris = "uris"
+    data = "data"
 
 
 class AddEmbedding(BaseModel):
@@ -33,7 +42,7 @@ class QueryEmbedding(BaseModel):
     where_document: Optional[Dict[Any, Any]] = {}
     query_embeddings: List[Any]
     n_results: int = 10
-    include: Include = ["metadatas", "documents", "distances"]
+    include: List[IncludeEnum] = Field(default=["metadatas", "documents"])
 
 
 class GetEmbedding(BaseModel):
@@ -43,7 +52,7 @@ class GetEmbedding(BaseModel):
     sort: Optional[str] = None
     limit: Optional[int] = None
     offset: Optional[int] = None
-    include: Include = ["metadatas", "documents"]
+    include: List[IncludeEnum] = Field(default=["metadatas", "documents"])
 
 
 class DeleteEmbedding(BaseModel):

--- a/clients/js/src/ChromaClient.ts
+++ b/clients/js/src/ChromaClient.ts
@@ -262,10 +262,10 @@ export class ChromaClient {
     offset,
   }: ListCollectionsParams = {}): Promise<CollectionType[]> {
     const response = await this.api.listCollections(
-      this.tenant,
-      this.database,
       limit,
       offset,
+      this.tenant,
+      this.database,
       this.api.options,
     );
     return handleSuccess(response);

--- a/clients/js/src/generated/api.ts
+++ b/clients/js/src/generated/api.ts
@@ -823,18 +823,18 @@ export const ApiApiFetchParamCreator = function (
     },
     /**
      * @summary List Collections
+     * @param {number | null} [limit]
+     * @param {number | null} [offset]
      * @param {string} [tenant]
      * @param {string} [database]
-     * @param {number} [limit]
-     * @param {number} [offset]
      * @param {RequestInit} [options] Override http request option.
      * @throws {RequiredError}
      */
     listCollections(
+      limit: number | null | undefined,
+      offset: number | null | undefined,
       tenant: string | undefined,
       database: string | undefined,
-      limit: number | undefined,
-      offset: number | undefined,
       options: RequestInit = {},
     ): FetchArgs {
       let localVarPath = `/api/v1/collections`;
@@ -855,20 +855,20 @@ export const ApiApiFetchParamCreator = function (
         localVarPath = localVarPath.substring(0, localVarPathQueryStart);
       }
 
-      if (tenant !== undefined) {
-        localVarQueryParameter.append("tenant", String(tenant));
-      }
-
-      if (database !== undefined) {
-        localVarQueryParameter.append("database", String(database));
-      }
-
       if (limit !== undefined) {
         localVarQueryParameter.append("limit", String(limit));
       }
 
       if (offset !== undefined) {
         localVarQueryParameter.append("offset", String(offset));
+      }
+
+      if (tenant !== undefined) {
+        localVarQueryParameter.append("tenant", String(tenant));
+      }
+
+      if (database !== undefined) {
+        localVarQueryParameter.append("database", String(database));
       }
 
       localVarRequestOptions.headers = localVarHeaderParameter;
@@ -1828,18 +1828,18 @@ export const ApiApiFp = function (configuration?: Configuration) {
     },
     /**
      * @summary List Collections
+     * @param {number | null} [limit]
+     * @param {number | null} [offset]
      * @param {string} [tenant]
      * @param {string} [database]
-     * @param {number} [limit]
-     * @param {number} [offset]
      * @param {RequestInit} [options] Override http request option.
      * @throws {RequiredError}
      */
     listCollections(
+      limit: number | null | undefined,
+      offset: number | null | undefined,
       tenant: string | undefined,
       database: string | undefined,
-      limit: number | undefined,
-      offset: number | undefined,
       options?: RequestInit,
     ): (
       fetch?: FetchAPI,
@@ -1847,7 +1847,7 @@ export const ApiApiFp = function (configuration?: Configuration) {
     ) => Promise<Api.ListCollections200Response> {
       const localVarFetchArgs = ApiApiFetchParamCreator(
         configuration,
-      ).listCollections(tenant, database, limit, offset, options);
+      ).listCollections(limit, offset, tenant, database, options);
       return (fetch: FetchAPI = defaultFetch, basePath: string = BASE_PATH) => {
         return fetch(
           basePath + localVarFetchArgs.url,
@@ -2404,25 +2404,25 @@ export class ApiApi extends BaseAPI {
 
   /**
    * @summary List Collections
+   * @param {number | null} [limit]
+   * @param {number | null} [offset]
    * @param {string} [tenant]
    * @param {string} [database]
-   * @param {number} [limit]
-   * @param {number} [offset]
    * @param {RequestInit} [options] Override http request option.
    * @throws {RequiredError}
    */
   public listCollections(
+    limit: number | null | undefined,
+    offset: number | null | undefined,
     tenant: string | undefined,
     database: string | undefined,
-    limit: number | undefined,
-    offset: number | undefined,
     options?: RequestInit,
   ) {
     return ApiApiFp(this.configuration).listCollections(
-      tenant,
-      database,
       limit,
       offset,
+      tenant,
+      database,
       options,
     )(this.fetch, this.basePath);
   }

--- a/clients/js/src/generated/models.ts
+++ b/clients/js/src/generated/models.ts
@@ -16,10 +16,10 @@ export namespace Api {
   export interface Add201Response {}
 
   export interface AddEmbedding {
-    embeddings?: Api.AddEmbedding.Embedding[];
-    metadatas?: Api.AddEmbedding.Metadata[];
-    documents?: string[];
-    uris?: string[];
+    embeddings?: Api.AddEmbedding.Embedding[] | null;
+    metadatas?: (Api.AddEmbedding.Metadatum | null)[] | null;
+    documents?: (string | null)[] | null;
+    uris?: (string | null)[] | null;
     ids: string[];
   }
 
@@ -30,7 +30,7 @@ export namespace Api {
   export namespace AddEmbedding {
     export interface Embedding {}
 
-    export interface Metadata {}
+    export interface Metadatum {}
   }
 
   export interface ADelete200Response {}
@@ -43,7 +43,7 @@ export namespace Api {
 
   export interface CreateCollection {
     name: string;
-    metadata?: Api.CreateCollection.Metadata;
+    metadata?: Api.CreateCollection.Metadata | null;
     get_or_create?: boolean;
   }
 
@@ -72,9 +72,9 @@ export namespace Api {
   export interface DeleteCollection200Response {}
 
   export interface DeleteEmbedding {
-    ids?: string[];
-    where?: Api.DeleteEmbedding.Where;
-    where_document?: Api.DeleteEmbedding.WhereDocument;
+    ids?: string[] | null;
+    where?: Api.DeleteEmbedding.Where | null;
+    where_document?: Api.DeleteEmbedding.WhereDocument | null;
   }
 
   /**
@@ -92,28 +92,21 @@ export namespace Api {
   export interface GetDatabase200Response {}
 
   export interface GetEmbedding {
-    ids?: string[];
-    where?: Api.GetEmbedding.Where;
-    where_document?: Api.GetEmbedding.WhereDocument;
-    sort?: string;
+    ids?: string[] | null;
+    where?: Api.GetEmbedding.Where | null;
+    where_document?: Api.GetEmbedding.WhereDocument | null;
+    sort?: string | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof GetEmbedding
      */
-    limit?: number;
+    limit?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof GetEmbedding
      */
-    offset?: number;
-    include?: (
-      | Api.GetEmbedding.Include.EnumValueEnum
-      | Api.GetEmbedding.Include.EnumValueEnum2
-      | Api.GetEmbedding.Include.EnumValueEnum3
-      | Api.GetEmbedding.Include.EnumValueEnum4
-      | Api.GetEmbedding.Include.EnumValueEnum5
-      | Api.GetEmbedding.Include.EnumValueEnum6
-    )[];
+    offset?: number | null;
+    include?: Api.IncludeEnum[];
   }
 
   /**
@@ -124,44 +117,6 @@ export namespace Api {
     export interface Where {}
 
     export interface WhereDocument {}
-
-    export type Include =
-      | Api.GetEmbedding.Include.EnumValueEnum
-      | Api.GetEmbedding.Include.EnumValueEnum2
-      | Api.GetEmbedding.Include.EnumValueEnum3
-      | Api.GetEmbedding.Include.EnumValueEnum4
-      | Api.GetEmbedding.Include.EnumValueEnum5
-      | Api.GetEmbedding.Include.EnumValueEnum6;
-
-    /**
-     * @export
-     * @namespace Include
-     */
-    export namespace Include {
-      export enum EnumValueEnum {
-        Documents = "documents",
-      }
-
-      export enum EnumValueEnum2 {
-        Embeddings = "embeddings",
-      }
-
-      export enum EnumValueEnum3 {
-        Metadatas = "metadatas",
-      }
-
-      export enum EnumValueEnum4 {
-        Distances = "distances",
-      }
-
-      export enum EnumValueEnum5 {
-        Uris = "uris",
-      }
-
-      export enum EnumValueEnum6 {
-        Data = "data",
-      }
-    }
   }
 
   export interface GetNearestNeighbors200Response {}
@@ -172,27 +127,29 @@ export namespace Api {
     detail?: Api.ValidationError[];
   }
 
+  export enum IncludeEnum {
+    Documents = "documents",
+    Embeddings = "embeddings",
+    Metadatas = "metadatas",
+    Distances = "distances",
+    Uris = "uris",
+    Data = "data",
+  }
+
   export interface ListCollections200Response {}
 
   export interface PreFlightChecks200Response {}
 
   export interface QueryEmbedding {
-    where?: Api.QueryEmbedding.Where;
-    where_document?: Api.QueryEmbedding.WhereDocument;
+    where?: Api.QueryEmbedding.Where | null;
+    where_document?: Api.QueryEmbedding.WhereDocument | null;
     query_embeddings: Api.QueryEmbedding.QueryEmbedding2[];
     /**
      * @type {number}
      * @memberof QueryEmbedding
      */
     n_results?: number;
-    include?: (
-      | Api.QueryEmbedding.Include.EnumValueEnum
-      | Api.QueryEmbedding.Include.EnumValueEnum2
-      | Api.QueryEmbedding.Include.EnumValueEnum3
-      | Api.QueryEmbedding.Include.EnumValueEnum4
-      | Api.QueryEmbedding.Include.EnumValueEnum5
-      | Api.QueryEmbedding.Include.EnumValueEnum6
-    )[];
+    include?: Api.IncludeEnum[];
   }
 
   /**
@@ -205,51 +162,13 @@ export namespace Api {
     export interface WhereDocument {}
 
     export interface QueryEmbedding2 {}
-
-    export type Include =
-      | Api.QueryEmbedding.Include.EnumValueEnum
-      | Api.QueryEmbedding.Include.EnumValueEnum2
-      | Api.QueryEmbedding.Include.EnumValueEnum3
-      | Api.QueryEmbedding.Include.EnumValueEnum4
-      | Api.QueryEmbedding.Include.EnumValueEnum5
-      | Api.QueryEmbedding.Include.EnumValueEnum6;
-
-    /**
-     * @export
-     * @namespace Include
-     */
-    export namespace Include {
-      export enum EnumValueEnum {
-        Documents = "documents",
-      }
-
-      export enum EnumValueEnum2 {
-        Embeddings = "embeddings",
-      }
-
-      export enum EnumValueEnum3 {
-        Metadatas = "metadatas",
-      }
-
-      export enum EnumValueEnum4 {
-        Distances = "distances",
-      }
-
-      export enum EnumValueEnum5 {
-        Uris = "uris",
-      }
-
-      export enum EnumValueEnum6 {
-        Data = "data",
-      }
-    }
   }
 
   export interface Update200Response {}
 
   export interface UpdateCollection {
-    new_name?: string;
-    new_metadata?: Api.UpdateCollection.NewMetadata;
+    new_name?: string | null;
+    new_metadata?: Api.UpdateCollection.NewMetadata | null;
   }
 
   /**
@@ -263,10 +182,10 @@ export namespace Api {
   export interface UpdateCollection200Response {}
 
   export interface UpdateEmbedding {
-    embeddings?: Api.UpdateEmbedding.Embedding[];
-    metadatas?: Api.UpdateEmbedding.Metadata[];
-    documents?: string[];
-    uris?: string[];
+    embeddings?: Api.UpdateEmbedding.Embedding[] | null;
+    metadatas?: (Api.UpdateEmbedding.Metadatum | null)[] | null;
+    documents?: (string | null)[] | null;
+    uris?: (string | null)[] | null;
     ids: string[];
   }
 
@@ -277,7 +196,7 @@ export namespace Api {
   export namespace UpdateEmbedding {
     export interface Embedding {}
 
-    export interface Metadata {}
+    export interface Metadatum {}
   }
 
   export interface Upsert200Response {}


### PR DESCRIPTION
Update fastapi types to publish through openapi spec for successful typescript client codegen

notes
- can/should probably remove the `ALLOW_RESET=True` on CLI
- can probably change the definition of `Include` instead of renaming it `IncludeEnum` - minimize the number of changes