### PR TITLE
[ENH] assert on subprocess exit code in tests, make logging more verbose

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -6,7 +6,7 @@ on:
       python_versions:
         description: 'Python versions to test (as json array)'
         required: false
-        default: '["3.8"]'
+        default: '["3.12"]'
         type: string
       property_testing_preset:
         description: 'Property testing preset'

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -6,7 +6,7 @@ on:
       python_versions:
         description: 'Python versions to test (as json array)'
         required: false
-        default: '["3.12"]'
+        default: '["3.12.1"]'
         type: string
       property_testing_preset:
         description: 'Property testing preset'

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -6,7 +6,7 @@ import subprocess
 import tempfile
 from types import ModuleType
 from typing import Generator, List, Tuple, Dict, Any, Callable, Type
-from hypothesis import given, settings
+from hypothesis import given, reproduce_failure, settings
 import hypothesis.strategies as st
 import pytest
 import json
@@ -261,6 +261,7 @@ collection_st: st.SearchStrategy[strategies.Collection] = st.shared(
     embeddings_strategy=strategies.recordsets(collection_st),
 )
 @settings(deadline=None)
+@reproduce_failure("6.104.2", b"AXicY2BgZEAGjDAuAABBAAQ=")
 def test_cycle_versions(
     version_settings: Tuple[str, Settings],
     collection_strategy: strategies.Collection,

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -260,8 +260,8 @@ collection_st: st.SearchStrategy[strategies.Collection] = st.shared(
     collection_strategy=collection_st,
     embeddings_strategy=strategies.recordsets(collection_st),
 )
-@settings(deadline=None)
-@reproduce_failure("6.104.2", b"AXicY2BgZEAGjDAuAABBAAQ=")
+@settings(deadline=None, max_examples=200)
+# @reproduce_failure("6.104.2", b"AXicY2BgZEAGjDAuAABBAAQ=")
 def test_cycle_versions(
     version_settings: Tuple[str, Settings],
     collection_strategy: strategies.Collection,
@@ -293,7 +293,7 @@ def test_cycle_versions(
     # Run the task in a separate process to avoid polluting the current process
     # with the old version. Using spawn instead of fork to avoid sharing the
     # current process memory which would cause the old version to be loaded
-    ctx = multiprocessing.get_context("spawn")
+    ctx = multiprocessing.get_context("forkserver")
     conn1, conn2 = multiprocessing.Pipe()
     p = ctx.Process(
         target=persist_generated_data_with_old_version,

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -261,7 +261,7 @@ collection_st: st.SearchStrategy[strategies.Collection] = st.shared(
     collection_strategy=collection_st,
     embeddings_strategy=strategies.recordsets(collection_st),
 )
-@settings(deadline=None)
+@settings(deadline=None, max_examples=100)
 def test_cycle_versions(
     version_settings: Tuple[str, Settings],
     collection_strategy: strategies.Collection,
@@ -307,8 +307,8 @@ def test_cycle_versions(
         e = conn1.recv()
         raise e
 
-    p.close()
     assert p.exitcode == 0
+    p.close()
 
     # Switch to the current version (local working directory) and check the invariants
     # are preserved for the collection

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -204,6 +204,7 @@ class PersistEmbeddingsStateMachine(EmbeddingStateMachineBase):
         collection_name = self.collection.name
         conn1, conn2 = multiprocessing.Pipe()
         ctx = get_multiprocessing_context()
+        ctx.log_to_stderr(logging.INFO)
         p = ctx.Process(
             target=load_and_check,
             args=(self.settings, collection_name, self.record_set_state, conn2),
@@ -216,6 +217,7 @@ class PersistEmbeddingsStateMachine(EmbeddingStateMachineBase):
             raise e
 
         p.close()
+        assert p.exitcode == 0
 
     def on_state_change(self, new_state: str) -> None:
         if new_state == PersistEmbeddingsStateMachineStates.persist:

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -216,8 +216,8 @@ class PersistEmbeddingsStateMachine(EmbeddingStateMachineBase):
             e = conn1.recv()
             raise e
 
-        p.close()
         assert p.exitcode == 0
+        p.close()
 
     def on_state_change(self, new_state: str) -> None:
         if new_state == PersistEmbeddingsStateMachineStates.persist:


### PR DESCRIPTION
Was unable to reproduce this test failure in both CI and local: https://github.com/chroma-core/chroma/actions/runs/9782475064/job/27008947722.

Hoping that this additional info will help us if it happens again.