### PR TITLE
[ENH] Add blockfile root

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -385,7 +385,7 @@ impl Block {
     /// Returns a reference to metadata of the block if any is present
     /// ### Notes
     /// - The metadata is stored in the Arrow RB schema as custom metadata
-    pub(crate) fn metadata<'me>(&'me self) -> &'me HashMap<String, String> {
+    pub(crate) fn metadata(&self) -> &HashMap<String, String> {
         let schema = self.data.schema_ref();
         schema.metadata()
     }

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
+use std::collections::HashMap;
 use std::io::SeekFrom;
 
 use crate::arrow::types::{ArrowReadableKey, ArrowReadableValue};
@@ -377,8 +378,16 @@ impl Block {
     }
 
     /// Returns the number of items in the block
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.data.num_rows()
+    }
+
+    /// Returns a reference to metadata of the block if any is present
+    /// ### Notes
+    /// - The metadata is stored in the Arrow RB schema as custom metadata
+    pub(crate) fn metadata<'me>(&'me self) -> &'me HashMap<String, String> {
+        let schema = self.data.schema_ref();
+        schema.metadata()
     }
 
     /*

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -1,13 +1,13 @@
-use super::provider::GetError;
+use super::provider::{GetError, RootManager};
 use super::root::{RootReader, RootWriter};
 use super::{block::delta::BlockDelta, provider::BlockManager};
 use super::{
     block::Block,
     flusher::ArrowBlockfileFlusher,
-    provider::SparseIndexManager,
     sparse_index::SparseIndex,
     types::{ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue},
 };
+use crate::arrow::root::CURRENT_VERSION;
 use crate::key::CompositeKey;
 use crate::key::KeyWrapper;
 use crate::BlockfileError;
@@ -23,9 +23,8 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct ArrowBlockfileWriter {
     block_manager: BlockManager,
-    sparse_index_manager: SparseIndexManager,
+    root_manager: RootManager,
     block_deltas: Arc<Mutex<HashMap<Uuid, BlockDelta>>>,
-    sparse_index: SparseIndex,
     root: RootWriter,
     id: Uuid,
     write_mutex: Arc<tokio::sync::Mutex<()>>,
@@ -50,57 +49,44 @@ impl ArrowBlockfileWriter {
     pub(super) fn new<K: ArrowWriteableKey, V: ArrowWriteableValue>(
         id: Uuid,
         block_manager: BlockManager,
-        sparse_index_manager: SparseIndexManager,
+        root_manager: RootManager,
     ) -> Self {
         let initial_block = block_manager.create::<K, V>();
         // TODO: we can update the constructor to take the initial block instead of having a seperate method
         let sparse_index = SparseIndex::new(id);
         sparse_index.add_initial_block(initial_block.id);
-
-        // TODO: remove clone and make this authorative source for sparse index
-        let root_writer = RootWriter::new(id, sparse_index.clone());
+        let root_writer = RootWriter::new(CURRENT_VERSION, id, sparse_index);
 
         let block_deltas = Arc::new(Mutex::new(HashMap::new()));
         {
             let mut block_deltas_map = block_deltas.lock();
             block_deltas_map.insert(initial_block.id, initial_block);
         }
-        tracing::debug!(
-            "Constructed blockfile writer on empty sparse index with id {:?}",
-            id
-        );
+        tracing::debug!("Constructed blockfile writer with id {:?}", id);
         Self {
             block_manager,
-            sparse_index_manager,
+            root_manager,
             block_deltas,
-            sparse_index,
             root: root_writer,
             id,
             write_mutex: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
-    // TODO: rename to fork_root and use root to/from instead of sparse index
-    pub(super) fn from_sparse_index(
+    pub(super) fn from_root(
         id: Uuid,
         block_manager: BlockManager,
-        sparse_index_manager: SparseIndexManager,
-        new_sparse_index: SparseIndex,
+        root_manager: RootManager,
+        new_root: RootWriter,
     ) -> Self {
-        tracing::debug!(
-            "Constructed blockfile writer from existing sparse index id {:?}",
-            id
-        );
+        tracing::debug!("Constructed blockfile writer from existing root {:?}", id);
         let block_deltas = Arc::new(Mutex::new(HashMap::new()));
-        // TODO: remove clone and make this authorative source for sparse index
-        let root_writer = RootWriter::new(id, new_sparse_index.clone());
 
         Self {
             block_manager,
-            sparse_index_manager,
+            root_manager,
             block_deltas,
-            sparse_index: new_sparse_index,
-            root: root_writer,
+            root: new_root,
             id,
             write_mutex: Arc::new(tokio::sync::Mutex::new(())),
         }
@@ -115,7 +101,7 @@ impl ArrowBlockfileWriter {
             // Skip empty blocks. Also, remove from sparse index.
             if delta.len() == 0 {
                 tracing::info!("Delta with id {:?} is empty", delta.id);
-                removed = self.sparse_index.remove_block(&delta.id);
+                removed = self.root.sparse_index.remove_block(&delta.id);
             }
             if !removed {
                 let block = self.block_manager.commit::<K, V>(delta);
@@ -125,9 +111,9 @@ impl ArrowBlockfileWriter {
 
         let flusher = ArrowBlockfileFlusher::new(
             self.block_manager,
-            self.sparse_index_manager,
+            self.root_manager,
             blocks,
-            self.sparse_index,
+            self.root,
             self.id,
         );
 
@@ -148,7 +134,7 @@ impl ArrowBlockfileWriter {
 
         // Get the target block id for the key
         let search_key = CompositeKey::new(prefix.to_string(), key.clone());
-        let target_block_id = self.sparse_index.get_target_block_id(&search_key);
+        let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
 
         // See if a delta for the target block already exists, if not create a new one and add it to the transaction state
         // Creating a delta loads the block entirely into memory
@@ -177,7 +163,8 @@ impl ArrowBlockfileWriter {
                 };
                 let new_id = new_delta.id;
                 // Blocks can be empty.
-                self.sparse_index
+                self.root
+                    .sparse_index
                     .replace_block(target_block_id, new_delta.id);
                 {
                     let mut deltas = self.block_deltas.lock();
@@ -194,7 +181,7 @@ impl ArrowBlockfileWriter {
         if delta.get_size::<K, V>() > self.block_manager.max_block_size_bytes() {
             let new_blocks = delta.split::<K, V>(self.block_manager.max_block_size_bytes());
             for (split_key, new_delta) in new_blocks {
-                self.sparse_index.add_block(split_key, new_delta.id);
+                self.root.sparse_index.add_block(split_key, new_delta.id);
                 let mut deltas = self.block_deltas.lock();
                 deltas.insert(new_delta.id, new_delta);
             }
@@ -211,7 +198,7 @@ impl ArrowBlockfileWriter {
         let _guard = self.write_mutex.lock().await;
         // Get the target block id for the key
         let search_key = CompositeKey::new(prefix.to_string(), key.clone());
-        let target_block_id = self.sparse_index.get_target_block_id(&search_key);
+        let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
 
         // TODO: clean this up as its redudant with the set method
         let delta = {
@@ -237,7 +224,8 @@ impl ArrowBlockfileWriter {
                     }
                 };
                 let new_id = new_delta.id;
-                self.sparse_index
+                self.root
+                    .sparse_index
                     .replace_block(target_block_id, new_delta.id);
                 {
                     let mut deltas = self.block_deltas.lock();
@@ -263,23 +251,20 @@ pub struct ArrowBlockfileReader<
     V: ArrowReadableValue<'me>,
 > {
     block_manager: BlockManager,
-    pub(super) sparse_index: SparseIndex,
-    // root: RootReader,
+    root: RootReader,
     loaded_blocks: Arc<Mutex<HashMap<Uuid, Box<Block>>>>,
     marker: std::marker::PhantomData<(K, V, &'me ())>,
-    id: Uuid,
 }
 
 impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me>>
     ArrowBlockfileReader<'me, K, V>
 {
-    pub(super) fn new(id: Uuid, block_manager: BlockManager, sparse_index: SparseIndex) -> Self {
+    pub(super) fn new(block_manager: BlockManager, root: RootReader) -> Self {
         Self {
             block_manager,
-            sparse_index,
+            root,
             loaded_blocks: Arc::new(Mutex::new(HashMap::new())),
             marker: std::marker::PhantomData,
-            id,
         }
     }
 
@@ -350,13 +335,16 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                 composite_keys.push(composite_key);
             }
         }
-        let target_block_ids = self.sparse_index.get_all_target_block_ids(composite_keys);
+        let target_block_ids = self
+            .root
+            .sparse_index
+            .get_all_target_block_ids(composite_keys);
         self.load_blocks(&target_block_ids).await;
     }
 
     pub(crate) async fn get(&'me self, prefix: &str, key: K) -> Result<V, Box<dyn ChromaError>> {
         let search_key = CompositeKey::new(prefix.to_string(), key.clone());
-        let target_block_id = self.sparse_index.get_target_block_id(&search_key);
+        let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
         let block = self.get_block(target_block_id).await;
         let res = match block {
             Ok(Some(block)) => block.get(prefix, key.clone()),
@@ -388,10 +376,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     ) -> Result<(&'me str, K, V), Box<dyn ChromaError>> {
         let mut block_offset = 0;
         let mut block = None;
-        let sparse_index_len = self.sparse_index.data.lock().len();
+        let sparse_index_len = self.root.sparse_index.data.lock().len();
         for i in 0..sparse_index_len {
             let uuid = {
-                let data = self.sparse_index.data.lock();
+                let data = self.root.sparse_index.data.lock();
                 *data.forward.iter().nth(i).unwrap().1
             };
             block = match self.get_block(uuid).await {
@@ -438,7 +426,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys > key from sparse index for this prefix.
-        let block_ids = self.sparse_index.get_block_ids_gt(prefix, key.clone());
+        let block_ids = self.root.sparse_index.get_block_ids_gt(prefix, key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys > key.
         for block_id in block_ids {
@@ -470,7 +458,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys < key from sparse index.
-        let block_ids = self.sparse_index.get_block_ids_lt(prefix, key.clone());
+        let block_ids = self.root.sparse_index.get_block_ids_lt(prefix, key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys < key.
         for block_id in block_ids {
@@ -502,7 +490,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys >= key from sparse index.
-        let block_ids = self.sparse_index.get_block_ids_gte(prefix, key.clone());
+        let block_ids = self
+            .root
+            .sparse_index
+            .get_block_ids_gte(prefix, key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys >= key.
         for block_id in block_ids {
@@ -534,7 +525,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys <= key from sparse index.
-        let block_ids = self.sparse_index.get_block_ids_lte(prefix, key.clone());
+        let block_ids = self
+            .root
+            .sparse_index
+            .get_block_ids_lte(prefix, key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys <= key.
         for block_id in block_ids {
@@ -564,7 +558,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         &'me self,
         prefix: &str,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
-        let block_ids = self.sparse_index.get_block_ids_prefix(prefix);
+        let block_ids = self.root.sparse_index.get_block_ids_prefix(prefix);
         let mut result: Vec<(K, V)> = vec![];
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {
@@ -595,7 +589,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<bool, Box<dyn ChromaError>> {
         let search_key = CompositeKey::new(prefix.to_string(), key.clone());
-        let target_block_id = self.sparse_index.get_target_block_id(&search_key);
+        let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
         let block = match self.get_block(target_block_id).await {
             Ok(Some(block)) => block,
             Ok(None) => {
@@ -615,7 +609,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     pub(crate) async fn count(&self) -> Result<usize, Box<dyn ChromaError>> {
         let mut block_ids: Vec<Uuid> = vec![];
         {
-            let lock_guard = self.sparse_index.data.lock();
+            let lock_guard = self.root.sparse_index.data.lock();
             let curr_iter = lock_guard.forward.iter();
             for (_, block_id) in curr_iter {
                 block_ids.push(*block_id);
@@ -641,7 +635,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     }
 
     pub(crate) fn id(&self) -> Uuid {
-        self.id
+        self.root.id
     }
 }
 
@@ -942,8 +936,8 @@ mod tests {
         // Sparse index should have 3 blocks
         match &reader {
             crate::BlockfileReader::ArrowBlockfileReader(reader) => {
-                assert_eq!(reader.sparse_index.len(), 3);
-                assert!(reader.sparse_index.is_valid());
+                assert_eq!(reader.root.sparse_index.len(), 3);
+                assert!(reader.root.sparse_index.is_valid());
             }
             _ => panic!("Unexpected reader type"),
         }
@@ -977,8 +971,8 @@ mod tests {
         // Sparse index should still have 3 blocks
         match &reader {
             crate::BlockfileReader::ArrowBlockfileReader(reader) => {
-                assert_eq!(reader.sparse_index.len(), 3);
-                assert!(reader.sparse_index.is_valid());
+                assert_eq!(reader.root.sparse_index.len(), 3);
+                assert!(reader.root.sparse_index.is_valid());
             }
             _ => panic!("Unexpected reader type"),
         }
@@ -1010,8 +1004,8 @@ mod tests {
         // Sparse index should have 6 blocks
         match &reader {
             crate::BlockfileReader::ArrowBlockfileReader(reader) => {
-                assert_eq!(reader.sparse_index.len(), 6);
-                assert!(reader.sparse_index.is_valid());
+                assert_eq!(reader.root.sparse_index.len(), 6);
+                assert!(reader.root.sparse_index.is_valid());
             }
             _ => panic!("Unexpected reader type"),
         }

--- a/rust/blockstore/src/arrow/config.rs
+++ b/rust/blockstore/src/arrow/config.rs
@@ -7,7 +7,8 @@ pub const TEST_MAX_BLOCK_SIZE_BYTES: usize = 16384;
 #[derive(Deserialize, Debug, Clone)]
 pub struct ArrowBlockfileProviderConfig {
     pub block_manager_config: BlockManagerConfig,
-    pub sparse_index_manager_config: SparseIndexManagerConfig,
+    #[serde(alias = "sparse_index_manager_config")]
+    pub root_manager_config: RootManagerConfig,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -17,6 +18,7 @@ pub struct BlockManagerConfig {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct SparseIndexManagerConfig {
-    pub sparse_index_cache_config: CacheConfig,
+pub struct RootManagerConfig {
+    #[serde(alias = "sparse_index_cache_config")]
+    pub root_cache_config: CacheConfig,
 }

--- a/rust/blockstore/src/arrow/mod.rs
+++ b/rust/blockstore/src/arrow/mod.rs
@@ -4,5 +4,6 @@ mod concurrency_test;
 pub mod config;
 pub(crate) mod flusher;
 pub mod provider;
-pub mod sparse_index;
+pub mod root;
+mod sparse_index;
 pub mod types;

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -2,7 +2,7 @@ use super::{
     block::{delta::BlockDelta, Block, BlockLoadError},
     blockfile::{ArrowBlockfileReader, ArrowBlockfileWriter},
     config::ArrowBlockfileProviderConfig,
-    sparse_index::SparseIndex,
+    root::{FromBlockError, RootReader, RootWriter},
     types::{ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue},
 };
 use crate::{
@@ -27,7 +27,7 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct ArrowBlockfileProvider {
     block_manager: BlockManager,
-    sparse_index_manager: SparseIndexManager,
+    root_manager: RootManager,
 }
 
 impl ArrowBlockfileProvider {
@@ -35,11 +35,11 @@ impl ArrowBlockfileProvider {
         storage: Storage,
         max_block_size_bytes: usize,
         block_cache: Box<dyn PersistentCache<Uuid, Block>>,
-        sparse_index_cache: Box<dyn PersistentCache<Uuid, SparseIndex>>,
+        root_cache: Box<dyn PersistentCache<Uuid, RootReader>>,
     ) -> Self {
         Self {
             block_manager: BlockManager::new(storage.clone(), max_block_size_bytes, block_cache),
-            sparse_index_manager: SparseIndexManager::new(storage, sparse_index_cache),
+            root_manager: RootManager::new(storage, root_cache),
         }
     }
 
@@ -51,10 +51,10 @@ impl ArrowBlockfileProvider {
         &self,
         id: &uuid::Uuid,
     ) -> Result<BlockfileReader<'new, K, V>, Box<OpenError>> {
-        let sparse_index = self.sparse_index_manager.get::<K>(id).await;
-        match sparse_index {
-            Ok(Some(sparse_index)) => Ok(BlockfileReader::ArrowBlockfileReader(
-                ArrowBlockfileReader::new(*id, self.block_manager.clone(), sparse_index),
+        let root = self.root_manager.get::<K>(id).await;
+        match root {
+            Ok(Some(root)) => Ok(BlockfileReader::ArrowBlockfileReader(
+                ArrowBlockfileReader::new(self.block_manager.clone(), root),
             )),
             Ok(None) => Err(Box::new(OpenError::NotFound)),
             Err(e) => Err(Box::new(OpenError::Other(Box::new(e)))),
@@ -73,14 +73,14 @@ impl ArrowBlockfileProvider {
         let file = ArrowBlockfileWriter::new::<K, V>(
             new_id,
             self.block_manager.clone(),
-            self.sparse_index_manager.clone(),
+            self.root_manager.clone(),
         );
         Ok(BlockfileWriter::ArrowBlockfileWriter(file))
     }
 
     pub async fn clear(&self) -> Result<(), CacheError> {
         self.block_manager.block_cache.clear().await?;
-        self.sparse_index_manager.cache.clear().await?;
+        self.root_manager.cache.clear().await?;
         Ok(())
     }
 
@@ -90,19 +90,15 @@ impl ArrowBlockfileProvider {
     ) -> Result<crate::BlockfileWriter, Box<CreateError>> {
         tracing::info!("Forking blockfile from {:?}", id);
         let new_id = Uuid::new_v4();
-        let new_sparse_index = self
-            .sparse_index_manager
-            .fork::<K>(id, new_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Error forking sparse index: {:?}", e);
-                Box::new(CreateError::Other(Box::new(e)))
-            })?;
-        let file = ArrowBlockfileWriter::from_sparse_index(
+        let new_root = self.root_manager.fork::<K>(id, new_id).await.map_err(|e| {
+            tracing::error!("Error forking root: {:?}", e);
+            Box::new(CreateError::Other(Box::new(e)))
+        })?;
+        let file = ArrowBlockfileWriter::from_root(
             new_id,
             self.block_manager.clone(),
-            self.sparse_index_manager.clone(),
-            new_sparse_index,
+            self.root_manager.clone(),
+            new_root,
         );
         Ok(BlockfileWriter::ArrowBlockfileWriter(file))
     }
@@ -124,18 +120,17 @@ impl Configurable<(ArrowBlockfileProviderConfig, Storage)> for ArrowBlockfilePro
                 return Err(e);
             }
         };
-        let sparse_index_cache = match chroma_cache::from_config_persistent(
-            &blockfile_config
-                .sparse_index_manager_config
-                .sparse_index_cache_config,
-        )
-        .await
-        {
-            Ok(cache) => cache,
-            Err(e) => {
-                return Err(e);
-            }
-        };
+        let sparse_index_cache: Box<dyn PersistentCache<_, _>> =
+            match chroma_cache::from_config_persistent(
+                &blockfile_config.root_manager_config.root_cache_config,
+            )
+            .await
+            {
+                Ok(cache) => cache,
+                Err(e) => {
+                    return Err(e);
+                }
+            };
         Ok(ArrowBlockfileProvider::new(
             storage.clone(),
             blockfile_config.block_manager_config.max_block_size_bytes,
@@ -353,8 +348,12 @@ impl ChromaError for BlockFlushError {
     }
 }
 
+// ==============
+// Root Manager
+// ==============
+
 #[derive(Error, Debug)]
-pub(super) enum SparseIndexManagerError {
+pub(super) enum RootManagerError {
     #[error("Not found")]
     NotFound,
     #[error(transparent)]
@@ -363,42 +362,48 @@ pub(super) enum SparseIndexManagerError {
     UUIDParseError(#[from] uuid::Error),
     #[error(transparent)]
     StorageGetError(#[from] chroma_storage::GetError),
+    #[error(transparent)]
+    FromBlockError(#[from] FromBlockError),
 }
 
-impl ChromaError for SparseIndexManagerError {
+impl ChromaError for RootManagerError {
     fn code(&self) -> ErrorCodes {
         match self {
-            SparseIndexManagerError::NotFound => ErrorCodes::NotFound,
-            SparseIndexManagerError::BlockLoadError(e) => e.code(),
-            SparseIndexManagerError::StorageGetError(e) => e.code(),
-            SparseIndexManagerError::UUIDParseError(_) => ErrorCodes::DataLoss,
+            RootManagerError::NotFound => ErrorCodes::NotFound,
+            RootManagerError::BlockLoadError(e) => e.code(),
+            RootManagerError::StorageGetError(e) => e.code(),
+            RootManagerError::UUIDParseError(_) => ErrorCodes::DataLoss,
+            RootManagerError::FromBlockError(e) => e.code(),
         }
     }
 }
 
 #[derive(Clone)]
-pub(super) struct SparseIndexManager {
-    cache: Arc<dyn PersistentCache<Uuid, SparseIndex>>,
+pub(super) struct RootManager {
+    cache: Arc<dyn PersistentCache<Uuid, RootReader>>,
     storage: Storage,
 }
 
-impl SparseIndexManager {
-    pub fn new(storage: Storage, cache: Box<dyn PersistentCache<Uuid, SparseIndex>>) -> Self {
-        let cache: Arc<dyn PersistentCache<Uuid, SparseIndex>> = cache.into();
+impl RootManager {
+    pub fn new(storage: Storage, cache: Box<dyn PersistentCache<Uuid, RootReader>>) -> Self {
+        let cache: Arc<dyn PersistentCache<Uuid, RootReader>> = cache.into();
         Self { cache, storage }
     }
 
     pub async fn get<'new, K: ArrowReadableKey<'new> + 'new>(
         &self,
         id: &Uuid,
-    ) -> Result<Option<SparseIndex>, SparseIndexManagerError> {
+    ) -> Result<Option<RootReader>, RootManagerError> {
         let index = self.cache.get(id).await.ok().flatten();
         match index {
             Some(index) => Ok(Some(index)),
             None => {
-                tracing::info!("Cache miss - fetching sparse index from storage");
+                tracing::info!("Cache miss - fetching root from storage");
+                // TODO(hammadb): For legacy and temporary development purposes, we are reading the file
+                // from a fixed location. The path is sparse_index/ for legacy reasons.
+                // This will be replaced with a full prefix-based storage shortly
                 let key = format!("sparse_index/{}", id);
-                tracing::debug!("Reading sparse index from storage with key: {}", key);
+                tracing::debug!("Reading root from storage with key: {}", key);
                 // TODO: This should pass through NAC as well.
                 let stream = self.storage.get_stream(&key).await;
                 let mut buf: Vec<u8> = Vec::new();
@@ -410,11 +415,8 @@ impl SparseIndexManager {
                                     buf.extend(chunk);
                                 }
                                 Err(e) => {
-                                    tracing::error!(
-                                        "Error reading sparse index from storage: {}",
-                                        e
-                                    );
-                                    return Err(SparseIndexManagerError::StorageGetError(e));
+                                    tracing::error!("Error reading root from storage: {}", e);
+                                    return Err(RootManagerError::StorageGetError(e));
                                 }
                             }
                         }
@@ -427,30 +429,28 @@ impl SparseIndexManager {
                                 // the sparse index copies the block so it can live as long as it needs to independently
                                 let promoted_block: &'new Block =
                                     unsafe { std::mem::transmute(block_ref) };
-                                let index = SparseIndex::from_block::<K>(promoted_block);
-                                match index {
-                                    Ok(index) => {
-                                        self.cache.insert(*id, index.clone()).await;
-                                        Ok(Some(index))
+                                // let index = SparseIndex::from_block::<K>(promoted_block);
+                                let root = RootReader::from_block::<K>(promoted_block);
+                                match root {
+                                    Ok(root) => {
+                                        self.cache.insert(*id, root.clone()).await;
+                                        Ok(Some(root))
                                     }
                                     Err(e) => {
-                                        tracing::error!(
-                                            "Error turning block into sparse index: {}",
-                                            e
-                                        );
-                                        Err(SparseIndexManagerError::UUIDParseError(e))
+                                        tracing::error!("Error turning block into root: {}", e);
+                                        Err(RootManagerError::FromBlockError(e))
                                     }
                                 }
                             }
                             Err(e) => {
                                 tracing::error!("Error turning bytes into block: {}", e);
-                                Err(SparseIndexManagerError::BlockLoadError(e))
+                                Err(RootManagerError::BlockLoadError(e))
                             }
                         }
                     }
                     Err(e) => {
-                        tracing::error!("Error reading sparse index from storage: {}", e);
-                        Err(SparseIndexManagerError::StorageGetError(e))
+                        tracing::error!("Error reading root from storage: {}", e);
+                        Err(RootManagerError::StorageGetError(e))
                     }
                 }
             }
@@ -459,33 +459,33 @@ impl SparseIndexManager {
 
     pub async fn flush<'read, K: ArrowWriteableKey + 'read>(
         &self,
-        index: &SparseIndex,
+        root: &RootWriter,
     ) -> Result<(), Box<dyn ChromaError>> {
-        let as_block = index.to_block::<K>();
+        let as_block = root.to_block::<K>();
         match as_block {
             Ok(block) => {
                 let bytes = match block.to_bytes() {
                     Ok(bytes) => bytes,
                     Err(e) => {
-                        tracing::error!("Failed to convert sparse index to bytes");
+                        tracing::error!("Failed to convert root to bytes");
                         return Err(Box::new(e));
                     }
                 };
-                let key = format!("sparse_index/{}", index.id);
+                let key = format!("sparse_index/{}", root.id);
                 let res = self.storage.put_bytes(&key, bytes).await;
                 match res {
                     Ok(_) => {
-                        tracing::info!("Sparse index written to storage");
+                        tracing::info!("Root written to storage");
                         Ok(())
                     }
                     Err(e) => {
-                        tracing::error!("Error writing sparse index to storage");
+                        tracing::error!("Error writing root to storage");
                         Err(Box::new(e))
                     }
                 }
             }
             Err(e) => {
-                tracing::error!("Failed to convert sparse index to block");
+                tracing::error!("Failed to convert root to block");
                 Err(e)
             }
         }
@@ -495,29 +495,15 @@ impl SparseIndexManager {
         &self,
         old_id: &Uuid,
         new_id: Uuid,
-    ) -> Result<SparseIndex, SparseIndexManagerError> {
-        tracing::info!("Forking sparse index from {:?}", old_id);
+    ) -> Result<RootWriter, RootManagerError> {
+        tracing::info!("Forking root from {:?}", old_id);
         let original = self.get::<K::ReadableKey<'key>>(old_id).await?;
         match original {
             Some(original) => {
                 let forked = original.fork(new_id);
                 Ok(forked)
             }
-            None => Err(SparseIndexManagerError::NotFound),
-        }
-    }
-}
-
-#[derive(Error, Debug)]
-pub enum SparseIndexFlushError {
-    #[error("Not found")]
-    NotFound,
-}
-
-impl ChromaError for SparseIndexFlushError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            SparseIndexFlushError::NotFound => ErrorCodes::NotFound,
+            None => Err(RootManagerError::NotFound),
         }
     }
 }

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -429,7 +429,6 @@ impl RootManager {
                                 // the sparse index copies the block so it can live as long as it needs to independently
                                 let promoted_block: &'new Block =
                                     unsafe { std::mem::transmute(block_ref) };
-                                // let index = SparseIndex::from_block::<K>(promoted_block);
                                 let root = RootReader::from_block::<K>(promoted_block);
                                 match root {
                                     Ok(root) => {

--- a/rust/blockstore/src/arrow/root.rs
+++ b/rust/blockstore/src/arrow/root.rs
@@ -1,0 +1,105 @@
+use super::{
+    block::{delta::BlockDelta, Block},
+    sparse_index::{SparseIndex, SparseIndexDelimiter},
+    types::ArrowWriteableKey,
+};
+use crate::key::KeyWrapper;
+use chroma_error::ChromaError;
+use std::{collections::HashMap, fmt::Display};
+use uuid::Uuid;
+
+const CURRENT_VERSION: Version = Version::V1_1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Version {
+    V1,
+    V1_1,
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Version::V1 => write!(f, "v1"),
+            Version::V1_1 => write!(f, "v1.1"),
+        }
+    }
+}
+
+impl From<&str> for Version {
+    fn from(s: &str) -> Self {
+        match s {
+            "v1" => Version::V1,
+            "v1.1" => Version::V1_1,
+            _ => panic!("Unknown version: {}", s),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RootWriter {
+    // TODO: Replace with writer
+    sparse_index: SparseIndex,
+    // Metadata
+    id: Uuid,
+    version: Version,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RootReader {
+    // TODO: Replace with reader
+    sparse_index: SparseIndex,
+    // Metadata
+    id: Uuid,
+    version: Version,
+}
+
+impl RootWriter {
+    pub(super) fn new(id: Uuid, sparse_index: SparseIndex) -> Self {
+        Self {
+            version: CURRENT_VERSION,
+            sparse_index,
+            id,
+        }
+    }
+
+    fn to_block<K: ArrowWriteableKey>(&self) -> Result<Block, Box<dyn ChromaError>> {
+        let data = self.sparse_index.data.lock();
+        if data.forward.is_empty() {
+            panic!("Invariant violation. No blocks in the sparse index");
+        }
+
+        // TODO: we could save the uuid not as a string to be more space efficient
+        // but given the scale is relatively small, this is fine for now
+        let delta = BlockDelta::new::<K, String>(self.id);
+        for (key, block_id) in data.forward.iter() {
+            match key {
+                SparseIndexDelimiter::Start => {
+                    delta.add("START", K::default(), block_id.to_string());
+                }
+                SparseIndexDelimiter::Key(k) => match &k.key {
+                    KeyWrapper::String(s) => {
+                        delta.add(&k.prefix, s.as_str(), block_id.to_string());
+                    }
+                    KeyWrapper::Float32(f) => {
+                        delta.add(&k.prefix, *f, block_id.to_string());
+                    }
+                    KeyWrapper::Bool(_b) => {
+                        unimplemented!();
+                        // delta.add("KEY", b, block_id.to_string().as_str());
+                    }
+                    KeyWrapper::Uint32(u) => {
+                        delta.add(&k.prefix, *u, block_id.to_string());
+                    }
+                },
+            }
+        }
+
+        let delta_id = delta.id;
+        let metadata = HashMap::from_iter(vec![
+            ("version".to_string(), self.version.to_string()),
+            ("id".to_string(), self.id.to_string()),
+        ]);
+        let record_batch = delta.finish::<K, String>(Some(metadata));
+        Ok(Block::from_record_batch(delta_id, record_batch))
+    }
+}

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -1,6 +1,7 @@
+use crate::arrow::root::RootReader;
+
 use super::arrow::block::Block;
 use super::arrow::provider::ArrowBlockfileProvider;
-use super::arrow::sparse_index::SparseIndex;
 use super::arrow::types::{
     ArrowReadableKey, ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue,
 };
@@ -48,13 +49,13 @@ impl BlockfileProvider {
         storage: Storage,
         max_block_size_bytes: usize,
         block_cache: Box<dyn PersistentCache<Uuid, Block>>,
-        sparse_index_cache: Box<dyn PersistentCache<Uuid, SparseIndex>>,
+        root_cache: Box<dyn PersistentCache<Uuid, RootReader>>,
     ) -> Self {
         BlockfileProvider::ArrowBlockfileProvider(ArrowBlockfileProvider::new(
             storage,
             max_block_size_bytes,
             block_cache,
-            sparse_index_cache,
+            root_cache,
         ))
     }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Introduces a root of the blockfile, which stores version, sparse index and id. 
	 - Add versioning to the metadata of the sparse index
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*
Existing tests + 1 test for version backwards compat is introduced higher in the stack
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None