### PR TITLE
feat: Add superfast wordllama embedding function

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -30,6 +30,7 @@ def test_get_builtins_holds() -> None:
         "SentenceTransformerEmbeddingFunction",
         "Text2VecEmbeddingFunction",
         "ChromaLangchainEmbeddingFunction",
+        "WordLlamaEmbeddingFunction",
     }
 
     assert expected_builtins == embedding_functions.get_builtins()

--- a/chromadb/test/ef/test_wordllama_ef.py
+++ b/chromadb/test/ef/test_wordllama_ef.py
@@ -1,0 +1,7 @@
+from chromadb.utils.embedding_functions.wordllama_embedding_function import WordLlamaEmbeddingFunction
+
+
+def test_wordllama() -> None:
+    ef = WordLlamaEmbeddingFunction()
+    embeddings = ef(["Here is an article about llamas...", "this is another article"])
+    assert len(embeddings) == 2

--- a/chromadb/utils/embedding_functions/wordllama_embedding_function.py
+++ b/chromadb/utils/embedding_functions/wordllama_embedding_function.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Literal, cast
+
+from chromadb.api.types import Documents, EmbeddingFunction, Embeddings
+
+if TYPE_CHECKING:
+    from wordllama.inference import WordLlamaInference
+
+
+class WordLlamaEmbeddingFunction(EmbeddingFunction[Documents]):
+    models: Dict[str, WordLlamaInference] = {}
+
+    def __init__(
+        self,
+        config: Literal["l2_supercat", "l3_supercat"] = "l2_supercat",
+        normalize_embeddings: bool = False,
+        **kwargs: Any,
+    ):
+        """Initialize WordLlamaEmbeddingFunction.
+
+        Args:
+            config (Literal["l2_supercat", "l3_supercat"]): Identifier of the WordLlama model, defaults to "l2_supercat"
+            normalize_embeddings (bool, optional): Whether to normalize returned vectors, defaults to False
+            **kwargs: Additional arguments to pass to the WordLlama.load function.
+        """
+        if config not in self.models:
+            try:
+                from wordllama import WordLlama
+            except ImportError:
+                raise ValueError(
+                    "The wordllama python package is not installed. Please install it with `pip install wordllama`"
+                )
+            self.models[config] = WordLlama.load(config, **kwargs)
+        self._model = self.models[config]
+        self._normalize_embeddings = normalize_embeddings
+
+    def __call__(self, input: Documents) -> Embeddings:
+        return cast(
+            Embeddings,
+            self._model.embed(
+                list(input),
+                return_np=True,
+                norm=self._normalize_embeddings,
+            ),
+        )


### PR DESCRIPTION
## Description of changes

Added new superfast WordLlama embedding function.

I was playing with [SeaGOAT](https://github.com/kantord/SeaGOAT), trying to make it better understand code, and make it faster. It uses chromadb, and embedding function is what defines it's speed and usefulness.

So, i tried adding this one.

![Embedding time benchmark](https://github.com/user-attachments/assets/9ea044d4-b531-4e3b-bd8c-0a0fe2474d85)

(source https://github.com/dleemiller/WordLlama?tab=readme-ov-file#how-fast-zap )

## Test plan

- [x] Tests pass locally with `pytest`

## Documentation Changes

I haven't changed any docs, let me know if we need to add it somewhere.
