### PR TITLE
[BUG] Smaller batch size

### DIFF
--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -157,7 +157,7 @@ class LogService(Producer, Consumer):
     @property
     @override
     def max_batch_size(self) -> int:
-        return 25000
+        return 100
 
     def push_logs(self, collection_id: UUID, records: Sequence[OperationRecord]) -> int:
         request = PushLogsRequest(collection_id=str(collection_id), records=records)

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -175,8 +175,8 @@ def test_add_large(
     reset(client)
 
     record_set = create_large_recordset(
-        min_size=client.get_max_batch_size(),
-        max_size=client.get_max_batch_size() * 250,
+        min_size=10000,
+        max_size=50000,
     )
     coll = client.create_collection(
         name=collection.name,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Reduce the batch size on logservice to be more conservative in order to prevent grpc payload limits from being hit.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None