### PR TITLE
[ENH] Implement `SignedRoaringBitmap` and update where/where_document AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "chroma-error",
  "prost 0.12.3",
  "prost-types",
+ "roaring",
  "thiserror",
  "tonic 0.10.2",
  "tonic-build",

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-tonic = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-uuid = { workspace = true }
+roaring = { workspace = true }
 thiserror = { workspace = true }
+tonic = { workspace = true }
+uuid = { workspace = true }
 
 chroma-error = { workspace = true }
 

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -1,14 +1,20 @@
-use crate::chroma_proto;
 use chroma_error::{ChromaError, ErrorCodes};
-use std::collections::{HashMap, HashSet};
+use roaring::RoaringBitmap;
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    ops::{BitAnd, BitOr},
+};
 use thiserror::Error;
+
+use crate::chroma_proto;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum UpdateMetadataValue {
-    Int(i32),
+    Bool(bool),
+    Int(i64),
     Float(f64),
     Str(String),
-    Bool(bool),
     None,
 }
 
@@ -31,17 +37,17 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for UpdateMetadataValue {
 
     fn try_from(value: &chroma_proto::UpdateMetadataValue) -> Result<Self, Self::Error> {
         match &value.value {
+            Some(chroma_proto::update_metadata_value::Value::BoolValue(value)) => {
+                Ok(UpdateMetadataValue::Bool(*value))
+            }
             Some(chroma_proto::update_metadata_value::Value::IntValue(value)) => {
-                Ok(UpdateMetadataValue::Int(*value as i32))
+                Ok(UpdateMetadataValue::Int(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::FloatValue(value)) => {
                 Ok(UpdateMetadataValue::Float(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::StringValue(value)) => {
                 Ok(UpdateMetadataValue::Str(value.clone()))
-            }
-            Some(chroma_proto::update_metadata_value::Value::BoolValue(value)) => {
-                Ok(UpdateMetadataValue::Bool(*value))
             }
             // Used to communicate that the user wants to delete this key.
             None => Ok(UpdateMetadataValue::None),
@@ -52,6 +58,9 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for UpdateMetadataValue {
 impl From<UpdateMetadataValue> for chroma_proto::UpdateMetadataValue {
     fn from(value: UpdateMetadataValue) -> Self {
         match value {
+            UpdateMetadataValue::Bool(value) => chroma_proto::UpdateMetadataValue {
+                value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
+            },
             UpdateMetadataValue::Int(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::IntValue(
                     value as i64,
@@ -67,9 +76,6 @@ impl From<UpdateMetadataValue> for chroma_proto::UpdateMetadataValue {
                     value,
                 )),
             },
-            UpdateMetadataValue::Bool(value) => chroma_proto::UpdateMetadataValue {
-                value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
-            },
             UpdateMetadataValue::None => chroma_proto::UpdateMetadataValue { value: None },
         }
     }
@@ -80,10 +86,10 @@ impl TryFrom<&UpdateMetadataValue> for MetadataValue {
 
     fn try_from(value: &UpdateMetadataValue) -> Result<Self, Self::Error> {
         match value {
+            UpdateMetadataValue::Bool(value) => Ok(MetadataValue::Bool(*value)),
             UpdateMetadataValue::Int(value) => Ok(MetadataValue::Int(*value)),
             UpdateMetadataValue::Float(value) => Ok(MetadataValue::Float(*value)),
             UpdateMetadataValue::Str(value) => Ok(MetadataValue::Str(value.clone())),
-            UpdateMetadataValue::Bool(value) => Ok(MetadataValue::Bool(*value)),
             UpdateMetadataValue::None => Err(MetadataValueConversionError::InvalidValue),
         }
     }
@@ -95,15 +101,35 @@ MetadataValue
 ===========================================
 */
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum MetadataValue {
-    Int(i32),
+    Bool(bool),
+    Int(i64),
     Float(f64),
     Str(String),
-    Bool(bool),
 }
 
-impl TryFrom<&MetadataValue> for i32 {
+impl Eq for MetadataValue {}
+
+#[allow(clippy::derive_ord_xor_partial_ord)]
+impl Ord for MetadataValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Equal)
+    }
+}
+
+impl TryFrom<&MetadataValue> for bool {
+    type Error = MetadataValueConversionError;
+
+    fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
+        match value {
+            MetadataValue::Bool(value) => Ok(*value),
+            _ => Err(MetadataValueConversionError::InvalidValue),
+        }
+    }
+}
+
+impl TryFrom<&MetadataValue> for i64 {
     type Error = MetadataValueConversionError;
 
     fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
@@ -120,17 +146,6 @@ impl TryFrom<&MetadataValue> for f64 {
     fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
         match value {
             MetadataValue::Float(value) => Ok(*value),
-            _ => Err(MetadataValueConversionError::InvalidValue),
-        }
-    }
-}
-
-impl TryFrom<&MetadataValue> for bool {
-    type Error = MetadataValueConversionError;
-
-    fn try_from(value: &MetadataValue) -> Result<Self, Self::Error> {
-        match value {
-            MetadataValue::Bool(value) => Ok(*value),
             _ => Err(MetadataValueConversionError::InvalidValue),
         }
     }
@@ -166,17 +181,17 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for MetadataValue {
 
     fn try_from(value: &chroma_proto::UpdateMetadataValue) -> Result<Self, Self::Error> {
         match &value.value {
+            Some(chroma_proto::update_metadata_value::Value::BoolValue(value)) => {
+                Ok(MetadataValue::Bool(*value))
+            }
             Some(chroma_proto::update_metadata_value::Value::IntValue(value)) => {
-                Ok(MetadataValue::Int(*value as i32))
+                Ok(MetadataValue::Int(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::FloatValue(value)) => {
                 Ok(MetadataValue::Float(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::StringValue(value)) => {
                 Ok(MetadataValue::Str(value.clone()))
-            }
-            Some(chroma_proto::update_metadata_value::Value::BoolValue(value)) => {
-                Ok(MetadataValue::Bool(*value))
             }
             _ => Err(MetadataValueConversionError::InvalidValue),
         }
@@ -186,6 +201,9 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for MetadataValue {
 impl From<MetadataValue> for chroma_proto::UpdateMetadataValue {
     fn from(value: MetadataValue) -> Self {
         match value {
+            MetadataValue::Bool(value) => chroma_proto::UpdateMetadataValue {
+                value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
+            },
             MetadataValue::Int(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::IntValue(
                     value as i64,
@@ -309,42 +327,40 @@ Metadata queries
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Where {
-    DirectWhereComparison(DirectComparison),
+    DirectWhereComparison(DirectWhereComparison),
+    DirectWhereDocumentComparison(DirectDocumentComparison),
     WhereChildren(WhereChildren),
 }
 
+impl Where {
+    pub fn conjunction(children: Vec<Where>) -> Self {
+        Self::WhereChildren(WhereChildren {
+            operator: BooleanOperator::And,
+            children,
+        })
+    }
+    pub fn disjunction(children: Vec<Where>) -> Self {
+        Self::WhereChildren(WhereChildren {
+            operator: BooleanOperator::Or,
+            children,
+        })
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
-pub struct DirectComparison {
+pub struct DirectWhereComparison {
     pub key: String,
-    pub comparison: WhereComparison,
+    pub comp: WhereComparison,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum WhereComparison {
-    SingleStringComparison(String, WhereClauseComparator),
-    SingleIntComparison(u32, WhereClauseComparator),
-    SingleDoubleComparison(f64, WhereClauseComparator),
-    StringListComparison(Vec<String>, WhereClauseListOperator),
-    IntListComparison(Vec<u32>, WhereClauseListOperator),
-    DoubleListComparison(Vec<f64>, WhereClauseListOperator),
-    BoolListComparison(Vec<bool>, WhereClauseListOperator),
-    SingleBoolComparison(bool, WhereClauseComparator),
-}
-
-#[derive(Debug)]
-pub enum MetadataType {
-    StringType,
-    IntType,
-    DoubleType,
-    StringListType,
-    IntListType,
-    DoubleListType,
-    BoolListType,
-    BoolType,
+    Primitive(PrimitiveOperator, MetadataValue),
+    Set(SetOperator, MetadataSetValue),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum WhereClauseComparator {
+pub enum PrimitiveOperator {
     Equal,
     NotEqual,
     GreaterThan,
@@ -354,15 +370,35 @@ pub enum WhereClauseComparator {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum WhereClauseListOperator {
+pub enum SetOperator {
     In,
     NotIn,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum MetadataSetValue {
+    Bool(Vec<bool>),
+    Int(Vec<i64>),
+    Float(Vec<f64>),
+    Str(Vec<String>),
+}
+
+impl MetadataSetValue {
+    pub fn into_vec(&self) -> Vec<MetadataValue> {
+        use MetadataSetValue::*;
+        match self {
+            Bool(vec) => vec.iter().map(|b| MetadataValue::Bool(*b)).collect(),
+            Int(vec) => vec.iter().map(|i| MetadataValue::Int(*i)).collect(),
+            Float(vec) => vec.iter().map(|f| MetadataValue::Float(*f)).collect(),
+            Str(vec) => vec.iter().map(|s| MetadataValue::Str(s.clone())).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct WhereChildren {
-    pub children: Vec<Where>,
     pub operator: BooleanOperator,
+    pub children: Vec<Where>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -372,27 +408,15 @@ pub enum BooleanOperator {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum WhereDocument {
-    DirectWhereDocumentComparison(DirectDocumentComparison),
-    WhereDocumentChildren(WhereDocumentChildren),
-}
-
-#[derive(Clone, Debug, PartialEq)]
 pub struct DirectDocumentComparison {
+    pub operator: DocumentOperator,
     pub document: String,
-    pub operator: WhereDocumentOperator,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum WhereDocumentOperator {
+pub enum DocumentOperator {
     Contains,
     NotContains,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct WhereDocumentChildren {
-    pub children: Vec<WhereDocument>,
-    pub operator: BooleanOperator,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -408,9 +432,9 @@ impl TryFrom<chroma_proto::Where> for Where {
     fn try_from(proto_where: chroma_proto::Where) -> Result<Self, Self::Error> {
         match proto_where.r#where {
             Some(chroma_proto::r#where::Where::DirectComparison(proto_comparison)) => {
-                let comparison = DirectComparison {
+                let comparison = DirectWhereComparison {
                     key: proto_comparison.key.clone(),
-                    comparison: proto_comparison.try_into()?,
+                    comp: proto_comparison.try_into()?,
                 };
                 Ok(Where::DirectWhereComparison(comparison))
             }
@@ -440,181 +464,118 @@ impl TryFrom<chroma_proto::DirectComparison> for WhereComparison {
     type Error = WhereConversionError;
 
     fn try_from(proto_comparison: chroma_proto::DirectComparison) -> Result<Self, Self::Error> {
-        match proto_comparison.r#comparison {
-            Some(chroma_proto::direct_comparison::Comparison::SingleStringOperand(
-                proto_string,
-            )) => {
-                let comparator = match TryInto::<chroma_proto::GenericComparator>::try_into(
-                    proto_string.comparator,
-                ) {
-                    Ok(comparator) => comparator,
-                    Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                };
-                Ok(WhereComparison::SingleStringComparison(
-                    proto_string.value,
-                    comparator.try_into()?,
-                ))
-            }
-            Some(chroma_proto::direct_comparison::Comparison::SingleBoolOperand(proto_bool)) => {
-                let comparator = match TryInto::<chroma_proto::GenericComparator>::try_into(
-                    proto_bool.comparator,
-                ) {
-                    Ok(comparator) => comparator,
-                    Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                };
-                Ok(WhereComparison::SingleBoolComparison(
-                    proto_bool.value,
-                    comparator.try_into()?,
-                ))
-            }
-            Some(chroma_proto::direct_comparison::Comparison::SingleIntOperand(proto_int)) => {
-                let comparator: WhereClauseComparator = match proto_int.comparator {
-                    Some(comparator) => match comparator {
-                        chroma_proto::single_int_comparison::Comparator::NumberComparator(
-                            proto_comparator,
-                        ) => {
-                            match TryInto::<chroma_proto::NumberComparator>::try_into(
-                                proto_comparator,
-                            ) {
-                                Ok(comparator) => comparator.try_into()?,
-                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                            }
-                        }
-                        chroma_proto::single_int_comparison::Comparator::GenericComparator(
-                            proto_comparator,
-                        ) => {
-                            match TryInto::<chroma_proto::GenericComparator>::try_into(
-                                proto_comparator,
-                            ) {
-                                Ok(comparator) => comparator.try_into()?,
-                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                            }
-                        }
+        let id_to_generic_comparator = |id| {
+            TryInto::<chroma_proto::GenericComparator>::try_into(id)
+                .map_err(|_| WhereConversionError::InvalidWhereComparison)?
+                .try_into()
+        };
+        let id_to_number_comparator = |id| {
+            TryInto::<chroma_proto::NumberComparator>::try_into(id)
+                .map_err(|_| WhereConversionError::InvalidWhereComparison)?
+                .try_into()
+        };
+        let id_to_set_comparator = |id| {
+            TryInto::<chroma_proto::ListOperator>::try_into(id)
+                .map_err(|_| WhereConversionError::InvalidWhereComparison)?
+                .try_into()
+        };
+        if let Some(proto_comp) = proto_comparison.r#comparison {
+            use chroma_proto::direct_comparison::Comparison::*;
+            match proto_comp {
+                SingleBoolOperand(single_bool_comparison) => Ok(WhereComparison::Primitive(
+                    id_to_generic_comparator(single_bool_comparison.comparator)?,
+                    MetadataValue::Bool(single_bool_comparison.value),
+                )),
+                SingleStringOperand(single_string_comparison) => Ok(WhereComparison::Primitive(
+                    id_to_generic_comparator(single_string_comparison.comparator)?,
+                    MetadataValue::Str(single_string_comparison.value),
+                )),
+                SingleIntOperand(single_int_comparison) => Ok(WhereComparison::Primitive(
+                    match single_int_comparison.comparator {
+                        Some(
+                            chroma_proto::single_int_comparison::Comparator::GenericComparator(
+                                proto_generic_comparator,
+                            ),
+                        ) => id_to_generic_comparator(proto_generic_comparator)?,
+                        Some(
+                            chroma_proto::single_int_comparison::Comparator::NumberComparator(
+                                proto_number_comparator,
+                            ),
+                        ) => id_to_number_comparator(proto_number_comparator)?,
+                        None => PrimitiveOperator::Equal,
                     },
-                    None => WhereClauseComparator::Equal,
-                };
-                Ok(WhereComparison::SingleIntComparison(
-                    proto_int.value as u32,
-                    comparator,
-                ))
-            }
-            Some(chroma_proto::direct_comparison::Comparison::SingleDoubleOperand(
-                proto_double,
-            )) => {
-                let comparator: WhereClauseComparator = match proto_double.comparator {
-                    Some(comparator) => match comparator {
-                        chroma_proto::single_double_comparison::Comparator::NumberComparator(
-                            proto_comparator,
-                        ) => {
-                            match TryInto::<chroma_proto::NumberComparator>::try_into(
-                                proto_comparator,
-                            ) {
-                                Ok(comparator) => comparator.try_into()?,
-                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                            }
-                        }
-                        chroma_proto::single_double_comparison::Comparator::GenericComparator(
-                            proto_comparator,
-                        ) => {
-                            match TryInto::<chroma_proto::GenericComparator>::try_into(
-                                proto_comparator,
-                            ) {
-                                Ok(comparator) => comparator.try_into()?,
-                                Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                            }
-                        }
+                    MetadataValue::Int(single_int_comparison.value),
+                )),
+                SingleDoubleOperand(single_double_comparison) => Ok(WhereComparison::Primitive(
+                    match single_double_comparison.comparator {
+                        Some(
+                            chroma_proto::single_double_comparison::Comparator::GenericComparator(
+                                proto_generic_comparator,
+                            ),
+                        ) => id_to_generic_comparator(proto_generic_comparator)?,
+                        Some(
+                            chroma_proto::single_double_comparison::Comparator::NumberComparator(
+                                proto_number_comparator,
+                            ),
+                        ) => id_to_number_comparator(proto_number_comparator)?,
+                        None => PrimitiveOperator::Equal,
                     },
-                    None => WhereClauseComparator::Equal,
-                };
-                Ok(WhereComparison::SingleDoubleComparison(
-                    proto_double.value,
-                    comparator,
-                ))
+                    MetadataValue::Float(single_double_comparison.value),
+                )),
+                BoolListOperand(bool_list_comparison) => Ok(WhereComparison::Set(
+                    id_to_set_comparator(bool_list_comparison.list_operator)?,
+                    MetadataSetValue::Bool(bool_list_comparison.values),
+                )),
+                StringListOperand(string_list_comparison) => Ok(WhereComparison::Set(
+                    id_to_set_comparator(string_list_comparison.list_operator)?,
+                    MetadataSetValue::Str(string_list_comparison.values),
+                )),
+                IntListOperand(int_list_comparison) => Ok(WhereComparison::Set(
+                    id_to_set_comparator(int_list_comparison.list_operator)?,
+                    MetadataSetValue::Int(int_list_comparison.values),
+                )),
+                DoubleListOperand(double_list_comparison) => Ok(WhereComparison::Set(
+                    id_to_set_comparator(double_list_comparison.list_operator)?,
+                    MetadataSetValue::Float(double_list_comparison.values),
+                )),
             }
-            Some(chroma_proto::direct_comparison::Comparison::StringListOperand(proto_list)) => {
-                let list_operator =
-                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
-                    {
-                        Ok(list_operator) => list_operator,
-                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                    };
-                Ok(WhereComparison::StringListComparison(
-                    proto_list.values,
-                    list_operator.try_into()?,
-                ))
-            }
-            Some(chroma_proto::direct_comparison::Comparison::IntListOperand(proto_list)) => {
-                let list_operator =
-                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
-                    {
-                        Ok(list_operator) => list_operator,
-                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                    };
-                Ok(WhereComparison::IntListComparison(
-                    proto_list.values.into_iter().map(|v| v as u32).collect(),
-                    list_operator.try_into()?,
-                ))
-            }
-            Some(chroma_proto::direct_comparison::Comparison::DoubleListOperand(proto_list)) => {
-                let list_operator =
-                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
-                    {
-                        Ok(list_operator) => list_operator,
-                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                    };
-                Ok(WhereComparison::DoubleListComparison(
-                    proto_list.values,
-                    list_operator.try_into()?,
-                ))
-            }
-            Some(chroma_proto::direct_comparison::Comparison::BoolListOperand(proto_list)) => {
-                let list_operator =
-                    match TryInto::<chroma_proto::ListOperator>::try_into(proto_list.list_operator)
-                    {
-                        Ok(list_operator) => list_operator,
-                        Err(_) => return Err(WhereConversionError::InvalidWhereComparison),
-                    };
-                Ok(WhereComparison::BoolListComparison(
-                    proto_list.values,
-                    list_operator.try_into()?,
-                ))
-            }
-            None => Err(WhereConversionError::InvalidWhereComparison),
+        } else {
+            Err(WhereConversionError::InvalidWhereComparison)
         }
     }
 }
 
-impl TryFrom<chroma_proto::NumberComparator> for WhereClauseComparator {
+impl TryFrom<chroma_proto::NumberComparator> for PrimitiveOperator {
     type Error = WhereConversionError;
 
     fn try_from(proto_comparator: chroma_proto::NumberComparator) -> Result<Self, Self::Error> {
         match proto_comparator {
-            chroma_proto::NumberComparator::Gt => Ok(WhereClauseComparator::GreaterThan),
-            chroma_proto::NumberComparator::Gte => Ok(WhereClauseComparator::GreaterThanOrEqual),
-            chroma_proto::NumberComparator::Lt => Ok(WhereClauseComparator::LessThan),
-            chroma_proto::NumberComparator::Lte => Ok(WhereClauseComparator::LessThanOrEqual),
+            chroma_proto::NumberComparator::Gt => Ok(PrimitiveOperator::GreaterThan),
+            chroma_proto::NumberComparator::Gte => Ok(PrimitiveOperator::GreaterThanOrEqual),
+            chroma_proto::NumberComparator::Lt => Ok(PrimitiveOperator::LessThan),
+            chroma_proto::NumberComparator::Lte => Ok(PrimitiveOperator::LessThanOrEqual),
         }
     }
 }
 
-impl TryFrom<chroma_proto::GenericComparator> for WhereClauseComparator {
+impl TryFrom<chroma_proto::GenericComparator> for PrimitiveOperator {
     type Error = WhereConversionError;
 
     fn try_from(proto_comparator: chroma_proto::GenericComparator) -> Result<Self, Self::Error> {
         match proto_comparator {
-            chroma_proto::GenericComparator::Eq => Ok(WhereClauseComparator::Equal),
-            chroma_proto::GenericComparator::Ne => Ok(WhereClauseComparator::NotEqual),
+            chroma_proto::GenericComparator::Eq => Ok(PrimitiveOperator::Equal),
+            chroma_proto::GenericComparator::Ne => Ok(PrimitiveOperator::NotEqual),
         }
     }
 }
 
-impl TryFrom<chroma_proto::ListOperator> for WhereClauseListOperator {
+impl TryFrom<chroma_proto::ListOperator> for SetOperator {
     type Error = WhereConversionError;
 
     fn try_from(proto_operator: chroma_proto::ListOperator) -> Result<Self, Self::Error> {
         match proto_operator {
-            chroma_proto::ListOperator::In => Ok(WhereClauseListOperator::In),
-            chroma_proto::ListOperator::Nin => Ok(WhereClauseListOperator::NotIn),
+            chroma_proto::ListOperator::In => Ok(SetOperator::In),
+            chroma_proto::ListOperator::Nin => Ok(SetOperator::NotIn),
         }
     }
 }
@@ -648,7 +609,7 @@ impl TryFrom<chroma_proto::BooleanOperator> for BooleanOperator {
     }
 }
 
-impl TryFrom<chroma_proto::WhereDocument> for WhereDocument {
+impl TryFrom<chroma_proto::WhereDocument> for Where {
     type Error = WhereConversionError;
 
     fn try_from(proto_document: chroma_proto::WhereDocument) -> Result<Self, Self::Error> {
@@ -664,7 +625,7 @@ impl TryFrom<chroma_proto::WhereDocument> for WhereDocument {
                     document: proto_comparison.document,
                     operator: operator.try_into()?,
                 };
-                Ok(WhereDocument::DirectWhereDocumentComparison(comparison))
+                Ok(Where::DirectWhereDocumentComparison(comparison))
             }
             Some(chroma_proto::where_document::WhereDocument::Children(proto_children)) => {
                 let operator = match TryInto::<chroma_proto::BooleanOperator>::try_into(
@@ -673,30 +634,80 @@ impl TryFrom<chroma_proto::WhereDocument> for WhereDocument {
                     Ok(operator) => operator,
                     Err(_) => return Err(WhereConversionError::InvalidWhereChildren),
                 };
-                let children = WhereDocumentChildren {
+                let children = WhereChildren {
                     children: proto_children
                         .children
                         .into_iter()
                         .map(|child| child.try_into())
-                        .collect::<Result<Vec<WhereDocument>, WhereConversionError>>()?,
+                        .collect::<Result<_, _>>()?,
                     operator: operator.try_into()?,
                 };
-                Ok(WhereDocument::WhereDocumentChildren(children))
+                Ok(Where::WhereChildren(children))
             }
             None => Err(WhereConversionError::InvalidWhere),
         }
     }
 }
 
-impl TryFrom<chroma_proto::WhereDocumentOperator> for WhereDocumentOperator {
+impl TryFrom<chroma_proto::WhereDocumentOperator> for DocumentOperator {
     type Error = WhereConversionError;
 
     fn try_from(proto_operator: chroma_proto::WhereDocumentOperator) -> Result<Self, Self::Error> {
         match proto_operator {
-            chroma_proto::WhereDocumentOperator::Contains => Ok(WhereDocumentOperator::Contains),
-            chroma_proto::WhereDocumentOperator::NotContains => {
-                Ok(WhereDocumentOperator::NotContains)
-            }
+            chroma_proto::WhereDocumentOperator::Contains => Ok(DocumentOperator::Contains),
+            chroma_proto::WhereDocumentOperator::NotContains => Ok(DocumentOperator::NotContains),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SignedRoaringBitmap {
+    Include(RoaringBitmap),
+    Exclude(RoaringBitmap),
+}
+
+impl SignedRoaringBitmap {
+    pub fn empty() -> Self {
+        Self::Include(RoaringBitmap::new())
+    }
+
+    pub fn full() -> Self {
+        Self::Exclude(RoaringBitmap::new())
+    }
+
+    pub fn flip(self) -> Self {
+        use SignedRoaringBitmap::*;
+        match self {
+            Include(rbm) => Exclude(rbm),
+            Exclude(rbm) => Include(rbm),
+        }
+    }
+}
+
+impl BitAnd for SignedRoaringBitmap {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        use SignedRoaringBitmap::*;
+        match (self, rhs) {
+            (Include(lhs), Include(rhs)) => Include(lhs & rhs),
+            (Include(lhs), Exclude(rhs)) => Include(lhs - rhs),
+            (Exclude(lhs), Include(rhs)) => Include(rhs - lhs),
+            (Exclude(lhs), Exclude(rhs)) => Exclude(lhs | rhs),
+        }
+    }
+}
+
+impl BitOr for SignedRoaringBitmap {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        use SignedRoaringBitmap::*;
+        match (self, rhs) {
+            (Include(lhs), Include(rhs)) => Include(lhs | rhs),
+            (Include(lhs), Exclude(rhs)) => Exclude(rhs - lhs),
+            (Exclude(lhs), Include(rhs)) => Exclude(lhs - rhs),
+            (Exclude(lhs), Exclude(rhs)) => Exclude(lhs & rhs),
         }
     }
 }
@@ -808,9 +819,9 @@ mod tests {
         match where_clause {
             Where::DirectWhereComparison(comparison) => {
                 assert_eq!(comparison.key, "foo");
-                match comparison.comparison {
-                    WhereComparison::SingleIntComparison(value, _) => {
-                        assert_eq!(value, 42);
+                match comparison.comp {
+                    WhereComparison::Primitive(_, value) => {
+                        assert_eq!(value, MetadataValue::Int(42));
                     }
                     _ => panic!("Invalid comparison type"),
                 }
@@ -880,11 +891,11 @@ mod tests {
                 },
             )),
         };
-        let where_document: WhereDocument = proto_where.try_into().unwrap();
+        let where_document: Where = proto_where.try_into().unwrap();
         match where_document {
-            WhereDocument::DirectWhereDocumentComparison(comparison) => {
+            Where::DirectWhereDocumentComparison(comparison) => {
                 assert_eq!(comparison.document, "foo");
-                assert_eq!(comparison.operator, WhereDocumentOperator::Contains);
+                assert_eq!(comparison.operator, DocumentOperator::Contains);
             }
             _ => panic!("Invalid where document type"),
         }
@@ -923,9 +934,9 @@ mod tests {
                 },
             )),
         };
-        let where_document: WhereDocument = proto_where.try_into().unwrap();
+        let where_document: Where = proto_where.try_into().unwrap();
         match where_document {
-            WhereDocument::WhereDocumentChildren(children) => {
+            Where::WhereChildren(children) => {
                 assert_eq!(children.children.len(), 2);
                 assert_eq!(children.operator, BooleanOperator::And);
             }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Updates `MetadataValue` so that the floating type is `f64` and the integer type is `i64`, which is consistent with proto definitions.
	 - Updates `WhereComparison` so that it can be handled with less code (in the subsequent PRs).
	 - Convert `DirectWhereDocumentComparison` as a variant of `Where` enum. This unifies the `Where` and `WhereDocument`, which facilitates a shared evaluation pipeline (in the subsequent PRs).

 - New functionality
	 - Introduce `SignedRoaringBitmap` which captures the idea of performing conjunction and disjunction on bitmaps without the knowledge of the whole domain. This is useful because in our case the domain is decided by the entries in the database that is not yet deleted, and currently it is costly to scan over the entire collection to determine existing entries. Since we would like to support `$ne` and `$nin`, whose results depend on the domain, we hope to delay the evaluation of the negation unless it is necessary to do so, and do it only once.

## Test plan
*How are these changes tested?*

This is guaranteed to break existing tests. Only the last PR in the stack addresses the breaking changes, and should pass the existing tests. In particular, any test involving the query node should fail because of compilation errors.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

N/A