### PR TITLE
[BUG] Log purge off by one

### DIFF
--- a/go/database/log/db/queries.sql.go
+++ b/go/database/log/db/queries.sql.go
@@ -134,7 +134,7 @@ type InsertRecordParams struct {
 }
 
 const purgeRecords = `-- name: PurgeRecords :exec
-DELETE FROM record_log r using collection c where r.collection_id = c.id and r.offset < c.record_compaction_offset_position
+DELETE FROM record_log r using collection c where r.collection_id = c.id and r.offset <= c.record_compaction_offset_position
 `
 
 func (q *Queries) PurgeRecords(ctx context.Context) error {

--- a/go/database/log/queries/queries.sql
+++ b/go/database/log/queries/queries.sql
@@ -32,4 +32,4 @@ UPDATE collection set record_enumeration_offset_position = $2 where id = $1;
 INSERT INTO collection (id, record_enumeration_offset_position, record_compaction_offset_position) values($1, $2, $3) returning *;
 
 -- name: PurgeRecords :exec
-DELETE FROM record_log r using collection c where r.collection_id = c.id and r.offset < c.record_compaction_offset_position;
+DELETE FROM record_log r using collection c where r.collection_id = c.id and r.offset <= c.record_compaction_offset_position;

--- a/go/database/log/schema/collection.sql
+++ b/go/database/log/schema/collection.sql
@@ -4,5 +4,5 @@ CREATE TABLE collection (
                         record_enumeration_offset_position bigint NOT NULL
                         );
 
--- The `record_compaction_offset_position` column indicates the offset position of the latest compaction.
+-- The `record_compaction_offset_position` column indicates the offset position of the latest compaction, offsets are 1-indexed.
 -- The `record_enenumeration_offset_position` column denotes the incremental offset for the most recent record in a collection.

--- a/go/pkg/log/server/property_test.go
+++ b/go/pkg/log/server/property_test.go
@@ -214,10 +214,10 @@ func (suite *LogServerTestSuite) modelPullLogs(ctx context.Context, t *rapid.T, 
 
 	// Pull logs from the model
 	modelLogs := suite.model.CollectionData[c]
-	// Find start offset in the model
+	// Find start offset in the model, which is the first offset that is greater than or equal to the start offset
 	startIndex := -1
 	for i, record := range modelLogs {
-		if record.offset == startOffset {
+		if record.offset >= startOffset {
 			startIndex = i
 			break
 		}
@@ -243,10 +243,8 @@ func (suite *LogServerTestSuite) modelPurgeLogs(ctx context.Context, t *rapid.T)
 
 		new_log := []ModelLogRecord{}
 		for _, record := range log {
-			// TODO: It is odd that the SUT purge behavior keeps the record
-			// with the compaction offset. Shouldn't we be able to purge this
-			// record?
-			if record.offset >= compactionOffset {
+			// Purge by adding everything after the compaction offset
+			if record.offset > compactionOffset {
 				new_log = append(new_log, record)
 			}
 		}
@@ -284,7 +282,7 @@ func (suite *LogServerTestSuite) modelGetAllCollectionInfoToCompact(ctx context.
 // State machine
 func (suite *LogServerTestSuite) TestRecordLogDb_PushLogs() {
 	ctx := context.Background()
-	maxCollections := 100
+	maxCollections := 1
 	collections := make(map[int]types.UniqueID)
 
 	collectionGen := rapid.Custom(func(t *rapid.T) types.UniqueID {
@@ -449,7 +447,7 @@ func (suite *LogServerTestSuite) TestRecordLogDb_PushLogs() {
 						records, err = suite.lr.PullRecords(ctx, id.String(), 0, 1, time.Now().UnixNano())
 						suite.NoError(err)
 						if len(records) > 0 {
-							suite.Equal(int64(offset), records[0].Offset)
+							suite.Equal(int64(offset)+1, records[0].Offset)
 						}
 					}
 				}

--- a/go/pkg/log/server/property_test.go
+++ b/go/pkg/log/server/property_test.go
@@ -282,7 +282,7 @@ func (suite *LogServerTestSuite) modelGetAllCollectionInfoToCompact(ctx context.
 // State machine
 func (suite *LogServerTestSuite) TestRecordLogDb_PushLogs() {
 	ctx := context.Background()
-	maxCollections := 1
+	maxCollections := 100
 	collections := make(map[int]types.UniqueID)
 
 	collectionGen := rapid.Custom(func(t *rapid.T) types.UniqueID {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - When revamping the prop tests in #1969 I noticed that the purge code was off by one - this remedies that.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
The tests TODO is updated with the correct behavior
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None