### PR TITLE
[BLD]: add debug info to Rust release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
    "rust/index",
    "rust/storage",
    "rust/types",
-   "rust/worker"
+   "rust/worker",
 ]
 
 [workspace.dependencies]
@@ -51,3 +51,6 @@ tempfile = "3.8.1"
 shuttle = "0.7.1"
 proptest = "1.4.0"
 proptest-state-machine = "0.1.0"
+
+[profile.release]
+debug = 2


### PR DESCRIPTION
## Description of changes

Allows us to use external tooling to debug prod workloads.

## Test plan
*How are these changes tested?*

Compaction binary size on macOS:

- before: 32MB
- after: 36MB

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
