### PR TITLE
[ENH]: lift frontend gRPC retry to application & trace

### DIFF
--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -1,6 +1,6 @@
 import sys
 
-from chromadb.proto.utils import get_default_grpc_options
+from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
 import grpc
 import time
 from chromadb.ingest import (
@@ -52,9 +52,8 @@ class LogService(Producer, Consumer):
     def start(self) -> None:
         self._channel = grpc.insecure_channel(
             f"{self._log_service_url}:{self._log_service_port}",
-            options=get_default_grpc_options(),
         )
-        interceptors = [OtelInterceptor()]
+        interceptors = [OtelInterceptor(), RetryOnRpcErrorClientInterceptor()]
         self._channel = grpc.intercept_channel(self._channel, *interceptors)
         self._log_service_stub = LogServiceStub(self._channel)  # type: ignore
         super().start()

--- a/chromadb/proto/utils.py
+++ b/chromadb/proto/utils.py
@@ -1,26 +1,66 @@
-import json
-from typing import Any, List, Tuple
+from typing import Optional, Set
+import grpc
+from tenacity import retry, stop_after_attempt, wait_exponential_jitter, retry_if_result
+from chromadb.telemetry.opentelemetry import tracer
+from opentelemetry.trace import Span
 
 
-def get_default_grpc_options() -> List[Tuple[str, Any]]:
-    service_config_str = json.dumps(
-        {
-            "methodConfig": [
-                {
-                    "name": [{}],
-                    "retryPolicy": {
-                        "maxAttempts": 5,
-                        "initialBackoff": "0.1s",
-                        "maxBackoff": "1s",
-                        "backoffMultiplier": 2,
-                        "retryableStatusCodes": ["UNAVAILABLE", "UNKNOWN"],
-                    },
-                }
-            ]
-        }
-    )
+class RetryOnRpcErrorClientInterceptor(
+    grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor
+):
+    """
+    A gRPC client interceptor that retries RPCs on specific status codes. By default, it retries on UNAVAILABLE and UNKNOWN status codes.
 
-    return [
-        ("grpc.enable_retries", 1),
-        ("grpc.service_config", service_config_str),
-    ]
+    This interceptor should be placed after the OpenTelemetry interceptor in the interceptor list.
+    """
+
+    max_attempts: int
+    retryable_status_codes: Set[grpc.StatusCode]
+
+    def __init__(
+        self,
+        max_attempts: int = 5,
+        retryable_status_codes: Set[grpc.StatusCode] = set(
+            [grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.UNKNOWN]
+        ),
+    ) -> None:
+        self.max_attempts = max_attempts
+        self.retryable_status_codes = retryable_status_codes
+
+    def _intercept_call(self, continuation, client_call_details, request_or_iterator):
+        sleep_span: Optional[Span] = None
+
+        def before_sleep(_):
+            if tracer is not None:
+                nonlocal sleep_span
+                sleep_span = tracer.start_span("Waiting to retry RPC")
+
+        @retry(
+            wait=wait_exponential_jitter(0.1, jitter=0.1),
+            stop=stop_after_attempt(self.max_attempts),
+            retry=retry_if_result(lambda x: x.code() in self.retryable_status_codes),
+            before_sleep=before_sleep,
+        )
+        def wrapped(*args, **kwargs):
+            nonlocal sleep_span
+            if sleep_span is not None:
+                sleep_span.end()
+            return continuation(*args, **kwargs)
+
+        return wrapped(client_call_details, request_or_iterator)
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        return self._intercept_call(continuation, client_call_details, request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        return self._intercept_call(continuation, client_call_details, request)
+
+    def intercept_stream_unary(
+        self, continuation, client_call_details, request_iterator
+    ):
+        return self._intercept_call(continuation, client_call_details, request_iterator)
+
+    def intercept_stream_stream(
+        self, continuation, client_call_details, request_iterator
+    ):
+        return self._intercept_call(continuation, client_call_details, request_iterator)

--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Optional, Sequence
-from chromadb.proto.utils import get_default_grpc_options
+from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
 from chromadb.segment import MetadataReader
 from chromadb.config import System
 from chromadb.types import Segment
@@ -37,10 +37,8 @@ class GrpcMetadataSegment(MetadataReader):
         if not self._segment["metadata"] or not self._segment["metadata"]["grpc_url"]:
             raise Exception("Missing grpc_url in segment metadata")
 
-        channel = grpc.insecure_channel(
-            self._segment["metadata"]["grpc_url"], options=get_default_grpc_options()
-        )
-        interceptors = [OtelInterceptor()]
+        channel = grpc.insecure_channel(self._segment["metadata"]["grpc_url"])
+        interceptors = [OtelInterceptor(), RetryOnRpcErrorClientInterceptor()]
         channel = grpc.intercept_channel(channel, *interceptors)
         self._metadata_reader_stub = MetadataReaderStub(channel)  # type: ignore
 

--- a/chromadb/segment/impl/vector/grpc_segment.py
+++ b/chromadb/segment/impl/vector/grpc_segment.py
@@ -1,4 +1,3 @@
-from chromadb.proto.utils import get_default_grpc_options
 from overrides import EnforceOverrides, override
 from typing import List, Optional, Sequence
 from chromadb.config import System
@@ -7,6 +6,7 @@ from chromadb.proto.convert import (
     from_proto_vector_query_result,
     to_proto_vector,
 )
+from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
 from chromadb.segment import VectorReader
 from chromadb.segment.impl.vector.hnsw_params import PersistentHnswParams
 from chromadb.telemetry.opentelemetry import (
@@ -42,10 +42,8 @@ class GrpcVectorSegment(VectorReader, EnforceOverrides):
         if segment["metadata"] is None or segment["metadata"]["grpc_url"] is None:
             raise Exception("Missing grpc_url in segment metadata")
 
-        channel = grpc.insecure_channel(
-            segment["metadata"]["grpc_url"], options=get_default_grpc_options()
-        )
-        interceptors = [OtelInterceptor()]
+        channel = grpc.insecure_channel(segment["metadata"]["grpc_url"])
+        interceptors = [OtelInterceptor(), RetryOnRpcErrorClientInterceptor()]
         channel = grpc.intercept_channel(channel, *interceptors)
         self._vector_reader_stub = VectorReaderStub(channel)  # type: ignore
         self._segment = segment

--- a/chromadb/test/proto/test_utils.py
+++ b/chromadb/test/proto/test_utils.py
@@ -1,0 +1,111 @@
+from concurrent import futures
+from queue import Queue
+from threading import Thread
+from typing import Any
+import grpc
+
+from chromadb.proto.convert import to_proto_submit
+from chromadb.proto.logservice_pb2 import PushLogsRequest, PushLogsResponse
+from chromadb.proto.logservice_pb2_grpc import (
+    LogServiceServicer,
+    LogServiceStub,
+    add_LogServiceServicer_to_server,
+)
+from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
+from chromadb.types import Operation, OperationRecord
+
+
+class FlakyLogServiceServicer(LogServiceServicer):
+    num_requests_to_fail: int
+    received_requests: Queue[Any]
+
+    def __init__(
+        self, num_requests_to_fail: int, received_requests: Queue[Any]
+    ) -> None:
+        super().__init__()
+        self.num_requests_to_fail = num_requests_to_fail
+        self.received_requests = received_requests
+
+    def PushLogs(
+        self, request: PushLogsRequest, context: grpc.ServicerContext
+    ) -> PushLogsResponse:
+        if self.num_requests_to_fail > 0:
+            self.num_requests_to_fail -= 1
+            context.set_code(grpc.StatusCode.UNAVAILABLE)
+            context.set_details("Service unavailable")
+            self.received_requests.put({"status": "failed", "request": request})
+            return PushLogsResponse()
+
+        self.received_requests.put({"status": "success", "request": request})
+        return PushLogsResponse(record_count=1)
+
+
+def start_server(
+    num_requests_to_fail: int,
+    received_requests: Queue[Any],
+    started_queue: Queue[Any],
+    stop_queue: Queue[Any],
+) -> None:
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    add_LogServiceServicer_to_server(  # type: ignore
+        FlakyLogServiceServicer(num_requests_to_fail, received_requests), server
+    )
+    server.add_insecure_port("[::]:50051")
+    server.start()
+    started_queue.put(1)
+    # Block until server stop is requested
+    stop_queue.get()
+    server.stop(0)
+
+
+class LogServiceRetryClient:
+    stub: LogServiceStub
+
+    def __init__(self, grpc_url: str) -> None:
+        channel = grpc.insecure_channel(grpc_url)
+        interceptors = [RetryOnRpcErrorClientInterceptor()]
+        channel = grpc.intercept_channel(channel, *interceptors)
+        self.stub = LogServiceStub(channel)  # type: ignore
+
+    def push_log(self, collection_id: str, record: OperationRecord) -> None:
+        proto_record = to_proto_submit(record)
+        request = PushLogsRequest(collection_id=collection_id, records=[proto_record])
+        self.stub.PushLogs(request)
+
+
+def test_retry_interceptor() -> None:
+    received_requests: Queue[Any] = Queue()
+    started_queue: Queue[Any] = Queue()
+    stop_queue: Queue[Any] = Queue()
+
+    server_thread = Thread(
+        target=start_server, args=(3, received_requests, started_queue, stop_queue)
+    )
+    server_thread.start()
+    # Wait for server to be ready
+    started_queue.get()
+
+    try:
+        client = LogServiceRetryClient("localhost:50051")
+        client.push_log(
+            "test",
+            OperationRecord(
+                id="1",
+                embedding=None,
+                encoding=None,
+                metadata=None,
+                operation=Operation.ADD,
+            ),
+        )
+
+        requests = []
+        while not received_requests.empty():
+            requests.append(received_requests.get())
+
+        # There should be 3 failed requests and 1 successful request
+        assert len(requests) == 4
+        assert all(r["status"] == "failed" for r in requests[:3])
+        assert requests[3]["status"] == "success"
+    finally:
+        stop_queue.put(1)
+        server_thread.join()


### PR DESCRIPTION
## Description of changes

Adds a gRPC interceptor for retrying requests instead of relying on gRPC's internal retry mechanism. This gives us much better visibility into retries, and also showed that the previous approach was not performing retries for some reason.

Example trace (tested by making this handler on the Go server randomly fail 50% of the time):

<img width="1682" alt="Screenshot 2024-08-13 at 3 05 36 PM" src="https://github.com/user-attachments/assets/92a3e6b1-db17-4176-b09e-0f20f9edbdf6">

## Test plan
*How are these changes tested?*

Added a new test that starts a flaky server, records requests, and asserts that the request was retried correctly. The new test also confirmed that the previous retry configuration wasn't working.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a