### PR TITLE
[DOC]: use `pnpm add <pkg>` instead of `pnpm install <pkg>`

### DIFF
--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -50,7 +50,7 @@ pnpm add chromadb chromadb-default-embed # [!code $]
 {% /codetab %}
 {% /codetabs %}
 
-Install chroma via `pypi` to easily run the backend server. (Docker also available)
+Install Chroma via `pypi` to easily run the backend server. (Docker also available)
 
 ```bash
 pip install chromadb # [!code $]

--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -44,7 +44,7 @@ npm install --save chromadb chromadb-default-embed # [!code $]
 {% codetab label="pnpm" %}
 
 ```bash {% codetab=true %}
-pnpm install chromadb chromadb-default-embed # [!code $]
+pnpm add chromadb chromadb-default-embed # [!code $]
 ```
 
 {% /codetab %}

--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -50,7 +50,7 @@ pnpm add chromadb chromadb-default-embed # [!code $]
 {% /codetab %}
 {% /codetabs %}
 
-Install Chroma via `pypi` to easily run the backend server. (Docker also available)
+Install chroma via `pypi` to easily run the backend server. (Docker also available)
 
 ```bash
 pip install chromadb # [!code $]


### PR DESCRIPTION
It should be `pnpm add <pkg>` instead of `pnpm install <pkg>`.

`pnpm install` is used to install all dependencies for a project while `pnpm add <pkg>` is used to install a package and any packages that it depends on.

More info (official source):

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

---

`pnpm install <pkg>` does the same as `pnpm add <pkg>` today, but it might stop functioning that way in future versions since the official docs clarify the difference between the two. It might be that `pnpm install <pkg>` was used in past versions, and the PNPM team didn't want to remove support for it right away after introducing `pnpm add <pkg>`.