### PR TITLE
[ENH] Propagate version through system

### DIFF
--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -9,6 +9,7 @@ from chromadb.types import (
     LogRecord,
     Metadata,
     Operation,
+    RequestVersionContext,
     ScalarEncoding,
     Segment,
     SegmentScope,
@@ -294,4 +295,22 @@ def from_proto_vector_query_result(
         id=vector_query_result.id,
         distance=vector_query_result.distance,
         embedding=from_proto_vector(vector_query_result.vector)[0],
+    )
+
+
+def from_proto_request_version_context(
+    request_version_context: proto.RequestVersionContext,
+) -> RequestVersionContext:
+    return RequestVersionContext(
+        collection_version=request_version_context.collection_version,
+        log_position=request_version_context.log_position,
+    )
+
+
+def to_proto_request_version_context(
+    request_version_context: RequestVersionContext,
+) -> proto.RequestVersionContext:
+    return proto.RequestVersionContext(
+        collection_version=request_version_context["collection_version"],
+        log_position=request_version_context["log_position"],
     )

--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional, Sequence
+from chromadb.proto.convert import to_proto_request_version_context
 from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
 from chromadb.segment import MetadataReader
 from chromadb.config import System
@@ -52,9 +53,12 @@ class GrpcMetadataSegment(MetadataReader):
         request: pb.CountRecordsRequest = pb.CountRecordsRequest(
             segment_id=self._segment["id"].hex,
             collection_id=self._segment["collection"].hex,
+            version_context=to_proto_request_version_context(request_version_context),
         )
         response: pb.CountRecordsResponse = self._metadata_reader_stub.CountRecords(
-            request, timeout=self._request_timeout_seconds
+            request,
+            timeout=self._request_timeout_seconds,
+            version_context=to_proto_request_version_context(request_version_context),
         )
         return response.count
 
@@ -107,7 +111,9 @@ class GrpcMetadataSegment(MetadataReader):
         )
 
         response: pb.QueryMetadataResponse = self._metadata_reader_stub.QueryMetadata(
-            request, timeout=self._request_timeout_seconds
+            request,
+            timeout=self._request_timeout_seconds,
+            version_context=to_proto_request_version_context(request_version_context),
         )
         results: List[MetadataEmbeddingRecord] = []
         for record in response.records:

--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -58,7 +58,6 @@ class GrpcMetadataSegment(MetadataReader):
         response: pb.CountRecordsResponse = self._metadata_reader_stub.CountRecords(
             request,
             timeout=self._request_timeout_seconds,
-            version_context=to_proto_request_version_context(request_version_context),
         )
         return response.count
 
@@ -108,12 +107,12 @@ class GrpcMetadataSegment(MetadataReader):
             limit=limit,
             offset=offset,
             include_metadata=include_metadata,
+            version_context=to_proto_request_version_context(request_version_context),
         )
 
         response: pb.QueryMetadataResponse = self._metadata_reader_stub.QueryMetadata(
             request,
             timeout=self._request_timeout_seconds,
-            version_context=to_proto_request_version_context(request_version_context),
         )
         results: List[MetadataEmbeddingRecord] = []
         for record in response.records:

--- a/chromadb/segment/impl/vector/grpc_segment.py
+++ b/chromadb/segment/impl/vector/grpc_segment.py
@@ -4,6 +4,7 @@ from chromadb.config import System
 from chromadb.proto.convert import (
     from_proto_vector_embedding_record,
     from_proto_vector_query_result,
+    to_proto_request_version_context,
     to_proto_vector,
 )
 from chromadb.proto.utils import RetryOnRpcErrorClientInterceptor
@@ -66,7 +67,9 @@ class GrpcVectorSegment(VectorReader, EnforceOverrides):
             collection_id=self._segment["collection"].hex,
         )
         response: GetVectorsResponse = self._vector_reader_stub.GetVectors(
-            request, timeout=self._request_timeout_seconds
+            request,
+            timeout=self._request_timeout_seconds,
+            version_context=to_proto_request_version_context(request_version_context),
         )
         results: List[VectorEmbeddingRecord] = []
         for vector in response.records:
