### PR TITLE
[CLN] Make memberlist reset() not wait longer than it needs to

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -72,8 +72,6 @@ hypothesis.settings.load_profile(CURRENT_PRESET)
 
 def reset(api: ServerAPI) -> None:
     api.reset()
-    if not NOT_CLUSTER_ONLY:
-        time.sleep(MEMBERLIST_SLEEP)
 
 
 def override_hypothesis_profile(
@@ -120,7 +118,6 @@ def override_hypothesis_profile(
 
 
 NOT_CLUSTER_ONLY = os.getenv("CHROMA_CLUSTER_TEST_ONLY") != "1"
-MEMBERLIST_SLEEP = 5
 COMPACTION_SLEEP = 120
 
 

--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -9,7 +9,6 @@ import time
 from chromadb.api.types import QueryResult
 from chromadb.test.conftest import (
     COMPACTION_SLEEP,
-    MEMBERLIST_SLEEP,
     skip_if_not_cluster,
 )
 
@@ -21,11 +20,6 @@ def test_add(
     api: ServerAPI,
 ) -> None:
     api.reset()
-
-    # Once we reset, we have to wait for sometime to let the memberlist on the frontends
-    # propagate, there isn't a clean way to do this so we sleep for a configured amount of time
-    # to ensure that the memberlist has propagated
-    time.sleep(MEMBERLIST_SLEEP)
 
     collection = api.create_collection(
         name="test",
@@ -71,8 +65,6 @@ def test_add(
 @skip_if_not_cluster()
 def test_add_include_all_with_compaction_delay(api: ServerAPI) -> None:
     api.reset()
-
-    time.sleep(MEMBERLIST_SLEEP)
 
     collection = api.create_collection(
         name="test_add_include_all_with_compaction_delay"

--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -48,7 +48,7 @@ func init() {
 
 	// Memberlist
 	Cmd.Flags().StringVar(&conf.KubernetesNamespace, "kubernetes-namespace", "chroma", "Kubernetes namespace")
-	Cmd.Flags().DurationVar(&conf.ReconcileInterval, "reconcile-interval", 5*time.Second, "Reconcile interval")
+	Cmd.Flags().DurationVar(&conf.ReconcileInterval, "reconcile-interval", 100*time.Millisecond, "Reconcile interval")
 	Cmd.Flags().UintVar(&conf.ReconcileCount, "reconcile-count", 10, "Reconcile count")
 
 	// Query service memberlist


### PR DESCRIPTION
## Description of changes

Objective of this PR is making CI faster by reducing waiting time to the minimal required time

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Change go memberlist reconcilation to be higher frequency
	 - Change the memberlist reset() logic in frontend to use a threading event to only wait until the ML is updated
	 - Now waits for ~0.3 seconds instead of 5
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
These changes are covered by existing tests.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
