### PR TITLE
[ENH] Use binary search for gt/gte/lt/lte

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -423,10 +423,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         &'me self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys > key from sparse index for this prefix.
         let block_ids = self.sparse_index.get_block_ids_gt(prefix, key.clone());
-        let mut result: Vec<(&str, K, V)> = vec![];
+        let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys > key.
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {
@@ -445,14 +445,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            match block.get_gt(prefix, key.clone()) {
-                Some(data) => {
-                    result.extend(data);
-                }
-                None => {
-                    return Err(Box::new(BlockfileError::NotFoundError));
-                }
-            };
+            result.extend(block.get_gt(prefix, key.clone()));
         }
         Ok(result)
     }
@@ -462,10 +455,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         &'me self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys < key from sparse index.
         let block_ids = self.sparse_index.get_block_ids_lt(prefix, key.clone());
-        let mut result: Vec<(&str, K, V)> = vec![];
+        let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys < key.
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {
@@ -484,14 +477,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            match block.get_lt(prefix, key.clone()) {
-                Some(data) => {
-                    result.extend(data);
-                }
-                None => {
-                    return Err(Box::new(BlockfileError::NotFoundError));
-                }
-            };
+            result.extend(block.get_lt(prefix, key.clone()));
         }
         Ok(result)
     }
@@ -501,10 +487,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         &'me self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys >= key from sparse index.
         let block_ids = self.sparse_index.get_block_ids_gte(prefix, key.clone());
-        let mut result: Vec<(&str, K, V)> = vec![];
+        let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys >= key.
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {
@@ -523,14 +509,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            match block.get_gte(prefix, key.clone()) {
-                Some(data) => {
-                    result.extend(data);
-                }
-                None => {
-                    return Err(Box::new(BlockfileError::NotFoundError));
-                }
-            };
+            result.extend(block.get_gte(prefix, key.clone()));
         }
         Ok(result)
     }
@@ -540,10 +519,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         &'me self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys <= key from sparse index.
         let block_ids = self.sparse_index.get_block_ids_lte(prefix, key.clone());
-        let mut result: Vec<(&str, K, V)> = vec![];
+        let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys <= key.
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {
@@ -562,14 +541,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            match block.get_lte(prefix, key.clone()) {
-                Some(data) => {
-                    result.extend(data);
-                }
-                None => {
-                    return Err(Box::new(BlockfileError::NotFoundError));
-                }
-            };
+            result.extend(block.get_lte(prefix, key.clone()));
         }
         Ok(result)
     }
@@ -578,9 +550,9 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     pub(crate) async fn get_by_prefix(
         &'me self,
         prefix: &str,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         let block_ids = self.sparse_index.get_block_ids_prefix(prefix);
-        let mut result: Vec<(&str, K, V)> = vec![];
+        let mut result: Vec<(K, V)> = vec![];
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {
                 Ok(Some(block)) => Some(block),
@@ -598,14 +570,8 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            match block.get_prefix(prefix) {
-                Some(data) => {
-                    result.extend(data);
-                }
-                None => {
-                    return Err(Box::new(BlockfileError::NotFoundError));
-                }
-            };
+
+            result.extend(block.get_prefix(prefix));
         }
         Ok(result)
     }
