### PR TITLE
[CHORE] Add tracing for task names, materialize logs tracing, and pull logs count

### DIFF
--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -235,6 +235,11 @@ mod tests {
     #[async_trait]
     impl Operator<f32, String> for MockOperator {
         type Error = ();
+
+        fn get_name(&self) -> &'static str {
+            "MockOperator"
+        }
+
         async fn run(&self, input: &f32) -> Result<String, Self::Error> {
             // sleep to simulate work
             tokio::time::sleep(tokio::time::Duration::from_millis(

--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -15,6 +15,7 @@ where
     // It would have been nice to do this with a default trait for result
     // but that's not stable in rust yet.
     async fn run(&self, input: &I) -> Result<O, Self::Error>;
+    fn get_name(&self) -> &'static str;
 }
 
 /// A task result is a wrapper around the result of a task.
@@ -56,6 +57,7 @@ pub(crate) type TaskMessage = Box<dyn TaskWrapper>;
 /// erase the I, O types from the Task struct so that tasks.
 #[async_trait]
 pub(crate) trait TaskWrapper: Send + Debug {
+    fn get_name(&self) -> &'static str;
     async fn run(&self);
     fn id(&self) -> Uuid;
 }
@@ -70,6 +72,10 @@ where
     Input: Send + Sync + Debug,
     Output: Send + Sync + Debug,
 {
+    fn get_name(&self) -> &'static str {
+        self.operator.get_name()
+    }
+
     async fn run(&self) {
         let result = self.operator.run(&self.input).await;
         let task_result = TaskResult {

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -64,6 +64,11 @@ impl ChromaError for CountRecordsError {
 #[async_trait]
 impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
     type Error = CountRecordsError;
+
+    fn get_name(&self) -> &'static str {
+        "CountRecordsOperator"
+    }
+
     async fn run(
         &self,
         input: &CountRecordsInput,
@@ -204,6 +209,7 @@ mod tests {
     use std::sync::atomic::AtomicU32;
     use std::sync::Arc;
     use std::{collections::HashMap, str::FromStr};
+    use tracing::Instrument;
     use uuid::Uuid;
 
     #[tokio::test]
@@ -286,6 +292,7 @@ mod tests {
             let materializer = LogMaterializer::new(record_segment_reader, data, None);
             let mat_records = materializer
                 .materialize()
+                .instrument(tracing::info_span!("Materialize logs"))
                 .await
                 .expect("Log materialization failed");
             segment_writer

--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -52,6 +52,10 @@ pub struct FlushS3Output {
 impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
     type Error = Box<dyn ChromaError>;
 
+    fn get_name(&self) -> &'static str {
+        "FlushS3Operator"
+    }
+
     async fn run(&self, input: &FlushS3Input) -> Result<FlushS3Output, Self::Error> {
         let record_segment_flusher = input.record_segment_writer.clone().commit();
         let record_segment_flush_info = match record_segment_flusher {

--- a/rust/worker/src/execution/operators/get_vectors_operator.rs
+++ b/rust/worker/src/execution/operators/get_vectors_operator.rs
@@ -80,6 +80,10 @@ impl ChromaError for GetVectorsOperatorError {
 impl Operator<GetVectorsOperatorInput, GetVectorsOperatorOutput> for GetVectorsOperator {
     type Error = GetVectorsOperatorError;
 
+    fn get_name(&self) -> &'static str {
+        "GetVectorsOperator"
+    }
+
     async fn run(
         &self,
         input: &GetVectorsOperatorInput,

--- a/rust/worker/src/execution/operators/merge_knn_results.rs
+++ b/rust/worker/src/execution/operators/merge_knn_results.rs
@@ -72,6 +72,10 @@ impl Operator<MergeKnnResultsOperatorInput, MergeKnnResultsOperatorOutput>
 {
     type Error = Box<dyn ChromaError>;
 
+    fn get_name(&self) -> &'static str {
+        "MergeKnnResultsOperator"
+    }
+
     async fn run(
         &self,
         input: &MergeKnnResultsOperatorInput,

--- a/rust/worker/src/execution/operators/normalize_vectors.rs
+++ b/rust/worker/src/execution/operators/normalize_vectors.rs
@@ -29,6 +29,10 @@ impl Operator<NormalizeVectorOperatorInput, NormalizeVectorOperatorOutput>
 {
     type Error = ();
 
+    fn get_name(&self) -> &'static str {
+        "NormalizeVectorOperator"
+    }
+
     async fn run(
         &self,
         input: &NormalizeVectorOperatorInput,

--- a/rust/worker/src/execution/operators/partition.rs
+++ b/rust/worker/src/execution/operators/partition.rs
@@ -124,6 +124,10 @@ impl PartitionOperator {
 impl Operator<PartitionInput, PartitionOutput> for PartitionOperator {
     type Error = PartitionError;
 
+    fn get_name(&self) -> &'static str {
+        "PartitionOperator"
+    }
+
     async fn run(&self, input: &PartitionInput) -> Result<PartitionOutput, PartitionError> {
         let records = &input.records;
         let partition_size = self.determine_partition_size(records.len(), input.max_partition_size);

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -137,6 +137,7 @@ impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
         if input.num_records.is_some() && result.len() > input.num_records.unwrap() as usize {
             result.truncate(input.num_records.unwrap() as usize);
         }
+        tracing::info!("[PullLogsOperator]: Read {} records", result.len());
         // Convert to DataChunk
         let data_chunk = Chunk::new(result.into());
         Ok(PullLogsOutput::new(data_chunk))

--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -88,6 +88,10 @@ impl PullLogsOutput {
 impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
     type Error = PullLogsError;
 
+    fn get_name(&self) -> &'static str {
+        "PullLogsOperator"
+    }
+
     async fn run(&self, input: &PullLogsInput) -> Result<PullLogsOutput, PullLogsError> {
         // We expect the log to be cheaply cloneable, we need to clone it since we need
         // a mutable reference to it. Not necessarily the best, but it works for our needs.

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -101,6 +101,10 @@ impl ChromaError for RegisterError {
 impl Operator<RegisterInput, RegisterOutput> for RegisterOperator {
     type Error = RegisterError;
 
+    fn get_name(&self) -> &'static str {
+        "RegisterOperator"
+    }
+
     async fn run(&self, input: &RegisterInput) -> Result<RegisterOutput, RegisterError> {
         let mut sysdb = input.sysdb.clone();
         let mut log = input.log.clone();

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -316,7 +316,7 @@ impl HnswQueryOrchestrator {
             Err(e) => {
                 match *e {
                     DistributedHNSWSegmentFromSegmentError::Uninitialized => {
-                        tracing::error!("[HnswQueryOperation]: Error creating distributed hnsw segment reader {:?}", *e);
+                        tracing::info!("[HnswQueryOperation]: Uninitialied reader {:?}", *e);
                         // no task, decrement the merge dependency count and return
                         // with an empty result
                         for (i, _) in self.query_vectors.iter().enumerate() {

--- a/rust/worker/src/execution/worker_thread.rs
+++ b/rust/worker/src/execution/worker_thread.rs
@@ -2,6 +2,7 @@ use super::{dispatcher::TaskRequestMessage, operator::TaskMessage};
 use crate::system::{Component, ComponentContext, ComponentRuntime, Handler, ReceiverForMessage};
 use async_trait::async_trait;
 use std::fmt::{Debug, Formatter, Result};
+use tracing::{trace_span, Instrument, Span};
 
 /// A worker thread is responsible for executing tasks
 /// It sends requests to the dispatcher for new tasks.
@@ -56,7 +57,9 @@ impl Handler<TaskMessage> for WorkerThread {
     type Result = ();
 
     async fn handle(&mut self, task: TaskMessage, ctx: &ComponentContext<WorkerThread>) {
-        task.run().await;
+        let child_span =
+            trace_span!(parent: Span::current(), "Task execution", name = task.get_name());
+        task.run().instrument(child_span).await;
         let req: TaskRequestMessage = TaskRequestMessage::new(ctx.receiver());
         let res = self.dispatcher.send(req, None).await;
         // TODO: task run should be able to error and we should send it as part of the result

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -449,6 +449,12 @@ impl<'me> LogMaterializer<'me> {
     pub(crate) async fn materialize(
         &'me self,
     ) -> Result<Chunk<MaterializedLogRecord<'me>>, LogMaterializerError> {
+        // Trace the total_len since len() iterates over the entire chunk
+        // and we don't want to do that just to trace the length.
+        tracing::info!(
+            "Total length of logs in materializer: {}",
+            self.logs.total_len()
+        );
         let next_offset_id;
         match self.curr_offset_id.as_ref() {
             Some(curr_offset_id) => {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -143,21 +143,16 @@ impl WorkerServer {
 
         let mut proto_results_for_all = Vec::new();
 
-        let parse_vectors_span = trace_span!("Input vectors parsing");
         let mut query_vectors = Vec::new();
-        let _ = parse_vectors_span.in_scope(|| {
-            for proto_query_vector in request.vectors {
-                let (query_vector, _encoding) = match proto_query_vector.try_into() {
-                    Ok((vector, encoding)) => (vector, encoding),
-                    Err(e) => {
-                        return Err(Status::internal(format!("Error converting vector: {}", e)));
-                    }
-                };
-                query_vectors.push(query_vector);
-            }
-            trace!("Parsed vectors {:?}", query_vectors);
-            Ok(())
-        });
+        for proto_query_vector in request.vectors {
+            let (query_vector, _encoding) = match proto_query_vector.try_into() {
+                Ok((vector, encoding)) => (vector, encoding),
+                Err(e) => {
+                    return Err(Status::internal(format!("Error converting vector: {}", e)));
+                }
+            };
+            query_vectors.push(query_vector);
+        }
 
         let dispatcher = match self.dispatcher {
             Some(ref dispatcher) => dispatcher.clone(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Auto trace all operators by name
	 - Add materialize logs instrumentation span where called
	 - Add count event for pull logs inside operator
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
