### PR TITLE
[ENH] Implement serde for SparseIndex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ version = "0.1.0"
 dependencies = [
  "arrow",
  "async-trait",
+ "bincode",
  "chroma-cache",
  "chroma-config",
  "chroma-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,7 @@ checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ tempfile = "3.8.1"
 shuttle = "0.7.1"
 proptest = "1.4.0"
 proptest-state-machine = "0.1.0"
+bincode = "1.3.3"
 
 [profile.release]
 debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 arrow = "52.0.0"
 thiserror = "1.0.50"
-uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 async-trait = "0.1.74"
 roaring = "0.10.3"
 futures = "0.3"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.1", features = ["serde"] }
 tracing = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-util = "0.7.10"

--- a/rust/benchmark-datasets/Cargo.toml
+++ b/rust/benchmark-datasets/Cargo.toml
@@ -8,23 +8,26 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.88"
+async-tempfile = "0.6.0"
 async-compression = { version = "0.4.12", features = [
   "tokio",
   "gzip",
   "bzip2",
 ] }
-async-tempfile = "0.6.0"
-bincode = "1.3.3"
+
+bincode = { workspace = true }
+futures = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tantivy = { workspace = true }
+tokio = { workspace = true }
+
 clap = { version = "4.5.17", features = ["derive"] }
 dirs = "5.0.1"
-futures.workspace = true
-rand.workspace = true
 reqwest = { version = "0.12.7", features = ["stream"] }
-serde.workspace = true
-serde_json.workspace = true
-tantivy.workspace = true
-tokio = { workspace = true }
 tokio-stream = { version = "0.1.16", features = ["full"] }
 tokio-util = "0.7.12"
-chroma-types = { workspace = true }
 bloom = "0.3.2"
+
+chroma-types = { workspace = true }

--- a/rust/blockstore/Cargo.toml
+++ b/rust/blockstore/Cargo.toml
@@ -35,3 +35,4 @@ rand = { workspace = true }
 tempfile = { workspace = true }
 proptest = { workspace = true }
 proptest-state-machine = { workspace = true }
+bincode = { workspace = true }

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -375,7 +375,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     ) -> Result<(&'me str, K, V), Box<dyn ChromaError>> {
         let mut block_offset = 0;
         let mut block = None;
-        let sparse_index_len = self.sparse_index.len();
+        let sparse_index_len = self.sparse_index.data.lock().len();
         for i in 0..sparse_index_len {
             let uuid = {
                 let data = self.sparse_index.data.lock();

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -378,8 +378,8 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let sparse_index_len = self.sparse_index.len();
         for i in 0..sparse_index_len {
             let uuid = {
-                let sparse_index_forward = self.sparse_index.forward.lock();
-                *sparse_index_forward.iter().nth(i).unwrap().1
+                let data = self.sparse_index.data.lock();
+                *data.forward.iter().nth(i).unwrap().1
             };
             block = match self.get_block(uuid).await {
                 Ok(Some(block)) => Some(block),
@@ -636,8 +636,8 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     pub(crate) async fn count(&self) -> Result<usize, Box<dyn ChromaError>> {
         let mut block_ids: Vec<Uuid> = vec![];
         {
-            let lock_guard = self.sparse_index.forward.lock();
-            let curr_iter = lock_guard.iter();
+            let lock_guard = self.sparse_index.data.lock();
+            let curr_iter = lock_guard.forward.iter();
             for (_, block_id) in curr_iter {
                 block_ids.push(*block_id);
             }

--- a/rust/blockstore/src/key.rs
+++ b/rust/blockstore/src/key.rs
@@ -1,8 +1,7 @@
-use std::hash::{Hash, Hasher};
-
-use chroma_error::{ChromaError, ErrorCodes};
-
 use super::Key;
+use chroma_error::{ChromaError, ErrorCodes};
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 // TODO(rescrv):  This used to be a panic/unwrap, but could be a nicer type.
 #[derive(thiserror::Error, Debug)]
@@ -15,7 +14,7 @@ impl ChromaError for InvalidKeyConversion {
     }
 }
 
-#[derive(Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, PartialOrd, Debug, Serialize, Deserialize)]
 pub enum KeyWrapper {
     String(String),
     Float32(f32),
@@ -103,7 +102,7 @@ impl TryFrom<&KeyWrapper> for u32 {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompositeKey {
     pub(super) prefix: String,
     pub(super) key: KeyWrapper,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Implements the serde traits for the sparse index
	 - Refactors out the forward/reverse mapping into one lock protected struct we serde from
	 - Clean up imports on the benchmark crate, since that uses bincode.
 - New functionality
	 - None

Notes
- I chose to implement this with the default serde impls because then we get zero-copy into the in memory struct. Since the serde is used for on-disk caching, that is preferable. A potential alternative would be to serialize to/from bytes and implement our own Serializer/Deserializer. 
- I forwarded the pattern of exposing the "forward" of the SparseIndex. This is a bad abstraction and I'll clean it up in a subsequent PR, preferring to keep it as is for now.

## Test plan
*How are these changes tested?*
Added a basic unit test using [bincode](https://github.com/bincode-org/bincode)
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
