### PR TITLE
[CHORE] Switch to debug_struct over f.write

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/storage.rs
@@ -27,11 +27,11 @@ pub enum BlockStorage {
 impl Debug for BlockStorage {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            BlockStorage::String(_) => write!(f, "String"),
-            BlockStorage::VecUInt32(_) => write!(f, "VecUInt32"),
-            BlockStorage::UInt32(_) => write!(f, "UInt32"),
-            BlockStorage::RoaringBitmap(_) => write!(f, "RoaringBitmap"),
-            BlockStorage::DataRecord(_) => write!(f, "DataRecord"),
+            BlockStorage::String(_) => f.debug_struct("String").finish(),
+            BlockStorage::VecUInt32(_) => f.debug_struct("VecUInt32").finish(),
+            BlockStorage::UInt32(_) => f.debug_struct("UInt32").finish(),
+            BlockStorage::RoaringBitmap(_) => f.debug_struct("RoaringBitmap").finish(),
+            BlockStorage::DataRecord(_) => f.debug_struct("DataRecord").finish(),
         }
     }
 }

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -535,11 +535,11 @@ impl Debug for SparseIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let forward = self.forward.lock();
         let reverse = self.reverse.lock();
-        write!(
-            f,
-            "SparseIndex {{ id: {}, forward: {:?}, reverse: {:?} }}",
-            self.id, forward, reverse
-        )
+        f.debug_struct("SparseIndex")
+            .field("id", &self.id)
+            .field("forward", &forward)
+            .field("reverse", &reverse)
+            .finish()
     }
 }
 

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -30,10 +30,10 @@ impl Debug for BlockfileProvider {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             BlockfileProvider::HashMapBlockfileProvider(_provider) => {
-                write!(f, "HashMapBlockfileProvider")
+                f.debug_struct("HashMapBlockfileProvider").finish()
             }
             BlockfileProvider::ArrowBlockfileProvider(_provider) => {
-                write!(f, "ArrowBlockfileProvider")
+                f.debug_struct("ArrowBlockfileProvider").finish()
             }
         }
     }

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -283,7 +283,7 @@ impl Component for CompactionManager {
 
 impl Debug for CompactionManager {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CompactionManager")
+        f.debug_struct("CompactionManager").finish()
     }
 }
 

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -29,7 +29,9 @@ pub(crate) struct DistributedHNSWSegmentWriter {
 
 impl Debug for DistributedHNSWSegmentWriter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DistributedHNSWSegment")
+        f.debug_struct("DistributedHNSWSegmentWriter")
+            .field("id", &self.id)
+            .finish()
     }
 }
 
@@ -254,23 +256,20 @@ impl SegmentFlusher for DistributedHNSWSegmentWriter {
 #[derive(Clone)]
 pub(crate) struct DistributedHNSWSegmentReader {
     index: HnswIndexRef,
-    hnsw_index_provider: HnswIndexProvider,
     pub(crate) id: Uuid,
 }
 
 impl Debug for DistributedHNSWSegmentReader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DistributedHNSWSegmentReader")
+        f.debug_struct("DistributedHNSWSegmentReader")
+            .field("id", &self.id)
+            .finish()
     }
 }
 
 impl DistributedHNSWSegmentReader {
-    fn new(index: HnswIndexRef, hnsw_index_provider: HnswIndexProvider, id: Uuid) -> Self {
-        return DistributedHNSWSegmentReader {
-            index,
-            hnsw_index_provider,
-            id,
-        };
+    fn new(index: HnswIndexRef, id: Uuid) -> Self {
+        return DistributedHNSWSegmentReader { index, id };
     }
 
     pub(crate) async fn from_segment(
@@ -341,9 +340,7 @@ impl DistributedHNSWSegmentReader {
                 };
 
             Ok(Box::new(DistributedHNSWSegmentReader::new(
-                index,
-                hnsw_index_provider,
-                segment.id,
+                index, segment.id,
             )))
         } else {
             return Err(Box::new(

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -47,7 +47,9 @@ pub(crate) struct MetadataSegmentWriter<'me> {
 
 impl Debug for MetadataSegmentWriter<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "MetadataSegmentWriter")
+        f.debug_struct("MetadataSegmentWriter")
+            .field("id", &self.id)
+            .finish()
     }
 }
 

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -31,7 +31,9 @@ pub(crate) struct RecordSegmentWriter {
 
 impl Debug for RecordSegmentWriter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "RecordSegmentWriter")
+        f.debug_struct("RecordSegmentWriter")
+            .field("id", &self.id)
+            .finish()
     }
 }
 
@@ -520,7 +522,7 @@ pub(crate) struct RecordSegmentFlusher {
 
 impl Debug for RecordSegmentFlusher {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "RecordSegmentFlusher")
+        f.debug_struct("RecordSegmentFlusher").finish()
     }
 }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This switches to `debug_struct` over `f.write` as per @rescrv's suggestion.
	 - Fixes a spurious warning about an unused struct field
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
We do not test the debug behavior.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None