@@ -91,7 +94,11 @@ class GrpcVectorSegment(VectorReader, EnforceOverrides):
             collection_id=self._segment["collection"].hex,
         )
         response: QueryVectorsResponse = self._vector_reader_stub.QueryVectors(
-            request, timeout=self._request_timeout_seconds
+            request,
+            timeout=self._request_timeout_seconds,
+            version_context=to_proto_request_version_context(
+                query["request_version_context"]
+            ),
         )
         results: List[List[VectorQueryResult]] = []
         for result in response.results:

--- a/chromadb/segment/impl/vector/grpc_segment.py
+++ b/chromadb/segment/impl/vector/grpc_segment.py
@@ -92,13 +92,13 @@ class GrpcVectorSegment(VectorReader, EnforceOverrides):
             include_embeddings=query["include_embeddings"],
             segment_id=self._segment["id"].hex,
             collection_id=self._segment["collection"].hex,
+            version_context=to_proto_request_version_context(
+                query["request_version_context"]
+            ),
         )
         response: QueryVectorsResponse = self._vector_reader_stub.QueryVectors(
             request,
             timeout=self._request_timeout_seconds,
-            version_context=to_proto_request_version_context(
-                query["request_version_context"]
-            ),
         )
         results: List[List[VectorQueryResult]] = []
         for result in response.results:

--- a/chromadb/segment/impl/vector/grpc_segment.py
+++ b/chromadb/segment/impl/vector/grpc_segment.py
@@ -65,11 +65,11 @@ class GrpcVectorSegment(VectorReader, EnforceOverrides):
             ids=ids,
             segment_id=self._segment["id"].hex,
             collection_id=self._segment["collection"].hex,
+            version_context=to_proto_request_version_context(request_version_context),
         )
         response: GetVectorsResponse = self._vector_reader_stub.GetVectors(
             request,
             timeout=self._request_timeout_seconds,
-            version_context=to_proto_request_version_context(request_version_context),
         )
         results: List[VectorEmbeddingRecord] = []
         for vector in response.records:

--- a/rust/error/src/lib.rs
+++ b/rust/error/src/lib.rs
@@ -10,7 +10,7 @@ pub enum ErrorCodes {
     // CANCELLED indicates the operation was cancelled (typically by the caller).
     Cancelled = 1,
     // UNKNOWN indicates an unknown error.
-    UNKNOWN = 2,
+    Unknown = 2,
     // INVALID_ARGUMENT indicates client specified an invalid argument.
     InvalidArgument = 3,
     // DEADLINE_EXCEEDED means operation expired before completion.
@@ -21,8 +21,6 @@ pub enum ErrorCodes {
     AlreadyExists = 6,
     // PERMISSION_DENIED indicates the caller does not have permission to execute the specified operation.
     PermissionDenied = 7,
-    // UNAUTHENTICATED indicates the request does not have valid authentication credentials for the operation.
-    UNAUTHENTICATED = 16,
     // RESOURCE_EXHAUSTED indicates some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of space.
     ResourceExhausted = 8,
     // FAILED_PRECONDITION indicates operation was rejected because the system is not in a state required for the operation's execution.
@@ -39,6 +37,10 @@ pub enum ErrorCodes {
     Unavailable = 14,
     // DATA_LOSS indicates unrecoverable data loss or corruption.
     DataLoss = 15,
+    // UNAUTHENTICATED indicates the request does not have valid authentication credentials for the operation.
+    Unauthenticated = 16,
+    // VERSION_MISMATCH indicates a version mismatch. This is not from the gRPC spec and is specific to Chroma.
+    VersionMismatch = 17,
 }
 
 pub trait ChromaError: Error + Send {

--- a/rust/worker/src/execution/operators/merge_knn_results.rs
+++ b/rust/worker/src/execution/operators/merge_knn_results.rs
@@ -63,7 +63,7 @@ pub enum MergeKnnResultsOperatorError {}
 
 impl ChromaError for MergeKnnResultsOperatorError {
     fn code(&self) -> ErrorCodes {
-        return ErrorCodes::UNKNOWN;
+        return ErrorCodes::Unknown;
     }
 }
 

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -150,8 +150,19 @@ impl CountQueryOrchestrator {
             }
         };
 
+        // If the collection version does not match the request version then we terminate with an error
+        if collection.version as u32 != self.collection_version {
+            terminate_with_error(
+                self.result_channel.take(),
+                Box::new(CountQueryOrchestratorError::CollectionVersionMismatch),
+                ctx,
+            );
+            return;
+        }
+
         self.record_segment = Some(record_segment);
         self.collection = Some(collection);
+        self.pull_logs(ctx).await;
     }
 
     // shared
@@ -319,7 +330,6 @@ impl Component for CountQueryOrchestrator {
 
     async fn on_start(&mut self, ctx: &crate::system::ComponentContext<Self>) -> () {
         self.start(ctx).await;
-        self.pull_logs(ctx).await;
     }
 }
 

--- a/rust/worker/src/execution/orchestration/get_vectors.rs
+++ b/rust/worker/src/execution/orchestration/get_vectors.rs
@@ -252,6 +252,16 @@ impl Component for GetVectorsOrchestrator {
             }
         };
 
