### PR TITLE
Revert "[RELEASE] 0.5.10 (#2862)"

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 __settings = Settings()
 
-__version__ = "0.5.10"
+__version__ = "0.5.9"
 
 
 # Workaround to deal with Colab's old sqlite3 version

--- a/docs/docs.trychroma.com/pages/deployment/migration.md
+++ b/docs/docs.trychroma.com/pages/deployment/migration.md
@@ -20,7 +20,7 @@ We will aim to provide:
 
 ## Migration Log
 
-### v0.5.10
+### v0.5.9
 
 The results returned by `collection.get()` is now ordered by internal ids. Whereas previously, the results were ordered by user provided ids, although this behavior was not explicitly documented. We would like to make the change because using user provided ids may not be ideal for performance in hosted Chroma, and we hope to propagate the change to local Chroma for consistency of behavior. In general, newer documents in Chroma has larger internal ids.
 


### PR DESCRIPTION
This reverts commit 07c7cdccb541e6596774a6e29a9bb985eaecbfd2.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
