### PR TITLE
[ENH] Tag operators as IO or other + dispatcher schedules IO tasks on the main runtime

### DIFF
--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 use uuid::Uuid;
 
 pub(crate) enum OperatorType {
-    IoOperatorType,
-    OtherType,
+    IoOperator,
+    Other,
 }
 
 /// An operator takes a generic input and returns a generic output.
@@ -28,7 +28,7 @@ where
     async fn run(&self, input: &I) -> Result<O, Self::Error>;
     fn get_name(&self) -> &'static str;
     fn get_type(&self) -> OperatorType {
-        OperatorType::OtherType
+        OperatorType::Other
     }
 }
 

--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -9,6 +9,11 @@ use std::{fmt::Debug, panic::AssertUnwindSafe};
 use thiserror::Error;
 use uuid::Uuid;
 
+pub(crate) enum OperatorType {
+    IoOperatorType,
+    OtherType,
+}
+
 /// An operator takes a generic input and returns a generic output.
 /// It is a definition of a function.
 #[async_trait]
@@ -22,6 +27,9 @@ where
     // but that's not stable in rust yet.
     async fn run(&self, input: &I) -> Result<O, Self::Error>;
     fn get_name(&self) -> &'static str;
+    fn get_type(&self) -> OperatorType {
+        OperatorType::OtherType
+    }
 }
 
 #[derive(Debug, Error)]
@@ -95,6 +103,7 @@ pub(crate) trait TaskWrapper: Send + Debug {
     fn get_name(&self) -> &'static str;
     async fn run(&self);
     fn id(&self) -> Uuid;
+    fn get_type(&self) -> OperatorType;
 }
 
 /// Implement the TaskWrapper trait for every Task. This allows us to
@@ -178,6 +187,10 @@ where
 
     fn id(&self) -> Uuid {
         self.task_id
+    }
+
+    fn get_type(&self) -> OperatorType {
+        self.operator.get_type()
     }
 }
 

--- a/rust/worker/src/execution/operators/record_segment_prefetch.rs
+++ b/rust/worker/src/execution/operators/record_segment_prefetch.rs
@@ -4,7 +4,7 @@ use tonic::async_trait;
 use crate::{
     blockstore::provider::BlockfileProvider,
     errors::{ChromaError, ErrorCodes},
-    execution::operator::Operator,
+    execution::operator::{Operator, OperatorType},
     segment::record_segment::RecordSegmentReader,
     types::Segment,
 };
@@ -108,5 +108,9 @@ impl Operator<RecordSegmentPrefetchIoInput, RecordSegmentPrefetchIoOutput>
             }
         }
         Ok(RecordSegmentPrefetchIoOutput {})
+    }
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IoOperatorType
     }
 }

--- a/rust/worker/src/execution/operators/record_segment_prefetch.rs
+++ b/rust/worker/src/execution/operators/record_segment_prefetch.rs
@@ -111,6 +111,6 @@ impl Operator<RecordSegmentPrefetchIoInput, RecordSegmentPrefetchIoOutput>
     }
 
     fn get_type(&self) -> OperatorType {
-        OperatorType::IoOperatorType
+        OperatorType::IoOperator
     }
 }


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- Only prefetch operator is tagged as IO currently. All others are tagged by default as "Other". Chose "other" instead of CPU as the tag name because  these operators do both cpu and io today although we do want to eventually move IO off them.
- Dispatcher spawns IO tasks on the main tokio runtime.


## Test plan
Modified existing rust test
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
