### PR TITLE
[TST] ML sleep

### DIFF
--- a/chromadb/segment/impl/distributed/segment_directory.py
+++ b/chromadb/segment/impl/distributed/segment_directory.py
@@ -15,6 +15,7 @@ from chromadb.telemetry.opentelemetry import (
     add_attributes_to_current_span,
     trace_method,
 )
+import time
 
 from chromadb.utils.rendezvous_hash import assign, murmur3hasher
 
@@ -118,6 +119,10 @@ class CustomResourceMemberlistProvider(MemberlistProvider, EnforceOverrides):
                 },
             )
             self._done_waiting_for_reset.wait(5.0)
+            # TODO: For some reason the above can flake and the memberlist won't be populated
+            # Given that this is a test harness, just sleep for an additional 500ms for now
+            # We should understand why this flaps
+            time.sleep(0.5)
 
     @override
     def get_memberlist(self) -> Memberlist:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - #2473 introduced a change to wait less, this flaps for some reason. In the interest of speeding up the test but not wasting time on debugging this as its only a test harness related change, just sleep to let the ML converge.
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
