### PR TITLE
[BLD]: bump version of upload-artifact actions

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -123,7 +123,7 @@ jobs:
         shell: bash
       - name: Upload logs as artifact
         if: success() || failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: ${{ steps.get-logs.outputs.logs_zip_path }}

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -126,7 +126,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ steps.get-logs.outputs.artifact_name }}
+          name: ${{ steps.get-logs.outputs.artifact_name }}
           path: ${{ steps.get-logs.outputs.logs_zip_path }}
 
   merge-cluster-logs:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -119,14 +119,25 @@ jobs:
         run: |
           bin/get-logs.sh "${{ matrix.test-globs }}" "${{ matrix.python }}"
           # Output the logs zip file path as a job output
+          echo "artifact_name=cluster_logs_$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
           echo "logs_zip_path=$(pwd)/$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}_logs.zip" >> $GITHUB_OUTPUT
         shell: bash
       - name: Upload logs as artifact
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: logs
+          name: logs-${{ steps.get-logs.outputs.artifact_name }}
           path: ${{ steps.get-logs.outputs.logs_zip_path }}
+
+  merge-cluster-logs:
+    runs-on: ubuntu-latest
+    needs: test-cluster-integration
+    steps:
+      - name: Merge
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cluster_test_logs
+          pattern: cluster_logs_*
 
   test-thin-client:
     strategy:

--- a/.github/workflows/_python-vulnerability-scan.yml
+++ b/.github/workflows/_python-vulnerability-scan.yml
@@ -17,7 +17,7 @@ jobs:
           bandit-config: 'bandit.yaml'
           output-file: 'bandit-report.json'
       - name: Upload Bandit Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bandit-artifact
           path: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -40,7 +40,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ steps.get-logs.outputs.artifact_name }}
+          name: ${{ steps.get-logs.outputs.artifact_name }}
           path: ${{ steps.get-logs.outputs.logs_zip_path }}
       - name: Send PagerDuty alert on failure
         if: ${{ failure() }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
       - name: Upload logs as artifact
         if: success() || failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: ${{ steps.get-logs.outputs.logs_zip_path }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -33,13 +33,14 @@ jobs:
         run: |
           bin/get-logs.sh "${{ matrix.test-globs }}" "3.12"
           # Output the logs zip file path as a job output
+          echo "artifact_name=cluster_logs_$(basename "${{ matrix.test-globs }}" .py)_3.12" >> $GITHUB_OUTPUT
           echo "logs_zip_path=$(pwd)/$(basename "${{ matrix.test-globs }}" .py)_3.12_logs.zip" >> $GITHUB_OUTPUT
         shell: bash
       - name: Upload logs as artifact
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: logs
+          name: logs-${{ steps.get-logs.outputs.artifact_name }}
           path: ${{ steps.get-logs.outputs.logs_zip_path }}
       - name: Send PagerDuty alert on failure
         if: ${{ failure() }}
@@ -47,3 +48,13 @@ jobs:
         with:
           pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
           pagerduty-dedup-key: distributed-test-failed-${{ matrix.test-globs}}
+
+  merge-cluster-logs:
+    runs-on: ubuntu-latest
+    needs: test-cluster
+    steps:
+      - name: Merge
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cluster_test_logs
+          pattern: cluster_logs_*


### PR DESCRIPTION
## Description of changes

Checks started failing today because v2 is too old.

## Test plan
*How are these changes tested?*

GitHub CI.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
