### PR TITLE
[ENH]: Client close (redo of #1792)

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -328,6 +328,11 @@ class BaseAPI(ABC):
         """Return the maximum number of records that can be created or mutated in a single call."""
         pass
 
+    @abstractmethod
+    def close(self) -> None:
+        """Close the client and release any resources."""
+        pass
+
 
 class ClientAPI(BaseAPI, ABC):
     tenant: str
@@ -528,6 +533,11 @@ class AdminAPI(ABC):
             tenant: The name of the tenant to get.
 
         """
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the client and release any resources."""
         pass
 
 

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -526,6 +526,11 @@ class AsyncAdminAPI(ABC):
         """
         pass
 
+    @abstractmethod
+    async def close(self) -> None:
+        """Closes the admin client and releases any resources."""
+        pass
+
 
 class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
     """An API instance that extends the relevant Base API methods by passing
@@ -589,4 +594,9 @@ class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> None:
+        pass
+
+    @abstractmethod
+    @override
+    async def close(self) -> None:
         pass

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -319,6 +319,11 @@ class AsyncBaseAPI(ABC):
         """Return the maximum number of records that can be created or mutated in a single call."""
         pass
 
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the client and release any resources."""
+        pass
+
 
 class AsyncClientAPI(AsyncBaseAPI, ABC):
     tenant: str

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -399,6 +399,12 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     async def get_max_batch_size(self) -> int:
         return await self._server.get_max_batch_size()
 
+    @override
+    async def close(self) -> None:
+        await self._server.close()
+        await self._admin_client.close()
+
+
     # endregion
 
 
@@ -434,3 +440,7 @@ class AsyncAdminClient(SharedSystemClient, AsyncAdminAPI):
         SharedSystemClient._populate_data_from_system(system)
         instance = cls(settings=system.settings)
         return instance
+
+    @override
+    async def close(self) -> None:
+        await self._server.close()

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -404,7 +404,6 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         await self._server.close()
         await self._admin_client.close()
 
-
     # endregion
 
 

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -82,6 +82,10 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         await self._cleanup()
 
     @override
+    def start(self) -> None:
+        super().start()
+
+    @override
     def stop(self) -> None:
         super().stop()
 
@@ -130,6 +134,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.heartbeat", OpenTelemetryGranularity.OPERATION)
     @override
     async def heartbeat(self) -> int:
+        self._raise_for_running()
         response = await self._make_request("get", "")
         return int(response["nanosecond heartbeat"])
 
@@ -140,6 +145,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         name: str,
         tenant: str = DEFAULT_TENANT,
     ) -> None:
+        self._raise_for_running()
         await self._make_request(
             "post",
             "/databases",
@@ -154,6 +160,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         name: str,
         tenant: str = DEFAULT_TENANT,
     ) -> Database:
+        self._raise_for_running()
         response = await self._make_request(
             "get",
             "/databases/" + name,
@@ -167,6 +174,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
     @override
     async def create_tenant(self, name: str) -> None:
+        self._raise_for_running()
         await self._make_request(
             "post",
             "/tenants",
@@ -176,6 +184,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)
     @override
     async def get_tenant(self, name: str) -> Tenant:
+        self._raise_for_running()
         resp_json = await self._make_request(
             "get",
             "/tenants/" + name,
@@ -192,6 +201,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
+        self._raise_for_running()
         resp_json = await self._make_request(
             "get",
             "/collections",
@@ -215,6 +225,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     async def count_collections(
         self, tenant: str = DEFAULT_TENANT, database: str = DEFAULT_DATABASE
     ) -> int:
+        self._raise_for_running()
         resp_json = await self._make_request(
             "get",
             "/count_collections",
@@ -235,6 +246,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
         """Creates a collection"""
+        self._raise_for_running()
         resp_json = await self._make_request(
             "post",
             "/collections",
@@ -260,6 +272,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
+        self._raise_for_running()
         if (name is None and id is None) or (name is not None and id is not None):
             raise ValueError("Name or id must be specified, but not both")
 
@@ -289,6 +302,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
+        self._raise_for_running()
         return await self.create_collection(
             name=name,
             configuration=configuration,
@@ -306,6 +320,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         new_name: Optional[str] = None,
         new_metadata: Optional[CollectionMetadata] = None,
     ) -> None:
+        self._raise_for_running()
         await self._make_request(
             "put",
             "/collections/" + str(id),
@@ -320,6 +335,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> None:
+        self._raise_for_running()
         await self._make_request(
             "delete",
             "/collections/" + name,
@@ -333,6 +349,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         collection_id: UUID,
     ) -> int:
         """Returns the number of embeddings in the database"""
+        self._raise_for_running()
         resp_json = await self._make_request(
             "get",
             "/collections/" + str(collection_id) + "/count",
@@ -347,6 +364,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         collection_id: UUID,
         n: int = 10,
     ) -> GetResult:
+        self._raise_for_running()
         return await self._get(
             collection_id,
             limit=n,
@@ -368,6 +386,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         where_document: Optional[WhereDocument] = {},
         include: Include = ["metadatas", "documents"],  # type: ignore[list-item]
     ) -> GetResult:
+        self._raise_for_running()
         if page and page_size:
             offset = (page - 1) * page_size
             limit = page_size
@@ -405,6 +424,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
     ) -> None:
+        self._raise_for_running()
         await self._make_request(
             "post",
             "/collections/" + str(collection_id) + "/delete",
@@ -427,6 +447,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         """
         Submits a batch of embeddings to the database
         """
+        self._raise_for_running()
         return await self._make_request(
             "post",
             url,
@@ -450,6 +471,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,
     ) -> bool:
+        self._raise_for_running()
         batch = (
             ids,
             convert_np_embeddings_to_list(embeddings),
@@ -472,6 +494,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,
     ) -> bool:
+        self._raise_for_running()
         batch = (
             ids,
             convert_np_embeddings_to_list(embeddings)
@@ -500,6 +523,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,
     ) -> bool:
+        self._raise_for_running()
         batch = (
             ids,
             convert_np_embeddings_to_list(embeddings),
@@ -524,6 +548,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         where_document: Optional[WhereDocument] = {},
         include: Include = ["metadatas", "documents", "distances"],  # type: ignore[list-item]
     ) -> QueryResult:
+        self._raise_for_running()
         resp_json = await self._make_request(
             "post",
             "/collections/" + str(collection_id) + "/query",
@@ -552,12 +577,14 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.reset", OpenTelemetryGranularity.ALL)
     @override
     async def reset(self) -> bool:
+        self._raise_for_running()
         resp_json = await self._make_request("post", "/reset")
         return cast(bool, resp_json)
 
     @trace_method("AsyncFastAPI.get_version", OpenTelemetryGranularity.OPERATION)
     @override
     async def get_version(self) -> str:
+        self._raise_for_running()
         resp_json = await self._make_request("get", "/version")
         return cast(str, resp_json)
 
@@ -568,7 +595,15 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.get_max_batch_size", OpenTelemetryGranularity.OPERATION)
     @override
     async def get_max_batch_size(self) -> int:
+        self._raise_for_running()
         if self._max_batch_size == -1:
             resp_json = await self._make_request("get", "/pre-flight-checks")
             self._max_batch_size = cast(int, resp_json["max_batch_size"])
         return self._max_batch_size
+
+    @trace_method("FastAPI.close", OpenTelemetryGranularity.OPERATION)
+    @override
+    def close(self) -> None:
+        self._raise_for_running()
+        self.stop()
+        self._system.stop()

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -604,6 +604,6 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("FastAPI.close", OpenTelemetryGranularity.OPERATION)
     @override
     async def close(self) -> None:
-        self._raise_for_running()
+        await self._cleanup()  # this is a bit hacky but when running close in a loop the async to sync cleanup doesn't work
         self.stop()
         self._system.stop()

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -603,7 +603,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
 
     @trace_method("FastAPI.close", OpenTelemetryGranularity.OPERATION)
     @override
-    def close(self) -> None:
+    async def close(self) -> None:
         self._raise_for_running()
         self.stop()
         self._system.stop()

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -64,6 +64,7 @@ class Client(SharedSystemClient, ClientAPI):
         self._server = self._system.instance(ServerAPI)
 
         self._submit_client_start_event()
+        self._server.start()
 
     @classmethod
     @override
@@ -402,6 +403,7 @@ class AdminClient(SharedSystemClient, AdminAPI):
     def __init__(self, settings: Settings = Settings()) -> None:
         super().__init__(settings)
         self._server = self._system.instance(ServerAPI)
+        self._server.start()
 
     @override
     def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -390,6 +390,11 @@ class Client(SharedSystemClient, ClientAPI):
 
     # endregion
 
+    @override
+    def close(self) -> None:
+        self._server.close()
+        self._admin_client.close()
+
 
 class AdminClient(SharedSystemClient, AdminAPI):
     _server: ServerAPI
@@ -413,6 +418,10 @@ class AdminClient(SharedSystemClient, AdminAPI):
     @override
     def get_tenant(self, name: str) -> Tenant:
         return self._server.get_tenant(name=name)
+
+    @override
+    def close(self) -> None:
+        self._server.close()
 
     @classmethod
     @override

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -132,9 +132,14 @@ class SegmentAPI(ServerAPI):
     def heartbeat(self) -> int:
         return int(time.time_ns())
 
+    @override
+    def start(self) -> None:
+        super().start()
+
     @trace_method("SegmentAPI.create_database", OpenTelemetryGranularity.OPERATION)
     @override
     def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+        self._raise_for_running()
         if len(name) < 3:
             raise ValueError("Database name must be at least 3 characters long")
 
@@ -147,11 +152,13 @@ class SegmentAPI(ServerAPI):
     @trace_method("SegmentAPI.get_database", OpenTelemetryGranularity.OPERATION)
     @override
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> t.Database:
+        self._raise_for_running()
         return self._sysdb.get_database(name=name, tenant=tenant)
 
     @trace_method("SegmentAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
     @override
     def create_tenant(self, name: str) -> None:
+        self._raise_for_running()
         if len(name) < 3:
             raise ValueError("Tenant name must be at least 3 characters long")
 
@@ -162,6 +169,7 @@ class SegmentAPI(ServerAPI):
     @trace_method("SegmentAPI.get_tenant", OpenTelemetryGranularity.OPERATION)
     @override
     def get_tenant(self, name: str) -> t.Tenant:
+        self._raise_for_running()
         return self._sysdb.get_tenant(name=name)
 
     # TODO: Actually fix CollectionMetadata type to remove type: ignore flags. This is
@@ -178,6 +186,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
+        self._raise_for_running()
         if metadata is not None:
             validate_metadata(metadata)
 
@@ -243,6 +252,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
+        self._raise_for_running()
         return self.create_collection(
             name=name,
             metadata=metadata,
@@ -264,6 +274,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
+        self._raise_for_running()
         if id is None and name is None or (id is not None and name is not None):
             raise ValueError("Name or id must be specified, but not both")
         existing = self._sysdb.get_collections(
@@ -284,6 +295,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
+        self._raise_for_running()
         return self._sysdb.get_collections(
             limit=limit, offset=offset, tenant=tenant, database=database
         )
@@ -295,6 +307,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> int:
+        self._raise_for_running()
         collection_count = len(
             self._sysdb.get_collections(tenant=tenant, database=database)
         )
@@ -309,6 +322,7 @@ class SegmentAPI(ServerAPI):
         new_name: Optional[str] = None,
         new_metadata: Optional[CollectionMetadata] = None,
     ) -> None:
+        self._raise_for_running()
         if new_name:
             # backwards compatibility in naming requirements (for now)
             check_index_name(new_name)
@@ -336,6 +350,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> None:
+        self._raise_for_running()
         existing = self._sysdb.get_collections(
             name=name, tenant=tenant, database=database
         )
@@ -360,6 +375,7 @@ class SegmentAPI(ServerAPI):
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,
     ) -> bool:
+        self._raise_for_running()
         self._quota.static_check(metadatas, documents, embeddings, str(collection_id))
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.ADD)
@@ -402,6 +418,7 @@ class SegmentAPI(ServerAPI):
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,
     ) -> bool:
+        self._raise_for_running()
         self._quota.static_check(metadatas, documents, embeddings, str(collection_id))
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.UPDATE)
@@ -446,6 +463,7 @@ class SegmentAPI(ServerAPI):
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,
     ) -> bool:
+        self._raise_for_running()
         self._quota.static_check(metadatas, documents, embeddings, str(collection_id))
         coll = self._get_collection(collection_id)
         self._manager.hint_use_collection(collection_id, t.Operation.UPSERT)
@@ -489,6 +507,7 @@ class SegmentAPI(ServerAPI):
         where_document: Optional[WhereDocument] = {},
         include: Include = ["embeddings", "metadatas", "documents"],  # type: ignore[list-item]
     ) -> GetResult:
+        self._raise_for_running()
         add_attributes_to_current_span(
             {
                 "collection_id": str(collection_id),
@@ -594,6 +613,7 @@ class SegmentAPI(ServerAPI):
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
     ) -> None:
+        self._raise_for_running()
         add_attributes_to_current_span(
             {
                 "collection_id": str(collection_id),
@@ -669,6 +689,7 @@ class SegmentAPI(ServerAPI):
     )
     @override
     def _count(self, collection_id: UUID) -> int:
+        self._raise_for_running()
         add_attributes_to_current_span({"collection_id": str(collection_id)})
         coll = self._get_collection(collection_id)
         request_version_context = t.RequestVersionContext(
@@ -703,6 +724,7 @@ class SegmentAPI(ServerAPI):
         where_document: WhereDocument = {},
         include: Include = ["documents", "metadatas", "distances"],  # type: ignore[list-item]
     ) -> QueryResult:
+        self._raise_for_running()
         add_attributes_to_current_span(
             {
                 "collection_id": str(collection_id),
@@ -842,6 +864,7 @@ class SegmentAPI(ServerAPI):
     @trace_method("SegmentAPI._peek", OpenTelemetryGranularity.OPERATION)
     @override
     def _peek(self, collection_id: UUID, n: int = 10) -> GetResult:
+        self._raise_for_running()
         add_attributes_to_current_span({"collection_id": str(collection_id)})
         return self._get(collection_id, limit=n)  # type: ignore
 
@@ -855,6 +878,7 @@ class SegmentAPI(ServerAPI):
 
     @override
     def reset(self) -> bool:
+        self._raise_for_running()
         self._system.reset_state()
         return True
 
@@ -864,6 +888,7 @@ class SegmentAPI(ServerAPI):
 
     @override
     def get_max_batch_size(self) -> int:
+        self._raise_for_running()
         return self._producer.max_batch_size
 
     # TODO: This could potentially cause race conditions in a distributed version of the
@@ -904,12 +929,19 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI._get_collection", OpenTelemetryGranularity.ALL)
     def _get_collection(self, collection_id: UUID) -> t.Collection:
+        self._raise_for_running()
         collections = self._sysdb.get_collections(id=collection_id)
         if not collections or len(collections) == 0:
             raise InvalidCollectionException(
                 f"Collection {collection_id} does not exist."
             )
         return collections[0]
+
+    @trace_method("SegmentAPI.close", OpenTelemetryGranularity.ALL)
+    @override
+    def close(self) -> None:
+        self._raise_for_running()
+        self._system.stop()
 
 
 def _records(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -130,6 +130,7 @@ class SegmentAPI(ServerAPI):
 
     @override
     def heartbeat(self) -> int:
+        self._raise_for_running()
         return int(time.time_ns())
 
     @override
@@ -940,7 +941,6 @@ class SegmentAPI(ServerAPI):
     @trace_method("SegmentAPI.close", OpenTelemetryGranularity.ALL)
     @override
     def close(self) -> None:
-        self._raise_for_running()
         self._system.stop()
 
 

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -143,7 +143,7 @@ class IncludeEnum(str, Enum):
 
 # This should ust be List[Literal["documents", "embeddings", "metadatas", "distances"]]
 # However, this provokes an incompatibility with the Overrides library and Python 3.7
-Include = List[IncludeEnum]
+Include = List[Union[IncludeEnum, str]]
 IncludeMetadataDocuments = Field(default=["metadatas", "documents"])
 IncludeMetadataDocumentsEmbeddings = Field(
     default=["metadatas", "documents", "embeddings"]

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -322,6 +322,10 @@ class Component(ABC, EnforceOverrides):
         called from tests."""
         logger.debug(f"Resetting component {self.__class__.__name__}")
 
+    def _raise_for_running(self) -> None:
+        if not self._running:
+            raise RuntimeError("Component not running or already closed")
+
 
 class System(Component):
     settings: Settings

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -381,6 +381,7 @@ def basic_http_client() -> Generator[System, None, None]:
     )
     system = System(settings)
     api = system.instance(ServerAPI)
