### PR TITLE
[BUG]: fix JS publish workflow

### DIFF
--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -48,7 +48,7 @@ jobs:
         jq --arg org "$ORG_NAME" --arg name "$PACKAGE_NAME" '.name = "\($org)/\($name)"' package.json > tmp.$$.json && mv tmp.$$.json package.json
       working-directory: ./clients/js/
     - name: Test & publish
-      run: npm run db:run && PORT=8001 npm run $NPM_SCRIPT
+      run: npm run $NPM_SCRIPT
       working-directory: ./clients/js/
       env:
         NODE_AUTH_TOKEN: ${{ matrix.registry == 'https://registry.npmjs.org' && secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of changes

The `db:run` script no longer exists and should not be necessary as the test fixture automatically creates and starts a container.

## Test plan
*How are these changes tested?*

🤷

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
