### PR TITLE
[CHORE] Cleanup clippy warnings in rust/blockstore

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/data_record.rs
+++ b/rust/blockstore/src/arrow/block/delta/data_record.rs
@@ -212,7 +212,7 @@ impl DataRecordStorage {
         // https://docs.rs/arrow-buffer/52.2.0/src/arrow_buffer/buffer/null.rs.html#153-155
         let validity_bytes = bit_util::round_upto_multiple_of_64(bit_util::ceil(self.len(), 8)) * 2;
 
-        let total_size = prefix_size
+        prefix_size
             + key_size
             + id_size
             + embedding_size
@@ -223,9 +223,7 @@ impl DataRecordStorage {
             + id_offset
             + metdata_offset
             + document_offset
-            + validity_bytes;
-
-        total_size
+            + validity_bytes
     }
 
     fn split_internal<K: ArrowWriteableKey>(&self, split_size: usize) -> SplitInformation {
@@ -295,7 +293,7 @@ impl DataRecordStorage {
             }
         }
 
-        return SplitInformation {
+        SplitInformation {
             split_key: split_key.expect("split key should be set"),
             remaining_prefix_size: inner.prefix_size - prefix_size,
             remaining_key_size: inner.key_size - key_size,
@@ -303,7 +301,7 @@ impl DataRecordStorage {
             remaining_embedding_size: inner.embedding_size - embedding_size,
             remaining_metadata_size: inner.metadata_size - metadata_size,
             remaining_document_size: inner.document_size - document_size,
-        };
+        }
     }
 
     pub(super) fn split<K: ArrowWriteableKey>(
@@ -340,7 +338,7 @@ impl DataRecordStorage {
         inner.storage.len()
     }
 
-    pub(super) fn to_arrow(
+    pub(super) fn into_arrow(
         self,
         key_builder: BlockKeyArrowBuilder,
     ) -> Result<RecordBatch, arrow::error::ArrowError> {
@@ -396,7 +394,7 @@ impl DataRecordStorage {
             }
         }
         // Build arrow key with fields.
-        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.to_arrow();
+        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.as_arrow();
 
         let id_field = Field::new("id", arrow::datatypes::DataType::Utf8, true);
         let embedding_field = Field::new(

--- a/rust/blockstore/src/arrow/block/delta/mod.rs
+++ b/rust/blockstore/src/arrow/block/delta/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod data_record;
+#[allow(clippy::module_inception)]
 mod delta;
 pub(super) mod single_column_size_tracker;
 pub(super) mod single_column_storage;

--- a/rust/blockstore/src/arrow/block/delta/single_column_size_tracker.rs
+++ b/rust/blockstore/src/arrow/block/delta/single_column_size_tracker.rs
@@ -34,7 +34,7 @@ impl SingleColumnSizeTracker {
 
     /// The raw unpadded size of the prefix data in bytes.
     pub(super) fn get_prefix_size(&self) -> usize {
-        return self.prefix_size;
+        self.prefix_size
     }
 
     /// The arrow padded size of the prefix data in bytes.
@@ -44,7 +44,7 @@ impl SingleColumnSizeTracker {
 
     /// The raw unpadded size of the key data in bytes.
     pub(super) fn get_key_size(&self) -> usize {
-        return self.key_size;
+        self.key_size
     }
 
     /// The arrow padded size of the key data in bytes.
@@ -56,7 +56,7 @@ impl SingleColumnSizeTracker {
 
     /// The raw unpadded size of the value data in bytes.
     pub(super) fn get_value_size(&self) -> usize {
-        return self.value_size;
+        self.value_size
     }
 
     /// The arrow padded size of the value data in bytes.

--- a/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
@@ -219,7 +219,7 @@ impl<T: ArrowWriteableValue> SingleColumnStorage<T> {
 }
 
 impl SingleColumnStorage<String> {
-    pub(super) fn to_arrow(
+    pub(super) fn into_arrow(
         self,
         key_builder: BlockKeyArrowBuilder,
     ) -> Result<RecordBatch, arrow::error::ArrowError> {
@@ -245,7 +245,7 @@ impl SingleColumnStorage<String> {
             }
         }
         // Build arrow key with fields.
-        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.to_arrow();
+        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.as_arrow();
         // Build arrow value with fields.
         let value_field = Field::new("value", arrow::datatypes::DataType::Utf8, false);
         let value_arr = value_builder.finish();
@@ -260,7 +260,7 @@ impl SingleColumnStorage<String> {
 }
 
 impl SingleColumnStorage<Vec<u32>> {
-    pub(super) fn to_arrow(
+    pub(super) fn into_arrow(
         self,
         key_builder: BlockKeyArrowBuilder,
     ) -> Result<RecordBatch, arrow::error::ArrowError> {
@@ -290,7 +290,7 @@ impl SingleColumnStorage<Vec<u32>> {
             }
         }
         // Build arrow key and value with fields.
-        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.to_arrow();
+        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.as_arrow();
 
         let value_field = Field::new(
             "value",
@@ -313,7 +313,7 @@ impl SingleColumnStorage<Vec<u32>> {
 }
 
 impl SingleColumnStorage<u32> {
-    pub(super) fn to_arrow(
+    pub(super) fn into_arrow(
         self,
         key_builder: BlockKeyArrowBuilder,
     ) -> Result<RecordBatch, arrow::error::ArrowError> {
@@ -339,7 +339,7 @@ impl SingleColumnStorage<u32> {
             }
         }
         // Build arrow key with fields.
-        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.to_arrow();
+        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.as_arrow();
         let value_field = Field::new("value", arrow::datatypes::DataType::UInt32, false);
         let value_arr = value_builder.finish();
         let value_arr = (&value_arr as &dyn Array).slice(0, value_arr.len());
@@ -353,7 +353,7 @@ impl SingleColumnStorage<u32> {
 }
 
 impl SingleColumnStorage<RoaringBitmap> {
-    pub(super) fn to_arrow(
+    pub(super) fn into_arrow(
         self,
         key_builder: BlockKeyArrowBuilder,
     ) -> Result<RecordBatch, arrow::error::ArrowError> {
@@ -389,7 +389,7 @@ impl SingleColumnStorage<RoaringBitmap> {
             }
         }
         // Build arrow key with fields.
-        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.to_arrow();
+        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.as_arrow();
 
         let value_field = Field::new("value", arrow::datatypes::DataType::Binary, true);
         let value_arr = value_builder.finish();

--- a/rust/blockstore/src/arrow/block/delta/storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/storage.rs
@@ -89,7 +89,7 @@ impl BlockKeyArrowBuilder {
         }
     }
 
-    pub fn to_arrow(&mut self) -> (Field, ArrayRef, Field, ArrayRef) {
+    pub fn as_arrow(&mut self) -> (Field, ArrayRef, Field, ArrayRef) {
         match self {
             BlockKeyArrowBuilder::String((ref mut prefix_builder, ref mut key_builder)) => {
                 let prefix_field = Field::new("prefix", arrow::datatypes::DataType::Utf8, false);
@@ -220,29 +220,29 @@ impl BlockStorage {
         }
     }
 
-    pub fn to_record_batch<K: ArrowWriteableKey>(self) -> RecordBatch {
+    pub fn into_record_batch<K: ArrowWriteableKey>(self) -> RecordBatch {
         let key_builder =
             K::get_arrow_builder(self.len(), self.get_prefix_size(), self.get_key_size());
         match self {
             BlockStorage::String(builder) => {
                 // TODO: handle error
-                builder.to_arrow(key_builder).unwrap()
+                builder.into_arrow(key_builder).unwrap()
             }
             BlockStorage::UInt32(builder) => {
                 // TODO: handle error
-                builder.to_arrow(key_builder).unwrap()
+                builder.into_arrow(key_builder).unwrap()
             }
             BlockStorage::DataRecord(builder) => {
                 // TODO: handle error
-                builder.to_arrow(key_builder).unwrap()
+                builder.into_arrow(key_builder).unwrap()
             }
             BlockStorage::VecUInt32(builder) => {
                 // TODO: handle error
-                builder.to_arrow(key_builder).unwrap()
+                builder.into_arrow(key_builder).unwrap()
             }
             BlockStorage::RoaringBitmap(builder) => {
                 // TODO: handle error
-                builder.to_arrow(key_builder).unwrap()
+                builder.into_arrow(key_builder).unwrap()
             }
         }
     }

--- a/rust/blockstore/src/arrow/block/value/data_record_value.rs
+++ b/rust/blockstore/src/arrow/block/value/data_record_value.rs
@@ -25,7 +25,7 @@ impl ArrowWriteableValue for &DataRecord<'_> {
     fn validity_size(item_count: usize) -> usize {
         let validity_bytes = bit_util::round_upto_multiple_of_64(bit_util::ceil(item_count, 8));
         // Both document and metadata can be null
-        return validity_bytes * 2;
+        validity_bytes * 2
     }
 
     fn add(prefix: &str, key: KeyWrapper, value: Self, delta: &BlockDelta) {
@@ -103,7 +103,7 @@ impl<'referred_data> ArrowReadableValue<'referred_data> for DataRecord<'referred
         };
 
         DataRecord {
-            id: &id_arr.value(index),
+            id: id_arr.value(index),
             embedding,
             metadata,
             document,

--- a/rust/blockstore/src/arrow/flusher.rs
+++ b/rust/blockstore/src/arrow/flusher.rs
@@ -32,6 +32,7 @@ impl ArrowBlockfileFlusher {
         }
     }
 
+    #[allow(clippy::extra_unused_type_parameters)]
     pub(crate) async fn flush<K: ArrowWriteableKey, V: ArrowWriteableValue>(
         self,
     ) -> Result<(), Box<dyn ChromaError>> {

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -37,18 +37,7 @@ impl Eq for SparseIndexDelimiter {}
 
 impl PartialOrd for SparseIndexDelimiter {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match (self, other) {
-            (SparseIndexDelimiter::Start, SparseIndexDelimiter::Start) => {
-                Some(std::cmp::Ordering::Equal)
-            }
-            (SparseIndexDelimiter::Start, SparseIndexDelimiter::Key(_)) => {
-                Some(std::cmp::Ordering::Less)
-            }
-            (SparseIndexDelimiter::Key(_), SparseIndexDelimiter::Start) => {
-                Some(std::cmp::Ordering::Greater)
-            }
-            (SparseIndexDelimiter::Key(k1), SparseIndexDelimiter::Key(k2)) => k1.partial_cmp(k2),
-        }
+        Some(self.cmp(other))
     }
 }
 
@@ -107,10 +96,10 @@ impl SparseIndex {
         search_keys.sort();
         let mut result_uuids = Vec::new();
         let forward = self.forward.lock();
-        let mut curr_iter = forward.iter();
+        let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut search_iter = search_keys.iter().peekable();
-        while let Some((curr_key, curr_block_id)) = curr_iter.next() {
+        for (curr_key, curr_block_id) in curr_iter {
             let search_key = match search_iter.peek() {
                 Some(key) => SparseIndexDelimiter::Key((**key).clone()),
                 None => {
@@ -147,9 +136,7 @@ impl SparseIndex {
             .range(..=SparseIndexDelimiter::Key(search_key.clone()))
             .next_back()
         {
-            Some((_, block_id)) => {
-                return *block_id;
-            }
+            Some((_, block_id)) => *block_id,
             None => {
                 panic!("No blocks in the sparse index");
             }
@@ -158,24 +145,22 @@ impl SparseIndex {
 
     pub(super) fn get_block_ids_prefix(&self, prefix: &str) -> Vec<Uuid> {
         let lock_guard = self.forward.lock();
-        let mut curr_iter = lock_guard.iter();
+        let curr_iter = lock_guard.iter();
         let mut next_iter = lock_guard.iter().skip(1);
         let mut block_ids = vec![];
-        while let Some((curr_key, curr_uuid)) = curr_iter.next() {
-            let non_start_curr_key: Option<&CompositeKey>;
-            match curr_key {
-                SparseIndexDelimiter::Start => non_start_curr_key = None,
-                SparseIndexDelimiter::Key(k) => non_start_curr_key = Some(k),
-            }
+        for (curr_key, curr_uuid) in curr_iter {
+            let non_start_curr_key: Option<&CompositeKey> = match curr_key {
+                SparseIndexDelimiter::Start => None,
+                SparseIndexDelimiter::Key(k) => Some(k),
+            };
             if let Some((next_key, _)) = next_iter.next() {
                 // This can't be a start key but we still need to extract it.
-                let non_start_next_key: Option<&CompositeKey>;
-                match next_key {
+                let non_start_next_key: Option<&CompositeKey> = match next_key {
                     SparseIndexDelimiter::Start => {
                         panic!("Invariant violation. Sparse index is not valid.");
                     }
-                    SparseIndexDelimiter::Key(k) => non_start_next_key = Some(k),
-                }
+                    SparseIndexDelimiter::Key(k) => Some(k),
+                };
                 // If delimeter starts with the same prefix then there will be keys inside the
                 // block with this prefix.
                 if non_start_curr_key.is_some()
@@ -209,10 +194,10 @@ impl SparseIndex {
         key: K,
     ) -> Vec<Uuid> {
         let lock_guard = self.forward.lock();
-        let mut curr_iter = lock_guard.iter();
+        let curr_iter = lock_guard.iter();
         let mut next_iter = lock_guard.iter().skip(1);
         let mut block_ids = vec![];
-        while let Some((curr_delim, curr_uuid)) = curr_iter.next() {
+        for (curr_delim, curr_uuid) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -226,18 +211,17 @@ impl SparseIndex {
                     SparseIndexDelimiter::Key(k) => Some(k),
                 };
             }
-            if curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix {
-                if next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix {
-                    block_ids.push(*curr_uuid);
-                }
+            if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
+                && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
+            {
+                block_ids.push(*curr_uuid);
             }
-            if curr_key.is_some() && curr_key.unwrap().prefix.as_str() == prefix {
-                if curr_key.unwrap().key > key.clone().into() {
+            if let Some(curr_key) = curr_key {
+                if (curr_key.key > key.clone().into())
+                    || next_key.is_none()
+                    || next_key.unwrap().key > key.clone().into()
+                {
                     block_ids.push(*curr_uuid);
-                } else {
-                    if next_key.is_none() || next_key.unwrap().key > key.clone().into() {
-                        block_ids.push(*curr_uuid);
-                    }
                 }
             }
         }
@@ -250,10 +234,10 @@ impl SparseIndex {
         key: K,
     ) -> Vec<Uuid> {
         let lock_guard = self.forward.lock();
-        let mut curr_iter = lock_guard.iter();
+        let curr_iter = lock_guard.iter();
         let mut next_iter = lock_guard.iter().skip(1);
         let mut block_ids = vec![];
-        while let Some((curr_delim, curr_uuid)) = curr_iter.next() {
+        for (curr_delim, curr_uuid) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -267,13 +251,13 @@ impl SparseIndex {
                     SparseIndexDelimiter::Key(k) => Some(k),
                 };
             }
-            if curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix {
-                if next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix {
-                    block_ids.push(*curr_uuid);
-                }
+            if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
+                && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
+            {
+                block_ids.push(*curr_uuid);
             }
-            if curr_key.is_some() && curr_key.unwrap().prefix.as_str() == prefix {
-                if curr_key.unwrap().key < key.clone().into() {
+            if let Some(curr_key) = curr_key {
+                if curr_key.prefix.as_str() == prefix && curr_key.key < key.clone().into() {
                     block_ids.push(*curr_uuid);
                 }
             }
@@ -287,10 +271,10 @@ impl SparseIndex {
         key: K,
     ) -> Vec<Uuid> {
         let lock_guard = self.forward.lock();
-        let mut curr_iter = lock_guard.iter();
+        let curr_iter = lock_guard.iter();
         let mut next_iter = lock_guard.iter().skip(1);
         let mut block_ids = vec![];
-        while let Some((curr_delim, curr_uuid)) = curr_iter.next() {
+        for (curr_delim, curr_uuid) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -304,18 +288,17 @@ impl SparseIndex {
                     SparseIndexDelimiter::Key(k) => Some(k),
                 };
             }
-            if curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix {
-                if next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix {
-                    block_ids.push(*curr_uuid);
-                }
+            if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
+                && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
+            {
+                block_ids.push(*curr_uuid);
             }
-            if curr_key.is_some() && curr_key.unwrap().prefix.as_str() == prefix {
-                if curr_key.unwrap().key >= key.clone().into() {
+            if let Some(curr_key) = curr_key {
+                if curr_key.key >= key.clone().into()
+                    || next_key.is_none()
+                    || next_key.unwrap().key >= key.clone().into()
+                {
                     block_ids.push(*curr_uuid);
-                } else {
-                    if next_key.is_none() || next_key.unwrap().key >= key.clone().into() {
-                        block_ids.push(*curr_uuid);
-                    }
                 }
             }
         }
@@ -328,10 +311,10 @@ impl SparseIndex {
         key: K,
     ) -> Vec<Uuid> {
         let lock_guard = self.forward.lock();
-        let mut curr_iter = lock_guard.iter();
+        let curr_iter = lock_guard.iter();
         let mut next_iter = lock_guard.iter().skip(1);
         let mut block_ids = vec![];
-        while let Some((curr_delim, curr_uuid)) = curr_iter.next() {
+        for (curr_delim, curr_uuid) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -345,13 +328,13 @@ impl SparseIndex {
                     SparseIndexDelimiter::Key(k) => Some(k),
                 };
             }
-            if curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix {
-                if next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix {
-                    block_ids.push(*curr_uuid);
-                }
+            if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
+                && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
+            {
+                block_ids.push(*curr_uuid);
             }
-            if curr_key.is_some() && curr_key.unwrap().prefix.as_str() == prefix {
-                if curr_key.unwrap().key <= key.clone().into() {
+            if let Some(curr_key) = curr_key {
+                if curr_key.prefix.as_str() == prefix && curr_key.key <= key.clone().into() {
                     block_ids.push(*curr_uuid);
                 }
             }
@@ -397,7 +380,7 @@ impl SparseIndex {
         let mut reverse = self.reverse.lock();
         if let Some(id) = forward.remove(&key_copy) {
             reverse.remove(&id);
-            forward.insert(SparseIndexDelimiter::Start, id.clone());
+            forward.insert(SparseIndexDelimiter::Start, id);
             reverse.insert(id, SparseIndexDelimiter::Start);
         }
     }
@@ -454,9 +437,9 @@ impl SparseIndex {
         let forward = self.forward.lock();
         let mut first = true;
         // Two pointer traversal to check if the keys are in order and that the start key is first
-        let mut iter_slow = forward.iter();
+        let iter_slow = forward.iter();
         let mut iter_fast = forward.iter().skip(1);
-        while let Some((curr_key, _)) = iter_slow.next() {
+        for (curr_key, _) in iter_slow {
             if first {
                 if curr_key != &SparseIndexDelimiter::Start {
                     return false;
@@ -660,20 +643,22 @@ mod tests {
         let block_id_3 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "f");
         sparse_index.add_block(blockfile_key.clone(), block_id_3);
-        let mut composite_keys = Vec::new();
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "b"));
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "c"));
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "d"));
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "e"));
+        let composite_keys = vec![
+            CompositeKey::new("prefix".to_string(), "b"),
+            CompositeKey::new("prefix".to_string(), "c"),
+            CompositeKey::new("prefix".to_string(), "d"),
+            CompositeKey::new("prefix".to_string(), "e"),
+        ];
         let blocks = sparse_index.get_all_target_block_ids(composite_keys);
         assert_eq!(blocks.len(), 2);
         assert!(blocks.contains(&block_id_1));
         assert!(blocks.contains(&block_id_2));
-        composite_keys = Vec::new();
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "f"));
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "g"));
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "h"));
-        composite_keys.push(CompositeKey::new("prefix".to_string(), "i"));
+        let composite_keys = vec![
+            CompositeKey::new("prefix".to_string(), "f"),
+            CompositeKey::new("prefix".to_string(), "g"),
+            CompositeKey::new("prefix".to_string(), "h"),
+            CompositeKey::new("prefix".to_string(), "i"),
+        ];
         let blocks = sparse_index.get_all_target_block_ids(composite_keys);
         assert_eq!(blocks.len(), 1);
         assert!(blocks.contains(&block_id_3));

--- a/rust/blockstore/src/key.rs
+++ b/rust/blockstore/src/key.rs
@@ -22,62 +22,70 @@ impl KeyWrapper {
     }
 }
 
-impl Into<KeyWrapper> for &str {
-    fn into(self) -> KeyWrapper {
-        KeyWrapper::String(self.to_string())
+impl From<&str> for KeyWrapper {
+    fn from(s: &str) -> KeyWrapper {
+        KeyWrapper::String(s.to_string())
     }
 }
 
-impl<'referred_data> From<&'referred_data KeyWrapper> for &'referred_data str {
-    fn from(key: &'referred_data KeyWrapper) -> Self {
+impl<'referred_data> TryFrom<&'referred_data KeyWrapper> for &'referred_data str {
+    type Error = &'static str;
+
+    fn try_from(key: &'referred_data KeyWrapper) -> Result<Self, &'static str> {
         match key {
-            KeyWrapper::String(s) => s,
-            _ => panic!("Invalid conversion"),
+            KeyWrapper::String(s) => Ok(s),
+            _ => Err("Invalid conversion"),
         }
     }
 }
 
-impl Into<KeyWrapper> for f32 {
-    fn into(self) -> KeyWrapper {
-        KeyWrapper::Float32(self)
+impl From<f32> for KeyWrapper {
+    fn from(f: f32) -> KeyWrapper {
+        KeyWrapper::Float32(f)
     }
 }
 
-impl From<&KeyWrapper> for f32 {
-    fn from(key: &KeyWrapper) -> Self {
+impl TryFrom<&KeyWrapper> for f32 {
+    type Error = &'static str;
+
+    fn try_from(key: &KeyWrapper) -> Result<Self, &'static str> {
         match key {
-            KeyWrapper::Float32(f) => f.clone(),
-            _ => panic!("Invalid conversion"),
+            KeyWrapper::Float32(f) => Ok(*f),
+            _ => Err("Invalid conversion"),
         }
     }
 }
 
-impl Into<KeyWrapper> for bool {
-    fn into(self) -> KeyWrapper {
-        KeyWrapper::Bool(self)
+impl From<bool> for KeyWrapper {
+    fn from(b: bool) -> KeyWrapper {
+        KeyWrapper::Bool(b)
     }
 }
 
-impl From<&KeyWrapper> for bool {
-    fn from(key: &KeyWrapper) -> Self {
+impl TryFrom<&KeyWrapper> for bool {
+    type Error = &'static str;
+
+    fn try_from(key: &KeyWrapper) -> Result<Self, &'static str> {
         match key {
-            KeyWrapper::Bool(b) => b.clone(),
-            _ => panic!("Invalid conversion"),
+            KeyWrapper::Bool(b) => Ok(*b),
+            _ => Err("Invalid conversion"),
         }
     }
 }
 
-impl Into<KeyWrapper> for u32 {
-    fn into(self) -> KeyWrapper {
-        KeyWrapper::Uint32(self)
+impl From<u32> for KeyWrapper {
+    fn from(u: u32) -> KeyWrapper {
+        KeyWrapper::Uint32(u)
     }
 }
 
-impl From<&KeyWrapper> for u32 {
-    fn from(key: &KeyWrapper) -> Self {
+impl TryFrom<&KeyWrapper> for u32 {
+    type Error = &'static str;
+
+    fn try_from(key: &KeyWrapper) -> Result<Self, &'static str> {
         match key {
-            KeyWrapper::Uint32(u) => u.clone(),
-            _ => panic!("Invalid conversion"),
+            KeyWrapper::Uint32(u) => Ok(*u),
+            _ => Err("Invalid conversion"),
         }
     }
 }
@@ -116,11 +124,7 @@ impl Eq for CompositeKey {}
 
 impl PartialOrd for CompositeKey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.prefix == other.prefix {
-            self.key.partial_cmp(&other.key)
-        } else {
-            self.prefix.partial_cmp(&other.prefix)
-        }
+        Some(self.cmp(other))
     }
 }
 

--- a/rust/blockstore/src/memory/storage.rs
+++ b/rust/blockstore/src/memory/storage.rs
@@ -1,5 +1,4 @@
 use crate::key::{CompositeKey, KeyWrapper};
-use arrow::array::Int32Array;
 use chroma_error::ChromaError;
 use chroma_types::DataRecord;
 use parking_lot::RwLock;
@@ -366,7 +365,7 @@ impl<'referred_data> Readable<'referred_data> for RoaringBitmap {
                 prefix: prefix.to_string(),
                 key,
             })
-            .map(|a| a.clone())
+            .cloned()
     }
 
     fn get_by_prefix_from_storage(
@@ -491,7 +490,7 @@ impl<'referred_data> Readable<'referred_data> for f32 {
                 prefix: prefix.to_string(),
                 key,
             })
-            .map(|a| *a)
+            .copied()
     }
 
     fn get_by_prefix_from_storage(
@@ -528,7 +527,7 @@ impl<'referred_data> Readable<'referred_data> for f32 {
             .f32_storage
             .iter()
             .filter(|(k, _)| k.prefix == prefix && k.key >= key)
-            .map(|(k, v)| (k, v.clone()))
+            .map(|(k, v)| (k, *v))
             .collect()
     }
 
@@ -541,7 +540,7 @@ impl<'referred_data> Readable<'referred_data> for f32 {
             .f32_storage
             .iter()
             .filter(|(k, _)| k.prefix == prefix && k.key < key)
-            .map(|(k, v)| (k, v.clone()))
+            .map(|(k, v)| (k, *v))
             .collect()
     }
 
@@ -554,7 +553,7 @@ impl<'referred_data> Readable<'referred_data> for f32 {
             .f32_storage
             .iter()
             .filter(|(k, _)| k.prefix == prefix && k.key <= key)
-            .map(|(k, v)| (k, v.clone()))
+            .map(|(k, v)| (k, *v))
             .collect()
     }
 
@@ -612,7 +611,7 @@ impl<'referred_data> Readable<'referred_data> for u32 {
                 prefix: prefix.to_string(),
                 key,
             })
-            .map(|a| *a)
+            .copied()
     }
 
     fn get_by_prefix_from_storage(
@@ -649,7 +648,7 @@ impl<'referred_data> Readable<'referred_data> for u32 {
             .u32_storage
             .iter()
             .filter(|(k, _)| k.prefix == prefix && k.key >= key)
-            .map(|(k, v)| (k, v.clone()))
+            .map(|(k, v)| (k, *v))
             .collect()
     }
 
@@ -662,7 +661,7 @@ impl<'referred_data> Readable<'referred_data> for u32 {
             .u32_storage
             .iter()
             .filter(|(k, _)| k.prefix == prefix && k.key < key)
-            .map(|(k, v)| (k, v.clone()))
+            .map(|(k, v)| (k, *v))
             .collect()
     }
 
@@ -675,7 +674,7 @@ impl<'referred_data> Readable<'referred_data> for u32 {
             .u32_storage
             .iter()
             .filter(|(k, _)| k.prefix == prefix && k.key <= key)
-            .map(|(k, v)| (k, v.clone()))
+            .map(|(k, v)| (k, *v))
             .collect()
     }
 
@@ -737,7 +736,7 @@ impl<'referred_data> Readable<'referred_data> for bool {
                 prefix: prefix.to_string(),
                 key,
             })
-            .map(|a| *a)
+            .copied()
     }
 
     fn get_by_prefix_from_storage(
@@ -885,14 +884,14 @@ impl<'referred_data> Readable<'referred_data> for DataRecord<'referred_data> {
         let id = storage.data_record_id_storage.get(&CompositeKey {
             prefix: prefix.to_string(),
             key: key.clone(),
-        });
+        })?;
         let embedding = storage.data_record_embedding_storage.get(&CompositeKey {
             prefix: prefix.to_string(),
             key,
-        });
+        })?;
         Some(DataRecord {
-            id: &id.unwrap(),
-            embedding: &embedding.unwrap(),
+            id,
+            embedding,
             metadata: None,
             document: None,
         })
@@ -1067,9 +1066,12 @@ pub struct StorageBuilder {
     // Roaring Bitmap Value
     roaring_bitmap_storage: Arc<RwLock<Option<BTreeMap<CompositeKey, RoaringBitmap>>>>,
     // UInt32 Array Value
+    #[allow(clippy::type_complexity)]
     uint32_array_storage: Arc<RwLock<Option<BTreeMap<CompositeKey, Vec<u32>>>>>,
     // Data Record Fields
+    #[allow(clippy::type_complexity)]
     data_record_id_storage: Arc<RwLock<Option<BTreeMap<CompositeKey, String>>>>,
+    #[allow(clippy::type_complexity)]
     data_record_embedding_storage: Arc<RwLock<Option<BTreeMap<CompositeKey, Vec<f32>>>>>,
     pub(super) id: uuid::Uuid,
 }

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -60,7 +60,11 @@ impl BlockfileProvider {
 
     pub async fn open<
         'new,
-        K: Key + Into<KeyWrapper> + From<&'new KeyWrapper> + ArrowReadableKey<'new> + 'new,
+        K: Key
+            + Into<KeyWrapper>
+            + TryFrom<&'new KeyWrapper, Error = &'static str>
+            + ArrowReadableKey<'new>
+            + 'new,
         V: Value + Readable<'new> + ArrowReadableValue<'new> + 'new,
     >(
         &self,
@@ -80,7 +84,7 @@ impl BlockfileProvider {
         &self,
     ) -> Result<BlockfileWriter, Box<CreateError>> {
         match self {
-            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.create::<K, V>(),
+            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.create(),
             BlockfileProvider::ArrowBlockfileProvider(provider) => provider.create::<K, V>(),
         }
     }
@@ -97,7 +101,7 @@ impl BlockfileProvider {
         id: &uuid::Uuid,
     ) -> Result<BlockfileWriter, Box<CreateError>> {
         match self {
-            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.fork::<K, V>(id),
+            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.fork(id),
             BlockfileProvider::ArrowBlockfileProvider(provider) => provider.fork::<K, V>(id).await,
         }
     }

--- a/rust/blockstore/src/types.rs
+++ b/rust/blockstore/src/types.rs
@@ -86,7 +86,7 @@ impl Value for Vec<u32> {
 
 impl Value for &[u32] {
     fn get_size(&self) -> usize {
-        self.len() * size_of::<u32>()
+        std::mem::size_of_val(*self)
     }
 }
 
@@ -236,7 +236,7 @@ impl<
         'referred_data,
         K: Key
             + Into<KeyWrapper>
-            + From<&'referred_data KeyWrapper>
+            + TryFrom<&'referred_data KeyWrapper, Error = &'static str>
             + ArrowReadableKey<'referred_data>,
         V: Value + Readable<'referred_data> + ArrowReadableValue<'referred_data>,
     > BlockfileReader<'referred_data, K, V>
@@ -269,12 +269,8 @@ impl<
             BlockfileReader::ArrowBlockfileReader(reader) => {
                 let count = reader.count().await;
                 match count {
-                    Ok(c) => {
-                        return Ok(c);
-                    }
-                    Err(_) => {
-                        return Err(Box::new(BlockfileError::BlockNotFound));
-                    }
+                    Ok(c) => Ok(c),
+                    Err(_) => Err(Box::new(BlockfileError::BlockNotFound)),
                 }
             }
         }
@@ -351,7 +347,7 @@ impl<
         }
     }
 
-    pub async fn load_blocks_for_keys(&self, prefixes: &[&str], keys: &[K]) -> () {
+    pub async fn load_blocks_for_keys(&self, prefixes: &[&str], keys: &[K]) {
         match self {
             BlockfileReader::MemoryBlockfileReader(_reader) => unimplemented!(),
             BlockfileReader::ArrowBlockfileReader(reader) => {

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -422,7 +422,7 @@ impl<'me> FullTextIndexReader<'me> {
                 panic!("Invariant violation. Multiple frequency values found for a token.");
             }
             let res = res[0];
-            if res.1 <= 0 {
+            if res.1 == 0 {
                 panic!("Invariant violation. Zero frequency token found.");
             }
             // Throw away the "value" since we store frequencies in the keys.

--- a/rust/types/src/data_chunk.rs
+++ b/rust/types/src/data_chunk.rs
@@ -25,6 +25,11 @@ impl<T> Chunk<T> {
         self.visibility.iter().filter(|&v| *v).count()
     }
 
+    /// Returns whether the chunk has zero visible elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the element at the given index
     /// if the index is out of bounds, it returns None
     /// # Arguments
@@ -140,28 +145,28 @@ mod tests {
         assert_eq!(chunk.len(), 2);
         let mut iter = chunk.iter();
         let elem = iter.next();
-        assert_eq!(elem.is_some(), true);
+        assert!(elem.is_some());
         let (record, index) = elem.unwrap();
         assert_eq!(record.record.id, "embedding_id_1");
         assert_eq!(index, 0);
         let elem = iter.next();
-        assert_eq!(elem.is_some(), true);
+        assert!(elem.is_some());
         let (record, index) = elem.unwrap();
         assert_eq!(record.record.id, "embedding_id_2");
         assert_eq!(index, 1);
         let elem = iter.next();
-        assert_eq!(elem.is_none(), true);
+        assert!(elem.is_none());
 
-        let visibility = vec![true, false].into();
+        let visibility = vec![true, false];
         chunk.set_visibility(visibility);
         assert_eq!(chunk.len(), 1);
         let mut iter = chunk.iter();
         let elem = iter.next();
-        assert_eq!(elem.is_some(), true);
+        assert!(elem.is_some());
         let (record, index) = elem.unwrap();
         assert_eq!(record.record.id, "embedding_id_1");
         assert_eq!(index, 0);
         let elem = iter.next();
-        assert_eq!(elem.is_none(), true);
+        assert!(elem.is_none());
     }
 }

--- a/rust/types/src/data_record.rs
+++ b/rust/types/src/data_record.rs
@@ -13,7 +13,7 @@ pub struct DataRecord<'a> {
 impl DataRecord<'_> {
     pub fn get_size(&self) -> usize {
         let id_size = self.id.len();
-        let embedding_size = self.embedding.len() * std::mem::size_of::<f32>();
+        let embedding_size = std::mem::size_of_val(self.embedding);
         let metadata_size = match &self.metadata {
             Some(metadata) => {
                 let metadata_proto = Into::<chroma_proto::UpdateMetadata>::into(metadata.clone());

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -45,14 +45,13 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for UpdateMetadataValue {
             }
             // Used to communicate that the user wants to delete this key.
             None => Ok(UpdateMetadataValue::None),
-            _ => Err(UpdateMetadataValueConversionError::InvalidValue),
         }
     }
 }
 
 impl From<UpdateMetadataValue> for chroma_proto::UpdateMetadataValue {
     fn from(value: UpdateMetadataValue) -> Self {
-        let proto_value = match value {
+        match value {
             UpdateMetadataValue::Int(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::IntValue(
                     value as i64,
@@ -72,8 +71,7 @@ impl From<UpdateMetadataValue> for chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
             },
             UpdateMetadataValue::None => chroma_proto::UpdateMetadataValue { value: None },
-        };
-        proto_value
+        }
     }
 }
 
@@ -187,7 +185,7 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for MetadataValue {
 
 impl From<MetadataValue> for chroma_proto::UpdateMetadataValue {
     fn from(value: MetadataValue) -> Self {
-        let proto_value = match value {
+        match value {
             MetadataValue::Int(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::IntValue(
                     value as i64,
@@ -206,8 +204,7 @@ impl From<MetadataValue> for chroma_proto::UpdateMetadataValue {
             MetadataValue::Bool(value) => chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::BoolValue(value)),
             },
-        };
-        proto_value
+        }
     }
 }
 
@@ -288,6 +285,7 @@ impl TryFrom<chroma_proto::UpdateMetadata> for Metadata {
     }
 }
 
+#[derive(Debug, Default)]
 pub struct MetadataDelta<'referred_data> {
     pub metadata_to_update: HashMap<
         &'referred_data str,
@@ -299,11 +297,7 @@ pub struct MetadataDelta<'referred_data> {
 
 impl<'referred_data> MetadataDelta<'referred_data> {
     pub fn new() -> Self {
-        Self {
-            metadata_to_update: HashMap::new(),
-            metadata_to_delete: HashMap::new(),
-            metadata_to_insert: HashMap::new(),
-        }
+        Self::default()
     }
 }
 
@@ -862,7 +856,7 @@ mod tests {
                             )),
                         },
                     ],
-                    operator: chroma_proto::BooleanOperator::And.try_into().unwrap(),
+                    operator: chroma_proto::BooleanOperator::And.into(),
                 },
             )),
         };
@@ -882,9 +876,7 @@ mod tests {
             r#where_document: Some(chroma_proto::where_document::WhereDocument::Direct(
                 chroma_proto::DirectWhereDocument {
                     document: "foo".to_string(),
-                    operator: chroma_proto::WhereDocumentOperator::Contains
-                        .try_into()
-                        .unwrap(),
+                    operator: chroma_proto::WhereDocumentOperator::Contains.into(),
                 },
             )),
         };
@@ -910,8 +902,7 @@ mod tests {
                                     chroma_proto::DirectWhereDocument {
                                         document: "foo".to_string(),
                                         operator: chroma_proto::WhereDocumentOperator::Contains
-                                            .try_into()
-                                            .unwrap(),
+                                            .into(),
                                     },
                                 ),
                             ),
@@ -922,14 +913,13 @@ mod tests {
                                     chroma_proto::DirectWhereDocument {
                                         document: "bar".to_string(),
                                         operator: chroma_proto::WhereDocumentOperator::Contains
-                                            .try_into()
-                                            .unwrap(),
+                                            .into(),
                                     },
                                 ),
                             ),
                         },
                     ],
-                    operator: chroma_proto::BooleanOperator::And.try_into().unwrap(),
+                    operator: chroma_proto::BooleanOperator::And.into(),
                 },
             )),
         };

--- a/rust/types/src/operation.rs
+++ b/rust/types/src/operation.rs
@@ -53,7 +53,6 @@ impl TryFrom<chroma_proto::Operation> for Operation {
             chroma_proto::Operation::Upsert => Ok(Operation::Upsert),
             chroma_proto::Operation::Update => Ok(Operation::Update),
             chroma_proto::Operation::Delete => Ok(Operation::Delete),
-            _ => Err(OperationConversionError::InvalidOperation),
         }
     }
 }
@@ -69,7 +68,6 @@ impl TryFrom<i32> for Operation {
                 chroma_proto::Operation::Upsert => Ok(Operation::Upsert),
                 chroma_proto::Operation::Update => Ok(Operation::Update),
                 chroma_proto::Operation::Delete => Ok(Operation::Delete),
-                _ => Err(OperationConversionError::InvalidOperation),
             },
             Err(_) => Err(OperationConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/types/src/record.rs
+++ b/rust/types/src/record.rs
@@ -178,19 +178,16 @@ fn vec_to_f32(bytes: &[u8]) -> Result<&[f32], VectorConversionError> {
 
     unsafe {
         let (pre, mid, post) = bytes.align_to::<f32>();
-        if pre.len() != 0 || post.len() != 0 {
+        if !pre.is_empty() || !post.is_empty() {
             return Err(VectorConversionError::InvalidByteLength);
         }
-        return Ok(mid);
+        Ok(mid)
     }
 }
 
 fn f32_to_vec(vector: &[f32]) -> Vec<u8> {
     unsafe {
-        std::slice::from_raw_parts(
-            vector.as_ptr() as *const u8,
-            vector.len() * std::mem::size_of::<f32>(),
-        )
+        std::slice::from_raw_parts(vector.as_ptr() as *const u8, std::mem::size_of_val(vector))
     }
     .to_vec()
 }
@@ -277,10 +274,7 @@ mod tests {
 
     fn as_byte_view(input: &[f32]) -> Vec<u8> {
         unsafe {
-            std::slice::from_raw_parts(
-                input.as_ptr() as *const u8,
-                input.len() * std::mem::size_of::<f32>(),
-            )
+            std::slice::from_raw_parts(input.as_ptr() as *const u8, std::mem::size_of_val(input))
         }
         .to_vec()
     }

--- a/rust/types/src/scalar_encoding.rs
+++ b/rust/types/src/scalar_encoding.rs
@@ -28,7 +28,6 @@ impl TryFrom<chroma_proto::ScalarEncoding> for ScalarEncoding {
         match encoding {
             chroma_proto::ScalarEncoding::Float32 => Ok(ScalarEncoding::FLOAT32),
             chroma_proto::ScalarEncoding::Int32 => Ok(ScalarEncoding::INT32),
-            _ => Err(ScalarEncodingConversionError::InvalidEncoding),
         }
     }
 }
@@ -42,7 +41,6 @@ impl TryFrom<i32> for ScalarEncoding {
             Ok(encoding) => match encoding {
                 chroma_proto::ScalarEncoding::Float32 => Ok(ScalarEncoding::FLOAT32),
                 chroma_proto::ScalarEncoding::Int32 => Ok(ScalarEncoding::INT32),
-                _ => Err(ScalarEncodingConversionError::InvalidEncoding),
             },
             Err(_) => Err(ScalarEncodingConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -119,7 +119,7 @@ impl TryFrom<chroma_proto::Segment> for Segment {
         Ok(Segment {
             id: segment_uuid,
             r#type: segment_type,
-            scope: scope,
+            scope,
             collection: collection_uuid,
             metadata: segment_metadata,
             file_path: file_paths,

--- a/rust/types/src/segment_scope.rs
+++ b/rust/types/src/segment_scope.rs
@@ -33,7 +33,6 @@ impl TryFrom<chroma_proto::SegmentScope> for SegmentScope {
             chroma_proto::SegmentScope::Metadata => Ok(SegmentScope::METADATA),
             chroma_proto::SegmentScope::Record => Ok(SegmentScope::RECORD),
             chroma_proto::SegmentScope::Sqlite => Ok(SegmentScope::SQLITE),
-            _ => Err(SegmentScopeConversionError::InvalidScope),
         }
     }
 }
@@ -49,7 +48,6 @@ impl TryFrom<i32> for SegmentScope {
                 chroma_proto::SegmentScope::Metadata => Ok(SegmentScope::METADATA),
                 chroma_proto::SegmentScope::Record => Ok(SegmentScope::RECORD),
                 chroma_proto::SegmentScope::Sqlite => Ok(SegmentScope::SQLITE),
-                _ => Err(SegmentScopeConversionError::InvalidScope),
             },
             Err(_) => Err(SegmentScopeConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/worker/src/execution/orchestration/hnsw.rs
+++ b/rust/worker/src/execution/orchestration/hnsw.rs
@@ -595,7 +595,7 @@ impl Component for HnswQueryOrchestrator {
 
         // If segment is uninitialized and dimension is not set then we assume
         // that this is a query before any add so return empty response.
-        if hnsw_segment.file_path.len() <= 0 && collection.dimension.is_none() {
+        if hnsw_segment.file_path.len() == 0 && collection.dimension.is_none() {
             self.terminate_with_empty_response(ctx);
             return;
         }

--- a/rust/worker/src/memberlist/memberlist_provider.rs
+++ b/rust/worker/src/memberlist/memberlist_provider.rs
@@ -150,7 +150,6 @@ impl CustomResourceMemberlistProvider {
         let stream = stream.then(|event| async move {
             match event {
                 Ok(event) => {
-                    let event = event;
                     println!("Kube stream event: {:?}", event);
                     Some(event)
                 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
- Clean up warnings under rust/types.

## Test plan
*How are these changes tested?*
- `cargo clippy --all-targets`

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
