### PR TITLE
[ENH] Automatically set version release as the latest release on Github

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -239,7 +239,8 @@ jobs:
           artifacts: "dist/chromadb-${{needs.get-version.outputs.version}}.tar.gz"
           allowUpdates: true
           removeArtifacts: true
-          prerelease: true
+          prerelease: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
+          makeLatest: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
 
   release-docs:
     name: Deploy docs to Vercel

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -17,4 +17,4 @@ git tag A.B.C <SHA>
 ```
 git push origin A.B.C
 ```
-6. On the right panel on Github, click on "Releases", and the new release should appear first. Edit it, and mark it as "latest".
+6. On the right panel on Github, click on "Releases", and the new release should appear first. Make sure it is marked as "latest".


### PR DESCRIPTION
## Description of changes
Automatically set a released version as the latest on Github

## Test plan
We will make a new release and see.

## Documentation Changes
Update the release process documentation
