### PR TITLE
[BUG] fix HNSW param defaults in new configuration logic & require batch_size < sync_threshold

### DIFF
--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -116,8 +116,8 @@ class ConfigurationInternal(JSONSerializable["ConfigurationInternal"]):
                 if not isinstance(parameter.value, type(definition.default_value)):
                     raise ValueError(f"Invalid parameter value: {parameter.value}")
 
-                validator = definition.validator
-                if not validator(parameter.value):
+                parameter_validator = definition.validator
+                if not parameter_validator(parameter.value):
                     raise ValueError(f"Invalid parameter value: {parameter.value}")
                 self.parameter_map[parameter.name] = parameter
         # Apply the defaults for any missing parameters
@@ -127,7 +127,7 @@ class ConfigurationInternal(JSONSerializable["ConfigurationInternal"]):
                     name=name, value=definition.default_value
                 )
 
-        self.validator()
+        self.configuration_validator()
 
     def __repr__(self) -> str:
         return f"Configuration({self.parameter_map.values()})"
@@ -137,7 +137,7 @@ class ConfigurationInternal(JSONSerializable["ConfigurationInternal"]):
             return NotImplemented
         return self.parameter_map == __value.parameter_map
 
-    def validator(self) -> None:
+    def configuration_validator(self) -> None:
         """Perform custom validation when parameters are dependent on each other.
 
         Raises an InvalidConfigurationError if the configuration is invalid.
@@ -273,7 +273,7 @@ class HNSWConfigurationInternal(ConfigurationInternal):
     }
 
     @override
-    def validator(self) -> None:
+    def configuration_validator(self) -> None:
         batch_size = self.parameter_map.get("batch_size")
         sync_threshold = self.parameter_map.get("sync_threshold")
 

--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -137,6 +137,7 @@ class ConfigurationInternal(JSONSerializable["ConfigurationInternal"]):
             return NotImplemented
         return self.parameter_map == __value.parameter_map
 
+    @abstractmethod
     def configuration_validator(self) -> None:
         """Perform custom validation when parameters are dependent on each other.
 
@@ -364,6 +365,10 @@ class CollectionConfigurationInternal(ConfigurationInternal):
             default_value=HNSWConfigurationInternal(),
         ),
     }
+
+    @override
+    def configuration_validator(self) -> None:
+        pass
 
 
 # This is the user-facing interface for HNSW index configuration parameters.

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -786,16 +786,14 @@ class SqlSysDB(SqlDB, SysDB):
                 sync_threshold = hnsw_configuration.get("sync_threshold")
 
                 if batch_size and sync_threshold and batch_size > sync_threshold:
-                    config_json["hnsw_configuration"][
-                        "sync_threshold"
-                    ] = HNSWConfigurationInternal.definitions[
-                        "sync_threshold"
-                    ].default_value
-                    config_json["hnsw_configuration"][
-                        "batch_size"
-                    ] = HNSWConfigurationInternal.definitions[
-                        "batch_size"
-                    ].default_value
+                    # Allow new defaults to be set
+                    hnsw_configuration = {
+                        k: v
+                        for k, v in hnsw_configuration.items()
+                        if k not in ["batch_size", "sync_threshold"]
+                    }
+                    config_json.update({"hnsw_configuration": hnsw_configuration})
+
                     configuration = CollectionConfigurationInternal.from_json(
                         config_json
                     )

--- a/chromadb/test/configurations/test_configurations.py
+++ b/chromadb/test/configurations/test_configurations.py
@@ -1,9 +1,9 @@
-from typing import Tuple
 from overrides import overrides
 import pytest
 from chromadb.api.configuration import (
     ConfigurationInternal,
     ConfigurationDefinition,
+    InvalidConfigurationError,
     StaticParameterError,
     ConfigurationParameter,
     HNSWConfiguration,
@@ -93,9 +93,9 @@ def test_configuration_validation() -> None:
         }
 
         @overrides
-        def validator(self) -> Tuple[bool, str | None]:
+        def validator(self) -> None:
             if self.parameter_map.get("foo") != "bar":
-                return False, "foo must be 'bar'"
+                raise InvalidConfigurationError("foo must be 'bar'")
             return super().validator()
 
     with pytest.raises(ValueError, match="foo must be 'bar'"):

--- a/chromadb/test/configurations/test_configurations.py
+++ b/chromadb/test/configurations/test_configurations.py
@@ -26,6 +26,10 @@ class TestConfiguration(ConfigurationInternal):
         ),
     }
 
+    @overrides
+    def configuration_validator(self) -> None:
+        pass
+
 
 def test_default_values() -> None:
     default_test_configuration = TestConfiguration()
@@ -96,7 +100,6 @@ def test_configuration_validation() -> None:
         def configuration_validator(self) -> None:
             if self.parameter_map.get("foo") != "bar":
                 raise InvalidConfigurationError("foo must be 'bar'")
-            return super().configuration_validator()
 
     with pytest.raises(ValueError, match="foo must be 'bar'"):
         FooConfiguration(parameters=[ConfigurationParameter(name="foo", value="baz")])

--- a/chromadb/test/configurations/test_configurations.py
+++ b/chromadb/test/configurations/test_configurations.py
@@ -4,6 +4,7 @@ from chromadb.api.configuration import (
     ConfigurationDefinition,
     StaticParameterError,
     ConfigurationParameter,
+    HNSWConfiguration,
 )
 
 
@@ -76,3 +77,8 @@ def test_validation() -> None:
     ]
     with pytest.raises(ValueError):
         TestConfiguration(parameters=invalid_parameter_names)
+
+
+def test_hnsw_validation() -> None:
+    with pytest.raises(ValueError, match="must be less than or equal"):
+        HNSWConfiguration(batch_size=500, sync_threshold=100)

--- a/chromadb/test/configurations/test_configurations.py
+++ b/chromadb/test/configurations/test_configurations.py
@@ -93,10 +93,10 @@ def test_configuration_validation() -> None:
         }
 
         @overrides
-        def validator(self) -> None:
+        def configuration_validator(self) -> None:
             if self.parameter_map.get("foo") != "bar":
                 raise InvalidConfigurationError("foo must be 'bar'")
-            return super().validator()
+            return super().configuration_validator()
 
     with pytest.raises(ValueError, match="foo must be 'bar'"):
         FooConfiguration(parameters=[ConfigurationParameter(name="foo", value="baz")])

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -306,11 +306,16 @@ def collections(
             metadata = {}
         metadata.update(test_hnsw_config)
         if use_persistent_hnsw_params:
-            metadata["hnsw:batch_size"] = draw(
-                st.integers(min_value=3, max_value=max_hnsw_batch_size)
-            )
             metadata["hnsw:sync_threshold"] = draw(
                 st.integers(min_value=3, max_value=max_hnsw_sync_threshold)
+            )
+            metadata["hnsw:batch_size"] = draw(
+                st.integers(
+                    min_value=3,
+                    max_value=min(
+                        [metadata["hnsw:sync_threshold"], max_hnsw_batch_size]
+                    ),
+                )
             )
         # Sometimes, select a space at random
         if draw(st.booleans()):


### PR DESCRIPTION
It doesn't really make sense to have a config where `hnsw:batch_size > hnsw:sync_threshold`, and although (I think) we don't depend on this invariant today we could accidentally depend on it in the future without enforcing it.