+    api.start()
     _await_server(api)
     system.start()
     yield system

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -305,6 +305,7 @@ def _fastapi_fixture(
         )
         system = System(settings)
         api = system.instance(ServerAPI)
+        api.start()
         system.start()
         _await_server(api if isinstance(api, FastAPI) else async_class_to_sync(api))
         yield system

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -780,7 +780,7 @@ def client_factories(system: System) -> Generator[ClientFactories, None, None]:
 @pytest.fixture(scope="function")
 def client(system: System) -> Generator[ClientAPI, None, None]:
     system.reset_state()
-
+    system.start()
     if system.settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
         client = cast(Any, AsyncClientCreatorSync.from_system_async(system))
         yield client

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -16,8 +16,6 @@ import chromadb.server.fastapi
 import pytest
 import tempfile
 
-from testcontainers.chroma import ChromaContainer
-
 
 @pytest.fixture
 def ephemeral_api() -> Generator[ClientAPI, None, None]:
@@ -115,15 +113,11 @@ def test_http_client_with_inconsistent_port_settings(
         )
 
 
-def test_persistent_client_close() -> None:
+def test_persistent_client_close(persistent_api: ClientAPI) -> None:
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
         pytest.skip(
             "Skipping test that closes the persistent client in integration test"
         )
