### PR TITLE
[CLN] Only use distance avx/neon/sse if enabled

### DIFF
--- a/rust/distance/src/lib.rs
+++ b/rust/distance/src/lib.rs
@@ -3,7 +3,12 @@ pub mod distance_neon;
 pub mod distance_sse;
 pub mod types;
 
+#[cfg(all(target_feature = "avx", target_feature = "fma"))]
 pub use distance_avx::*;
+
+#[cfg(target_feature = "neon")]
 pub use distance_neon::*;
+
+#[cfg(target_feature = "sse")]
 pub use distance_sse::*;
 pub use types::*;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Cleanup some warnings by only building distance modules when required features are enabled
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
None