### PR TITLE
[BUG] fix multi collection log purge

### DIFF
--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -9,6 +9,7 @@ import uvicorn
 import os
 import webbrowser
 
+from chromadb.api.client import Client
 from chromadb.cli.utils import get_directory_size, set_log_file_path, sizeof_fmt
 from chromadb.config import Settings, System
 from chromadb.db.impl.sqlite import SqliteDB
@@ -132,6 +133,7 @@ def vacuum(
     settings.persist_directory = path
     system = System(settings=settings)
     system.start()
+    client = Client.from_system(system)
     sqlite = system.instance(SqliteDB)
 
     directory_size_before_vacuum = get_directory_size(path)
@@ -143,11 +145,8 @@ def vacuum(
         TextColumn("[progress.description]{task.description}"),
         transient=True,
     ) as progress:
-        with sqlite.tx() as cur:
-            cur.execute("SELECT id FROM collections")
-            collection_ids = [row[0] for row in cur.fetchall()]
-
-        task = progress.add_task("Purging the log...", total=len(collection_ids))
+        collections = client.list_collections()
+        task = progress.add_task("Purging the log...", total=len(collections))
         try:
             # Cleaning the log after upgrading to >=0.6 is dependent on vector segments migrating their max_seq_id from the pickled metadata file to SQLite.
             # Vector segments migrate this field automatically on init, but at this point the segment has not been loaded yet.
@@ -155,8 +154,8 @@ def vacuum(
                 sqlite, system.instance(SegmentManager)
             )
 
-            for collection_id in collection_ids:
-                sqlite.purge_log(collection_id)
+            for collection in collections:
+                sqlite.purge_log(collection_id=collection.id)
                 progress.update(task, advance=1)
         except Exception as e:
             console.print(f"[bold red]Error purging the log:[/bold red] {e}")

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -131,6 +131,8 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
     @trace_method("SqlEmbeddingsQueue.purge_log", OpenTelemetryGranularity.ALL)
     @override
     def purge_log(self, collection_id: UUID) -> None:
+        # (We need to purge on a per topic/collection basis, because the maximum sequence ID is tracked on a per topic/collection basis.)
+
         segments_t = Table("segments")
         segment_ids_q = (
             self.querybuilder()

--- a/chromadb/ingest/__init__.py
+++ b/chromadb/ingest/__init__.py
@@ -42,7 +42,7 @@ class Producer(Component):
         pass
 
     @abstractmethod
-    def purge_log(self) -> None:
+    def purge_log(self, collection_id: UUID) -> None:
         """Truncates the log for the given collection, removing all seen records."""
         pass
 

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -76,7 +76,7 @@ class LogService(Producer, Consumer):
 
     @trace_method("LogService.purge_log", OpenTelemetryGranularity.ALL)
     @override
-    def purge_log(self) -> None:
+    def purge_log(self, collection_id: UUID) -> None:
         raise NotImplementedError("Not implemented")
 
     @trace_method("LogService.submit_embedding", OpenTelemetryGranularity.ALL)

--- a/chromadb/test/db/test_log_purge.py
+++ b/chromadb/test/db/test_log_purge.py
@@ -1,0 +1,26 @@
+from chromadb.api.client import Client
+from chromadb.config import System
+from chromadb.test.property import invariants
+
+
+def test_log_purge(sqlite_persistent: System) -> None:
+    client = Client.from_system(sqlite_persistent)
+
+    first_collection = client.create_collection(
+        "first_collection", metadata={"hnsw:sync_threshold": 10, "hnsw:batch_size": 10}
+    )
+    second_collection = client.create_collection(
+        "second_collection", metadata={"hnsw:sync_threshold": 10, "hnsw:batch_size": 10}
+    )
+    collections = [first_collection, second_collection]
+
+    # (Does not trigger a purge)
+    for i in range(5):
+        first_collection.add(ids=str(i), embeddings=[i, i])
+
+    # (Should trigger a purge)
+    for i in range(100):
+        second_collection.add(ids=str(i), embeddings=[i, i])
+
+    # The purge of the second collection should not be blocked by the first
+    invariants.log_size_below_max(client._system, collections, True)

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -1,6 +1,5 @@
 import gc
 import math
-from chromadb.api.configuration import HNSWConfigurationInternal
 from chromadb.config import System
 from chromadb.db.base import get_sql
 from chromadb.db.impl.sqlite import SqliteDB
@@ -334,7 +333,7 @@ def _total_embedding_queue_log_size(sqlite: SqliteDB) -> int:
 
 
 def log_size_below_max(
-    system: System, collection: Collection, has_collection_mutated: bool
+    system: System, collections: List[Collection], has_collection_mutated: bool
 ) -> None:
     sqlite = system.instance(SqliteDB)
 
@@ -342,21 +341,21 @@ def log_size_below_max(
         # Must always keep one entry to avoid reusing seq_ids
         assert _total_embedding_queue_log_size(sqlite) >= 1
 
-        hnsw_config = cast(
-            HNSWConfigurationInternal,
-            collection.get_model()
-            .get_configuration()
-            .get_parameter("hnsw_configuration")
-            .value,
+        # We purge per-collection as the sync_threshold is a per-collection setting
+        sync_threshold_sum = sum(
+            collection.metadata.get("hnsw:sync_threshold", 1000)
+            for collection in collections
         )
-        sync_threshold = cast(int, hnsw_config.get_parameter("sync_threshold").value)
-        batch_size = cast(int, hnsw_config.get_parameter("batch_size").value)
+        batch_size_sum = sum(
+            collection.metadata.get("hnsw:batch_size", 1000)
+            for collection in collections
+        )
 
         # -1 is used because the queue is always at least 1 entry long, so deletion stops before the max ack'ed sequence ID.
         # And if the batch_size != sync_threshold, the queue can have up to batch_size - 1 more entries.
         assert (
             _total_embedding_queue_log_size(sqlite) - 1
-            <= sync_threshold + batch_size - 1
+            <= sync_threshold_sum + batch_size_sum - 1
         )
     else:
         assert _total_embedding_queue_log_size(sqlite) == 0

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -344,10 +344,14 @@ def log_size_below_max(
         # We purge per-collection as the sync_threshold is a per-collection setting
         sync_threshold_sum = sum(
             collection.metadata.get("hnsw:sync_threshold", 1000)
+            if collection.metadata is not None
+            else 1000
             for collection in collections
         )
         batch_size_sum = sum(
-            collection.metadata.get("hnsw:batch_size", 1000)
+            collection.metadata.get("hnsw:batch_size", 100)
+            if collection.metadata is not None
+            else 100
             for collection in collections
         )
 

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -372,8 +372,8 @@ def test_cycle_versions(
         embeddings_queue, system.instance(SegmentManager)
     )
 
-    embeddings_queue.purge_log()
-    invariants.log_size_below_max(system, coll, True)
+    embeddings_queue.purge_log(coll.id)
+    invariants.log_size_below_max(system, [coll], True)
 
     # Should be able to add embeddings
     coll.add(**embeddings_strategy)  # type: ignore
@@ -383,7 +383,7 @@ def test_cycle_versions(
     invariants.documents_match(coll, embeddings_strategy)
     invariants.ids_match(coll, embeddings_strategy)
     invariants.ann_accuracy(coll, embeddings_strategy)
-    invariants.log_size_below_max(system, coll, True)
+    invariants.log_size_below_max(system, [coll], True)
 
     # Shutdown system
     system.stop()

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -222,7 +222,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
     def log_size_below_max(self) -> None:
         system: System = self.client._system  # type: ignore
         invariants.log_size_below_max(
-            system, self.collection, self.has_collection_mutated
+            system, [self.collection], self.has_collection_mutated
         )
 
     def _upsert_embeddings(self, record_set: strategies.RecordSet) -> None:


### PR DESCRIPTION
## Description of changes

Fixes a bug where if any collection had dangling logs, any logs created after those by other collections would not get purged.

Also fixes a small, somewhat related bug with `chroma utils vacuum` (see PR comment below).

## Test plan
*How are these changes tested?*

Added a new regression test that was formerly failing.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
