### PR TITLE
[ENH] Make Rust/C++ FFI error handling robust

### DIFF
--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -112,6 +112,7 @@ public:
         {
             throw std::runtime_error("Index not inited");
         }
+
         appr_alg->addPoint(data, id);
     }
 
@@ -119,7 +120,7 @@ public:
     {
         if (!index_inited)
         {
-            throw std::runtime_error("Index not inited");
+            throw std::runtime_error("Inde not inited");
         }
         std::vector<data_t> ret_data = appr_alg->template getDataByLabel<data_t>(id); // This checks if id is deleted
         for (int i = 0; i < dim; i++)
@@ -233,6 +234,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -247,6 +249,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -261,6 +264,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -275,6 +279,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -289,6 +294,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -303,6 +309,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -351,6 +358,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }
@@ -387,6 +395,7 @@ extern "C"
         catch (std::exception &e)
         {
             last_error = e.what();
+            return;
         }
         last_error.clear();
     }

--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -201,8 +201,12 @@ public:
     }
 };
 
+// All these methods except for len and capacity can throw std::exception
+// and populate the last_error thread-local variable
 extern "C"
 {
+
+    // Can throw std::exception
     Index<float> *create_index(const char *space_name, const int dim)
     {
         Index<float> *index;
@@ -219,6 +223,7 @@ extern "C"
         return new Index<float>(space_name, dim);
     }
 
+    // Can throw std::exception
     void init_index(Index<float> *index, const size_t max_elements, const size_t M, const size_t ef_construction, const size_t random_seed, const bool allow_replace_deleted, const bool is_persistent_index, const char *persistence_location)
     {
         try
@@ -232,6 +237,7 @@ extern "C"
         last_error.clear();
     }
 
+    // Can throw std::exception
     void load_index(Index<float> *index, const char *path_to_index, const bool allow_replace_deleted, const bool is_persistent_index)
     {
         try
@@ -245,6 +251,7 @@ extern "C"
         last_error.clear();
     }
 
+    // Can throw std::exception
     void persist_dirty(Index<float> *index)
     {
         try
@@ -258,6 +265,7 @@ extern "C"
         last_error.clear();
     }
 
+    // Can throw std::exception
     void add_item(Index<float> *index, const float *data, const hnswlib::labeltype id, const bool replace_deleted)
     {
         try
@@ -271,6 +279,7 @@ extern "C"
         last_error.clear();
     }
 
+    // Can throw std::exception
     void get_item(Index<float> *index, const hnswlib::labeltype id, float *data)
     {
         try
@@ -284,6 +293,7 @@ extern "C"
         last_error.clear();
     }
 
+    // Can throw std::exception
     void mark_deleted(Index<float> *index, const hnswlib::labeltype id)
     {
         try
@@ -297,6 +307,7 @@ extern "C"
         last_error.clear();
     }
 
+    // Can throw std::exception
     size_t knn_query(Index<float> *index, const float *query_vector, const size_t k, hnswlib::labeltype *ids, float *distance, const hnswlib::labeltype *allowed_ids, const size_t allowed_id_length, const hnswlib::labeltype *disallowed_ids, const size_t disallowed_id_length)
     {
         size_t result;
@@ -313,6 +324,7 @@ extern "C"
         return result;
     }
 
+    // Can throw std::exception
     int get_ef(Index<float> *index)
     {
         int ret;
@@ -329,6 +341,7 @@ extern "C"
         return ret;
     }
 
+    // Can throw std::exception
     void set_ef(Index<float> *index, const size_t ef)
     {
         try
@@ -342,38 +355,29 @@ extern "C"
         last_error.clear();
     }
 
+    // Can not throw std::exception
     int len(Index<float> *index)
     {
-        int ret;
-        try
+        if (!index->index_inited)
         {
-            ret = index->appr_alg->getCurrentElementCount();
-        }
-        catch (std::exception &e)
-        {
-            last_error = e.what();
-            return -1;
-        }
-        last_error.clear();
-        return ret;
-    }
-
-    size_t capacity(Index<float> *index)
-    {
-        size_t ret;
-        try
-        {
-            ret = index->appr_alg->max_elements_;
-        }
-        catch (std::exception &e)
-        {
-            last_error = e.what();
             return 0;
         }
-        last_error.clear();
-        return ret;
+
+        return index->appr_alg->getCurrentElementCount() - index->appr_alg->getDeletedCount();
     }
 
+    // Can not throw std::exception
+    size_t capacity(Index<float> *index)
+    {
+        if (!index->index_inited)
+        {
+            return 0;
+        }
+
+        return index->appr_alg->max_elements_;
+    }
+
+    // Can throw std::exception
     void resize_index(Index<float> *index, size_t new_size)
     {
         try

--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -202,8 +202,11 @@ public:
     }
 };
 
