### PR TITLE
[ENH] Evict other versions of hnsw index of the collection when another version is fetched

### DIFF
--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -324,7 +324,7 @@ impl DistributedHNSWSegmentReader {
             };
 
             let index =
-                match hnsw_index_provider.get(&index_uuid) {
+                match hnsw_index_provider.get(&index_uuid, &segment.collection) {
                     Some(index) => index,
                     None => {
                         match hnsw_index_provider


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 It was seen that query nodes OOM in load tests. One area where we could optimize the memory footprint is the HNSW index cache. This PR restricts the cache to keep one entry per collection. Ideally, we would like the index version of this entry to be of the latest but there is no guarantee with this PR. Once the versioning changes land, we could improve this. For e.g. one bad case could be:
For the same collection:
1. get index version v1
2. get index version v2 (> v1)
3. get index version v1 (can happen due to an inflight query that started before compaction of v2 occured) -- this will evict v2 even though it is more recent and will be used again in future

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
