### PR TITLE
[DOC]: Update Langchain integration example and fix broken link

### DIFF
--- a/docs/docs.trychroma.com/pages/integrations/langchain.md
+++ b/docs/docs.trychroma.com/pages/integrations/langchain.md
@@ -16,31 +16,4 @@ title: 🦜️🔗 Langchain
 
 ## Langchain - JS
 
-Here is an [example in LangChainJS](https://github.com/langchain-ai/langchainjs/blob/main/examples/src/indexes/vector_stores/chroma/fromDocs.ts)
-
-```typescript
-import { Chroma } from "@langchain/community/vectorstores/chroma";
-import { OpenAIEmbeddings } from "@langchain/openai";
-import { TextLoader } from "langchain/document_loaders/fs/text";
-
-// Create docs with a loader
-const loader = new TextLoader("src/document_loaders/example_data/example.txt");
-const docs = await loader.load();
-
-// Create vector store and index the docs
-const vectorStore = await Chroma.fromDocuments(docs, new OpenAIEmbeddings(), {
-  collectionName: "a-test-collection",
-  url: "http://localhost:8000", // Optional, will default to this value
-  collectionMetadata: {
-    "hnsw:space": "cosine",
-  }, // Optional, can be used to specify the distance method of the embedding space https://docs.trychroma.com/guides#changing-the-distance-function
-});
-
-// Search for the most similar document
-const response = await vectorStore.similaritySearch("hello", 1);
-
-console.log(response);
-
-```
-
 - [LangChainJS Chroma Documentation](https://js.langchain.com/docs/modules/indexes/vector_stores/integrations/chroma)


### PR DESCRIPTION
## Description of changes

 - Improvements & Bug fixes
	 - Removed the code example from the Langchain integration documentation as per @jeffchuber's request.
	
 - New functionality
	 - n/a

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

- The example in the docs has been updated. There are no other documentation changes required.