-// All these methods except for len and capacity can throw std::exception
-// and populate the last_error thread-local variable
+// All these methods except for len() and capacity() can "throw" a std::exception
+// and populate the last_error thread-local variable. This is how we communicate
+// errors across the FFI boundary - the C++ layer will catch all exceptions and
+// set the last_error variable, which the Rust layer can then check.
+// Comments referring to "throwing" exceptions in this block refer to this mechanism.
 extern "C"
 {
 

--- a/rust/index/build.rs
+++ b/rust/index/build.rs
@@ -1,4 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Tell cargo to rerun this build script if the bindings change.
+    println!("cargo:rerun-if-changed=bindings.cpp");
     // Compile the hnswlib bindings.
     cc::Build::new()
         .cpp(true)

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -860,7 +860,7 @@ pub mod test {
 
     #[test]
     fn it_can_catch_error() {
-        let n = 1;
+        let n = 10;
         let d: usize = 960;
         let distance_function = DistanceFunction::Euclidean;
         let tmp_dir = tempdir().unwrap();
@@ -872,7 +872,7 @@ pub mod test {
             },
             Some(&HnswIndexConfig {
                 max_elements: n,
-                m: 16,
+                m: 10,
                 ef_construction: 100,
                 ef_search: 100,
                 random_seed: 0,
@@ -894,17 +894,12 @@ pub mod test {
             index.add(ids[i], data).expect("Should not error");
         });
 
-        // Query the data
-        let query = &data[0..d];
-        let allow_ids = &[];
-        let disallow_ids = &[];
-        let (ids, distances) = index.query(query, 1, allow_ids, disallow_ids).unwrap();
-
-        // inserted error should print at this point
-
-        // assert_eq!(ids.len(), 1);
-        // assert_eq!(distances.len(), 1);
-        // assert_eq!(ids[0], 0);
-        // assert_eq!(distances[0], 0.0);
+        // Add more elements than the index can hold
+        let data = &data[0..d];
+        let res = index.add(n, data);
+        match res {
+            Err(_) => {}
+            Ok(_) => panic!("Expected error"),
+        }
     }
 }

--- a/rust/index/src/types.rs
+++ b/rust/index/src/types.rs
@@ -65,16 +65,16 @@ pub trait Index<C> {
     ) -> Result<Self, Box<dyn ChromaError>>
     where
         Self: Sized;
-    fn add(&self, id: usize, vector: &[f32]);
-    fn delete(&self, id: usize);
+    fn add(&self, id: usize, vector: &[f32]) -> Result<(), Box<dyn ChromaError>>;
+    fn delete(&self, id: usize) -> Result<(), Box<dyn ChromaError>>;
     fn query(
         &self,
         vector: &[f32],
         k: usize,
         allowed_ids: &[usize],
         disallow_ids: &[usize],
-    ) -> (Vec<usize>, Vec<f32>);
-    fn get(&self, id: usize) -> Option<Vec<f32>>;
+    ) -> Result<(Vec<usize>, Vec<f32>), Box<dyn ChromaError>>;
+    fn get(&self, id: usize) -> Result<Option<Vec<f32>>, Box<dyn ChromaError>>;
 }
 
 /// The persistent index trait.

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -349,7 +349,7 @@ impl DistributedHNSWSegmentReader {
         k: usize,
         allowed_ids: &[usize],
         disallowd_ids: &[usize],
-    ) -> (Vec<usize>, Vec<f32>) {
+    ) -> Result<(Vec<usize>, Vec<f32>), Box<dyn ChromaError>> {
         let index = self.index.read();
         index.query(vector, k, allowed_ids, disallowd_ids)
     }

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -321,7 +321,7 @@ impl ChromaError for ApplyMaterializedLogError {
             ApplyMaterializedLogError::FTSDocumentDeleteError => ErrorCodes::Internal,
             ApplyMaterializedLogError::FTSDocumentUpdateError => ErrorCodes::Internal,
             ApplyMaterializedLogError::EmbeddingNotSet => ErrorCodes::InvalidArgument,
-            ApplyMaterializedLogError::HnswIndexAddError(_) => ErrorCodes::Internal,
+            ApplyMaterializedLogError::HnswIndexError(_) => ErrorCodes::Internal,
         }
     }
 }

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -305,6 +305,8 @@ pub enum ApplyMaterializedLogError {
     FTSDocumentDeleteError,
     #[error("FTS Document update error")]
     FTSDocumentUpdateError,
+    #[error("Error writing to hnsw index")]
+    HnswIndexError(#[from] Box<dyn ChromaError>),
 }
 
 impl ChromaError for ApplyMaterializedLogError {
@@ -319,6 +321,7 @@ impl ChromaError for ApplyMaterializedLogError {
             ApplyMaterializedLogError::FTSDocumentDeleteError => ErrorCodes::Internal,
             ApplyMaterializedLogError::FTSDocumentUpdateError => ErrorCodes::Internal,
             ApplyMaterializedLogError::EmbeddingNotSet => ErrorCodes::InvalidArgument,
+            ApplyMaterializedLogError::HnswIndexAddError(_) => ErrorCodes::Internal,
         }
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Introduces a mechanism to propagate errors from C++ into rust by catching errors in the bindings and then populating a thread_local variable.
	 - Build the c++ code automatically on change
	 - Propagate new errors up through the codebase
	 - Coalesce shared functionality in rust hnsw tests
	 - the c++ bindings were creating errors, but not throwing them, this path is purely defensive so it was never excercised, this fixes that. 
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Added a new test to test add() errors
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None