### PR TITLE
[BUG]: Auth + custom headers + SSL-cert support for async client

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -121,6 +121,8 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             self._clients[loop_hash] = httpx.AsyncClient(
                 timeout=None, headers=self._headers, verify=self._verify
             )
+        else:
+            self._clients[loop_hash].headers.update(self._headers)
 
         return self._clients[loop_hash]
 

--- a/chromadb/test/auth/strategies.py
+++ b/chromadb/test/auth/strategies.py
@@ -6,6 +6,7 @@ import yaml
 import string
 
 from chromadb import TokenTransportHeader
+from chromadb.api import AsyncServerAPI
 from chromadb.test.property.strategies import collection_name
 
 
@@ -233,3 +234,7 @@ def _dump_to_tmpfile(data: Any) -> str:
     with open(tmp.name, "w") as f:
         yaml.dump(data, f)
     return tmp.name
+
+
+async def list_col_async(client: AsyncServerAPI):
+    return await client.list_collections()

--- a/chromadb/test/auth/test_basic_authn.py
+++ b/chromadb/test/auth/test_basic_authn.py
@@ -1,14 +1,35 @@
+import asyncio
+from typing import Union
+from chromadb.test.auth.strategies import (
+    list_col_async,
+)
 import pytest
 
-from chromadb.api import ServerAPI
+from chromadb.api import ServerAPI, AsyncServerAPI
 
 
-def test_invalid_auth_cred(api_wrong_cred: ServerAPI) -> None:
+def test_invalid_auth_cred(api_wrong_cred: Union[AsyncServerAPI, ServerAPI]) -> None:
     with pytest.raises(Exception) as e:
-        api_wrong_cred.list_collections()
+        if (
+            api_wrong_cred.get_settings().chroma_api_impl
+            == "chromadb.api.async_fastapi.AsyncFastAPI"
+        ):
+            asyncio.get_event_loop().run_until_complete(list_col_async(api_wrong_cred))
+        else:
+            api_wrong_cred.list_collections()
     assert "Forbidden" in str(e.value)
 
 
-def test_server_basic_auth(api_with_server_auth: ServerAPI) -> None:
-    cols = api_with_server_auth.list_collections()
+def test_server_basic_auth(
+    api_with_server_auth: Union[AsyncServerAPI, ServerAPI]
+) -> None:
+    if (
+        api_with_server_auth.get_settings().chroma_api_impl
+        == "chromadb.api.async_fastapi.AsyncFastAPI"
+    ):
+        cols = asyncio.get_event_loop().run_until_complete(
+            list_col_async(api_with_server_auth)
+        )
+    else:
+        cols = api_with_server_auth.list_collections()
     assert len(cols) == 0

--- a/chromadb/test/auth/test_token_authn.py
+++ b/chromadb/test/auth/test_token_authn.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from hypothesis import given, settings
 from typing import Any, Dict
 
@@ -11,13 +13,21 @@ from chromadb.test.auth.strategies import (
     random_token,
     random_token_transport_header,
     token_test_conf,
+    list_col_async,
 )
 
 
 @settings(max_examples=10)
-@given(token_test_conf(), random_token_transport_header(), st.booleans())
+@given(
+    token_test_conf(),
+    random_token_transport_header(),
+    st.booleans(),
+    st.sampled_from(
+        ["chromadb.api.async_fastapi.AsyncFastAPI", "chromadb.api.fastapi.FastAPI"]
+    ),
+)
 def test_fastapi_server_token_authn_allows_when_it_should_allow(
-    tconf: Dict[str, Any], transport_header: str, persistence: bool
+    tconf: Dict[str, Any], transport_header: str, persistence: bool, api_impl: str
 ) -> None:
     for user in tconf["users"]:
         for token in user["tokens"]:
