### PR TITLE
Fix environment variables in GCP deployment guide

### DIFF
--- a/examples/deployments/google-cloud-compute/README.md
+++ b/examples/deployments/google-cloud-compute/README.md
@@ -38,8 +38,8 @@ ssh-keygen -t RSA -b 4096 -C "Chroma AWS Key" -N "" -f ./chroma-aws && chmod 400
 
 ```bash
 export TF_VAR_project_id=<your_project_id> #take note of this as it must be present in all of the subsequent steps
-export TF_ssh_public_key="./chroma-aws.pub" #path to the public key you generated above (or can be different if you want to use your own key)
-export TF_ssh_private_key="./chroma-aws" #path to the private key you generated above (or can be different if you want to use your own key) - used for formatting the Chroma data volume
+export TF_VAR_ssh_public_key="./chroma-aws.pub" #path to the public key you generated above (or can be different if you want to use your own key)
+export TF_VAR_ssh_private_key="./chroma-aws" #path to the private key you generated above (or can be different if you want to use your own key) - used for formatting the Chroma data volume
 export TF_VAR_chroma_release="0.4.9" #set the chroma release to deploy
 export TF_VAR_zone="us-central1-a" # AWS region to deploy the chroma instance to
 export TF_VAR_public_access="true" #enable public access to the chroma instance on port 8000


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
Fix the environment variables names in the GCP deployment guide. The prefix should be `TF_VAR_` instead of `TF_`.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
