### PR TITLE
[ENH] Generate IDs when not given in upsert and add

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -74,40 +74,6 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             uris,
         )
 
-<<<<<<< HEAD
-=======
-        normalized_embeddings = (
-            self._normalize_embeddings(unpacked_embedding_set["embeddings"])
-            if unpacked_embedding_set["embeddings"] is not None
-            else None
-        )
-
-        updated_ids = self._generate_ids_when_not_present(
-            unpacked_embedding_set["ids"],
-            unpacked_embedding_set["documents"],
-            unpacked_embedding_set["uris"],
-            unpacked_embedding_set["images"],
-            unpacked_embedding_set["embeddings"],
-        )
-
-        self._validate_embedding_set(
-            updated_ids,
-            normalized_embeddings,
-            unpacked_embedding_set["metadatas"],
-            unpacked_embedding_set["documents"],
-            unpacked_embedding_set["images"],
-            unpacked_embedding_set["uris"],
-            require_embeddings_or_data=False,
-        )
-
-        prepared_embeddings = self._prepare_embeddings(
-            unpacked_embedding_set["embeddings"],
-            unpacked_embedding_set["documents"],
-            unpacked_embedding_set["images"],
-            unpacked_embedding_set["uris"],
-        )
-
->>>>>>> da00cd7b (minor fixes and add tests)
         await self._client._add(
             cast(IDs, embedding_set["ids"]),
             self.id,
@@ -297,7 +263,6 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             ids, embeddings, metadatas, documents, images, uris
         )
 
