### PR TITLE
[ENH]: replace `get_block_ids_*` with `get_block_ids_range()` in SparseIndex

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -615,7 +615,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         &'me self,
         prefix: &str,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
-        let block_ids = self.root.sparse_index.get_block_ids_prefix(prefix);
+        let block_ids = self
+            .root
+            .sparse_index
+            .get_block_ids_range::<K, _, _>(prefix.to_string()..=prefix.to_string(), ..);
         let mut result: Vec<(K, V)> = vec![];
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -477,14 +477,14 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     }
 
     /// Returns all arrow records whose key > supplied key.
-    pub(crate) async fn get_gt(
+    pub(crate) async fn get_gt<'a>(
         &'me self,
-        prefix: &str,
+        prefix: &'a str,
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys > key from sparse index for this prefix.
         let block_ids = self.root.sparse_index.get_block_ids_range(
-            prefix.to_string()..=prefix.to_string(),
+            prefix..=prefix,
             (
                 std::ops::Bound::Excluded(key.clone()),
                 std::ops::Bound::Unbounded,
@@ -524,7 +524,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let block_ids = self
             .root
             .sparse_index
-            .get_block_ids_range(prefix.to_string()..=prefix.to_string(), ..key.clone());
+            .get_block_ids_range(prefix..=prefix, ..key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys < key.
         for block_id in block_ids {
@@ -559,7 +559,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let block_ids = self
             .root
             .sparse_index
-            .get_block_ids_range(prefix.to_string()..=prefix.to_string(), key.clone()..);
+            .get_block_ids_range(prefix..=prefix, key.clone()..);
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys >= key.
         for block_id in block_ids {
@@ -594,7 +594,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let block_ids = self
             .root
             .sparse_index
-            .get_block_ids_range(prefix.to_string()..=prefix.to_string(), ..=key.clone());
+            .get_block_ids_range(prefix..=prefix, ..=key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys <= key.
         for block_id in block_ids {
@@ -627,7 +627,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let block_ids = self
             .root
             .sparse_index
-            .get_block_ids_range::<K, _, _>(prefix.to_string()..=prefix.to_string(), ..);
+            .get_block_ids_range::<K, _, _>(prefix..=prefix, ..);
         let mut result: Vec<(K, V)> = vec![];
         for block_id in block_ids {
             let block_opt = match self.get_block(block_id).await {

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -477,9 +477,9 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     }
 
     /// Returns all arrow records whose key > supplied key.
-    pub(crate) async fn get_gt<'a>(
+    pub(crate) async fn get_gt(
         &'me self,
-        prefix: &'a str,
+        prefix: &str,
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys > key from sparse index for this prefix.

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -483,7 +483,13 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys > key from sparse index for this prefix.
-        let block_ids = self.root.sparse_index.get_block_ids_gt(prefix, key.clone());
+        let block_ids = self.root.sparse_index.get_block_ids_range(
+            prefix.to_string()..=prefix.to_string(),
+            (
+                std::ops::Bound::Excluded(key.clone()),
+                std::ops::Bound::Unbounded,
+            ),
+        );
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys > key.
         for block_id in block_ids {
@@ -515,7 +521,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         key: K,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         // Get all block ids that contain keys < key from sparse index.
-        let block_ids = self.root.sparse_index.get_block_ids_lt(prefix, key.clone());
+        let block_ids = self
+            .root
+            .sparse_index
+            .get_block_ids_range(prefix.to_string()..=prefix.to_string(), ..key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys < key.
         for block_id in block_ids {
@@ -550,7 +559,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let block_ids = self
             .root
             .sparse_index
-            .get_block_ids_gte(prefix, key.clone());
+            .get_block_ids_range(prefix.to_string()..=prefix.to_string(), key.clone()..);
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys >= key.
         for block_id in block_ids {
@@ -585,7 +594,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let block_ids = self
             .root
             .sparse_index
-            .get_block_ids_lte(prefix, key.clone());
+            .get_block_ids_range(prefix.to_string()..=prefix.to_string(), ..=key.clone());
         let mut result: Vec<(K, V)> = vec![];
         // Read all the blocks individually to get keys <= key.
         for block_id in block_ids {

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -1,5 +1,5 @@
 use super::types::ArrowReadableKey;
-use crate::key::{CompositeKey, KeyWrapper};
+use crate::key::CompositeKey;
 use chroma_error::ChromaError;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -361,19 +361,14 @@ impl SparseIndexReader {
         result_uuids
     }
 
-    pub(super) fn get_block_ids_range<
-        'prefix,
-        'a,
-        K: ArrowReadableKey<'a> + Into<KeyWrapper>,
-        PrefixRange,
-        KeyRange,
-    >(
+    pub(super) fn get_block_ids_range<'prefix, 'referred_data, K, PrefixRange, KeyRange>(
         &self,
         // These key ranges are flattened instead of using a single RangeBounds<CompositeKey> because not all keys have a well-defined min and max value. E.x. if the key is a string, there would be no way to get the range for all keys within a specific prefix.
         prefix_range: PrefixRange,
         key_range: KeyRange,
     ) -> Vec<Uuid>
     where
+        K: ArrowReadableKey<'referred_data>,
         PrefixRange: RangeBounds<&'prefix str>,
         KeyRange: RangeBounds<K>,
     {


### PR DESCRIPTION
## Description of changes

Replaces specialized methods like `get_block_ids_gt` and `get_block_ids_lt` with a single `get_block_ids_range()` method that behaves similarly to the std `BTreeMap::range()` method. This reduces complexity/repetition and also enables queries that are bounded in both directions.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
