### PR TITLE
[ENH]: HNSW Replace Deleted flag

### DIFF
--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -202,6 +202,7 @@ class LocalHnswSegment(VectorReader):
             max_elements=DEFAULT_CAPACITY,
             ef_construction=self._params.construction_ef,
             M=self._params.M,
+            allow_replace_deleted=True,
         )
         index.set_ef(self._params.search_ef)
         index.set_num_threads(self._params.num_threads)
@@ -266,7 +267,7 @@ class LocalHnswSegment(VectorReader):
             index = cast(hnswlib.Index, self._index)
 
             # First, update the index
-            index.add_items(vectors_to_write, labels_to_write)
+            index.add_items(vectors_to_write, labels_to_write, replace_deleted=True)
 
             # If that succeeds, update the mappings
             for i, id in enumerate(written_ids):

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -209,6 +209,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                 max_elements=int(
                     max(self.count() * self._params.resize_factor, DEFAULT_CAPACITY)
                 ),
+                allow_replace_deleted=True,
             )
         else:
             index.init_index(
@@ -217,6 +218,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                 M=self._params.M,
                 is_persistent_index=True,
                 persistence_location=self._get_storage_folder(),
+                allow_replace_deleted=True,
             )
 
         index.set_ef(self._params.search_ef)


### PR DESCRIPTION
## Description of changes

Closes #2594

*Summarize the changes made by this PR.*
 - New functionality
	 - Added replace deleted flag on index init and when adding items

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

# The problem

