### PR TITLE
[ENH] Deterministic index building

### DIFF
--- a/chromadb/segment/impl/vector/batch.py
+++ b/chromadb/segment/impl/vector/batch.py
@@ -1,5 +1,5 @@
-from typing import Dict, List, Set, cast
-
+from typing import Dict, List, cast
+from collections import OrderedDict
 from chromadb.types import LogRecord, Operation, SeqId, Vector
 
 
@@ -7,18 +7,18 @@ class Batch:
     """Used to model the set of changes as an atomic operation"""
 
     _ids_to_records: Dict[str, LogRecord]
-    _deleted_ids: Set[str]
-    _written_ids: Set[str]
-    _upsert_add_ids: Set[str]  # IDs that are being added in an upsert
+    _deleted_ids: OrderedDict[str, None]
+    _written_ids: OrderedDict[str, None]
+    _upsert_add_ids: OrderedDict[str, None]  # IDs that are being added in an upsert
     add_count: int
     update_count: int
     max_seq_id: SeqId
 
     def __init__(self) -> None:
         self._ids_to_records = {}
-        self._deleted_ids = set()
-        self._written_ids = set()
-        self._upsert_add_ids = set()
+        self._deleted_ids = OrderedDict()
+        self._written_ids = OrderedDict()
+        self._upsert_add_ids = OrderedDict()
         self.add_count = 0
         self.update_count = 0
         self.max_seq_id = 0
@@ -29,11 +29,11 @@ class Batch:
 
     def get_deleted_ids(self) -> List[str]:
         """Get the list of deleted embeddings in this batch"""
-        return list(self._deleted_ids)
+        return list(self._deleted_ids.keys())
 
     def get_written_ids(self) -> List[str]:
         """Get the list of written embeddings in this batch"""
-        return list(self._written_ids)
+        return list(self._written_ids.keys())
 
     def get_written_vectors(self, ids: List[str]) -> List[Vector]:
         """Get the list of vectors to write in this batch"""
@@ -64,25 +64,25 @@ class Batch:
             # If the ID was previously written, remove it from the written set
             # And update the add/update/delete counts
             if id in self._written_ids:
-                self._written_ids.remove(id)
+                del self._written_ids[id]
                 if self._ids_to_records[id]["record"]["operation"] == Operation.ADD:
                     self.add_count -= 1
                 elif (
                     self._ids_to_records[id]["record"]["operation"] == Operation.UPDATE
                 ):
                     self.update_count -= 1
-                    self._deleted_ids.add(id)
+                    self._deleted_ids[id] = None
                 elif (
                     self._ids_to_records[id]["record"]["operation"] == Operation.UPSERT
                 ):
                     if id in self._upsert_add_ids:
                         self.add_count -= 1
-                        self._upsert_add_ids.remove(id)
+                        del self._upsert_add_ids[id]
                     else:
                         self.update_count -= 1
-                        self._deleted_ids.add(id)
+                        self._deleted_ids[id] = None
             elif id not in self._deleted_ids:
-                self._deleted_ids.add(id)
+                self._deleted_ids[id] = None
 
             # Remove the record from the batch
             if id in self._ids_to_records:
@@ -90,18 +90,18 @@ class Batch:
 
         else:
             self._ids_to_records[id] = record
-            self._written_ids.add(id)
+            self._written_ids[id] = None
 
             # If the ID was previously deleted, remove it from the deleted set
             # And update the delete count
             if id in self._deleted_ids:
-                self._deleted_ids.remove(id)
+                del self._deleted_ids[id]
 
             # Update the add/update counts
             if record["record"]["operation"] == Operation.UPSERT:
                 if not exists_already:
                     self.add_count += 1
-                    self._upsert_add_ids.add(id)
+                    self._upsert_add_ids[id] = None
                 else:
                     self.update_count += 1
             elif record["record"]["operation"] == Operation.ADD:

--- a/chromadb/segment/impl/vector/hnsw_params.py
+++ b/chromadb/segment/impl/vector/hnsw_params.py
@@ -11,6 +11,7 @@ param_validators: Dict[str, Validator] = {
     "hnsw:space": lambda p: bool(re.match(r"^(l2|cosine|ip)$", str(p))),
     "hnsw:construction_ef": lambda p: isinstance(p, int),
     "hnsw:search_ef": lambda p: isinstance(p, int),
+    "hnsw:random_seed": lambda p : isinstance(p, int),
     "hnsw:M": lambda p: isinstance(p, int),
     "hnsw:num_threads": lambda p: isinstance(p, int),
     "hnsw:resize_factor": lambda p: isinstance(p, (int, float)),
@@ -47,6 +48,7 @@ class HnswParams(Params):
     space: str
     construction_ef: int
     search_ef: int
+    random_seed: int
     M: int
     num_threads: int
     resize_factor: float
@@ -56,6 +58,7 @@ class HnswParams(Params):
         self.space = str(metadata.get("hnsw:space", "l2"))
         self.construction_ef = int(metadata.get("hnsw:construction_ef", 100))
         self.search_ef = int(metadata.get("hnsw:search_ef", 10))
+        self.random_seed = int(metadata.get("hnsw:random_seed", 42))
         self.M = int(metadata.get("hnsw:M", 16))
         self.num_threads = int(
             metadata.get("hnsw:num_threads", multiprocessing.cpu_count())

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -202,6 +202,7 @@ class LocalHnswSegment(VectorReader):
             max_elements=DEFAULT_CAPACITY,
             ef_construction=self._params.construction_ef,
             M=self._params.M,
+            random_seed=self._params.random_seed,
         )
         index.set_ef(self._params.search_ef)
         index.set_num_threads(self._params.num_threads)

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -215,6 +215,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                 max_elements=DEFAULT_CAPACITY,
                 ef_construction=self._params.construction_ef,
                 M=self._params.M,
+                random_seed=self._params.random_seed,
                 is_persistent_index=True,
                 persistence_location=self._get_storage_folder(),
             )


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements
	 - Make HNSW index building as deterministic as possible by setting random_seed and preserving the order of IDs in `chromadb/segment/impl/vector/batch.py`.

 - New functionality
	 - Set the random_seed through a new parameter: `hnsw:random_seed`.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest chromadb/test/segment/` for python

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
