### PR TITLE
[ENH]  Make block and sparse index caches use persistent type.

### DIFF
--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -11,7 +11,7 @@ use super::memory::storage::{Readable, Writeable};
 use super::types::BlockfileWriter;
 use super::{BlockfileReader, Key, Value};
 use async_trait::async_trait;
-use chroma_cache::Cache;
+use chroma_cache::PersistentCache;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
@@ -47,8 +47,8 @@ impl BlockfileProvider {
     pub fn new_arrow(
         storage: Storage,
         max_block_size_bytes: usize,
-        block_cache: Box<dyn Cache<Uuid, Block>>,
-        sparse_index_cache: Box<dyn Cache<Uuid, SparseIndex>>,
+        block_cache: Box<dyn PersistentCache<Uuid, Block>>,
+        sparse_index_cache: Box<dyn PersistentCache<Uuid, SparseIndex>>,
     ) -> Self {
         BlockfileProvider::ArrowBlockfileProvider(ArrowBlockfileProvider::new(
             storage,

--- a/rust/cache/src/nop.rs
+++ b/rust/cache/src/nop.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use super::{CacheError, Weighted};
+use super::{CacheError, StorageKey, StorageValue, Weighted};
 
 /// A zero-configuration cache that doesn't evict.
 pub struct NopCache;
@@ -22,4 +22,11 @@ where
     async fn clear(&self) -> Result<(), CacheError> {
         Ok(())
     }
+}
+
+impl<K, V> super::PersistentCache<K, V> for NopCache
+where
+    K: Clone + Send + Sync + Eq + PartialEq + Hash + StorageKey + 'static,
+    V: Clone + Send + Sync + Weighted + StorageValue + 'static,
+{
 }

--- a/rust/cache/src/unbounded.rs
+++ b/rust/cache/src/unbounded.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use super::{CacheError, Weighted};
+use super::{CacheError, StorageKey, StorageValue, Weighted};
 
 /// A zero-configuration cache that doesn't evict.
 /// Mostly useful for testing.
@@ -12,12 +12,12 @@ use super::{CacheError, Weighted};
 pub struct UnboundedCacheConfig {}
 
 impl UnboundedCacheConfig {
-    pub fn build<K, V>(&self) -> Box<dyn super::Cache<K, V>>
+    pub fn build<K, V>(&self) -> UnboundedCache<K, V>
     where
         K: Clone + Send + Sync + Eq + PartialEq + Hash + 'static,
         V: Clone + Send + Sync + Clone + Weighted + 'static,
     {
-        Box::new(UnboundedCache::new(self))
+        UnboundedCache::new(self)
     }
 }
 
@@ -66,4 +66,11 @@ where
         self.cache.write().clear();
         Ok(())
     }
+}
+
+impl<K, V> super::PersistentCache<K, V> for UnboundedCache<K, V>
+where
+    K: Clone + Send + Sync + Eq + PartialEq + Hash + StorageKey + 'static,
+    V: Clone + Send + Sync + Weighted + StorageValue + 'static,
+{
 }

--- a/rust/index/benches/full_text.rs
+++ b/rust/index/benches/full_text.rs
@@ -82,8 +82,8 @@ const BLOCK_SIZE: usize = 8 * 1024 * 1024; // 8MB
 
 fn create_blockfile_provider(storage_dir: &str) -> BlockfileProvider {
     let storage = Storage::Local(LocalStorage::new(storage_dir));
-    let block_cache = UnboundedCacheConfig {}.build();
-    let sparse_index_cache = UnboundedCacheConfig {}.build();
+    let block_cache = Box::new(UnboundedCacheConfig {}.build()) as _;
+    let sparse_index_cache = Box::new(UnboundedCacheConfig {}.build()) as _;
     let arrow_blockfile_provider =
         ArrowBlockfileProvider::new(storage.clone(), BLOCK_SIZE, block_cache, sparse_index_cache);
     BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider)

--- a/rust/index/build.rs
+++ b/rust/index/build.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .flag("-std=c++11")
         .flag("-Ofast")
         .flag("-DHAVE_CXX0X")
-        .flag("-fpic")
+        .flag("-fPIC")
         .flag("-ftree-vectorize")
         .flag("-w")
         .compile("bindings");

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -568,7 +568,7 @@ pub enum HnswIndexProviderFileError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chroma_cache::new_cache_for_test;
+    use chroma_cache::new_non_persistent_cache_for_test;
     use chroma_storage::local::LocalStorage;
     use chroma_types::SegmentType;
     use std::collections::HashMap;
@@ -582,7 +582,7 @@ mod tests {
         tokio::fs::create_dir_all(&hnsw_tmp_path).await.unwrap();
 
         let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
-        let cache = new_cache_for_test();
+        let cache = new_non_persistent_cache_for_test();
         let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache);
         let segment = Segment {
             id: Uuid::new_v4(),

--- a/rust/types/build.rs
+++ b/rust/types/build.rs
@@ -1,6 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile the protobuf files in the chromadb proto directory.
-    let mut proto_paths = vec![
+    let proto_paths = vec![
         "../../idl/chromadb/proto/chroma.proto",
         "../../idl/chromadb/proto/coordinator.proto",
         "../../idl/chromadb/proto/logservice.proto",

--- a/rust/types/build.rs
+++ b/rust/types/build.rs
@@ -1,6 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile the protobuf files in the chromadb proto directory.
-    let proto_paths = vec![
+    let mut proto_paths = vec![
         "../../idl/chromadb/proto/chroma.proto",
         "../../idl/chromadb/proto/coordinator.proto",
         "../../idl/chromadb/proto/logservice.proto",
@@ -9,7 +9,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Can't use #[cfg(test)] here because a build for tests is technically a regular debug build, meaning that #[cfg(test)] is useless in build.rs.
     // See https://github.com/rust-lang/cargo/issues/1581
     #[cfg(debug_assertions)]
-    proto_paths.push("../../idl/chromadb/proto/debug.proto");
+    let debug_assertions = true;
+    #[cfg(not(debug_assertions))]
+    let debug_assertions = false;
+
+    if debug_assertions {
+        proto_paths.push("../../idl/chromadb/proto/debug.proto");
+    }
 
     tonic_build::configure()
         .emit_rerun_if_changed(true)

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -338,7 +338,7 @@ mod tests {
     use crate::log::log::InternalLogRecord;
     use crate::sysdb::test_sysdb::TestSysDb;
     use chroma_blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
-    use chroma_cache::new_cache_for_test;
+    use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
     use chroma_storage::local::LocalStorage;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord, Segment};
     use std::collections::HashMap;
@@ -527,7 +527,7 @@ mod tests {
 
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
-        let hnsw_cache = new_cache_for_test();
+        let hnsw_cache = new_non_persistent_cache_for_test();
         let mut manager = CompactionManager::new(
             scheduler,
             log,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -649,8 +649,8 @@ mod tests {
     use crate::system;
     use chroma_blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
     #[cfg(test)]
-    use chroma_cache::new_cache_for_test;
     #[cfg(debug_assertions)]
+    use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
     use chroma_proto::debug_client::DebugClient;
     use chroma_storage::{local::LocalStorage, Storage};
     use tempfile::tempdir;
@@ -664,7 +664,7 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
-        let hnsw_index_cache = new_cache_for_test();
+        let hnsw_index_cache = new_non_persistent_cache_for_test();
         let port = random_port::PortPicker::new().pick().unwrap();
         let mut server = WorkerServer {
             dispatcher: None,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -643,6 +643,8 @@ impl chroma_proto::debug_server::Debug for WorkerServer {
 #[cfg(test)]
 mod tests {
     #[cfg(debug_assertions)]
+    use super::*;
+    #[cfg(debug_assertions)]
     use crate::execution::dispatcher;
     #[cfg(debug_assertions)]
     use crate::log::log::InMemoryLog;

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -642,17 +642,23 @@ impl chroma_proto::debug_server::Debug for WorkerServer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    #[cfg(debug_assertions)]
     use crate::execution::dispatcher;
+    #[cfg(debug_assertions)]
     use crate::log::log::InMemoryLog;
+    #[cfg(debug_assertions)]
     use crate::sysdb::test_sysdb::TestSysDb;
+    #[cfg(debug_assertions)]
     use crate::system;
+    #[cfg(debug_assertions)]
     use chroma_blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
-    #[cfg(test)]
     #[cfg(debug_assertions)]
     use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
+    #[cfg(debug_assertions)]
     use chroma_proto::debug_client::DebugClient;
+    #[cfg(debug_assertions)]
     use chroma_storage::{local::LocalStorage, Storage};
+    #[cfg(debug_assertions)]
     use tempfile::tempdir;
 
     #[tokio::test]


### PR DESCRIPTION
End-to-end tests confirm that with this change foyer will initialize the disk path (assuming it's writable) and instantiate a disk.  A memory cache will also instantiate.

Note that the PersistentCache type means that the key and value implement StorageKey and StorageValue, so it's totally acceptable for every non-persistent cache to implement the trait.  This means that any place that takes a persistent cache will also take the non-persistent versions.  It's trait logic, not "is a".

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