-    persistent_api = chromadb.PersistentClient(
-        path=os.path.join(tempfile.gettempdir(), "test_server-" + uuid.uuid4().hex),
-        settings=Settings(),
-    )
     current_process = psutil.Process()
     col = persistent_api.create_collection("test")
     temp_persist_dir = persistent_api.get_settings().persist_directory
@@ -146,15 +140,11 @@ def test_persistent_client_close() -> None:
     assert len(post_filtered_open_files) == 0
 
 
-def test_persistent_client_use_after_close() -> None:
+def test_persistent_client_use_after_close(persistent_api: ClientAPI) -> None:
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
         pytest.skip(
             "Skipping test that closes the persistent client in integration test"
         )
-    persistent_api = chromadb.PersistentClient(
-        path=os.path.join(tempfile.gettempdir(), "test_server-" + uuid.uuid4().hex),
-        settings=Settings(),
-    )
     current_process = psutil.Process()
     col = persistent_api.create_collection("test" + uuid.uuid4().hex)
     temp_persist_dir = persistent_api.get_settings().persist_directory
@@ -202,27 +192,6 @@ def test_persistent_client_use_after_close() -> None:
         persistent_api.heartbeat()
 
 
-@pytest.fixture(params=["sync_client", "async_client"])
-def http_client_with_tc(
-    request: pytest.FixtureRequest,
-) -> Generator[ClientAPI, None, None]:
-    with ChromaContainer() as chroma:
-        config = chroma.get_config()
-        if request.param == "sync_client":
-            http_api = chromadb.HttpClient(host=config["host"], port=config["port"])
-            yield http_api
-            http_api.clear_system_cache()
-        else:
-
-            async def init_client() -> AsyncClientAPI:
-                http_api = await chromadb.AsyncHttpClient(
-                    host=config["host"], port=config["port"]
-                )
-                return http_api
-
-            yield asyncio.get_event_loop().run_until_complete(init_client())
-
-
 def get_connection_count(api_client: ClientAPI) -> int:
     if isinstance(api_client, AsyncClientAPI):
         connections = 0
