### PR TITLE
[CLN] Make delete return None

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -254,7 +254,7 @@ class BaseAPI(ABC):
         ids: Optional[IDs],
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> IDs:
+    ) -> None:
         """[Internal] Deletes entries from a collection specified by UUID.
 
         Args:

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -245,7 +245,7 @@ class AsyncBaseAPI(ABC):
         ids: Optional[IDs],
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> IDs:
+    ) -> None:
         """[Internal] Deletes entries from a collection specified by UUID.
 
         Args:

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -356,8 +356,8 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         ids: Optional[IDs],
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> IDs:
-        return await self._server._delete(
+    ) -> None:
+        await self._server._delete(
             collection_id=collection_id,
             ids=ids,
             where=where,

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -404,14 +404,13 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         ids: Optional[IDs] = None,
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> IDs:
-        resp_json = await self._make_request(
+    ) -> None:
+        await self._make_request(
             "post",
             "/collections/" + str(collection_id) + "/delete",
             json={"where": where, "ids": ids, "where_document": where_document},
         )
-
-        return cast(IDs, resp_json)
+        return None
 
     @trace_method("AsyncFastAPI._submit_batch", OpenTelemetryGranularity.ALL)
     async def _submit_batch(

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -308,8 +308,8 @@ class Client(SharedSystemClient, ClientAPI):
         ids: Optional[IDs],
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> IDs:
-        return self._server._delete(
+    ) -> None:
+        self._server._delete(
             collection_id=collection_id,
             ids=ids,
             where=where,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -365,9 +365,9 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         ids: Optional[IDs] = None,
         where: Optional[Where] = {},
         where_document: Optional[WhereDocument] = {},
-    ) -> IDs:
+    ) -> None:
         """Deletes embeddings from the database"""
-        resp_json = self._make_request(
+        self._make_request(
             "post",
             "/collections/" + str(collection_id) + "/delete",
             json={
@@ -376,7 +376,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
                 "where_document": where_document,
             },
         )
-        return cast(IDs, resp_json)
+        return None
 
     @trace_method("FastAPI._submit_batch", OpenTelemetryGranularity.ALL)
     def _submit_batch(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -572,7 +572,7 @@ class SegmentAPI(ServerAPI):
         ids: Optional[IDs] = None,
         where: Optional[Where] = None,
         where_document: Optional[WhereDocument] = None,
-    ) -> IDs:
+    ) -> None:
         add_attributes_to_current_span(
             {
                 "collection_id": str(collection_id),
@@ -625,7 +625,7 @@ class SegmentAPI(ServerAPI):
             ids_to_delete = ids
 
         if len(ids_to_delete) == 0:
-            return []
+            return
 
         records_to_submit = list(
             _records(operation=t.Operation.DELETE, ids=ids_to_delete)
@@ -638,7 +638,6 @@ class SegmentAPI(ServerAPI):
                 collection_uuid=str(collection_id), delete_amount=len(ids_to_delete)
             )
         )
-        return ids_to_delete
 
     @trace_method("SegmentAPI._count", OpenTelemetryGranularity.OPERATION)
     @retry(  # type: ignore[misc]

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -102,7 +102,7 @@ class DB(Component):
         collection_uuid: Optional[UUID] = None,
         ids: Optional[IDs] = None,
         where_document: WhereDocument = {},
-    ) -> List[str]:
+    ) -> None:
         pass
 
     @abstractmethod

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -3,7 +3,6 @@ from typing import (
     Callable,
     cast,
     Dict,
-    List,
     Sequence,
     Optional,
     Tuple,
@@ -21,7 +20,6 @@ from fastapi.responses import JSONResponse, ORJSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
-from uuid import UUID
 
 from chromadb.api.configuration import CollectionConfigurationInternal
 from pydantic import BaseModel
@@ -905,8 +903,8 @@ class FastAPI(Server):
     @trace_method("FastAPI.delete", OpenTelemetryGranularity.OPERATION)
     async def delete(
         self, collection_id: str, request: Request, body: DeleteEmbedding = Body(...)
-    ) -> List[UUID]:
-        def process_delete(request: Request, raw_body: bytes) -> List[str]:
+    ) -> None:
+        def process_delete(request: Request, raw_body: bytes) -> None:
             delete = validate_model(DeleteEmbedding, orjson.loads(raw_body))
             self.auth_and_get_tenant_and_database_for_request(
                 request.headers,
@@ -922,14 +920,11 @@ class FastAPI(Server):
                 where_document=delete.where_document,
             )
 
-        return cast(
-            List[UUID],
-            await to_thread.run_sync(
-                process_delete,
-                request,
-                await request.body(),
-                limiter=self._capacity_limiter,
-            ),
+        await to_thread.run_sync(
+            process_delete,
+            request,
+            await request.body(),
+            limiter=self._capacity_limiter,
         )
 
     @trace_method("FastAPI.count", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -364,6 +364,12 @@ def test_delete(client):
     with pytest.raises(Exception):
         collection.delete()
 
+def test_delete_returns_none(client):
+    client.reset()
+    collection = client.create_collection("testspace")
+    collection.add(**batch_records)
+    assert collection.count() == 2
+    assert collection.delete(ids=batch_records["ids"]) is None
 
 def test_delete_with_index(client):
     client.reset()

--- a/clients/js/src/Collection.ts
+++ b/clients/js/src/Collection.ts
@@ -367,16 +367,18 @@ export class Collection {
    * });
    * ```
    */
-  async delete({ ids, where, whereDocument }: DeleteParams = {}): Promise<
-    string[]
-  > {
+  async delete({
+    ids,
+    where,
+    whereDocument,
+  }: DeleteParams = {}): Promise<void> {
     await this.client.init();
     let idsArray = undefined;
     if (ids !== undefined) idsArray = toArray(ids);
-    return (await this.client.api.aDelete(
+    await this.client.api.aDelete(
       this.id,
       { ids: idsArray, where: where, where_document: whereDocument },
       this.client.api.options,
-    )) as string[];
+    );
   }
 }


### PR DESCRIPTION
## Description of changes

The `Collection.delete` API seemingly returns None, but our internal implementation returns a list of the IDs that were deleted. This PR makes all `delete` implementations return `None` for consistency.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
The documentation does not mention the API returning a list of deleted IDs, so it is consistent with the expected behavior.
