### PR TITLE
[ENH] prefetch APIs for Record segment and blockfile

### DIFF
--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -276,6 +276,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     }
 
     pub(super) async fn load_blocks(&self, block_ids: Vec<Uuid>) -> () {
+        // TODO: These need to be tasks enqueued onto dispatcher.
         let mut futures = Vec::new();
         for block_id in block_ids {
             futures.push(self.get_block(block_id));

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -284,7 +284,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         join_all(futures).await;
     }
 
-    pub(crate) async fn load_blocks_for_keys(&self, prefixes: &Vec<&str>, keys: &Vec<K>) -> () {
+    pub(crate) async fn load_blocks_for_keys(&self, prefixes: Vec<&str>, keys: Vec<K>) -> () {
         let mut composite_keys = Vec::new();
         let mut prefix_iter = prefixes.iter();
         let mut key_iter = keys.iter();
@@ -294,9 +294,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                 composite_keys.push(composite_key);
             }
         }
-        let target_block_ids = self
-            .sparse_index
-            .get_all_target_block_ids(&mut composite_keys);
+        let target_block_ids = self.sparse_index.get_all_target_block_ids(composite_keys);
         self.load_blocks(target_block_ids).await;
     }
 

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -10,6 +10,7 @@ use crate::blockstore::key::KeyWrapper;
 use crate::blockstore::BlockfileError;
 use crate::errors::ErrorCodes;
 use crate::{blockstore::key::CompositeKey, errors::ChromaError};
+use futures::future::join_all;
 use parking_lot::Mutex;
 use std::mem::transmute;
 use std::{collections::HashMap, sync::Arc};
@@ -272,6 +273,30 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         }
 
         None
