### PR TITLE
[ENH]: purge block cache after compaction

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -79,20 +79,9 @@ impl ArrowBlockfileProvider {
         Ok(BlockfileWriter::ArrowBlockfileWriter(file))
     }
 
-    pub fn purge_all_entries(&self) {
-        loop {
-            match self.block_manager.block_cache.pop() {
-                Some(_) => {}
-                None => break,
-            }
-        }
-
-        loop {
-            match self.sparse_index_manager.cache.pop() {
-                Some(_) => {}
-                None => break,
-            }
-        }
+    pub fn clear(&self) {
+        self.block_manager.block_cache.clear();
+        self.sparse_index_manager.cache.clear();
     }
 
     pub async fn fork<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -80,12 +80,18 @@ impl ArrowBlockfileProvider {
     }
 
     pub fn purge_all_entries(&self) {
-        while let Some((key, _)) = self.block_manager.block_cache.pop() {
-            self.block_manager.block_cache.remove(&key);
+        loop {
+            match self.block_manager.block_cache.pop() {
+                Some(_) => {}
+                None => break,
+            }
         }
 
-        while let Some((key, _)) = self.sparse_index_manager.cache.pop() {
-            self.sparse_index_manager.cache.remove(&key);
+        loop {
+            match self.sparse_index_manager.cache.pop() {
+                Some(_) => {}
+                None => break,
+            }
         }
     }
 

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -79,6 +79,16 @@ impl ArrowBlockfileProvider {
         Ok(BlockfileWriter::ArrowBlockfileWriter(file))
     }
 
+    pub fn purge_all_entries(&self) {
+        while let Some((key, _)) = self.block_manager.block_cache.pop() {
+            self.block_manager.block_cache.remove(&key);
+        }
+
+        while let Some((key, _)) = self.sparse_index_manager.cache.pop() {
+            self.sparse_index_manager.cache.remove(&key);
+        }
+    }
+
     pub async fn fork<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(
         &self,
         id: &uuid::Uuid,

--- a/rust/blockstore/src/memory/provider.rs
+++ b/rust/blockstore/src/memory/provider.rs
@@ -49,8 +49,8 @@ impl MemoryBlockfileProvider {
         Ok(BlockfileWriter::MemoryBlockfileWriter(writer))
     }
 
-    pub(crate) fn purge_all_entries(&self) {
-        self.storage_manager.purge_all_entries();
+    pub(crate) fn clear(&self) {
+        self.storage_manager.clear();
     }
 
     pub(crate) fn fork<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(

--- a/rust/blockstore/src/memory/provider.rs
+++ b/rust/blockstore/src/memory/provider.rs
@@ -49,6 +49,10 @@ impl MemoryBlockfileProvider {
         Ok(BlockfileWriter::MemoryBlockfileWriter(writer))
     }
 
+    pub(crate) fn purge_all_entries(&self) {
+        self.storage_manager.purge_all_entries();
+    }
+
     pub(crate) fn fork<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(
         &self,
         _id: &uuid::Uuid,

--- a/rust/blockstore/src/memory/storage.rs
+++ b/rust/blockstore/src/memory/storage.rs
@@ -1166,7 +1166,7 @@ impl StorageManager {
         storage
     }
 
-    pub(super) fn purge_all_entries(&self) {
+    pub(super) fn clear(&self) {
         let mut write_cache_guard = self.write_cache.write();
         write_cache_guard.clear();
         write_cache_guard.shrink_to_fit();

--- a/rust/blockstore/src/memory/storage.rs
+++ b/rust/blockstore/src/memory/storage.rs
@@ -1165,4 +1165,13 @@ impl StorageManager {
         read_cache_guard.insert(id, storage.clone());
         storage
     }
+
+    pub(super) fn purge_all_entries(&self) {
+        let mut write_cache_guard = self.write_cache.write();
+        write_cache_guard.clear();
+        write_cache_guard.shrink_to_fit();
+        let mut read_cache_guard = self.read_cache.write();
+        read_cache_guard.clear();
+        read_cache_guard.shrink_to_fit();
+    }
 }

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -85,10 +85,10 @@ impl BlockfileProvider {
         }
     }
 
-    pub fn purge_all_entries(&self) {
+    pub fn clear(&self) {
         match self {
-            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.purge_all_entries(),
-            BlockfileProvider::ArrowBlockfileProvider(provider) => provider.purge_all_entries(),
+            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.clear(),
+            BlockfileProvider::ArrowBlockfileProvider(provider) => provider.clear(),
         }
     }
 

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -85,6 +85,13 @@ impl BlockfileProvider {
         }
     }
 
+    pub fn purge_all_entries(&self) {
+        match self {
+            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.purge_all_entries(),
+            BlockfileProvider::ArrowBlockfileProvider(provider) => provider.purge_all_entries(),
+        }
+    }
+
     pub async fn fork<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(
         &self,
         id: &uuid::Uuid,

--- a/rust/cache/src/cache.rs
+++ b/rust/cache/src/cache.rs
@@ -72,6 +72,19 @@ impl<K: Send + Sync + Clone + Hash + Eq + 'static, V: Send + Sync + Clone + 'sta
             }
         }
     }
+
+    pub fn clear(&self) {
+        match self {
+            Cache::Unbounded(cache) => {
+                let mut write_guard = cache.cache.write();
+                write_guard.clear();
+                write_guard.shrink_to_fit();
+            }
+            Cache::Foyer(cache) => {
+                cache.clear();
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -174,6 +187,10 @@ where
             }
             None => None,
         }
+    }
+
+    pub fn clear(&self) {
+        self.cache.clear();
     }
 }
 

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -301,7 +301,7 @@ impl Handler<ScheduleMessage> for CompactionManager {
         self.compact_batch().await;
 
         self.hnsw_index_provider.purge_all_entries().await;
-        self.blockfile_provider.purge_all_entries();
+        self.blockfile_provider.clear();
 
         // Compaction is done, schedule the next compaction
         ctx.scheduler

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -301,6 +301,7 @@ impl Handler<ScheduleMessage> for CompactionManager {
         self.compact_batch().await;
 
         self.hnsw_index_provider.purge_all_entries().await;
+        self.blockfile_provider.purge_all_entries();
 
         // Compaction is done, schedule the next compaction
         ctx.scheduler


### PR DESCRIPTION
## Description of changes

After a successful compaction, the blocks in the cache are obsolete. This purges the cache of old blocks which helps to clarify memory usage patterns (memory usage should no longer grow over time).

## Test plan
*How are these changes tested?*

Tested by profiling memory usage and confirming that usage did not grow after subsequent compactions.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a