+        // If the collection version does not match the request version then we terminate with an error
+        if collection.version as u32 != self.collection_version {
+            terminate_with_error(
+                self.result_channel.take(),
+                Box::new(GetVectorsError::CollectionVersionMismatch),
+                ctx,
+            );
+            return;
+        }
+
         let record_segment =
             match get_record_segment_by_collection_id(self.sysdb.clone(), collection_id).await {
                 Ok(segment) => segment,

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -583,6 +583,16 @@ impl Component for HnswQueryOrchestrator {
             }
         };
 
+        // If the collection version does not match the request version then we terminate with an error
+        if collection.version as u32 != self.collection_version {
+            terminate_with_error(
+                self.result_channel.take(),
+                Box::new(HnswSegmentQueryError::CollectionVersionMismatch),
+                ctx,
+            );
+            return;
+        }
+
         // If segment is uninitialized and dimension is not set then we assume
         // that this is a query before any add so return empty response.
         if hnsw_segment.file_path.len() <= 0 && collection.dimension.is_none() {

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -65,6 +65,9 @@ pub(crate) struct MetadataQueryOrchestrator {
     include_metadata: bool,
     // Result channel
     result_channel: Option<tokio::sync::oneshot::Sender<MetadataQueryOrchestratorResult>>,
+    // Request version context
+    collection_version: u32,
+    log_position: u64,
 }
 
 #[derive(Error, Debug)]
@@ -81,6 +84,8 @@ enum MetadataQueryOrchestratorError {
     CollectionNotFound(Uuid),
     #[error("Get collection error: {0}")]
     GetCollectionError(#[from] GetCollectionsError),
+    #[error("Collection version mismatch")]
+    CollectionVersionMismatch,
 }
 
 impl ChromaError for MetadataQueryOrchestratorError {
@@ -94,6 +99,9 @@ impl ChromaError for MetadataQueryOrchestratorError {
             MetadataQueryOrchestratorError::SystemTimeError(_) => ErrorCodes::Internal,
             MetadataQueryOrchestratorError::CollectionNotFound(_) => ErrorCodes::NotFound,
             MetadataQueryOrchestratorError::GetCollectionError(e) => e.code(),
+            MetadataQueryOrchestratorError::CollectionVersionMismatch => {
+                ErrorCodes::VersionMismatch
+            }
         }
     }
 }
@@ -113,6 +121,8 @@ impl MetadataQueryOrchestrator {
         offset: Option<u32>,
         limit: Option<u32>,
         include_metadata: bool,
+        collection_version: u32,
+        log_position: u64,
     ) -> Self {
         Self {
             state: ExecutionState::Pending,
@@ -134,6 +144,8 @@ impl MetadataQueryOrchestrator {
             limit,
             include_metadata,
             result_channel: None,
+            collection_version,
+            log_position,
         }
     }
 
@@ -211,7 +223,9 @@ impl MetadataQueryOrchestrator {
         let input = PullLogsInput::new(
             collection.id,
             // The collection log position is inclusive, and we want to start from the next log.
-            collection.log_position + 1,
+            // Note: We use the log position sent in the request for transactionality
+            // TODO: Change log service to use u64 instead of i64
+            (self.log_position as i64) + 1,
             100,
             None,
             Some(end_timestamp),

--- a/rust/worker/src/execution/orchestration/metadata.rs
+++ b/rust/worker/src/execution/orchestration/metadata.rs
@@ -194,8 +194,19 @@ impl MetadataQueryOrchestrator {
             }
         };
 
+        // If the collection version does not match the version in the request, return an error
+        if collection.version as u32 != self.collection_version {
+            terminate_with_error(
+                self.result_channel.take(),
+                Box::new(MetadataQueryOrchestratorError::CollectionVersionMismatch),
+                ctx,
+            );
+            return;
+        }
+
         self.record_segment = Some(record_segment);
         self.collection = Some(collection);
+        self.pull_logs(ctx).await;
     }
 
     async fn pull_logs(&mut self, ctx: &ComponentContext<Self>) {
@@ -399,7 +410,6 @@ impl Component for MetadataQueryOrchestrator {
 
     async fn on_start(&mut self, ctx: &crate::system::ComponentContext<Self>) -> () {
         self.start(ctx).await;
-        self.pull_logs(ctx).await;
     }
 }
 

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -182,6 +182,8 @@ impl WorkerServer {
                     self.hnsw_index_provider.clone(),
                     self.blockfile_provider.clone(),
                     dispatcher,
+                    request.version_context,
+                    request.version_context.log_position,
                 );
                 orchestrator.run().await
             }

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -146,6 +146,16 @@ impl WorkerServer {
             }
         };
 
+        let (collection_version, log_position) = match request.version_context {
+            Some(version_context) => (
+                version_context.collection_version,
+                version_context.log_position,
+            ),
+            None => {
+                return Err(Status::invalid_argument("No version context provided"));
+            }
+        };
+
         let mut proto_results_for_all = Vec::new();
 
         let mut query_vectors = Vec::new();
@@ -182,8 +192,8 @@ impl WorkerServer {
                     self.hnsw_index_provider.clone(),
                     self.blockfile_provider.clone(),
                     dispatcher,
-                    request.version_context,
-                    request.version_context.log_position,
+                    collection_version,
+                    log_position,
                 );
                 orchestrator.run().await
             }
