### PR TITLE
[CLN] Increasing timeouts && S3 storage error tracing

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -60,7 +60,7 @@ compaction_service:
             host: "sysdb.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 5000
+            request_timeout_ms: 60000 # 1 minute
     storage:
         S3:
             bucket: "chroma-storage"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -27,7 +27,7 @@ query_service:
             bucket: "chroma-storage"
             credentials: "Minio"
             connect_timeout_ms: 5000
-            request_timeout_ms: 5000
+            request_timeout_ms: 30000 # 1 minute
     log:
         Grpc:
             host: "logservice.chroma"
@@ -60,13 +60,13 @@ compaction_service:
             host: "sysdb.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 60000 # 1 minute
+            request_timeout_ms: 5000
     storage:
         S3:
             bucket: "chroma-storage"
             credentials: "Minio"
             connect_timeout_ms: 5000
-            request_timeout_ms: 5000
+            request_timeout_ms: 60000 # 1 minute
     log:
         Grpc:
             host: "logservice.chroma"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -80,7 +80,7 @@ compaction_service:
     compactor:
         compaction_manager_queue_size: 1000
         max_concurrent_jobs: 100
-        compaction_interval_sec: 1
+        compaction_interval_sec: 10
         min_compaction_size: 10
     blockfile_provider:
         Arrow:

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -21,19 +21,19 @@ query_service:
             host: "sysdb.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 1000
+            request_timeout_ms: 5000
     storage:
         S3:
             bucket: "chroma-storage"
             credentials: "Minio"
             connect_timeout_ms: 5000
-            request_timeout_ms: 1000
+            request_timeout_ms: 5000
     log:
         Grpc:
             host: "logservice.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 1000
+            request_timeout_ms: 5000
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -60,19 +60,19 @@ compaction_service:
             host: "sysdb.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 1000
+            request_timeout_ms: 5000
     storage:
         S3:
             bucket: "chroma-storage"
             credentials: "Minio"
             connect_timeout_ms: 5000
-            request_timeout_ms: 1000
+            request_timeout_ms: 5000
     log:
         Grpc:
             host: "logservice.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 1000
+            request_timeout_ms: 5000
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -80,7 +80,7 @@ compaction_service:
     compactor:
         compaction_manager_queue_size: 1000
         max_concurrent_jobs: 100
-        compaction_interval_sec: 60
+        compaction_interval_sec: 1
         min_compaction_size: 10
     blockfile_provider:
         Arrow:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Tests can timeout when the s3 flush takes long. For blockfile we expect small timeouts to be ok, but for HNSW segments in test of a reasonable size, it can still be slow. I picked 60 seconds as the S3 timeout as that is ~6GB / 180 MB/s * 2. 
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None