### PR TITLE
[ENH] add `.clean_log()` to Producers

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -31,9 +31,12 @@ jobs:
                    "chromadb/test/property/test_embeddings.py",
                    "chromadb/test/property/test_filtering.py",
                    "chromadb/test/property/test_persist.py",
-                   "chromadb/test/property/test_restart_persist.py"]
+                   "chromadb/test/property/test_restart_persist.py",
+                   "chromadb/test/property/test_clean_log.py"]
         include:
           - test-globs: "chromadb/test/property/test_embeddings.py"
+            parallelized: true
+          - test-globs: "chromadb/test/property/test_clean_log.py"
             parallelized: true
 
     runs-on: ${{ matrix.platform }}

--- a/chromadb/db/base.py
+++ b/chromadb/db/base.py
@@ -119,8 +119,6 @@ class SqlDB(Component):
         """Return a PyPika Parameter object for the given index"""
         return pypika.Parameter(self.parameter_format().format(idx))
 
-    # todo: should the below two methods be somewhere else?
-    # todo: other areas should use these methods
     @staticmethod
     def decode_seq_id(seq_id_bytes: Union[bytes, int]) -> SeqId:
         """Decode a byte array into a SeqID"""

--- a/chromadb/db/base.py
+++ b/chromadb/db/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Sequence, Tuple, Type
+from typing import Any, Optional, Sequence, Tuple, Type, Union
 from types import TracebackType
 from typing_extensions import Protocol, Self, Literal
 from abc import ABC, abstractmethod
@@ -9,6 +9,8 @@ import pypika.queries
 from chromadb.config import System, Component
 from uuid import UUID
 from itertools import islice, count
+
+from chromadb.types import SeqId
 
 
 class NotFoundError(Exception):
@@ -116,6 +118,31 @@ class SqlDB(Component):
     def param(self, idx: int) -> pypika.Parameter:
         """Return a PyPika Parameter object for the given index"""
         return pypika.Parameter(self.parameter_format().format(idx))
+
+    # todo: should the below two methods be somewhere else?
+    # todo: other areas should use these methods
+    @staticmethod
+    def decode_seq_id(seq_id_bytes: Union[bytes, int]) -> SeqId:
+        """Decode a byte array into a SeqID"""
+        if isinstance(seq_id_bytes, int):
+            return seq_id_bytes
+
+        if len(seq_id_bytes) == 8:
+            return int.from_bytes(seq_id_bytes, "big")
+        elif len(seq_id_bytes) == 24:
+            return int.from_bytes(seq_id_bytes, "big")
+        else:
+            raise ValueError(f"Unknown SeqID type with length {len(seq_id_bytes)}")
+
+    @staticmethod
+    def encode_seq_id(seq_id: SeqId) -> bytes:
+        """Encode a SeqID into a byte array"""
+        if seq_id.bit_length() <= 64:
+            return int.to_bytes(seq_id, 8, "big")
+        elif seq_id.bit_length() <= 192:
+            return int.to_bytes(seq_id, 24, "big")
+        else:
+            raise ValueError(f"Unsupported SeqID: {seq_id}")
 
 
 _context = local()

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -147,7 +147,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             cur.execute(sql, params)
             results = cur.fetchall()
             if results:
-                min_seq_id = min(SqlDB.decode_seq_id(row[0]) for row in results)
+                min_seq_id = min(self.decode_seq_id(row[0]) for row in results)
             else:
                 min_seq_id = -1
 
