### PR TITLE
[PERF]: remove mutex around tokenizer

### DIFF
--- a/rust/index/src/fulltext/tokenizer.rs
+++ b/rust/index/src/fulltext/tokenizer.rs
@@ -1,9 +1,6 @@
-use parking_lot::Mutex;
-use std::sync::Arc;
 use tantivy::tokenizer::{NgramTokenizer, Token, TokenStream, Tokenizer};
 
 pub trait ChromaTokenStream: Send {
-    fn process(&mut self, sink: &mut dyn FnMut(&Token));
     fn get_tokens(&self) -> &Vec<Token>;
 }
 
@@ -18,36 +15,28 @@ impl TantivyChromaTokenStream {
 }
 
 impl ChromaTokenStream for TantivyChromaTokenStream {
-    fn process(&mut self, sink: &mut dyn FnMut(&Token)) {
-        for token in &self.tokens {
-            sink(token);
-        }
-    }
-
     fn get_tokens(&self) -> &Vec<Token> {
         &self.tokens
     }
 }
 
-pub trait ChromaTokenizer: Send {
+pub trait ChromaTokenizer: Send + Sync {
     fn encode(&self, text: &str) -> Box<dyn ChromaTokenStream>;
 }
 
 pub struct TantivyChromaTokenizer {
-    tokenizer: Arc<Mutex<Box<NgramTokenizer>>>,
+    tokenizer: NgramTokenizer,
 }
 
 impl TantivyChromaTokenizer {
-    pub fn new(tokenizer: Box<NgramTokenizer>) -> Self {
-        TantivyChromaTokenizer {
-            tokenizer: Arc::new(Mutex::new(tokenizer)),
-        }
+    pub fn new(tokenizer: NgramTokenizer) -> Self {
+        TantivyChromaTokenizer { tokenizer }
     }
 }
 
 impl ChromaTokenizer for TantivyChromaTokenizer {
     fn encode(&self, text: &str) -> Box<dyn ChromaTokenStream> {
-        let mut tokenizer = self.tokenizer.lock();
+        let mut tokenizer = self.tokenizer.clone();
         let mut token_stream = tokenizer.token_stream(text);
         let mut tokens = Vec::new();
         token_stream.process(&mut |token| {
@@ -61,22 +50,8 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_chroma_tokenizer() {
-        let tokenizer: Box<NgramTokenizer> = Box::new(NgramTokenizer::new(1, 1, false).unwrap());
-        let chroma_tokenizer = TantivyChromaTokenizer::new(tokenizer);
-        let mut token_stream = chroma_tokenizer.encode("hello world");
-        let mut tokens = Vec::new();
-        token_stream.process(&mut |token| {
-            tokens.push(token.clone());
-        });
-        assert_eq!(tokens.len(), 11);
-        assert_eq!(tokens[0].text, "h");
-        assert_eq!(tokens[1].text, "e");
-    }
-
-    #[test]
     fn test_get_tokens() {
-        let tokenizer: Box<NgramTokenizer> = Box::new(NgramTokenizer::new(1, 1, false).unwrap());
+        let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let chroma_tokenizer = TantivyChromaTokenizer::new(tokenizer);
         let token_stream = chroma_tokenizer.encode("hello world");
         let tokens = token_stream.get_tokens();

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -176,9 +176,9 @@ impl<'me> MetadataSegmentWriter<'me> {
         };
         let full_text_index_reader = match (pls_reader, freqs_reader) {
             (Some(pls_reader), Some(freqs_reader)) => {
-                let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+                let tokenizer = Box::new(TantivyChromaTokenizer::new(
                     NgramTokenizer::new(3, 3, false).unwrap(),
-                )));
+                ));
                 Some(FullTextIndexReader::new(
                     pls_reader,
                     freqs_reader,
@@ -189,9 +189,9 @@ impl<'me> MetadataSegmentWriter<'me> {
             _ => return Err(MetadataSegmentError::IncorrectNumberOfFiles),
         };
 
-        let full_text_writer_tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+        let full_text_writer_tokenizer = Box::new(TantivyChromaTokenizer::new(
             NgramTokenizer::new(3, 3, false).unwrap(),
-        )));
+        ));
         let full_text_index_writer = FullTextIndexWriter::new(
             full_text_index_reader,
             pls_writer,
@@ -1019,9 +1019,9 @@ impl MetadataSegmentReader<'_> {
         };
         let full_text_index_reader = match (pls_reader, freqs_reader) {
             (Some(pls_reader), Some(freqs_reader)) => {
-                let tokenizer = Box::new(TantivyChromaTokenizer::new(Box::new(
+                let tokenizer = Box::new(TantivyChromaTokenizer::new(
                     NgramTokenizer::new(3, 3, false).unwrap(),
-                )));
+                ));
                 Some(FullTextIndexReader::new(
                     pls_reader,
                     freqs_reader,


### PR DESCRIPTION
## Description of changes

Saves around 1,300ms when ingesting 15k documents (averaging 1000 chars each).

We spend 1.5x the tokenization time just cloning the tokens, which should be avoidable but is not included in this PR because the lifetimes get hairy and the % that tokenization takes in the total compaction time is currently fairly low.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - removes the mutex from the tokenizer, reducing overhead
	 - simplifies types by removing a `Box` wrapper

## Test plan
*How are these changes tested?*

Covered by existing tests.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
