### PR TITLE
[ENH] Call purge_one when evicting from cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "thiserror",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -13,10 +13,11 @@ anyhow = "1.0"
 # TODO(rescrv):  Deprecated.  Find a suitable replacement for such things.
 serde_yaml = "0.9"
 
-thiserror = { workspace = true }
-serde = { workspace = true }
 async-trait = { workspace = true }
 parking_lot = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -86,7 +86,7 @@ pub trait Weighted {
 /// the persistent cache trait.  Attempts to construct a disk-based cache will return an error.
 pub async fn from_config_with_event_listener<K, V>(
     config: &CacheConfig,
-    tx: tokio::sync::mpsc::Sender<K>,
+    tx: tokio::sync::mpsc::UnboundedSender<K>,
 ) -> Result<Box<dyn Cache<K, V>>, Box<dyn ChromaError>>
 where
     K: Clone + Send + Sync + Eq + PartialEq + Hash + 'static,

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -74,6 +74,7 @@ impl Configurable<(HnswProviderConfig, Storage)> for HnswIndexProvider {
         config: &(HnswProviderConfig, Storage),
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (hnsw_config, storage) = config;
+        // TODO(rescrv):  Long-term we should migrate this to the component API.
         let (tx, rx) = tokio::sync::mpsc::channel(100);
         let cache =
             chroma_cache::from_config_with_event_listener(&hnsw_config.hnsw_cache_config, tx)

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -51,6 +51,8 @@ pub struct HnswIndexProvider {
     pub temporary_storage_path: PathBuf,
     storage: Storage,
     write_mutex: Arc<tokio::sync::Mutex<()>>,
+    #[allow(dead_code)]
+    purger: Option<Arc<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Clone)]
@@ -72,14 +74,16 @@ impl Configurable<(HnswProviderConfig, Storage)> for HnswIndexProvider {
         config: &(HnswProviderConfig, Storage),
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (hnsw_config, storage) = config;
-        let cache = chroma_cache::from_config(&hnsw_config.hnsw_cache_config).await?;
-        let cache: Arc<dyn Cache<_, _>> = cache.into();
-        Ok(Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        let cache =
+            chroma_cache::from_config_with_event_listener(&hnsw_config.hnsw_cache_config, tx)
+                .await?;
+        Ok(Self::new(
+            storage.clone(),
+            PathBuf::from(&hnsw_config.hnsw_temporary_path),
             cache,
-            storage: storage.clone(),
-            temporary_storage_path: PathBuf::from(&hnsw_config.hnsw_temporary_path),
-            write_mutex: Arc::new(tokio::sync::Mutex::new(())),
-        })
+            rx,
+        ))
     }
 }
 
@@ -98,13 +102,21 @@ impl HnswIndexProvider {
         storage: Storage,
         storage_path: PathBuf,
         cache: Box<dyn Cache<Uuid, HnswIndexRef>>,
+        mut evicted: tokio::sync::mpsc::Receiver<Uuid>,
     ) -> Self {
         let cache: Arc<dyn Cache<Uuid, HnswIndexRef>> = cache.into();
+        let temporary_storage_path = storage_path.to_path_buf();
+        let purger = Some(Arc::new(tokio::task::spawn(async move {
+            while let Some(id) = evicted.recv().await {
+                let _ = Self::purge_one_id(&temporary_storage_path, id).await;
+            }
+        })));
         Self {
             cache,
             storage,
             temporary_storage_path: storage_path,
             write_mutex: Arc::new(tokio::sync::Mutex::new(())),
+            purger,
         }
     }
 
@@ -431,6 +443,12 @@ impl HnswIndexProvider {
         }
     }
 
+    pub async fn purge_one_id(path: &Path, id: Uuid) -> tokio::io::Result<()> {
+        let index_storage_path = path.join(id.to_string());
+        tokio::fs::remove_dir_all(index_storage_path).await?;
+        Ok(())
+    }
+
     async fn remove_temporary_files(&self, id: &Uuid) -> tokio::io::Result<()> {
         let index_storage_path = self.temporary_storage_path.join(id.to_string());
         tokio::fs::remove_dir_all(index_storage_path).await
@@ -583,7 +601,8 @@ mod tests {
 
         let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
         let cache = new_non_persistent_cache_for_test();
-        let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache);
+        let (_tx, rx) = tokio::sync::mpsc::channel(100);
+        let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache, rx);
         let segment = Segment {
             id: Uuid::new_v4(),
             r#type: SegmentType::HnswDistributed,

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -528,6 +528,7 @@ mod tests {
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let hnsw_cache = new_non_persistent_cache_for_test();
+        let (_, rx) = tokio::sync::mpsc::channel(1000);
         let mut manager = CompactionManager::new(
             scheduler,
             log,
@@ -543,6 +544,7 @@ mod tests {
                 storage,
                 PathBuf::from(tmpdir.path().to_str().unwrap()),
                 hnsw_cache,
+                rx,
             ),
             compaction_manager_queue_size,
             compaction_interval,

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -528,7 +528,7 @@ mod tests {
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::channel(1000);
+        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let mut manager = CompactionManager::new(
             scheduler,
             log,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -673,6 +673,7 @@ mod tests {
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let hnsw_index_cache = new_non_persistent_cache_for_test();
+        let (_, rx) = tokio::sync::mpsc::channel(1);
         let port = random_port::PortPicker::new().pick().unwrap();
         let mut server = WorkerServer {
             dispatcher: None,
@@ -683,6 +684,7 @@ mod tests {
                 storage.clone(),
                 tmp_dir.path().to_path_buf(),
                 hnsw_index_cache,
+                rx,
             ),
             blockfile_provider: BlockfileProvider::new_arrow(
                 storage,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -673,7 +673,7 @@ mod tests {
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let hnsw_index_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::channel(1);
+        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let port = random_port::PortPicker::new().pick().unwrap();
         let mut server = WorkerServer {
             dispatcher: None,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Anything that implements the hnsw provider will evict files from disk when evicted from cache.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
