### PR TITLE
[TST] Enable cache eviction for shuttle concurrency test

### DIFF
--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -14,7 +14,6 @@ use parking_lot::Mutex;
 use std::mem::transmute;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
-use tracing::{trace_span, Instrument, Span};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -535,14 +534,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
 
 #[cfg(test)]
 mod tests {
-    use crate::blockstore::arrow::sparse_index;
     use crate::cache::cache::Cache;
     use crate::cache::config::{CacheConfig, UnboundedCacheConfig};
     use crate::{
+        blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES,
         blockstore::arrow::provider::ArrowBlockfileProvider,
-        blockstore::{arrow::config::TEST_MAX_BLOCK_SIZE_BYTES, BlockfileError},
-        cache,
-        log::config::{self, GrpcLogConfig},
         segment::DataRecord,
         storage::{local::LocalStorage, Storage},
         types::MetadataValue,

--- a/rust/worker/src/blockstore/arrow/concurrency_test.rs
+++ b/rust/worker/src/blockstore/arrow/concurrency_test.rs
@@ -4,7 +4,7 @@ mod tests {
         blockstore::arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
         cache::{
             cache::Cache,
-            config::{CacheConfig, UnboundedCacheConfig},
+            config::{CacheConfig, LruConfig},
         },
         storage::{local::LocalStorage, Storage},
     };
@@ -13,13 +13,18 @@ mod tests {
 
     #[test]
     fn test_blockfile_shuttle() {
+        const BLOCK_CACHE_CAPACITY: usize = 1000;
+        const SPARSE_INDEX_CACHE_CAPACITY: usize = 1000;
         shuttle::check_random(
             || {
                 let tmp_dir = tempfile::tempdir().unwrap();
                 let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-                let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-                let sparse_index_cache =
-                    Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+                let block_cache = Cache::new(&CacheConfig::Lru(LruConfig {
+                    capacity: BLOCK_CACHE_CAPACITY,
+                }));
+                let sparse_index_cache = Cache::new(&CacheConfig::Lru(LruConfig {
+                    capacity: SPARSE_INDEX_CACHE_CAPACITY,
+                }));
                 let blockfile_provider = ArrowBlockfileProvider::new(
                     storage,
                     TEST_MAX_BLOCK_SIZE_BYTES,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR enables cache eviction for the concurrency test. 
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
