### PR TITLE
[BUG] Add release version regex to setuptools

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -47,6 +47,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+tag_regex = '^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
+git_describe_command = 'git describe --tags --long --match "[0-9]*.[0-9]*.[0-9]*"'
 
 [tool.setuptools]
 packages = ["chromadb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+tag_regex = '^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
+git_describe_command = 'git describe --tags --long --match "[0-9]*.[0-9]*.[0-9]*"'
 
 [tool.setuptools]
 packages = ["chromadb"]


### PR DESCRIPTION
## Description of changes

* `setuptools_scm` will now ignore tags that are not major/minor releases.
* Align thin client versioning with `chromadb` versions.

## Test plan
* Tested locally for both `dev` versions and when creating tags for new releases.
* Freed up space on Test PyPi.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
Updating our release guide.
