### PR TITLE
[ENH]: replace `.get_*` methods on blockfile API with `.get_range()`

### DIFF
--- a/rust/blockstore/src/blockfile_writer_test.rs
+++ b/rust/blockstore/src/blockfile_writer_test.rs
@@ -177,16 +177,12 @@ mod tests {
             assert_eq!(block_on(reader.count()).unwrap(), ref_last_commit.len());
 
             // Check that entries are ordered and match expected
-            if let Some(min_key) = ref_last_commit.keys().next() {
-                let all_entries =
-                    block_on(reader.get_gte(min_key.0.as_str(), min_key.1.as_str())).unwrap();
+            let all_entries = block_on(reader.get_range(.., ..)).unwrap();
 
-                for (blockfile_entry, expected_entry) in
-                    all_entries.iter().zip(ref_last_commit.iter())
-                {
-                    assert_eq!(blockfile_entry.0, expected_entry.0 .1); // key matches
-                    assert_eq!(blockfile_entry.1, expected_entry.1); // value matches
-                }
+            for (blockfile_entry, expected_entry) in all_entries.iter().zip(ref_last_commit.iter())
+            {
+                assert_eq!(blockfile_entry.0, expected_entry.0 .1); // key matches
+                assert_eq!(blockfile_entry.1, expected_entry.1); // value matches
             }
         }
     }

--- a/rust/blockstore/src/types.rs
+++ b/rust/blockstore/src/types.rs
@@ -283,7 +283,7 @@ impl<
         key_range: KeyRange,
     ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>>
     where
-        PrefixRange: RangeBounds<&'prefix str> + Clone, // todo: can remove Clone bound?
+        PrefixRange: RangeBounds<&'prefix str> + Clone,
         KeyRange: RangeBounds<K> + Clone,
     {
         match self {

--- a/rust/blockstore/src/types.rs
+++ b/rust/blockstore/src/types.rs
@@ -13,7 +13,7 @@ use chroma_types::DataRecord;
 use roaring::RoaringBitmap;
 use std::fmt::{Debug, Display};
 use std::mem::size_of;
-use std::ops::Bound;
+use std::ops::RangeBounds;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -277,76 +277,21 @@ impl<
         }
     }
 
-    pub async fn get_by_prefix(
+    pub async fn get_range<'prefix, PrefixRange, KeyRange>(
         &'referred_data self,
-        prefix: &str,
-    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
-        match self {
-            BlockfileReader::MemoryBlockfileReader(reader) => reader.get_range(prefix..=prefix, ..),
-            BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, ..).await
-            }
-        }
-    }
-
-    pub async fn get_gt(
-        &'referred_data self,
-        prefix: &str,
-        key: K,
-    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
+        prefix_range: PrefixRange,
+        key_range: KeyRange,
+    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>>
+    where
+        PrefixRange: RangeBounds<&'prefix str> + Clone, // todo: can remove Clone bound?
+        KeyRange: RangeBounds<K> + Clone,
+    {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, (Bound::Excluded(key), Bound::Unbounded))
+                reader.get_range(prefix_range, key_range)
             }
             BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader
