### PR TITLE
[ENH]: update JS CloudClient to accept `tenant` parameter

### DIFF
--- a/clients/js/src/CloudClient.ts
+++ b/clients/js/src/CloudClient.ts
@@ -7,12 +7,19 @@ import { AuthOptions } from "./auth";
 interface CloudClientParams {
   apiKey?: string;
   database?: string;
+  tenant?: string;
   cloudHost?: string;
   cloudPort?: string;
 }
 
 class CloudClient extends ChromaClient {
-  constructor({ apiKey, database, cloudHost, cloudPort }: CloudClientParams) {
+  constructor({
+    apiKey,
+    database,
+    tenant,
+    cloudHost,
+    cloudPort,
+  }: CloudClientParams) {
     // If no API key is provided, try to load it from the environment variable
     if (!apiKey) {
       apiKey = process.env.CHROMA_API_KEY;
@@ -35,7 +42,8 @@ class CloudClient extends ChromaClient {
     return new ChromaClient({
       path: path,
       auth: auth,
-      database: database,
+      database,
+      tenant,
     });
 
     super();


### PR DESCRIPTION
## Description of changes

Adds the `tenant` parameter to the JS CloudClient.

## Test plan
*How are these changes tested?*

Confirmed that the CloudClient now works with staging.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
