### PR TITLE
[TST] Bound hypothesis version for breaking changes

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,8 +2,8 @@ black==23.3.0 # match what's in pyproject.toml
 build
 grpcio-tools==1.62.3 # Later version not compatible with protobuf 4.25.5
 httpx
-hypothesis>=6.103.1
-hypothesis[numpy]>=6.103.1
+hypothesis==6.112.2 # TODO: Resolve breaking changes and bump version
+hypothesis[numpy]==6.112.2 # TODO: Resolve breaking changes and bump version
 mypy-protobuf
 pre-commit
 protobuf==4.25.5 # Later version not compatible with opentelemetry 1.27.0


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Bound `hypothesis` package version to `6.112.2`, since changes in the next version breaks our python tests. We need to address the breaking changes and fix the tests in the future.
 - New functionality
	 - N/A

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A