### PR TITLE
[ENH]: allow configuring replicaCount and nodeSelector on log service

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.4.23"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/logservice.yaml
+++ b/k8s/distributed-chroma/templates/logservice.yaml
@@ -4,7 +4,7 @@ metadata:
   name: logservice
   namespace: {{ .Values.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.logService.replicaCount }}
   selector:
     matchLabels:
       app: logservice
@@ -35,6 +35,10 @@ spec:
           ports:
             - containerPort: 50051
               name: grpc
+      {{if .Values.logService.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.logService.nodeSelector | nindent 8 }}
+      {{ end }}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -58,6 +58,7 @@ logService:
     - name: OPTL_TRACING_ENDPOINT
       value: 'value: "jaeger:4317"'
   flags:
+  replicaCount: 1
 
 queryService:
   image:


### PR DESCRIPTION
## Description of changes

Allows configuring repliaCount and nodeSelector on the logservice, in line with other services.

## Test plan
*How are these changes tested?*

Tested locally with Tilt.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
