### PR TITLE
[ENH]: GET /databases should return 404 instead of 500 for not found

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -22,7 +22,7 @@ from chromadb.api.types import (
     URIs,
 )
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
-from chromadb.errors import ChromaError
+from chromadb.errors import ChromaError, NotFoundError
 from chromadb.types import Database, Tenant, Where, WhereDocument
 import chromadb.utils.embedding_functions as ef
 
@@ -122,10 +122,13 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
             raise ValueError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
-        except Exception:
-            raise ValueError(
-                f"Could not connect to database {database} for tenant {tenant}. Are you sure it exists?"
-            )
+        except Exception as e:
+            if isinstance(e, NotFoundError):
+                raise ValueError(
+                    f"Could not connect to database {database} for tenant {tenant}. Are you sure it exists?"
+                )
+
+            raise e
 
     # region BaseAPI Methods
     # Note - we could do this in less verbose ways, but they break type checking

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -22,7 +22,7 @@ from chromadb.api.types import (
     URIs,
 )
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
-from chromadb.errors import ChromaError, NotFoundError
+from chromadb.errors import ChromaError
 from chromadb.types import Database, Tenant, Where, WhereDocument
 import chromadb.utils.embedding_functions as ef
 
@@ -122,13 +122,6 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
             raise ValueError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
