### PR TITLE
[ENH] Network Admission Control APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ dependencies = [
  "chroma-config",
  "chroma-error",
  "futures",
+ "parking_lot",
  "rand",
  "rand_xorshift",
  "serde",

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+parking_lot = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -7,8 +7,8 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 use thiserror::Error;
 use tracing::{Instrument, Span};
 
-// Wrapper over s3 storage that provides proxy features such as
-// request coalescing, rate limiting, etc.
+/// Wrapper over s3 storage that provides proxy features such as
+/// request coalescing, rate limiting, etc.
 #[derive(Clone)]
 pub struct AdmissionControlledS3Storage {
     storage: S3Storage,

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -6,7 +6,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 
 pub mod config;
 pub mod local;
-pub mod network_admission_control;
+pub mod admissioncontrolleds3;
 pub mod s3;
 pub mod stream;
 use futures::Stream;

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -4,9 +4,9 @@ use self::stream::ByteStreamItem;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 
+pub mod admissioncontrolleds3;
 pub mod config;
 pub mod local;
-pub mod admissioncontrolleds3;
 pub mod s3;
 pub mod stream;
 use futures::Stream;

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -6,6 +6,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 
 pub mod config;
 pub mod local;
+pub mod network_admission_control;
 pub mod s3;
 pub mod stream;
 use futures::Stream;
@@ -17,7 +18,7 @@ pub enum Storage {
     Local(local::LocalStorage),
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum GetError {
     #[error("No such key: {0}")]
     NoSuchKey(String),

--- a/rust/storage/src/network_admission_control.rs
+++ b/rust/storage/src/network_admission_control.rs
@@ -1,0 +1,146 @@
+use super::{GetError, Storage};
+use chroma_error::{ChromaError, ErrorCodes};
+use futures::{future::Shared, FutureExt, StreamExt};
+use parking_lot::Mutex;
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use thiserror::Error;
+use tracing::{Instrument, Span};
+
+#[derive(Clone)]
+pub struct NetworkAdmissionControl {
+    storage: Storage,
+    outstanding_requests: Arc<
+        Mutex<
+            HashMap<
+                String,
+                Shared<
+                    Pin<
+                        Box<
+                            dyn Future<Output = Result<(), Box<NetworkAdmissionControlError>>>
+                                + Send
+                                + 'static,
+                        >,
+                    >,
+                >,
+            >,
+        >,
+    >,
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum NetworkAdmissionControlError {
+    #[error("Error performing a get call from storage {0}")]
+    StorageGetError(#[from] GetError),
+    #[error("IO Error")]
+    IOError,
+    #[error("Error deserializing to block")]
+    DeserializationError,
+}
+
+impl ChromaError for NetworkAdmissionControlError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            NetworkAdmissionControlError::StorageGetError(e) => e.code(),
+            NetworkAdmissionControlError::IOError => ErrorCodes::Internal,
+            NetworkAdmissionControlError::DeserializationError => ErrorCodes::Internal,
+        }
+    }
+}
+
+impl NetworkAdmissionControl {
+    pub fn new(storage: Storage) -> Self {
+        Self {
+            storage,
+            outstanding_requests: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn read_from_storage<F, R>(
+        storage: Storage,
+        key: String,
+        f: F,
+    ) -> Result<(), Box<NetworkAdmissionControlError>>
+    where
+        R: Future<Output = Result<(), Box<NetworkAdmissionControlError>>> + Send + 'static,
+        F: (FnOnce(Vec<u8>) -> R) + Send + 'static,
+    {
+        let stream = storage
+            .get(&key)
+            .instrument(tracing::trace_span!(parent: Span::current(), "Storage get"))
+            .await;
+        match stream {
+            Ok(mut bytes) => {
+                let read_block_span =
+                    tracing::trace_span!(parent: Span::current(), "Read bytes to end");
+                let buf = read_block_span
+                    .in_scope(|| async {
+                        let mut buf: Vec<u8> = Vec::new();
+                        while let Some(res) = bytes.next().await {
+                            match res {
+                                Ok(chunk) => {
+                                    buf.extend(chunk);
+                                }
+                                Err(e) => {
+                                    tracing::error!("Error reading from storage: {}", e);
+                                    return Err(Box::new(
+                                        NetworkAdmissionControlError::StorageGetError(e),
+                                    ));
+                                }
+                            }
+                        }
+                        Ok(Some(buf))
+                    })
+                    .await?;
+                let buf = match buf {
+                    Some(buf) => buf,
+                    None => {
+                        // Buffer is empty. Nothing interesting to do.
+                        return Ok(());
+                    }
+                };
+                tracing::info!("Read {:?} bytes from s3", buf.len());
+                return f(buf).await;
+            }
+            Err(e) => {
+                tracing::error!("Error reading from storage: {}", e);
+                return Err(Box::new(NetworkAdmissionControlError::StorageGetError(e)));
+            }
+        }
+    }
+
+    pub async fn get<F, R>(
+        &self,
+        key: String,
+        f: F,
+    ) -> Result<(), Box<NetworkAdmissionControlError>>
+    where
+        R: Future<Output = Result<(), Box<NetworkAdmissionControlError>>> + Send + 'static,
+        F: (FnOnce(Vec<u8>) -> R) + Send + 'static,
+    {
+        let future_to_await;
+        {
+            let mut requests = self.outstanding_requests.lock();
+            let maybe_inflight = requests.get(&key).map(|fut| fut.clone());
+            future_to_await = match maybe_inflight {
+                Some(fut) => fut,
+                None => {
+                    let get_storage_future = NetworkAdmissionControl::read_from_storage(
+                        self.storage.clone(),
+                        key.clone(),
+                        f,
+                    )
+                    .boxed()
+                    .shared();
+                    requests.insert(key.clone(), get_storage_future.clone());
+                    get_storage_future
+                }
+            };
+        }
+        let res = future_to_await.await;
+        {
+            let mut requests = self.outstanding_requests.lock();
+            requests.remove(&key);
+        }
+        res
+    }
+}

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -55,7 +55,7 @@ impl ChromaError for S3PutError {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum S3GetError {
     #[error("S3 GET error: {0}")]
     S3GetError(String),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
- Introduces Network Admission Control that gates all network IOs leaving the system.
- Downstream users can submit get requests to NAC. NAC returns a future that they can await on.
- It performs request coalescing by tracking outstanding remote calls and their respective futures in a hashmap and deduplicating requests for the same key. The future stored in the hashmap is a shared future for this purpose to ensure that duplicate users await the same future.

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
