### PR TITLE
[ENH]: skip querying `MetadataSegmentReader` for empty where clause

### DIFF
--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -356,10 +356,10 @@ def log_size_below_max(
         )
 
         # -1 is used because the queue is always at least 1 entry long, so deletion stops before the max ack'ed sequence ID.
-        # And if the batch_size != sync_threshold, the queue can have up to batch_size - 1 more entries.
+        # And if the batch_size != sync_threshold, the queue can have up to batch_size more entries.
         assert (
             _total_embedding_queue_log_size(sqlite) - 1
-            <= sync_threshold_sum + batch_size_sum - 1
+            <= sync_threshold_sum + batch_size_sum
         )
     else:
         assert _total_embedding_queue_log_size(sqlite) == 0

--- a/rust/worker/src/execution/operator.rs
+++ b/rust/worker/src/execution/operator.rs
@@ -124,6 +124,10 @@ where
 
         match result {
             Ok(result) => {
+                if let Err(err) = result.as_ref() {
+                    tracing::error!("Task {} failed with error: {:?}", self.task_id, err);
+                }
+
                 // If this (or similarly, the .send() below) errors, it means the receiver was dropped.
                 // There are valid reasons for this to happen (e.g. the component was stopped) so we ignore the error.
                 // Another valid case is when the PrefetchIoOperator finishes

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -1,12 +1,7 @@
 use crate::execution::dispatcher::Dispatcher;
 use crate::execution::operator::{wrap, TaskResult};
-use crate::execution::operators::merge_metadata_results::{
-    MergeMetadataResultsOperator, MergeMetadataResultsOperatorError,
-    MergeMetadataResultsOperatorInput, MergeMetadataResultsOperatorOutput,
-};
-use crate::execution::operators::metadata_filtering::{
-    MetadataFilteringError, MetadataFilteringInput, MetadataFilteringOperator,
-    MetadataFilteringOutput,
+use crate::execution::operators::count_records::{
+    CountRecordsError, CountRecordsInput, CountRecordsOperator, CountRecordsOutput,
 };
 use crate::execution::operators::pull_log::{PullLogsInput, PullLogsOperator, PullLogsOutput};
 use crate::execution::orchestration::common::terminate_with_error;
@@ -17,51 +12,30 @@ use crate::{log::log::Log, sysdb::sysdb::SysDb, system::System};
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_types::{Chunk, Segment};
-use chroma_types::{Collection, LogRecord, Metadata, SegmentType};
-use chroma_types::{Where, WhereDocument};
+use chroma_types::Segment;
+use chroma_types::{Collection, SegmentType};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use tracing::Span;
 use uuid::Uuid;
 
 #[derive(Debug)]
-enum ExecutionState {
-    Pending,
-    PullLogs,
-    Filter, // Filter logs and search metadata segment
-    MergeResults,
-}
-
-// Returns the ids, metadata, and documents
-type MetadataQueryOrchestratorResult =
-    Result<(Vec<String>, Vec<Option<Metadata>>, Vec<Option<String>>), Box<dyn ChromaError>>;
-
-#[derive(Debug)]
-pub(crate) struct MetadataQueryOrchestrator {
-    state: ExecutionState,
+pub(crate) struct CountQueryOrchestrator {
     // Component Execution
     system: System,
     // Query state
     metadata_segment_id: Uuid,
     collection_id: Uuid,
-    query_ids: Option<Vec<String>>,
     // State fetched or created for query execution
     record_segment: Option<Segment>,
-    metadata_segment: Option<Segment>,
     collection: Option<Collection>,
-    // State machine management
-    merge_dependency_count: u32,
     // Services
     log: Box<Log>,
     sysdb: Box<SysDb>,
     dispatcher: ComponentHandle<Dispatcher>,
     blockfile_provider: BlockfileProvider,
-    // Query params
-    where_clause: Option<Where>,
-    where_document_clause: Option<WhereDocument>,
     // Result channel
-    result_channel: Option<tokio::sync::oneshot::Sender<MetadataQueryOrchestratorResult>>,
+    result_channel: Option<tokio::sync::oneshot::Sender<Result<usize, Box<dyn ChromaError>>>>,
 }
 
 #[derive(Error, Debug)]
@@ -93,42 +67,33 @@ impl ChromaError for MetadataSegmentQueryError {
     }
 }
 
-impl MetadataQueryOrchestrator {
+impl CountQueryOrchestrator {
     pub(crate) fn new(
         system: System,
         metadata_segment_id: &Uuid,
         collection_id: &Uuid,
-        query_ids: Option<Vec<String>>,
         log: Box<Log>,
         sysdb: Box<SysDb>,
         dispatcher: ComponentHandle<Dispatcher>,
         blockfile_provider: BlockfileProvider,
-        where_clause: Option<Where>,
-        where_document_clause: Option<WhereDocument>,
     ) -> Self {
         Self {
-            state: ExecutionState::Pending,
             system,
             metadata_segment_id: *metadata_segment_id,
             collection_id: *collection_id,
-            query_ids,
             record_segment: None,
-            metadata_segment: None,
             collection: None,
-            merge_dependency_count: 2,
             log,
             sysdb,
             dispatcher,
             blockfile_provider,
-            where_clause,
-            where_document_clause,
             result_channel: None,
         }
     }
 
     async fn start(&mut self, ctx: &ComponentContext<Self>) {
-        tracing::info!("Starting Metadata Query Orchestrator");
-        // Populate the orchestrator with the initial state - The Metadata Segment, The Record Segment and the Collection
+        println!("Starting Count Query Orchestrator");
+        // Populate the orchestrator with the initial state - The Record Segment and the Collection
         let metdata_segment = self
             .get_metadata_segment_from_id(
                 self.sysdb.clone(),
@@ -140,13 +105,13 @@ impl MetadataQueryOrchestrator {
         let metadata_segment = match metdata_segment {
             Ok(segment) => segment,
             Err(e) => {
+                tracing::error!("Error getting metadata segment: {:?}", e);
                 terminate_with_error(self.result_channel.take(), e, ctx);
                 return;
             }
         };
 
         let collection_id = metadata_segment.collection;
-        self.metadata_segment = Some(metadata_segment);
 
         let record_segment = self
             .get_record_segment_from_collection_id(self.sysdb.clone(), &collection_id)
@@ -155,6 +120,7 @@ impl MetadataQueryOrchestrator {
         let record_segment = match record_segment {
             Ok(segment) => segment,
             Err(e) => {
+                tracing::error!("Error getting record segment: {:?}", e);
                 terminate_with_error(self.result_channel.take(), e, ctx);
                 return;
             }
@@ -166,6 +132,7 @@ impl MetadataQueryOrchestrator {
         {
             Ok(collection) => collection,
             Err(e) => {
+                tracing::error!("Error getting collection: {:?}", e);
                 terminate_with_error(self.result_channel.take(), e, ctx);
                 return;
             }
@@ -176,14 +143,14 @@ impl MetadataQueryOrchestrator {
     }
 
     async fn pull_logs(&mut self, ctx: &ComponentContext<Self>) {
-        println!("Pulling logs");
-        self.state = ExecutionState::PullLogs;
+        println!("Count query orchestrator pulling logs");
 
         let operator = PullLogsOperator::new(self.log.clone());
         let end_timestamp = SystemTime::now().duration_since(UNIX_EPOCH);
         let end_timestamp = match end_timestamp {
             Ok(end_timestamp) => end_timestamp.as_nanos() as i64,
             Err(e) => {
+                tracing::error!("Error getting system time: {:?}", e);
                 terminate_with_error(
                     self.result_channel.take(),
                     Box::new(MetadataSegmentQueryError::SystemTimeError(e)),
@@ -212,39 +179,7 @@ impl MetadataQueryOrchestrator {
             Err(e) => {
                 // Log an error - this implies the dispatcher was dropped somehow
                 // and is likely fatal
-                println!("Error sending Metadata Query task: {:?}", e);
-            }
-        }
-    }
-
-    async fn filter(&mut self, mut logs: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
-        tracing::debug!("Filtering logs and searching metadata segment");
-        self.state = ExecutionState::Filter;
-
-        let input = MetadataFilteringInput::new(
-            logs,
-            self.record_segment
-                .as_ref()
-                .expect("Expected record segment to be set")
-                .clone(),
-            self.metadata_segment
-                .as_ref()
-                .expect("Expected metadata segment to be set")
-                .clone(),
-            self.blockfile_provider.clone(),
-            self.where_clause.clone(),
-            self.where_document_clause.clone(),
-            self.query_ids.clone(),
-        );
-
-        let op = MetadataFilteringOperator::new();
-        let task = wrap(op, input, ctx.receiver());
-        match self.dispatcher.send(task, Some(Span::current())).await {
-            Ok(_) => (),
-            Err(e) => {
-                // Log an error - this implies the dispatcher was dropped somehow
-                // and is likely fatal
-                println!("Error sending Metadata Query task: {:?}", e);
+                println!("Error sending Count Query task: {:?}", e);
             }
         }
     }
@@ -344,7 +279,7 @@ impl MetadataQueryOrchestrator {
     ///  # Note
     ///  Use this over spawning the component directly. This method will start the component and
     ///  wait for it to finish before returning the result.
-    pub(crate) async fn run(mut self) -> MetadataQueryOrchestratorResult {
+    pub(crate) async fn run(mut self) -> Result<usize, Box<dyn ChromaError>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.result_channel = Some(tx);
         let mut handle = self.system.clone().start_component(self);
@@ -355,9 +290,9 @@ impl MetadataQueryOrchestrator {
 }
 
 #[async_trait]
-impl Component for MetadataQueryOrchestrator {
+impl Component for CountQueryOrchestrator {
     fn get_name() -> &'static str {
-        "Metadata Query Orchestrator"
+        "Count Query Orchestrator"
     }
 
     fn queue_size(&self) -> usize {
@@ -371,7 +306,7 @@ impl Component for MetadataQueryOrchestrator {
 }
 
 #[async_trait]
-impl Handler<TaskResult<PullLogsOutput, PullLogsError>> for MetadataQueryOrchestrator {
+impl Handler<TaskResult<PullLogsOutput, PullLogsError>> for CountQueryOrchestrator {
     type Result = ();
 
     async fn handle(
@@ -382,11 +317,26 @@ impl Handler<TaskResult<PullLogsOutput, PullLogsError>> for MetadataQueryOrchest
         let message = message.into_inner();
         match message {
             Ok(logs) => {
-                let logs = logs.logs();
-                self.filter(logs, ctx).await;
+                let operator = CountRecordsOperator::new();
+                let input = CountRecordsInput::new(
+                    self.record_segment
+                        .as_ref()
+                        .expect("Expect segment")
+                        .clone(),
+                    self.blockfile_provider.clone(),
+                    logs.logs(),
+                );
+                let msg = wrap(operator, input, ctx.receiver());
+                match self.dispatcher.send(msg, None).await {
+                    Ok(_) => (),
+                    Err(e) => {
+                        // Log an error - this implies the dispatcher was dropped somehow
+                        // and is likely fatal
+                        println!("Error sending Count Query task: {:?}", e);
+                    }
+                }
             }
             Err(e) => {
-                tracing::error!("Error pulling logs: {:?}", e);
                 terminate_with_error(self.result_channel.take(), Box::new(e), ctx);
             }
         }
@@ -394,86 +344,30 @@ impl Handler<TaskResult<PullLogsOutput, PullLogsError>> for MetadataQueryOrchest
 }
 
 #[async_trait]
-impl Handler<TaskResult<MetadataFilteringOutput, MetadataFilteringError>>
-    for MetadataQueryOrchestrator
-{
+impl Handler<TaskResult<CountRecordsOutput, CountRecordsError>> for CountQueryOrchestrator {
     type Result = ();
 
     async fn handle(
         &mut self,
-        message: TaskResult<MetadataFilteringOutput, MetadataFilteringError>,
+        message: TaskResult<CountRecordsOutput, CountRecordsError>,
         ctx: &ComponentContext<Self>,
     ) {
         let message = message.into_inner();
-        let output = match message {
-            Ok(output) => output,
+        let msg = match message {
+            Ok(m) => m,
             Err(e) => {
-                tracing::error!("Error merging metadata results: {:?}", e);
                 return terminate_with_error(self.result_channel.take(), Box::new(e), ctx);
             }
         };
-
-        self.state = ExecutionState::MergeResults;
-
-        let operator = MergeMetadataResultsOperator::new();
-        let input = MergeMetadataResultsOperatorInput::new(
-            output.log_records,
-            output.user_supplied_filtered_offset_ids,
-            output.where_condition_filtered_offset_ids,
-            self.record_segment
-                .as_ref()
-                .expect("Invariant violation. Record segment is not set.")
-                .clone(),
-            self.blockfile_provider.clone(),
-        );
-
-        let task = wrap(operator, input, ctx.receiver());
-        match self.dispatcher.send(task, Some(Span::current())).await {
-            Ok(_) => (),
-            Err(e) => {
-                // Log an error - this implies the dispatcher was dropped somehow
-                // and is likely fatal
-                println!("Error sending Metadata Query task: {:?}", e);
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl Handler<TaskResult<MergeMetadataResultsOperatorOutput, MergeMetadataResultsOperatorError>>
-    for MetadataQueryOrchestrator
-{
-    type Result = ();
-
-    async fn handle(
-        &mut self,
-        message: TaskResult<MergeMetadataResultsOperatorOutput, MergeMetadataResultsOperatorError>,
-        ctx: &ComponentContext<Self>,
-    ) {
-        let message = message.into_inner();
-        let output = match message {
-            Ok(output) => output,
-            Err(e) => {
-                tracing::error!("Error merging metadata results: {:?}", e);
-                return terminate_with_error(self.result_channel.take(), Box::new(e), ctx);
-            }
-        };
-
-        let result_channel = self
+        let channel = self
             .result_channel
             .take()
-            .expect("Invariant violation. Result channel is not set.");
-
-        let output = (output.ids, output.metadata, output.documents);
-        tracing::trace!("Merged metadata results: {:?}", output);
-
-        match result_channel.send(Ok(output)) {
+            .expect("Expect channel to be present");
+        match channel.send(Ok(msg.count)) {
             Ok(_) => (),
             Err(e) => {
                 // Log an error - this implied the listener was dropped
-                println!(
-                    "[MetadataQueryOrchestrator] Result channel dropped before sending result"
-                );
+                println!("[CountQueryOrchestrator] Result channel dropped before sending result");
             }
         }
     }

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -219,7 +219,7 @@ impl MetadataQueryOrchestrator {
         }
     }
 
-    async fn filter(&mut self, mut logs: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
+    async fn filter(&mut self, logs: Chunk<LogRecord>, ctx: &ComponentContext<Self>) {
         tracing::debug!("Filtering logs and searching metadata segment");
         self.state = ExecutionState::Filter;
 

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,9 +1,11 @@
 mod common;
 mod compact;
+mod count;
 mod get_vectors;
 mod hnsw;
 mod metadata;
 pub(crate) use compact::*;
+pub(crate) use count::*;
 pub(crate) use get_vectors::*;
 pub(crate) use hnsw::*;
 pub(crate) use metadata::*;


### PR DESCRIPTION
## Description of changes

Skips querying the `MetadataSegmentReader` when there's no where clause which should result in a performance bump.

Also splits the `CountQueryOrchestrator` into a new file.

## Test plan
*How are these changes tested?*

Covered by existing tests. Confirmed that the reader was not queried for a `.get()` call missing where clauses.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
