### PR TITLE
[TST] Move clippy into the lint job

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -16,6 +16,22 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup
         uses: ./.github/actions/rust
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo nextest run
+  clippy:
+    strategy:
+      matrix:
+        platform: [depot-ubuntu-22.04]
+    runs-on: ${{ matrix.platform }}
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: ./.github/actions/rust
       - name: Clippy
         run: cargo clippy --all-targets --all-features --keep-going -- -D warnings
       - name: Build

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -34,10 +34,6 @@ jobs:
         uses: ./.github/actions/rust
       - name: Clippy
         run: cargo clippy --all-targets --all-features --keep-going -- -D warnings
-      - name: Build
-        run: cargo build --verbose
-      - name: Test
-        run: cargo nextest run
   test-integration:
     strategy:
       matrix:

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -20,20 +20,6 @@ jobs:
         run: cargo build --verbose
       - name: Test
         run: cargo nextest run
-  clippy:
-    strategy:
-      matrix:
-        platform: [depot-ubuntu-22.04]
-    runs-on: ${{ matrix.platform }}
-    env:
-      CARGO_TERM_COLOR: always
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/actions/rust
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features --keep-going -- -D warnings
   test-integration:
     strategy:
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -132,9 +132,13 @@ jobs:
           pre-commit run --all-files flake8
           pre-commit run --all-files prettier
           pre-commit run --all-files check-yaml
+      - name: Setup
+        uses: ./.github/actions/rust
       - name: Cargo fmt check
         shell: bash
         run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features --keep-going -- -D warnings
 
   # This job exists for our branch protection rule.
   # We want to require status checks to pass before merging, but the set of

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Install pre-commit
         shell: bash
         run: python -m pip install -r requirements_dev.txt
+      - name: Setup Rust
+        uses: ./.github/actions/rust
       - name: Run pre-commit
         shell: bash
         run: |
@@ -132,11 +134,11 @@ jobs:
           pre-commit run --all-files flake8
           pre-commit run --all-files prettier
           pre-commit run --all-files check-yaml
-      - name: Setup
-        uses: ./.github/actions/rust
+        continue-on-error: true
       - name: Cargo fmt check
         shell: bash
         run: cargo fmt -- --check
+        continue-on-error: true
       - name: Clippy
         run: cargo clippy --all-targets --all-features --keep-going -- -D warnings
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Moves clippy into its own job so that we don't block tests. It is good to be able to run these separately. 
	 - Unifies the rust lint jobs into the lint action, where `cargo fmt` was already running.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
