### PR TITLE
[ENH] Make rust consume configuration instead of metadata

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -405,6 +405,12 @@ mod tests {
             _ => panic!("Invalid sysdb type"),
         }
 
+        let hnsw_configuration = r#"{
+            "M": 16,
+            "construction_ef": 100,
+            "search_ef": 100
+        }"#;
+
         let collection_1_record_segment = Segment {
             id: Uuid::new_v4(),
             r#type: crate::types::SegmentType::BlockfileRecord,
@@ -412,6 +418,7 @@ mod tests {
             collection: Some(collection_uuid_1),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
 
         let collection_2_record_segment = Segment {
@@ -421,6 +428,7 @@ mod tests {
             collection: Some(collection_uuid_2),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
 
         let collection_1_hnsw_segment = Segment {
@@ -430,6 +438,7 @@ mod tests {
             collection: Some(collection_uuid_1),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: serde_json::from_str(hnsw_configuration).unwrap(),
         };
 
         let collection_2_hnsw_segment = Segment {
@@ -439,6 +448,7 @@ mod tests {
             collection: Some(collection_uuid_2),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: serde_json::from_str(hnsw_configuration).unwrap(),
         };
 
         let collection_1_metadata_segment = Segment {
@@ -448,6 +458,7 @@ mod tests {
             collection: Some(collection_uuid_1),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
 
         let collection_2_metadata_segment = Segment {
@@ -457,6 +468,7 @@ mod tests {
             collection: Some(collection_uuid_2),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
 
         match *sysdb {

--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -6,19 +6,15 @@ use crate::execution::operators::normalize_vectors::normalize;
 use crate::segment::record_segment::RecordSegmentReader;
 use crate::segment::LogMaterializer;
 use crate::segment::LogMaterializerError;
-use crate::segment::MaterializedLogRecord;
 use crate::types::LogRecord;
 use crate::types::MaterializedLogOperation;
-use crate::types::Operation;
 use crate::types::Segment;
 use crate::{distance::DistanceFunction, execution::operator::Operator};
 use async_trait::async_trait;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::trace;
 use tracing::Instrument;
 use tracing::Span;
 
@@ -251,6 +247,7 @@ mod tests {
             collection: Some(uuid!("00000000-0000-0000-0000-000000000000")),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         return (blockfile_provider, record_segment_definition);
     }

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -224,6 +224,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -365,6 +366,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
 
         // Add 1, 2. Delete 1. Add 3. Upsert 3. Expected count is 2.

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -426,6 +426,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -436,6 +437,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -721,6 +723,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -731,6 +734,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -791,6 +791,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -801,6 +802,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -1010,6 +1012,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -1020,6 +1023,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -1200,6 +1204,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -1210,6 +1215,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -202,6 +202,7 @@ mod tests {
             collection: Some(collection_uuid_1),
             metadata: None,
             file_path: file_path_1.clone(),
+            configuration_json: None,
         };
 
         let mut file_path_2 = HashMap::new();
@@ -214,6 +215,7 @@ mod tests {
             collection: Some(collection_uuid_2),
             metadata: None,
             file_path: file_path_2.clone(),
+            configuration_json: None,
         };
         match *sysdb {
             SysDb::Test(ref mut sysdb) => {

--- a/rust/worker/src/index/hnsw_provider.rs
+++ b/rust/worker/src/index/hnsw_provider.rs
@@ -509,6 +509,13 @@ mod tests {
         // Create the directories needed
         std::fs::create_dir_all(&hnsw_tmp_path).unwrap();
 
+        // create the config
+        let configuration = r#"{
+            "M": 16,
+            "construction_ef": 100,
+            "search_ef": 100
+        }"#;
+
         let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache);
@@ -519,6 +526,7 @@ mod tests {
             collection: Some(Uuid::new_v4()),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: serde_json::from_str(configuration).unwrap(),
         };
 
         let dimensionality = 128;

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -14,7 +14,6 @@ use uuid::Uuid;
 use super::record_segment::ApplyMaterializedLogError;
 use super::types::{MaterializedLogRecord, SegmentWriter};
 use super::SegmentFlusher;
-use crate::blockstore::key::KeyWrapper;
 use crate::blockstore::provider::{BlockfileProvider, CreateError, OpenError};
 use crate::errors::{ChromaError, ErrorCodes};
 use crate::index::fulltext::tokenizer::TantivyChromaTokenizer;
@@ -1908,6 +1907,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -1918,6 +1918,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -2199,6 +2200,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -2209,6 +2211,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -2456,6 +2459,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -2466,6 +2470,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -2682,6 +2687,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -2692,6 +2698,7 @@ mod test {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -927,6 +927,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -937,6 +938,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -1221,6 +1223,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -1231,6 +1234,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -1507,6 +1511,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         let mut metadata_segment = crate::types::Segment {
             id: Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
@@ -1517,6 +1522,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =
@@ -1812,6 +1818,7 @@ mod tests {
             ),
             metadata: None,
             file_path: HashMap::new(),
+            configuration_json: None,
         };
         {
             let segment_writer =


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR switches the rust hnsw index to consume all configuration from segment configuration instead of from metadata
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
I refactored existing tests for the metadata based configuration for the hnsw configuration
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None