### PR TITLE
[ENH] Add manual test pypi release Github action

### DIFF
--- a/.github/workflows/manual-test-pypi-release.yml
+++ b/.github/workflows/manual-test-pypi-release.yml
@@ -1,0 +1,68 @@
+name: 👋📦 Manual Release to Test PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        default: 'main'
+        required: true
+
+env:
+  GHCR_IMAGE_NAME: "ghcr.io/chroma-core/chroma"
+  DOCKERHUB_IMAGE_NAME: "chromadb/chroma"
+
+jobs:
+  release-pypi:
+    name: Publish to Test PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}  # Use the selected branch
+          fetch-depth: 0
+      - name: Setup Python
+        uses: ./.github/actions/python
+        with:
+          python-version: '3.10'
+      - name: Build Client
+        run: python -m build
+      - name: Test Client Package
+        run: bin/test-package/test-package.sh dist/*.tar.gz
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "built-chromadb-package"
+          path: "dist/chromadb-*.tar.gz"
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+  release-thin-pypi:
+    name: Publish Thin Client to Test PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}  # Use the selected branch
+          fetch-depth: 0
+      - name: Set up Python
+        uses: ./.github/actions/python
+        with:
+          python-version: '3.12'
+      - name: Build Thin Client
+        run: ./clients/python/build_python_thin_client.sh
+      - name: Test Thin Client Package
+        run: bin/test-package/test-thin-client-package.sh dist/*.tar.gz
+      - name: Install setuptools_scm
+        run: python -m pip install setuptools_scm
+      - name: Publish Thin Client to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_PYTHON_CLIENT_PUBLISH_KEY }}
+          repository-url: https://test.pypi.org/legacy/
+          verbose: 'true'

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -18,3 +18,6 @@ git tag A.B.C <SHA>
 git push origin A.B.C
 ```
 6. On the right panel on Github, click on "Releases", and the new release should appear first. Edit it, and mark it as "latest".
+
+#### Troubleshooting
+If you run into any issues with PyPi uploads, look at the logs from these failed jobs. Use the `Manual Release to Test PyPI` Github Action to further debug after any changes made before attempting a full release again. It can be run on a branch of your choosing. 


### PR DESCRIPTION
## Description of changes

Adding a manually triggered Github Action workflow for uploading releases to Test PyPi. This should allow us to debug any issues with PyPi when releases break.

## Test plan
N/A

## Documentation Changes
Added to release process
