### PR TITLE
[ENH] [PERF] add indices to metadata columns

### DIFF
--- a/chromadb/migrations/metadb/00004-metadata-indices.sqlite.sql
+++ b/chromadb/migrations/metadb/00004-metadata-indices.sqlite.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS embedding_metadata_int_value ON embedding_metadata (key, int_value) WHERE int_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS embedding_metadata_float_value ON embedding_metadata (key, float_value) WHERE float_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS embedding_metadata_string_value ON embedding_metadata (key, string_value) WHERE string_value IS NOT NULL;

--- a/chromadb/migrations/metadb/00004-metadata-indices.sqlite.sql
+++ b/chromadb/migrations/metadb/00004-metadata-indices.sqlite.sql
@@ -1,3 +1,3 @@
 CREATE INDEX IF NOT EXISTS embedding_metadata_int_value ON embedding_metadata (key, int_value) WHERE int_value IS NOT NULL;
 CREATE INDEX IF NOT EXISTS embedding_metadata_float_value ON embedding_metadata (key, float_value) WHERE float_value IS NOT NULL;
-CREATE INDEX IF NOT EXISTS embedding_metadata_string_value ON embedding_metadata (key, string_value) WHERE string_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS embedding_metadata_string_value ON embedding_metadata (key, string_value) WHERE string_value IS NOT NULL; 

--- a/chromadb/migrations/metadb/00004-metadata-indices.sqlite.sql
+++ b/chromadb/migrations/metadb/00004-metadata-indices.sqlite.sql
@@ -1,3 +1,3 @@
 CREATE INDEX IF NOT EXISTS embedding_metadata_int_value ON embedding_metadata (key, int_value) WHERE int_value IS NOT NULL;
 CREATE INDEX IF NOT EXISTS embedding_metadata_float_value ON embedding_metadata (key, float_value) WHERE float_value IS NOT NULL;
-CREATE INDEX IF NOT EXISTS embedding_metadata_string_value ON embedding_metadata (key, string_value) WHERE string_value IS NOT NULL; 
+CREATE INDEX IF NOT EXISTS embedding_metadata_string_value ON embedding_metadata (key, string_value) WHERE string_value IS NOT NULL;


### PR DESCRIPTION
## Description of changes

Add indexes to sqlite metadata value columns.

This greatly improves the performance of queries that filter based on equality or comparison to metadata fields:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/ea959a63-21e4-476a-8ae9-834d25f2c616">

<img width="895" alt="image" src="https://github.com/user-attachments/assets/8837967f-5501-418b-a11f-a900b18dbf53">

Note that the index only improves performance when the filter is highly selective. If there are large numbers of records that match the filter, processing is still slow (as they must all realized in memory and passed to the vector search.)

### Migration Plan

Creating the indexes on a database of ~40,000 embeddings with ~600,000 metadata rows takes less than ten seconds. It will seamlessly be applied to existing databases the first time they are loaded.

The change should be both forward and backward compatible. The only effect of the presence or absence of indices should be on the underlying sqlite query plan: result set semantics should be invariant according to SQL semantics.

### Downsides

This change does have an small constant effect on insert speed:

<img width="881" alt="image" src="https://github.com/user-attachments/assets/4306f981-8d56-4d0d-9510-08539ce004ca">

It also yields somewhat larger sqlite database sizes: 1.7gb vs 1.5gb, for the scenario where each embedding has 15 metadata fields (5 ints, 5 floats, 5 strings of 1-10 words)

## Test plan

- Unit and property tests pass in CI

## Documentation Changes

- None required

