### PR TITLE
[CLN] Move validation logic to server

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -25,8 +25,8 @@ from chromadb.api.types import (
     GetResult,
     QueryResult,
     CollectionMetadata,
-    validate_batch,
     convert_np_embeddings_to_list,
+    validate_batch,
 )
 from chromadb.auth import (
     ClientAuthProvider,

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -57,7 +57,7 @@ Embeddings = List[Embedding]
 
 
 def maybe_cast_one_to_many_embedding(
-    target: Union[OneOrMany[Embedding], OneOrMany[PyEmbedding]]
+    target: Union[Optional[OneOrMany[Embedding]], Optional[OneOrMany[PyEmbedding]]]
 ) -> Optional[Embeddings]:
     if target is None:
         return None
@@ -614,6 +614,37 @@ def validate_batch(
         raise ValueError(
             f"Batch size {len(batch[0])} exceeds maximum batch size {limits['max_batch_size']}"
         )
+
+
+def validate_record_set(
+    record_set: RecordSet,
+    require_data: bool,
+) -> None:
+    validate_ids(record_set["ids"])
+    validate_embeddings(record_set["embeddings"]) if record_set[
+        "embeddings"
+    ] is not None else None
+    validate_metadatas(record_set["metadatas"]) if record_set[
+        "metadatas"
+    ] is not None else None
+
+    # Only one of documents or images can be provided
+    if record_set["documents"] is not None and record_set["images"] is not None:
+        raise ValueError("You can only provide documents or images, not both.")
+
+    required_fields: Include = ["embeddings", "documents", "images", "uris"]  # type: ignore[list-item]
+    if not require_data:
+        required_fields += ["metadatas"]  # type: ignore[list-item]
+
+    if not record_set_contains_one_of(record_set, include=required_fields):
+        raise ValueError(f"You must provide one of {', '.join(required_fields)}")
+
+    valid_ids = record_set["ids"]
+    for key in ["embeddings", "metadatas", "documents", "images", "uris"]:
+        if record_set[key] is not None and len(record_set[key]) != len(valid_ids):  # type: ignore[literal-required]
+            raise ValueError(
+                f"Number of {key} {len(record_set[key])} must match number of ids {len(valid_ids)}"  # type: ignore[literal-required]
+            )
 
 
 def convert_np_embeddings_to_list(embeddings: Embeddings) -> PyEmbeddings:

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -20,6 +20,13 @@ class ChromaError(Exception, EnforceOverrides):
         pass
 
 
+class InvalidInputException(ChromaError):
+    @classmethod
+    @overrides
+    def name(cls) -> str:
+        return "InvalidInput"
+
+
 class InvalidDimensionException(ChromaError):
     @classmethod
     @overrides
@@ -137,6 +144,7 @@ class VersionMismatchError(ChromaError):
 
 
 error_types: Dict[str, Type[ChromaError]] = {
+    "InvalidInput": InvalidInputException,
     "InvalidDimension": InvalidDimensionException,
     "InvalidCollection": InvalidCollectionException,
     "IDAlreadyExists": IDAlreadyExistsError,

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -10,9 +10,9 @@ from typing import Dict, Set, cast, Union, DefaultDict, Any, List
 from dataclasses import dataclass
 from chromadb.api.types import (
     ID,
-    Embeddings,
     Include,
     IDs,
+    Embeddings,
     validate_embeddings,
     maybe_cast_one_to_many_embedding,
 )
@@ -803,7 +803,6 @@ def test_autocasting_validate_embeddings_for_compatible_types(
     supported_types: List[Any],
 ) -> None:
     embds = strategies.create_embeddings(10, 10, supported_types)
-
     validated_embeddings = validate_embeddings(maybe_cast_one_to_many_embedding(embds))  # type: ignore[arg-type]
     assert all(
         [

--- a/clients/js/src/ChromaFetch.ts
+++ b/clients/js/src/ChromaFetch.ts
@@ -59,7 +59,7 @@ export const chromaFetch: FetchAPI = async (
       switch (resp.status) {
         case 400:
           throw new ChromaClientError(
-            `Bad request to ${input} with status: ${resp.statusText}`,
+            `Bad request to ${input} with message: ${respBody?.message}`,
           );
         case 401:
           throw new ChromaUnauthorizedError(`Unauthorized`);

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -133,11 +133,9 @@ describe("add collections", () => {
     const ids = IDS.concat(["test1"]);
     const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
     const metadatas = METADATAS.concat([{ test: "test1", float_value: 0.1 }]);
-    try {
+    expect(async () => {
       await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("duplicates");
-    }
+    }).rejects.toThrow("found duplicates");
   });
 
   test("should error on empty embedding", async () => {
@@ -145,11 +143,9 @@ describe("add collections", () => {
     const ids = ["id1"];
     const embeddings = [[]];
     const metadatas = [{ test: "test1", float_value: 0.1 }];
-    try {
+    expect(async () => {
       await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("got empty embedding at pos");
-    }
+    }).rejects.toThrow("got empty embedding at pos");
   });
 
   if (!process.env.OLLAMA_SERVER_URL) {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Move validation logic for embedding set operations from client to server
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