@@ -28,23 +38,35 @@ def test_fastapi_server_token_authn_allows_when_it_should_allow(
                 chroma_server_authn_credentials_file=tconf["filename"],
                 chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider",
                 chroma_client_auth_credentials=token,
+                chroma_api_impl=api_impl,
             )
             _sys: System = next(api)
             _sys.reset_state()
             _api = _sys.instance(ServerAPI)
             _api.heartbeat()
-            assert _api.list_collections() == []
+            if api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
+                cols = asyncio.get_event_loop().run_until_complete(list_col_async(_api))  # type: ignore
+            else:
+                cols = _api.list_collections()
+            assert cols == []
 
 
 @settings(max_examples=10)
 @given(
-    token_test_conf(), random_token(), random_token_transport_header(), st.booleans()
+    token_test_conf(),
+    random_token(),
+    random_token_transport_header(),
+    st.booleans(),
+    st.sampled_from(
+        ["chromadb.api.async_fastapi.AsyncFastAPI", "chromadb.api.fastapi.FastAPI"]
+    ),
 )
 def test_fastapi_server_token_authn_rejects_when_it_should_reject(
     tconf: Dict[str, Any],
     unauthorized_token: str,
     transport_header: str,
     persistence: bool,
+    api_impl: str,
 ) -> None:
     # Make sure we actually have an unauthorized token
     for user in tconf["users"]:
@@ -61,12 +83,16 @@ def test_fastapi_server_token_authn_rejects_when_it_should_reject(
                 chroma_server_authn_credentials_file=tconf["filename"],
                 chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider",
                 chroma_client_auth_credentials=unauthorized_token,
+                chroma_api_impl=api_impl,
             )
             _sys: System = next(_api)
             _sys.reset_state()
             api = _sys.instance(ServerAPI)
             api.heartbeat()
             with pytest.raises(Exception) as e:
-                api.list_collections()
+                if api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
+                    asyncio.get_event_loop().run_until_complete(list_col_async(api))  # type: ignore
+                else:
+                    api.list_collections()
 
             assert "Forbidden" in str(e)

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -639,22 +639,34 @@ def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, N
 
 def system_fixtures_auth() -> List[Callable[[], Generator[System, None, None]]]:
     fixtures = [
-        pytest.param((
-            fastapi_server_basic_auth_valid_cred_single_user,
-            "chromadb.api.fastapi.FastAPI",
-        ),id="fastapi_server_basic_auth_valid_cred_single_user_sync"),
-        pytest.param((
-            fastapi_server_basic_auth_valid_cred_single_user,
-            "chromadb.api.async_fastapi.AsyncFastAPI",
-        ),id="fastapi_server_basic_auth_valid_cred_single_user_async"),
-        pytest.param((
-            fastapi_server_basic_auth_valid_cred_multiple_users,
-            "chromadb.api.async_fastapi.AsyncFastAPI",
-        ),id="fastapi_server_basic_auth_valid_cred_multiple_users_async"),
-        pytest.param((
-            fastapi_server_basic_auth_valid_cred_multiple_users,
-            "chromadb.api.fastapi.FastAPI",
-        ),id="fastapi_server_basic_auth_valid_cred_multiple_users_sync"),
+        pytest.param(
+            (
+                fastapi_server_basic_auth_valid_cred_single_user,
+                "chromadb.api.fastapi.FastAPI",
+            ),
+            id="fastapi_server_basic_auth_valid_cred_single_user_sync",
+        ),
+        pytest.param(
+            (
+                fastapi_server_basic_auth_valid_cred_single_user,
+                "chromadb.api.async_fastapi.AsyncFastAPI",
+            ),
+            id="fastapi_server_basic_auth_valid_cred_single_user_async",
+        ),
+        pytest.param(
+            (
+                fastapi_server_basic_auth_valid_cred_multiple_users,
+                "chromadb.api.async_fastapi.AsyncFastAPI",
+            ),
+            id="fastapi_server_basic_auth_valid_cred_multiple_users_async",
+        ),
+        pytest.param(
+            (
+                fastapi_server_basic_auth_valid_cred_multiple_users,
+                "chromadb.api.fastapi.FastAPI",
+            ),
+            id="fastapi_server_basic_auth_valid_cred_multiple_users_sync",
+        ),
     ]
     return fixtures
 
