### PR TITLE
[ENH]: fix compactor traces, add additional info to trace

### DIFF
--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -318,7 +318,7 @@ mod tests {
             // dispatch a new task every DISPATCH_FREQUENCY_MS for DISPATCH_COUNT times
             let duration = std::time::Duration::from_millis(DISPATCH_FREQUENCY_MS);
             ctx.scheduler
-                .schedule_interval((), duration, Some(DISPATCH_COUNT), ctx);
+                .schedule_interval((), duration, Some(DISPATCH_COUNT), ctx, || None);
         }
     }
     #[async_trait]
@@ -381,7 +381,7 @@ mod tests {
             // dispatch a new task every DISPATCH_FREQUENCY_MS for DISPATCH_COUNT times
             let duration = std::time::Duration::from_millis(DISPATCH_FREQUENCY_MS);
             ctx.scheduler
-                .schedule_interval((), duration, Some(DISPATCH_COUNT), ctx);
+                .schedule_interval((), duration, Some(DISPATCH_COUNT), ctx, || None);
         }
     }
     #[async_trait]

--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use chroma_error::ChromaError;
 use chroma_types::SegmentFlushInfo;
 use std::sync::Arc;
+use tracing::Instrument;
 
 #[derive(Debug)]
 pub struct FlushS3Operator {}
@@ -60,7 +61,10 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
         let record_segment_flush_info = match record_segment_flusher {
             Ok(flusher) => {
                 let segment_id = input.record_segment_writer.id;
-                let res = flusher.flush().await;
+                let res = flusher
+                    .flush()
+                    .instrument(tracing::info_span!("Flush record segment"))
+                    .await;
                 match res {
                     Ok(res) => {
                         tracing::info!("Record Segment Flushed. File paths {:?}", res);
@@ -85,7 +89,10 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
         let hnsw_segment_flush_info = match hnsw_segment_flusher {
             Ok(flusher) => {
                 let segment_id = input.hnsw_segment_writer.id;
-                let res = flusher.flush().await;
+                let res = flusher
+                    .flush()
+                    .instrument(tracing::info_span!("Flush HNSW segment"))
+                    .await;
                 match res {
                     Ok(res) => {
                         tracing::info!("HNSW Segment Flushed. File paths {:?}", res);
@@ -110,7 +117,10 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
         let metadata_segment_flush_info = match metadata_segment_flusher {
             Ok(flusher) => {
                 let segment_id = input.metadata_segment_writer.id;
-                let res = flusher.flush().await;
+                let res = flusher
+                    .flush()
+                    .instrument(tracing::info_span!("Flush metadata segment"))
+                    .await;
                 match res {
                     Ok(res) => {
                         tracing::info!("Metadata Segment Flushed. File paths {:?}", res);

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -160,6 +160,9 @@ impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator
         match input
             .record_segment_writer
             .apply_materialized_log_chunk(res.clone())
+            .instrument(tracing::trace_span!(
+                "Apply materialized logs to record segment"
+            ))
             .await
         {
             Ok(()) => (),
@@ -171,6 +174,9 @@ impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator
         match input
             .metadata_segment_writer
             .apply_materialized_log_chunk(res.clone())
+            .instrument(tracing::trace_span!(
+                "Apply materialized logs to metadata segment"
+            ))
             .await
         {
             Ok(()) => (),
@@ -182,6 +188,9 @@ impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator
         match input
             .hnsw_segment_writer
             .apply_materialized_log_chunk(res)
+            .instrument(tracing::trace_span!(
+                "Apply materialized logs to HNSW segment"
+            ))
             .await
         {
             Ok(()) => (),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -223,7 +223,7 @@ impl CompactOrchestrator {
             Some(end_timestamp),
         );
         let task = wrap(operator, input, self_address);
-        match self.dispatcher.send(task, None).await {
+        match self.dispatcher.send(task, Some(Span::current())).await {
             Ok(_) => (),
             Err(e) => {
                 tracing::error!("Error dispatching pull logs for compaction {:?}", e);
@@ -247,7 +247,7 @@ impl CompactOrchestrator {
         println!("Sending N Records: {:?}", records.len());
         let input = PartitionInput::new(records, max_partition_size);
         let task = wrap(operator, input, self_address);
-        match self.dispatcher.send(task, None).await {
+        match self.dispatcher.send(task, Some(Span::current())).await {
             Ok(_) => (),
             Err(e) => {
                 tracing::error!("Error dispatching partition for compaction {:?}", e);
@@ -356,7 +356,7 @@ impl CompactOrchestrator {
         );
 
         let task = wrap(operator, input, self_address);
-        match self.dispatcher.send(task, None).await {
+        match self.dispatcher.send(task, Some(Span::current())).await {
             Ok(_) => (),
             Err(e) => {
                 tracing::error!("Error dispatching register for compaction {:?}", e);


### PR DESCRIPTION
## Description of changes

Fixes traces for the compaction service so that each scheduled compaction is a root span, rather than everything being in the same span.

Also adds some additional tracing to functions called by the compactor.

## Test plan
*How are these changes tested?*

Tested locally with Jaeger:

<img width="1244" alt="Screenshot 2024-08-09 at 2 24 01 PM" src="https://github.com/user-attachments/assets/58a1e346-716f-47f6-8c5a-75e37dbbabc3">
<img width="1674" alt="Screenshot 2024-08-09 at 2 23 13 PM" src="https://github.com/user-attachments/assets/24a65799-0c46-4748-a4b5-5ba92b9661eb">


## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
