### PR TITLE
[CHORE] Cleanup some clippy errors and all warnings for rust/types

### DIFF
--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -422,7 +422,7 @@ impl<'me> FullTextIndexReader<'me> {
                 panic!("Invariant violation. Multiple frequency values found for a token.");
             }
             let res = res[0];
-            if res.1 <= 0 {
+            if res.1 == 0 {
                 panic!("Invariant violation. Zero frequency token found.");
             }
             // Throw away the "value" since we store frequencies in the keys.

--- a/rust/types/src/data_chunk.rs
+++ b/rust/types/src/data_chunk.rs
@@ -25,6 +25,11 @@ impl<T> Chunk<T> {
         self.visibility.iter().filter(|&v| *v).count()
     }
 
+    /// Returns whether the chunk has zero visible elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the element at the given index
     /// if the index is out of bounds, it returns None
     /// # Arguments
@@ -140,28 +145,28 @@ mod tests {
         assert_eq!(chunk.len(), 2);
         let mut iter = chunk.iter();
         let elem = iter.next();
-        assert_eq!(elem.is_some(), true);
+        assert!(elem.is_some());
         let (record, index) = elem.unwrap();
         assert_eq!(record.record.id, "embedding_id_1");
         assert_eq!(index, 0);
         let elem = iter.next();
-        assert_eq!(elem.is_some(), true);
+        assert!(elem.is_some());
         let (record, index) = elem.unwrap();
         assert_eq!(record.record.id, "embedding_id_2");
         assert_eq!(index, 1);
         let elem = iter.next();
-        assert_eq!(elem.is_none(), true);
+        assert!(elem.is_none());
 
-        let visibility = vec![true, false].into();
+        let visibility = vec![true, false];
         chunk.set_visibility(visibility);
         assert_eq!(chunk.len(), 1);
         let mut iter = chunk.iter();
         let elem = iter.next();
-        assert_eq!(elem.is_some(), true);
+        assert!(elem.is_some());
         let (record, index) = elem.unwrap();
         assert_eq!(record.record.id, "embedding_id_1");
         assert_eq!(index, 0);
         let elem = iter.next();
-        assert_eq!(elem.is_none(), true);
+        assert!(elem.is_none());
     }
 }

--- a/rust/types/src/data_record.rs
+++ b/rust/types/src/data_record.rs
@@ -13,7 +13,7 @@ pub struct DataRecord<'a> {
 impl DataRecord<'_> {
     pub fn get_size(&self) -> usize {
         let id_size = self.id.len();
-        let embedding_size = self.embedding.len() * std::mem::size_of::<f32>();
+        let embedding_size = std::mem::size_of_val(self.embedding);
         let metadata_size = match &self.metadata {
             Some(metadata) => {
                 let metadata_proto = Into::<chroma_proto::UpdateMetadata>::into(metadata.clone());

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -45,14 +45,13 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for UpdateMetadataValue {
             }
             // Used to communicate that the user wants to delete this key.
             None => Ok(UpdateMetadataValue::None),
-            _ => Err(UpdateMetadataValueConversionError::InvalidValue),
         }
     }
 }
 
 impl From<UpdateMetadataValue> for chroma_proto::UpdateMetadataValue {
     fn from(value: UpdateMetadataValue) -> Self {
-        let proto_value = match value {
+        match value {
             UpdateMetadataValue::Int(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::IntValue(
                     value as i64,
@@ -72,8 +71,7 @@ impl From<UpdateMetadataValue> for chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
             },
             UpdateMetadataValue::None => chroma_proto::UpdateMetadataValue { value: None },
-        };
-        proto_value
+        }
     }
 }
 
@@ -187,7 +185,7 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for MetadataValue {
 
 impl From<MetadataValue> for chroma_proto::UpdateMetadataValue {
     fn from(value: MetadataValue) -> Self {
-        let proto_value = match value {
+        match value {
             MetadataValue::Int(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::IntValue(
                     value as i64,
@@ -206,8 +204,7 @@ impl From<MetadataValue> for chroma_proto::UpdateMetadataValue {
             MetadataValue::Bool(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
             },
-        };
-        proto_value
+        }
     }
 }
 
@@ -288,6 +285,7 @@ impl TryFrom<chroma_proto::UpdateMetadata> for Metadata {
     }
 }
 
+#[derive(Debug, Default)]
 pub struct MetadataDelta<'referred_data> {
     pub metadata_to_update: HashMap<
         &'referred_data str,
@@ -299,11 +297,7 @@ pub struct MetadataDelta<'referred_data> {
 
 impl<'referred_data> MetadataDelta<'referred_data> {
     pub fn new() -> Self {
-        Self {
-            metadata_to_update: HashMap::new(),
-            metadata_to_delete: HashMap::new(),
-            metadata_to_insert: HashMap::new(),
-        }
+        Self::default()
     }
 }
 
@@ -862,7 +856,7 @@ mod tests {
                             )),
                         },
                     ],
-                    operator: chroma_proto::BooleanOperator::And.try_into().unwrap(),
+                    operator: chroma_proto::BooleanOperator::And.into(),
                 },
             )),
         };
