### PR TITLE
[CHORE] Finish clippy work.  Enable it.  Make docs not warn too.

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup
         uses: ./.github/actions/rust
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Build
         run: cargo build --verbose
       - name: Test

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/rust
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features --keep-going -- -D warnings
       - name: Build
         run: cargo build --verbose
       - name: Test

--- a/rust/benchmark-datasets/src/datasets/ms_marco_queries.rs
+++ b/rust/benchmark-datasets/src/datasets/ms_marco_queries.rs
@@ -11,7 +11,7 @@ use tokio::{fs::File, io::AsyncBufReadExt};
 use tokio_stream::{wrappers::LinesStream, Stream, StreamExt};
 use tokio_util::io::StreamReader;
 
-/// Dataset from https://github.com/microsoft/MS-MARCO-Web-Search.
+/// Dataset from <https://github.com/microsoft/MS-MARCO-Web-Search>.
 /// Metadata:
 /// - id: The query ID.
 /// - language_codes: The language codes of the query (e.g. en-US).

--- a/rust/benchmark-datasets/src/datasets/scidocs.rs
+++ b/rust/benchmark-datasets/src/datasets/scidocs.rs
@@ -19,7 +19,7 @@ struct SciDocsCorpusLine {
     text: String,
 }
 
-/// Dataset from https://huggingface.co/datasets/BeIR/scidocs.
+/// Dataset from <https://huggingface.co/datasets/BeIR/scidocs>.
 /// Metadata:
 /// - id: The record ID.
 /// - title: The title of the record.

--- a/rust/chroma/src/lib.rs
+++ b/rust/chroma/src/lib.rs
@@ -1,4 +1,7 @@
 #[cfg(test)]
-fn test() {
-    println!("Hello, test!");
+mod tests {
+    #[test]
+    fn test() {
+        println!("Hello, test!");
+    }
 }

--- a/rust/chroma/src/lib.rs
+++ b/rust/chroma/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+fn test() {
+    println!("Hello, test!");
+}

--- a/rust/chroma/src/main.rs
+++ b/rust/chroma/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/rust/distance/src/distance_avx.rs
+++ b/rust/distance/src/distance_avx.rs
@@ -202,6 +202,7 @@ copyright Qdrant, licensed under the Apache 2.0 license.
 #![allow(clippy::missing_safety_doc)]
 
 #[cfg(target_arch = "x86_64")]
+#[allow(unused_imports)]
 use std::arch::x86_64::*;
 
 #[cfg(all(target_feature = "avx", target_feature = "fma"))]

--- a/rust/distance/src/distance_avx.rs
+++ b/rust/distance/src/distance_avx.rs
@@ -199,6 +199,7 @@ copyright Qdrant, licensed under the Apache 2.0 license.
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+#![allow(clippy::missing_safety_doc)]
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;

--- a/rust/distance/src/distance_sse.rs
+++ b/rust/distance/src/distance_sse.rs
@@ -199,6 +199,7 @@ copyright Qdrant, licensed under the Apache 2.0 license.
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+#![allow(clippy::missing_safety_doc)]
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/rust/distance/src/types.rs
+++ b/rust/distance/src/types.rs
@@ -211,7 +211,7 @@ use thiserror::Error;
 /// - `Cosine` - The cosine distance. Specifically, 1 - cosine.
 /// - `InnerProduct` - The inner product. Specifically, 1 - inner product.
 /// # Notes
-/// See https://docs.trychroma.com/guides#changing-the-distance-function
+/// See <https://docs.trychroma.com/guides#changing-the-distance-function>
 #[derive(Clone, Debug, PartialEq)]
 pub enum DistanceFunction {
     Euclidean,

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -162,10 +162,6 @@ impl S3Storage {
                                  tracing::error!("invalid object state: {}", msg);
                                 Err(S3GetError::S3GetError(msg.to_string()))
                             }
-                            aws_sdk_s3::operation::get_object::GetObjectError::Unhandled(_) =>  {
-                                 tracing::error!("unhandled error");
-                                Err(S3GetError::S3GetError("unhandled error".to_string()))
-                            }
                             _ => {
                                  tracing::error!("error: {}", inner.to_string());
                                 Err(S3GetError::S3GetError(inner.to_string()))
@@ -242,9 +238,6 @@ impl S3Storage {
                             }
                             aws_sdk_s3::operation::get_object::GetObjectError::InvalidObjectState(msg) => {
                                 Err(S3GetError::S3GetError(msg.to_string()))
-                            }
-                            aws_sdk_s3::operation::get_object::GetObjectError::Unhandled(_) => {
-                                Err(S3GetError::S3GetError("unhandled error".to_string()))
                             }
                             _ => {
                                 Err(S3GetError::S3GetError(inner.to_string()))

--- a/rust/worker/src/system/types.rs
+++ b/rust/worker/src/system/types.rs
@@ -94,8 +94,8 @@ impl ConsumableJoinHandle {
     }
 
     async fn consume(&mut self) -> Result<(), JoinError> {
-        // NOTE(rescrv):  Do not clean this up by silencing the warning; refactor.
-        match self.handle.lock().take() {
+        let handle = { self.handle.lock().take() };
+        match handle {
             Some(handle) => {
                 handle.await?;
                 Ok(())


### PR DESCRIPTION
This removes use of a deprecated error type and refactors some mutexes held across await points to be held prior to the await point.

## Description of changes

*Summarize the changes made by this PR.*
 - Clippy errors be gone

## Test plan
*cargo test locally && ci globally

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
