### PR TITLE
[ENH] Add log position to FE

### DIFF
--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -214,6 +214,7 @@ def from_proto_collection(collection: proto.Collection) -> Collection:
         database=collection.database,
         tenant=collection.tenant,
         version=collection.version,
+        log_position=collection.log_position,
     )
 
 

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -66,9 +66,10 @@ class Collection(
     dimension: Optional[int]
     tenant: str
     database: str
-    # The version is only used in the distributed version of chroma
+    # The version and log position is only used in the distributed version of chroma
     # in single-node chroma, this field is always 0
     version: int
+    log_position: int
 
     def __init__(
         self,
@@ -80,6 +81,7 @@ class Collection(
         tenant: str,
         database: str,
         version: int = 0,
+        log_position: int = 0,
     ):
         super().__init__(
             id=id,
@@ -90,6 +92,7 @@ class Collection(
             tenant=tenant,
             database=database,
             version=version,
+            log_position=log_position,
         )
 
     # TODO: This throws away type information.

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -56,6 +56,7 @@ describe("collection operations", () => {
       "name": "test",
       "tenant": "default_tenant",
       "version": 0,
+      "log_position": 0,
     }
   `);
 
@@ -94,6 +95,7 @@ describe("collection operations", () => {
       "name": "test2",
       "tenant": "default_tenant",
       "version": 0,
+      "log_position": 0,
     }
   `);
   });

--- a/clients/js/test/collection.client.test.ts
+++ b/clients/js/test/collection.client.test.ts
@@ -52,11 +52,11 @@ describe("collection operations", () => {
       "database": "default_database",
       "dimension": null,
       "id": undefined,
+      "log_position": 0,
       "metadata": null,
       "name": "test",
       "tenant": "default_tenant",
       "version": 0,
-      "log_position": 0,
     }
   `);
 
@@ -89,13 +89,13 @@ describe("collection operations", () => {
       "database": "default_database",
       "dimension": null,
       "id": undefined,
+      "log_position": 0,
       "metadata": {
         "test": "test",
       },
       "name": "test2",
       "tenant": "default_tenant",
       "version": 0,
-      "log_position": 0,
     }
   `);
   });


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This PR simply hydrates the python representation of the collection with the log position that comes from the proto. Following the convention for version, this is 0 and unused in single node.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None