### PR TITLE
[ENH]: only use multipart upload if object size > part size

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -28,7 +28,7 @@ query_service:
             credentials: "Minio"
             connect_timeout_ms: 5000
             request_timeout_ms: 30000 # 1 minute
-            upload_part_size_bytes: 8388608 # 8MB
+            upload_part_size_bytes: 536870912 # 512MiB
     log:
         Grpc:
             host: "logservice.chroma"
@@ -81,7 +81,7 @@ compaction_service:
             credentials: "Minio"
             connect_timeout_ms: 5000
             request_timeout_ms: 60000 # 1 minute
-            upload_part_size_bytes: 8388608 # 8MB
+            upload_part_size_bytes: 536870912 # 512MiB
     log:
         Grpc:
             host: "logservice.chroma"


### PR DESCRIPTION
## Description of changes

We observed that using multipart upload for every object put causes enough overhead to cause test failures in CI with existing timeouts, so this PR will bypass multipart upload if the object size is below the part size.

This also bumps the part size to 512MB, as blocks will never be more than 8MB anyways.

## Test plan
*How are these changes tested?*

covered by existing tests, confirmed that both code paths are tested

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
