### PR TITLE
[ENH] return `chroma-trace-id` header, include trace ID in thrown errors

### DIFF
--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -85,6 +85,10 @@ class BaseHTTPClient:
                 if body["error"] in errors.error_types:
                     chroma_error = errors.error_types[body["error"]](body["message"])
 
+                    trace_id = resp.headers.get("chroma-trace-id")
+                    if trace_id:
+                        chroma_error.trace_id = trace_id
+
         except BaseException:
             pass
 

--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -100,7 +100,5 @@ class BaseHTTPClient:
         except httpx.HTTPStatusError:
             trace_id = resp.headers.get("chroma-trace-id")
             if trace_id:
-                raise Exception(
-                    f"Chroma request failed: {resp.text}. Trace ID: {trace_id}."
-                )
+                raise Exception(f"{resp.text} (trace ID: {trace_id})")
             raise (Exception(resp.text))

--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -98,4 +98,9 @@ class BaseHTTPClient:
         try:
             resp.raise_for_status()
         except httpx.HTTPStatusError:
+            trace_id = resp.headers.get("chroma-trace-id")
+            if trace_id:
+                raise Exception(
+                    f"Chroma request failed: {resp.text}. Trace ID: {trace_id}."
+                )
             raise (Exception(resp.text))

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -248,7 +248,7 @@ class SegmentAPI(ServerAPI):
         if existing:
             return existing[0]
         else:
-            raise ValueError(f"Collection {name} does not exist.")
+            raise InvalidCollectionException(f"Collection {name} does not exist.")
 
     @trace_method("SegmentAPI.list_collection", OpenTelemetryGranularity.OPERATION)
     @override

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -1,9 +1,11 @@
 from abc import abstractmethod
-from typing import Dict, Type
+from typing import Dict, Optional, Type
 from overrides import overrides, EnforceOverrides
 
 
 class ChromaError(Exception, EnforceOverrides):
+    trace_id: Optional[str] = None
+
     def code(self) -> int:
         """Return an appropriate HTTP response code for this error"""
         return 400  # Bad Request

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -590,8 +590,8 @@ def sqlite_persistent() -> Generator[System, None, None]:
             raise e
 
 
-def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
-    fixtures = [fastapi, async_fastapi, fastapi_persistent]
+def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
+    fixtures = [fastapi, async_fastapi, fastapi_persistent, sqlite, sqlite_persistent]
     if "CHROMA_INTEGRATION_TEST" in os.environ:
         fixtures.append(integration)
     if "CHROMA_INTEGRATION_TEST_ONLY" in os.environ:
@@ -601,9 +601,12 @@ def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, N
     return fixtures
 
 
-def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
-    fixtures = system_http_server_fixtures()
-    fixtures.extend([sqlite, sqlite_persistent])
+def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
+    fixtures = [
+        fixture
+        for fixture in system_fixtures()
+        if fixture != sqlite and fixture != sqlite_persistent
+    ]
     return fixtures
 
 

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -590,14 +590,20 @@ def sqlite_persistent() -> Generator[System, None, None]:
             raise e
 
 
-def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
-    fixtures = [fastapi, async_fastapi, fastapi_persistent, sqlite, sqlite_persistent]
+def system_http_server_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
+    fixtures = [fastapi, async_fastapi, fastapi_persistent]
     if "CHROMA_INTEGRATION_TEST" in os.environ:
         fixtures.append(integration)
     if "CHROMA_INTEGRATION_TEST_ONLY" in os.environ:
         fixtures = [integration]
     if "CHROMA_CLUSTER_TEST_ONLY" in os.environ:
         fixtures = [basic_http_client]
+    return fixtures
+
+
+def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
+    fixtures = system_http_server_fixtures()
+    fixtures.extend([sqlite, sqlite_persistent])
     return fixtures
 
 
@@ -642,6 +648,13 @@ def system_wrong_auth(
 
 @pytest.fixture(scope="module", params=system_fixtures_authn_rbac_authz())
 def system_authn_rbac_authz(
+    request: pytest.FixtureRequest,
+) -> Generator[ServerAPI, None, None]:
+    yield from request.param()
+
+
+@pytest.fixture(scope="module", params=system_http_server_fixtures())
+def system_http_server(
     request: pytest.FixtureRequest,
 ) -> Generator[ServerAPI, None, None]:
     yield from request.param()
@@ -754,6 +767,23 @@ def client(system: System) -> Generator[ClientAPI, None, None]:
         client.clear_system_cache()
     else:
         client = ClientCreator.from_system(system)
+        yield client
+        client.clear_system_cache()
+
+
+@pytest.fixture(scope="function")
+def http_client(system_http_server: System) -> Generator[ClientAPI, None, None]:
+    system_http_server.reset_state()
+
+    if (
+        system_http_server.settings.chroma_api_impl
+        == "chromadb.api.async_fastapi.AsyncFastAPI"
+    ):
+        client = cast(Any, AsyncClientCreatorSync.from_system_async(system_http_server))
+        yield client
+        client.clear_system_cache()
+    else:
+        client = ClientCreator.from_system(system_http_server)
         yield client
         client.clear_system_cache()
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -3,6 +3,7 @@ import traceback
 import httpx
 
 import chromadb
+from chromadb.errors import ChromaError
 from chromadb.api.fastapi import FastAPI
 from chromadb.api.types import QueryResult, EmbeddingFunction, Document
 from chromadb.config import Settings
@@ -523,6 +524,18 @@ def test_add_a_collection(client):
     # get collection should throw an error if collection does not exist
     with pytest.raises(Exception):
         collection = client.get_collection("testspace2")
+
+
+def test_error_includes_trace_id(client):
+    if client._system.settings.chroma_server_host is None:
+        pytest.skip("Trace IDs are only attached for HTTP requests")
+
+    client.reset()
+
+    with pytest.raises(ChromaError) as error:
+        client.get_collection("testspace2")
+
+    assert error.value.trace_id is not None
 
 
 def test_list_collections(client):

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -526,14 +526,11 @@ def test_add_a_collection(client):
         collection = client.get_collection("testspace2")
 
 
-def test_error_includes_trace_id(client):
-    if client._system.settings.chroma_server_host is None:
-        pytest.skip("Trace IDs are only attached for HTTP requests")
-
-    client.reset()
+def test_error_includes_trace_id(http_client):
+    http_client.reset()
 
     with pytest.raises(ChromaError) as error:
-        client.get_collection("testspace2")
+        http_client.get_collection("testspace2")
 
     assert error.value.trace_id is not None
 


### PR DESCRIPTION
Returns a new `chroma-trace-id` header for both successful and errored responses.

Tested locally with Jaeger.