-<<<<<<< HEAD
         await self._client._update(
             self.id,
             embedding_set["ids"],
@@ -306,9 +271,6 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
-=======
-        await self._client._update(self.id, cast(IDs, embedding_set["ids"]), cast(Embeddings, embedding_set["embeddings"]), embedding_set["metadatas"], embedding_set["documents"], embedding_set["uris"])
->>>>>>> b7728942 (resolve merge conflicts)
 
     async def upsert(
         self,
@@ -338,7 +300,6 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         embedding_set = self._process_upsert_or_update_request(
             ids, embeddings, metadatas, documents, images, uris
         )
-
 
         await self._client._upsert(
             collection_id=self.id,

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def add(
         self,
-        ids: OneOrMany[ID],
+        ids: Optional[OneOrMany[ID]],
         embeddings: Optional[
             Union[
                 OneOrMany[Embedding],
@@ -74,8 +74,42 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             uris,
         )
 
+<<<<<<< HEAD
+=======
+        normalized_embeddings = (
+            self._normalize_embeddings(unpacked_embedding_set["embeddings"])
+            if unpacked_embedding_set["embeddings"] is not None
+            else None
+        )
+
+        updated_ids = self._generate_ids_when_not_present(
+            unpacked_embedding_set["ids"],
+            unpacked_embedding_set["documents"],
+            unpacked_embedding_set["uris"],
+            unpacked_embedding_set["images"],
+            unpacked_embedding_set["embeddings"],
+        )
+
+        self._validate_embedding_set(
+            updated_ids,
+            normalized_embeddings,
+            unpacked_embedding_set["metadatas"],
+            unpacked_embedding_set["documents"],
+            unpacked_embedding_set["images"],
+            unpacked_embedding_set["uris"],
+            require_embeddings_or_data=False,
+        )
+
+        prepared_embeddings = self._prepare_embeddings(
+            unpacked_embedding_set["embeddings"],
+            unpacked_embedding_set["documents"],
+            unpacked_embedding_set["images"],
+            unpacked_embedding_set["uris"],
+        )
+
+>>>>>>> da00cd7b (minor fixes and add tests)
         await self._client._add(
-            embedding_set["ids"],
+            cast(IDs, embedding_set["ids"]),
             self.id,
             cast(Embeddings, embedding_set["embeddings"]),
             embedding_set["metadatas"],
@@ -259,10 +293,11 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         Returns:
             None
         """
-        embedding_set = self._process_update_request(
+        embedding_set = self._process_upsert_or_update_request(
             ids, embeddings, metadatas, documents, images, uris
         )
 
+<<<<<<< HEAD
         await self._client._update(
             self.id,
             embedding_set["ids"],
@@ -271,6 +306,9 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
+=======
+        await self._client._update(self.id, cast(IDs, embedding_set["ids"]), cast(Embeddings, embedding_set["embeddings"]), embedding_set["metadatas"], embedding_set["documents"], embedding_set["uris"])
+>>>>>>> b7728942 (resolve merge conflicts)
 
     async def upsert(
         self,
@@ -297,13 +335,14 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         Returns:
             None
         """
-        embedding_set = self._process_upsert_request(
+        embedding_set = self._process_upsert_or_update_request(
             ids, embeddings, metadatas, documents, images, uris
         )
 
+
         await self._client._upsert(
             collection_id=self.id,
-            ids=embedding_set["ids"],
+            ids=cast(IDs, embedding_set["ids"]),
             embeddings=cast(Embeddings, embedding_set["embeddings"]),
             metadatas=embedding_set["metadatas"],
             documents=embedding_set["documents"],

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -83,9 +83,9 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
-        
+
         return {
-            "ids":embedding_set["ids"],
+            "ids": embedding_set["ids"],
         }
 
     async def count(self) -> int:

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from chromadb.api.types import (
     URI,
+    AddResult,
     CollectionMetadata,
     Embedding,
     Include,
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def add(
         self,
-        ids: Optional[OneOrMany[ID]],
+        ids: Optional[OneOrMany[ID]] = None,
         embeddings: Optional[
             Union[
                 OneOrMany[Embedding],
@@ -44,7 +45,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         documents: Optional[OneOrMany[Document]] = None,
         images: Optional[OneOrMany[Image]] = None,
         uris: Optional[OneOrMany[URI]] = None,
-    ) -> None:
+    ) -> AddResult:
         """Add embeddings to the data store.
         Args:
             ids: The ids of the embeddings you wish to add
@@ -82,6 +83,10 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
+        
+        return {
+            "ids":embedding_set["ids"],
+        }
 
     async def count(self) -> int:
         """The total number of embeddings added to the database

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -90,7 +90,7 @@ class Collection(CollectionCommon["ServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
-        
+
         return {
             "ids": embedding_set["ids"],
         }

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -261,18 +261,14 @@ class Collection(CollectionCommon["ServerAPI"]):
             ids, embeddings, metadatas, documents, images, uris
         )
 
-<<<<<<< HEAD
         self._client._update(
             self.id,
-            embedding_set["ids"],
+            cast(IDs, embedding_set["ids"]),
             cast(Embeddings, embedding_set["embeddings"]),
             embedding_set["metadatas"],
             embedding_set["documents"],
             embedding_set["uris"],
         )
-=======
-        self._client._update(self.id, cast(IDs, embedding_set["ids"]), cast(Embeddings, embedding_set["embeddings"]), embedding_set["metadatas"], embedding_set["documents"], embedding_set["uris"])
->>>>>>> b7728942 (resolve merge conflicts)
 
     def upsert(
         self,

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -40,7 +40,7 @@ class Collection(CollectionCommon["ServerAPI"]):
 
     def add(
         self,
-        ids: OneOrMany[ID],
+        ids: Optional[OneOrMany[ID]],
         embeddings: Optional[  # type: ignore[type-arg]
             Union[
                 OneOrMany[Embedding],
@@ -82,7 +82,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         )
 
         self._client._add(
-            embedding_set["ids"],
+            cast(IDs, embedding_set["ids"]),
             self.id,
             cast(Embeddings, embedding_set["embeddings"]),
             embedding_set["metadatas"],
@@ -257,10 +257,11 @@ class Collection(CollectionCommon["ServerAPI"]):
         Returns:
             None
         """
-        embedding_set = self._process_update_request(
+        embedding_set = self._process_upsert_or_update_request(
             ids, embeddings, metadatas, documents, images, uris
         )
 
+<<<<<<< HEAD
         self._client._update(
             self.id,
             embedding_set["ids"],
@@ -269,6 +270,9 @@ class Collection(CollectionCommon["ServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
+=======
+        self._client._update(self.id, cast(IDs, embedding_set["ids"]), cast(Embeddings, embedding_set["embeddings"]), embedding_set["metadatas"], embedding_set["documents"], embedding_set["uris"])
+>>>>>>> b7728942 (resolve merge conflicts)
 
     def upsert(
         self,
@@ -295,13 +299,13 @@ class Collection(CollectionCommon["ServerAPI"]):
         Returns:
             None
         """
-        embedding_set = self._process_upsert_request(
+        embedding_set = self._process_upsert_or_update_request(
             ids, embeddings, metadatas, documents, images, uris
         )
 
         self._client._upsert(
             collection_id=self.id,
-            ids=embedding_set["ids"],
+            ids=cast(IDs, embedding_set["ids"]),
             embeddings=cast(Embeddings, embedding_set["embeddings"]),
             metadatas=embedding_set["metadatas"],
             documents=embedding_set["documents"],

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -9,6 +9,7 @@ from chromadb.api.types import (
     Include,
     Metadata,
     Document,
+    AddResult,
     Image,
     Where,
     IDs,
@@ -40,7 +41,7 @@ class Collection(CollectionCommon["ServerAPI"]):
 
     def add(
         self,
-        ids: Optional[OneOrMany[ID]],
+        ids: Optional[OneOrMany[ID]] = None,
         embeddings: Optional[  # type: ignore[type-arg]
             Union[
                 OneOrMany[Embedding],
@@ -51,7 +52,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         documents: Optional[OneOrMany[Document]] = None,
         images: Optional[OneOrMany[Image]] = None,
         uris: Optional[OneOrMany[URI]] = None,
-    ) -> None:
+    ) -> AddResult:
         """Add embeddings to the data store.
         Args:
             ids: The ids of the embeddings you wish to add
@@ -89,6 +90,10 @@ class Collection(CollectionCommon["ServerAPI"]):
             embedding_set["documents"],
             embedding_set["uris"],
         )
+        
+        return {
+            "ids": embedding_set["ids"],
+        }
 
     def get(
         self,

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -10,7 +10,7 @@ from typing import (
     cast,
 )
 import numpy as np
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import chromadb.utils.embedding_functions as ef
 from chromadb.api.types import (
@@ -151,7 +151,7 @@ class CollectionCommon(Generic[ClientT]):
 
     def _unpack_embedding_set(
         self,
-        ids: OneOrMany[ID],
+        ids: Optional[OneOrMany[ID]],
         embeddings: Optional[
             Union[
                 OneOrMany[Embedding],
@@ -181,7 +181,7 @@ class CollectionCommon(Generic[ClientT]):
 
     def _validate_embedding_set(
         self,
-        ids: IDs,
+        ids: Optional[IDs],
         embeddings: Optional[Embeddings],
         metadatas: Optional[Metadatas],
         documents: Optional[Documents],
@@ -197,10 +197,6 @@ class CollectionCommon(Generic[ClientT]):
             validate_metadatas(metadatas) if metadatas is not None else None
         )
 
-        valid_documents = maybe_cast_one_to_many_document(documents)
-        valid_images = maybe_cast_one_to_many_image(images)
-        valid_uris = maybe_cast_one_to_many_uri(uris)
-
         # Check that one of embeddings or ducuments or images is provided
         if require_embeddings_or_data:
             if (
@@ -214,7 +210,7 @@ class CollectionCommon(Generic[ClientT]):
                 )
 
         # Only one of documents or images can be provided
-        if valid_documents is not None and valid_images is not None:
+        if documents is not None and images is not None:
             raise ValueError("You can only provide documents or images, not both.")
 
         # Check that, if they're provided, the lengths of the arrays match the length of ids
@@ -226,17 +222,17 @@ class CollectionCommon(Generic[ClientT]):
             raise ValueError(
                 f"Number of metadatas {len(valid_metadatas)} must match number of ids {len(valid_ids)}"
             )
-        if valid_documents is not None and len(valid_documents) != len(valid_ids):
+        if documents is not None and len(documents) != len(valid_ids):
             raise ValueError(
-                f"Number of documents {len(valid_documents)} must match number of ids {len(valid_ids)}"
+                f"Number of documents {len(documents)} must match number of ids {len(valid_ids)}"
             )
-        if valid_images is not None and len(valid_images) != len(valid_ids):
+        if images is not None and len(images) != len(valid_ids):
             raise ValueError(
-                f"Number of images {len(valid_images)} must match number of ids {len(valid_ids)}"
+                f"Number of images {len(images)} must match number of ids {len(valid_ids)}"
             )
-        if valid_uris is not None and len(valid_uris) != len(valid_ids):
+        if uris is not None and len(uris) != len(valid_ids):
             raise ValueError(
-                f"Number of uris {len(valid_uris)} must match number of ids {len(valid_ids)}"
+                f"Number of uris {len(uris)} must match number of ids {len(valid_ids)}"
             )
 
     def _prepare_embeddings(
@@ -426,9 +422,39 @@ class CollectionCommon(Generic[ClientT]):
         if metadata:
             self._model["metadata"] = metadata
 
+<<<<<<< HEAD
+=======
+    @staticmethod
+    def _generate_ids_when_not_present(
+        ids: Optional[IDs],
+        documents: Optional[Documents],
+        uris: Optional[URIs],
+        images: Optional[Images],
+        embeddings: Optional[Embeddings],
+    ) -> IDs:
+        if ids is not None and len(ids) > 0:
+            return ids
+
+        n = 0
+        if documents is not None:
+            n = len(documents)
+        elif uris is not None:
+            n = len(uris)
+        elif images is not None:
+            n = len(images)
+        elif embeddings is not None:
+            n = len(embeddings)
+
+        generated_ids = []
+        for _ in range(n):
+            generated_ids.append(str(uuid4()))
+
+        return generated_ids
+    
+>>>>>>> b7728942 (resolve merge conflicts)
     def _process_add_request(
         self,
-        ids: OneOrMany[ID],
+        ids: Optional[OneOrMany[ID]],
         embeddings: Optional[
             Union[
                 OneOrMany[Embedding],
@@ -454,9 +480,17 @@ class CollectionCommon(Generic[ClientT]):
             if unpacked_embedding_set["embeddings"] is not None
             else None
         )
+        
+        generated_ids = self._generate_ids_when_not_present(
+            unpacked_embedding_set["ids"],
+            unpacked_embedding_set["documents"],
+            unpacked_embedding_set["uris"],
+            unpacked_embedding_set["images"],
+            normalized_embeddings,
+        )
 
         self._validate_embedding_set(
-            unpacked_embedding_set["ids"],
+            generated_ids,
             normalized_embeddings,
             unpacked_embedding_set["metadatas"],
             unpacked_embedding_set["documents"],
@@ -473,7 +507,7 @@ class CollectionCommon(Generic[ClientT]):
         )
 
         return {
-            "ids": unpacked_embedding_set["ids"],
+            "ids": generated_ids,
             "embeddings": prepared_embeddings,
             "metadatas": unpacked_embedding_set["metadatas"],
             "documents": unpacked_embedding_set["documents"],
@@ -481,7 +515,7 @@ class CollectionCommon(Generic[ClientT]):
             "uris": unpacked_embedding_set["uris"],
         }
 
-    def _prepare_update_request(
+    def _prepare_upsert_or_update_request(
         self,
         embeddings: Optional[Embeddings],
         documents: Optional[Documents],
@@ -495,7 +529,12 @@ class CollectionCommon(Generic[ClientT]):
 
         return cast(Embeddings, embeddings)
 
+<<<<<<< HEAD
     def _process_update_request(
+=======
+
+    def _process_upsert_or_update_request(
+>>>>>>> b7728942 (resolve merge conflicts)
         self,
         ids: OneOrMany[ID],
         embeddings: Optional[  # type: ignore[type-arg]
@@ -528,6 +567,7 @@ class CollectionCommon(Generic[ClientT]):
             unpacked_embedding_set["uris"],
             require_embeddings_or_data=False,
         )
+<<<<<<< HEAD
 
         prepared_embeddings = self._prepare_update_request(
             normalized_embeddings,
@@ -593,6 +633,10 @@ class CollectionCommon(Generic[ClientT]):
         )
 
         prepared_embeddings = self._prepare_upsert_request(
+=======
+
+        prepared_embeddings = self._prepare_upsert_or_update_request(
+>>>>>>> b7728942 (resolve merge conflicts)
             normalized_embeddings,
             unpacked_embedding_set["documents"],
             unpacked_embedding_set["images"],

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -422,8 +422,6 @@ class CollectionCommon(Generic[ClientT]):
         if metadata:
             self._model["metadata"] = metadata
 
-<<<<<<< HEAD
-=======
     @staticmethod
     def _generate_ids_when_not_present(
         ids: Optional[IDs],
@@ -450,8 +448,7 @@ class CollectionCommon(Generic[ClientT]):
             generated_ids.append(str(uuid4()))
 
         return generated_ids
-    
->>>>>>> b7728942 (resolve merge conflicts)
+
     def _process_add_request(
         self,
         ids: Optional[OneOrMany[ID]],
@@ -480,7 +477,7 @@ class CollectionCommon(Generic[ClientT]):
             if unpacked_embedding_set["embeddings"] is not None
             else None
         )
-        
+
         generated_ids = self._generate_ids_when_not_present(
             unpacked_embedding_set["ids"],
             unpacked_embedding_set["documents"],
@@ -529,12 +526,7 @@ class CollectionCommon(Generic[ClientT]):
 
         return cast(Embeddings, embeddings)
 
-<<<<<<< HEAD
-    def _process_update_request(
-=======
-
     def _process_upsert_or_update_request(
->>>>>>> b7728942 (resolve merge conflicts)
         self,
         ids: OneOrMany[ID],
         embeddings: Optional[  # type: ignore[type-arg]
@@ -567,76 +559,8 @@ class CollectionCommon(Generic[ClientT]):
             unpacked_embedding_set["uris"],
             require_embeddings_or_data=False,
         )
-<<<<<<< HEAD
-
-        prepared_embeddings = self._prepare_update_request(
-            normalized_embeddings,
-            unpacked_embedding_set["documents"],
-            unpacked_embedding_set["images"],
-        )
-
-        return {
-            "ids": unpacked_embedding_set["ids"],
-            "embeddings": prepared_embeddings,
-            "metadatas": unpacked_embedding_set["metadatas"],
-            "documents": unpacked_embedding_set["documents"],
-            "images": unpacked_embedding_set["images"],
-            "uris": unpacked_embedding_set["uris"],
-        }
-
-    def _prepare_upsert_request(
-        self,
-        embeddings: Optional[Embeddings],
-        documents: Optional[Documents],
-        images: Optional[Images],
-    ) -> Embeddings:
-        if embeddings is None:
-            if documents is not None:
-                embeddings = self._embed(input=documents)
-            elif images is not None:
-                embeddings = self._embed(input=images)
-
-        return cast(Embeddings, embeddings)
-
-    def _process_upsert_request(
-        self,
-        ids: OneOrMany[ID],
-        embeddings: Optional[  # type: ignore[type-arg]
-            Union[
-                OneOrMany[Embedding],
-                OneOrMany[np.ndarray],
-            ]
-        ],
-        metadatas: Optional[OneOrMany[Metadata]],
-        documents: Optional[OneOrMany[Document]],
-        images: Optional[OneOrMany[Image]],
-        uris: Optional[OneOrMany[URI]],
-    ) -> EmbeddingSet:
-        unpacked_embedding_set = self._unpack_embedding_set(
-            ids, embeddings, metadatas, documents, images, uris
-        )
-
-        normalized_embeddings = (
-            self._normalize_embeddings(unpacked_embedding_set["embeddings"])
-            if unpacked_embedding_set["embeddings"] is not None
-            else None
-        )
-
-        self._validate_embedding_set(
-            unpacked_embedding_set["ids"],
-            normalized_embeddings,
-            unpacked_embedding_set["metadatas"],
-            unpacked_embedding_set["documents"],
-            unpacked_embedding_set["images"],
-            unpacked_embedding_set["uris"],
-            require_embeddings_or_data=False,
-        )
-
-        prepared_embeddings = self._prepare_upsert_request(
-=======
 
         prepared_embeddings = self._prepare_upsert_or_update_request(
->>>>>>> b7728942 (resolve merge conflicts)
             normalized_embeddings,
             unpacked_embedding_set["documents"],
             unpacked_embedding_set["images"],

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -200,8 +200,10 @@ D = TypeVar("D", bound=Embeddable, contravariant=True)
 Loadable = List[Optional[Image]]
 L = TypeVar("L", covariant=True, bound=Loadable)
 
+
 class AddResult(TypedDict):
     ids: IDs
+
 
 class GetResult(TypedDict):
     ids: List[ID]

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -200,6 +200,8 @@ D = TypeVar("D", bound=Embeddable, contravariant=True)
 Loadable = List[Optional[Image]]
 L = TypeVar("L", covariant=True, bound=Loadable)
 
+class AddResult(TypedDict):
+    ids: IDs
 
 class GetResult(TypedDict):
     ids: List[ID]

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -292,6 +292,10 @@ def validate_ids(ids: IDs) -> IDs:
     for id_ in ids:
         if not isinstance(id_, str):
             raise ValueError(f"Expected ID to be a str, got {id_}")
+
+        if len(id_) == 0:
+            raise ValueError("Expected ID to be a non-empty str, got an empty string")
+        
         if id_ in seen:
             dups.add(id_)
         else:

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -295,7 +295,7 @@ def validate_ids(ids: IDs) -> IDs:
 
         if len(id_) == 0:
             raise ValueError("Expected ID to be a non-empty str, got an empty string")
-        
+
         if id_ in seen:
             dups.add(id_)
         else:

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -458,17 +458,26 @@ def recordsets(
     num_unique_metadata: Optional[int] = None,
     min_metadata_size: int = 0,
     max_metadata_size: Optional[int] = None,
+    # ids can only be optional for add operations
+    for_add: bool = False,
 ) -> RecordSet:
     collection = draw(collection_strategy)
-
     ids = list(
         draw(st.lists(id_strategy, min_size=min_size, max_size=max_size, unique=True))
     )
+    
+    # This probablistic event is used to mimic user behavior when they don't provide ids
+    if for_add and np.random.rand() < 0.5:
+        ids = []
+        
+    n = len(ids)
+    if len(ids) == 0:
+        n = int(draw(st.integers(min_value=min_size, max_value=max_size)))
 
     embeddings: Optional[Embeddings] = None
     if collection.has_embeddings:
-        embeddings = create_embeddings(collection.dimension, len(ids), collection.dtype)
-    num_metadata = num_unique_metadata if num_unique_metadata is not None else len(ids)
+        embeddings = create_embeddings(collection.dimension, n, collection.dtype)
+    num_metadata = num_unique_metadata if num_unique_metadata is not None else n
     generated_metadatas = draw(
         st.lists(
             metadata(
@@ -479,20 +488,20 @@ def recordsets(
         )
     )
     metadatas = []
-    for i in range(len(ids)):
+    for i in range(n):
         metadatas.append(generated_metadatas[i % len(generated_metadatas)])
 
     documents: Optional[Documents] = None
     if collection.has_documents:
         documents = draw(
-            st.lists(document(collection), min_size=len(ids), max_size=len(ids))
+            st.lists(document(collection), min_size=n, max_size=n)
         )
 
     # in the case where we have a single record, sometimes exercise
     # the code that handles individual values rather than lists.
     # In this case, any field may be a list or a single value.
-    if len(ids) == 1:
-        single_id: Union[str, List[str]] = ids[0] if draw(st.booleans()) else ids
+    if n == 1:
+        single_id: Union[str, List[str]] = ids[0] if len(ids) == 1 else ids
         single_embedding = (
             embeddings[0]
             if embeddings is not None and draw(st.booleans())

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -465,11 +465,11 @@ def recordsets(
     ids = list(
         draw(st.lists(id_strategy, min_size=min_size, max_size=max_size, unique=True))
     )
-    
+
     # This probablistic event is used to mimic user behavior when they don't provide ids
     if for_add and np.random.rand() < 0.5:
         ids = []
-        
+
     n = len(ids)
     if len(ids) == 0:
         n = int(draw(st.integers(min_value=min_size, max_value=max_size)))
@@ -493,9 +493,7 @@ def recordsets(
 
     documents: Optional[Documents] = None
     if collection.has_documents:
-        documents = draw(
-            st.lists(document(collection), min_size=n, max_size=n)
-        )
+        documents = draw(st.lists(document(collection), min_size=n, max_size=n))
 
     # in the case where we have a single record, sometimes exercise
     # the code that handles individual values rather than lists.

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -8,7 +8,13 @@ import hypothesis.strategies as st
 from hypothesis import given, settings, HealthCheck
 from typing import Dict, Set, cast, Union, DefaultDict, Any, List
 from dataclasses import dataclass
-from chromadb.api.types import ID, Embeddings, Include, IDs, validate_embeddings, maybe_cast_one_to_many_ids
+from chromadb.api.types import (
+    ID,
+    Embeddings,
+    Include,
+    IDs,
+    validate_embeddings,
+)
 from chromadb.config import System
 import chromadb.errors as errors
 from chromadb.api import ClientAPI
@@ -114,7 +120,10 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
             record_set
         )
 
-        if normalized_record_set["metadatas"] is not None and len(normalized_record_set["metadatas"]) > 0:
+        if (
+            normalized_record_set["metadatas"] is not None
+            and len(normalized_record_set["metadatas"]) > 0
+        ):
             trace("add_more_embeddings")
 
         intersection = set(normalized_record_set["ids"]).intersection(
@@ -144,9 +153,9 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
             result = self.collection.add(**normalized_record_set)  # type: ignore[arg-type]
             ids = result["ids"]
             normalized_record_set["ids"] = ids
-        
+
             self._upsert_embeddings(cast(strategies.RecordSet, normalized_record_set))
-            
+
             return multiple(*ids)
 
     @rule(ids=st.lists(consumes(embedding_ids), min_size=1))
@@ -688,6 +697,8 @@ def test_add_delete_add(client: ClientAPI) -> None:
     state.fields_match()
     if not NOT_CLUSTER_ONLY:
         state.wait_for_compaction()
+
+
 def test_multi_add(client: ClientAPI) -> None:
     reset(client)
     coll = client.create_collection(name="foo")

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1207,6 +1207,11 @@ def test_invalid_id(client):
         collection.add(embeddings=[0, 0, 0], ids=[1], metadatas=[{}])
     assert "ID" in str(e.value)
 
+    # Upsert with an empty id
+    with pytest.raises(ValueError) as e:
+        collection.upsert(embeddings=[0, 0, 0], ids=[""])
+    assert "non-empty" in str(e.value)
+
     # Get with non-list id
     with pytest.raises(ValueError) as e:
         collection.get(ids=1)
@@ -1534,7 +1539,6 @@ def test_collection_upsert_with_invalid_collection_throws(client):
         InvalidCollectionException, match=r"Collection .* does not exist."
     ):
         collection.upsert(**initial_records)
-
 
 # test to make sure add, query, update, upsert error on invalid embeddings input
 

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -5,7 +5,7 @@ import httpx
 import chromadb
 from chromadb.errors import ChromaError
 from chromadb.api.fastapi import FastAPI
-from chromadb.api.types import QueryResult, EmbeddingFunction, Document, Image
+from chromadb.api.types import QueryResult, EmbeddingFunction, Document
 from chromadb.config import Settings
 from chromadb.errors import InvalidCollectionException
 import chromadb.server.fastapi

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -5,7 +5,7 @@ import httpx
 import chromadb
 from chromadb.errors import ChromaError
 from chromadb.api.fastapi import FastAPI
-from chromadb.api.types import QueryResult, EmbeddingFunction, Document
+from chromadb.api.types import QueryResult, EmbeddingFunction, Document, Image
 from chromadb.config import Settings
 from chromadb.errors import InvalidCollectionException
 import chromadb.server.fastapi

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -1540,6 +1540,7 @@ def test_collection_upsert_with_invalid_collection_throws(client):
     ):
         collection.upsert(**initial_records)
 
+
 # test to make sure add, query, update, upsert error on invalid embeddings input
 
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Refactored functions to adhere to SRP to reduce the level of abstractions. 
 - New functionality
	 - when a user uses add and upsert on an collection, they are no longer required to pass in an array of IDs. They will be automatically generated if not given. 

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