@@ -235,43 +204,49 @@ def get_connection_count(api_client: ClientAPI) -> int:
         return len(_pool._connections)
 
 
-def test_http_client_close(http_client_with_tc: ClientAPI) -> None:
+def test_http_client_close(client: ClientAPI) -> None:
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
         pytest.skip(
             "Skipping test that closes the persistent client in integration test"
         )
 
+    if client.get_settings().chroma_api_impl == "chromadb.api.segment.SegmentAPI":
+        pytest.skip("Skipping test for persistent clients.")
+
     async def run_in_async(c: AsyncClientAPI):
         col = await c.create_collection("test" + uuid.uuid4().hex)
         await col.add(ids=["1"], documents=["test"])
-        assert get_connection_count(http_client_with_tc) > 0
+        assert get_connection_count(client) > 0
         await c.close()
-        assert get_connection_count(http_client_with_tc) == 0
+        assert get_connection_count(client) == 0
 
-    if isinstance(http_client_with_tc, AsyncClientAPI):
+    if isinstance(client, AsyncClientAPI):
         asyncio.get_event_loop().run_until_complete(
-            run_in_async(cast(AsyncClientAPI, http_client_with_tc))
+            run_in_async(cast(AsyncClientAPI, client))
         )
     else:
-        col = http_client_with_tc.create_collection("test" + uuid.uuid4().hex)
+        col = client.create_collection("test" + uuid.uuid4().hex)
         col.add(ids=["1"], documents=["test"])