@@ -670,34 +682,50 @@ def system_fixtures_root_and_singleton_tenant_db_user() -> (
     List[Callable[[], Generator[System, None, None]]]
 ):
     fixtures = [
-        pytest.param((
-            fastapi_fixture_admin_and_singleton_tenant_db_user,
-            "chromadb.api.fastapi.FastAPI",
-        ),id="fastapi_fixture_admin_and_singleton_tenant_db_user_sync"),
-        pytest.param((
-            fastapi_fixture_admin_and_singleton_tenant_db_user,
-            "chromadb.api.fastapi.AsyncFastAPI",
-        ),id="fastapi_fixture_admin_and_singleton_tenant_db_user_async"),
+        pytest.param(
+            (
+                fastapi_fixture_admin_and_singleton_tenant_db_user,
+                "chromadb.api.fastapi.FastAPI",
+            ),
+            id="fastapi_fixture_admin_and_singleton_tenant_db_user_sync",
+        ),
+        pytest.param(
+            (
+                fastapi_fixture_admin_and_singleton_tenant_db_user,
+                "chromadb.api.fastapi.AsyncFastAPI",
+            ),
+            id="fastapi_fixture_admin_and_singleton_tenant_db_user_async",
+        ),
     ]
     return fixtures
 
 
 def system_fixtures_wrong_auth() -> List[Callable[[], Generator[System, None, None]]]:
     fixtures = [
-        pytest.param((fastapi_server_basic_auth_invalid_cred,
-                      "chromadb.api.fastapi.FastAPI"), id="fastapi_server_basic_auth_invalid_cred_sync"),
-        pytest.param((
-            fastapi_server_basic_auth_invalid_cred,
-            "chromadb.api.async_fastapi.AsyncFastAPI",
-        ), id="fastapi_server_basic_auth_invalid_cred_async"),
+        pytest.param(
+            (fastapi_server_basic_auth_invalid_cred, "chromadb.api.fastapi.FastAPI"),
+            id="fastapi_server_basic_auth_invalid_cred_sync",
+        ),
+        pytest.param(
+            (
+                fastapi_server_basic_auth_invalid_cred,
+                "chromadb.api.async_fastapi.AsyncFastAPI",
+            ),
+            id="fastapi_server_basic_auth_invalid_cred_async",
+        ),
     ]
     return fixtures
 
 
 def system_fixtures_ssl() -> List[Callable[[], Generator[System, None, None]]]:
     fixtures = [
-        pytest.param((fastapi_ssl, "chromadb.api.fastapi.FastAPI"), id="fastapi_ssl_sync"),
-        pytest.param((fastapi_ssl, "chromadb.api.async_fastapi.AsyncFastAPI"), id="fastapi_ssl_async"),
+        pytest.param(
+            (fastapi_ssl, "chromadb.api.fastapi.FastAPI"), id="fastapi_ssl_sync"
+        ),
+        pytest.param(
+            (fastapi_ssl, "chromadb.api.async_fastapi.AsyncFastAPI"),
+            id="fastapi_ssl_async",
+        ),
     ]
     return fixtures
 

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -692,7 +692,7 @@ def system_fixtures_root_and_singleton_tenant_db_user() -> (
         pytest.param(
             (
                 fastapi_fixture_admin_and_singleton_tenant_db_user,
-                "chromadb.api.fastapi.AsyncFastAPI",
+                "chromadb.api.async_fastapi.AsyncFastAPI",
             ),
             id="fastapi_fixture_admin_and_singleton_tenant_db_user_async",
         ),

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -639,22 +639,22 @@ def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, N
 
 def system_fixtures_auth() -> List[Callable[[], Generator[System, None, None]]]:
     fixtures = [
-        (
-            fastapi_server_basic_auth_valid_cred_single_user,
-            "chromadb.api.async_fastapi.AsyncFastAPI",
-        ),
-        (
+        pytest.param((
             fastapi_server_basic_auth_valid_cred_single_user,
             "chromadb.api.fastapi.FastAPI",
-        ),
-        (
+        ),id="fastapi_server_basic_auth_valid_cred_single_user_sync"),
+        pytest.param((
+            fastapi_server_basic_auth_valid_cred_single_user,
+            "chromadb.api.async_fastapi.AsyncFastAPI",
+        ),id="fastapi_server_basic_auth_valid_cred_single_user_async"),
+        pytest.param((
             fastapi_server_basic_auth_valid_cred_multiple_users,
             "chromadb.api.async_fastapi.AsyncFastAPI",
-        ),
-        (
+        ),id="fastapi_server_basic_auth_valid_cred_multiple_users_async"),
+        pytest.param((
             fastapi_server_basic_auth_valid_cred_multiple_users,
             "chromadb.api.fastapi.FastAPI",
-        ),
+        ),id="fastapi_server_basic_auth_valid_cred_multiple_users_sync"),
     ]
     return fixtures
 
@@ -670,33 +670,34 @@ def system_fixtures_root_and_singleton_tenant_db_user() -> (
     List[Callable[[], Generator[System, None, None]]]
 ):
     fixtures = [
-        (
+        pytest.param((
             fastapi_fixture_admin_and_singleton_tenant_db_user,
             "chromadb.api.fastapi.FastAPI",
-        ),
-        (
+        ),id="fastapi_fixture_admin_and_singleton_tenant_db_user_sync"),
+        pytest.param((
             fastapi_fixture_admin_and_singleton_tenant_db_user,
             "chromadb.api.fastapi.AsyncFastAPI",
-        ),
+        ),id="fastapi_fixture_admin_and_singleton_tenant_db_user_async"),
     ]
     return fixtures
 
 
 def system_fixtures_wrong_auth() -> List[Callable[[], Generator[System, None, None]]]:
     fixtures = [
-        (fastapi_server_basic_auth_invalid_cred, "chromadb.api.fastapi.FastAPI"),
-        (
+        pytest.param((fastapi_server_basic_auth_invalid_cred,
+                      "chromadb.api.fastapi.FastAPI"), id="fastapi_server_basic_auth_invalid_cred_sync"),
+        pytest.param((
             fastapi_server_basic_auth_invalid_cred,
             "chromadb.api.async_fastapi.AsyncFastAPI",
-        ),
+        ), id="fastapi_server_basic_auth_invalid_cred_async"),
     ]
     return fixtures
 
 
 def system_fixtures_ssl() -> List[Callable[[], Generator[System, None, None]]]:
     fixtures = [
-        (fastapi_ssl, "chromadb.api.fastapi.FastAPI"),
-        (fastapi_ssl, "chromadb.api.async_fastapi.AsyncFastAPI"),
+        pytest.param((fastapi_ssl, "chromadb.api.fastapi.FastAPI"), id="fastapi_ssl_sync"),
+        pytest.param((fastapi_ssl, "chromadb.api.async_fastapi.AsyncFastAPI"), id="fastapi_ssl_async"),
     ]
     return fixtures
 

--- a/chromadb/utils/async_to_sync.py
+++ b/chromadb/utils/async_to_sync.py
@@ -19,6 +19,9 @@ def async_to_sync(func: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, R]:
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
+            loop = None
+
+        if loop is None or loop.is_closed():
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
 


### PR DESCRIPTION
Closes #2488 
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	- Added the support for auth provider in Async client
	- Added support for custom client-provided headers in Async client
	- Added support for SSL cert ignore or custom SSL certs via chroma_server_ssl_verify
	- Updated test rig for Auth tests
	- Updated test rig to support SSL tests for async
	- Fixed an issue with stale headers in async client

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
TBD
