### PR TITLE
[ENH] Configurable block size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,6 +3324,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "sec1"
@@ -3442,6 +3457,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4698,6 +4738,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test",
  "shuttle",
  "tantivy",
  "tempfile",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -64,6 +64,7 @@ proptest-state-machine = "0.1.0"
 rayon = "1.8.0"
 criterion = "0.3"
 random-port = "0.1.1"
+serial_test = "3.1.1"
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -38,6 +38,9 @@ query_service:
         num_worker_threads: 4
         dispatcher_queue_size: 100
         worker_queue_size: 100
+    blockfile_provider:
+        Arrow:
+            max_block_size_bytes: 16384
 
 compaction_service:
     service_name: "compaction-service"
@@ -79,3 +82,6 @@ compaction_service:
         max_concurrent_jobs: 100
         compaction_interval_sec: 60
         min_compaction_size: 10
+    blockfile_provider:
+        Arrow:
+            max_block_size_bytes: 16384

--- a/rust/worker/src/blockstore/arrow/block/delta.rs
+++ b/rust/worker/src/blockstore/arrow/block/delta.rs
@@ -1,9 +1,6 @@
 use super::delta_storage::BlockStorage;
 use crate::blockstore::{
-    arrow::{
-        blockfile::MAX_BLOCK_SIZE,
-        types::{ArrowWriteableKey, ArrowWriteableValue},
-    },
+    arrow::types::{ArrowWriteableKey, ArrowWriteableValue},
     key::CompositeKey,
 };
 use arrow::{array::RecordBatch, util::bit_util};
