### PR TITLE
[CLN]: Replacing FastAPI HTTPException with custom ChromaAuthError in basic/token auth

### DIFF
--- a/chromadb/auth/basic_authn/__init__.py
+++ b/chromadb/auth/basic_authn/__init__.py
@@ -7,7 +7,6 @@ import traceback
 import bcrypt
 import logging
 
-from fastapi import HTTPException
 from overrides import override
 from pydantic import SecretStr
 
@@ -19,6 +18,7 @@ from chromadb.auth import (
     AuthError,
 )
 from chromadb.config import System
+from chromadb.errors import ChromaAuthError
 from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
@@ -143,4 +143,4 @@ class BasicAuthenticationServerProvider(ServerAuthenticationProvider):
         time.sleep(
             random.uniform(0.001, 0.005)
         )  # add some jitter to avoid timing attacks
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise ChromaAuthError()

--- a/chromadb/auth/token_authn/__init__.py
+++ b/chromadb/auth/token_authn/__init__.py
@@ -20,6 +20,7 @@ from chromadb.auth import (
     AuthError,
 )
 from chromadb.config import System
+from chromadb.errors import ChromaAuthError
 from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
@@ -231,6 +232,4 @@ class TokenAuthenticationServerProvider(ServerAuthenticationProvider):
         time.sleep(
             random.uniform(0.001, 0.005)
         )  # add some jitter to avoid timing attacks
-        from fastapi import HTTPException
-
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise ChromaAuthError()

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -43,6 +43,21 @@ class IDAlreadyExistsError(ChromaError):
         return "IDAlreadyExists"
 
 
+class ChromaAuthError(ChromaError):
+    @overrides
+    def code(self) -> int:
+        return 403
+
+    @classmethod
+    @overrides
+    def name(cls) -> str:
+        return "AuthError"
+
+    @overrides
+    def message(self) -> str:
+        return "Forbidden"
+
+
 class DuplicateIDError(ChromaError):
     @classmethod
     @overrides


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Removing dynamic import of FastAPI HTTPException in hot path and replacing it with custom ChromaAuthError handled by exception middleware. This retains the user facing error message and removes the need for dynamic import addressing @HammadB comments 

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
