### PR TITLE
[ENH]: allow using node selectors for pods instead of tolerations

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.4.23"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -64,6 +64,10 @@ spec:
       tolerations:
         {{ toYaml .Values.compactionService.tolerations | nindent 8 }}
       {{ end }}
+      {{if .Values.compactionService.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.compactionService.nodeSelector | nindent 8 }}
+      {{ end }}
       updateStrategy:
         type: RollingUpdate
         rollingUpdate:

--- a/k8s/distributed-chroma/templates/frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/frontend-service.yaml
@@ -54,6 +54,10 @@ spec:
       tolerations:
         {{ toYaml .Values.frontendService.tolerations | nindent 8 }}
       {{ end }}
+      {{if .Values.frontendService.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.frontendService.nodeSelector | nindent 8 }}
+      {{ end }}
       volumes:
         - name: chroma
           emptyDir: {}

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -83,6 +83,10 @@ spec:
       tolerations:
         {{ toYaml .Values.queryService.tolerations | nindent 8 }}
       {{ end }}
+      {{if .Values.queryService.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.queryService.nodeSelector | nindent 8 }}
+      {{ end }}
       updateStrategy:
         type: RollingUpdate
         rollingUpdate:


### PR DESCRIPTION
## Description of changes

We want to bind pods to nodes, instead of disallowing other pods from being scheduled on specific nodes.

## Test plan
*How are these changes tested?*

Tested locally with Tilt.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a