### PR TITLE
[DOC] getting started page refactor

### DIFF
--- a/docs/docs.trychroma.com/components/CodeBlock.tsx
+++ b/docs/docs.trychroma.com/components/CodeBlock.tsx
@@ -132,7 +132,7 @@ export function CodeBlock({children, 'data-language': language, filename, codeta
   }
 
   return (
-    <div className="rounded-md code reset text-sm" aria-live="polite"
+    <div className="rounded-md code reset text-sm overflow-hidden" aria-live="polite"
       style={{borderRadius: '0.5rem', position: 'relative', marginBottom: marginBottom}}
     >
       <CopyToClipboardButton className={`absolute ${copyIconColor} border-0 right-3 p-0.5`} textToCopy={newChildren} customStyle={{top: copyButtonTop}}/>

--- a/docs/docs.trychroma.com/components/markdoc/misc.tsx
+++ b/docs/docs.trychroma.com/components/markdoc/misc.tsx
@@ -1,3 +1,7 @@
 export function Br() {
   return <br/>
 }
+
+export function Underline({ children }) {
+  return <span className="underline underline-offset-4">{children}</span>
+}

--- a/docs/docs.trychroma.com/markdoc/tags/index.ts
+++ b/docs/docs.trychroma.com/markdoc/tags/index.ts
@@ -1,5 +1,5 @@
 /* Use this file to export your markdoc tags */
 export * from './tabs.markdoc'
-export {note, br, math} from './note.markdoc';
+export {note, br, math, u} from './note.markdoc';
 export {special_table} from './special_table.markdoc';
 export {codetabs, codetab} from './codetabs.markdoc';

--- a/docs/docs.trychroma.com/markdoc/tags/note.markdoc.ts
+++ b/docs/docs.trychroma.com/markdoc/tags/note.markdoc.ts
@@ -1,6 +1,7 @@
 import MathComponent from "../../components/markdoc/Math";
 import { Note } from "../../components/markdoc/Note";
-import { Br } from "../../components/markdoc/misc";
+import { Br, Underline } from "../../components/markdoc/misc";
+
 
 export const note = {
   render: Note,
@@ -25,4 +26,8 @@ export const math = {
       type: String
     },
   }
+};
+
+export const u = {
+  render: Underline,
 };

--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -214,7 +214,7 @@ console.log(results)
 
 ### 6. See Results
 
-A query about `What should I make for a Hawaiin themed dinner?` returns the document about pineapples.
+A query about `What should I make for a Hawaiian themed dinner?` returns the document about pineapples.
 
 This makes sense if you consider that conceptually pineapples are most closely related to tropical places like Hawaii, and that the fact that it is edible is conceptually related to a question about food.
 
@@ -236,7 +236,7 @@ The JSON has an array of ararys because you can pass multiple query texts and ge
 
 ### 7. Add Metadata
 
-You can also add metadata to your records. This might be data that you would want to search over later (such as keywords), or data that you will need when you retrieve the original documents (such as the URL that the document originally came from).
+You can also add metadata to your records. This might be data that you would want to search over later, or data that you will need when you retrieve the original documents (such as the URL that the document originally came from).
 
 {% tabs group="code-lang" hideTabs=true %}
 {% tab label="Python" %}
@@ -283,7 +283,7 @@ await collection.add({
 
 ### 8. More ways to search your Collection
 
-Use `metadata search` and its operators to search over metadata fields. Use the `.get` API if you want to search metadata.
+Use {%u%}**metadata search**{%/u%} and its operators to search over metadata fields. Use the `.get` API if you want to search metadata.
 
 {% tabs group="code-lang" hideTabs=true %}
 {% tab label="Python" %}
@@ -302,7 +302,7 @@ const recentlyUpdated = await collection.get({
 {% /tab %}
 {% /tabs %}
 
-Use `document search` to do full-text search. Use the `.get` API if you want to search metadata.
+Use {%u%}**document search**{%/u%} to do full-text search. Use the `.get` API if you want to search metadata.
 
 {% tabs group="code-lang" hideTabs=true %}
 {% tab label="Python" %}


### PR DESCRIPTION
This is a new getting started page. 

- should we have a "kitchen sink" code block where you can copy all code on the page OR should we have the same idea but "open in google colab" or something like that? (colab would not support JS)

I composed all this code into python and JS scripts and confirmed it works as expected. 