@@ -751,7 +717,7 @@ mod tests {
                 Ok(c) => {
                     let mut kv_map = HashMap::new();
                     for entry in c {
-                        kv_map.insert(format!("{}/{}", entry.0, entry.1), entry.2);
+                        kv_map.insert(format!("{}/{}", prefix_query, entry.0), entry.1);
                     }
                     for j in 1..=5 {
                         let prefix = format!("{}/{}", "prefix", j);
@@ -821,7 +787,7 @@ mod tests {
                 Ok(c) => {
                     let mut kv_map = HashMap::new();
                     for entry in c {
-                        kv_map.insert(entry.1, entry.2);
+                        kv_map.insert(entry.0, entry.1);
                     }
                     for i in 1..num_keys {
                         let key = format!("{}/{}", "key", i);

--- a/rust/blockstore/src/memory/reader_writer.rs
+++ b/rust/blockstore/src/memory/reader_writer.rs
@@ -99,20 +99,14 @@ impl<
     pub(crate) fn get_by_prefix(
         &'storage self,
         prefix: &str,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         let values = V::get_by_prefix_from_storage(prefix, &self.storage);
         if values.is_empty() {
             return Err(Box::new(BlockfileError::NotFoundError));
         }
         let values = values
             .iter()
-            .map(|(key, value)| {
-                (
-                    key.prefix.as_str(),
-                    K::try_from(&key.key).unwrap(),
-                    value.clone(),
-                )
-            })
+            .map(|(key, value)| (K::try_from(&key.key).unwrap(), value.clone()))
             .collect();
         Ok(values)
     }
@@ -122,7 +116,7 @@ impl<
         &'storage self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
         let values = V::read_gt_from_storage(prefix, key, &self.storage);
         if values.is_empty() {
@@ -130,13 +124,7 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| {
-                (
-                    key.prefix.as_str(),
-                    K::try_from(&key.key).unwrap(),
-                    value.clone(),
-                )
-            })
+            .map(|(key, value)| (K::try_from(&key.key).unwrap(), value.clone()))
             .collect();
         Ok(values)
     }
@@ -146,7 +134,7 @@ impl<
         &'storage self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
         let values = V::read_lt_from_storage(prefix, key, &self.storage);
         if values.is_empty() {
@@ -154,13 +142,7 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| {
-                (
-                    key.prefix.as_str(),
-                    K::try_from(&key.key).unwrap(),
-                    value.clone(),
-                )
-            })
+            .map(|(key, value)| (K::try_from(&key.key).unwrap(), value.clone()))
             .collect();
         Ok(values)
     }
@@ -170,7 +152,7 @@ impl<
         &'storage self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
         let values = V::read_gte_from_storage(prefix, key, &self.storage);
         if values.is_empty() {
@@ -178,13 +160,7 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| {
-                (
-                    key.prefix.as_str(),
-                    K::try_from(&key.key).unwrap(),
-                    value.clone(),
-                )
-            })
+            .map(|(key, value)| (K::try_from(&key.key).unwrap(), value.clone()))
             .collect();
         Ok(values)
     }
@@ -194,7 +170,7 @@ impl<
         &'storage self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         let key = key.into();
         let values = V::read_lte_from_storage(prefix, key, &self.storage);
         if values.is_empty() {
@@ -202,13 +178,7 @@ impl<
         }
         let values = values
             .iter()
-            .map(|(key, value)| {
-                (
-                    key.prefix.as_str(),
-                    K::try_from(&key.key).unwrap(),
-                    value.clone(),
-                )
-            })
+            .map(|(key, value)| (K::try_from(&key.key).unwrap(), value.clone()))
             .collect();
         Ok(values)
     }
@@ -401,12 +371,12 @@ mod tests {
             MemoryBlockfileReader::open(writer.id, storage_manager);
         let values = reader.get_by_prefix("prefix").unwrap();
         assert_eq!(values.len(), 2);
-        assert!(values.iter().any(|(prefix, key, value)| *prefix == "prefix"
-            && *key == "key1"
-            && *value == "value1"));
-        assert!(values.iter().any(|(prefix, key, value)| *prefix == "prefix"
-            && *key == "key2"
-            && *value == "value2"));
+        assert!(values
+            .iter()
+            .any(|(key, value)| *key == "key1" && *value == "value1"));
+        assert!(values
+            .iter()
+            .any(|(key, value)| *key == "key2" && *value == "value2"));
     }
 
     #[test]
@@ -439,13 +409,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+            .any(|(key, value)| *key == 1 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+            .any(|(key, value)| *key == 3 && *value == "value3"));
     }
 
     #[test]
@@ -463,10 +433,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+            .any(|(key, value)| *key == 3 && *value == "value3"));
     }
 
     #[test]
@@ -499,13 +469,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+            .any(|(key, value)| *key == 1.0 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+            .any(|(key, value)| *key == 3.0 && *value == "value3"));
     }
 
     #[test]
@@ -523,10 +493,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+            .any(|(key, value)| *key == 3.0 && *value == "value3"));
     }
 
     #[test]
@@ -559,13 +529,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+            .any(|(key, value)| *key == 1 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+            .any(|(key, value)| *key == 3 && *value == "value3"));
     }
 
     #[test]
@@ -583,10 +553,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+            .any(|(key, value)| *key == 3 && *value == "value3"));
     }
 
     #[test]
@@ -619,13 +589,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+            .any(|(key, value)| *key == 1.0 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+            .any(|(key, value)| *key == 3.0 && *value == "value3"));
     }
 
     #[test]
@@ -643,10 +613,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+            .any(|(key, value)| *key == 3.0 && *value == "value3"));
     }
 
     #[test]
@@ -679,13 +649,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+            .any(|(key, value)| *key == 1 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+            .any(|(key, value)| *key == 3 && *value == "value3"));
     }
 
     #[test]
@@ -703,10 +673,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+            .any(|(key, value)| *key == 1 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
     }
 
     #[test]
@@ -739,13 +709,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+            .any(|(key, value)| *key == 1.0 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+            .any(|(key, value)| *key == 3.0 && *value == "value3"));
     }
 
     #[test]
@@ -763,10 +733,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+            .any(|(key, value)| *key == 1.0 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
     }
 
     #[test]
