### PR TITLE
[BUG] Fix 3.12 cross version persist tests by building the wheel manu…

### DIFF
--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -166,6 +166,16 @@ def install_version(version: str) -> None:
 def install(pkg: str, path: str) -> int:
     # -q -q to suppress pip output to ERROR level
     # https://pip.pypa.io/en/stable/cli/pip/#quiet
+    print("Purging pip cache")
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "cache",
+            "purge",
+        ]
+    )
     print(f"Installing chromadb version {pkg} to {path}")
     return subprocess.check_call(
         [
@@ -176,6 +186,7 @@ def install(pkg: str, path: str) -> int:
             "-q",
             "install",
             pkg,
+            "--no-binary=chroma-hnswlib",
             "--target={}".format(path),
         ]
     )
@@ -279,7 +290,7 @@ def test_cycle_versions(
         embeddings_strategy["metadatas"], list
     ):
         embeddings_strategy["metadatas"] = [
-            m if m is None or len(m) > 0 else None  # type: ignore
+            m if m is None or len(m) > 0 else None
             for m in embeddings_strategy["metadatas"]
         ]
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Now that we build hnswlib wheels for 3.12, the old version of chroma fetches wheels which do not work. This change explicitly makes the cross version tests rebuild the wheels. This was silently failing as the incompatible wheels failed in python with invalid instruction. Testing if the deps work out of the box for old versions is out of scope for this test. That should be handled by the existing tests that promote a given version, not retroactive tests.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
These fix tests on main
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
