### PR TITLE
[BUG] Fix cross version persistence tests after 0.5.4 release

### DIFF
--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -21,7 +21,10 @@ import multiprocessing
 from chromadb.config import Settings
 from chromadb.api.client import Client as ClientCreator
 
-MINIMUM_VERSION = "0.4.1"
+# Minimum persisted version we support, and other substantial change versions
+# 0.4.1 is the first version with persistence
+# 0.5.3 is the first version with the new API where the serverapi and client api return types and arguments differ
+BASELINE_VERSIONS = ["0.4.1", "0.5.3"]
 version_re = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
 # Some modules do not work across versions, since we upgrade our support for them, and should be explicitly reimported in the subprocess
@@ -36,7 +39,7 @@ def versions() -> List[str]:
     # Older versions on pypi contain "devXYZ" suffixes
     versions = [v for v in versions if version_re.match(v)]
     versions.sort(key=packaging_version.Version)
-    return [MINIMUM_VERSION, versions[-1]]
+    return BASELINE_VERSIONS + [versions[-1]]
 
 
 def _bool_to_int(metadata: Dict[str, Any]) -> Dict[str, Any]:
@@ -234,6 +237,12 @@ def persist_generated_data_with_old_version(
         system.start()
 
         api.reset()
+        # In 0.5.4 we changed the API of the server api level to
+        # deal with collection models instead of collections
+        # in order to work with this we need to wrap the api in a client
+        # for versions greater than or equal to 0.5.4
+        if packaging_version.Version(version) >= packaging_version.Version("0.5.4"):
+            api = old_module.api.client.Client.from_system(system)
         coll = api.create_collection(
             name=collection_strategy.name,
             metadata=collection_strategy.metadata,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - 0.5.4 release breaks CVP tests because the server API no longer returns the collection object and instead returns a model
	 - Added a fix for this by special casing the version (no other way really)
	 - Added BASELINE_VERSIONS to also test 0.5.3 
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None