### PR TITLE
[BUG] S3 client not respecting timeout

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -374,6 +374,15 @@ impl Configurable<StorageConfig> for S3Storage {
                     }
                     super::config::S3CredentialsConfig::AWS => {
                         let config = aws_config::load_from_env().await;
+                        let timeout_config_builder = TimeoutConfigBuilder::default()
+                            .connect_timeout(Duration::from_millis(s3_config.connect_timeout_ms))
+                            .read_timeout(Duration::from_millis(s3_config.request_timeout_ms));
+                        let retry_config = RetryConfig::standard();
+                        let config = config
+                            .to_builder()
+                            .timeout_config(timeout_config_builder.build())
+                            .retry_config(retry_config)
+                            .build();
                         aws_sdk_s3::Client::new(&config)
                     }
                 };


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - We only applied the timeouts in the case of Minio credentials. This applies in in both places
	 - Some minor code duplication - I am OK with it since its very local. 
 - New functionality
	 - Non

## Test plan
*How are these changes tested?*
I do not think there is a sensible way to test this against real s3?
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