@@ -309,7 +309,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             """,
                 (
                     self.uuid_to_db(subscription.segment_id),
-                    SqlDB.encode_seq_id(up_to_seq_id),
+                    self.encode_seq_id(up_to_seq_id),
                 ),
             )
 

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -146,7 +146,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             if results:
                 min_seq_id = min(self.decode_seq_id(row[0]) for row in results)
             else:
-                min_seq_id = -1
+                return
 
             t = Table("embeddings_queue")
             q = (

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -435,13 +435,3 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             )
             if _called_from_test:
                 raise e
-
-    @trace_method(
-        "SqlEmbeddingsQueue._get_subscription_by_id", OpenTelemetryGranularity.ALL
-    )
-    def _get_subscription_by_id(self, subscription_id: UUID) -> Optional[Subscription]:
-        for subscriptions in self._subscriptions.values():
-            for subscription in subscriptions:
-                if subscription.id == subscription_id:
-                    return subscription
-        return None

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -116,9 +116,9 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             sql, params = get_sql(q, self.parameter_format())
             cur.execute(sql, params)
 
-    @trace_method("SqlEmbeddingsQueue.clean_log", OpenTelemetryGranularity.ALL)
+    @trace_method("SqlEmbeddingsQueue.purge_log", OpenTelemetryGranularity.ALL)
     @override
-    def clean_log(self, collection_id: UUID) -> None:
+    def purge_log(self, collection_id: UUID) -> None:
         topic_name = create_topic_name(
             self._tenant, self._topic_namespace, collection_id
         )

--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -42,6 +42,10 @@ class Producer(Component):
         pass
 
     @abstractmethod
+    def clean_log(self, collection_id: UUID) -> None:
+        pass
+
+    @abstractmethod
     def submit_embedding(
         self, collection_id: UUID, embedding: OperationRecord
     ) -> SeqId:
@@ -82,7 +86,7 @@ class Consumer(Component):
         end: Optional[SeqId] = None,
         id: Optional[UUID] = None,
     ) -> UUID:
-        """Register a function that will be called to recieve embeddings for a given
+        """Register a function that will be called to receive embeddings for a given
         collections log stream. The given function may be called any number of times, with any number of
         records, and may be called concurrently.
 
@@ -103,6 +107,12 @@ class Consumer(Component):
     def unsubscribe(self, subscription_id: UUID) -> None:
         """Unregister a subscription. The consume function will no longer be invoked,
         and resources associated with the subscription will be released."""
+        pass
+
+    @abstractmethod
+    def ack(self, segment_id: UUID, up_to_seq_id: SeqId) -> None:
+        """Acknowledge that all records up to and including the given SeqID have been
+        processed. (This allows the stream to delete old records.)"""
         pass
 
     @abstractmethod

--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -81,6 +81,7 @@ class Consumer(Component):
     def subscribe(
         self,
         collection_id: UUID,
+        segment_id: UUID,
         consume_fn: ConsumerCallbackFn,
         start: Optional[SeqId] = None,
         end: Optional[SeqId] = None,
@@ -110,7 +111,7 @@ class Consumer(Component):
         pass
 
     @abstractmethod
-    def ack(self, segment_id: UUID, up_to_seq_id: SeqId) -> None:
+    def ack(self, subscription_id: UUID, up_to_seq_id: SeqId) -> None:
         """Acknowledge that all records up to and including the given SeqID have been
         processed. (This allows the stream to delete old records.)"""
         pass

--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -81,7 +81,6 @@ class Consumer(Component):
     def subscribe(
         self,
         collection_id: UUID,
-        segment_id: UUID,
         consume_fn: ConsumerCallbackFn,
         start: Optional[SeqId] = None,
         end: Optional[SeqId] = None,
@@ -108,12 +107,6 @@ class Consumer(Component):
     def unsubscribe(self, subscription_id: UUID) -> None:
         """Unregister a subscription. The consume function will no longer be invoked,
         and resources associated with the subscription will be released."""
-        pass
-
-    @abstractmethod
-    def ack(self, subscription_id: UUID, up_to_seq_id: SeqId) -> None:
-        """Acknowledge that all records up to and including the given SeqID have been
-        processed. (This allows the stream to delete old records.)"""
         pass
 
     @abstractmethod

--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -42,7 +42,8 @@ class Producer(Component):
         pass
 
     @abstractmethod
-    def clean_log(self, collection_id: UUID) -> None:
+    def purge_log(self, collection_id: UUID) -> None:
+        """Truncates the log for the given collection, removing all seen records."""
         pass
 
     @abstractmethod

--- a/chromadb/ingest/impl/utils.py
+++ b/chromadb/ingest/impl/utils.py
@@ -2,6 +2,9 @@ import re
 from typing import Tuple
 from uuid import UUID
 
+from chromadb.db.base import SqlDB
+from chromadb.segment import SegmentManager, VectorReader
+
 topic_regex = r"persistent:\/\/(?P<tenant>.+)\/(?P<namespace>.+)\/(?P<topic>.+)"
 
 
@@ -15,3 +18,29 @@ def parse_topic_name(topic_name: str) -> Tuple[str, str, str]:
 
 def create_topic_name(tenant: str, namespace: str, collection_id: UUID) -> str:
     return f"persistent://{tenant}/{namespace}/{str(collection_id)}"
+
+
+def trigger_vector_segments_max_seq_id_migration(
+    db: SqlDB, segment_manager: SegmentManager
+) -> None:
+    """
+    Trigger the migration of vector segments' max_seq_id from the pickled metadata file to SQLite.
+
+    Vector segments migrate this field automatically on init—so this should be used when we know segments are likely unmigrated and unloaded.
+    """
+    with db.tx() as cur:
+        cur.execute(
+            """
+            SELECT collection
+            FROM "segments"
+            WHERE "id" NOT IN (SELECT "segment_id" FROM "max_seq_id")
+        """
+        )
+        collection_ids_with_unmigrated_segments = [row[0] for row in cur.fetchall()]
+
+    if len(collection_ids_with_unmigrated_segments) == 0:
+        return
+
+    for collection_id in collection_ids_with_unmigrated_segments:
+        # Loading the segment triggers the migration on init
+        segment_manager.get_segment(UUID(collection_id), VectorReader)

--- a/chromadb/ingest/impl/utils.py
+++ b/chromadb/ingest/impl/utils.py
@@ -33,7 +33,8 @@ def trigger_vector_segments_max_seq_id_migration(
             """
             SELECT collection
             FROM "segments"
