### PR TITLE
[ENH] - Fix `get_or_create_collection` semantic inconsistencies

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -441,9 +441,9 @@ class ClientAPI(BaseAPI, ABC):
         Args:
             name: The name of the collection to get or create
             metadata: Optional metadata to associate with the collection. If
-            the collection alredy exists, the metadata will be updated if
-            provided and not None. If the collection does not exist, the
-            new collection will be created with the provided metadata.
+            the collection already exists, the metadata provided is ignored.
+            If the collection does not exist, the new collection will be created
+            with the provided metadata.
             embedding_function: Optional function to use to embed documents
             data_loader: Optional function to use to load records (documents, images, etc.)
 

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -432,9 +432,9 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
         Args:
             name: The name of the collection to get or create
             metadata: Optional metadata to associate with the collection. If
-            the collection alredy exists, the metadata will be updated if
-            provided and not None. If the collection does not exist, the
-            new collection will be created with the provided metadata.
+            the collection already exists, the metadata provided is ignored.
+            If the collection does not exist, the new collection will be created
+            with the provided metadata.
             embedding_function: Optional function to use to embed documents
             data_loader: Optional function to use to load records (documents, images, etc.)
 

--- a/chromadb/db/impl/grpc/server.py
+++ b/chromadb/db/impl/grpc/server.py
@@ -290,10 +290,6 @@ class GrpcMockSysDB(SysDBServicer, Component):
         if len(matches) > 0:
             if request.get_or_create:
                 existing_collection = matches[0]
-                if request.HasField("metadata"):
-                    existing_collection["metadata"] = from_proto_metadata(
-                        request.metadata
-                    )
                 return CreateCollectionResponse(
                     status=proto.Status(code=200),
                     collection=to_proto_collection(existing_collection),

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -216,16 +216,10 @@ class SqlSysDB(SqlDB, SysDB):
         existing = self.get_collections(name=name, tenant=tenant, database=database)
         if existing:
             if get_or_create:
-                # We ignore configuration on the get path - configuration is immutable
                 collection = existing[0]
-                if metadata is not None and collection["metadata"] != metadata:
-                    self.update_collection(
-                        collection.id,
-                        metadata=metadata,
-                    )
                 return (
                     self.get_collections(
-                        id=collection["id"], tenant=tenant, database=database
+                        id=collection.id, tenant=tenant, database=database
                     )[0],
                     False,
                 )

--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -297,11 +297,12 @@ def test_get_or_create_collection(sysdb: SysDB) -> None:
             metadata=collection["metadata"],
         )
 
-    # get_or_create = True overwrites metadata
+    # get_or_create = True does not overwrite metadata
     overlayed_metadata: Dict[str, Union[str, int, float]] = {
         "test_new_str": "new_str",
         "test_int": 1,
     }
+
     result, created = sysdb.create_collection(
         name=sample_collections[2].name,
         id=sample_collections[2].id,
@@ -310,9 +311,10 @@ def test_get_or_create_collection(sysdb: SysDB) -> None:
         metadata=overlayed_metadata,
     )
 
-    assert result["metadata"] == overlayed_metadata
+    assert result["metadata"] != overlayed_metadata
+    assert result["metadata"] == sample_collections[2]["metadata"]
 
-    # get_or_create = False with None metadata does not overwrite metadata
+    # get_or_create = True with None metadata does not overwrite metadata
     result, created = sysdb.create_collection(
         name=sample_collections[2].name,
         id=sample_collections[2].id,
@@ -320,7 +322,7 @@ def test_get_or_create_collection(sysdb: SysDB) -> None:
         get_or_create=True,
         metadata=None,
     )
-    assert result["metadata"] == overlayed_metadata
+    assert result["metadata"] == sample_collections[2]["metadata"]
 
 
 def test_create_get_delete_database_and_collection(sysdb: SysDB) -> None:

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -129,7 +129,6 @@ class CollectionStateMachine(RuleBasedStateMachine):
         # Case 0
         # new_metadata is none, coll is an existing collection
         # get_or_create should return the existing collection with existing metadata
-        # Essentially - an update with none is a no-op
 
         # Case 1
         # new_metadata is none, coll is a new collection
@@ -137,15 +136,11 @@ class CollectionStateMachine(RuleBasedStateMachine):
 
         # Case 2
         # new_metadata is not none, coll is an existing collection
-        # get_or_create should return the existing collection with updated metadata
+        # get_or_create should return the existing collection with the original metadata
 
         # Case 3
         # new_metadata is not none, coll is a new collection
