### PR TITLE
[ENH] Fetch blocks in parallel and make load_blocks take a slice instead

### DIFF
--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -809,7 +809,11 @@ impl RecordSegmentReader<'_> {
     }
 
     pub(crate) async fn count(&self) -> Result<usize, Box<dyn ChromaError>> {
-        self.id_to_data.count().await
+        // We query using the id_to_user_id blockfile since it is likely to be the smallest
+        // and count loads all the data
+        // In the future, we can optimize this by making the underlying blockfile
+        // store counts in the sparse index.
+        self.id_to_user_id.count().await
     }
 
     pub(crate) async fn prefetch_id_to_data(&self, keys: &[u32]) -> () {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Uses the id_to_user_id for count instead of id_to_data, since this is likely to be smaller
	 - Changes load_blocks to take a slice so callers don't transfer ownership
	 - Adds some documentation
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Existing tests should cover this change as its non-functional / not a new behavior. 
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None