-                    .get_range(prefix..=prefix, (Bound::Excluded(key), Bound::Unbounded))
-                    .await
-            }
-        }
-    }
-
-    pub async fn get_lt(
-        &'referred_data self,
-        prefix: &str,
-        key: K,
-    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
-        match self {
-            BlockfileReader::MemoryBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, ..key)
-            }
-            BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, ..key).await
-            }
-        }
-    }
-
-    pub async fn get_gte(
-        &'referred_data self,
-        prefix: &str,
-        key: K,
-    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
-        match self {
-            BlockfileReader::MemoryBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, key..)
-            }
-            BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, key..).await
-            }
-        }
-    }
-
-    pub async fn get_lte(
-        &'referred_data self,
-        prefix: &str,
-        key: K,
-    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>> {
-        match self {
-            BlockfileReader::MemoryBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, ..=key)
-            }
-            BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.get_range(prefix..=prefix, ..=key).await
+                reader.get_range(prefix_range, key_range).await
             }
         }
     }

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -412,7 +412,7 @@ impl<'me> FullTextIndexReader<'me> {
             .then(|token| async {
                 let positional_posting_list = self
                     .posting_lists_blockfile_reader
-                    .get_by_prefix(token.text.as_str())
+                    .get_range(token.text.as_str()..=token.text.as_str(), ..)
                     .await?;
                 Ok::<_, FullTextIndexError>(positional_posting_list)
             })
@@ -514,7 +514,7 @@ impl<'me> FullTextIndexReader<'me> {
     ) -> Result<Vec<(u32, Vec<u32>)>, FullTextIndexError> {
         let positional_posting_list = self
             .posting_lists_blockfile_reader
-            .get_by_prefix(token)
+            .get_range(token..=token, ..)
             .await?;
         let mut results = vec![];
         for (doc_id, positions) in positional_posting_list.iter() {
@@ -528,7 +528,7 @@ impl<'me> FullTextIndexReader<'me> {
     async fn get_frequencies_for_token(&self, token: &str) -> Result<u32, FullTextIndexError> {
         let res = self
             .frequencies_blockfile_reader
-            .get_by_prefix(token)
+            .get_range(token..=token, ..)
             .await?;
         if res.is_empty() {
             return Ok(0);

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -8,6 +8,7 @@ use core::ops::BitOr;
 use roaring::RoaringBitmap;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::ops::Bound;
 use std::sync::Arc;
 
 #[derive(Debug, Error)]
@@ -563,7 +564,9 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => {
-                    let read = blockfile_reader.get_lt(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(metadata_key..metadata_key, ..*k)
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -579,7 +582,9 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => {
-                    let read = blockfile_reader.get_lt(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(metadata_key..metadata_key, ..*k)
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -605,7 +610,9 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => {
-                    let read = blockfile_reader.get_lte(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(metadata_key..=metadata_key, ..=*k)
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -621,7 +628,9 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => {
-                    let read = blockfile_reader.get_lte(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(metadata_key..=metadata_key, ..=*k)
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -647,7 +656,12 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => {
-                    let read = blockfile_reader.get_gt(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(
+                            metadata_key..=metadata_key,
+                            (Bound::Excluded(*k), Bound::Unbounded),
+                        )
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -663,7 +677,12 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => {
-                    let read = blockfile_reader.get_gt(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(
+                            metadata_key..=metadata_key,
+                            (Bound::Excluded(*k), Bound::Unbounded),
+                        )
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -689,7 +708,9 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => {
-                    let read = blockfile_reader.get_gte(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(metadata_key..=metadata_key, *k..)
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();
@@ -705,7 +726,9 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => {
-                    let read = blockfile_reader.get_gte(metadata_key, *k).await;
+                    let read = blockfile_reader
+                        .get_range(metadata_key..=metadata_key, *k..)
+                        .await;
                     match read {
                         Ok(records) => {
                             let mut result = RoaringBitmap::new();

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -565,7 +565,7 @@ impl<'me> MetadataIndexReader<'me> {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => {
                     let read = blockfile_reader
-                        .get_range(metadata_key..metadata_key, ..*k)
+                        .get_range(metadata_key..=metadata_key, ..*k)
                         .await;
                     match read {
                         Ok(records) => {
@@ -583,7 +583,7 @@ impl<'me> MetadataIndexReader<'me> {
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => {
                     let read = blockfile_reader
-                        .get_range(metadata_key..metadata_key, ..*k)
+                        .get_range(metadata_key..=metadata_key, ..*k)
                         .await;
                     match read {
                         Ok(records) => {


### PR DESCRIPTION
## Description of changes

Last PR in this stack. Propagates `.get_range()` API to the rest of the codebase.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a