### PR TITLE
[ENH] Add metadata to block

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/delta.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::storage::BlockStorage;
 use crate::{
     arrow::types::{ArrowWriteableKey, ArrowWriteableValue},
@@ -66,9 +68,17 @@ impl BlockDelta {
         self.builder.get_size::<K>()
     }
 
+    /// Finishes the block delta and converts it into a record batch.
+    /// # Arguments
+    /// - metadata: the metadata to attach to the record batch.
+    /// # Returns
+    /// A record batch with the key value pairs in the block delta.
     #[allow(clippy::extra_unused_type_parameters)]
-    pub fn finish<K: ArrowWriteableKey, V: ArrowWriteableValue>(self) -> RecordBatch {
-        self.builder.into_record_batch::<K>()
+    pub fn finish<K: ArrowWriteableKey, V: ArrowWriteableValue>(
+        self,
+        metadata: Option<HashMap<String, String>>,
+    ) -> RecordBatch {
+        self.builder.into_record_batch::<K>(metadata)
     }
 
     /// Splits the block delta into two block deltas. The split point is the last key

--- a/rust/blockstore/src/arrow/mod.rs
+++ b/rust/blockstore/src/arrow/mod.rs
@@ -4,6 +4,5 @@ mod concurrency_test;
 pub mod config;
 pub(crate) mod flusher;
 pub mod provider;
-mod root;
 pub mod sparse_index;
 pub mod types;

--- a/rust/blockstore/src/arrow/mod.rs
+++ b/rust/blockstore/src/arrow/mod.rs
@@ -4,5 +4,6 @@ mod concurrency_test;
 pub mod config;
 pub(crate) mod flusher;
 pub mod provider;
+mod root;
 pub mod sparse_index;
 pub mod types;

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -250,7 +250,7 @@ impl BlockManager {
         delta: BlockDelta,
     ) -> Block {
         let delta_id = delta.id;
-        let record_batch = delta.finish::<K, V>();
+        let record_batch = delta.finish::<K, V>(None);
         Block::from_record_batch(delta_id, record_batch)
     }
 

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -505,7 +505,7 @@ impl SparseIndex {
         }
 
         let delta_id = delta.id;
-        let record_batch = delta.finish::<K, String>();
+        let record_batch = delta.finish::<K, String>(None);
         Ok(Block::from_record_batch(delta_id, record_batch))
     }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Introduces the ability to attach metadata to a block
	 - We use the RecordBatch ability to store a custom HashMap of metadata in its schema.
	 - The delta.finish() method is used to pass the metadata. So metadata is a one-time writeable piece of data.
	 - into_arrow returns the arrow fields, not the actual record batch, so that schema can be attached.
 - New functionality
	 - /

## Test plan
*How are these changes tested?*
Tests for this functionality are in a higher PR in the stack
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
