### PR TITLE
[BUG]: fix nightly test workflow

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -31,7 +31,7 @@ jobs:
         id: get-logs
         if: success() || failure()
         run: |
-          bin/get-logs.sh "${{ matrix.test-globs }}"
+          bin/get-logs.sh "${{ matrix.test-globs }}" "3.12"
           # Output the logs zip file path as a job output
           echo "logs_zip_path=$(pwd)/$(basename "${{ matrix.test-globs }}" .py)_logs.zip" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
## Description of changes

Jobs here were failing because the get-logs.sh script was changed but usage was not updated here.

## Test plan
*How are these changes tested?*

n/a

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
