### PR TITLE
[ENH] add `bulk_upsert()`

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -1,5 +1,4 @@
 import inspect
-import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,6 +30,7 @@ from chromadb.api.types import (
 
 from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.utils.batch_utils import create_batches
+from chromadb.utils.environment import running_in_interactive_environment
 
 if TYPE_CHECKING:
     from chromadb.api import AsyncServerAPI  # noqa: F401
@@ -327,7 +327,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         on_batch_processed: Optional[
             Callable[[IDs], Union[Awaitable[Any], None]]
         ] = None,
-        print_progress: bool = sys.stdout.isatty(),
+        print_progress: bool = running_in_interactive_environment(),
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist. This method is optimized for inserting large amounts of data, but unlike other collection methods it is not atomic. If an error occurs during the bulk upsert, some of your data may be inserted and some may not.
 

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -326,7 +327,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         on_batch_processed: Optional[
             Callable[[IDs], Union[Awaitable[Any], None]]
         ] = None,
-        print_progress: bool = False,
+        print_progress: bool = sys.stdout.isatty(),
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist. This method is optimized for inserting large amounts of data, but unlike other collection methods it is not atomic. If an error occurs during the bulk upsert, some of your data may be inserted and some may not.
 

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -30,7 +30,6 @@ from chromadb.api.types import (
 
 from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.utils.batch_utils import create_batches
-from chromadb.utils.environment import running_in_interactive_environment
 
 if TYPE_CHECKING:
     from chromadb.api import AsyncServerAPI  # noqa: F401
@@ -327,7 +326,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         on_batch_processed: Optional[
             Callable[[IDs], Union[Awaitable[Any], None]]
         ] = None,
-        print_progress: bool = running_in_interactive_environment(),
+        print_progress: Optional[bool] = None,
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist. This method is optimized for inserting large amounts of data, but unlike other collection methods it is not atomic. If an error occurs during the bulk upsert, some of your data may be inserted and some may not.
 

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -40,7 +40,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def add(
         self,
         ids: OneOrMany[ID],
-        embeddings: Optional[  # type: ignore
+        embeddings: Optional[  # type: ignore[type-arg]
             Union[
                 OneOrMany[Embedding],
                 OneOrMany[np.ndarray],
@@ -99,7 +99,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         where_document: Optional[WhereDocument] = None,
-        include: Include = ["metadatas", "documents"],  # type: ignore
+        include: Include = ["metadatas", "documents"],  # type: ignore[list-item]
     ) -> GetResult:
         """Get embeddings and their associate data from the data store. If no ids or where filter is provided returns
         all embeddings up to limit starting at offset.
@@ -149,7 +149,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
 
     async def query(
         self,
-        query_embeddings: Optional[  # type: ignore
+        query_embeddings: Optional[  # type: ignore[type-arg]
             Union[
                 OneOrMany[Embedding],
                 OneOrMany[np.ndarray],
@@ -161,7 +161,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         n_results: int = 10,
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
-        include: Include = ["metadatas", "documents", "distances"],  # type: ignore
+        include: Include = ["metadatas", "documents", "distances"],  # type: ignore[list-item]
     ) -> QueryResult:
         """Get the n_results nearest neighbor embeddings for provided query_embeddings or query_texts.
 
@@ -237,7 +237,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def update(
         self,
         ids: OneOrMany[ID],
-        embeddings: Optional[  # type: ignore
+        embeddings: Optional[  # type: ignore[type-arg]
             Union[
                 OneOrMany[Embedding],
                 OneOrMany[np.ndarray],
@@ -274,7 +274,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def upsert(
         self,
         ids: OneOrMany[ID],
-        embeddings: Optional[  # type: ignore
+        embeddings: Optional[  # type: ignore[type-arg]
             Union[
                 OneOrMany[Embedding],
                 OneOrMany[np.ndarray],
@@ -318,7 +318,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def bulk_upsert(
         self,
         ids: IDs,
-        embeddings: Optional[Union[Embeddings, List[np.ndarray]]] = None,  # type: ignore
+        embeddings: Optional[Union[Embeddings, List[np.ndarray]]] = None,  # type: ignore[type-arg]
         metadatas: Optional[List[Optional[Metadata]]] = None,
         documents: Optional[List[Optional[Document]]] = None,
         images: Optional[List[Optional[Image]]] = None,
@@ -354,7 +354,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             else None,
             batch_size=min(absolute_max_batch_size, max_batch_size),
         ):
-            await self.upsert(*batch)  # type: ignore
+            await self.upsert(*batch)  # type: ignore[arg-type]
             if on_batch_processed:
                 if inspect.iscoroutinefunction(on_batch_processed):
                     await on_batch_processed(batch[0])

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -319,16 +319,18 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         documents: Optional[List[Optional[Document]]] = None,
         images: Optional[List[Optional[Image]]] = None,
         uris: Optional[List[Optional[URI]]] = None,
-        batch_size: int = 1024,
+        max_batch_size: int = 1024,
         progress_callback: Optional[Callable[[IDs], None]] = None,
         print_progress: bool = False,
     ) -> None:
+        absolute_max_batch_size = await self._client.get_max_batch_size()
+
         for batch in create_batches(
             (ids, embeddings, metadatas, documents, images, uris),
             print_progress_description=f"Upserting {len(ids)} documents..."
             if print_progress
             else None,
-            max_batch_size=batch_size,
+            batch_size=min(absolute_max_batch_size, max_batch_size),
         ):
             await self.upsert(*batch)  # type: ignore
             if progress_callback:

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -311,7 +311,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             uris=uris,
         )
 
-    async def batch_upsert(
+    async def bulk_upsert(
         self,
         ids: IDs,
         embeddings: Optional[Union[Embeddings, List[np.ndarray]]] = None,  # type: ignore

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -308,7 +308,7 @@ class Collection(CollectionCommon["ServerAPI"]):
             uris=uris,
         )
 
-    def batch_upsert(
+    def bulk_upsert(
         self,
         ids: IDs,
         embeddings: Optional[Union[Embeddings, List[np.ndarray]]] = None,  # type: ignore[type-arg]

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -93,7 +93,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         where_document: Optional[WhereDocument] = None,
-        include: Include = ["metadatas", "documents"],  # type: ignore
+        include: Include = ["metadatas", "documents"],  # type: ignore[list-item]
     ) -> GetResult:
         """Get embeddings and their associate data from the data store. If no ids or where filter is provided returns
         all embeddings up to limit starting at offset.
@@ -155,7 +155,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         n_results: int = 10,
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
-        include: Include = ["metadatas", "documents", "distances"],  # type: ignore
+        include: Include = ["metadatas", "documents", "distances"],  # type: ignore[list-item]
     ) -> QueryResult:
         """Get the n_results nearest neighbor embeddings for provided query_embeddings or query_texts.
 

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,3 @@
-import sys
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 import numpy as np
 
@@ -21,6 +20,7 @@ from chromadb.api.types import (
     WhereDocument,
 )
 from chromadb.utils.batch_utils import create_batches
+from chromadb.utils.environment import running_in_interactive_environment
 
 import logging
 
@@ -319,7 +319,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         uris: Optional[List[Optional[URI]]] = None,
         max_batch_size: int = 1024,
         on_batch_processed: Optional[Callable[[IDs], None]] = None,
-        print_progress: bool = sys.stdout.isatty(),
+        print_progress: bool = running_in_interactive_environment(),
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist. This method is optimized for inserting large amounts of data, but unlike other collection methods it is not atomic. If an error occurs during the bulk upsert, some of your data may be inserted and some may not.
 

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -316,16 +316,18 @@ class Collection(CollectionCommon["ServerAPI"]):
         documents: Optional[List[Optional[Document]]] = None,
         images: Optional[List[Optional[Image]]] = None,
         uris: Optional[List[Optional[URI]]] = None,
-        batch_size: int = 1024,
+        max_batch_size: int = 1024,
         progress_callback: Optional[Callable[[IDs], None]] = None,
         print_progress: bool = False,
     ) -> None:
+        absolute_max_batch_size = self._client.get_max_batch_size()
+
         for batch in create_batches(
             (ids, embeddings, metadatas, documents, images, uris),
             print_progress_description=f"Upserting {len(ids)} documents..."
             if print_progress
             else None,
-            max_batch_size=batch_size,
+            batch_size=min(absolute_max_batch_size, max_batch_size),
         ):
             self.upsert(*batch)  # type: ignore[arg-type]
             if progress_callback:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -20,7 +20,6 @@ from chromadb.api.types import (
     WhereDocument,
 )
 from chromadb.utils.batch_utils import create_batches
-from chromadb.utils.environment import running_in_interactive_environment
 
 import logging
 
@@ -319,7 +318,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         uris: Optional[List[Optional[URI]]] = None,
         max_batch_size: int = 1024,
         on_batch_processed: Optional[Callable[[IDs], None]] = None,
-        print_progress: bool = running_in_interactive_environment(),
+        print_progress: Optional[bool] = None,
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist. This method is optimized for inserting large amounts of data, but unlike other collection methods it is not atomic. If an error occurs during the bulk upsert, some of your data may be inserted and some may not.
 
@@ -341,9 +340,8 @@ class Collection(CollectionCommon["ServerAPI"]):
 
         for batch in create_batches(
             (ids, embeddings, metadatas, documents, images, uris),
-            print_progress_description=f"Upserting {len(ids)} documents..."
-            if print_progress
-            else None,
+            print_progress_description=f"Upserting {len(ids)} documents...",
+            print_progress=print_progress,
             batch_size=min(absolute_max_batch_size, max_batch_size),
         ):
             self.upsert(*batch)  # type: ignore[arg-type]

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 import numpy as np
 
@@ -318,7 +319,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         uris: Optional[List[Optional[URI]]] = None,
         max_batch_size: int = 1024,
         on_batch_processed: Optional[Callable[[IDs], None]] = None,
-        print_progress: bool = False,
+        print_progress: bool = sys.stdout.isatty(),
     ) -> None:
         """Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist. This method is optimized for inserting large amounts of data, but unlike other collection methods it is not atomic. If an error occurs during the bulk upsert, some of your data may be inserted and some may not.
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -182,7 +182,6 @@ def test_add_large(
     initial_version = coll.get_model()["version"]
 
     for ids, embeddings, metadatas, documents in create_batches(
-        client,
         (
             cast(List[str], record_set["ids"]),
             cast(Embeddings, record_set["embeddings"]),

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -247,7 +247,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
         self.collection.bulk_upsert(
             **normalized_record_set,  # type: ignore
             max_batch_size=batch_size,
-            progress_callback=on_batch_ingested,
+            on_batch_processed=on_batch_ingested,
         )
 
     @invariant()

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -246,7 +246,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
 
         self.collection.batch_upsert(
             **normalized_record_set,  # type: ignore[arg-type]
-            batch_size=batch_size,
+            max_batch_size=batch_size,
             progress_callback=on_batch_ingested,
         )
 

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -244,8 +244,8 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
 
             self._upsert_embeddings(ingested_records)
 
-        self.collection.batch_upsert(
-            **normalized_record_set,  # type: ignore[arg-type]
+        self.collection.bulk_upsert(
+            **normalized_record_set,  # type: ignore
             max_batch_size=batch_size,
             progress_callback=on_batch_ingested,
         )

--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -2,6 +2,8 @@ from typing import Any, Iterator, List, Optional, Tuple, TypeVar, Union, cast
 import numpy as np
 from rich.progress import track
 
+from chromadb.utils.environment import running_in_interactive_environment
+
 # (Can't provide type arguments to ndarray < 3.9.)
 T = TypeVar("T", bound=Tuple[Union[List[Any], np.ndarray, None], ...])  # type: ignore[type-arg]
 
@@ -10,6 +12,7 @@ def create_batches(
     records: T,
     batch_size: Optional[int] = 1024,
     print_progress_description: Optional[str] = None,
+    print_progress: Optional[bool] = None,
 ) -> Iterator[T]:
     """
     Takes tuples like `([0, 1], [2, 3])` and yields batches of the tuple like `([0], [2])` and `([1], [3])`.
@@ -48,10 +51,16 @@ def create_batches(
     if set_size == -1:
         raise ValueError("Records must contain a list field")
 
+    print_progress = (
+        print_progress
+        if print_progress is not None
+        else running_in_interactive_environment()
+    )
+
     for i in track(
         range(0, set_size, batch_size),
         description=print_progress_description or "",
-        disable=not print_progress_description,
+        disable=not print_progress,
         complete_style="#f3d846",
         finished_style="#4b77f7",
     ):

--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -52,6 +52,8 @@ def create_batches(
         range(0, set_size, batch_size),
         description=print_progress_description or "",
         disable=not print_progress_description,
+        complete_style="#f3d846",
+        finished_style="#4b77f7",
     ):
         yield cast(
             T,

--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -1,5 +1,4 @@
 from typing import Any, Iterator, List, Optional, Tuple, TypeVar, Union, cast
-from chromadb.api import ClientAPI
 import numpy as np
 from rich.progress import track
 
@@ -8,7 +7,6 @@ T = TypeVar("T", bound=Tuple[Union[List[Any], np.ndarray, None], ...])  # type: 
 
 
 def create_batches(
-    client: ClientAPI,
     records: T,
     max_batch_size: Optional[int] = 1024,
     print_progress_description: Optional[str] = None,
@@ -39,7 +37,7 @@ def create_batches(
         max_batch_size: The maximum batch size to use, defaults to 1024
         print_progress_description: If specified, a progress bar will be displayed with this description
     """
-    max_batch_size = min(client.get_max_batch_size(), max_batch_size or 1024)
+    max_batch_size = max_batch_size or 1024
 
     set_size = -1
     for field in records:

--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -8,7 +8,7 @@ T = TypeVar("T", bound=Tuple[Union[List[Any], np.ndarray, None], ...])  # type: 
 
 def create_batches(
     records: T,
-    max_batch_size: Optional[int] = 1024,
+    batch_size: Optional[int] = 1024,
     print_progress_description: Optional[str] = None,
 ) -> Iterator[T]:
     """
@@ -34,10 +34,10 @@ def create_batches(
     Args:
         client: A chromadb client
         records: A tuple of lists or numpy arrays
-        max_batch_size: The maximum batch size to use, defaults to 1024
+        batch_size: The batch size to use, defaults to 1024
         print_progress_description: If specified, a progress bar will be displayed with this description
     """
-    max_batch_size = max_batch_size or 1024
+    batch_size = batch_size or 1024
 
     set_size = -1
     for field in records:
@@ -49,14 +49,14 @@ def create_batches(
         raise ValueError("Records must contain a list field")
 
     for i in track(
-        range(0, set_size, max_batch_size),
+        range(0, set_size, batch_size),
         description=print_progress_description or "",
         disable=not print_progress_description,
     ):
         yield cast(
             T,
             tuple(
-                None if field is None else field[i : i + max_batch_size]
+                None if field is None else field[i : i + batch_size]
                 for field in records
             ),
         )

--- a/chromadb/utils/environment.py
+++ b/chromadb/utils/environment.py
@@ -1,0 +1,19 @@
+import sys
+
+
+# https://stackoverflow.com/a/39662359
+def running_inside_notebook() -> bool:
+    try:
+        shell = get_ipython().__class__.__name__  # type: ignore
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False  # Probably standard Python interpreter
+
+
+def running_in_interactive_environment() -> bool:
+    return running_inside_notebook() or sys.stdout.isatty()

--- a/docs/docs.trychroma.com/pages/guides/index.md
+++ b/docs/docs.trychroma.com/pages/guides/index.md
@@ -351,9 +351,17 @@ Valid options for `hnsw:space` are "l2", "ip, "or "cosine". The **default** is "
 {% tabs group="code-lang" hideTabs=true %}
 {% tab label="Python" %}
 
-Add data to Chroma with `.add`.
+When ingesting data for the first time, we recommend using the `.bulk_upsert()` method as it's optimized for large amounts of data (it also displays a progress bar by default):
 
-Raw documents:
+```python
+collection.bulk_upsert(
+    documents=["lorem ipsum...", "doc2", "doc3", ...],
+    metadatas=[{"chapter": "3", "verse": "16"}, {"chapter": "3", "verse": "5"}, {"chapter": "29", "verse": "11"}, ...],
+    ids=["id1", "id2", "id3", ...]
+)
+```
+
+You can also add data to Chroma with `.add()`:
 
 ```python
 collection.add(
@@ -362,6 +370,8 @@ collection.add(
     ids=["id1", "id2", "id3", ...]
 )
 ```
+
+Note that `.bulk_upsert()` is not atomic: if it fails partway through some of your data will have been added/updated and some of it will not have been. You should use `.add()` or `.upsert()` if you require atomicity for your application.
 
 {% /tab %}
 {% tab label="Javascript" %}

--- a/docs/docs.trychroma.com/pages/guides/index.md
+++ b/docs/docs.trychroma.com/pages/guides/index.md
@@ -371,7 +371,7 @@ collection.add(
 )
 ```
 
-Note that `.bulk_upsert()` is not atomic: if it fails partway through some of your data will have been added/updated and some of it will not have been. You should use `.add()` or `.upsert()` if you require atomicity for your application.
+Note that `.bulk_upsert()` is not atomic: if it fails partway through some of your data will have been added or updated. You should use `.add()` or `.upsert()` if you require atomicity for your application.
 
 {% /tab %}
 {% tab label="Javascript" %}


### PR DESCRIPTION
## Description of changes

Adds a `Collection.bulk_upsert()` method. I can add a `.bulk_add()` method in a subsequent PR if we want it.

I unfortunately had to tweak the design slightly from the last proposal in the linked issue, because you can't have a function that's either blocking or yielding depending on the calling context. Usage is now:

```python
collection.batch_upsert(ids=....)
```

or

```python
collection.batch_upsert(
	ids=..., 
    on_batch_processed=lambda ids: user_db.update(ids, ingested=True),
)
```

A progress bar is automatically displayed if stdout is a TTY device (i.e. an interactive environment). Demo:

https://github.com/user-attachments/assets/7d7220dd-11a9-453a-b86d-792cfc094738

Inside a notebook:

https://github.com/user-attachments/assets/8e687edd-4411-49dd-b2d0-f56b04b5b35f

(Chroma colors :))


## Test plan
*How are these changes tested?*

Added a new rule to the existing state machine for property tests.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

Need some feedback here, do we want to replace `.add()` with `.batch_upsert()` in the Getting Started section even though there's only 3 documents? What would be a good place to put this? The main usage guide?