-        # get_or_create should create a new collection with the new metadata, ignoring
-        # the metdata of in the input coll.
-
-        # The fact that we ignore the metadata of the generated collections is a
-        # bit weird, but it is the easiest way to excercise all cases
+        # get_or_create should create a new collection with the new metadata
 
         if new_metadata is not None and len(new_metadata) == 0:
             with pytest.raises(Exception):
@@ -160,12 +155,7 @@ class CollectionStateMachine(RuleBasedStateMachine):
         if coll.name not in self.model:
             # Handles case 1 and 3
             coll.metadata = new_metadata
-        else:
-            # Handles case 0 and 2
-            coll.metadata = (
-                self.model[coll.name] if new_metadata is None else new_metadata
-            )
-        self.set_model(coll.name, coll.metadata)  # type: ignore[arg-type]
+            self.set_model(coll.name, coll.metadata)  # type: ignore[arg-type]
 
         # Update API
         c = self.client.get_or_create_collection(

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -445,25 +445,25 @@ def test_modify_warn_on_DF_change(client, caplog):
 def test_metadata_cru(client):
     client.reset()
     metadata_a = {"a": 1, "b": 2}
-    # Test create metatdata
+    # Test create metadata
     collection = client.create_collection("testspace", metadata=metadata_a)
     assert collection.metadata is not None
     assert collection.metadata["a"] == 1
     assert collection.metadata["b"] == 2
 
-    # Test get metatdata
+    # Test get metadata
     collection = client.get_collection("testspace")
     assert collection.metadata is not None
     assert collection.metadata["a"] == 1
     assert collection.metadata["b"] == 2
 
-    # Test modify metatdata
+    # Test modify metadata
     collection.modify(metadata={"a": 2, "c": 3})
     assert collection.metadata["a"] == 2
     assert collection.metadata["c"] == 3
     assert "b" not in collection.metadata
 
-    # Test get after modify metatdata
+    # Test get after modify metadata
     collection = client.get_collection("testspace")
     assert collection.metadata is not None
     assert collection.metadata["a"] == 2

--- a/docs/docs.trychroma.com/pages/reference/py-client.md
+++ b/docs/docs.trychroma.com/pages/reference/py-client.md
@@ -382,8 +382,7 @@ Get or create a collection with the given name and metadata.
 
 - `name` - The name of the collection to get or create
 - `metadata` - Optional metadata to associate with the collection. If
-  the collection alredy exists, the metadata will be updated if
-  provided and not None. If the collection does not exist, the
+  the collection alredy exists, the metadata will be ignored. If the collection does not exist, the
   new collection will be created with the provided metadata.
 - `embedding_function` - Optional function to use to embed documents
 - `data_loader` - Optional function to use to load records (documents, images, etc.)

--- a/go/pkg/metastore/coordinator/table_catalog.go
+++ b/go/pkg/metastore/coordinator/table_catalog.go
@@ -238,20 +238,7 @@ func (tc *Catalog) CreateCollection(ctx context.Context, createCollection *model
 		if len(existing) != 0 {
 			if createCollection.GetOrCreate {
 				collection := convertCollectionToModel(existing)[0]
-				if createCollection.Metadata != nil && !createCollection.Metadata.Equals(collection.Metadata) {
-					updatedCollection, err := tc.UpdateCollection(ctx, &model.UpdateCollection{
-						ID:           collection.ID,
-						Metadata:     createCollection.Metadata,
-						TenantID:     tenantID,
-						DatabaseName: databaseName,
-					}, ts)
-					if err != nil {
-						log.Error("error updating collection", zap.Error(err))
-					}
-					result = updatedCollection
-				} else {
-					result = collection
-				}
+				result = collection
 				return nil
 			} else {
 				return common.ErrCollectionUniqueConstraintViolation


### PR DESCRIPTION
## Description of changes
`get_or_create` collection was overriding metadata on the "get" path when the collection already exists. This PR removes this behavior to make the API consistent with its name. Users can utilize `Collection.modify` to change a collection's metadata.

One idea for `get_or_create` was to rename arguments prefix arguments with `create_`, to make it clear that they only apply to the `create` path. We decided to remove the overriding behavior on the `get` path without renaming the arguments to minimize breakage.

Another idea for future consideration is to add a `Client.modify_collection` API. This would make it clear at a quick glance that a separate modifying API is available. A caveat is that we already have a `Collection.modify` API.

## Test plan
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
Documentation updated to reflect this change.
