### PR TITLE
[ENH] Update client telemetry for developer cloud

### DIFF
--- a/chromadb/telemetry/product/__init__.py
+++ b/chromadb/telemetry/product/__init__.py
@@ -64,9 +64,12 @@ class ProductTelemetryClient(Component):
         for whitelisted in TELEMETRY_WHITELISTED_SETTINGS:
             telemetry_settings[whitelisted] = settings[whitelisted]
 
+        hosted = self._system.settings.chroma_server_host == "api.trychroma.com"
+
         self._context = {
             "chroma_version": chroma_version,
             "server_context": self.SERVER_CONTEXT.value,
+            "hosted": hosted,
             **telemetry_settings,
         }
         return self._context

--- a/docs/docs.trychroma.com/pages/telemetry.md
+++ b/docs/docs.trychroma.com/pages/telemetry.md
@@ -39,6 +39,7 @@ We will only track usage details that help us make product decisions, specifical
 
 - Chroma version and environment details (e.g. OS, Python version, is it running in a container, or in a jupyter notebook)
 - Usage of embedding functions that ship with Chroma and aggregated usage of custom embeddings (we collect no information about the custom embeddings themselves)
+- Client interactions with our hosted Chroma Cloud service.
 - Collection commands. We track the anonymized uuid of a collection as well as the number of items
   - `add`
   - `update`


### PR DESCRIPTION
## Description of changes

Update Posthog telemetry to indicate which events are associated with Chroma Cloud interactions by clients.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- [x] Verify on Posthog that we get the new `hosted` property on events, as well as the new `CloudError` events for errors.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
