### PR TITLE
[BLD] log artifacts per python version

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -116,9 +116,9 @@ jobs:
         id: get-logs
         if: success() || failure()
         run: |
-          bin/get-logs.sh "${{ matrix.test-globs }}"
+          bin/get-logs.sh "${{ matrix.test-globs }}" "${{ matrix.python }}"
           # Output the logs zip file path as a job output
-          echo "logs_zip_path=$(pwd)/$(basename "${{ matrix.test-globs }}" .py)_logs.zip" >> $GITHUB_OUTPUT
+          echo "logs_zip_path=$(pwd)/$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}_logs.zip" >> $GITHUB_OUTPUT
         shell: bash
       - name: Upload logs as artifact
         if: success() || failure()

--- a/bin/get-logs.sh
+++ b/bin/get-logs.sh
@@ -5,20 +5,22 @@ set -e
 NAMESPACE=chroma
 echo "Namespace: $NAMESPACE"
 
-# Check if the test-name is provided as an argument
-if [ -z "$1" ]; then
-  echo "Usage: $0 <test-file-path>"
-  exit 1
+# Check if the test-name and version-number are provided as arguments
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <test-name> <version-number>"
+  exit 1  # Exit with code 1 indicating an error
 fi
 
 TEST_FILE_PATH=$1
+TEST_VERSION=$2
 
 # Extract the test file name from the path and remove the ".py" extension
 TEST_NAME=$(basename "$TEST_FILE_PATH" .py)
 echo "Test name: $TEST_NAME"
+echo "Test version: $TEST_VERSION"
 
 # Create a directory with the test name to store logs
-LOGS_DIR="./logs/${TEST_NAME}"
+LOGS_DIR="./logs/${TEST_NAME}_${TEST_VERSION}"
 echo "Logs directory: $LOGS_DIR"
 mkdir -p "$LOGS_DIR"
 echo "Created logs dir: $LOGS_DIR"
@@ -35,10 +37,10 @@ for POD in $PODS; do
 done
 
 # Zip all log files
-zip -r "${TEST_NAME}_logs.zip" "$LOGS_DIR"
+zip -r "${TEST_NAME}_${TEST_VERSION}_logs.zip" "$LOGS_DIR"
 
 # Print confirmation message
-echo "Logs have been zipped to ${TEST_NAME}_logs.zip"
+echo "Logs have been zipped to ${TEST_NAME}_${TEST_VERSION}_logs.zip"
 
 # Output the path to the zip file
-echo "logs_zip_path=$(pwd)/${TEST_NAME}_logs.zip" >> $GITHUB_OUTPUT
+echo "logs_zip_path=$(pwd)/${TEST_NAME}_${TEST_VERSION}_logs.zip" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Previously, we were not uploading artifacts per python version. Because of this we only retained the logs of the last python version that ran per test.

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
