### PR TITLE
[ENH] fix embedding validation span pollution

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -344,17 +344,17 @@ class SegmentAPI(ServerAPI):
             (ids, embeddings, metadatas, documents, uris),
             {"max_batch_size": self.get_max_batch_size()},
         )
-        records_to_submit = []
-        for r in _records(
-            t.Operation.ADD,
-            ids=ids,
-            embeddings=embeddings,
-            metadatas=metadatas,
-            documents=documents,
-            uris=uris,
-        ):
-            self._validate_embedding_record(coll, r)
-            records_to_submit.append(r)
+        records_to_submit = list(
+            _records(
+                t.Operation.ADD,
+                ids=ids,
+                embeddings=embeddings,
+                metadatas=metadatas,
+                documents=documents,
+                uris=uris,
+            )
+        )
+        self._validate_embedding_record_set(coll, records_to_submit)
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
         self._product_telemetry_client.capture(
@@ -386,17 +386,17 @@ class SegmentAPI(ServerAPI):
             (ids, embeddings, metadatas, documents, uris),
             {"max_batch_size": self.get_max_batch_size()},
         )
-        records_to_submit = []
-        for r in _records(
-            t.Operation.UPDATE,
-            ids=ids,
-            embeddings=embeddings,
-            metadatas=metadatas,
-            documents=documents,
-            uris=uris,
-        ):
-            self._validate_embedding_record(coll, r)
-            records_to_submit.append(r)
+        records_to_submit = list(
+            _records(
+                t.Operation.UPDATE,
+                ids=ids,
+                embeddings=embeddings,
+                metadatas=metadatas,
+                documents=documents,
+                uris=uris,
+            )
+        )
+        self._validate_embedding_record_set(coll, records_to_submit)
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
         self._product_telemetry_client.capture(
@@ -430,17 +430,17 @@ class SegmentAPI(ServerAPI):
             (ids, embeddings, metadatas, documents, uris),
             {"max_batch_size": self.get_max_batch_size()},
         )
-        records_to_submit = []
-        for r in _records(
-            t.Operation.UPSERT,
-            ids=ids,
-            embeddings=embeddings,
-            metadatas=metadatas,
-            documents=documents,
-            uris=uris,
-        ):
-            self._validate_embedding_record(coll, r)
-            records_to_submit.append(r)
+        records_to_submit = list(
+            _records(
+                t.Operation.UPSERT,
+                ids=ids,
+                embeddings=embeddings,
+                metadatas=metadatas,
+                documents=documents,
+                uris=uris,
+            )
+        )
+        self._validate_embedding_record_set(coll, records_to_submit)
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
         return True
@@ -606,10 +606,10 @@ class SegmentAPI(ServerAPI):
         if len(ids_to_delete) == 0:
             return []
 
-        records_to_submit = []
-        for r in _records(operation=t.Operation.DELETE, ids=ids_to_delete):
-            self._validate_embedding_record(coll, r)
-            records_to_submit.append(r)
+        records_to_submit = list(
+            _records(operation=t.Operation.DELETE, ids=ids_to_delete)
+        )
+        self._validate_embedding_record_set(coll, records_to_submit)
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
         self._product_telemetry_client.capture(
@@ -795,16 +795,21 @@ class SegmentAPI(ServerAPI):
     # system, since the cache is only local.
     # TODO: promote collection -> topic to a base class method so that it can be
     # used for channel assignment in the distributed version of the system.
-    @trace_method("SegmentAPI._validate_embedding_record", OpenTelemetryGranularity.ALL)
-    def _validate_embedding_record(
-        self, collection: t.Collection, record: t.OperationRecord
+    @trace_method(
+        "SegmentAPI._validate_embedding_record_set", OpenTelemetryGranularity.ALL
+    )
+    def _validate_embedding_record_set(
+        self, collection: t.Collection, records: List[t.OperationRecord]
     ) -> None:
         """Validate the dimension of an embedding record before submitting it to the system."""
         add_attributes_to_current_span({"collection_id": str(collection["id"])})
-        if record["embedding"]:
-            self._validate_dimension(collection, len(record["embedding"]), update=True)
+        for record in records:
+            if record["embedding"]:
+                self._validate_dimension(
+                    collection, len(record["embedding"]), update=True
+                )
 
-    @trace_method("SegmentAPI._validate_dimension", OpenTelemetryGranularity.ALL)
+    # This method is intentionally left untraced because otherwise it can emit thousands of spans for requests containing many embeddings.
     def _validate_dimension(
         self, collection: t.Collection, dim: int, update: bool
     ) -> None:


### PR DESCRIPTION
## Description of changes

Previous to this change, we emitted 2 spans per embedding for every `/add`, `/upsert`, etc call. This pollutes the traces and contributes to our burst usage on our observability provider during load testing.

Now, one span is emitted per request for embedding validation.

Happy to revise this if there's a better solution.

## Test plan
*How are these changes tested?*

Tested locally with Jaeger.

<img width="1682" alt="Screenshot 2024-08-12 at 10 34 49 AM" src="https://github.com/user-attachments/assets/1e826f03-0174-4753-81ba-ae841986200a">

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
