### PR TITLE
[ENH] Change the semantics of `$ne`, `$nin`, and `$not_contains` for local Chroma

### DIFF
--- a/chromadb/test/property/test_filtering.py
+++ b/chromadb/test/property/test_filtering.py
@@ -26,14 +26,7 @@ import numpy as np
 
 def _filter_where_clause(clause: Where, metadata: Optional[Metadata]) -> bool:
     """Return true if the where clause is true for the given metadata map"""
-    if metadata is None:
-        # None metadata does not match any clause
-        # Note: This includes cases where filtering for $ne or $nin
-        # as we require that the key is present in the metadata
-        # i.e for a record set of [{}, {}] and a filter of {"where": {"test": {"$ne": 1}}}
-        # the result should be [] as the key "test" is not present in the metadata
-        return False
-
+    metadata = metadata or dict()
     key, expr = list(clause.items())[0]
 
     # Handle the shorthand for equal: {key: val} where val is a simple value
@@ -53,40 +46,35 @@ def _filter_where_clause(clause: Where, metadata: Optional[Metadata]) -> bool:
     if key == "$or":
         assert isinstance(expr, list)
         return any(_filter_where_clause(clause, metadata) for clause in expr)
-    if key == "$in":
-        assert isinstance(expr, list)
-        return metadata[key] in expr if key in metadata else False  # type: ignore[comparison-overlap]
-    if key == "$nin":
-        assert isinstance(expr, list)
-        return metadata[key] not in expr  # type: ignore[comparison-overlap]
 
     # expr is an operator expression
     assert isinstance(expr, dict)
     op, val = list(expr.items())[0]
     assert isinstance(metadata, dict)
-    if key not in metadata:
-        return False
-    metadata_key = metadata[key]
     if op == "$eq":
-        return key in metadata and metadata_key == val
+        return key in metadata and metadata[key] == val
     elif op == "$ne":
-        return key in metadata and metadata_key != val
+        return key not in metadata or metadata[key] != val
     elif op == "$in":
-        return key in metadata and metadata_key in val  # type: ignore[operator]
+        return key in metadata and metadata[key] in val  # type: ignore[operator]
     elif op == "$nin":
-        return key in metadata and metadata_key not in val  # type: ignore[operator]
+        return key not in metadata or metadata[key] not in val  # type: ignore[operator]
 
     # The following conditions only make sense for numeric values
-    assert isinstance(metadata_key, int) or isinstance(metadata_key, float)
+    assert (
+        key not in metadata
+        or isinstance(metadata[key], int)
+        or isinstance(metadata[key], float)
+    )
     assert isinstance(val, int) or isinstance(val, float)
     if op == "$gt":
-        return (key in metadata) and (metadata_key > val)
+        return key in metadata and metadata[key] > val
     elif op == "$gte":
-        return key in metadata and metadata_key >= val
+        return key in metadata and metadata[key] >= val
     elif op == "$lt":
-        return key in metadata and metadata_key < val
+        return key in metadata and metadata[key] < val
     elif op == "$lte":
-        return key in metadata and metadata_key <= val
+        return key in metadata and metadata[key] <= val
     else:
         raise ValueError("Unknown operator: {}".format(key))
 
@@ -114,7 +102,7 @@ def _filter_where_doc_clause(clause: WhereDocument, doc: Document) -> bool:
         return expr in doc
     elif key == "$not_contains":
         if not doc:
-            return False
+            return True
         # SQLite FTS handles % and _ as word boundaries that are ignored so we need to
         # treat them as wildcards
         if "%" in expr or "_" in expr:
@@ -216,7 +204,7 @@ def test_filterable_metadata_get(
         # some minimal size
         if should_compact and len(invariants.wrap(record_set["ids"])) > 10:
             # Wait for the model to be updated
-            wait_for_version_increase(client, collection.name, initial_version)
+            wait_for_version_increase(client, collection.name, initial_version)  # type: ignore
 
     for filter in filters:
         result_ids = coll.get(**filter)["ids"]
@@ -268,7 +256,7 @@ def test_filterable_metadata_get_limit_offset(
         # some minimal size
         if should_compact and len(invariants.wrap(record_set["ids"])) > 10:
             # Wait for the model to be updated
-            wait_for_version_increase(client, collection.name, initial_version)
+            wait_for_version_increase(client, collection.name, initial_version)  # type: ignore
 
     for filter in filters:
         # add limit and offset to filter
@@ -330,7 +318,7 @@ def test_filterable_metadata_query(
         # some minimal size
         if should_compact and len(invariants.wrap(record_set["ids"])) > 10:
             # Wait for the model to be updated
-            wait_for_version_increase(client, collection.name, initial_version)
+            wait_for_version_increase(client, collection.name, initial_version)  # type: ignore
 
     total_count = len(normalized_record_set["ids"])
     # Pick a random vector
@@ -384,7 +372,7 @@ def test_empty_filter(client: ClientAPI) -> None:
     )
     assert res["ids"] == [[]]
     if res["embeddings"] is not None:
-        assert cast(np.ndarray, res["embeddings"][0]).size == 0
+        assert cast(np.ndarray, res["embeddings"][0]).size == 0  # type: ignore
     assert res["distances"] == [[]]
     assert res["metadatas"] == [[]]
     assert set(res["included"]) == set(["embeddings", "distances", "metadatas"])


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Updates the semantics of `$ne`, `$nin`, and `$not_contains` to be the exact opposite of `$eq`, `$in`, and `not_contains`. Previously, `$ne` and `$nin` only returns records with the specified key in the metadata, while `$not_contains` only returns records with documents. Now `$ne` and `$nin` returns all records excluding those matching `$eq` and `$in`, and `$not_contains` returns all records excluding those matching `$contains`. 
 - New functionality
	 - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

This is a breaking change that should be documented on the migration guides.