Recently, a [user reported](https://discord.com/channels/1073293645303795742/1267281910145745007) seeing an increase in memory consumption even though his dataset stayed relatively stable in size. Upon further investigation, the user’s workflow can be considered as mostly a common approach to RAG systems whereby data is added, and if it is updated, then it is removed and re-added (not always, as sometimes users prefer using update).

Investigation showed that as data is added and deleted, the HNSW index grows, this is a known behavior of the HNSW lib. Removing points from the graph is expensive. Therefore, HNSW has opted in to simply flag nodes as deleted and not return them in the search results. This behaviour has several undesirable properties:

- The size on the disk of the index is unbounded - after only 500k (1536dims embeddings) add/delete loops whereby the result is that no records are present in the collection, the index grows to some 3GB (see graphs below).
- The memory footprint of the index follows a similar trajectory as the disk size (see graphs below)
- Increased disk IO - even though no items are really added, we keep flushing the ever-increasing HNSW (measuring a process disk IO on a Mac system is not trivial therefore, we’ve left that part out of the graphs)

To demonstrate the above effects, we’ve created a small [benchmarking program](https://gist.github.com/tazarov/4d10d807b02fb7e2b5c5f56816d8772f) that will test our worst-case scenario, in which items are added, queried, and removed immediately.

The setup:

- 1000 cycles/iterations
- 500 embeddings added/removed on iteration
- 1536 dims per embedding

Things we measured:

- Memory consumption (although in a dynamically typed language like Python this can be misleading)
- Disk usage (only folder sizes)
- CPU usage - this may not be as evident from the above stated undesirable properties, but as with everything
- HNSW segmentation ratio - calculated based on the following formula
    - `((hnsw_item_count-index_active_items) / hnsw_item_count) * 100`  - expressed as percentage where 0 is not fragmentation and 100 is fully fragmented. `hnsw_item_count` represents the items the HNSW index reports as being in the index (including deleted), `index_active_items` is the items in the collection.
- Timings of `add`, `query`, and `delete` operations

With the above in mind let’s see some benchmark graphs.

First, we start with storage. The following graph shows how the storage grows over our 1000 iterations:

![size-over-cycles](https://github.com/user-attachments/assets/812c06b5-5c70-4c4c-bba7-9b919c172fa5)


Grows pretty linearly. It is important to note that at the end of all iterations our collection contains `0` items however the HNSW index has swollen to over `3GB.` 

This leads us to our second graph which is memory consumption:

![memory-over-cycles-no-replacement](https://github.com/user-attachments/assets/16eea530-175f-43da-aeff-9725691f236f)

As mentioned above due to the dynamic nature of Python and the fact that we generate the data as part of our benchmarking, it is not surprising to see such graph. The important thing to observe here (with a hind-side of knowing the outcome of a candidate solution) is the growth slope aka how fast do we increase memory consumption. Arguable we can do a much better job at measuring the memory consumption of the HNSW index alone, but for now we’re satisfied with the outcome and we can demonstrate the actual consumption of the index with the below code:

```python
import hnswlib
import psutil
import os
def get_process_memory_usage() -> float:
    return psutil.Process(os.getpid()).memory_info().rss / 1024 / 1024

print("Before loading", get_process_memory_usage())
index = hnswlib.Index(space='l2', dim=1536)
index.load_index("hsnw_no_replacement/2853129b-c825-4dcc-b227-98c5836de120/",is_persistent_index=True,max_elements=501)
print("After loading", get_process_memory_usage())
```

The output os more than indicative:

```
Before loading 68.890625
After loading 3142.265625
```

While we have not generated a graph for the disk IO, it is kind of a 1-to-1 proxy metric for the size on disk of the HNSW index. That means that we’ve written the equivalent of about 3GB to disk due to how `persist_dirty` works in HNSW, persisting only the parts that have been modified since last persist.

# A solution (with trade-offs)

“No free lunch” quote comes to mind when exploring the the solution space of the problem statement above. While there are multiple ways to solve the problem, investigation shows that each of them has tradeoffs. Exploring and comparing all these solutions is a formidable task so we here we only present a single solution, which we think is the simplest approach with fair tradeoffs - Replacing deleted items in the HNSW graph.

Replacing deleted items allows the HNSW lib to save memory by doing exactly what the feature suggests, replacing deleted items with newly added ones thus keeping the graph small and with little to none dead items.

The change in Chroma is trivial - [patch here](https://gist.github.com/tazarov/cbc541a94e65401186df11b06e6c71f8) (same as the changes in 

Ok, but what are the trade-offs here?

The gist of the trade-offs: we trade off memory and storage reduction for increased CPU cycles. But that is a reductionist view, so let’s dig a little deeper and see what statistics tell us.

Let’s start with an ambiguous graph of memory consumption:

![memory-over-cycles-with-replacement](https://github.com/user-attachments/assets/c779a7e1-713e-4b64-8021-57328a9e257f)

Again paying attention to the slooowly rising slow in the first part. When we run the same code to see how much memory the index actually consumes in memory:

```python
import hnswlib
import psutil
import os
def get_process_memory_usage() -> float:
    return psutil.Process(os.getpid()).memory_info().rss / 1024 / 1024

print("Before loading", get_process_memory_usage())
index = hnswlib.Index(space='l2', dim=1536)
index.load_index("hsnw_with_replacement/fc6e9a96-7488-4e74-93c1-082dff7e9e69/",is_persistent_index=True,max_elements=501)
print("After loading", get_process_memory_usage())
```

There results show what the intuition behind the slow rising slope suggests:

```python
Before loading 68.6875
After loading 75.8125
```

Now let’s look at what happens with CPU cycles. The diagrams and stats below are generated using [this notebook](https://gist.github.com/tazarov/2ca1f27b61526cda8f5139f75b9b2c56).

![stats_compare_add_time](https://github.com/user-attachments/assets/fc3bc0da-6c72-444a-8550-03ffab0e04b4)

```python
Mean add_time of With Replacement: 0.789898
Mean add_time of No Replacement: 0.702067
Difference in means (add_time): 0.087831
T-statistic: 18.3090
P-value: 0.0000
```

In simple terms what the above comparison shows is that the difference in add_time is statistically significant with an average of `88ms` added when using deleted replacement flag. It is important to note that add times here are measured with HNSW defaults and `500` items added at a time. Equality important to note that this benchmark is run on an M3 MAX with 16 cores. Mileage will vary on other systems and with different configurations, but such extensive testing can be performed further down the road.

CPU usage also reflects above observation on added latency:

![stats_compare_add_cpu_usage](https://github.com/user-attachments/assets/94c086ef-1289-4773-b819-66051ad7c512)

```python
Mean add_cpu_usage of With Replacement: 1032.175000
Mean add_cpu_usage of No Replacement: 859.388700
Difference in means (add_cpu_usage): 172.786300
T-statistic: 55.0184
P-value: 0.0000
```

Query Times seem a bit wonky due to a [bug](https://github.com/chroma-core/chroma/issues/2620) in HNSW related to our test scenario, but they should generally be the same:

![stats_compare_query_time](https://github.com/user-attachments/assets/0ca3e641-e2a7-4516-be89-1c3f3084e626)

```python
Mean query_time of With Replacement: 0.001376
Mean query_time of No Replacement: 0.012869
Difference in means (query_time): -0.011492
T-statistic: -75.7259
P-value: 0.0000
```

Query CPU usage reflects the above timings:

![stats_compare_query_cpu_usage](https://github.com/user-attachments/assets/c25eea74-ada3-48e1-8ba0-5d4f95e6f988)

```python
Mean query_cpu_usage of With Replacement: 99.302600
Mean query_cpu_usage of No Replacement: 100.256600
Difference in means (query_cpu_usage): -0.954000
T-statistic: -2.9745
P-value: 0.0030
```

Where we see some wins is the delete times, which is probably related to the size of the HNSW index:

![stats_compare_delete_time](https://github.com/user-attachments/assets/9be08ee4-a330-42b1-9808-e5f63dc42c3b)

```python
Mean delete_time of With Replacement: 0.079926
Mean delete_time of No Replacement: 0.156675
Difference in means (delete_time): -0.076750
T-statistic: -54.2405
P-value: 0.0000
```

The CPU usage reflects the above timing observation for deletes:

![stats_compare_delete_cpu_usage](https://github.com/user-attachments/assets/d56a1751-9b1b-404d-863b-c46a0e128d09)

```python
Mean delete_cpu_usage of With Replacement: 98.587300
Mean delete_cpu_usage of No Replacement: 99.258500
Difference in means (delete_cpu_usage): -0.671200
T-statistic: -4.8053
P-value: 0.0000
```

Conclusion from the above metrics is that while we see a net increase in both CPU and timings for `add()` across the rest - `query()` and `delete()` we see a slight net decrease in timings and CPU, but without further testing it is difficult to say wether these slight ebbs and flows in CPU and times are consistent over other hardware setups. The latter tests will be performed shortly and findings updated as needed.  

# Future work

- Add the flag to Rust implementation.
- Verify accuracy over long use
    - Should accuracy be lost maybe consider adding tooling to to rebuild the HNSW index after a certain point