@@ -882,9 +876,7 @@ mod tests {
             r#where_document: Some(chroma_proto::where_document::WhereDocument::Direct(
                 chroma_proto::DirectWhereDocument {
                     document: "foo".to_string(),
-                    operator: chroma_proto::WhereDocumentOperator::Contains
-                        .try_into()
-                        .unwrap(),
+                    operator: chroma_proto::WhereDocumentOperator::Contains.into(),
                 },
             )),
         };
@@ -910,8 +902,7 @@ mod tests {
                                     chroma_proto::DirectWhereDocument {
                                         document: "foo".to_string(),
                                         operator: chroma_proto::WhereDocumentOperator::Contains
-                                            .try_into()
-                                            .unwrap(),
+                                            .into(),
                                     },
                                 ),
                             ),
@@ -922,14 +913,13 @@ mod tests {
                                     chroma_proto::DirectWhereDocument {
                                         document: "bar".to_string(),
                                         operator: chroma_proto::WhereDocumentOperator::Contains
-                                            .try_into()
-                                            .unwrap(),
+                                            .into(),
                                     },
                                 ),
                             ),
                         },
                     ],
-                    operator: chroma_proto::BooleanOperator::And.try_into().unwrap(),
+                    operator: chroma_proto::BooleanOperator::And.into(),
                 },
             )),
         };

--- a/rust/types/src/operation.rs
+++ b/rust/types/src/operation.rs
@@ -53,7 +53,6 @@ impl TryFrom<chroma_proto::Operation> for Operation {
             chroma_proto::Operation::Upsert => Ok(Operation::Upsert),
             chroma_proto::Operation::Update => Ok(Operation::Update),
             chroma_proto::Operation::Delete => Ok(Operation::Delete),
-            _ => Err(OperationConversionError::InvalidOperation),
         }
     }
 }
