### PR TITLE
[DOC] Add description for query_uris parameter in collection query method

### DIFF
--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -160,6 +160,7 @@ class Collection(CollectionCommon["ServerAPI"]):
             query_embeddings: The embeddings to get the closes neighbors of. Optional.
             query_texts: The document texts to get the closes neighbors of. Optional.
             query_images: The images to get the closes neighbors of. Optional.
+            query_uris: The URIs to be used with data loader. Optional.
             n_results: The number of neighbors to return for each query_embedding or query_texts. Optional.
             where: A Where type dict used to filter results by. E.g. `{"$and": [{"color" : "red"}, {"price": {"$gte": 4.20}}]}`. Optional.
             where_document: A WhereDocument type dict used to filter by the documents. E.g. `{$contains: {"text": "hello"}}`. Optional.


### PR DESCRIPTION
## Description of changes
Updated missing description for "query_uris" parameter on user-facing query method under Collection API.
	 

## Test plan
*How are these changes tested?*

- [x] I tested whether the updated docstring shows up on VS Code Hover Information.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
Docstring for user-facing API updated. No documentation changes required in the docs repository.
