### PR TITLE
[CHORE] Move pull log trace record count to structured field

### DIFF
--- a/rust/worker/src/execution/operators/pull_log.rs
+++ b/rust/worker/src/execution/operators/pull_log.rs
@@ -137,7 +137,7 @@ impl Operator<PullLogsInput, PullLogsOutput> for PullLogsOperator {
         if input.num_records.is_some() && result.len() > input.num_records.unwrap() as usize {
             result.truncate(input.num_records.unwrap() as usize);
         }
-        tracing::info!("[PullLogsOperator]: Read {} records", result.len());
+        tracing::info!(name: "Pulled log records", num_records = result.len());
         // Convert to DataChunk
         let data_chunk = Chunk::new(result.into());
         Ok(PullLogsOutput::new(data_chunk))


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Move the pulled record count to a structured field so its queryable
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
this is a non-functional change. I verified that it shows up in jaeger as expected locally.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