@@ -28,6 +25,9 @@ pub struct BlockDelta {
 
 impl BlockDelta {
     /// Creates a new block delta from a block.
+    /// # Arguments
+    /// - id: the id of the block delta.
+    /// - max_block_size_bytes: the maximum size of the block in bytes.
     pub fn new<K: ArrowWriteableKey, V: ArrowWriteableValue>(id: Uuid) -> Self {
         BlockDelta {
             builder: V::get_delta_builder(),
@@ -122,8 +122,9 @@ impl BlockDelta {
     /// split point.
     pub fn split<'referred_data, K: ArrowWriteableKey, V: ArrowWriteableValue>(
         &'referred_data self,
+        max_block_size_bytes: usize,
     ) -> Vec<(CompositeKey, BlockDelta)> {
-        let half_size = MAX_BLOCK_SIZE / 2;
+        let half_size = max_block_size_bytes / 2;
 
         let mut blocks_to_split = Vec::new();
         blocks_to_split.push(self.clone());
@@ -165,16 +166,13 @@ impl BlockDelta {
             let new_delta = curr_block
                 .builder
                 .split(&split_key.prefix, split_key.key.clone());
-            let new_block = BlockDelta {
-                builder: new_delta,
-                id: Uuid::new_v4(),
-            };
+            let new_block = BlockDelta::new::<K, V>(Uuid::new_v4());
             if first_iter {
                 first_iter = false;
             } else {
                 output.push((curr_block.builder.get_key(0).clone(), curr_block));
             }
-            if new_block.get_size::<K, V>() > MAX_BLOCK_SIZE {
+            if new_block.get_size::<K, V>() > max_block_size_bytes {
                 blocks_to_split.push(new_block);
             } else {
                 output.push((split_key.clone(), new_block));
@@ -203,6 +201,9 @@ mod test {
     use roaring::RoaringBitmap;
     use std::collections::HashMap;
 
+    // A small block size for testing, so that triggering splits etc is easier
+    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
+
     /// Saves a block to a random file under the given path, then loads the block
     /// and validates that the loaded block has the same size as the original block.
     /// ### Returns
@@ -223,7 +224,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
-        let block_manager = BlockManager::new(storage);
+        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let delta = block_manager.create::<&str, &Int32Array>();
 
         let n = 2000;
@@ -254,7 +255,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-        let block_manager = BlockManager::new(storage);
+        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let delta = block_manager.create::<&str, &str>();
         let delta_id = delta.id.clone();
 
@@ -300,7 +301,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
-        let block_manager = BlockManager::new(storage);
+        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let delta = block_manager.create::<f32, &str>();
 
         let n = 2000;
@@ -325,7 +326,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
-        let block_manager = BlockManager::new(storage);
+        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let delta = block_manager.create::<&str, &RoaringBitmap>();
 
         let n = 2000;
@@ -357,7 +358,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
-        let block_manager = BlockManager::new(storage);
+        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let ids = vec!["embedding_id_2", "embedding_id_0", "embedding_id_1"];
         let embeddings = vec![
             vec![1.0, 2.0, 3.0],
@@ -418,7 +419,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
-        let block_manager = BlockManager::new(storage);
+        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let delta = block_manager.create::<u32, &str>();
 
         let n = 2000;

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -529,7 +529,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
 #[cfg(test)]
 mod tests {
     use crate::{
-        blockstore::arrow::provider::ArrowBlockfileProvider,
+        blockstore::arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
         segment::DataRecord,
         storage::{local::LocalStorage, Storage},
         types::MetadataValue,
@@ -540,8 +540,6 @@ mod tests {
     use rand::seq::IteratorRandom;
     use std::collections::HashMap;
     use tokio::runtime::Runtime;
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_count() {

--- a/rust/worker/src/blockstore/arrow/concurrency_test.rs
+++ b/rust/worker/src/blockstore/arrow/concurrency_test.rs
@@ -1,13 +1,11 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        blockstore::arrow::provider::ArrowBlockfileProvider,
+        blockstore::arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
         storage::{local::LocalStorage, Storage},
     };
     use rand::Rng;
     use shuttle::{future, thread};
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[test]
     fn test_blockfile_shuttle() {

--- a/rust/worker/src/blockstore/arrow/concurrency_test.rs
+++ b/rust/worker/src/blockstore/arrow/concurrency_test.rs
@@ -7,13 +7,16 @@ mod tests {
     use rand::Rng;
     use shuttle::{future, thread};
 
+    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
+
     #[test]
     fn test_blockfile_shuttle() {
         shuttle::check_random(
             || {
                 let tmp_dir = tempfile::tempdir().unwrap();
                 let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-                let blockfile_provider = ArrowBlockfileProvider::new(storage);
+                let blockfile_provider =
+                    ArrowBlockfileProvider::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
                 let writer = blockfile_provider.create::<&str, u32>().unwrap();
                 let id = writer.id();
 

--- a/rust/worker/src/blockstore/arrow/config.rs
+++ b/rust/worker/src/blockstore/arrow/config.rs
@@ -1,0 +1,1 @@
+pub(crate) enum ArrowBlockfileProviderConfig {}

--- a/rust/worker/src/blockstore/arrow/config.rs
+++ b/rust/worker/src/blockstore/arrow/config.rs
@@ -1,1 +1,12 @@
-pub(crate) enum ArrowBlockfileProviderConfig {}
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct ArrowBlockfileProviderConfig {
+    // Note: This provider has two dependent components that
+    // are both internal to the arrow blockfile provider.
+    // The BlockManager and the SparseIndexManager.
+    // We could have a BlockManagerConfig and a SparseIndexManagerConfig
+    // but the only configuration that is needed is the max_block_size_bytes
+    // so for now we just hoid this configuration in the ArrowBlockfileProviderConfig.
+    pub(crate) max_block_size_bytes: usize,
+}

--- a/rust/worker/src/blockstore/arrow/config.rs
+++ b/rust/worker/src/blockstore/arrow/config.rs
@@ -1,5 +1,9 @@
 use serde::Deserialize;
 
+#[cfg(test)]
+// A small block size for testing, so that triggering splits etc is easier
+pub(crate) const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
+
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct ArrowBlockfileProviderConfig {
     // Note: This provider has two dependent components that

--- a/rust/worker/src/blockstore/arrow/mod.rs
+++ b/rust/worker/src/blockstore/arrow/mod.rs
@@ -1,6 +1,7 @@
 mod block;
 pub(crate) mod blockfile;
 mod concurrency_test;
+pub(crate) mod config;
 pub(crate) mod flusher;
 pub(crate) mod provider;
 mod sparse_index;

--- a/rust/worker/src/blockstore/arrow/provider.rs
+++ b/rust/worker/src/blockstore/arrow/provider.rs
@@ -30,9 +30,9 @@ pub(crate) struct ArrowBlockfileProvider {
 }
 
 impl ArrowBlockfileProvider {
-    pub(crate) fn new(storage: Storage) -> Self {
+    pub(crate) fn new(storage: Storage, max_block_size_bytes: usize) -> Self {
         Self {
-            block_manager: BlockManager::new(storage.clone()),
+            block_manager: BlockManager::new(storage.clone(), max_block_size_bytes),
             sparse_index_manager: SparseIndexManager::new(storage),
         }
     }
@@ -100,13 +100,15 @@ impl ArrowBlockfileProvider {
 pub(super) struct BlockManager {
     read_cache: Arc<RwLock<HashMap<Uuid, Block>>>,
     storage: Storage,
+    max_block_size_bytes: usize,
 }
 
 impl BlockManager {
-    pub(super) fn new(storage: Storage) -> Self {
+    pub(super) fn new(storage: Storage, max_block_size_bytes: usize) -> Self {
         Self {
             read_cache: Arc::new(RwLock::new(HashMap::new())),
             storage,
+            max_block_size_bytes,
         }
     }
 
@@ -224,6 +226,10 @@ impl BlockManager {
                 return Err(Box::new(BlockFlushError::NotFound));
             }
         }
+    }
+
+    pub(super) fn max_block_size_bytes(&self) -> usize {
+        self.max_block_size_bytes
     }
 }
 

--- a/rust/worker/src/blockstore/arrow/sparse_index.rs
+++ b/rust/worker/src/blockstore/arrow/sparse_index.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use super::block::delta::BlockDelta;
-use super::block::{self, Block};
-use super::provider::BlockManager;
+use super::block::Block;
 use super::types::{ArrowReadableKey, ArrowWriteableKey, ArrowWriteableValue};
 
 /// A sentinel blockfilekey wrapper to represent the start blocks range

--- a/rust/worker/src/blockstore/config.rs
+++ b/rust/worker/src/blockstore/config.rs
@@ -1,0 +1,4 @@
+pub(crate) enum BlockfileProviderConfig {
+    Arrow(super::arrow::config::ArrowBlockfileProviderConfig),
+    Memory,
+}

--- a/rust/worker/src/blockstore/config.rs
+++ b/rust/worker/src/blockstore/config.rs
@@ -1,3 +1,6 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
 pub(crate) enum BlockfileProviderConfig {
     Arrow(super::arrow::config::ArrowBlockfileProviderConfig),
     Memory,

--- a/rust/worker/src/blockstore/memory/provider.rs
+++ b/rust/worker/src/blockstore/memory/provider.rs
@@ -14,11 +14,11 @@ use crate::blockstore::{
 /// # Note
 /// This is not intended for production use.
 #[derive(Clone)]
-pub(crate) struct HashMapBlockfileProvider {
+pub(crate) struct MemoryBlockfileProvider {
     storage_manager: StorageManager,
 }
 
-impl HashMapBlockfileProvider {
+impl MemoryBlockfileProvider {
     pub(crate) fn new() -> Self {
         Self {
             storage_manager: StorageManager::new(),
@@ -115,7 +115,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let provider = HashMapBlockfileProvider::new();
+        let provider = MemoryBlockfileProvider::new();
         // let mut writer = provider.create::<&str, DataRecord>().unwrap();
         // let id = writer.id();
         // for record in data_records {

--- a/rust/worker/src/blockstore/mod.rs
+++ b/rust/worker/src/blockstore/mod.rs
@@ -2,6 +2,7 @@ pub mod positional_posting_list_value;
 mod types;
 
 pub mod arrow;
+pub(crate) mod config;
 pub mod key;
 pub mod memory;
 pub(crate) mod provider;

--- a/rust/worker/src/blockstore/provider.rs
+++ b/rust/worker/src/blockstore/provider.rs
@@ -3,7 +3,7 @@ use super::arrow::types::{
     ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue,
 };
 use super::key::KeyWrapper;
-use super::memory::provider::HashMapBlockfileProvider;
+use super::memory::provider::MemoryBlockfileProvider;
 use super::memory::storage::{Readable, Writeable};
 use super::types::BlockfileWriter;
 use super::{BlockfileReader, Key, Value};
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 #[derive(Clone)]
 pub(crate) enum BlockfileProvider {
-    HashMapBlockfileProvider(HashMapBlockfileProvider),
+    HashMapBlockfileProvider(MemoryBlockfileProvider),
     ArrowBlockfileProvider(ArrowBlockfileProvider),
 }
 
@@ -34,11 +34,14 @@ impl Debug for BlockfileProvider {
 
 impl BlockfileProvider {
     pub(crate) fn new_memory() -> Self {
-        BlockfileProvider::HashMapBlockfileProvider(HashMapBlockfileProvider::new())
+        BlockfileProvider::HashMapBlockfileProvider(MemoryBlockfileProvider::new())
     }
 
-    pub(crate) fn new_arrow(storage: Storage) -> Self {
-        BlockfileProvider::ArrowBlockfileProvider(ArrowBlockfileProvider::new(storage))
+    pub(crate) fn new_arrow(storage: Storage, max_block_size_bytes: usize) -> Self {
+        BlockfileProvider::ArrowBlockfileProvider(ArrowBlockfileProvider::new(
+            storage,
+            max_block_size_bytes,
+        ))
     }
 
     pub(crate) async fn open<

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -224,14 +224,18 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
 
         // TODO: real path
         let path = PathBuf::from("~/tmp");
-        // TODO: blockfile proivder should be injected somehow
         // TODO: hnsw index provider should be injected somehow
+        let blockfile_provider = BlockfileProvider::try_from_config(&(
+            config.blockfile_provider.clone(),
+            storage.clone(),
+        ))
+        .await?;
         Ok(CompactionManager::new(
             scheduler,
             log,
             sysdb,
             storage.clone(),
-            BlockfileProvider::new_arrow(storage.clone()),
+            blockfile_provider,
             HnswIndexProvider::new(storage.clone(), path),
             compaction_manager_queue_size,
             Duration::from_secs(compaction_interval_sec),

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -296,6 +296,7 @@ mod tests {
     use super::*;
     use crate::assignment::assignment_policy::AssignmentPolicy;
     use crate::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
+    use crate::blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
     use crate::execution::dispatcher::Dispatcher;
     use crate::log::log::InMemoryLog;
     use crate::log::log::InternalLogRecord;
@@ -309,8 +310,6 @@ mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
     use uuid::Uuid;
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_compaction_manager() {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -8,7 +8,6 @@ use crate::config::Configurable;
 use crate::errors::ChromaError;
 use crate::errors::ErrorCodes;
 use crate::execution::dispatcher::Dispatcher;
-use crate::execution::operator::TaskMessage;
 use crate::execution::orchestration::CompactOrchestrator;
 use crate::execution::orchestration::CompactionResponse;
 use crate::index::hnsw_provider::HnswIndexProvider;
@@ -290,8 +289,6 @@ impl Handler<Memberlist> for CompactionManager {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
     use crate::assignment::assignment_policy::AssignmentPolicy;
     use crate::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
@@ -305,8 +302,11 @@ mod tests {
     use crate::types::Operation;
     use crate::types::OperationRecord;
     use crate::types::Segment;
+    use std::collections::HashMap;
     use std::str::FromStr;
     use uuid::Uuid;
+
+    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_compaction_manager() {
@@ -490,7 +490,7 @@ mod tests {
             log,
             sysdb,
             storage.clone(),
-            BlockfileProvider::new_arrow(storage.clone()),
+            BlockfileProvider::new_arrow(storage.clone(), TEST_MAX_BLOCK_SIZE_BYTES),
             HnswIndexProvider::new(storage, PathBuf::from(tmpdir.path().to_str().unwrap())),
             compaction_manager_queue_size,
             compaction_interval,

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -103,6 +103,7 @@ pub(crate) struct QueryServiceConfig {
     pub(crate) storage: crate::storage::config::StorageConfig,
     pub(crate) log: crate::log::config::LogConfig,
     pub(crate) dispatcher: crate::execution::config::DispatcherConfig,
+    pub(crate) blockfile_provider: crate::blockstore::config::BlockfileProviderConfig,
 }
 
 #[derive(Deserialize)]
@@ -128,6 +129,7 @@ pub(crate) struct CompactionServiceConfig {
     pub(crate) log: crate::log::config::LogConfig,
     pub(crate) dispatcher: crate::execution::config::DispatcherConfig,
     pub(crate) compactor: crate::compactor::config::CompactorConfig,
+    pub(crate) blockfile_provider: crate::blockstore::config::BlockfileProviderConfig,
 }
 
 /// # Description

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -148,8 +148,10 @@ pub(crate) trait Configurable<T> {
 mod tests {
     use super::*;
     use figment::Jail;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_config_from_default_path() {
         Jail::expect_with(|jail| {
             let _ = jail.create_file(
@@ -190,6 +192,9 @@ mod tests {
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -231,6 +236,9 @@ mod tests {
                         max_concurrent_jobs: 100
                         compaction_interval_sec: 60
                         min_compaction_size: 10
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
                 "#,
             );
             let config = RootConfig::load();
@@ -247,6 +255,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_config_from_specific_path() {
         Jail::expect_with(|jail| {
             let _ = jail.create_file(
@@ -287,6 +296,9 @@ mod tests {
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -328,6 +340,9 @@ mod tests {
                         max_concurrent_jobs: 100
                         compaction_interval_sec: 60
                         min_compaction_size: 10
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
                 "#,
             );
             let config = RootConfig::load_from_path("random_path.yaml");
@@ -345,6 +360,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[serial]
     fn test_config_missing_required_field() {
         Jail::expect_with(|jail| {
             let _ = jail.create_file(
@@ -402,6 +418,9 @@ mod tests {
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -443,6 +462,9 @@ mod tests {
                         max_concurrent_jobs: 100
                         compaction_interval_sec: 60
                         min_compaction_size: 10
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
                 "#,
             );
             let config = RootConfig::load();
@@ -456,6 +478,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_config_with_env_override() {
         Jail::expect_with(|jail| {
             let _ = jail.set_env("CHROMA_QUERY_SERVICE__MY_MEMBER_ID", "query-service-0");
@@ -511,6 +534,9 @@ mod tests {
                         num_worker_threads: 4
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -544,6 +570,9 @@ mod tests {
                         max_concurrent_jobs: 100
                         compaction_interval_sec: 60
                         min_compaction_size: 10
+                    blockfile_provider:
+                        Arrow:
+                            max_block_size_bytes: 16384
                 "#,
             );
             let config = RootConfig::load();
@@ -571,6 +600,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_default_config_path() {
         // Sanity check that root config loads from default path correctly
         let _ = RootConfig::load();

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -10,10 +10,7 @@ use crate::{
     utils::merge_sorted_vecs_conjunction,
 };
 use async_trait::async_trait;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{atomic::AtomicU32, Arc},
-};
+use std::collections::HashSet;
 use thiserror::Error;
 use tracing::{error, trace};
 
@@ -360,14 +357,6 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
 
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::HashMap,
-        str::FromStr,
-        sync::{atomic::AtomicU32, Arc},
-    };
-
-    use uuid::Uuid;
-
     use crate::{
         blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
         execution::{
@@ -387,12 +376,17 @@ mod test {
         storage::{local::LocalStorage, Storage},
         types::{LogRecord, MetadataValue, Operation, OperationRecord, UpdateMetadataValue},
     };
+    use std::{collections::HashMap, str::FromStr};
+    use uuid::Uuid;
+
+    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_merge_and_hydrate() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-        let arrow_blockfile_provider = ArrowBlockfileProvider::new(storage);
+        let arrow_blockfile_provider =
+            ArrowBlockfileProvider::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let mut record_segment = crate::types::Segment {
@@ -680,7 +674,8 @@ mod test {
     async fn test_merge_and_hydrate_full_scan() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-        let arrow_blockfile_provider = ArrowBlockfileProvider::new(storage);
+        let arrow_blockfile_provider =
+            ArrowBlockfileProvider::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let mut record_segment = crate::types::Segment {

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -358,7 +358,10 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
 #[cfg(test)]
 mod test {
     use crate::{
-        blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
+        blockstore::{
+            arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
+            provider::BlockfileProvider,
+        },
         execution::{
             data::data_chunk::Chunk,
             operator::Operator,
@@ -378,8 +381,6 @@ mod test {
     };
     use std::{collections::HashMap, str::FromStr};
     use uuid::Uuid;
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_merge_and_hydrate() {

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -723,7 +723,10 @@ impl Operator<MetadataFilteringInput, MetadataFilteringOutput> for MetadataFilte
 #[cfg(test)]
 mod test {
     use crate::{
-        blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
+        blockstore::{
+            arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
+            provider::BlockfileProvider,
+        },
         execution::{
             data::data_chunk::Chunk,
             operator::Operator,
@@ -745,8 +748,6 @@ mod test {
     };
     use std::{collections::HashMap, str::FromStr};
     use uuid::Uuid;
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn where_and_where_document_from_log() {

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -744,8 +744,6 @@ pub(crate) trait SegmentFlusher {
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
-
     use super::*;
     use crate::{
         blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
@@ -754,12 +752,16 @@ mod tests {
         types::{MetadataValue, Operation, OperationRecord, UpdateMetadataValue},
     };
     use std::{collections::HashMap, str::FromStr};
+    use uuid::Uuid;
+
+    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_materializer() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-        let arrow_blockfile_provider = ArrowBlockfileProvider::new(storage);
+        let arrow_blockfile_provider =
+            ArrowBlockfileProvider::new(storage, TEST_MAX_BLOCK_SIZE_BYTES);
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let mut record_segment = crate::types::Segment {

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -746,15 +746,16 @@ pub(crate) trait SegmentFlusher {
 mod tests {
     use super::*;
     use crate::{
-        blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider},
+        blockstore::{
+            arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
+            provider::BlockfileProvider,
+        },
         segment::record_segment::{RecordSegmentReaderCreationError, RecordSegmentWriter},
         storage::{local::LocalStorage, Storage},
         types::{MetadataValue, Operation, OperationRecord, UpdateMetadataValue},
     };
     use std::{collections::HashMap, str::FromStr};
     use uuid::Uuid;
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn test_materializer() {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -567,18 +567,16 @@ impl chroma_proto::debug_server::Debug for WorkerServer {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
     use crate::execution::dispatcher;
     use crate::log::log::InMemoryLog;
     use crate::storage::local::LocalStorage;
     use crate::storage::Storage;
     use crate::sysdb::test_sysdb::TestSysDb;
     use crate::system;
-
-    use super::*;
     use chroma_proto::debug_client::DebugClient;
     use tempfile::tempdir;
-
-    const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 
     #[tokio::test]
     async fn gracefully_handles_panics() {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-use std::path::PathBuf;
-
 use crate::blockstore::provider::BlockfileProvider;
 use crate::chroma_proto::{
     self, CountRecordsRequest, CountRecordsResponse, QueryMetadataRequest, QueryMetadataResponse,
@@ -11,7 +8,6 @@ use crate::chroma_proto::{
 use crate::config::{Configurable, QueryServiceConfig};
 use crate::errors::ChromaError;
 use crate::execution::dispatcher::Dispatcher;
-use crate::execution::operator::TaskMessage;
 use crate::execution::orchestration::{
     CountQueryOrchestrator, GetVectorsOrchestrator, HnswQueryOrchestrator,
     MetadataQueryOrchestrator,
@@ -24,6 +20,8 @@ use crate::tracing::util::wrap_span_with_parent_context;
 use crate::types::MetadataValue;
 use crate::types::ScalarEncoding;
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::PathBuf;
 use tokio::signal::unix::{signal, SignalKind};
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::{trace, trace_span, Instrument};

--- a/rust/worker/src/storage/config.rs
+++ b/rust/worker/src/storage/config.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use std::path::Path;
 
 #[derive(Deserialize, Debug)]
 /// The configuration for the chosen storage.


### PR DESCRIPTION
## Description of changes
*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Makes the block size configurable, leaving default the same as before.
	 - Add Blockfile provider config, removing a todo 
	 - Runs config tests in serial, since they can race
 - New functionality
	 - None really

## Test plan
*How are these changes tested?*
Existing tests, this is a non-functional change
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None