### PR TITLE
[ENH] Introduce stream abstraction and enable concurrency test for blockfile

### DIFF
--- a/rust/worker/src/blockstore/arrow/concurrency_test.rs
+++ b/rust/worker/src/blockstore/arrow/concurrency_test.rs
@@ -2,88 +2,82 @@
 mod tests {
     use crate::{
         blockstore::arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
-        storage::{local::LocalStorage, Storage},
+        cache::{
+            cache::Cache,
+            config::{CacheConfig, UnboundedCacheConfig},
+        },
+        storage::{sync_local::SyncLocalStorage, Storage},
     };
     use rand::Rng;
     use shuttle::{future, thread};
 
     #[test]
     fn test_blockfile_shuttle() {
-        // shuttle::check_random(
-        //     || {
-        //         let tmp_dir = tempfile::tempdir().unwrap();
-        //         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-        //         let blockfile_provider = ArrowBlockfileProvider::new(storage);
-        //         let writer = blockfile_provider.create::<&str, u32>().unwrap();
-        //         let id = writer.id();
-        //         // Generate N datapoints and then have T threads write them to the blockfile
-        //         let range_min = 10;
-        //         let range_max = 10000;
-        //         let n = shuttle::rand::thread_rng().gen_range(range_min..range_max);
-        //         // Make the max threads the number of cores * 2
-        //         let max_threads = num_cpus::get() * 2;
-        //         let t = shuttle::rand::thread_rng().gen_range(2..max_threads);
-        //         let mut join_handles = Vec::with_capacity(t);
-        //         for i in 0..t {
-        //             let range_start = i * n / t;
-        //             let range_end = (i + 1) * n / t;
-        //             let writer = writer.clone();
-        //             let handle = thread::spawn(move || {
-        //                 println!("Thread {} writing keys {} to {}", i, range_start, range_end);
-        //                 for j in range_start..range_end {
-        //                     let key_string = format!("key{}", j);
-        //                     future::block_on(async {
-        //                         writer
-        //                             .set::<&str, u32>("", key_string.as_str(), j as u32)
-        //                             .await
-        //                             .unwrap_or_else(|e| {
-        //                                 println!(
-        //                                     "Expect key to be set successfully, but got error: {:?}",
-        //                                     e
-        //                                 )
-        //                             });
-        //                     });
-        //                 }
-        //             });
-        //             join_handles.push(handle);
-        //         }
+        shuttle::check_random(
+            || {
+                let tmp_dir = tempfile::tempdir().unwrap();
+                let storage =
+                    Storage::SyncLocal(SyncLocalStorage::new(tmp_dir.path().to_str().unwrap()));
+                let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+                let sparse_index_cache =
+                    Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+                let blockfile_provider = ArrowBlockfileProvider::new(
+                    storage,
+                    TEST_MAX_BLOCK_SIZE_BYTES,
+                    block_cache,
+                    sparse_index_cache,
+                );
+                let writer = blockfile_provider.create::<&str, u32>().unwrap();
+                let id = writer.id();
+                // Generate N datapoints and then have T threads write them to the blockfile
+                let range_min = 10;
+                let range_max = 10000;
+                let n = shuttle::rand::thread_rng().gen_range(range_min..range_max);
+                // Make the max threads the number of cores * 2
+                let max_threads = num_cpus::get() * 2;
+                let t = shuttle::rand::thread_rng().gen_range(2..max_threads);
+                let mut join_handles = Vec::with_capacity(t);
+                for i in 0..t {
+                    let range_start = i * n / t;
+                    let range_end = (i + 1) * n / t;
+                    let writer = writer.clone();
+                    let handle = thread::spawn(move || {
+                        for j in range_start..range_end {
+                            let key_string = format!("key{}", j);
+                            future::block_on(async {
+                                writer
+                                    .set::<&str, u32>("", key_string.as_str(), j as u32)
+                                    .await
+                                    .unwrap();
+                            });
+                        }
+                    });
+                    join_handles.push(handle);
+                }
 
-        //         for handle in join_handles {
-        //             handle.join().unwrap();
-        //         }
+                for handle in join_handles {
+                    handle.join().unwrap();
+                }
 
-        //         // commit the writer
-        //         future::block_on(async {
-        //             let flusher = writer.commit::<&str, u32>().unwrap();
-        //             flusher.flush::<&str, u32>().await.unwrap();
-        //         });
+                // commit the writer
+                future::block_on(async {
+                    let flusher = writer.commit::<&str, u32>().unwrap();
+                    flusher.flush::<&str, u32>().await.unwrap();
+                });
 
-        //         let reader = future::block_on(async {
-        //             blockfile_provider.open::<&str, u32>(&id).await.unwrap()
-        //         });
-        //         // Read the data back
-        //         for i in 0..n {
-        //             let key_string = format!("key{}", i);
-        //             println!("Reading key {}", key_string);
-        //             future::block_on(async {
-        //                 match reader.get("", key_string.as_str()).await {
-        //                     Ok(value) => {
-        //                         // value.expect("Expect key to exist and there to be no error");
-        //                         assert_eq!(value, i as u32);
-        //                     }
-        //                     Err(e) => {
-        //                         println!(
-        //                             "Expect key to exist and there to be no error, but got error: {:?}",
-        //                             e
-        //                         )
-        //                     }
-        //                 }
-        //             });
-        //             // let value = value.expect("Expect key to exist and there to be no error");
-        //             // assert_eq!(value, i as u32);
-        //         }
-        //     },
-        //     100,
-        // );
+                let reader = future::block_on(async {
+                    blockfile_provider.open::<&str, u32>(&id).await.unwrap()
+                });
+                // Read the data back
+                for i in 0..n {
+                    let key_string = format!("key{}", i);
+                    let value =
+                        future::block_on(async { reader.get("", key_string.as_str()).await });
+                    let value = value.expect("Expect key to exist and there to be no error");
+                    assert_eq!(value, i as u32);
+                }
+            },
+            100,
+        );
     }
 }

