### PR TITLE
[ENH]: use jemalloc for compactor service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,6 +4404,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,6 +5371,7 @@ dependencies = [
  "tantivy",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tonic 0.10.2",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -28,6 +28,9 @@ opentelemetry-otlp = "0.12.0"
 regex = "1.10.5"
 figment = { version = "0.10.12", features = ["env", "yaml", "test"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 arrow = { workspace = true }

--- a/rust/worker/src/bin/compaction_service.rs
+++ b/rust/worker/src/bin/compaction_service.rs
@@ -1,5 +1,12 @@
 use worker::compaction_service_entrypoint;
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[tokio::main]
 async fn main() {
     compaction_service_entrypoint().await;


### PR DESCRIPTION
## Description of changes

This should fix unbounded memory growth when running inside a container. 

Background:

- we continue to observe OOM errors on the compaction service in production
- unbounded memory growth cannot be reproduced when running the binary natively under macOS
- unbounded memory growth *can* be reproduced when running the built container under macOS
- according to both Instruments.app and heaptrack (running inside the built container) there is no memory leak

It seems like glibc's malloc was not marking freed memory as free to the OS for some reason. When periodically running `malloc_trim()`, memory usage stayed within expected bounds.

Switching to jemalloc appears to resolve the issue.

### Test procedure

1. Load [SciDocs](https://github.com/allenai/scidocs) dataset.
2. Insert first 15k documents into a new collection and compact after every 5k inserts.
3. Do the same on a new, second collection.

### Results

Here is the resident memory usage, as reported by `htop`, after the end of every compaction job.

**jemalloc**:

- `582M`
- `1126M`
- `1487M`
- (created a second collection to start inserting to)
- `762M`
- `1251M`
- `1531M`

**glibc malloc**:

- `331M`
- `1227M`
- `2118M`
- (created a second collection to start inserting to)
- `2568M`
- `3361M`
- `4137M`

Notice that glibc's malloc appears to not reuse reserved memory when inserting to the second collection, while jemalloc frees or reuses reserved memory.

### Does this impact performance?

No. Compacting the entire SciDocs dataset takes 1m3s with jemalloc vs 1m6s with glibc.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
