### PR TITLE
[TST] Enable tests for $ne, $nin, and $not_contains for hosted Chroma

### DIFF
--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -554,10 +554,7 @@ def where_clause(draw: st.DrawFn, collection: Collection) -> types.Where:
     # need to avoid generating these operators for now in that case.
     # TODO: Remove this once the distributed system supports $in and $nin
     legal_ops: List[Optional[str]]
-    if not NOT_CLUSTER_ONLY:
-        legal_ops = [None, "$eq"]
-    else:
-        legal_ops = [None, "$eq", "$ne", "$in", "$nin"]
+    legal_ops = [None, "$eq", "$ne", "$in", "$nin"]
 
     if not isinstance(value, str) and not isinstance(value, bool):
         legal_ops.extend(["$gt", "$lt", "$lte", "$gte"])
@@ -603,10 +600,7 @@ def where_doc_clause(draw: st.DrawFn, collection: Collection) -> types.WhereDocu
     # This is hacky, but the distributed system does not support $not_contains
     # so we need to avoid generating these operators for now in that case.
     # TODO: Remove this once the distributed system supports $not_contains
-    if not NOT_CLUSTER_ONLY:
-        op = draw(st.sampled_from(["$contains"]))
-    else:
-        op = draw(st.sampled_from(["$contains", "$not_contains"]))
+    op = draw(st.sampled_from(["$contains", "$not_contains"]))
 
     if op == "$contains":
         return {"$contains": word}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Enable the tests for `$ne`, `$nin`, and `$not_contains` on distributed chroma.
 - New functionality
	 - N/A

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