--- a/rust/worker/src/storage/config.rs
+++ b/rust/worker/src/storage/config.rs
@@ -13,6 +13,8 @@ pub(crate) enum StorageConfig {
     S3(S3StorageConfig),
     #[serde(alias = "local")]
     Local(LocalStorageConfig),
+    #[serde(alias = "sync_local")]
+    SyncLocal(LocalStorageConfig),
 }
 
 #[derive(Deserialize, PartialEq, Debug)]

--- a/rust/worker/src/storage/stream.rs
+++ b/rust/worker/src/storage/stream.rs
@@ -1,0 +1,130 @@
+use super::s3::S3GetError;
+use super::GetError;
+use aws_sdk_s3::primitives::ByteStream as AWSS3ByteStream;
+use futures::stream::Stream;
+use std::io::Read;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncRead;
+
+pub type ByteStreamItem = Result<Vec<u8>, GetError>;
+
+pub trait ByteStream {
+    type Stream: Stream<Item = ByteStreamItem> + Unpin;
+
+    fn byte_stream(self) -> Self::Stream;
+}
+
+pub struct SyncFileStream {
+    reader: std::fs::File,
+}
+
+impl SyncFileStream {
+    pub fn new(file: std::fs::File) -> Self {
+        let reader = file;
+        SyncFileStream { reader }
+    }
+}
+
+impl Stream for SyncFileStream {
+    type Item = ByteStreamItem;
+
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // hardcode buffer size since it is only for testing
+        let mut buffer = vec![0; 8192];
+        let result = self.reader.read(&mut buffer);
+        match result {
+            Ok(n) => {
+                if n == 0 {
+                    Poll::Ready(None)
+                } else {
+                    let mut data = Vec::new();
+                    data.extend_from_slice(&buffer[..n]);
+                    Poll::Ready(Some(Ok(data)))
+                }
+            }
+            Err(e) => Poll::Ready(Some(Err(GetError::LocalError(e.to_string())))),
+        }
+    }
+}
+
+impl ByteStream for std::fs::File {
+    type Stream = SyncFileStream;
+
+    fn byte_stream(self) -> Self::Stream {
+        SyncFileStream::new(self)
+    }
+}
+
+pub struct AsyncFileStream {
+    reader: tokio::fs::File,
+}
+
+impl AsyncFileStream {
+    pub fn new(file: tokio::fs::File) -> Self {
+        let reader = file;
+        AsyncFileStream { reader }
+    }
+}
+
+impl Stream for AsyncFileStream {
+    type Item = ByteStreamItem;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // hardcode buffer size since it is only for testing
+        let mut buffer = vec![0; 8192];
+        let mut read_buf = tokio::io::ReadBuf::new(&mut buffer);
+        match Pin::new(&mut self.reader).poll_read(cx, &mut read_buf) {
+            Poll::Ready(Ok(())) => {
+                let n = read_buf.filled().len();
+                if n == 0 {
+                    Poll::Ready(None)
+                } else {
+                    let mut data = Vec::new();
+                    data.extend_from_slice(&read_buf.filled());
+                    Poll::Ready(Some(Ok(data)))
+                }
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(GetError::LocalError(e.to_string())))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl ByteStream for tokio::fs::File {
+    type Stream = AsyncFileStream;
+
+    fn byte_stream(self) -> Self::Stream {
+        AsyncFileStream::new(self)
+    }
+}
+
+pub struct S3ByteStream {
+    inner: AWSS3ByteStream,
+}
+
+impl S3ByteStream {
+    pub fn new(body: AWSS3ByteStream) -> Self {
+        S3ByteStream { inner: body }
+    }
+}
+
+impl Stream for S3ByteStream {
+    type Item = ByteStreamItem;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let me = self.get_mut();
+        match Pin::new(&mut me.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                let mut data = Vec::new();
+                data.extend_from_slice(&chunk);
+                Poll::Ready(Some(Ok(data)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(GetError::S3Error(
+                S3GetError::ByteStreamError(e.to_string()),
+            )))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - The tokio filesystem API will trigger panic if not invoked in the tokio runtime. However, the shuttle concurrency test has its runtime and can not properly run if tokio filesystem APIs are called. 
	 - To fix the above issue, this PR introduces the stream abstraction to support sync and async local filesystem APIs. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
