### PR TITLE
[ENH]: replace `get_*` methods on Arrow blocks with `get_range()`

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -161,7 +161,7 @@ impl Block {
             Less => None,
             Equal => Some(base),
             Greater => {
-                if prefix_array.value(base - 1) == prefix {
+                if base > 0 && prefix_array.value(base - 1) == prefix {
                     Some(base - 1)
                 } else {
                     None

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -121,7 +121,8 @@ impl Block {
 
     /// Binary search the block to find the last index of the specified prefix.
     /// Returns None if prefix does not exist in the block.
-    /// [`std::slice::partition_point`]: std::slice::partition_point
+    ///
+    /// Partly based on `std::slice::binary_search_by`: https://doc.rust-lang.org/src/core/slice/mod.rs.html#2770
     #[inline]
     fn binary_search_last_index(&self, prefix: &str) -> Option<usize> {
         let mut size = self.len();
@@ -146,8 +147,8 @@ impl Block {
             let mid = base - half;
 
             // SAFETY: the call is made safe by the following inconstants:
-            // - `mid >= 0`: by definition
-            // - `mid < size`: `mid = size / 2 - size / 4 - size / 8 ...`
+            // - `mid < size`: by definition
+            // - `mid >= 0`: `mid = size - 1 - size / 2 - size / 4 ...`
             let cmp = prefix_array.value(mid).cmp(prefix);
 
             base = if cmp == Greater { mid } else { base };
@@ -171,7 +172,6 @@ impl Block {
     }
 
     /// Binary search the blockfile to find the partition point of the specified prefix and key.
-    /// The implementation is based on [`std::slice::partition_point`].
     ///
     /// `(prefix, key)` serves as the search key, and it is sorted in ascending order.
     /// The partition predicate is defined by: `|x| x < (prefix, key)`.
@@ -179,7 +179,7 @@ impl Block {
     /// The code is a result of inlining this predicate in [`std::slice::partition_point`].
     /// If the key is unspecified (i.e. `None`), we find the first index of the prefix.
     ///
-    /// [`std::slice::partition_point`]: std::slice::partition_point
+    /// Partly based on `std::slice::binary_search_by`: https://doc.rust-lang.org/src/core/slice/mod.rs.html#2770
     #[inline]
     fn binary_search_index<'me, K: ArrowReadableKey<'me>>(
         &'me self,

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -17,6 +17,7 @@ use futures::future::join_all;
 use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::mem::transmute;
+use std::ops::Bound;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 use uuid::Uuid;
@@ -509,7 +510,10 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            result.extend(block.get_gt(prefix, key.clone()));
+            result.extend(block.get_range(
+                prefix..=prefix,
+                (Bound::Excluded(key.clone()), Bound::Unbounded),
+            ));
         }
         Ok(result)
     }
@@ -544,7 +548,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            result.extend(block.get_lt(prefix, key.clone()));
+            result.extend(block.get_range(prefix..=prefix, ..key.clone()));
         }
         Ok(result)
     }
@@ -579,7 +583,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            result.extend(block.get_gte(prefix, key.clone()));
+            result.extend(block.get_range(prefix..=prefix, key.clone()..));
         }
         Ok(result)
     }
@@ -614,7 +618,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
                 }
             };
-            result.extend(block.get_lte(prefix, key.clone()));
+            result.extend(block.get_range(prefix..=prefix, ..=key.clone()));
         }
         Ok(result)
     }
@@ -647,7 +651,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                 }
             };
 
-            result.extend(block.get_prefix(prefix));
+            result.extend(block.get_range(prefix..=prefix, ..));
         }
         Ok(result)
     }

--- a/rust/blockstore/src/types.rs
+++ b/rust/blockstore/src/types.rs
@@ -13,6 +13,7 @@ use chroma_types::DataRecord;
 use roaring::RoaringBitmap;
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
+use std::ops::Bound;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -282,7 +283,9 @@ impl<
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_by_prefix(prefix),
-            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_by_prefix(prefix).await,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.get_range(prefix..=prefix, ..).await
+            }
         }
     }
 
@@ -293,7 +296,11 @@ impl<
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_gt(prefix, key),
-            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_gt(prefix, key).await,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader
+                    .get_range(prefix..=prefix, (Bound::Excluded(key), Bound::Unbounded))
+                    .await
+            }
         }
     }
 
@@ -304,7 +311,9 @@ impl<
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_lt(prefix, key),
-            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_lt(prefix, key).await,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.get_range(prefix..=prefix, ..key).await
+            }
         }
     }
 
@@ -315,7 +324,9 @@ impl<
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_gte(prefix, key),
-            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_gte(prefix, key).await,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.get_range(prefix..=prefix, key..).await
+            }
         }
     }
 
@@ -326,7 +337,9 @@ impl<
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.get_lte(prefix, key),
-            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_lte(prefix, key).await,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.get_range(prefix..=prefix, ..=key).await
+            }
         }
     }
 


### PR DESCRIPTION
## Description of changes

Replaces specialized methods like get_gt and get_lt with a single get_range() method that behaves similarly to the std BTreeMap::range() method. This reduces complexity/repetition and also enables queries that are bounded in both directions.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
