### PR TITLE
[ENH] run `PRAGMA optimize` on startup

### DIFF
--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -98,6 +98,10 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
         with self.tx() as cur:
             cur.execute("PRAGMA foreign_keys = ON")
             cur.execute("PRAGMA case_sensitive_like = ON")
+            # The SQLite docs recommend running this at startup for applications with long-lived connections.
+            # > the "PRAGMA optimize" command automatically limits the scope of ANALYZE subcommands so that the overall "PRAGMA optimize" command completes quickly even on enormous databases
+            # https://www.sqlite.org/lang_analyze.html
+            cur.execute("PRAGMA optimize=0x10002")
         self.initialize_migrations()
 
     @trace_method("SqliteDB.stop", OpenTelemetryGranularity.ALL)


### PR DESCRIPTION
Recommended by SQLite docs to help the query planner make better decisions.

On most startups this should be effectively a no-op; but when users first upgrade to a version with this change or their amount of data substantially changes (increased/decreased by 10x at time of writing according to SQLite docs) this adds additional latency to startup.

Using [this script](https://github.com/chroma-core/chroma/blob/cip-wal-pruning/docs/cip/CIP-07102024_Write_Ahead_Log_Pruning_Vacuuming.md#incremental-vacuum-experiment) to create a test database, I observed that the duration of `PRAGMA optimize` scales roughly linearly with database size:

- 1GB: 178ms
- 10GB: 6,054ms
- 20GB: 13,228ms