-        assert get_connection_count(http_client_with_tc) > 0
-        http_client_with_tc.close()
-        assert get_connection_count(http_client_with_tc) == 0
+        assert get_connection_count(client) > 0
+        client.close()
+        assert get_connection_count(client) == 0
 
 
-def test_http_client_use_after_close(http_client_with_tc: ClientAPI) -> None:
+def test_http_client_use_after_close(client: ClientAPI) -> None:
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
         pytest.skip(
             "Skipping test that closes the persistent client in integration test"
         )
 
+    if client.get_settings().chroma_api_impl == "chromadb.api.segment.SegmentAPI":
+        pytest.skip("Skipping test for persistent clients.")
+
     async def run_in_async(c: AsyncClientAPI):
         col = await c.create_collection("test" + uuid.uuid4().hex)
         await col.add(ids=["1"], documents=["test"])
-        assert get_connection_count(http_client_with_tc) > 0
+        assert get_connection_count(client) > 0
         await c.close()
-        assert get_connection_count(http_client_with_tc) == 0
+        assert get_connection_count(client) == 0
         with pytest.raises(RuntimeError, match="Component not running"):
             await c.heartbeat()
         with pytest.raises(RuntimeError, match="Component not running"):
@@ -293,18 +268,18 @@ def test_http_client_use_after_close(http_client_with_tc: ClientAPI) -> None:
         with pytest.raises(RuntimeError, match="Component not running"):
             await c.list_collections()
 
