### PR TITLE
Add cache mounts to query and compactor services

### DIFF
--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -43,6 +43,8 @@ spec:
           volumeMounts:
             - name: compaction-service-config
               mountPath: /config/
+            - name: compaction-service-cache
+              mountPath: /cache
           {{ end }}
           ports:
             - containerPort: 50051
@@ -50,6 +52,8 @@ spec:
             {{if .Values.compactionService.configuration}}
             - name: CONFIG_PATH
               value: /config/config.yaml
+            - name: CACHE_PATH
+              value: /cache/
             {{ end }}
             {{ range .Values.compactionService.env }}
             - name: {{ .name }}

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -62,6 +62,8 @@ spec:
           volumeMounts:
             - name: query-service-config
               mountPath: /config/
+            - name: query-service-cache
+              mountPath: /cache/
           {{ end }}
           ports:
             - containerPort: 50051
@@ -69,6 +71,8 @@ spec:
             {{if .Values.queryService.configuration}}
             - name: CONFIG_PATH
               value: /config/config.yaml
+            - name: CACHE_PATH
+              value: /cache/
             {{ end }}
             {{ range .Values.queryService.env }}
             - name: {{ .name }}


### PR DESCRIPTION
## Description of changes
 - New functionality
	 - this adds a `/cache` volume mount to our query and compaction services as well as a `CACHE_PATH` environment variable with the setting.

## Test plan
- `tilt up` -- verify that the `compaction-service` and `query-service` pods come up with the expected k8s config.

- [x] (n/a) Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
n/a