-        except Exception as e:
-            if isinstance(e, NotFoundError):
-                raise ValueError(
-                    f"Could not connect to database {database} for tenant {tenant}. Are you sure it exists?"
-                )
-
-            raise e
 
     # region BaseAPI Methods
     # Note - we could do this in less verbose ways, but they break type checking

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -24,7 +24,7 @@ from chromadb.api.types import (
 from chromadb.config import Settings, System
 from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE
 from chromadb.api.models.Collection import Collection
-from chromadb.errors import ChromaError, NotFoundError
+from chromadb.errors import ChromaError
 from chromadb.types import Database, Tenant, Where, WhereDocument
 import chromadb.utils.embedding_functions as ef
 
@@ -387,13 +387,6 @@ class Client(SharedSystemClient, ClientAPI):
             raise ValueError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
-        except Exception as e:
-            if isinstance(e, NotFoundError):
-                raise ValueError(
-                    f"Could not connect to database {database} for tenant {tenant}. Are you sure it exists?"
-                )
-
-            raise e
 
     # endregion
 

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -24,7 +24,7 @@ from chromadb.api.types import (
 from chromadb.config import Settings, System
 from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE
 from chromadb.api.models.Collection import Collection
-from chromadb.errors import ChromaError
+from chromadb.errors import ChromaError, NotFoundError
 from chromadb.types import Database, Tenant, Where, WhereDocument
 import chromadb.utils.embedding_functions as ef
 
@@ -387,10 +387,13 @@ class Client(SharedSystemClient, ClientAPI):
             raise ValueError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
-        except Exception:
-            raise ValueError(
-                f"Could not connect to database {database} for tenant {tenant}. Are you sure it exists?"
-            )
+        except Exception as e:
+            if isinstance(e, NotFoundError):
+                raise ValueError(
+                    f"Could not connect to database {database} for tenant {tenant}. Are you sure it exists?"
+                )
+
+            raise e
 
     # endregion
 

--- a/chromadb/db/base.py
+++ b/chromadb/db/base.py
@@ -13,12 +13,6 @@ from itertools import islice, count
 from chromadb.types import SeqId
 
 
-class NotFoundError(Exception):
-    """Raised when a delete or update operation affects no rows"""
-
-    pass
-
-
 class UniqueConstraintError(Exception):
     """Raised when an insert operation would violate a unique constraint"""
 

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -4,8 +4,9 @@ from uuid import UUID
 from overrides import overrides
 from chromadb.api.configuration import CollectionConfigurationInternal
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, System, logger
-from chromadb.db.base import NotFoundError, UniqueConstraintError
+from chromadb.db.base import UniqueConstraintError
 from chromadb.db.system import SysDB
+from chromadb.errors import NotFoundError
 from chromadb.proto.convert import (
     from_proto_collection,
     from_proto_segment,

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -105,7 +105,9 @@ class GrpcSysDB(SysDB):
             request, timeout=self._request_timeout_seconds
         )
         if response.status.code == 404:
-            raise NotFoundError()
+            raise NotFoundError(
+                f"Could not fetch database {name} for tenant {tenant}. Are you sure it exists?"
+            )
         return Database(
             id=UUID(hex=response.database.id),
             name=response.database.name,
@@ -128,7 +130,9 @@ class GrpcSysDB(SysDB):
             request, timeout=self._request_timeout_seconds
         )
         if response.status.code == 404:
-            raise NotFoundError()
+            raise NotFoundError(
+                f"Could not fetch tenant {name}. Are you sure it exists?"
+            )
         return Tenant(
             name=response.tenant.name,
         )

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -17,10 +17,10 @@ from chromadb.db.base import (
     SqlDB,
     ParameterValue,
     get_sql,
-    NotFoundError,
     UniqueConstraintError,
 )
 from chromadb.db.system import SysDB
+from chromadb.errors import NotFoundError
 from chromadb.telemetry.opentelemetry import (
     add_attributes_to_current_span,
     OpenTelemetryClient,
@@ -342,14 +342,14 @@ class SqlSysDB(SqlDB, SysDB):
                 rows = list(segment_rows)
                 type = str(rows[0][1])
                 scope = SegmentScope(str(rows[0][2]))
-                collection = self.uuid_from_db(rows[0][3])
+                collection = self.uuid_from_db(rows[0][3])  # type: ignore[assignment]
                 metadata = self._metadata_from_rows(rows)
                 segments.append(
                     Segment(
                         id=cast(UUID, id),
                         type=type,
                         scope=scope,
-                        collection=cast(UUID, collection),
+                        collection=collection,
                         metadata=metadata,
                     )
                 )

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -99,9 +99,13 @@ class SqlSysDB(SqlDB, SysDB):
             sql, params = get_sql(q, self.parameter_format())
             row = cur.execute(sql, params).fetchone()
             if not row:
-                raise NotFoundError(f"Database {name} not found for tenant {tenant}")
+                raise NotFoundError(
+                    f"Database {name} not found for tenant {tenant}. Are you sure it exists?"
+                )
             if row[0] is None:
-                raise NotFoundError(f"Database {name} not found for tenant {tenant}")
+                raise NotFoundError(
+                    f"Database {name} not found for tenant {tenant}. Are you sure it exists?"
+                )
             id: UUID = cast(UUID, self.uuid_from_db(row[0]))
             return Database(
                 id=id,

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -92,6 +92,17 @@ class AuthorizationError(ChromaError):
         return "AuthorizationError"
 
 
+class NotFoundError(ChromaError):
+    @overrides
+    def code(self) -> int:
+        return 404
+
+    @classmethod
+    @overrides
+    def name(cls) -> str:
+        return "NotFoundError"
+
+
 error_types: Dict[str, Type[ChromaError]] = {
     "InvalidDimension": InvalidDimensionException,
     "InvalidCollection": InvalidCollectionException,
@@ -100,4 +111,5 @@ error_types: Dict[str, Type[ChromaError]] = {
     "InvalidUUID": InvalidUUIDError,
     "InvalidHTTPVersion": InvalidHTTPVersion,
     "AuthorizationError": AuthorizationError,
+    "NotFoundError": NotFoundError,
 }

--- a/chromadb/test/api/test_get_database.py
+++ b/chromadb/test/api/test_get_database.py
@@ -1,0 +1,9 @@
+import pytest
+from chromadb.test.conftest import ClientFactories
+
+
+def test_get_database_not_found(client_factories: ClientFactories) -> None:
+    with pytest.raises(ValueError) as e_info:
+        client_factories.create_client(database="does_not_exist")
+
+    assert "Are you sure it exists?" in str(e_info.value)

--- a/chromadb/test/api/test_get_database.py
+++ b/chromadb/test/api/test_get_database.py
@@ -1,9 +1,10 @@
 import pytest
+from chromadb.errors import NotFoundError
 from chromadb.test.conftest import ClientFactories
 
 
 def test_get_database_not_found(client_factories: ClientFactories) -> None:
-    with pytest.raises(ValueError) as e_info:
+    with pytest.raises(NotFoundError) as e_info:
         client_factories.create_client(database="does_not_exist")
 
     assert "Are you sure it exists?" in str(e_info.value)

--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -6,6 +6,7 @@ from typing import Generator, List, Callable, Dict, Union
 
 from chromadb.db.impl.grpc.client import GrpcSysDB
 from chromadb.db.impl.grpc.server import GrpcMockSysDB
+from chromadb.errors import NotFoundError
 from chromadb.test.conftest import find_free_port
 from chromadb.types import Collection, Segment, SegmentScope
 from chromadb.db.impl.sqlite import SqliteDB
@@ -16,7 +17,7 @@ from chromadb.config import (
     Settings,
 )
 from chromadb.db.system import SysDB
-from chromadb.db.base import NotFoundError, UniqueConstraintError
+from chromadb.db.base import UniqueConstraintError
 from pytest import FixtureRequest
 import uuid
 from chromadb.api.configuration import CollectionConfigurationInternal


### PR DESCRIPTION
## Description of changes

When a database is not found, a 404 HTTP status code is now returned instead of a 500.

## Test plan
*How are these changes tested?*

Added a new test. It doesn't strictly test the status code (difficult if we want to keep the more friendly error message), but exercises the code path.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
