### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -66,7 +66,7 @@ pip install chromadb # [!code $]
 
 ```python
 import chromadb
-chroma_client = chromadb.Client()
+chroma_client = chromadb.PersistentClient(path="LOCAL_PATH")
 ```
 
 {% /tab %}


### PR DESCRIPTION
changing chromadb.Client() to chromadb.PersistentClient() in create a chroma client (python-doc)

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Changing the create a chroma client part of Getting Started docs 
	 from `chroma_client = chromadb.Client()` to `chroma_client = chromadb.PersistentClient(path="LOCAL_PATH")`

## Test plan
*How are these changes tested?*

- ✅ Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