-    if isinstance(http_client_with_tc, AsyncClientAPI):
+    if isinstance(client, AsyncClientAPI):
         asyncio.get_event_loop().run_until_complete(
-            run_in_async(cast(AsyncClientAPI, http_client_with_tc))
+            run_in_async(cast(AsyncClientAPI, client))
         )
     else:
-        col = http_client_with_tc.create_collection("test" + uuid.uuid4().hex)
+        col = client.create_collection("test" + uuid.uuid4().hex)
         col.add(ids=["1"], documents=["test"])
-        assert get_connection_count(http_client_with_tc) > 0
-        http_client_with_tc.close()
-        assert get_connection_count(http_client_with_tc) == 0
+        assert get_connection_count(client) > 0
+        client.close()
+        assert get_connection_count(client) == 0
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.heartbeat()
+            client.heartbeat()
         with pytest.raises(RuntimeError, match="Component not running"):
             col.add(ids=["1"], documents=["test"])
         with pytest.raises(RuntimeError, match="Component not running"):
@@ -316,16 +291,16 @@ def test_http_client_use_after_close(http_client_with_tc: ClientAPI) -> None:
         with pytest.raises(RuntimeError, match="Component not running"):
             col.count()
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.create_collection("test1")
+            client.create_collection("test1")
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.get_collection("test")
+            client.get_collection("test")
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.get_or_create_collection("test")
+            client.get_or_create_collection("test")
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.list_collections()
+            client.list_collections()
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.delete_collection("test")
+            client.delete_collection("test")
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.count_collections()
+            client.count_collections()
         with pytest.raises(RuntimeError, match="Component not running"):
-            http_client_with_tc.heartbeat()
+            client.heartbeat()

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -1,12 +1,22 @@
 import asyncio
+import os
+import re
+import shutil
+import uuid
 from typing import Any, Callable, Generator, cast
 from unittest.mock import patch
+
+import psutil
+
 import chromadb
+from chromadb import AsyncClientAPI
 from chromadb.config import Settings
 from chromadb.api import ClientAPI
 import chromadb.server.fastapi
 import pytest
 import tempfile
+
+from testcontainers.chroma import ChromaContainer
 
 
 @pytest.fixture
@@ -20,9 +30,13 @@ def ephemeral_api() -> Generator[ClientAPI, None, None]:
 def persistent_api() -> Generator[ClientAPI, None, None]:
     client = chromadb.PersistentClient(
         path=tempfile.gettempdir() + "/test_server",
+        settings=Settings(
+            allow_reset=True,
+        ),
     )
     yield client
     client.clear_system_cache()
+    shutil.rmtree(tempfile.gettempdir() + "/test_server", ignore_errors=True)
 
 
 HttpAPIFactory = Callable[..., ClientAPI]
@@ -99,3 +113,219 @@ def test_http_client_with_inconsistent_port_settings(
             str(e)
             == "Chroma server http port provided in settings[8001] is different to the one provided in HttpClient: [8002]"
         )
