### PR TITLE
[ENH] Propagate error codes through rust services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,6 +1209,9 @@ dependencies = [
 [[package]]
 name = "chroma-error"
 version = "0.1.0"
+dependencies = [
+ "tonic 0.10.2",
+]
 
 [[package]]
 name = "chroma-index"

--- a/rust/error/Cargo.toml
+++ b/rust/error/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
+tonic = { workspace = true }

--- a/rust/error/src/lib.rs
+++ b/rust/error/src/lib.rs
@@ -54,3 +54,28 @@ impl ChromaError for Box<dyn ChromaError> {
         self.as_ref().code()
     }
 }
+
+impl From<ErrorCodes> for tonic::Code {
+    fn from(err: ErrorCodes) -> tonic::Code {
+        match err {
+            ErrorCodes::Success => tonic::Code::Ok,
+            ErrorCodes::Cancelled => tonic::Code::Cancelled,
+            ErrorCodes::Unknown => tonic::Code::Unknown,
+            ErrorCodes::InvalidArgument => tonic::Code::InvalidArgument,
+            ErrorCodes::DeadlineExceeded => tonic::Code::DeadlineExceeded,
+            ErrorCodes::NotFound => tonic::Code::NotFound,
+            ErrorCodes::AlreadyExists => tonic::Code::AlreadyExists,
+            ErrorCodes::PermissionDenied => tonic::Code::PermissionDenied,
+            ErrorCodes::ResourceExhausted => tonic::Code::ResourceExhausted,
+            ErrorCodes::FailedPrecondition => tonic::Code::FailedPrecondition,
+            ErrorCodes::Aborted => tonic::Code::Aborted,
+            ErrorCodes::OutOfRange => tonic::Code::OutOfRange,
+            ErrorCodes::Unimplemented => tonic::Code::Unimplemented,
+            ErrorCodes::Internal => tonic::Code::Internal,
+            ErrorCodes::Unavailable => tonic::Code::Unavailable,
+            ErrorCodes::DataLoss => tonic::Code::DataLoss,
+            ErrorCodes::Unauthenticated => tonic::Code::Unauthenticated,
+            ErrorCodes::VersionMismatch => tonic::Code::Internal,
+        }
+    }
+}

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -205,10 +205,11 @@ impl WorkerServer {
         let result = match result {
             Ok(result) => result,
             Err(e) => {
-                return Err(Status::internal(format!(
-                    "Error running orchestrator: {}",
-                    e
-                )));
+                tracing::error!("Error running orchestrator: {}", e);
+                return Err(Status::new(
+                    e.code().into(),
+                    format!("Error running orchestrator: {}", e),
+                ));
             }
         };
 
@@ -308,10 +309,11 @@ impl WorkerServer {
         let mut result = match result {
             Ok(result) => result,
             Err(e) => {
-                return Err(Status::internal(format!(
-                    "Error running orchestrator: {}",
-                    e
-                )));
+                tracing::error!("Error running orchestrator: {}", e);
+                return Err(Status::new(
+                    e.code().into(),
+                    format!("Error running orchestrator: {}", e),
+                ));
             }
         };
 
@@ -435,10 +437,10 @@ impl WorkerServer {
             Ok(result) => result,
             Err(e) => {
                 tracing::error!("Error running orchestrator: {}", e);
-                return Err(Status::internal(format!(
-                    "Error running orchestrator: {}",
-                    e
-                )));
+                return Err(Status::new(
+                    e.code().into(),
+                    format!("Error running orchestrator: {}", e),
+                ));
             }
         };
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Send error codes back to calling services from `Box<dyn ChromaError>`s
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
