### PR TITLE
[CHORE] Remove the need to pop from the disk cache during compaction

### DIFF
--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -428,7 +428,7 @@ impl HnswIndexProvider {
         Ok(())
     }
 
-    /// Purge all entries from the cache and remove temporary files from disk.
+    /// Purge entries from the cache by index ID and remove temporary files from disk.
     pub async fn purge_by_id(&mut self, index_ids: &[Uuid]) {
         for index_id in index_ids {
             match self.remove_temporary_files(&index_id).await {

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -429,9 +429,8 @@ impl HnswIndexProvider {
     }
 
     /// Purge all entries from the cache and remove temporary files from disk.
-    pub async fn purge_all_entries(&mut self) {
-        while let Some((_, index)) = self.cache.pop() {
-            let index_id = index.inner.read().id;
+    pub async fn purge_by_id(&mut self, index_ids: &[Uuid]) {
+        for index_id in index_ids {
             match self.remove_temporary_files(&index_id).await {
                 Ok(_) => {}
                 Err(e) => {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -162,7 +162,7 @@ impl CompactionManager {
             match job {
                 Ok(result) => {
                     println!("Compaction completed: {:?}", result);
-                    compacted.push(result.id);
+                    compacted.push(result.compaction_job.collection_id);
                     num_completed_jobs += 1;
                 }
                 Err(e) => {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -552,8 +552,13 @@ mod tests {
         let dispatcher_handle = system.start_component(dispatcher);
         manager.set_dispatcher(dispatcher_handle);
         manager.set_system(system);
-        let (num_completed, number_failed) = manager.compact_batch().await;
+        let mut compacted = vec![];
+        let (num_completed, number_failed) = manager.compact_batch(&mut compacted).await;
         assert_eq!(num_completed, 2);
         assert_eq!(number_failed, 0);
+        assert!(
+            (compacted == vec![collection_uuid_1, collection_uuid_2])
+                || (compacted == vec![collection_uuid_2, collection_uuid_1])
+        );
     }
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -152,7 +152,7 @@ impl ChromaError for CompactionError {
 // TODO: we need to improve this response
 #[derive(Debug)]
 pub struct CompactionResponse {
-    id: Uuid,
+    pub(crate) id: Uuid,
     compaction_job: CompactionJob,
     message: String,
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -153,8 +153,8 @@ impl ChromaError for CompactionError {
 #[derive(Debug)]
 pub struct CompactionResponse {
     pub(crate) id: Uuid,
-    compaction_job: CompactionJob,
-    message: String,
+    pub(crate) compaction_job: CompactionJob,
+    pub(crate) message: String,
 }
 
 impl CompactOrchestrator {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Compaction doesn't need to use the cache.pop.  We know exactly which compactions we trigger.
 - This will unblock upgrading foyer within chroma.

## Test plan
*How are these changes tested?*

- [ ] `cargo check` locally + ci

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