+
+
+def test_persistent_client_close() -> None:
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
+        pytest.skip(
+            "Skipping test that closes the persistent client in integration test"
+        )
+    persistent_api = chromadb.PersistentClient(
+        path=os.path.join(tempfile.gettempdir(), "test_server-" + uuid.uuid4().hex),
+        settings=Settings(),
+    )
+    current_process = psutil.Process()
+    col = persistent_api.create_collection("test")
+    temp_persist_dir = persistent_api.get_settings().persist_directory
+    col1 = persistent_api.create_collection("test1" + uuid.uuid4().hex)
+    col.add(ids=["1"], documents=["test"])
+    col1.add(ids=["1"], documents=["test1"])
+    open_files = current_process.open_files()
+    filtered_open_files = [
+        file for file in open_files if re.search(re.escape(temp_persist_dir), file.path)
+    ]
+    assert len(filtered_open_files) > 0
+    persistent_api.close()
+    open_files = current_process.open_files()
+    post_filtered_open_files = [
+        file
+        for file in open_files
+        if re.search(re.escape(temp_persist_dir) + ".*chroma.sqlite3", file.path)
+        or re.search(re.escape(temp_persist_dir) + ".*data_level0.bin", file.path)
+    ]
+    assert len(post_filtered_open_files) == 0
+
+
+def test_persistent_client_use_after_close() -> None:
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
+        pytest.skip(
+            "Skipping test that closes the persistent client in integration test"
+        )
+    persistent_api = chromadb.PersistentClient(
+        path=os.path.join(tempfile.gettempdir(), "test_server-" + uuid.uuid4().hex),
+        settings=Settings(),
+    )
+    current_process = psutil.Process()
+    col = persistent_api.create_collection("test" + uuid.uuid4().hex)
+    temp_persist_dir = persistent_api.get_settings().persist_directory
+    col.add(ids=["1"], documents=["test"])
+    open_files = current_process.open_files()
+    filtered_open_files = [
+        file
+        for file in open_files
+        if re.search(re.escape(temp_persist_dir) + ".*chroma.sqlite3", file.path)
+        or re.search(re.escape(temp_persist_dir) + ".*data_level0.bin", file.path)
+    ]
+    assert len(filtered_open_files) > 0
+    persistent_api.close()
+    open_files = current_process.open_files()
+    post_filtered_open_files = [
+        file
+        for file in open_files
+        if re.search(re.escape(temp_persist_dir) + ".*chroma.sqlite3", file.path)
+        or re.search(re.escape(temp_persist_dir) + ".*data_level0.bin", file.path)
+    ]
+    assert len(post_filtered_open_files) == 0
+    with pytest.raises(RuntimeError, match="Component not running"):
+        col.add(ids=["1"], documents=["test"])
+    with pytest.raises(RuntimeError, match="Component not running"):
+        col.delete(ids=["1"])
+    with pytest.raises(RuntimeError, match="Component not running"):
+        col.update(ids=["1"], documents=["test1231"])
+    with pytest.raises(RuntimeError, match="Component not running"):
+        col.upsert(ids=["1"], documents=["test1231"])
+    with pytest.raises(RuntimeError, match="Component not running"):
+        col.count()
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.create_collection("test1")
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.get_collection("test")
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.get_or_create_collection("test")
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.list_collections()
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.delete_collection("test")
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.count_collections()
+    with pytest.raises(RuntimeError, match="Component not running"):
+        persistent_api.heartbeat()
+
+
+@pytest.fixture(params=["sync_client", "async_client"])
+def http_client_with_tc(
+    request: pytest.FixtureRequest,
+) -> Generator[ClientAPI, None, None]:
+    with ChromaContainer() as chroma:
+        config = chroma.get_config()
+        if request.param == "sync_client":
+            http_api = chromadb.HttpClient(host=config["host"], port=config["port"])
+            yield http_api
+            http_api.clear_system_cache()
+        else:
+
+            async def init_client() -> AsyncClientAPI:
+                http_api = await chromadb.AsyncHttpClient(
+                    host=config["host"], port=config["port"]
+                )
+                return http_api
+
+            yield asyncio.get_event_loop().run_until_complete(init_client())
+
+
+def get_connection_count(api_client: ClientAPI) -> int:
+    if isinstance(api_client, AsyncClientAPI):
+        connections = 0
+        for k, client in api_client._server._clients.items():
+            _pool = client._transport._pool  # type: ignore
+            connections += len(_pool._connections)
+        return connections
+    else:
+        _pool = api_client._server._session._transport._pool  # type: ignore
+        return len(_pool._connections)
+
+
+def test_http_client_close(http_client_with_tc: ClientAPI) -> None:
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
+        pytest.skip(
+            "Skipping test that closes the persistent client in integration test"
+        )
+
+    async def run_in_async(c: AsyncClientAPI):
+        col = await c.create_collection("test" + uuid.uuid4().hex)
+        await col.add(ids=["1"], documents=["test"])
+        assert get_connection_count(http_client_with_tc) > 0
+        await c.close()
+        assert get_connection_count(http_client_with_tc) == 0
+
+    if isinstance(http_client_with_tc, AsyncClientAPI):
+        asyncio.get_event_loop().run_until_complete(
+            run_in_async(cast(AsyncClientAPI, http_client_with_tc))
+        )
+    else:
+        col = http_client_with_tc.create_collection("test" + uuid.uuid4().hex)
+        col.add(ids=["1"], documents=["test"])
+        assert get_connection_count(http_client_with_tc) > 0
+        http_client_with_tc.close()
+        assert get_connection_count(http_client_with_tc) == 0
+
+
+def test_http_client_use_after_close(http_client_with_tc: ClientAPI) -> None:
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
+        pytest.skip(
+            "Skipping test that closes the persistent client in integration test"
+        )
+
+    async def run_in_async(c: AsyncClientAPI):
+        col = await c.create_collection("test" + uuid.uuid4().hex)
+        await col.add(ids=["1"], documents=["test"])
+        assert get_connection_count(http_client_with_tc) > 0
+        await c.close()
+        assert get_connection_count(http_client_with_tc) == 0
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await c.heartbeat()
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await col.add(ids=["1"], documents=["test"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await col.delete(ids=["1"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await col.update(ids=["1"], documents=["test1231"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await col.upsert(ids=["1"], documents=["test1231"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await col.count()
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await c.create_collection("test1")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await c.get_collection("test")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await c.get_or_create_collection("test")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            await c.list_collections()
+
+    if isinstance(http_client_with_tc, AsyncClientAPI):
+        asyncio.get_event_loop().run_until_complete(
+            run_in_async(cast(AsyncClientAPI, http_client_with_tc))
+        )
+    else:
+        col = http_client_with_tc.create_collection("test" + uuid.uuid4().hex)
+        col.add(ids=["1"], documents=["test"])
+        assert get_connection_count(http_client_with_tc) > 0
+        http_client_with_tc.close()
+        assert get_connection_count(http_client_with_tc) == 0
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.heartbeat()
+        with pytest.raises(RuntimeError, match="Component not running"):
+            col.add(ids=["1"], documents=["test"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            col.delete(ids=["1"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            col.update(ids=["1"], documents=["test1231"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            col.upsert(ids=["1"], documents=["test1231"])
+        with pytest.raises(RuntimeError, match="Component not running"):
+            col.count()
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.create_collection("test1")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.get_collection("test")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.get_or_create_collection("test")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.list_collections()
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.delete_collection("test")
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.count_collections()
+        with pytest.raises(RuntimeError, match="Component not running"):
+            http_client_with_tc.heartbeat()

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -113,11 +113,15 @@ def test_http_client_with_inconsistent_port_settings(
         )
 
 
-def test_persistent_client_close(persistent_api: ClientAPI) -> None:
+def test_persistent_client_close() -> None:
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
         pytest.skip(
             "Skipping test that closes the persistent client in integration test"
         )
+    persistent_api = chromadb.PersistentClient(
+        path=os.path.join(tempfile.gettempdir(), "test_server-" + uuid.uuid4().hex),
+        settings=Settings(),
+    )
     current_process = psutil.Process()
     col = persistent_api.create_collection("test")
     temp_persist_dir = persistent_api.get_settings().persist_directory
@@ -140,11 +144,15 @@ def test_persistent_client_close(persistent_api: ClientAPI) -> None:
     assert len(post_filtered_open_files) == 0
 
 
-def test_persistent_client_use_after_close(persistent_api: ClientAPI) -> None:
+def test_persistent_client_use_after_close() -> None:
     if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY") == "1":
         pytest.skip(
             "Skipping test that closes the persistent client in integration test"
         )
+    persistent_api = chromadb.PersistentClient(
+        path=os.path.join(tempfile.gettempdir(), "test_server-" + uuid.uuid4().hex),
+        settings=Settings(),
+    )
     current_process = psutil.Process()
     col = persistent_api.create_collection("test" + uuid.uuid4().hex)
     temp_persist_dir = persistent_api.get_settings().persist_directory

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,5 +12,5 @@ pytest
 pytest-asyncio
 pytest-xdist
 setuptools_scm
-testcontainers[chroma]
+testcontainers[chroma]>=4.7.0
 types-protobuf

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,5 +12,4 @@ pytest
 pytest-asyncio
 pytest-xdist
 setuptools_scm
-testcontainers[chroma]>=4.7.0
 types-protobuf

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,4 +12,5 @@ pytest
 pytest-asyncio
 pytest-xdist
 setuptools_scm
+testcontainers[chroma]
 types-protobuf


### PR DESCRIPTION
Closes #1756

Refs:
- https://discord.com/channels/1073293645303795742/1209706648243929128
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Ability to close and release resources for Persistent (open files) and Http (connections). This is a redo of #1792 

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

Docs about the new API can be stacked on top of this PR