@@ -258,6 +268,16 @@ impl WorkerServer {
             }
         };
 
+        let (collection_version, log_position) = match request.version_context {
+            Some(version_context) => (
+                version_context.collection_version,
+                version_context.log_position,
+            ),
+            None => {
+                return Err(Status::invalid_argument("No version context provided"));
+            }
+        };
+
         let dispatcher = match self.dispatcher {
             Some(ref dispatcher) => dispatcher.clone(),
             None => {
@@ -281,6 +301,8 @@ impl WorkerServer {
             self.sysdb.clone(),
             dispatcher,
             self.blockfile_provider.clone(),
+            collection_version,
+            log_position,
         );
         let result = orchestrator.run().await;
         let mut result = match result {
@@ -334,6 +356,16 @@ impl WorkerServer {
             Ok(uuid) => uuid,
             Err(_) => {
                 return Err(Status::invalid_argument("Invalid Collection UUID"));
+            }
+        };
+
+        let (collection_version, log_position) = match request.version_context {
+            Some(version_context) => (
+                version_context.collection_version,
+                version_context.log_position,
+            ),
+            None => {
+                return Err(Status::invalid_argument("No version context provided"));
             }
         };
 
@@ -394,6 +426,8 @@ impl WorkerServer {
             request.offset,
             request.limit,
             request.include_metadata,
+            collection_version,
+            log_position,
         );
 
         let result = orchestrator.run().await;
@@ -508,7 +542,16 @@ impl chroma_proto::metadata_reader_server::MetadataReader for WorkerServer {
             }
         };
 
-        println!("Querying count for segment {}", segment_uuid);
+        let (collection_version, log_position) = match request.version_context {
+            Some(version_context) => (
+                version_context.collection_version,
+                version_context.log_position,
+            ),
+            None => {
+                return Err(Status::invalid_argument("No version context provided"));
+            }
+        };
+
         let dispatcher = match self.dispatcher {
             Some(ref dispatcher) => dispatcher,
             None => {
@@ -531,6 +574,8 @@ impl chroma_proto::metadata_reader_server::MetadataReader for WorkerServer {
             self.sysdb.clone(),
             dispatcher.clone(),
             self.blockfile_provider.clone(),
+            collection_version,
+            log_position,
         );
 
         let result = orchestrator.run().await;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Pass the request_version_context into the protobufs and to the rust code. In the rust orchestrators, we error on mismatches and propagate this error up to python.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
