### PR TITLE
[ENH]: make test_sanity recall based

### DIFF
--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -2,21 +2,14 @@
 # instead of a property based test. We can use the delta to get the property
 # test working and then enable
 import random
-from typing import List
-
-import numpy as np
-from chromadb.api import ClientAPI
 import time
-
-from chromadb.api.types import QueryResult
+from chromadb.api import ClientAPI
 from chromadb.test.conftest import (
     COMPACTION_SLEEP,
     reset,
     skip_if_not_cluster,
 )
-from chromadb.utils.distance_functions import l2
-
-EPS = 1e-6
+from chromadb.test.property import invariants
 
 
 @skip_if_not_cluster()
@@ -47,26 +40,17 @@ def test_add(
     random_query = [random.random(), random.random(), random.random()]
     print("Generated data with seed ", seed)
 
-    # Query the collection with a random query
-    results = collection.query(
-        query_embeddings=[random_query],  # type: ignore
-        n_results=10,
-        include=["distances"],  # type: ignore[list-item]
+    invariants.ann_accuracy(
+        collection,
+        {
+            "ids": ids,
+            "embeddings": embeddings,  # type: ignore[typeddict-item]
+            "metadatas": None,
+            "documents": None,
+        },
+        10,
+        query_embeddings=[random_query],
     )
-
-    # Check that the distances are correct in l2
-    ground_truth_distances = [
-        l2(np.array(random_query), np.array(embedding)) for embedding in embeddings
-    ]
-    ground_truth_distances.sort()
-    retrieved_distances = results["distances"][0]  # type: ignore
-
-    # Check that the query results are sorted by distance
-    for i in range(1, len(retrieved_distances)):
-        assert retrieved_distances[i - 1] <= retrieved_distances[i]
-
-    for i in range(len(retrieved_distances)):
-        assert np.allclose(ground_truth_distances[i], retrieved_distances[i], atol=EPS)
 
 
 @skip_if_not_cluster()
@@ -82,13 +66,15 @@ def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
 
     ids = []
     embeddings = []
+    documents = []
     for i in range(1000):
         ids.append(str(i))
         embeddings.append([random.random(), random.random(), random.random()])
+        documents.append(f"document_{i}")
         collection.add(
             ids=[str(i)],
             embeddings=[embeddings[-1]],  # type: ignore
-            documents=f"document_{i}",
+            documents=[documents[-1]],
         )
 
     time.sleep(COMPACTION_SLEEP)  # Wait for the documents to be compacted
@@ -98,61 +84,14 @@ def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
     print("Generated data with seed ", seed)
 
     # Query the collection with a random query
-    results = collection.query(
-        query_embeddings=[random_query_1, random_query_2],  # type: ignore
-        n_results=10,
-        include=["metadatas", "documents", "distances", "embeddings"],  # type: ignore[list-item]
+    invariants.ann_accuracy(
+        collection,
+        {
+            "ids": ids,
+            "embeddings": embeddings,  # type: ignore[typeddict-item]
+            "metadatas": None,
+            "documents": documents,
+        },
+        10,
+        query_embeddings=[random_query_1, random_query_2],
     )
-
-    ids_and_embeddings = list(zip(ids, embeddings))
-
-    def validate(results: QueryResult, query: List[float], result_index: int) -> None:
-        # Check that the distances are correct in l2
-        gt_ids_distances_embeddings = [
-            (id, sum((a - b) ** 2 for a, b in zip(embedding, query)), embedding)
-            for id, embedding in ids_and_embeddings
-        ]
-        gt_ids_distances_embeddings.sort(key=lambda x: x[1])
-        retrieved_distances = results["distances"][result_index]  # type: ignore
-
-        # Check that the query results are sorted by distance
-        for i in range(1, len(retrieved_distances)):
-            assert retrieved_distances[i - 1] <= retrieved_distances[i]
-
-        for i in range(len(retrieved_distances)):
-            assert abs(gt_ids_distances_embeddings[i][1] - retrieved_distances[i]) < EPS
-
-        # Check that the ids are correct
-        retrieved_ids = results["ids"][result_index]
-        for i in range(len(retrieved_ids)):
-            assert retrieved_ids[i] == gt_ids_distances_embeddings[i][0]
-
-        # Check that the documents are correct
-        if "documents" in results and results["documents"] is not None:
-            retrieved_documents = results["documents"][result_index]
-            for i in range(len(retrieved_documents)):
-                assert (
-                    retrieved_documents[i]
-                    == f"document_{gt_ids_distances_embeddings[i][0]}"
-                )
-        else:
-            assert False
-
-        # Check that the embeddings are correct
-        if "embeddings" in results and results["embeddings"] is not None:
-            retrieved_embeddings = results["embeddings"][result_index]
-            for i in range(len(retrieved_embeddings)):
-                # eps compare the embeddings
-                for j in range(3):
-                    assert (
-                        abs(
-                            retrieved_embeddings[i][j]
-                            - gt_ids_distances_embeddings[i][2][j]
-                        )
-                        < EPS
-                    )
-        else:
-            assert False
-
-    validate(results, random_query_1, 0)
-    validate(results, random_query_2, 1)

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -202,6 +202,7 @@ def ann_accuracy(
     min_recall: float = 0.99,
     embedding_function: Optional[types.EmbeddingFunction] = None,  # type: ignore[type-arg]
     query_indices: Optional[List[int]] = None,
+    query_embeddings: Optional[types.Embeddings] = None,
 ) -> None:
     """Validate that the API performs nearest_neighbor searches correctly"""
     normalized_record_set = wrap_all(record_set)
@@ -239,9 +240,12 @@ def ann_accuracy(
             distance_function = distance_functions.ip
 
     # Perform exact distance computation
-    query_embeddings = (
-        embeddings if query_indices is None else [embeddings[i] for i in query_indices]
-    )
+    if query_embeddings is None:
+        query_embeddings = (
+            embeddings
+            if query_indices is None
+            else [embeddings[i] for i in query_indices]
+        )
     query_documents = normalized_record_set["documents"]
     if query_indices is not None and query_documents is not None:
         query_documents = [query_documents[i] for i in query_indices]


### PR DESCRIPTION
## Description of changes

We now test that the results are approximately what we expect rather than an exact match as distributed uses ANN.

By making this test recall-based, it should no longer flake in CI. 

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
