### PR TITLE
[ENH] catch panics in handlers

### DIFF
--- a/rust/worker/src/system/receiver.rs
+++ b/rust/worker/src/system/receiver.rs
@@ -65,15 +65,17 @@ impl ChromaError for ChannelError {
     }
 }
 
-#[derive(Error, Debug)]
-pub enum ChannelRequestError {
+#[derive(Error, Debug, PartialEq)]
+pub enum RequestError {
     #[error("Failed to send request")]
-    RequestError,
+    SendError,
     #[error("Failed to receive response")]
-    ResponseError,
+    ReceiveError,
+    #[error("Message handler panicked")]
+    HandlerPanic(Option<String>),
 }
 
-impl ChromaError for ChannelRequestError {
+impl ChromaError for RequestError {
     fn code(&self) -> ErrorCodes {
         ErrorCodes::Internal
     }

--- a/rust/worker/src/system/types.rs
+++ b/rust/worker/src/system/types.rs
@@ -1,4 +1,6 @@
-use super::{scheduler::Scheduler, ChannelError, ChannelRequestError, WrappedMessage};
+use super::{
+    scheduler::Scheduler, ChannelError, MessageHandlerError, RequestError, WrappedMessage,
+};
 use async_trait::async_trait;
 use core::panic;
 use futures::Stream;
@@ -141,7 +143,7 @@ impl<C: Component> ComponentSender<C> {
         &self,
         message: M,
         tracing_context: Option<tracing::Span>,
-    ) -> Result<C::Result, ChannelRequestError>
+    ) -> Result<C::Result, RequestError>
     where
         C: Handler<M>,
         M: Message,
@@ -150,10 +152,16 @@ impl<C: Component> ComponentSender<C> {
         self.sender
             .send(WrappedMessage::new(message, Some(tx), tracing_context))
             .await
-            .map_err(|_| ChannelRequestError::RequestError)?;
+            .map_err(|_| RequestError::SendError)?;
 
-        let result = rx.await.map_err(|_| ChannelRequestError::ResponseError)?;
-        Ok(result)
+        let result = rx.await.map_err(|_| RequestError::ReceiveError)?;
+
+        match result {
+            Ok(result) => Ok(result),
+            Err(err) => match err {
+                MessageHandlerError::Panic(p) => Err(RequestError::HandlerPanic(p)),
+            },
+        }
     }
 }
 
@@ -253,7 +261,7 @@ impl<C: Component> ComponentHandle<C> {
         &self,
         message: M,
         tracing_context: Option<tracing::Span>,
-    ) -> Result<C::Result, ChannelRequestError>
+    ) -> Result<C::Result, RequestError>
     where
         C: Handler<M>,
         M: Message,


### PR DESCRIPTION
Panics inside component handlers are now caught and propagated to the caller if they used `.request()`. Otherwise, the panic is silently ignored (besides being recorded by the existing tracing hook).

See new test for how this works.