+    }
+
+    pub(super) async fn load_blocks(&self, block_ids: Vec<Uuid>) -> () {
+        let mut futures = Vec::new();
+        for block_id in block_ids {
+            futures.push(self.get_block(block_id));
+        }
+        join_all(futures).await;
+    }
+
+    pub(crate) async fn load_blocks_for_keys(&self, prefixes: &Vec<&str>, keys: &Vec<K>) -> () {
+        let mut composite_keys = Vec::new();
+        let mut prefix_iter = prefixes.iter();
+        let mut key_iter = keys.iter();
+        while let Some(prefix) = prefix_iter.next() {
+            if let Some(key) = key_iter.next() {
+                let composite_key = CompositeKey::new(prefix.to_string(), key.clone());
+                composite_keys.push(composite_key);
+            }
+        }
+        let target_block_ids = self
+            .sparse_index
+            .get_all_target_block_ids(&mut composite_keys);
+        self.load_blocks(target_block_ids).await;
     }
 
     pub(crate) async fn get(&'me self, prefix: &str, key: K) -> Result<V, Box<dyn ChromaError>> {

--- a/rust/worker/src/blockstore/arrow/provider.rs
+++ b/rust/worker/src/blockstore/arrow/provider.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use core::panic;
-use futures::StreamExt;
+use futures::{future::join_all, StreamExt};
 use thiserror::Error;
 use tracing::{Instrument, Span};
 use uuid::Uuid;
@@ -218,7 +218,7 @@ impl BlockManager {
                     ).await;
                     match stream {
                         Ok(mut bytes) => {
-                            let read_block_span = tracing::trace_span!(parent: Span::current(), "BlockManager read bytes to end");
+                            let read_block_span = tracing::trace_span!(parent: Span::current(), "BlockManager read bytes to end for block get");
                             let buf = read_block_span.in_scope(|| async {
                                 let mut buf: Vec<u8> = Vec::new();
                                 while let Some(res) = bytes.next().await {
@@ -243,7 +243,7 @@ impl BlockManager {
                                     return None;
                                 }
                             };
-                            tracing::info!("Read {:?} bytes from s3", buf.len());
+                            tracing::info!("Read {:?} bytes from s3 for block get", buf.len());
                             let deserialization_span = tracing::trace_span!(parent: Span::current(), "BlockManager deserialize block");
                             let block = deserialization_span.in_scope(|| Block::from_bytes(&buf, *id));
                             match block {

--- a/rust/worker/src/blockstore/arrow/provider.rs
+++ b/rust/worker/src/blockstore/arrow/provider.rs
@@ -218,7 +218,7 @@ impl BlockManager {
                     ).await;
                     match stream {
                         Ok(mut bytes) => {
-                            let read_block_span = tracing::trace_span!(parent: Span::current(), "BlockManager read bytes to end for block get");
+                            let read_block_span = tracing::trace_span!(parent: Span::current(), "BlockManager read bytes to end");
                             let buf = read_block_span.in_scope(|| async {
                                 let mut buf: Vec<u8> = Vec::new();
                                 while let Some(res) = bytes.next().await {
@@ -243,7 +243,7 @@ impl BlockManager {
                                     return None;
                                 }
                             };
-                            tracing::info!("Read {:?} bytes from s3 for block get", buf.len());
+                            tracing::info!("Read {:?} bytes from s3", buf.len());
                             let deserialization_span = tracing::trace_span!(parent: Span::current(), "BlockManager deserialize block");
                             let block = deserialization_span.in_scope(|| Block::from_bytes(&buf, *id));
                             match block {

--- a/rust/worker/src/blockstore/arrow/sparse_index.rs
+++ b/rust/worker/src/blockstore/arrow/sparse_index.rs
@@ -99,10 +99,7 @@ impl SparseIndex {
         reverse.insert(block_id, SparseIndexDelimiter::Start);
     }
 
-    pub(super) fn get_all_target_block_ids(
-        &self,
-        search_keys: &mut Vec<CompositeKey>,
-    ) -> Vec<Uuid> {
+    pub(super) fn get_all_target_block_ids(&self, mut search_keys: Vec<CompositeKey>) -> Vec<Uuid> {
         // Sort so that we can search in one iteration.
         search_keys.sort();
         let mut result_uuids = Vec::new();

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -351,7 +351,7 @@ impl<
         }
     }
 
-    pub(crate) async fn load_blocks_for_keys(&self, prefixes: &Vec<&str>, keys: &Vec<K>) -> () {
+    pub(crate) async fn load_blocks_for_keys(&self, prefixes: Vec<&str>, keys: Vec<K>) -> () {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => unimplemented!(),
             BlockfileReader::ArrowBlockfileReader(reader) => {

--- a/rust/worker/src/blockstore/types.rs
+++ b/rust/worker/src/blockstore/types.rs
@@ -350,4 +350,13 @@ impl<
             BlockfileReader::ArrowBlockfileReader(reader) => reader.id(),
         }
     }
+
+    pub(crate) async fn load_blocks_for_keys(&self, prefixes: &Vec<&str>, keys: &Vec<K>) -> () {
+        match self {
+            BlockfileReader::MemoryBlockfileReader(reader) => unimplemented!(),
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.load_blocks_for_keys(prefixes, keys).await
+            }
+        }
+    }
 }

--- a/rust/worker/src/execution/operators/merge_knn_results.rs
+++ b/rust/worker/src/execution/operators/merge_knn_results.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use thiserror::Error;
-use tracing::{Instrument, Span};
 
 #[derive(Debug)]
 pub struct MergeKnnResultsOperator {}

--- a/rust/worker/src/execution/operators/merge_knn_results.rs
+++ b/rust/worker/src/execution/operators/merge_knn_results.rs
@@ -96,25 +96,6 @@ impl Operator<MergeKnnResultsOperatorInput, MergeKnnResultsOperatorOutput>
                     if input.include_vectors {
                         hnsw_result_vectors = Some(Vec::new());
                     }
-                    // Prefetch data.
-                    // Note: This will be moved to an operator.
-                    let offset_ids = input
-                        .hnsw_result_offset_ids
-                        .iter()
-                        .map(|x| *x as u32)
-                        .collect();
-                    reader
-                        .prefetch_id_to_user_id(&offset_ids)
-                        .instrument(
-                            tracing::trace_span!(parent: Span::current(), "[MergeKnnResultsOperator] Prefetch id to user id"),
-                        )
-                        .await;
-                    reader
-                        .prefetch_id_to_data(&offset_ids)
-                        .instrument(
-                            tracing::trace_span!(parent: Span::current(), "[MergeKnnResultsOperator] Prefetch id to data"),
-                        )
-                        .await;
                     for offset_id in &input.hnsw_result_offset_ids {
                         let user_id = reader.get_user_id_for_offset_id(*offset_id as u32).await;
                         match user_id {

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -243,24 +243,6 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
                         }
                     }
                 };
-                // Prefetch data.
-                // Note: This will be moved to an operator.
-                let merged_ids_copy = merged_ids.clone();
-                let mut ids_to_hydrate = Vec::new();
-                for merged_id in merged_ids_copy {
-                    if visited_ids.contains(&merged_id) {
-                        continue;
-                    }
-                    ids_to_hydrate.push(merged_id);
-                }
-                record_segment_reader
-                    .prefetch_id_to_data(&ids_to_hydrate)
-                    .instrument(tracing::trace_span!(parent: Span::current(), "[MergeMetadataResults] Prefetch id to data"))
-                    .await;
-                record_segment_reader
-                    .prefetch_id_to_user_id(&ids_to_hydrate)
-                    .instrument(tracing::trace_span!(parent: Span::current(), "[MergeMetadataResults] Prefetch id to user id"))
-                    .await;
                 for merged_id in merged_ids {
                     // Skip already taken from log.
                     if visited_ids.contains(&merged_id) {

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -243,6 +243,24 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
                         }
                     }
                 };
+                // Prefetch data.
+                // Note: This will be moved to an operator.
+                let merged_ids_copy = merged_ids.clone();
+                let mut ids_to_hydrate = Vec::new();
+                for merged_id in merged_ids_copy {
+                    if visited_ids.contains(&merged_id) {
+                        continue;
+                    }
+                    ids_to_hydrate.push(merged_id);
+                }
+                record_segment_reader
+                    .prefetch_id_to_data(&ids_to_hydrate)
+                    .instrument(tracing::trace_span!(parent: Span::current(), "[MergeMetadataResults] Prefetch id to data"))
+                    .await;
+                record_segment_reader
+                    .prefetch_id_to_user_id(&ids_to_hydrate)
+                    .instrument(tracing::trace_span!(parent: Span::current(), "[MergeMetadataResults] Prefetch id to user id"))
+                    .await;
                 for merged_id in merged_ids {
                     // Skip already taken from log.
                     if visited_ids.contains(&merged_id) {

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -1,7 +1,9 @@
 use super::types::{MaterializedLogRecord, SegmentWriter};
 use super::{DataRecord, SegmentFlusher};
+use crate::blockstore::arrow::types::ArrowReadableKey;
+use crate::blockstore::key::KeyWrapper;
 use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
-use crate::blockstore::{BlockfileFlusher, BlockfileReader, BlockfileWriter};
+use crate::blockstore::{BlockfileFlusher, BlockfileReader, BlockfileWriter, Key};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::execution::data::data_chunk::Chunk;
 use crate::types::{MaterializedLogOperation, Operation, Segment, SegmentType};
@@ -810,5 +812,24 @@ impl RecordSegmentReader<'_> {
 
     pub(crate) async fn count(&self) -> Result<usize, Box<dyn ChromaError>> {
         self.id_to_data.count().await
+    }
+
+    pub(crate) async fn prefetch_id_to_data(&self, keys: &Vec<u32>) -> () {
+        let prefixes = vec![""; keys.len()];
+        self.id_to_data.load_blocks_for_keys(&prefixes, keys).await
+    }
+
+    pub(crate) async fn prefetch_user_id_to_id(&self, keys: &Vec<&str>) -> () {
+        let prefixes = vec![""; keys.len()];
+        self.user_id_to_id
+            .load_blocks_for_keys(&prefixes, keys)
+            .await
+    }
+
+    pub(crate) async fn prefetch_id_to_user_id(&self, keys: &Vec<u32>) -> () {
+        let prefixes = vec![""; keys.len()];
+        self.id_to_user_id
+            .load_blocks_for_keys(&prefixes, keys)
+            .await
     }
 }

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -814,22 +814,22 @@ impl RecordSegmentReader<'_> {
         self.id_to_data.count().await
     }
 
-    pub(crate) async fn prefetch_id_to_data(&self, keys: &Vec<u32>) -> () {
+    pub(crate) async fn prefetch_id_to_data(&self, keys: Vec<u32>) -> () {
         let prefixes = vec![""; keys.len()];
-        self.id_to_data.load_blocks_for_keys(&prefixes, keys).await
+        self.id_to_data.load_blocks_for_keys(prefixes, keys).await
     }
 
-    pub(crate) async fn prefetch_user_id_to_id(&self, keys: &Vec<&str>) -> () {
+    pub(crate) async fn prefetch_user_id_to_id(&self, keys: Vec<&str>) -> () {
         let prefixes = vec![""; keys.len()];
         self.user_id_to_id
-            .load_blocks_for_keys(&prefixes, keys)
+            .load_blocks_for_keys(prefixes, keys)
             .await
     }
 
-    pub(crate) async fn prefetch_id_to_user_id(&self, keys: &Vec<u32>) -> () {
+    pub(crate) async fn prefetch_id_to_user_id(&self, keys: Vec<u32>) -> () {
         let prefixes = vec![""; keys.len()];
         self.id_to_user_id
-            .load_blocks_for_keys(&prefixes, keys)
+            .load_blocks_for_keys(prefixes, keys)
             .await
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Implement prefetch() API at the blockfile level for a set of blocks and use it to prefetch record segment indexes

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None