### PR TITLE
[BUG] Add release version regex to setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+tag_regex = '^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
+git_describe_command = 'git describe --tags --long --match "[0-9]*.[0-9]*.[0-9]*"'
 
 [tool.setuptools]
 packages = ["chromadb"]


### PR DESCRIPTION
## Description of changes
Added a regex filter on tags for setuptools, so we only consider release number tags.

## Test plan
Made sure we get dev and numbered versions, and that "js_release" tags are ignored.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
Updating release guide.
