### PR TITLE
[TST]: update test_persist to create 1+ collections

### DIFF
--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -3,7 +3,7 @@ import multiprocessing
 from multiprocessing.connection import Connection
 import multiprocessing.context
 import time
-from typing import Generator, Callable
+from typing import Generator, Callable, List
 from uuid import UUID
 from hypothesis import given
 import hypothesis.strategies as st
@@ -73,37 +73,62 @@ collection_st = st.shared(
 )
 
 
+@st.composite
+def collection_and_embeddings_strategy(
+    draw: st.DrawFn,
+) -> tuple[strategies.Collection, strategies.RecordSet]:
+    collection_strategy = draw(
+        strategies.collections(
+            with_hnsw_params=True,
+            with_persistent_hnsw_params=st.just(True),
+            # Makes it more likely to find persist-related bugs (by default these are set to 2000).
+            max_hnsw_batch_size=10,
+            max_hnsw_sync_threshold=10,
+        )
+    )
+    embeddings_strategy = draw(strategies.recordsets(st.just(collection_strategy)))
+    return collection_strategy, embeddings_strategy
+
+
 @given(
-    collection_strategy=collection_st,
-    embeddings_strategy=strategies.recordsets(collection_st),
+    collection_and_embeddings_strategies=st.lists(
+        collection_and_embeddings_strategy(),
+        min_size=1,
+        unique_by=(lambda x: x[0].name, lambda x: x[0].name),
+    )
 )
 def test_persist(
     settings: Settings,
-    collection_strategy: strategies.Collection,
-    embeddings_strategy: strategies.RecordSet,
+    collection_and_embeddings_strategies: List[
+        tuple[strategies.Collection, strategies.RecordSet]
+    ],
 ) -> None:
     system_1 = System(settings)
     system_1.start()
     client_1 = ClientCreator.from_system(system_1)
 
     client_1.reset()
-    coll = client_1.create_collection(
-        name=collection_strategy.name,
-        metadata=collection_strategy.metadata,  # type: ignore[arg-type]
-        embedding_function=collection_strategy.embedding_function,
-    )
-
-    coll.add(**embeddings_strategy)  # type: ignore[arg-type]
-
-    invariants.count(coll, embeddings_strategy)
-    invariants.metadatas_match(coll, embeddings_strategy)
-    invariants.documents_match(coll, embeddings_strategy)
-    invariants.ids_match(coll, embeddings_strategy)
-    invariants.ann_accuracy(
-        coll,
+    for (
+        collection_strategy,
         embeddings_strategy,
-        embedding_function=collection_strategy.embedding_function,
-    )
+    ) in collection_and_embeddings_strategies:
+        coll = client_1.create_collection(
+            name=collection_strategy.name,
+            metadata=collection_strategy.metadata,  # type: ignore[arg-type]
+            embedding_function=collection_strategy.embedding_function,
+        )
+
+        coll.add(**embeddings_strategy)  # type: ignore[arg-type]
+
+        invariants.count(coll, embeddings_strategy)
+        invariants.metadatas_match(coll, embeddings_strategy)
+        invariants.documents_match(coll, embeddings_strategy)
+        invariants.ids_match(coll, embeddings_strategy)
+        invariants.ann_accuracy(
+            coll,
+            embeddings_strategy,
+            embedding_function=collection_strategy.embedding_function,
+        )
 
     system_1.stop()
     del client_1
@@ -113,19 +138,23 @@ def test_persist(
     system_2.start()
     client_2 = ClientCreator.from_system(system_2)
 
-    coll = client_2.get_collection(
-        name=collection_strategy.name,
-        embedding_function=collection_strategy.embedding_function,
-    )
-    invariants.count(coll, embeddings_strategy)
-    invariants.metadatas_match(coll, embeddings_strategy)
-    invariants.documents_match(coll, embeddings_strategy)
-    invariants.ids_match(coll, embeddings_strategy)
-    invariants.ann_accuracy(
-        coll,
+    for (
+        collection_strategy,
         embeddings_strategy,
-        embedding_function=collection_strategy.embedding_function,
-    )
+    ) in collection_and_embeddings_strategies:
+        coll = client_2.get_collection(
+            name=collection_strategy.name,
+            embedding_function=collection_strategy.embedding_function,
+        )
+        invariants.count(coll, embeddings_strategy)
+        invariants.metadatas_match(coll, embeddings_strategy)
+        invariants.documents_match(coll, embeddings_strategy)
+        invariants.ids_match(coll, embeddings_strategy)
+        invariants.ann_accuracy(
+            coll,
+            embeddings_strategy,
+            embedding_function=collection_strategy.embedding_function,
+        )
 
     system_2.stop()
     del client_2

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -100,7 +100,7 @@ def collection_and_recordset_strategy(
 )
 def test_persist(
     settings: Settings,
-    collection_and_recordsets_strategies: List[
+    collection_and_recordset_strategies: List[
         Tuple[strategies.Collection, strategies.RecordSet]
     ],
 ) -> None:
@@ -112,7 +112,7 @@ def test_persist(
     for (
         collection_strategy,
         recordset_strategy,
-    ) in collection_and_recordsets_strategies:
+    ) in collection_and_recordset_strategies:
         coll = client_1.create_collection(
             name=collection_strategy.name,
             metadata=collection_strategy.metadata,  # type: ignore[arg-type]
@@ -142,7 +142,7 @@ def test_persist(
     for (
         collection_strategy,
         recordset_strategy,
-    ) in collection_and_recordsets_strategies:
+    ) in collection_and_recordset_strategies:
         coll = client_2.get_collection(
             name=collection_strategy.name,
             embedding_function=collection_strategy.embedding_function,

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -3,7 +3,7 @@ import multiprocessing
 from multiprocessing.connection import Connection
 import multiprocessing.context
 import time
-from typing import Generator, Callable, List
+from typing import Generator, Callable, List, Tuple
 from uuid import UUID
 from hypothesis import given
 import hypothesis.strategies as st
@@ -76,7 +76,7 @@ collection_st = st.shared(
 @st.composite
 def collection_and_embeddings_strategy(
     draw: st.DrawFn,
-) -> tuple[strategies.Collection, strategies.RecordSet]:
+) -> Tuple[strategies.Collection, strategies.RecordSet]:
     collection_strategy = draw(
         strategies.collections(
             with_hnsw_params=True,
@@ -100,7 +100,7 @@ def collection_and_embeddings_strategy(
 def test_persist(
     settings: Settings,
     collection_and_embeddings_strategies: List[
-        tuple[strategies.Collection, strategies.RecordSet]
+        Tuple[strategies.Collection, strategies.RecordSet]
     ],
 ) -> None:
     system_1 = System(settings)


### PR DESCRIPTION
## Description of changes

Updates `test_persist` to test persisting potentially multiple collections. This is to prevent introducing bugs like https://github.com/chroma-core/chroma/pull/2923 in the future.

I ran this new test against 0.5.12 and Hypothesis easily caught the bug.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a

Closes #2927 