### PR TITLE
[ENH] Block manager and HNSW provider consume Network Admission Control

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -316,6 +316,7 @@ impl SparseIndexManager {
                 tracing::info!("Cache miss - fetching sparse index from storage");
                 let key = format!("sparse_index/{}", id);
                 tracing::debug!("Reading sparse index from storage with key: {}", key);
+                // TODO: This should pass through NAC as well.
                 let stream = self.storage.get_stream(&key).await;
                 let mut buf: Vec<u8> = Vec::new();
                 match stream {

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -212,7 +212,7 @@ impl BlockManager {
         let block = self.block_cache.get(id);
         match block {
             Some(block) => Some(block.clone()),
-            None => {
+            None => async {
                 let key = format!("block/{}", id);
                 let bytes_res = self
                     .storage
@@ -248,7 +248,7 @@ impl BlockManager {
                         return None;
                     }
                 }
-            }
+            }.instrument(tracing::trace_span!(parent: Span::current(), "BlockManager get cold")).await
         }
     }
 

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -89,14 +89,14 @@ impl AdmissionControlledS3Storage {
     ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
         let bytes_res = storage
             .get(&key)
-            .instrument(tracing::trace_span!(parent: Span::current(), "Storage get"))
+            .instrument(tracing::trace_span!(parent: Span::current(), "S3 get"))
             .await;
         match bytes_res {
             Ok(bytes) => {
                 return Ok(bytes);
             }
             Err(e) => {
-                tracing::error!("Error reading from storage: {}", e);
+                tracing::error!("Error reading from s3: {}", e);
                 return Err(AdmissionControlledS3StorageError::S3GetError(e));
             }
         }

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -172,9 +172,9 @@ impl S3Storage {
     pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, S3GetError> {
         let mut stream = self
             .get_stream(key)
-            .instrument(tracing::trace_span!(parent: Span::current(), "Storage get"))
+            .instrument(tracing::trace_span!(parent: Span::current(), "S3 get stream"))
             .await?;
-        let read_block_span = tracing::trace_span!(parent: Span::current(), "Read bytes to end");
+        let read_block_span = tracing::trace_span!(parent: Span::current(), "S3 read bytes to end");
         let buf = read_block_span
             .in_scope(|| async {
                 let mut buf: Vec<u8> = Vec::new();
@@ -184,7 +184,7 @@ impl S3Storage {
                             buf.extend(chunk);
                         }
                         Err(err) => {
-                            tracing::error!("Error reading from storage: {}", err);
+                            tracing::error!("Error reading from S3: {}", err);
                             match err {
                                 GetError::S3Error(e) => {
                                     return Err(e);


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
- Blockfile Manager and HNSW Index Provider uses the NAC when doing get() calls.
- NAC returns a future that they can await on. Once they have the bytes, they can perform specific operations such as deserializing to block, writing to local disk, etc. These operations need to be made thread safe.

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
