### PR TITLE
[BLD]: use cache mount in Rust Dockerfile

### DIFF
--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -1,82 +1,46 @@
-FROM rust:1.79.0 as builder
+FROM rust:1.79.0 AS builder
 ARG CHROMA_KUBERNETES_INTEGRATION=0
-ENV CHROMA_KUBERNETES_INTEGRATION $CHROMA_KUBERNETES_INTEGRATION
+ENV CHROMA_KUBERNETES_INTEGRATION=$CHROMA_KUBERNETES_INTEGRATION
 
 ARG RELEASE_MODE=
 
 WORKDIR /
 RUN git clone https://github.com/chroma-core/hnswlib.git
 
-# Cache dependencies by building them without our code first.
-# https://dev.to/rogertorres/first-steps-with-docker-rust-30oi
-# https://www.reddit.com/r/rust/comments/126xeyx/exploring_the_problem_of_faster_cargo_docker/
 WORKDIR /chroma/
-COPY Cargo.toml Cargo.toml
-COPY Cargo.lock Cargo.lock
-COPY idl/ idl/
-COPY /rust/blockstore/Cargo.toml rust/blockstore/Cargo.toml
-COPY /rust/cache/Cargo.toml rust/cache/Cargo.toml
-COPY /rust/config/Cargo.toml rust/config/Cargo.toml
-COPY /rust/error/Cargo.toml rust/error/Cargo.toml
-COPY /rust/storage/Cargo.toml rust/storage/Cargo.toml
-COPY /rust/types/Cargo.toml rust/types/Cargo.toml
-COPY /rust/distance/Cargo.toml rust/distance/Cargo.toml
-COPY /rust/index/Cargo.toml rust/index/Cargo.toml
-COPY /rust/worker/Cargo.toml rust/worker/Cargo.toml
+
 ENV PROTOC_ZIP=protoc-25.1-linux-x86_64.zip
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/$PROTOC_ZIP \
     && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
     && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
     && rm -f $PROTOC_ZIP
 
-FROM builder as query_service_builder
-# We need to replace the query node's real main() and all packages lib.rs with a dummy at the expected location. This forces a build of the dependencies only.
-RUN for dir in blockstore cache config error storage types distance index; do \
-    mkdir -p rust/$dir/src && echo "pub fn main() {}" > rust/$dir/src/lib.rs; \
-    done
-RUN mkdir -p rust/worker/src/bin/ && echo "fn main() {}" > rust/worker/src/bin/query_service.rs
-RUN if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin query_service --release; else cargo build --bin query_service; fi
-RUN rm -rf rust/
-
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY idl/ idl/
 COPY rust/ rust/
-# We touch the files to hint to docker that these files are changed
-RUN for dir in blockstore cache config error storage types distance index; do \
-    touch rust/$dir/src/lib.rs; \
-    done
-RUN touch rust/worker/src/bin/query_service.rs
 
-RUN if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin query_service --release; else cargo build --bin query_service; fi
-RUN if [ "$RELEASE_MODE" = "1" ]; then mv target/release/query_service .; else mv target/debug/query_service .; fi
+FROM builder AS query_service_builder
+RUN --mount=type=cache,target=/chroma/target/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin query_service --release; else cargo build --bin query_service; fi && \
+    if [ "$RELEASE_MODE" = "1" ]; then mv target/release/query_service ./query_service; else mv target/debug/query_service ./query_service; fi
 
-FROM debian:bookworm-slim as query_service
+FROM builder AS compaction_service_builder
+RUN --mount=type=cache,target=/chroma/target/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin compaction_service --release; else cargo build --bin compaction_service; fi && \
+    if [ "$RELEASE_MODE" = "1" ]; then mv target/release/compaction_service ./compaction_service; else mv target/debug/compaction_service ./compaction_service; fi
 
-RUN apt-get update && apt-get install -y libssl-dev ca-certificates
+
+FROM debian:bookworm-slim AS runner
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
+
+FROM runner AS query_service
 COPY --from=query_service_builder /chroma/query_service .
-COPY --from=query_service_builder /chroma/rust/worker/chroma_config.yaml .
-
 ENTRYPOINT [ "./query_service" ]
 
-FROM builder as compaction_service_builder
-# We need to replace the compaction node's real main() with a dummy at the expected location. This forces a build of the dependencies only.
-RUN for dir in blockstore cache config error storage types distance index; do \
-    mkdir -p rust/$dir/src && echo "pub fn main() {}" > rust/$dir/src/lib.rs; \
-    done
-RUN mkdir -p rust/worker/src/bin/ && echo "fn main() {}" > rust/worker/src/bin/compaction_service.rs
-RUN if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin compaction_service --release; else cargo build --bin compaction_service; fi
-RUN rm -rf rust/
-
-COPY rust/ rust/
-RUN for dir in blockstore cache config error storage types distance index; do \
-    touch rust/$dir/src/lib.rs; \
-    done
-RUN touch rust/worker/src/bin/compaction_service.rs
-RUN if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin compaction_service --release; else cargo build --bin compaction_service; fi
-RUN if [ "$RELEASE_MODE" = "1" ]; then mv target/release/compaction_service .; else mv target/debug/compaction_service .; fi
-
-FROM debian:bookworm-slim as compaction_service
-
-RUN apt-get update && apt-get install -y libssl-dev ca-certificates
+FROM runner AS compaction_service
 COPY --from=compaction_service_builder /chroma/compaction_service .
-COPY --from=compaction_service_builder /chroma/rust/worker/chroma_config.yaml .
-
 ENTRYPOINT [ "./compaction_service" ]

--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -21,14 +21,15 @@ COPY idl/ idl/
 COPY rust/ rust/
 
 FROM builder AS query_service_builder
-RUN --mount=type=cache,target=/chroma/target/ \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
+# sharing=locked is necessary to prevent cargo build from running concurrently on the same mounted directory
+RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
+    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin query_service --release; else cargo build --bin query_service; fi && \
     if [ "$RELEASE_MODE" = "1" ]; then mv target/release/query_service ./query_service; else mv target/debug/query_service ./query_service; fi
 
 FROM builder AS compaction_service_builder
-RUN --mount=type=cache,target=/chroma/target/ \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
+RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
+    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin compaction_service --release; else cargo build --bin compaction_service; fi && \
     if [ "$RELEASE_MODE" = "1" ]; then mv target/release/compaction_service ./compaction_service; else mv target/debug/compaction_service ./compaction_service; fi
 


### PR DESCRIPTION
## Description of changes

Uses Docker cache mounts to cache Rust artifacts instead of layer caching. A cache mount persists across `docker build`s and is not stored as a layer in the image. Using a cache mount is better because:

- if a dependency changes, it does not require all dependencies to be rebuilt
- only changed Chroma code will be rebuilt

I tested the savings by performing an incremental build (with target `compaction_service`) after touching a file in the worker crate.

**Before**:

- `debug`: 35s
- `release`: 1m8s

**After**:

- `debug`: 14s
- `release`: 58s

It doesn't seem to speed up release builds as much as I was hoping, but a 2x reduction in debug build time is a nice win. Also makes the Dockerfile easier to read. Savings may be more pronounced when running multiple builds concurrently (e.g. the query and compactor service inside Tilt).

## Test plan
*How are these changes tested?*

Built debug & release images locally.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
