### PR TITLE
[ENH]: make S3 endpoint configurable

### DIFF
--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -29,6 +29,7 @@ pub enum S3CredentialsConfig {
 /// - bucket: The name of the bucket to use.
 pub struct S3StorageConfig {
     pub bucket: String,
+    pub endpoint: String,
     pub credentials: S3CredentialsConfig,
     pub connect_timeout_ms: u64,
     pub request_timeout_ms: u64,

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -538,7 +538,7 @@ impl Configurable<StorageConfig> for S3Storage {
 
                         // Set up s3 client
                         let config = aws_sdk_s3::config::Builder::new()
-                            .endpoint_url("http://minio.chroma:9000".to_string())
+                            .endpoint_url(s3_config.endpoint.clone())
                             .credentials_provider(cred)
                             .behavior_version_latest()
                             .region(aws_sdk_s3::config::Region::new("us-east-1"))

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -26,6 +26,7 @@ query_service:
         AdmissionControlledS3:
             s3_config:
                 bucket: "chroma-storage"
+                endpoint: "http://minio.chroma:9000"
                 credentials: "Minio"
                 connect_timeout_ms: 5000
                 request_timeout_ms: 30000 # 1 minute
@@ -84,6 +85,7 @@ compaction_service:
         AdmissionControlledS3:
             s3_config:
                 bucket: "chroma-storage"
+                endpoint: "http://minio.chroma:9000"
                 credentials: "Minio"
                 connect_timeout_ms: 5000
                 request_timeout_ms: 60000 # 1 minute

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -167,6 +167,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
@@ -225,6 +226,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
@@ -311,6 +313,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
@@ -369,6 +372,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
@@ -473,6 +477,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
@@ -531,6 +536,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000
@@ -596,6 +602,10 @@ mod tests {
             );
             let _ = jail.set_env("CHROMA_COMPACTION_SERVICE__MY_PORT", 50051);
             let _ = jail.set_env("CHROMA_COMPACTION_SERVICE__STORAGE__S3__BUCKET", "buckets!");
+            let _ = jail.set_env(
+                "CHROMA_COMPACTION_SERVICE__STORAGE__S3__ENDPOINT",
+                "http://minio.chroma:9000",
+            );
             let _ = jail.set_env("CHROMA_COMPACTION_SERVICE__STORAGE__S3__CREDENTIALS", "AWS");
             let _ = jail.set_env(
                 "CHROMA_COMPACTION_SERVICE__STORAGE__S3__upload_part_size_bytes",
@@ -637,6 +647,7 @@ mod tests {
                         AdmissionControlledS3:
                             s3_config:
                                 bucket: "chroma"
+                                endpoint: "http://minio.chroma:9000"
                                 credentials: Minio
                                 connect_timeout_ms: 5000
                                 request_timeout_ms: 1000


### PR DESCRIPTION
## Description of changes

Splitting up and pulling in some of my changes from https://github.com/chroma-core/chroma/pull/2728 to make it easier for people to run the compactor & query service outside of Tilt for good profilling support.

This makes the S3 endpoint configurable since the value when running inside the cluster is different than when running outside the cluster.

## Test plan
*How are these changes tested?*

Covered by existing tests.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
