### PR TITLE
[ENH] Add error trace in log service for GetAllCollectionInfoToCompact

### DIFF
--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -96,6 +96,11 @@ func (r *LogRepository) GetAllCollectionInfoToCompact(ctx context.Context, minCo
 	if collectionToCompact == nil {
 		collectionToCompact = []log.GetAllCollectionsToCompactRow{}
 	}
+	if err != nil {
+		trace_log.Error("Error in getting collections to compact from record_log table", zap.Error(err))
+	} else {
+		trace_log.Info("Got collections to compact from record_log table", zap.Int("collectionCount", len(collectionToCompact)))
+	}
 	return
 }
 func (r *LogRepository) UpdateCollectionCompactionOffsetPosition(ctx context.Context, collectionId string, offsetPosition int64) (err error) {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Traces the error msg in honeycomb/jaeger

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
