### PR TITLE
Update onnx_mini_lm_l6_v2.py

### DIFF
--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -97,7 +97,7 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
         which makes mypy unhappy. If some smart folk knows how to fix this in an
         elegant way, please do so.
         """
-        with httpx.stream("GET", url) as resp:
+        with httpx.stream("GET", url, timeout=None) as resp:
             total = int(resp.headers.get("content-length", 0))
             with open(fname, "wb") as file, self.tqdm(
                 desc=str(fname),


### PR DESCRIPTION
fix for https://github.com/chroma-core/chroma/issues/2910

specify timeout, as start of download might take some time because of corporate proxies, firewalls, content scanning etc.

## Description of changes

*Summarize the changes made by this PR.*
 -specifed timeout in httpx call
- start of download might take some time because of corporate proxies, firewalls, content scanning etc
- it failed with timeout

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