-            WHERE "id" NOT IN (SELECT "segment_id" FROM "max_seq_id")
+            WHERE "id" NOT IN (SELECT "segment_id" FROM "max_seq_id") AND
+                  "type" = 'urn:chroma:segment/vector/hnsw-local-persisted'
         """
         )
         collection_ids_with_unmigrated_segments = [row[0] for row in cur.fetchall()]

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -118,6 +118,7 @@ class LogService(Producer, Consumer):
     def subscribe(
         self,
         collection_id: UUID,
+        segment_id: UUID,
         consume_fn: ConsumerCallbackFn,
         start: Optional[SeqId] = None,
         end: Optional[SeqId] = None,

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -74,9 +74,9 @@ class LogService(Producer, Consumer):
     def delete_log(self, collection_id: UUID) -> None:
         raise NotImplementedError("Not implemented")
 
-    @trace_method("LogService.clean_log", OpenTelemetryGranularity.ALL)
+    @trace_method("LogService.purge_log", OpenTelemetryGranularity.ALL)
     @override
-    def clean_log(self, collection_id: UUID) -> None:
+    def purge_log(self, collection_id: UUID) -> None:
         raise NotImplementedError("Not implemented")
 
     @trace_method("LogService.submit_embedding", OpenTelemetryGranularity.ALL)

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -118,7 +118,6 @@ class LogService(Producer, Consumer):
     def subscribe(
         self,
         collection_id: UUID,
-        segment_id: UUID,
         consume_fn: ConsumerCallbackFn,
         start: Optional[SeqId] = None,
         end: Optional[SeqId] = None,
@@ -131,11 +130,6 @@ class LogService(Producer, Consumer):
     @override
     def unsubscribe(self, subscription_id: UUID) -> None:
         logger.info(f"Unsubscribing from {subscription_id}, noop for logservice")
-
-    @trace_method("LogService.ack", OpenTelemetryGranularity.ALL)
-    @override
-    def ack(self, subscription_id: UUID, up_to_seq_id: SeqId) -> None:
-        logger.info(f"Acking {up_to_seq_id} for {subscription_id}, noop for logservice")
 
     @override
     def min_seqid(self) -> SeqId:

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -74,6 +74,11 @@ class LogService(Producer, Consumer):
     def delete_log(self, collection_id: UUID) -> None:
         raise NotImplementedError("Not implemented")
 
+    @trace_method("LogService.clean_log", OpenTelemetryGranularity.ALL)
+    @override
+    def clean_log(self, collection_id: UUID) -> None:
+        raise NotImplementedError("Not implemented")
+
     @trace_method("LogService.submit_embedding", OpenTelemetryGranularity.ALL)
     @override
     def submit_embedding(

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -131,6 +131,11 @@ class LogService(Producer, Consumer):
     def unsubscribe(self, subscription_id: UUID) -> None:
         logger.info(f"Unsubscribing from {subscription_id}, noop for logservice")
 
+    @trace_method("LogService.ack", OpenTelemetryGranularity.ALL)
+    @override
+    def ack(self, subscription_id: UUID, up_to_seq_id: SeqId) -> None:
+        logger.info(f"Acking {up_to_seq_id} for {subscription_id}, noop for logservice")
+
     @override
     def min_seqid(self) -> SeqId:
         return 0

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -503,6 +503,8 @@ class SqliteMetadataSegment(MetadataReader):
                 elif record["record"]["operation"] == Operation.UPDATE:
                     self._update_record(cur, record)
 
+        self._consumer.ack(self._id, records[-1]["log_offset"])
+
     @trace_method(
         "SqliteMetadataSegment._where_map_criterion", OpenTelemetryGranularity.ALL
     )

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -62,6 +62,7 @@ class SqliteMetadataSegment(MetadataReader):
             seq_id = self.max_seqid()
             self._subscription = self._consumer.subscribe(
                 collection_id=self._collection_id,
+                segment_id=self._id,
                 consume_fn=self._write_metadata,
                 start=seq_id,
             )
@@ -503,7 +504,8 @@ class SqliteMetadataSegment(MetadataReader):
                 elif record["record"]["operation"] == Operation.UPDATE:
                     self._update_record(cur, record)
 
-        self._consumer.ack(self._id, records[-1]["log_offset"])
+        if self._subscription:
+            self._consumer.ack(self._subscription, records[-1]["log_offset"])
 
     @trace_method(
         "SqliteMetadataSegment._where_map_criterion", OpenTelemetryGranularity.ALL

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -278,7 +278,7 @@ class LocalHnswSegment(VectorReader):
             self._total_elements_added += batch.add_count
 
             # If that succeeds, finally the seq ID
-            self._max_seq_id = max(self._max_seq_id, batch.max_seq_id)
+            self._max_seq_id = batch.max_seq_id
 
     @trace_method("LocalHnswSegment._write_records", OpenTelemetryGranularity.ALL)
     def _write_records(self, records: Sequence[LogRecord]) -> None:

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -90,7 +90,7 @@ class LocalHnswSegment(VectorReader):
         if self._collection:
             seq_id = self.max_seqid()
             self._subscription = self._consumer.subscribe(
-                self._collection, self._write_records, start=seq_id
+                self._collection, self._id, self._write_records, start=seq_id
             )
 
     @trace_method("LocalHnswSegment.stop", OpenTelemetryGranularity.ALL)
@@ -320,7 +320,8 @@ class LocalHnswSegment(VectorReader):
 
             self._apply_batch(batch)
 
-        self._consumer.ack(self._id, self._max_seq_id)
+        if self._subscription:
+            self._consumer.ack(self._subscription, self._max_seq_id)
 
     @override
     def delete(self) -> None:

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -90,7 +90,7 @@ class LocalHnswSegment(VectorReader):
         if self._collection:
             seq_id = self.max_seqid()
             self._subscription = self._consumer.subscribe(
-                self._collection, self._id, self._write_records, start=seq_id
+                self._collection, self._write_records, start=seq_id
             )
 
     @trace_method("LocalHnswSegment.stop", OpenTelemetryGranularity.ALL)
@@ -319,9 +319,6 @@ class LocalHnswSegment(VectorReader):
                     batch.apply(record, label is not None)
 
             self._apply_batch(batch)
-
-        if self._subscription:
-            self._consumer.ack(self._subscription, self._max_seq_id)
 
     @override
     def delete(self) -> None:

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -114,7 +114,6 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
             )
             self._dimensionality = self._persist_data.dimensionality
             self._total_elements_added = self._persist_data.total_elements_added
-            # self._max_seq_id = self._persist_data.max_seq_id
             self._id_to_label = self._persist_data.id_to_label
             self._label_to_id = self._persist_data.label_to_id
             self._id_to_seq_id = self._persist_data.id_to_seq_id

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -222,7 +222,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
         if self._num_log_records_since_last_persist >= self._sync_threshold:
             self._persist()
             if self._subscription:
-                self._consumer.ack(self._id, self._max_seq_id)
+                self._consumer.ack(self._subscription, self._max_seq_id)
 
         self._num_log_records_since_last_batch = 0
 

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -86,8 +86,6 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
     _persist_directory: str
     _allow_reset: bool
 
-    _invalid_operations_since_last_persist: int = 0
-
     _opentelemtry_client: OpenTelemetryClient
 
     _num_log_records_since_last_batch: int = 0
@@ -223,8 +221,6 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
             self._persist()
             if self._subscription:
                 self._consumer.ack(self._subscription, self._max_seq_id)
-
-        self._num_log_records_since_last_batch = 0
 
         self._num_log_records_since_last_batch = 0
 

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -267,10 +267,6 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                             self._brute_force_index.delete([record])
                     else:
                         logger.warning(f"Delete of nonexisting embedding ID: {id}")
-                        # todo: needed?
-                        self._curr_batch.max_seq_id = max(
-                            self._curr_batch.max_seq_id, record["log_offset"]
-                        )
 
                 elif op == Operation.UPDATE:
                     if record["record"]["embedding"] is not None:

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -542,7 +542,7 @@ def integration() -> Generator[System, None, None]:
     system.stop()
 
 
-def sqlite() -> Generator[System, None, None]:
+def sqlite_fixture() -> Generator[System, None, None]:
     """Fixture generator for segment-based API using in-memory Sqlite"""
     settings = Settings(
         chroma_api_impl="chromadb.api.segment.SegmentAPI",
@@ -557,6 +557,11 @@ def sqlite() -> Generator[System, None, None]:
     system.start()
     yield system
     system.stop()
+
+
+@pytest.fixture
+def sqlite() -> Generator[System, None, None]:
+    yield from sqlite_fixture()
 
 
 def sqlite_persistent_fixture() -> Generator[System, None, None]:
@@ -590,7 +595,7 @@ def sqlite_persistent_fixture() -> Generator[System, None, None]:
             raise e
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def sqlite_persistent() -> Generator[System, None, None]:
     yield from sqlite_persistent_fixture()
 
@@ -600,7 +605,7 @@ def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
         fastapi,
         async_fastapi,
         fastapi_persistent,
-        sqlite,
+        sqlite_fixture,
         sqlite_persistent_fixture,
     ]
     if "CHROMA_INTEGRATION_TEST" in os.environ:

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -621,7 +621,7 @@ def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, N
     fixtures = [
         fixture
         for fixture in system_fixtures()
-        if fixture != sqlite and fixture != sqlite_persistent_fixture
+        if fixture != sqlite_fixture and fixture != sqlite_persistent_fixture
     ]
     return fixtures
 

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -226,6 +226,9 @@ class hashing_embedding_function(types.EmbeddingFunction[Documents]):
 
         return embeddings
 
+    def __repr__(self) -> str:
+        return f"hashing_embedding_function(dim={self.dim}, dtype={self.dtype})"
+
 
 class not_implemented_embedding_function(types.EmbeddingFunction[Documents]):
     def __call__(self, input: Documents) -> Embeddings:

--- a/chromadb/test/property/test_clean_log.py
+++ b/chromadb/test/property/test_clean_log.py
@@ -63,7 +63,7 @@ class LogCleanEmbeddingStateMachine(EmbeddingStateMachineBase):
         producer = self.system.instance(Producer)
         sqlite = self.system.instance(SqliteDB)
 
-        producer.clean_log(self.collection.id)
+        producer.purge_log(self.collection.id)
 
         if self.has_collection_mutated:
             # Must always keep one entry to avoid reusing seq_ids

--- a/chromadb/test/property/test_clean_log.py
+++ b/chromadb/test/property/test_clean_log.py
@@ -1,0 +1,148 @@
+from typing import Generator, cast
+from chromadb.ingest import Producer
+from overrides import overrides
+import pytest
+from chromadb.api.client import Client
+from chromadb.config import System
+from chromadb.db.base import get_sql
+from chromadb.db.impl.sqlite import SqliteDB
+from pypika import Table, functions
+import hypothesis.strategies as st
+from hypothesis.stateful import (
+    rule,
+    run_state_machine_as_test,
+    initialize,
+)
+
+from chromadb.test.conftest import sqlite_fixture, sqlite_persistent_fixture
+from chromadb.test.property.test_embeddings import (
+    EmbeddingStateMachineBase,
+    EmbeddingStateMachineStates,
+    trace,
+)
+import chromadb.test.property.strategies as strategies
+
+
+# todo: needed?
+collection_persistent_st = st.shared(
+    # Set a small batch size, otherwise it's unlikely that .clean_log() will have any effect
+    strategies.collections(
+        with_hnsw_params=True,
+        with_persistent_hnsw_params=st.just(True),
+        max_hnsw_sync_threshold=5,
+        max_hnsw_batch_size=5,
+    ),
+    key="coll_persistent",
+)
+
+
+def total_embedding_queue_log_size(sqlite: SqliteDB) -> int:
+    t = Table("embeddings_queue")
+    q = sqlite.querybuilder().from_(t)
+
+    with sqlite.tx() as cur:
+        sql, params = get_sql(
+            q.select(functions.Count(t.seq_id)), sqlite.parameter_format()
+        )
+        result = cur.execute(sql, params)
+        return cast(int, result.fetchone()[0])
+
+
+# todo: combine with RestartablePersistedEmbeddingStateMachine
+class LogCleanEmbeddingStateMachine(EmbeddingStateMachineBase):
+    has_collection_mutated = False
+    system: System
+
+    def __init__(self, system: System) -> None:
+        self.system = system
+        client = Client.from_system(system)
+        super().__init__(client)
+
+    @rule()
+    def log_empty_after_cleaning(self) -> None:
+        producer = self.system.instance(Producer)
+        sqlite = self.system.instance(SqliteDB)
+
+        producer.clean_log(self.collection.id)
+
+        if self.has_collection_mutated:
+            # Must always keep one entry to avoid reusing seq_ids
+            assert total_embedding_queue_log_size(sqlite) >= 1
+
+            if self.system.settings.is_persistent:
+                sync_threshold = self.collection.metadata.get("hnsw:sync_threshold", -1)
+                batch_size = self.collection.metadata.get("hnsw:batch_size", -1)
+
+                # -1 is used because the queue is always at least 1 entry long, so deletion stops before the max ack'ed sequence ID.
+                # And if the batch_size != sync_threshold, the queue can have up to batch_size - 1 more entries.
+                assert (
+                    total_embedding_queue_log_size(sqlite) - 1
+                    <= sync_threshold + batch_size - 1
+                )
+            else:
+                assert total_embedding_queue_log_size(sqlite) <= 1
+        else:
+            assert total_embedding_queue_log_size(sqlite) == 0
+
+    @overrides
+    def on_state_change(self, new_state: str) -> None:
+        if new_state != EmbeddingStateMachineStates.initialize:
+            self.has_collection_mutated = True
+
+
+# This machine shares a lot of similarity with the machine in chromadb/test/property/test_persist.py, but it's a separate machine because test_persist makes assertions
+class PersistentLogCleanEmbeddingStateMachine(LogCleanEmbeddingStateMachine):
+    @initialize(collection=collection_persistent_st)  # type: ignore
+    @overrides
+    def initialize(self, collection: strategies.Collection):
+        self.client.reset()
+
+        self.collection = self.client.create_collection(
+            name=collection.name,
+            metadata=collection.metadata,  # type: ignore
+            embedding_function=collection.embedding_function,
+        )
+        self.embedding_function = collection.embedding_function
+        trace("init")
+        self.on_state_change(EmbeddingStateMachineStates.initialize)
+
+        self.record_set_state = strategies.StateMachineRecordSet(
+            ids=[], metadatas=[], documents=[], embeddings=[]
+        )
+
+    @rule()
+    def restart_system(self) -> None:
+        # Simulates restarting chromadb
+        # (there's some edge cases around correctly tracking sequence IDs at client startup)
+        self.system.stop()
+        self.system = System(self.system.settings)
+        self.system.start()
+        self.client.clear_system_cache()
+        self.client = Client.from_system(self.system)
+        self.collection = self.client.get_collection(
+            self.collection.name, embedding_function=self.embedding_function
+        )
+
+    @overrides
+    def teardown(self) -> None:
+        super().teardown()
+        # Need to manually stop the system to cleanup resources because we may have created a new system (above rule).
+        # Normally, we wouldn't have to worry about this as the system from the fixture is shared between state machine runs.
+        # (This helps avoid a "too many open files" error.)
+        self.system.stop()
+
+
+@pytest.fixture(params=[sqlite_fixture, sqlite_persistent_fixture])
+def any_sqlite(request: pytest.FixtureRequest) -> Generator[System, None, None]:
+    yield from request.param()
+
+
+def test_clean_log(any_sqlite: System) -> None:
+    if any_sqlite.settings.is_persistent:
+        run_state_machine_as_test(
+            lambda: PersistentLogCleanEmbeddingStateMachine(any_sqlite),
+        )  # type: ignore
+    else:
+        run_state_machine_as_test(
+            lambda: LogCleanEmbeddingStateMachine(any_sqlite),
+        )  # type: ignore

--- a/chromadb/test/property/test_clean_log.py
+++ b/chromadb/test/property/test_clean_log.py
@@ -78,7 +78,11 @@ class LogCleanEmbeddingStateMachine(EmbeddingStateMachineBase):
 class PersistentLogCleanEmbeddingStateMachine(
     LogCleanEmbeddingStateMachine, RestartablePersistedEmbeddingStateMachine
 ):
-    ...
+    def __init__(self, system: System) -> None:
+        super(RestartablePersistedEmbeddingStateMachine, self).__init__(
+            Client.from_system(system)
+        )
+        super(LogCleanEmbeddingStateMachine, self).__init__(system)
 
 
 @pytest.fixture(params=[sqlite_fixture, sqlite_persistent_fixture])

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -357,7 +357,7 @@ def test_cycle_versions(
         embeddings_queue, system.instance(SegmentManager)
     )
 
-    embeddings_queue.clean_log(coll.id)
+    embeddings_queue.purge_log(coll.id)
     invariants.log_size_below_max(system, coll, True)
 
     # Should be able to add embeddings

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -13,6 +13,9 @@ import json
 from urllib import request
 from chromadb import config
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
+from chromadb.db.impl.sqlite import SqliteDB
+from chromadb.ingest.impl.utils import trigger_vector_segments_max_seq_id_migration
+from chromadb.segment import SegmentManager
 import chromadb.test.property.strategies as strategies
 import chromadb.test.property.invariants as invariants
 from packaging import version as packaging_version
@@ -344,6 +347,18 @@ def test_cycle_versions(
         name=collection_strategy.name,
         embedding_function=not_implemented_ef(),  # type: ignore
     )
+
+    # Should be able to clean log immediately after updating
+    embeddings_queue = system.instance(SqliteDB)
+
+    # Cleaning the log is dependent on vector segments migrating their max_seq_id from the pickled metadata file to SQLite.
+    # Vector segments migrate this field automatically on init, but at this point the segment has not been loaded yet.
+    trigger_vector_segments_max_seq_id_migration(
+        embeddings_queue, system.instance(SegmentManager)
+    )
+
+    embeddings_queue.clean_log(coll.id)
+    invariants.log_size_below_max(system, coll, True)
 
     # Should be able to add embeddings
     coll.add(**embeddings_strategy)  # type: ignore

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -351,6 +351,7 @@ def test_cycle_versions(
     # Should be able to clean log immediately after updating
     embeddings_queue = system.instance(SqliteDB)
 
+    # 07/29/24: the max_seq_id for vector segments was moved from the pickled metadata file to SQLite.
     # Cleaning the log is dependent on vector segments migrating their max_seq_id from the pickled metadata file to SQLite.
     # Vector segments migrate this field automatically on init, but at this point the segment has not been loaded yet.
     trigger_vector_segments_max_seq_id_migration(

--- a/clients/python/integration-test.sh
+++ b/clients/python/integration-test.sh
@@ -23,14 +23,14 @@ export CHROMA_SERVER_HOST=localhost
 export CHROMA_SERVER_HTTP_PORT=8000
 export CHROMA_SERVER_NOFILE=65535
 
-echo testing: python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py' --ignore 'chromadb/test/property/test_collections_with_database_tenant_overwrite.py'
+echo testing: python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py' --ignore-glob 'chromadb/test/property/test_clean_log.py' --ignore 'chromadb/test/property/test_collections_with_database_tenant_overwrite.py'
 
 # Copy the thin client flag script in place, uvicorn takes a while to startup inside docker
 sleep 5
 cp "$is_thin_client_py" "$is_thin_client_target"
-python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py' --ignore 'chromadb/test/property/test_collections_with_database_tenant_overwrite.py'
+python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py' --ignore-glob 'chromadb/test/property/test_clean_log.py' --ignore 'chromadb/test/property/test_collections_with_database_tenant_overwrite.py'
 
 # Test async client
 export CHROMA_API_IMPL="chromadb.api.async_fastapi.AsyncFastAPI"
 
-python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py' --ignore 'chromadb/test/property/test_collections_with_database_tenant_overwrite.py'
+python -m pytest 'chromadb/test/property/' --ignore-glob 'chromadb/test/property/*persist.py' --ignore-glob 'chromadb/test/property/test_clean_log.py' --ignore 'chromadb/test/property/test_collections_with_database_tenant_overwrite.py'


### PR DESCRIPTION
Depends on https://github.com/chroma-core/chroma/pull/2545.

Changes:

- Adds a `clean_log()` method to producers (not called automatically in this PR).
- The existing table `max_seq_id` is now used to track the maximum seen sequence ID for both metadata and vector segments (formerly only used by metadata segments).
- Segments are expected to update the `max_seq_id` table themselves.
- Vector segments will automatically migrate the `max_seq_id` field from the old pickled metadata file source into the database upon init.

In this PR, log entries are deleted on a per-collection basis. The next PR in this stack deletes entries globally.