### PR TITLE
[BLD]: Unpinning hnswlib in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
   'build >= 1.0.3',
   'pydantic >= 1.9',
-  'chroma-hnswlib==0.7.3',
+  'chroma-hnswlib>=0.7.3',
   'fastapi >= 0.95.2',
   'uvicorn[standard] >= 0.18.3',
   'numpy >= 1.22.5, < 2.0.0',


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Currently due to pinned hnsw dep in pyproject installing chroma on py312 causes rebuild hnsw - this change aligns requirements and pyproject.toml to unpin the version and allow for 0.7.5 (py312) binary whl to be installed

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