@@ -69,7 +68,6 @@ impl TryFrom<i32> for Operation {
                 chroma_proto::Operation::Upsert => Ok(Operation::Upsert),
                 chroma_proto::Operation::Update => Ok(Operation::Update),
                 chroma_proto::Operation::Delete => Ok(Operation::Delete),
-                _ => Err(OperationConversionError::InvalidOperation),
             },
             Err(_) => Err(OperationConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/types/src/record.rs
+++ b/rust/types/src/record.rs
@@ -178,19 +178,16 @@ fn vec_to_f32(bytes: &[u8]) -> Result<&[f32], VectorConversionError> {
 
     unsafe {
         let (pre, mid, post) = bytes.align_to::<f32>();
-        if pre.len() != 0 || post.len() != 0 {
+        if !pre.is_empty() || !post.is_empty() {
             return Err(VectorConversionError::InvalidByteLength);
         }
-        return Ok(mid);
+        Ok(mid)
     }
 }
 
 fn f32_to_vec(vector: &[f32]) -> Vec<u8> {
     unsafe {
-        std::slice::from_raw_parts(
-            vector.as_ptr() as *const u8,
-            vector.len() * std::mem::size_of::<f32>(),
-        )
+        std::slice::from_raw_parts(vector.as_ptr() as *const u8, std::mem::size_of_val(vector))
     }
     .to_vec()
 }
@@ -277,10 +274,7 @@ mod tests {
 
     fn as_byte_view(input: &[f32]) -> Vec<u8> {
         unsafe {
-            std::slice::from_raw_parts(
-                input.as_ptr() as *const u8,
-                input.len() * std::mem::size_of::<f32>(),
-            )
+            std::slice::from_raw_parts(input.as_ptr() as *const u8, std::mem::size_of_val(input))
         }
         .to_vec()
     }

--- a/rust/types/src/scalar_encoding.rs
+++ b/rust/types/src/scalar_encoding.rs
@@ -28,7 +28,6 @@ impl TryFrom<chroma_proto::ScalarEncoding> for ScalarEncoding {
         match encoding {
             chroma_proto::ScalarEncoding::Float32 => Ok(ScalarEncoding::FLOAT32),
             chroma_proto::ScalarEncoding::Int32 => Ok(ScalarEncoding::INT32),
-            _ => Err(ScalarEncodingConversionError::InvalidEncoding),
         }
     }
 }
@@ -42,7 +41,6 @@ impl TryFrom<i32> for ScalarEncoding {
             Ok(encoding) => match encoding {
                 chroma_proto::ScalarEncoding::Float32 => Ok(ScalarEncoding::FLOAT32),
                 chroma_proto::ScalarEncoding::Int32 => Ok(ScalarEncoding::INT32),
-                _ => Err(ScalarEncodingConversionError::InvalidEncoding),
             },
             Err(_) => Err(ScalarEncodingConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -119,7 +119,7 @@ impl TryFrom<chroma_proto::Segment> for Segment {
         Ok(Segment {
             id: segment_uuid,
             r#type: segment_type,
-            scope: scope,
+            scope,
             collection: collection_uuid,
             metadata: segment_metadata,
             file_path: file_paths,

--- a/rust/types/src/segment_scope.rs
+++ b/rust/types/src/segment_scope.rs
@@ -33,7 +33,6 @@ impl TryFrom<chroma_proto::SegmentScope> for SegmentScope {
             chroma_proto::SegmentScope::Metadata => Ok(SegmentScope::METADATA),
             chroma_proto::SegmentScope::Record => Ok(SegmentScope::RECORD),
             chroma_proto::SegmentScope::Sqlite => Ok(SegmentScope::SQLITE),
-            _ => Err(SegmentScopeConversionError::InvalidScope),
         }
     }
 }
@@ -49,7 +48,6 @@ impl TryFrom<i32> for SegmentScope {
                 chroma_proto::SegmentScope::Metadata => Ok(SegmentScope::METADATA),
                 chroma_proto::SegmentScope::Record => Ok(SegmentScope::RECORD),
                 chroma_proto::SegmentScope::Sqlite => Ok(SegmentScope::SQLITE),
-                _ => Err(SegmentScopeConversionError::InvalidScope),
             },
             Err(_) => Err(SegmentScopeConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -595,7 +595,7 @@ impl Component for HnswQueryOrchestrator {
 
         // If segment is uninitialized and dimension is not set then we assume
         // that this is a query before any add so return empty response.
-        if hnsw_segment.file_path.len() <= 0 && collection.dimension.is_none() {
+        if hnsw_segment.file_path.len() == 0 && collection.dimension.is_none() {
             self.terminate_with_empty_response(ctx);
             return;
         }

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -150,7 +150,6 @@ impl CustomResourceMemberlistProvider {
         let stream = stream.then(|event| async move {
             match event {
                 Ok(event) => {
-                    let event = event;
                     println!("Kube stream event: {:?}", event);
                     Some(event)
                 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
- Clean up warnings under rust/types.

## Test plan
*How are these changes tested?*
- `cargo clippy --all-targets`

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
