### PR TITLE
[PERF]: speed up `get_target_block_id()`

### DIFF
--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -139,19 +139,14 @@ impl SparseIndex {
 
     pub(super) fn get_target_block_id(&self, search_key: &CompositeKey) -> Uuid {
         let forward = self.forward.lock();
-        let mut iter_curr = forward.iter();
-        let mut iter_next = forward.iter().skip(1);
-        let search_key = SparseIndexDelimiter::Key(search_key.clone());
-        while let Some((curr_key, curr_block_id)) = iter_curr.next() {
-            if let Some((next_key, _)) = iter_next.next() {
-                if search_key >= *curr_key && search_key < *next_key {
-                    return *curr_block_id;
-                }
-            } else {
-                return *curr_block_id;
-            }
-        }
-        panic!("No blocks in the sparse index");
+
+        let (_, block_id) = forward
+            .range(SparseIndexDelimiter::Key(search_key.clone())..)
+            .next()
+            .or_else(|| forward.iter().next_back())
+            .expect("No blocks in the sparse index");
+
+        return *block_id;
     }
 
     pub(super) fn get_block_ids_prefix(&self, prefix: &str) -> Vec<Uuid> {

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -140,13 +140,17 @@ impl SparseIndex {
     pub(super) fn get_target_block_id(&self, search_key: &CompositeKey) -> Uuid {
         let forward = self.forward.lock();
 
-        let (_, block_id) = forward
-            .range(SparseIndexDelimiter::Key(search_key.clone())..)
-            .next()
-            .or_else(|| forward.iter().next_back())
-            .expect("No blocks in the sparse index");
-
-        return *block_id;
+        match forward
+            .range(..=SparseIndexDelimiter::Key(search_key.clone()))
+            .next_back()
+        {
+            Some((_, block_id)) => {
+                return *block_id;
+            }
+            None => {
+                panic!("No blocks in the sparse index");
+            }
+        }
     }
 
     pub(super) fn get_block_ids_prefix(&self, prefix: &str) -> Vec<Uuid> {


### PR DESCRIPTION
## Description of changes

Fixes `get_target_block_id()` to run in `O(log n)` instead of `O(n)`. Shaves around 2.6s off total compaction time for 26k documents.

[get-target-block-id.trace.zip](https://github.com/user-attachments/files/16808322/get-target-block-id.trace.zip)

## Test plan
*How are these changes tested?*

Covered by existing tests.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
