### PR TITLE
[BUG]: Pydantic 1.x Union Types

### DIFF
--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -134,7 +134,6 @@ class Collection(
 
     def get_model_fields(self) -> Dict[Any, Any]:
         """Used for backward compatibility with Pydantic 1.x"""
-        print("bppp")
         try:
             return self.model_fields  # pydantic 2.x
         except AttributeError:

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -60,7 +60,9 @@ class Collection(
     id: UUID
     name: str
     configuration_json: Dict[str, Any]
-    metadata: Optional[Metadata]
+    metadata: Optional[
+        Dict[str, Any]
+    ]  # Dict[str, Any] needed by pydantic 1.x as it doesn't work well Union types and converts all types to str
     dimension: Optional[int]
     tenant: str
     database: str
@@ -132,6 +134,7 @@ class Collection(
 
     def get_model_fields(self) -> Dict[Any, Any]:
         """Used for backward compatibility with Pydantic 1.x"""
+        print("bppp")
         try:
             return self.model_fields  # pydantic 2.x
         except AttributeError:


### PR DESCRIPTION
Reproduction:

```bash
pip install chromadb pydantic==1.10.17
```

```python
import uuid

import chromadb

local_client = chromadb.PersistentClient(path="metadata_casting")

collection = local_client.get_or_create_collection(f"{uuid.uuid4()}",metadata={"string":"string","int":1,"float":1.0,"bool":True})
print(collection.metadata)
# results in : {'string': 'string', 'int': '1', 'float': '1.0', 'bool': 'True'}
```

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Pydantic 1.x uses left_to_right union mode and thus converting all metadata values to str. This PR makes the model attr be a `Dict[str,Any]` to prevent that from happening. The __init__ still uses Metadata type

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

