### PR TITLE
[PERF] Multipart s3 downloads passing through NAC

### DIFF
--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -188,7 +188,6 @@ impl HnswIndexProvider {
         index_storage_path: &Path,
     ) -> Result<(), Box<HnswIndexProviderFileError>> {
         // Fetch the files from storage and put them in the index storage path.
-        // TODO: Fetch multiple chunks in parallel from S3.
         for file in FILES.iter() {
             let key = self.format_key(source_id, file);
             tracing::info!("Loading hnsw index file: {}", key);

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -192,7 +192,7 @@ impl HnswIndexProvider {
         for file in FILES.iter() {
             let key = self.format_key(source_id, file);
             tracing::info!("Loading hnsw index file: {}", key);
-            let bytes_res = self.storage.get(&key).await;
+            let bytes_res = self.storage.get_parallel(&key).await;
             let bytes_read;
             let buf = match bytes_res {
                 Ok(buf) => {

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -6,11 +6,14 @@ use crate::{
 use async_trait::async_trait;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
-use futures::{future::Shared, FutureExt, Stream};
+use futures::{future::Shared, stream, FutureExt, Stream, StreamExt};
 use parking_lot::Mutex;
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 use thiserror::Error;
-use tokio::sync::{Semaphore, SemaphorePermit};
+use tokio::{
+    io::AsyncReadExt,
+    sync::{Semaphore, SemaphorePermit},
+};
 use tracing::{Instrument, Span};
 
 /// Wrapper over s3 storage that provides proxy features such as
@@ -94,10 +97,69 @@ impl AdmissionControlledS3Storage {
         }
     }
 
-    async fn read_from_storage(
+    async fn parallel_fetch(
         storage: S3Storage,
+        rate_limiter: Arc<RateLimitPolicy>,
         key: String,
     ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
+        let (content_length, ranges) = storage.get_key_ranges(&key).await;
+        let part_size = storage.download_part_size_bytes;
+        tracing::info!(
+            "[AdmissionControlledS3][Parallel fetch] Content length: {}, key ranges: {:?}",
+            content_length,
+            ranges
+        );
+        let mut output_buffer: Vec<u8> = vec![0; content_length as usize];
+        let mut output_slices = output_buffer.chunks_mut(part_size).collect::<Vec<_>>();
+        let range_and_output_slices = ranges.iter().zip(output_slices.drain(..));
+        let mut futures = Vec::new();
+        let mut permits = Vec::new();
+        let num_parts = range_and_output_slices.len();
+        for (range, output_slice) in range_and_output_slices {
+            // Acquire permit.
+            permits.push(rate_limiter.enter().await);
+            let range_str = format!("bytes={}-{}", range.0, range.1);
+            let fut = storage
+                .fetch_range(key.clone(), range_str)
+                .then(|res| async move {
+                    match res {
+                        Ok(output) => {
+                            let body = output.body;
+                            let mut reader = body.into_async_read();
+                            match reader.read_exact(output_slice).await {
+                                Ok(_) => Ok(()),
+                                Err(e) => {
+                                    tracing::error!("Error reading from s3: {}", e);
+                                    return Err(AdmissionControlledS3StorageError::S3GetError(
+                                        S3GetError::ByteStreamError(e.to_string()),
+                                    ));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("Error reading from s3: {}", e);
+                            return Err(AdmissionControlledS3StorageError::S3GetError(e));
+                        }
+                    }
+                });
+            futures.push(fut);
+        }
+        // Await all futures and return the result.
+        let _ = stream::iter(futures)
+            .buffer_unordered(num_parts)
+            .collect::<Vec<_>>()
+            .await;
+        Ok(Arc::new(output_buffer))
+        // All the permits get dropped due to RAII here.
+    }
+
+    async fn read_from_storage(
+        storage: S3Storage,
+        rate_limiter: Arc<RateLimitPolicy>,
+        key: String,
+    ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
+        // Acquire permit.
+        let permit = rate_limiter.enter().await;
         let bytes_res = storage
             .get(&key)
             .instrument(tracing::trace_span!(parent: Span::current(), "S3 get"))
@@ -111,6 +173,42 @@ impl AdmissionControlledS3Storage {
                 return Err(AdmissionControlledS3StorageError::S3GetError(e));
             }
         }
+        // Permit gets dropped here due to RAII.
+    }
+
+    pub async fn get_parallel(
+        &self,
+        key: String,
+    ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
+        // If there is a duplicate request and the original request finishes
+        // before we look it up in the map below then we will end up with another
+        // request to S3.
+        let future_to_await;
+        {
+            let mut requests = self.outstanding_requests.lock();
+            let maybe_inflight = requests.get(&key).map(|fut| fut.clone());
+            future_to_await = match maybe_inflight {
+                Some(fut) => fut,
+                None => {
+                    let get_parallel_storage_future = AdmissionControlledS3Storage::parallel_fetch(
+                        self.storage.clone(),
+                        self.rate_limiter.clone(),
+                        key.clone(),
+                    )
+                    .boxed()
+                    .shared();
+                    requests.insert(key.clone(), get_parallel_storage_future.clone());
+                    get_parallel_storage_future
+                }
+            };
+        }
+
+        let res = future_to_await.await;
+        {
+            let mut requests = self.outstanding_requests.lock();
+            requests.remove(&key);
+        }
+        res
     }
 
     pub async fn get(
@@ -119,32 +217,25 @@ impl AdmissionControlledS3Storage {
     ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
         // If there is a duplicate request and the original request finishes
         // before we look it up in the map below then we will end up with another
-        // request to S3. We rely on synchronization on the cache
-        // by the upstream consumer to make sure that this works correctly.
+        // request to S3.
         let future_to_await;
-        let is_dupe: bool;
         {
             let mut requests = self.outstanding_requests.lock();
             let maybe_inflight = requests.get(&key).map(|fut| fut.clone());
-            (future_to_await, is_dupe) = match maybe_inflight {
-                Some(fut) => (fut, true),
+            future_to_await = match maybe_inflight {
+                Some(fut) => fut,
                 None => {
                     let get_storage_future = AdmissionControlledS3Storage::read_from_storage(
                         self.storage.clone(),
+                        self.rate_limiter.clone(),
                         key.clone(),
                     )
                     .boxed()
                     .shared();
                     requests.insert(key.clone(), get_storage_future.clone());
-                    (get_storage_future, false)
+                    get_storage_future
                 }
             };
-        }
-
-        // Acquire permit.
-        let permit: SemaphorePermit<'_>;
-        if is_dupe {
-            permit = self.rate_limiter.enter().await;
         }
 
         let res = future_to_await.await;
@@ -152,9 +243,7 @@ impl AdmissionControlledS3Storage {
             let mut requests = self.outstanding_requests.lock();
             requests.remove(&key);
         }
-
         res
-        // Permit gets dropped here since it is RAII.
     }
 
     pub async fn put_file(&self, key: &str, path: &str) -> Result<(), S3PutError> {
@@ -243,6 +332,8 @@ impl Configurable<RateLimitingConfig> for RateLimitPolicy {
 mod tests {
     use std::sync::Arc;
 
+    use rand::{distributions::Alphanumeric, Rng};
+
     use crate::{admissioncontrolleds3::AdmissionControlledS3Storage, s3::S3Storage};
 
     fn get_s3_client() -> aws_sdk_s3::Client {
@@ -267,6 +358,54 @@ mod tests {
         aws_sdk_s3::Client::from_conf(config)
     }
 
+    async fn test_multipart_get_for_size(value_size: usize) {
+        let client = get_s3_client();
+
+        let storage = S3Storage {
+            bucket: "test".to_string(),
+            client,
+            upload_part_size_bytes: 1024 * 1024 * 8,
+            download_part_size_bytes: 1024 * 1024 * 8,
+        };
+        storage.create_bucket().await.unwrap();
+        let admission_controlled_storage =
+            AdmissionControlledS3Storage::new_with_default_policy(storage);
+
+        // Randomly generate a 16 byte utf8 string.
+        let test_data_key: String = rand::thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect();
+        // Randomly generate 19 MB of data.
+        let test_data_value_string: String = rand::thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(value_size)
+            .map(char::from)
+            .collect();
+        admission_controlled_storage
+            .put_bytes(
+                test_data_key.as_str(),
+                test_data_value_string.as_bytes().to_vec(),
+            )
+            .await
+            .unwrap();
+        println!(
+            "Wrote key {} with value of size {}",
+            test_data_key,
+            test_data_value_string.len()
+        );
+
+        // Parallel fetch.
+        let buf = admission_controlled_storage
+            .get_parallel(test_data_key.to_string())
+            .await
+            .unwrap();
+
+        let buf = String::from_utf8(Arc::unwrap_or_clone(buf)).unwrap();
+        assert_eq!(buf, test_data_value_string);
+    }
+
     #[tokio::test]
     #[cfg(CHROMA_KUBERNETES_INTEGRATION)]
     async fn test_put_get_key() {
@@ -276,6 +415,7 @@ mod tests {
             bucket: "test".to_string(),
             client,
             upload_part_size_bytes: 1024 * 1024 * 8,
+            download_part_size_bytes: 1024 * 1024 * 8,
         };
         storage.create_bucket().await.unwrap();
         let admission_controlled_storage =
@@ -294,5 +434,16 @@ mod tests {
 
         let buf = String::from_utf8(Arc::unwrap_or_clone(buf)).unwrap();
         assert_eq!(buf, test_data);
+    }
+
+    #[tokio::test]
+    #[cfg(CHROMA_KUBERNETES_INTEGRATION)]
+    async fn test_multipart_get() {
+        // At 8 MB.
+        test_multipart_get_for_size(1024 * 1024 * 8).await;
+        // At < 8 MB.
+        test_multipart_get_for_size(1024 * 1024 * 7).await;
+        // At > 8 MB.
+        test_multipart_get_for_size(1024 * 1024 * 19).await;
     }
 }

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -33,6 +33,7 @@ pub struct S3StorageConfig {
     pub connect_timeout_ms: u64,
     pub request_timeout_ms: u64,
     pub upload_part_size_bytes: usize,
+    pub download_part_size_bytes: usize,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -106,7 +106,13 @@ impl Storage {
                     },
                 }
             }
-            Storage::Local(_) => unimplemented!(),
+            Storage::Local(local) => {
+                let res = local.get(key).await;
+                match res {
+                    Ok(res) => Ok(res),
+                    Err(e) => Err(GetError::LocalError(e)),
+                }
+            }
             Storage::AdmissionControlledS3(admission_controlled_storage) => {
                 let res = admission_controlled_storage
                     .get_parallel(key.to_string())

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -16,8 +16,11 @@ use async_trait::async_trait;
 use aws_config::retry::RetryConfig;
 use aws_config::timeout::TimeoutConfigBuilder;
 use aws_sdk_s3;
+use aws_sdk_s3::config::http::HttpResponse;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::create_bucket::CreateBucketError;
+use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::CompletedMultipartUpload;
 use aws_sdk_s3::types::CompletedPart;
@@ -35,6 +38,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
+use tokio::io::AsyncReadExt;
 use tracing::Instrument;
 use tracing::Span;
 
@@ -43,6 +47,7 @@ pub struct S3Storage {
     pub(super) bucket: String,
     pub(super) client: aws_sdk_s3::Client,
     pub(super) upload_part_size_bytes: usize,
+    pub(super) download_part_size_bytes: usize,
 }
 
 #[derive(Error, Debug)]
@@ -76,11 +81,17 @@ impl ChromaError for S3GetError {
 }
 
 impl S3Storage {
-    fn new(bucket: &str, client: aws_sdk_s3::Client, upload_part_size_bytes: usize) -> S3Storage {
+    fn new(
+        bucket: &str,
+        client: aws_sdk_s3::Client,
+        upload_part_size_bytes: usize,
+        download_part_size_bytes: usize,
+    ) -> S3Storage {
         return S3Storage {
             bucket: bucket.to_string(),
             client,
             upload_part_size_bytes,
+            download_part_size_bytes,
         };
     }
 
@@ -167,6 +178,118 @@ impl S3Storage {
                 return Err(S3GetError::S3GetError(e.to_string()));
             }
         }
+    }
+
+    pub(super) async fn get_key_ranges(&self, key: &str) -> (i64, Vec<(i64, i64)>) {
+        let part_size = self.download_part_size_bytes as i64;
+        let head_res = self
+            .client
+            .head_object()
+            .bucket(self.bucket.clone())
+            .key(key)
+            .send()
+            .await;
+        let content_length = match head_res {
+            Ok(res) => match res.content_length {
+                Some(len) => len,
+                None => {
+                    panic!("No content length in head response");
+                }
+            },
+            Err(e) => {
+                panic!("Error in head request: {:?}", e);
+            }
+        };
+        // Round up.
+        let num_parts = (content_length as f64 / part_size as f64).ceil() as i64;
+        let mut ranges = Vec::new();
+        for i in 0..num_parts {
+            let start = i * part_size;
+            let end = if i == num_parts - 1 {
+                content_length - 1
+            } else {
+                (i + 1) * part_size - 1
+            };
+            ranges.push((start, end));
+        }
+        (content_length, ranges)
+    }
+
+    pub(super) async fn fetch_range(
+        &self,
+        key: String,
+        range_str: String,
+    ) -> Result<GetObjectOutput, S3GetError> {
+        let res = self
+            .client
+            .get_object()
+            .bucket(self.bucket.clone())
+            .key(key)
+            .range(range_str)
+            .send()
+            .await;
+        match res {
+            Ok(output) => Ok(output),
+            Err(e) => {
+                tracing::error!("Error fetching range: {:?}", e);
+                match e {
+                    SdkError::ServiceError(err) => {
+                        let inner = err.into_err();
+                        match inner {
+                            aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(msg) => {
+                                return Err(S3GetError::NoSuchKey(msg.to_string()));
+                            }
+                            aws_sdk_s3::operation::get_object::GetObjectError::InvalidObjectState(msg) => {
+                                return Err(S3GetError::S3GetError(msg.to_string()));
+                            }
+                            aws_sdk_s3::operation::get_object::GetObjectError::Unhandled(_) => {
+                                return Err(S3GetError::S3GetError("unhandled error".to_string()));
+                            }
+                            _ => {
+                                return Err(S3GetError::S3GetError(inner.to_string()));
+                            }
+                        };
+                    }
+                    _ => {
+                        return Err(S3GetError::S3GetError(e.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, S3GetError> {
+        let (content_length, ranges) = self.get_key_ranges(key).await;
+        let part_size = self.download_part_size_bytes;
+        let mut output_buffer: Vec<u8> = vec![0; content_length as usize];
+        let mut output_slices = output_buffer.chunks_mut(part_size).collect::<Vec<_>>();
+        let range_and_output_slices = ranges.iter().zip(output_slices.drain(..));
+        let mut get_futures = Vec::new();
+        for (range, output_slice) in range_and_output_slices {
+            let range_str = format!("bytes={}-{}", range.0, range.1);
+            let fut = self
+                .fetch_range(key.to_string(), range_str)
+                .then(|res| async move {
+                    match res {
+                        Ok(res) => {
+                            let body = res.body;
+                            let mut reader = body.into_async_read();
+                            match reader.read_exact(output_slice).await {
+                                Ok(_) => Ok(()),
+                                Err(e) => {
+                                    tracing::error!("Error reading range: {:?}", e);
+                                    Err(S3GetError::ByteStreamError(e.to_string()))
+                                }
+                            }
+                        }
+                        Err(e) => Err(e),
+                    }
+                });
+            get_futures.push(fut);
+        }
+        // Await all futures and return the result.
+        futures::future::join_all(get_futures).await;
+        Ok(Arc::new(output_buffer))
     }
 
     pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, S3GetError> {
@@ -431,8 +554,12 @@ impl Configurable<StorageConfig> for S3Storage {
                         aws_sdk_s3::Client::new(&config)
                     }
                 };
-                let storage =
-                    S3Storage::new(&s3_config.bucket, client, s3_config.upload_part_size_bytes);
+                let storage = S3Storage::new(
+                    &s3_config.bucket,
+                    client,
+                    s3_config.upload_part_size_bytes,
+                    s3_config.download_part_size_bytes,
+                );
                 // for minio we create the bucket since it is only used for testing
                 match &s3_config.credentials {
                     super::config::S3CredentialsConfig::Minio => {
@@ -495,6 +622,7 @@ mod tests {
             bucket: "test".to_string(),
             client,
             upload_part_size_bytes: 1024 * 1024 * 8,
+            download_part_size_bytes: 1024 * 1024 * 8,
         };
         storage.create_bucket().await.unwrap();
 
@@ -522,13 +650,18 @@ mod tests {
         assert_eq!(buf, test_data);
     }
 
-    async fn test_put_file(file_size: usize, upload_part_size_bytes: usize) {
+    async fn test_put_file(
+        file_size: usize,
+        upload_part_size_bytes: usize,
+        download_part_size_bytes: usize,
+    ) {
         let client = get_s3_client();
 
         let storage = S3Storage {
             bucket: "test".to_string(),
             client,
             upload_part_size_bytes,
+            download_part_size_bytes,
         };
         storage.create_bucket().await.unwrap();
 
@@ -572,19 +705,27 @@ mod tests {
     #[cfg(CHROMA_KUBERNETES_INTEGRATION)]
     async fn test_put_file_scenarios() {
         let test_upload_part_size_bytes = 1024 * 1024 * 8; // 8MB
+        let test_download_part_size_bytes = 1024 * 1024 * 8; // 8MB
 
         // Under part size
-        test_put_file(1024, test_upload_part_size_bytes).await;
+        test_put_file(
+            1024,
+            test_upload_part_size_bytes,
+            test_download_part_size_bytes,
+        )
+        .await;
         // At part size
         test_put_file(
             test_upload_part_size_bytes as usize,
             test_upload_part_size_bytes,
+            test_download_part_size_bytes,
         )
         .await;
         // Over part size
         test_put_file(
             (test_upload_part_size_bytes as f64 * 2.5) as usize,
             test_upload_part_size_bytes,
+            test_download_part_size_bytes,
         )
         .await;
     }

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -30,6 +30,7 @@ query_service:
                 connect_timeout_ms: 5000
                 request_timeout_ms: 30000 # 1 minute
                 upload_part_size_bytes: 536870912 # 512MiB
+                download_part_size_bytes: 8388608 # 8MiB
             rate_limiting_policy:
                 CountBasedPolicy:
                     max_concurrent_requests: 15
@@ -87,6 +88,7 @@ compaction_service:
                 connect_timeout_ms: 5000
                 request_timeout_ms: 60000 # 1 minute
                 upload_part_size_bytes: 536870912 # 512MiB
+                download_part_size_bytes: 8388608 # 8MiB
             rate_limiting_policy:
                 CountBasedPolicy:
                     max_concurrent_requests: 15

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -171,6 +171,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -228,6 +229,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -311,6 +313,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -368,6 +371,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -469,6 +473,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -526,6 +531,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -590,6 +596,10 @@ mod tests {
                 format!("{}", 1024 * 1024 * 8),
             );
             let _ = jail.set_env(
+                "CHROMA_COMPACTION_SERVICE__STORAGE__S3__download_part_size_bytes",
+                format!("{}", 1024 * 1024 * 8),
+            );
+            let _ = jail.set_env(
                 "CHROMA_COMPACTION_SERVICE__STORAGE__S3__CONNECT_TIMEOUT_MS",
                 5000,
             );
@@ -625,6 +635,7 @@ mod tests {
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
                                 upload_part_size_bytes: 8388608
+                                download_part_size_bytes: 8388608
                             rate_limiting_policy:
                                 CountBasedPolicy:
                                     max_concurrent_requests: 15
@@ -723,6 +734,7 @@ mod tests {
                     assert_eq!(s.connect_timeout_ms, 5000);
                     assert_eq!(s.request_timeout_ms, 1000);
                     assert_eq!(s.upload_part_size_bytes, 1024 * 1024 * 8);
+                    assert_eq!(s.download_part_size_bytes, 1024 * 1024 * 8);
                 }
                 _ => panic!("Invalid storage config"),
             }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Introduces a parallel fetch API that splits up gets into 8 MB parallel downloads
 - This passes through Admission control so it is rate limited and deduped
 - HNSW provider consumes this API

## Test plan
Added rust test
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
