### PR TITLE
[ENH] Weighted LRU for HNSW provider cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "async-trait",
  "chroma-config",
  "chroma-error",
+ "chroma-types",
  "foyer",
  "parking_lot",
  "serde",

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -10,6 +10,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::Value;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::io::SeekFrom;
 use thiserror::Error;
@@ -34,6 +35,12 @@ pub struct Block {
     // These are stored in sorted order by prefix and key for efficient lookups.
     pub data: RecordBatch,
     pub id: Uuid,
+}
+
+impl Value for Block {
+    fn size(&self) -> usize {
+        self.get_size()
+    }
 }
 
 impl Block {

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -10,7 +10,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_types::Value;
+use chroma_types::Cacheable;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::io::SeekFrom;
 use thiserror::Error;
@@ -37,8 +37,8 @@ pub struct Block {
     pub id: Uuid,
 }
 
-impl Value for Block {
-    fn size(&self) -> usize {
+impl Cacheable for Block {
+    fn weight(&self) -> usize {
         self.get_size()
     }
 }

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -37,11 +37,7 @@ pub struct Block {
     pub id: Uuid,
 }
 
-impl Cacheable for Block {
-    fn weight(&self) -> usize {
-        self.get_size()
-    }
-}
+impl Cacheable for Block {}
 
 impl Block {
     /// Create a concrete block from an id and the underlying record batch of data

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -9,8 +9,8 @@ use arrow::{
     array::{Array, StringArray},
     record_batch::RecordBatch,
 };
+use chroma_cache::cache::Cacheable;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_types::Cacheable;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::io::SeekFrom;
 use thiserror::Error;

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -81,11 +81,7 @@ pub struct SparseIndex {
     pub(super) id: Uuid,
 }
 
-impl Cacheable for SparseIndex {
-    fn weight(&self) -> usize {
-        self.forward.lock().len()
-    }
-}
+impl Cacheable for SparseIndex {}
 
 impl SparseIndex {
     pub(super) fn new(id: Uuid) -> Self {

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -1,6 +1,6 @@
 use crate::key::{CompositeKey, KeyWrapper};
+use chroma_cache::cache::Cacheable;
 use chroma_error::ChromaError;
-use chroma_types::Cacheable;
 use core::panic;
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashMap};

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -1,5 +1,6 @@
 use crate::key::{CompositeKey, KeyWrapper};
 use chroma_error::ChromaError;
+use chroma_types::Value;
 use core::panic;
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashMap};
@@ -78,6 +79,12 @@ pub struct SparseIndex {
     pub(super) forward: Arc<Mutex<BTreeMap<SparseIndexDelimiter, Uuid>>>,
     reverse: Arc<Mutex<HashMap<Uuid, SparseIndexDelimiter>>>,
     pub(super) id: Uuid,
+}
+
+impl Value for SparseIndex {
+    fn size(&self) -> usize {
+        self.forward.lock().len()
+    }
 }
 
 impl SparseIndex {

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -1,6 +1,6 @@
 use crate::key::{CompositeKey, KeyWrapper};
 use chroma_error::ChromaError;
-use chroma_types::Value;
+use chroma_types::Cacheable;
 use core::panic;
 use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashMap};
@@ -81,8 +81,8 @@ pub struct SparseIndex {
     pub(super) id: Uuid,
 }
 
-impl Value for SparseIndex {
-    fn size(&self) -> usize {
+impl Cacheable for SparseIndex {
+    fn weight(&self) -> usize {
         self.forward.lock().len()
     }
 }

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -16,3 +16,4 @@ parking_lot = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
+chroma-types = { workspace = true}

--- a/rust/cache/src/cache.rs
+++ b/rust/cache/src/cache.rs
@@ -28,7 +28,9 @@ impl<
     pub fn new(config: &CacheConfig) -> Self {
         match config {
             CacheConfig::Unbounded(_) => Cache::Unbounded(UnboundedCache::new(config)),
-            _ => Cache::Foyer(FoyerCacheWrapper::new(config)),
+            CacheConfig::Lru(_) => Cache::Foyer(FoyerCacheWrapper::new(config)),
+            CacheConfig::Lfu(_) => Cache::Foyer(FoyerCacheWrapper::new(config)),
+            CacheConfig::WeightedLru(_) => Cache::Foyer(FoyerCacheWrapper::new(config)),
         }
     }
 
@@ -111,7 +113,9 @@ where
             CacheConfig::Unbounded(_) => UnboundedCache {
                 cache: Arc::new(RwLock::new(HashMap::new())),
             },
-            _ => panic!("Invalid cache configuration"),
+            CacheConfig::Lru(_) => panic!("Invalid cache configuration"),
+            CacheConfig::Lfu(_) => panic!("Invalid cache configuration"),
+            CacheConfig::WeightedLru(_) => panic!("Invalid cache configuration"),
         }
     }
 

--- a/rust/cache/src/cache.rs
+++ b/rust/cache/src/cache.rs
@@ -2,6 +2,7 @@ use crate::config::CacheConfig;
 use async_trait::async_trait;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::Value;
 use core::hash::Hash;
 use foyer::{Cache as FoyerCache, CacheBuilder, LfuConfig, LruConfig};
 use parking_lot::RwLock;
@@ -13,13 +14,13 @@ use thiserror::Error;
 pub enum Cache<K, V>
 where
     K: Send + Sync + Clone + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     Unbounded(UnboundedCache<K, V>),
     Foyer(FoyerCacheWrapper<K, V>),
 }
 
-impl<K: Send + Sync + Clone + Hash + Eq + 'static, V: Send + Sync + Clone + 'static> Cache<K, V> {
+impl<K: Send + Sync + Clone + Hash + Eq + 'static, V: Value> Cache<K, V> {
     pub fn new(config: &CacheConfig) -> Self {
         match config {
             CacheConfig::Unbounded(_) => Cache::Unbounded(UnboundedCache::new(config)),
@@ -91,7 +92,7 @@ impl<K: Send + Sync + Clone + Hash + Eq + 'static, V: Send + Sync + Clone + 'sta
 pub struct UnboundedCache<K, V>
 where
     K: Send + Sync + Clone + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     cache: Arc<RwLock<HashMap<K, V>>>,
 }
@@ -99,7 +100,7 @@ where
 impl<K, V> UnboundedCache<K, V>
 where
     K: Send + Sync + Clone + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     pub fn new(config: &CacheConfig) -> Self {
         match config {
@@ -140,7 +141,7 @@ where
 pub struct FoyerCacheWrapper<K, V>
 where
     K: Send + Sync + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     cache: FoyerCache<K, V>,
 }
@@ -148,15 +149,16 @@ where
 impl<K, V> FoyerCacheWrapper<K, V>
 where
     K: Send + Sync + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     pub fn new(config: &CacheConfig) -> Self {
         match config {
             CacheConfig::Lru(lru) => {
                 // TODO: add more eviction config
                 let eviction_config = LruConfig::default();
-                let cache_builder =
-                    CacheBuilder::new(lru.capacity).with_eviction_config(eviction_config);
+                let cache_builder = CacheBuilder::new(lru.capacity)
+                    .with_eviction_config(eviction_config)
+                    .with_weighter(|_key: &_, value: &V| value.size());
                 FoyerCacheWrapper {
                     cache: cache_builder.build(),
                 }
@@ -164,8 +166,9 @@ where
             CacheConfig::Lfu(lfu) => {
                 // TODO: add more eviction config
                 let eviction_config = LfuConfig::default();
-                let cache_builder =
-                    CacheBuilder::new(lfu.capacity).with_eviction_config(eviction_config);
+                let cache_builder = CacheBuilder::new(lfu.capacity)
+                    .with_eviction_config(eviction_config)
+                    .with_weighter(|_key: &_, value: &V| value.size());
                 FoyerCacheWrapper {
                     cache: cache_builder.build(),
                 }
@@ -198,7 +201,7 @@ where
 impl<K, V> Configurable<CacheConfig> for UnboundedCache<K, V>
 where
     K: Send + Sync + Clone + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     async fn try_from_config(config: &CacheConfig) -> Result<Self, Box<dyn ChromaError>> {
         match config {
@@ -212,7 +215,7 @@ where
 impl<K, V> Configurable<CacheConfig> for FoyerCacheWrapper<K, V>
 where
     K: Send + Sync + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     async fn try_from_config(config: &CacheConfig) -> Result<Self, Box<dyn ChromaError>> {
         match config {

--- a/rust/cache/src/cache.rs
+++ b/rust/cache/src/cache.rs
@@ -2,7 +2,6 @@ use crate::config::CacheConfig;
 use async_trait::async_trait;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_types::Cacheable;
 use core::hash::Hash;
 use foyer::{Cache as FoyerCache, CacheBuilder, LfuConfig, LruConfig};
 use parking_lot::RwLock;
@@ -182,7 +181,7 @@ where
             CacheConfig::WeightedLru(weighted_lru) => {
                 // TODO: add more eviction config
                 let eviction_config = LruConfig::default();
-                let cache_builder = CacheBuilder::new(weighted_lru.capacity_bytes)
+                let cache_builder = CacheBuilder::new(weighted_lru.capacity)
                     .with_eviction_config(eviction_config)
                     .with_weighter(|_key: &_, value: &V| value.weight());
                 FoyerCacheWrapper {
@@ -256,5 +255,12 @@ impl ChromaError for CacheConfigError {
         match self {
             CacheConfigError::InvalidCacheConfig => ErrorCodes::InvalidArgument,
         }
+    }
+}
+
+pub trait Cacheable {
+    // By default the weight of a type that is cacheable is 1.
+    fn weight(&self) -> usize {
+        return 1;
     }
 }

--- a/rust/cache/src/config.rs
+++ b/rust/cache/src/config.rs
@@ -28,5 +28,5 @@ pub struct LfuConfig {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct WeightedLruConfig {
-    pub capacity_bytes: usize,
+    pub capacity: usize,
 }

--- a/rust/cache/src/config.rs
+++ b/rust/cache/src/config.rs
@@ -9,6 +9,8 @@ pub enum CacheConfig {
     Lru(LruConfig),
     #[serde(alias = "lfu")]
     Lfu(LfuConfig),
+    #[serde(alias = "weighted_lru")]
+    WeightedLru(WeightedLruConfig),
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -22,4 +24,9 @@ pub struct LruConfig {
 #[derive(Deserialize, Debug, Clone)]
 pub struct LfuConfig {
     pub capacity: usize,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct WeightedLruConfig {
+    pub capacity_bytes: usize,
 }

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -5,12 +5,13 @@ use crate::cache::Cache;
 use crate::config::CacheConfig;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
+use chroma_types::Value;
 use std::hash::Hash;
 
 pub async fn from_config<K, V>(config: &CacheConfig) -> Result<Cache<K, V>, Box<dyn ChromaError>>
 where
     K: Send + Sync + Clone + Hash + Eq + 'static,
-    V: Send + Sync + Clone + 'static,
+    V: Value,
 {
     match config {
         CacheConfig::Unbounded(_) => Ok(Cache::Unbounded(

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -3,9 +3,9 @@ pub mod config;
 
 use crate::cache::Cache;
 use crate::config::CacheConfig;
+use cache::Cacheable;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
-use chroma_types::Cacheable;
 use std::hash::Hash;
 
 pub async fn from_config<K, V>(config: &CacheConfig) -> Result<Cache<K, V>, Box<dyn ChromaError>>

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -5,19 +5,25 @@ use crate::cache::Cache;
 use crate::config::CacheConfig;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
-use chroma_types::Value;
+use chroma_types::Cacheable;
 use std::hash::Hash;
 
 pub async fn from_config<K, V>(config: &CacheConfig) -> Result<Cache<K, V>, Box<dyn ChromaError>>
 where
     K: Send + Sync + Clone + Hash + Eq + 'static,
-    V: Value,
+    V: Send + Sync + Clone + Cacheable + 'static,
 {
     match config {
         CacheConfig::Unbounded(_) => Ok(Cache::Unbounded(
             crate::cache::UnboundedCache::try_from_config(config).await?,
         )),
-        _ => Ok(Cache::Foyer(
+        CacheConfig::Lru(_) => Ok(Cache::Foyer(
+            crate::cache::FoyerCacheWrapper::try_from_config(config).await?,
+        )),
+        CacheConfig::Lfu(_) => Ok(Cache::Foyer(
+            crate::cache::FoyerCacheWrapper::try_from_config(config).await?,
+        )),
+        CacheConfig::WeightedLru(_) => Ok(Cache::Foyer(
             crate::cache::FoyerCacheWrapper::try_from_config(config).await?,
         )),
     }

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -125,7 +125,7 @@ impl HnswIndexConfig {
 /// synchronize access to the index between reads and writes.
 pub struct HnswIndex {
     ffi_ptr: *const IndexPtrFFI,
-    dimensionality: i32,
+    pub dimensionality: i32,
     pub id: Uuid,
 }
 

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -125,7 +125,7 @@ impl HnswIndexConfig {
 /// synchronize access to the index between reads and writes.
 pub struct HnswIndex {
     ffi_ptr: *const IndexPtrFFI,
-    pub dimensionality: i32,
+    dimensionality: i32,
     pub id: Uuid,
 }
 
@@ -328,6 +328,10 @@ impl HnswIndex {
     pub fn len(&self) -> usize {
         unsafe { len(self.ffi_ptr) as usize }
         // Does not return an error
+    }
+
+    pub fn dimensionality(&self) -> i32 {
+        self.dimensionality
     }
 
     pub fn capacity(&self) -> usize {

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -12,8 +12,7 @@ use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use chroma_error::ErrorCodes;
 use chroma_storage::Storage;
-use chroma_types::Segment;
-use chroma_types::Value;
+use chroma_types::{Cacheable, Segment};
 use parking_lot::RwLock;
 use rand::seq::index;
 use std::fmt::Debug;
@@ -60,8 +59,8 @@ pub struct HnswIndexRef {
     inner: Arc<RwLock<HnswIndex>>,
 }
 
-impl Value for HnswIndexRef {
-    fn size(&self) -> usize {
+impl Cacheable for HnswIndexRef {
+    fn weight(&self) -> usize {
         let index = self.inner.read();
         index.len() * std::mem::size_of::<f32>() * index.dimensionality as usize
     }

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -62,6 +62,9 @@ pub struct HnswIndexRef {
 impl Cacheable for HnswIndexRef {
     fn weight(&self) -> usize {
         let index = self.inner.read();
+        if index.len() == 0 {
+            return 1;
+        }
         index.len() * std::mem::size_of::<f32>() * index.dimensionality() as usize
     }
 }

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -7,12 +7,12 @@ use super::{
 };
 
 use async_trait::async_trait;
-use chroma_cache::cache::Cache;
+use chroma_cache::cache::{Cache, Cacheable};
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use chroma_error::ErrorCodes;
 use chroma_storage::Storage;
-use chroma_types::{Cacheable, Segment};
+use chroma_types::Segment;
 use parking_lot::RwLock;
 use rand::seq::index;
 use std::fmt::Debug;
@@ -62,7 +62,7 @@ pub struct HnswIndexRef {
 impl Cacheable for HnswIndexRef {
     fn weight(&self) -> usize {
         let index = self.inner.read();
-        index.len() * std::mem::size_of::<f32>() * index.dimensionality as usize
+        index.len() * std::mem::size_of::<f32>() * index.dimensionality() as usize
     }
 }
 

--- a/rust/types/src/types.rs
+++ b/rust/types/src/types.rs
@@ -31,10 +31,3 @@ impl ChromaError for ConversionError {
         }
     }
 }
-
-pub trait Cacheable {
-    // By default the weight of a type that is cacheable is 1.
-    fn weight(&self) -> usize {
-        return 1;
-    }
-}

--- a/rust/types/src/types.rs
+++ b/rust/types/src/types.rs
@@ -32,8 +32,9 @@ impl ChromaError for ConversionError {
     }
 }
 
-pub trait Value: Send + Sync + Clone + 'static {
-    fn size(&self) -> usize {
+pub trait Cacheable {
+    // By default the weight of a type that is cacheable is 1.
+    fn weight(&self) -> usize {
         return 1;
     }
 }

--- a/rust/types/src/types.rs
+++ b/rust/types/src/types.rs
@@ -31,3 +31,9 @@ impl ChromaError for ConversionError {
         }
     }
 }
+
+pub trait Value: Send + Sync + Clone + 'static {
+    fn size(&self) -> usize {
+        return 1;
+    }
+}

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -59,7 +59,7 @@ query_service:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
-                capacity_bytes: 8589934592 # 8GB
+                capacity: 8589934592 # 8GB
 
 compaction_service:
     service_name: "compaction-service"
@@ -124,4 +124,4 @@ compaction_service:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
-                capacity_bytes: 8589934592 # 8GB
+                capacity: 8589934592 # 8GB

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -58,8 +58,8 @@ query_service:
     hnsw_provider:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
-            lru:
-                capacity: 1000
+            weighted_lru:
+                capacity_bytes: 8 * 1024 * 1024 * 1024 # 8GB
 
 compaction_service:
     service_name: "compaction-service"
@@ -123,5 +123,5 @@ compaction_service:
     hnsw_provider:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
-            lru:
-                capacity: 1000
+            weighted_lru:
+                capacity_bytes: 8 * 1024 * 1024 * 1024 # 8GB

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -59,7 +59,7 @@ query_service:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
-                capacity_bytes: 8 * 1024 * 1024 * 1024 # 8GB
+                capacity_bytes: 8589934592 # 8GB
 
 compaction_service:
     service_name: "compaction-service"
@@ -124,4 +124,4 @@ compaction_service:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
-                capacity_bytes: 8 * 1024 * 1024 * 1024 # 8GB
+                capacity_bytes: 8589934592 # 8GB

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -200,7 +200,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1073741824
+                                capacity: 1073741824
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -265,7 +265,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1073741824
+                                capacity: 1073741824
                 "#,
             );
             let config = RootConfig::load();
@@ -344,7 +344,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1073741824
+                                capacity: 1073741824
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -409,7 +409,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1073741824
+                                capacity: 1073741824
                 "#,
             );
             let config = RootConfig::load_from_path("random_path.yaml");

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -199,8 +199,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity_bytes: 1 * 1024 * 1024 * 1024
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -264,8 +264,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity_bytes: 1 * 1024 * 1024 * 1024
                 "#,
             );
             let config = RootConfig::load();
@@ -343,8 +343,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity_bytes: 1 * 1024 * 1024 * 1024
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -408,8 +408,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity_bytes: 1 * 1024 * 1024 * 1024
                 "#,
             );
             let config = RootConfig::load_from_path("random_path.yaml");
@@ -505,8 +505,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity: 1 * 1024 * 1024 * 1024
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -570,8 +570,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity: 1 * 1024 * 1024 * 1024
                 "#,
             );
             let config = RootConfig::load();
@@ -669,8 +669,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity: 1 * 1024 * 1024 * 1024
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -720,8 +720,8 @@ mod tests {
                     hnsw_provider:
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
-                            lru:
-                                capacity: 1000
+                            weighted_lru:
+                                capacity: 1 * 1024 * 1024 * 1024
                 "#,
             );
             let config = RootConfig::load();

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -506,7 +506,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity: 1 * 1024 * 1024 * 1024
+                                capacity: 1073741824
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -571,7 +571,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity: 1 * 1024 * 1024 * 1024
+                                capacity: 1073741824
                 "#,
             );
             let config = RootConfig::load();
@@ -670,7 +670,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity: 1 * 1024 * 1024 * 1024
+                                capacity: 1073741824
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -721,7 +721,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity: 1 * 1024 * 1024 * 1024
+                                capacity: 1073741824
                 "#,
             );
             let config = RootConfig::load();

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -200,7 +200,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1 * 1024 * 1024 * 1024
+                                capacity_bytes: 1073741824
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -265,7 +265,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1 * 1024 * 1024 * 1024
+                                capacity_bytes: 1073741824
                 "#,
             );
             let config = RootConfig::load();
@@ -344,7 +344,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1 * 1024 * 1024 * 1024
+                                capacity_bytes: 1073741824
 
                 compaction_service:
                     service_name: "compaction-service"
@@ -409,7 +409,7 @@ mod tests {
                         hnsw_temporary_path: "~/tmp"
                         hnsw_cache_config:
                             weighted_lru:
-                                capacity_bytes: 1 * 1024 * 1024 * 1024
+                                capacity_bytes: 1073741824
                 "#,
             );
             let config = RootConfig::load_from_path("random_path.yaml");


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Made HNSW cache weighted LRU where the weight is the size of the value.
	 - Changed the config to have capacity in terms of bytes and not counts

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
