### PR TITLE
[ENH] Network Admission Control + Consumers

### DIFF
--- a/rust/worker/src/blockstore/arrow/block/delta.rs
+++ b/rust/worker/src/blockstore/arrow/block/delta.rs
@@ -195,6 +195,7 @@ mod test {
     use crate::cache::cache::Cache;
     use crate::cache::config::CacheConfig;
     use crate::cache::config::UnboundedCacheConfig;
+    use crate::storage::network_admission_control::NetworkAdmissionControl;
     use crate::{
         blockstore::arrow::{
             block::Block, config::TEST_MAX_BLOCK_SIZE_BYTES, provider::BlockManager,
@@ -229,7 +230,13 @@ mod test {
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
+        let block_manager = BlockManager::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            cache,
+            network_admission_control,
+        );
         let delta = block_manager.create::<&str, &Int32Array>();
 
         let n = 2000;
@@ -272,7 +279,13 @@ mod test {
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
+        let block_manager = BlockManager::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            cache,
+            network_admission_control,
+        );
         let delta = block_manager.create::<&str, &str>();
         let delta_id = delta.id.clone();
 
@@ -329,7 +342,13 @@ mod test {
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
+        let block_manager = BlockManager::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            cache,
+            network_admission_control,
+        );
         let delta = block_manager.create::<f32, &str>();
 
         let n = 2000;
@@ -366,7 +385,13 @@ mod test {
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
+        let block_manager = BlockManager::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            cache,
+            network_admission_control,
+        );
         let delta = block_manager.create::<&str, &RoaringBitmap>();
 
         let n = 2000;
@@ -401,7 +426,13 @@ mod test {
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
+        let block_manager = BlockManager::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            cache,
+            network_admission_control,
+        );
         let ids = vec!["embedding_id_2", "embedding_id_0", "embedding_id_1"];
         let embeddings = vec![
             vec![1.0, 2.0, 3.0],
@@ -464,7 +495,13 @@ mod test {
         let path = tmp_dir.path().to_str().unwrap();
         let storage = Storage::Local(LocalStorage::new(path));
         let cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
-        let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
+        let block_manager = BlockManager::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            cache,
+            network_admission_control,
+        );
         let delta = block_manager.create::<u32, &str>();
 
         let n = 2000;

--- a/rust/worker/src/blockstore/arrow/blockfile.rs
+++ b/rust/worker/src/blockstore/arrow/blockfile.rs
@@ -536,6 +536,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
 mod tests {
     use crate::cache::cache::Cache;
     use crate::cache::config::{CacheConfig, UnboundedCacheConfig};
+    use crate::storage::network_admission_control::NetworkAdmissionControl;
     use crate::{
         blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES,
         blockstore::arrow::provider::ArrowBlockfileProvider,
@@ -556,11 +557,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &Int32Array>().unwrap();
         let id = writer.id();
@@ -596,11 +599,13 @@ mod tests {
             let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
             let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
             let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+            let network_admission_control = NetworkAdmissionControl::new(storage.clone());
             let blockfile_provider = ArrowBlockfileProvider::new(
                 storage,
                 TEST_MAX_BLOCK_SIZE_BYTES,
                 block_cache,
                 sparse_index_cache,
+                network_admission_control,
             );
             let writer = blockfile_provider.create::<&str, u32>().unwrap();
             let id = writer.id();
@@ -661,11 +666,13 @@ mod tests {
             let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
             let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
             let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+            let network_admission_control = NetworkAdmissionControl::new(storage.clone());
             let blockfile_provider = ArrowBlockfileProvider::new(
                 storage,
                 TEST_MAX_BLOCK_SIZE_BYTES,
                 block_cache,
                 sparse_index_cache,
+                network_admission_control,
             );
             let writer = blockfile_provider.create::<&str, u32>().unwrap();
             let id = writer.id();
@@ -776,11 +783,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &Int32Array>().unwrap();
         let id = writer.id();
@@ -816,11 +825,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &Int32Array>().unwrap();
         let id_1 = writer.id();
@@ -930,11 +941,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &Int32Array>().unwrap();
         let id_1 = writer.id();
@@ -972,11 +985,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
 
         let writer = blockfile_provider.create::<&str, &str>().unwrap();
@@ -1009,11 +1024,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
 
         let writer = provider.create::<f32, &str>().unwrap();
@@ -1043,11 +1060,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
 
         let writer = blockfile_provider
@@ -1089,11 +1108,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
 
         let writer = blockfile_provider.create::<u32, u32>().unwrap();
@@ -1123,11 +1144,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
 
         let writer = blockfile_provider.create::<&str, &DataRecord>().unwrap();
@@ -1175,11 +1198,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
 
         let writer = blockfile_provider.create::<&str, &str>().unwrap();
@@ -1207,11 +1232,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &str>().unwrap();
         let id = writer.id();
@@ -1270,11 +1297,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &Int32Array>().unwrap();
         let id_1 = writer.id();
@@ -1309,11 +1338,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let writer = blockfile_provider.create::<&str, &Int32Array>().unwrap();
         let id_1 = writer.id();

--- a/rust/worker/src/blockstore/arrow/concurrency_test.rs
+++ b/rust/worker/src/blockstore/arrow/concurrency_test.rs
@@ -6,7 +6,7 @@ mod tests {
             cache::Cache,
             config::{CacheConfig, LruConfig},
         },
-        storage::{local::LocalStorage, Storage},
+        storage::{local::LocalStorage, network_admission_control::NetworkAdmissionControl, Storage},
     };
     use rand::Rng;
     use shuttle::{future, thread};
@@ -25,11 +25,13 @@ mod tests {
                 let sparse_index_cache = Cache::new(&CacheConfig::Lru(LruConfig {
                     capacity: SPARSE_INDEX_CACHE_CAPACITY,
                 }));
+                let network_admission_control = NetworkAdmissionControl::new(storage.clone());
                 let blockfile_provider = ArrowBlockfileProvider::new(
                     storage,
                     TEST_MAX_BLOCK_SIZE_BYTES,
                     block_cache,
                     sparse_index_cache,
+                    network_admission_control,
                 );
                 let writer = blockfile_provider.create::<&str, u32>().unwrap();
                 let id = writer.id();

--- a/rust/worker/src/blockstore/arrow/provider.rs
+++ b/rust/worker/src/blockstore/arrow/provider.rs
@@ -5,7 +5,6 @@ use super::{
     sparse_index::SparseIndex,
     types::{ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue},
 };
-use crate::cache::cache::Cache;
 use crate::{
     blockstore::{
         key::KeyWrapper,
@@ -15,13 +14,14 @@ use crate::{
     },
     config::Configurable,
     errors::{ChromaError, ErrorCodes},
-    storage::Storage,
+    storage::{network_admission_control::NetworkAdmissionControlError, Storage},
 };
+use crate::{cache::cache::Cache, storage::network_admission_control::NetworkAdmissionControl};
 use async_trait::async_trait;
 use core::panic;
 use futures::StreamExt;
 use thiserror::Error;
-use tracing::{Instrument, Span};
+use tracing::Span;
 use uuid::Uuid;
 
 /// A BlockFileProvider that creates ArrowBlockfiles (Arrow-backed blockfiles used for production).
@@ -38,9 +38,15 @@ impl ArrowBlockfileProvider {
         max_block_size_bytes: usize,
         block_cache: Cache<Uuid, Block>,
         sparse_index_cache: Cache<Uuid, SparseIndex>,
+        network_admission_control: NetworkAdmissionControl,
     ) -> Self {
         Self {
-            block_manager: BlockManager::new(storage.clone(), max_block_size_bytes, block_cache),
+            block_manager: BlockManager::new(
+                storage.clone(),
+                max_block_size_bytes,
+                block_cache,
+                network_admission_control,
+            ),
             sparse_index_manager: SparseIndexManager::new(storage, sparse_index_cache),
         }
     }
@@ -99,11 +105,21 @@ impl ArrowBlockfileProvider {
 }
 
 #[async_trait]
-impl Configurable<(ArrowBlockfileProviderConfig, Storage)> for ArrowBlockfileProvider {
+impl
+    Configurable<(
+        ArrowBlockfileProviderConfig,
+        Storage,
+        NetworkAdmissionControl,
+    )> for ArrowBlockfileProvider
+{
     async fn try_from_config(
-        config: &(ArrowBlockfileProviderConfig, Storage),
+        config: &(
+            ArrowBlockfileProviderConfig,
+            Storage,
+            NetworkAdmissionControl,
+        ),
     ) -> Result<Self, Box<dyn ChromaError>> {
-        let (blockfile_config, storage) = config;
+        let (blockfile_config, storage, nac) = config;
         let block_cache = match crate::cache::from_config(
             &blockfile_config.block_manager_config.block_cache_config,
         )
@@ -131,6 +147,7 @@ impl Configurable<(ArrowBlockfileProviderConfig, Storage)> for ArrowBlockfilePro
             blockfile_config.block_manager_config.max_block_size_bytes,
             block_cache,
             sparse_index_cache,
+            nac.clone(),
         ))
     }
 }
@@ -146,6 +163,7 @@ pub(super) struct BlockManager {
     block_cache: Cache<Uuid, Block>,
     storage: Storage,
     max_block_size_bytes: usize,
+    network_admission_control: NetworkAdmissionControl,
 }
 
 impl BlockManager {
@@ -153,11 +171,13 @@ impl BlockManager {
         storage: Storage,
         max_block_size_bytes: usize,
         block_cache: Cache<Uuid, Block>,
+        network_admission_control: NetworkAdmissionControl,
     ) -> Self {
         Self {
             block_cache,
             storage,
             max_block_size_bytes,
+            network_admission_control,
         }
     }
 
@@ -211,65 +231,39 @@ impl BlockManager {
         match block {
             Some(block) => Some(block.clone()),
             None => {
-                async {
-                    let key = format!("block/{}", id);
-                    let stream = self.storage.get(&key).instrument(
-                        tracing::trace_span!(parent: Span::current(), "BlockManager storage get"),
-                    ).await;
-                    match stream {
-                        Ok(mut bytes) => {
-                            let read_block_span = tracing::trace_span!(parent: Span::current(), "BlockManager read bytes to end");
-                            let buf = read_block_span.in_scope(|| async {
-                                let mut buf: Vec<u8> = Vec::new();
-                                while let Some(res) = bytes.next().await {
-                                    match res {
-                                        Ok(chunk) => {
-                                            buf.extend(chunk);
-                                        }
-                                        Err(e) => {
-                                            tracing::error!("Error reading block from storage: {}", e);
-                                            return None;
-                                        }
-                                    }
-                                }
-                                Some(buf)
-                            }
-                            ).await;
-                            let buf =  match buf {
-                                Some(buf) => {
-                                    buf
-                                }
-                                None => {
-                                    return None;
-                                }
-                            };
-                            tracing::info!("Read {:?} bytes from s3", buf.len());
-                            let deserialization_span = tracing::trace_span!(parent: Span::current(), "BlockManager deserialize block");
-                            let block = deserialization_span.in_scope(|| Block::from_bytes(&buf, *id));
-                            match block {
-                                Ok(block) => {
-                                    self.block_cache.insert(*id, block.clone());
-                                    Some(block)
-                                }
-                                Err(e) => {
-                                    // TODO: Return an error to callsite instead of None.
-                                    tracing::error!(
-                                        "Error converting bytes to Block {:?}/{:?}",
-                                        key,
-                                        e
-                                    );
-                                    None
-                                }
-                            }
-                        },
+                let key = format!("block/{}", id);
+                // Clone the cache is cheap since it is arc type.
+                let cache_clone = self.block_cache.clone();
+                let id_copy = id.clone();
+                let cb = move |buf: Vec<u8>| async move {
+                    let deserialization_span = tracing::trace_span!(parent: Span::current(), "BlockManager deserialize block");
+                    let block = deserialization_span.in_scope(|| Block::from_bytes(&buf, id_copy));
+                    match block {
+                        Ok(block) => {
+                            cache_clone.insert(id_copy, block.clone());
+                        }
                         Err(e) => {
-                            tracing::error!("Error reading block from storage: {}", e);
-                            None
+                            tracing::error!("Error converting bytes to Block {:?}", e);
+                            return Err(Box::new(
+                                NetworkAdmissionControlError::DeserializationError,
+                            ));
                         }
                     }
+                    Ok(())
+                };
+                match self.network_admission_control.get(key, cb).await {
+                    Ok(()) => {}
+                    Err(e) => {
+                        // TODO: Return error here.
+                        tracing::error!(
+                            "Error getting block from the network admission control {}",
+                            e
+                        );
+                        return None;
+                    }
                 }
-                .instrument(tracing::trace_span!(parent: Span::current(), "BlockManager get cold"))
-                .await
+                // Cache must be populated now.
+                self.block_cache.get(id)
             }
         }
     }

--- a/rust/worker/src/execution/operators/merge_metadata_results.rs
+++ b/rust/worker/src/execution/operators/merge_metadata_results.rs
@@ -368,9 +368,12 @@ impl Operator<MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOut
 
 #[cfg(test)]
 mod test {
-    use crate::blockstore::{
-        arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
-        provider::BlockfileProvider,
+    use crate::{
+        blockstore::{
+            arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
+            provider::BlockfileProvider,
+        },
+        storage::network_admission_control::NetworkAdmissionControl,
     };
     use std::{
         collections::HashMap,
@@ -409,11 +412,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -704,11 +709,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -740,7 +740,6 @@ mod test {
 
     use uuid::Uuid;
 
-    use crate::cache::cache::Cache;
     use crate::cache::config::CacheConfig;
     use crate::cache::config::UnboundedCacheConfig;
     use crate::{
@@ -767,6 +766,7 @@ mod test {
             UpdateMetadataValue, Where, WhereComparison, WhereDocument,
         },
     };
+    use crate::{cache::cache::Cache, storage::network_admission_control::NetworkAdmissionControl};
 
     #[tokio::test]
     async fn where_and_where_document_from_log() {
@@ -774,11 +774,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -993,11 +995,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -1183,11 +1187,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -1878,7 +1878,9 @@ mod test {
             },
             LogMaterializer, SegmentFlusher, SegmentWriter,
         },
-        storage::{local::LocalStorage, Storage},
+        storage::{
+            local::LocalStorage, network_admission_control::NetworkAdmissionControl, Storage,
+        },
         types::{
             DirectComparison, DirectDocumentComparison, LogRecord, MetadataValue, Operation,
             OperationRecord, UpdateMetadataValue, Where, WhereComparison, WhereDocument,
@@ -1891,11 +1893,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -2182,11 +2186,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -2439,11 +2445,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -2665,11 +2673,13 @@ mod test {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -886,6 +886,7 @@ mod tests {
     use super::*;
     use crate::cache::cache::Cache;
     use crate::cache::config::{CacheConfig, UnboundedCacheConfig};
+    use crate::storage::network_admission_control::NetworkAdmissionControl;
     use crate::{
         blockstore::{
             arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
@@ -910,11 +911,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -1204,11 +1207,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -1490,11 +1495,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
@@ -1795,11 +1802,13 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
         let sparse_index_cache = Cache::new(&CacheConfig::Unbounded(UnboundedCacheConfig {}));
+        let network_admission_control = NetworkAdmissionControl::new(storage.clone());
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
             storage,
             TEST_MAX_BLOCK_SIZE_BYTES,
             block_cache,
             sparse_index_cache,
+            network_admission_control,
         );
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);

--- a/rust/worker/src/storage/mod.rs
+++ b/rust/worker/src/storage/mod.rs
@@ -5,6 +5,7 @@ use crate::config::Configurable;
 use crate::errors::{ChromaError, ErrorCodes};
 pub(crate) mod config;
 pub(crate) mod local;
+pub(crate) mod network_admission_control;
 pub(crate) mod s3;
 pub(crate) mod stream;
 use futures::Stream;
@@ -16,7 +17,7 @@ pub(crate) enum Storage {
     Local(local::LocalStorage),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum GetError {
     #[error("No such key: {0}")]
     NoSuchKey(String),

--- a/rust/worker/src/storage/network_admission_control.rs
+++ b/rust/worker/src/storage/network_admission_control.rs
@@ -1,0 +1,146 @@
+use super::{GetError, Storage};
+use crate::errors::{ChromaError, ErrorCodes};
+use futures::{future::Shared, FutureExt, StreamExt};
+use parking_lot::Mutex;
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use thiserror::Error;
+use tracing::{Instrument, Span};
+
+#[derive(Clone)]
+pub(crate) struct NetworkAdmissionControl {
+    storage: Storage,
+    outstanding_requests: Arc<
+        Mutex<
+            HashMap<
+                String,
+                Shared<
+                    Pin<
+                        Box<
+                            dyn Future<Output = Result<(), Box<NetworkAdmissionControlError>>>
+                                + Send
+                                + 'static,
+                        >,
+                    >,
+                >,
+            >,
+        >,
+    >,
+}
+
+#[derive(Error, Debug, Clone)]
+pub(crate) enum NetworkAdmissionControlError {
+    #[error("Error performing a get call from storage {0}")]
+    StorageGetError(#[from] GetError),
+    #[error("IO Error")]
+    IOError,
+    #[error("Error deserializing to block")]
+    DeserializationError,
+}
+
+impl ChromaError for NetworkAdmissionControlError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            NetworkAdmissionControlError::StorageGetError(e) => e.code(),
+            NetworkAdmissionControlError::IOError => ErrorCodes::Internal,
+            NetworkAdmissionControlError::DeserializationError => ErrorCodes::Internal,
+        }
+    }
+}
+
+impl NetworkAdmissionControl {
+    pub(crate) fn new(storage: Storage) -> Self {
+        Self {
+            storage,
+            outstanding_requests: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub(crate) async fn read_from_storage<F, R>(
+        storage: Storage,
+        key: String,
+        f: F,
+    ) -> Result<(), Box<NetworkAdmissionControlError>>
+    where
+        R: Future<Output = Result<(), Box<NetworkAdmissionControlError>>> + Send + 'static,
+        F: (FnOnce(Vec<u8>) -> R) + Send + 'static,
+    {
+        let stream = storage
+            .get(&key)
+            .instrument(tracing::trace_span!(parent: Span::current(), "Storage get"))
+            .await;
+        match stream {
+            Ok(mut bytes) => {
+                let read_block_span =
+                    tracing::trace_span!(parent: Span::current(), "Read bytes to end");
+                let buf = read_block_span
+                    .in_scope(|| async {
+                        let mut buf: Vec<u8> = Vec::new();
+                        while let Some(res) = bytes.next().await {
+                            match res {
+                                Ok(chunk) => {
+                                    buf.extend(chunk);
+                                }
+                                Err(e) => {
+                                    tracing::error!("Error reading from storage: {}", e);
+                                    return Err(Box::new(
+                                        NetworkAdmissionControlError::StorageGetError(e),
+                                    ));
+                                }
+                            }
+                        }
+                        Ok(Some(buf))
+                    })
+                    .await?;
+                let buf = match buf {
+                    Some(buf) => buf,
+                    None => {
+                        // Buffer is empty. Nothing interesting to do.
+                        return Ok(());
+                    }
+                };
+                tracing::info!("Read {:?} bytes from s3", buf.len());
+                return f(buf).await;
+            }
+            Err(e) => {
+                tracing::error!("Error reading from storage: {}", e);
+                return Err(Box::new(NetworkAdmissionControlError::StorageGetError(e)));
+            }
+        }
+    }
+
+    pub(crate) async fn get<F, R>(
+        &self,
+        key: String,
+        f: F,
+    ) -> Result<(), Box<NetworkAdmissionControlError>>
+    where
+        R: Future<Output = Result<(), Box<NetworkAdmissionControlError>>> + Send + 'static,
+        F: (FnOnce(Vec<u8>) -> R) + Send + 'static,
+    {
+        let future_to_await;
+        {
+            let mut requests = self.outstanding_requests.lock();
+            let maybe_inflight = requests.get(&key).map(|fut| fut.clone());
+            future_to_await = match maybe_inflight {
+                Some(fut) => fut,
+                None => {
+                    let get_storage_future = NetworkAdmissionControl::read_from_storage(
+                        self.storage.clone(),
+                        key.clone(),
+                        f,
+                    )
+                    .boxed()
+                    .shared();
+                    requests.insert(key.clone(), get_storage_future.clone());
+                    get_storage_future
+                }
+            };
+        }
+        let res = future_to_await.await;
+        {
+            let mut requests = self.outstanding_requests.lock();
+            requests.remove(&key);
+        }
+        res
+    }
+}

--- a/rust/worker/src/storage/s3.rs
+++ b/rust/worker/src/storage/s3.rs
@@ -46,7 +46,7 @@ impl ChromaError for S3PutError {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum S3GetError {
     #[error("S3 GET error: {0}")]
     S3GetError(String),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
- Introduces Network Admission Control that gates all network IOs leaving the system.
- HNSW provider and blockfile manager submit s3 get requests to NAC. NAC returns a future that they can await on. As part of the request, they also submit a callback to NAC that is invoked once the remote get() finishes with the buffer as the argument.
- For e.g. the blockfile manager in its callback, deserializes the buffer to a block and inserts it into its cache. Similarly, the HNSW provider, writes the buffer out to its local disk as part of the callback. This separation ensures that the NAC does not have to be aware about the individual data formats that the upper layers deal with and it only deals with data at byte format.
- NAC performs request coalescing by tracking outstanding remote calls and their respective futures in a hashmap and deduplicating requests for the same key. The future stored in the hashmap is a shared future for this purpose.
- NAC is constructed in the beginning when the service starts and both the HNSW and blockfile providers store it.
- [Next PR] NAC should also rate limit requests. This is not implemented in this PR and will be the next PR.


## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