@@ -799,13 +769,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+            .any(|(key, value)| *key == 1 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3 && *value == "value3"));
+            .any(|(key, value)| *key == 3 && *value == "value3"));
     }
 
     #[test]
@@ -823,10 +793,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1 && *value == "value1"));
+            .any(|(key, value)| *key == 1 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2 && *value == "value2"));
+            .any(|(key, value)| *key == 2 && *value == "value2"));
     }
 
     #[test]
@@ -859,13 +829,13 @@ mod tests {
         assert_eq!(values.len(), 3);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+            .any(|(key, value)| *key == 1.0 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 3.0 && *value == "value3"));
+            .any(|(key, value)| *key == 3.0 && *value == "value3"));
     }
 
     #[test]
@@ -883,10 +853,10 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 1.0 && *value == "value1"));
+            .any(|(key, value)| *key == 1.0 && *value == "value1"));
         assert!(values
             .iter()
-            .any(|(prefix, key, value)| *prefix == "prefix" && *key == 2.0 && *value == "value2"));
+            .any(|(key, value)| *key == 2.0 && *value == "value2"));
     }
 
     #[test]

--- a/rust/blockstore/src/types.rs
+++ b/rust/blockstore/src/types.rs
@@ -279,7 +279,7 @@ impl<
     pub async fn get_by_prefix(
         &'referred_data self,
         prefix: &str,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_by_prefix(prefix),
             BlockfileReader::ArrowBlockfileReader(reader) => reader.get_by_prefix(prefix).await,
@@ -290,7 +290,7 @@ impl<
         &'referred_data self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_gt(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => reader.get_gt(prefix, key).await,
@@ -301,7 +301,7 @@ impl<
         &'referred_data self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_lt(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => reader.get_lt(prefix, key).await,
@@ -312,7 +312,7 @@ impl<
         &'referred_data self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_gte(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => reader.get_gte(prefix, key).await,
@@ -323,7 +323,7 @@ impl<
         &'referred_data self,
         prefix: &str,
         key: K,
-    ) -> Result<Vec<(&str, K, V)>, Box<dyn ChromaError>> {
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_lte(prefix, key),
             BlockfileReader::ArrowBlockfileReader(reader) => reader.get_lte(prefix, key).await,

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -429,7 +429,7 @@ impl<'me> FullTextIndexReader<'me> {
                 .enumerate()
                 .map(|(i, posting_list)| {
                     if pointers[i] < posting_list.len() {
-                        Some(posting_list[pointers[i]].1)
+                        Some(posting_list[pointers[i]].0)
                     } else {
                         None
                     }
@@ -449,7 +449,7 @@ impl<'me> FullTextIndexReader<'me> {
                 // All tokens appear in the same document, so check positional alignment.
                 let mut positions_per_posting_list = Vec::with_capacity(num_tokens);
                 for (i, posting_list) in posting_lists.iter().enumerate() {
-                    let (_, _, positions) = posting_list[pointers[i]];
+                    let (_, positions) = posting_list[pointers[i]];
                     positions_per_posting_list.push(positions);
                 }
 
@@ -514,7 +514,7 @@ impl<'me> FullTextIndexReader<'me> {
             .get_by_prefix(token)
             .await?;
         let mut results = vec![];
-        for (_, doc_id, positions) in positional_posting_list.iter() {
+        for (doc_id, positions) in positional_posting_list.iter() {
             results.push((*doc_id, positions.to_vec()));
         }
         Ok(results)
@@ -533,7 +533,7 @@ impl<'me> FullTextIndexReader<'me> {
         if res.len() > 1 {
             panic!("Invariant violation. Multiple frequency values found for a token.");
         }
-        Ok(res[0].1)
+        Ok(res[0].0)
     }
 }
 

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -567,7 +567,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -583,7 +583,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -609,7 +609,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -625,7 +625,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -651,7 +651,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -667,7 +667,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -693,7 +693,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)
@@ -709,7 +709,7 @@ impl<'me> MetadataIndexReader<'me> {
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
-                            for (_, _, rbm) in records {
+                            for (_, rbm) in records {
                                 result = result.bitor(&rbm);
                             }
                             Ok(result)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Updates the binary search algorithm for arrow block to match the latest std impl
	 - The binary search now identifies the partition point instead of returning the value at the location
	 - New utility function to scan a range of values for the same prefix
	 - Now methods that yields a vector of records like `get_by_prefix` and `get_gt` returns `Vec<(K, V)>` instead of `Option<Vec<&str, K, V>>`. The empty vector is sufficient to indicate the absence of the specified `(prefix, key)`
 - New functionality
	 - With all the refactoring above, now `get_gt/gte/lt/lte` finds the starting point of the scan using binary search. Previously, we scan the entire block.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
