### PR TITLE
[ENH]: add record count to span when submitting embeddings

### DIFF
--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -20,6 +20,7 @@ from chromadb.config import System
 from chromadb.telemetry.opentelemetry import (
     OpenTelemetryClient,
     OpenTelemetryGranularity,
+    add_attributes_to_current_span,
     trace_method,
 )
 from overrides import override
@@ -96,6 +97,12 @@ class LogService(Producer, Consumer):
     ) -> Sequence[SeqId]:
         logger.info(
             f"Submitting {len(embeddings)} embeddings to log for collection {collection_id}"
+        )
+
+        add_attributes_to_current_span(
+            {
+                "records_count": len(embeddings),
+            }
         )
 
         if not self._running:


### PR DESCRIPTION
## Description of changes

Adds the record count to the LogService.submit_embeddings span. Useful when debugging.

## Test plan
*How are these changes tested?*

Tested locally with Jaeger.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
