### PR TITLE
[PERF] Move write to blockfiles off main runtime

### DIFF
--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -57,6 +57,24 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
     }
 
     async fn run(&self, input: &FlushS3Input) -> Result<FlushS3Output, Self::Error> {
+        // TODO: Ideally we shouldn't even have to make an explicit call to
+        // write_to_blockfiles since it is not the workflow for other segments
+        // and is exclusive to metadata segment. We should figure out a way
+        // to make this call a part of commit itself. It's not obvious directly
+        // how to do that since commit is per partition but write_to_blockfiles
+        // only need to be called once across all partitions combined.
+        let mut writer = input.metadata_segment_writer.clone();
+        match writer
+            .write_to_blockfiles()
+            .instrument(tracing::info_span!("Writing to blockfiles"))
+            .await
+        {
+            Ok(()) => (),
+            Err(e) => {
+                tracing::error!("Error writing metadata segment out to blockfiles: {:?}", e);
+                return Err(Box::new(e));
+            }
+        }
         let record_segment_flusher = input.record_segment_writer.clone().commit();
         let record_segment_flush_info = match record_segment_flusher {
             Ok(flusher) => {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - write_to_blockfiles is an intense operation, there should be no reason to hog the main runtime. Moved it to a worker thread as part of flush operation. I am hesitant to create a new operator exclusively for this as all of this seems temporary and eventually we want the blockfile to support read then write semantics

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
