### PR TITLE
[ENH]: allow configuring replica count of compaction service

### DIFF
--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -18,7 +18,7 @@ metadata:
   name: compaction-service
   namespace: {{ .Values.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.compactionService.replicaCount }}
   selector:
     matchLabels:
       app: compaction-service

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -70,6 +70,7 @@ compactionService:
     repository: 'local'
     tag: 'compaction-service'
   env:
+  replicaCount: 1
 
 sysdbMigration:
   image:


### PR DESCRIPTION
## Description of changes

Allows Helm chart consumers to configure replica count of compaction service.

## Test plan
*How are these changes tested?*

n/a

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
