### PR TITLE
[ENH] Add count index

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/storage.rs
@@ -44,7 +44,7 @@ pub enum BlockKeyArrowBuilder {
 }
 
 impl BlockKeyArrowBuilder {
-    pub(super) fn add_key(&mut self, key: CompositeKey) {
+    pub(crate) fn add_key(&mut self, key: CompositeKey) {
         match key.key {
             KeyWrapper::String(value) => {
                 let builder = match self {

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -385,6 +385,7 @@ impl Block {
     /// Returns a reference to metadata of the block if any is present
     /// ### Notes
     /// - The metadata is stored in the Arrow RB schema as custom metadata
+    #[allow(dead_code)]
     pub(crate) fn metadata(&self) -> &HashMap<String, String> {
         let schema = self.data.schema_ref();
         schema.metadata()

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -104,7 +104,8 @@ impl ArrowBlockfileWriter {
             if !removed {
                 self.root
                     .sparse_index
-                    .set_count(delta.id, delta.len() as u32);
+                    .set_count(delta.id, delta.len() as u32)
+                    .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
                 let block = self.block_manager.commit::<K, V>(delta);
                 blocks.push(block);
             }

--- a/rust/blockstore/src/arrow/concurrency_test.rs
+++ b/rust/blockstore/src/arrow/concurrency_test.rs
@@ -56,7 +56,7 @@ mod tests {
 
                 // commit the writer
                 future::block_on(async {
-                    let flusher = writer.commit::<&str, u32>().unwrap();
+                    let flusher = writer.commit::<&str, u32>().await.unwrap();
                     flusher.flush::<&str, u32>().await.unwrap();
                 });
 

--- a/rust/blockstore/src/arrow/root.rs
+++ b/rust/blockstore/src/arrow/root.rs
@@ -194,7 +194,7 @@ pub struct RootReader {
     pub(super) sparse_index: SparseIndexReader,
     // Metadata
     pub(super) id: Uuid,
-    version: Version,
+    pub(super) version: Version,
 }
 
 impl chroma_cache::Weighted for RootReader {

--- a/rust/blockstore/src/arrow/root.rs
+++ b/rust/blockstore/src/arrow/root.rs
@@ -373,13 +373,16 @@ mod test {
 
         root_writer
             .sparse_index
-            .add_block(CompositeKey::new("prefix".to_string(), "a"), block_ids[1]);
+            .add_block(CompositeKey::new("prefix".to_string(), "a"), block_ids[1])
+            .expect("No error");
         root_writer
             .sparse_index
-            .add_block(CompositeKey::new("prefix".to_string(), "b"), block_ids[2]);
+            .add_block(CompositeKey::new("prefix".to_string(), "b"), block_ids[2])
+            .expect("No error");
         root_writer
             .sparse_index
-            .add_block(CompositeKey::new("prefix".to_string(), "c"), block_ids[3]);
+            .add_block(CompositeKey::new("prefix".to_string(), "c"), block_ids[3])
+            .expect("No error");
 
         root_writer.sparse_index.set_count(block_ids[0], 1);
         root_writer.sparse_index.set_count(block_ids[1], 2);

--- a/rust/blockstore/src/arrow/root.rs
+++ b/rust/blockstore/src/arrow/root.rs
@@ -1,20 +1,35 @@
 use super::{
-    block::Block,
-    sparse_index::{SparseIndexReader, SparseIndexWriter},
+    block::{Block, BlockToBytesError},
+    sparse_index::{SparseIndexReader, SparseIndexValue, SparseIndexWriter},
     types::{ArrowReadableKey, ArrowWriteableKey},
+};
+use crate::{arrow::sparse_index::SparseIndexDelimiter, key::CompositeKey};
+use arrow::{
+    array::{
+        Array, BinaryArray, BinaryBuilder, RecordBatch, StringArray, UInt32Array, UInt32Builder,
+    },
+    datatypes::{DataType, Field, Schema},
 };
 use chroma_error::ChromaError;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Display,
+    sync::Arc,
+};
 use thiserror::Error;
 use uuid::Uuid;
 
 pub(super) const CURRENT_VERSION: Version = Version::V1_1;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+// ================
+// Version
+// ================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub(super) enum Version {
-    V1,
-    V1_1,
+    V1 = 1,
+    V1_1 = 2,
 }
 
 impl Display for Version {
@@ -49,6 +64,10 @@ impl TryFrom<&str> for Version {
     }
 }
 
+// ================
+// RootWriter
+// ================
+
 #[derive(Debug, Clone)]
 pub(super) struct RootWriter {
     pub(super) sparse_index: SparseIndexWriter,
@@ -66,16 +85,114 @@ impl RootWriter {
         }
     }
 
-    pub(super) fn to_block<K: ArrowWriteableKey>(&self) -> Result<Block, Box<dyn ChromaError>> {
-        let delta = self.sparse_index.to_delta::<K>()?;
+    pub(super) fn to_bytes<K: ArrowWriteableKey>(&self) -> Result<Vec<u8>, Box<dyn ChromaError>> {
+        // Serialize the sparse index as an arrow record batch
+        // TODO(hammadb): Note that this should ideally use the Block API to serialize the sparse
+        // index, but we are currently using the arrow API directly because the block api
+        // does not support multiple columns with different types. When we add support for this
+        // we can switch to using the block API.
+        let sparse_index_data = self.sparse_index.data.lock();
+        let mut prefix_cap = 0;
+        let mut key_cap = 0;
+        for (key, _) in sparse_index_data.forward.iter() {
+            match key {
+                SparseIndexDelimiter::Start => {}
+                SparseIndexDelimiter::Key(k) => {
+                    prefix_cap += k.prefix.len();
+                    key_cap += k.key.get_size();
+                }
+            }
+        }
+        let mut key_builder =
+            K::get_arrow_builder(sparse_index_data.forward.len(), prefix_cap, key_cap);
+        let mut ids_builder = BinaryBuilder::new();
+        let mut count_builder = UInt32Builder::new();
+
+        for (key, value) in sparse_index_data.forward.iter() {
+            match key {
+                SparseIndexDelimiter::Start => key_builder.add_key(CompositeKey {
+                    prefix: "START".to_string(),
+                    key: K::default().into(),
+                }),
+                SparseIndexDelimiter::Key(k) => {
+                    key_builder.add_key(k.clone());
+                }
+            };
+            ids_builder.append_value(value.into_bytes());
+        }
+
+        for (_, value) in sparse_index_data.counts.iter() {
+            count_builder.append_value(*value);
+        }
+
+        let (prefix_field, prefix_arr, key_field, key_arr) = key_builder.as_arrow();
+        let built_ids = ids_builder.finish();
+        let built_counts = count_builder.finish();
+
+        println!("prefix_len: {}", prefix_arr.len());
+        println!("key_len: {}", key_arr.len());
+        println!("id_len: {}", built_ids.len());
+        println!("count_len: {}", built_counts.len());
+
         let metadata = HashMap::from_iter(vec![
             ("version".to_string(), self.version.to_string()),
             ("id".to_string(), self.id.to_string()),
         ]);
-        let record_batch = delta.finish::<K, String>(Some(metadata));
-        Ok(Block::from_record_batch(self.id, record_batch))
+
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![
+                prefix_field,
+                key_field,
+                Field::new("id", DataType::Binary, false),
+                Field::new("count", DataType::UInt32, false),
+            ],
+            metadata,
+        ));
+
+        let record_batch = match RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(prefix_arr),
+                Arc::new(key_arr),
+                Arc::new(built_ids),
+                Arc::new(built_counts),
+            ],
+        ) {
+            Ok(record_batch) => record_batch,
+            Err(e) => return Err(Box::new(ToBytesError::ArrowError(e))),
+        };
+
+        match Block::from_record_batch(self.id, record_batch).to_bytes() {
+            Ok(bytes) => Ok(bytes),
+            Err(e) => Err(Box::new(ToBytesError::BlockToBytesError(e))),
+        }
     }
 }
+
+// ================
+// Writer Errors
+// ================
+
+#[derive(Error, Debug)]
+pub enum ToBytesError {
+    #[error(transparent)]
+    BlockToBytesError(#[from] BlockToBytesError),
+    #[error(transparent)]
+    ArrowError(#[from] arrow::error::ArrowError),
+}
+
+impl ChromaError for ToBytesError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            ToBytesError::BlockToBytesError(_) => chroma_error::ErrorCodes::Internal,
+            ToBytesError::ArrowError(_) => chroma_error::ErrorCodes::Internal,
+        }
+    }
+}
+
+// ================
+// RootReader
+// ================
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RootReader {
@@ -92,7 +209,7 @@ impl chroma_cache::Weighted for RootReader {
 }
 
 #[derive(Error, Debug)]
-pub(super) enum FromBlockError {
+pub(super) enum FromBytesError {
     #[error("Error parsing UUID: {0}")]
     UuidParseError(#[from] uuid::Error),
     #[error("Error parsing version: {0}")]
@@ -100,57 +217,207 @@ pub(super) enum FromBlockError {
     #[error("Missing metadata: {0}")]
     MissingMetadata(String),
     #[error(transparent)]
+    ArrowError(#[from] arrow::error::ArrowError),
+    #[error("No data")]
+    NoDataError,
+    #[error("Stored id does not match provided id")]
+    IdMismatch,
+    #[error(transparent)]
     VersionError(#[from] VersionError),
 }
 
-impl ChromaError for FromBlockError {
+impl ChromaError for FromBytesError {
     fn code(&self) -> chroma_error::ErrorCodes {
         match self {
-            FromBlockError::UuidParseError(_) => chroma_error::ErrorCodes::InvalidArgument,
-            FromBlockError::VersionParseError(_) => chroma_error::ErrorCodes::InvalidArgument,
-            FromBlockError::MissingMetadata(_) => chroma_error::ErrorCodes::InvalidArgument,
-            FromBlockError::VersionError(e) => e.code(),
+            FromBytesError::UuidParseError(_) => chroma_error::ErrorCodes::InvalidArgument,
+            FromBytesError::VersionParseError(_) => chroma_error::ErrorCodes::InvalidArgument,
+            FromBytesError::MissingMetadata(_) => chroma_error::ErrorCodes::InvalidArgument,
+            FromBytesError::ArrowError(_) => chroma_error::ErrorCodes::Internal,
+            FromBytesError::NoDataError => chroma_error::ErrorCodes::Internal,
+            FromBytesError::IdMismatch => chroma_error::ErrorCodes::InvalidArgument,
+            FromBytesError::VersionError(e) => e.code(),
         }
     }
 }
 
 impl RootReader {
-    pub(super) fn from_block<'block, K: ArrowReadableKey<'block> + 'block>(
-        block: &'block Block,
-    ) -> Result<Self, FromBlockError> {
-        // Parse metadata
-        let block_metadata = block.metadata();
-        let (version, id) = match (block_metadata.get("version"), block_metadata.get("id")) {
-            (Some(version), Some(id)) => {
-                (Version::try_from(version.as_str())?, Uuid::parse_str(id)?)
-            }
-            (Some(_), None) => return Err(FromBlockError::MissingMetadata("id".to_string())),
+    pub(super) fn from_bytes<'data, K: ArrowReadableKey<'data>>(
+        bytes: &[u8],
+        id: Uuid,
+    ) -> Result<Self, FromBytesError> {
+        let mut cursor = std::io::Cursor::new(bytes);
+        let arrow_reader = arrow::ipc::reader::FileReader::try_new(&mut cursor, None);
+
+        let record_batch = match arrow_reader {
+            Ok(mut reader) => match reader.next() {
+                Some(Ok(batch)) => batch,
+                Some(Err(e)) => return Err(FromBytesError::ArrowError(e)),
+                None => {
+                    return Err(FromBytesError::NoDataError);
+                }
+            },
+            Err(e) => return Err(FromBytesError::ArrowError(e)),
+        };
+
+        let metadata = &record_batch.schema_ref().metadata;
+        let (version, read_id) = match (metadata.get("version"), metadata.get("id")) {
+            (Some(version), Some(read_id)) => (
+                Version::try_from(version.as_str())?,
+                Uuid::parse_str(read_id)?,
+            ),
+            (Some(_), None) => return Err(FromBytesError::MissingMetadata("id".to_string())),
             (None, Some(_)) => {
-                return Err(FromBlockError::MissingMetadata("version".to_string()));
+                return Err(FromBytesError::MissingMetadata("version".to_string()));
             }
             // We default to the current version in the absence of metadata for these fields for
             // backwards compatibility
-            (None, None) => (Version::V1, block.id),
+            (None, None) => (Version::V1, id),
         };
 
-        let sparse_index = match SparseIndexReader::from_block::<K>(block) {
-            Ok(sparse_index) => sparse_index,
-            Err(e) => return Err(FromBlockError::UuidParseError(e)),
-        };
+        if read_id != id {
+            return Err(FromBytesError::IdMismatch);
+        }
 
+        let prefix_arr = record_batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Prefix array to be a StringArray");
+        // Use unsafe to promote the liftimes using unsafe, we know record batch lives as long as it needs to.
+        // It only needs to live as long as the sparse index is being constructed.
+        // The sparse index copies the data so it can live as long as it needs to independently
+        let record_batch: &'data RecordBatch = unsafe { std::mem::transmute(&record_batch) };
+        let key_arr = record_batch.column(1);
+        let id_arr = record_batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("ID array to be a BinaryArray");
+
+        // Version 1.1 is the first version to have a count column
+        let mut counts = None;
+        if version >= Version::V1_1 {
+            let count_arr = record_batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("Count array to be a UInt32Array");
+            counts = Some(count_arr);
+        }
+
+        let sparse_index_len = prefix_arr.len();
+        let mut forward = BTreeMap::new();
+        for i in 0..sparse_index_len {
+            let prefix = prefix_arr.value(i);
+            let key = K::get(key_arr, i);
+            let block_id = match Uuid::from_slice(id_arr.value(i)) {
+                Ok(block_id) => block_id,
+                Err(e) => return Err(FromBytesError::UuidParseError(e)),
+            };
+
+            let count = match counts {
+                Some(count_arr) => count_arr.value(i),
+                None => 0,
+            };
+
+            match prefix {
+                "START" => {
+                    forward.insert(
+                        SparseIndexDelimiter::Start,
+                        SparseIndexValue::new(block_id, count),
+                    );
+                }
+                _ => {
+                    forward.insert(
+                        SparseIndexDelimiter::Key(CompositeKey::new(prefix.to_string(), key)),
+                        SparseIndexValue::new(block_id, count),
+                    );
+                }
+            }
+        }
+
+        let sparse_index_reader = SparseIndexReader::new(forward);
         Ok(Self {
             version,
-            sparse_index,
+            sparse_index: sparse_index_reader,
             id,
         })
     }
 
     pub(super) fn fork(&self, new_id: Uuid) -> RootWriter {
-        let new_sparse_index = self.sparse_index.fork(new_id);
+        let new_sparse_index = self.sparse_index.fork();
         RootWriter {
             version: self.version,
             sparse_index: new_sparse_index,
             id: new_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_to_from_bytes() {
+        let block_ids = [
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        ];
+        let sparse_index = SparseIndexWriter::new(block_ids[0]);
+
+        let bf_id = Uuid::new_v4();
+        let root_writer = RootWriter::new(CURRENT_VERSION, bf_id, sparse_index);
+
+        root_writer
+            .sparse_index
+            .add_block(CompositeKey::new("prefix".to_string(), "a"), block_ids[1]);
+        root_writer
+            .sparse_index
+            .add_block(CompositeKey::new("prefix".to_string(), "b"), block_ids[2]);
+        root_writer
+            .sparse_index
+            .add_block(CompositeKey::new("prefix".to_string(), "c"), block_ids[3]);
+
+        root_writer.sparse_index.set_count(block_ids[0], 1);
+        root_writer.sparse_index.set_count(block_ids[1], 2);
+        root_writer.sparse_index.set_count(block_ids[2], 3);
+        root_writer.sparse_index.set_count(block_ids[3], 4);
+
+        let bytes = root_writer
+            .to_bytes::<&str>()
+            .expect("To be able to serialize");
+        let root_reader =
+            RootReader::from_bytes::<&str>(&bytes, bf_id).expect("To be able to deserialize");
+
+        assert_eq!(
+            root_writer.sparse_index.len(),
+            root_reader.sparse_index.len()
+        );
+
+        // Check that the block mapping is the same
+        for (key, value) in root_writer.sparse_index.data.lock().forward.iter() {
+            assert_eq!(
+                root_reader.sparse_index.data.forward.get(key).unwrap().id,
+                *value
+            );
+        }
+
+        // Check that counts are the same
+        let writer_data = &root_writer.sparse_index.data.lock();
+        for (key, _) in writer_data.forward.iter() {
+            assert_eq!(
+                root_reader
+                    .sparse_index
+                    .data
+                    .forward
+                    .get(key)
+                    .unwrap()
+                    .count,
+                *writer_data.counts.get(key).unwrap()
+            );
         }
     }
 }

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -1,5 +1,5 @@
+use super::types::ArrowReadableKey;
 use crate::key::{CompositeKey, KeyWrapper};
-use chroma_error::ChromaError;
 use core::panic;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -8,9 +8,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use super::block::delta::BlockDelta;
-use super::block::Block;
-use super::types::{ArrowReadableKey, ArrowWriteableKey};
+#[cfg(test)]
+use thiserror::Error;
 
 // ============
 // Sparse Index Delimeter
@@ -65,13 +64,15 @@ impl Ord for SparseIndexDelimiter {
 #[derive(Clone)]
 pub struct SparseIndexWriter {
     pub(super) data: Arc<Mutex<SparseIndexWriterData>>,
-    // TODO: I don't think we need id here naymore since we have root_id
-    pub(super) id: Uuid,
 }
 
 pub(super) struct SparseIndexWriterData {
     pub(super) forward: BTreeMap<SparseIndexDelimiter, Uuid>,
     reverse: HashMap<Uuid, SparseIndexDelimiter>,
+    // The number of keys in each block in the sparse index.
+    // This is not intended updated incrementally, and is only populated
+    // at commit time of the blockfile.
+    pub(super) counts: BTreeMap<SparseIndexDelimiter, u32>,
 }
 
 impl SparseIndexWriterData {
@@ -81,18 +82,22 @@ impl SparseIndexWriterData {
 }
 
 impl SparseIndexWriter {
-    pub(super) fn new(id: Uuid, initial_block_id: Uuid) -> Self {
+    pub(super) fn new(initial_block_id: Uuid) -> Self {
         let mut forward = BTreeMap::new();
         let mut reverse = HashMap::new();
+        let counts = BTreeMap::new();
 
         forward.insert(SparseIndexDelimiter::Start, initial_block_id);
         reverse.insert(initial_block_id, SparseIndexDelimiter::Start);
 
-        let data = SparseIndexWriterData { forward, reverse };
+        let data = SparseIndexWriterData {
+            forward,
+            reverse,
+            counts,
+        };
 
         Self {
             data: Arc::new(Mutex::new(data)),
-            id,
         }
     }
 
@@ -109,14 +114,32 @@ impl SparseIndexWriter {
         if let Some(old_start_key) = data.reverse.remove(&old_block_id) {
             data.forward.remove(&old_start_key);
             data.forward.insert(old_start_key.clone(), new_block_id);
-            data.reverse.insert(new_block_id, old_start_key);
+            data.reverse.insert(new_block_id, old_start_key.clone());
+            let old_count = data
+                .counts
+                .remove(&old_start_key)
+                .expect("Invariant Violation, these maps are always in sync");
+            data.counts.insert(old_start_key, old_count);
         }
+    }
+
+    /// Set the number of keys in a block in the sparse index.
+    /// This is not intended to be updated incrementally, and is only populated
+    /// at commit time of the blockfile.
+    /// # Arguments
+    /// * `block_id` - The block id to set the count for
+    /// * `count` - The number of keys in the block
+    pub(super) fn set_count(&self, block_id: Uuid, count: u32) {
+        let mut data = self.data.lock();
+        // TODO: error if block_id does not exist
+        let start_key = data.reverse.get(&block_id).unwrap().clone();
+        data.counts.insert(start_key, count);
     }
 
     pub(super) fn get_target_block_id(&self, search_key: &CompositeKey) -> Uuid {
         let data = self.data.lock();
         let forward = &data.forward;
-        get_target_block_id(search_key, forward)
+        *get_target_block(search_key, forward)
     }
 
     pub(super) fn len(&self) -> usize {
@@ -136,6 +159,7 @@ impl SparseIndexWriter {
         if data.len() > 1 {
             if let Some(start_key) = data.reverse.remove(block_id) {
                 data.forward.remove(&start_key);
+                data.counts.remove(&start_key).expect("Invariant violation");
             }
             removed = true;
         }
@@ -163,56 +187,46 @@ impl SparseIndexWriter {
             }
             key_copy = key.clone();
         }
-        tracing::info!("Correcting start key of sparse index {:?}", self.id);
+        tracing::info!("Correcting start key of sparse index");
         if let Some(id) = data.forward.remove(&key_copy) {
             data.reverse.remove(&id);
             data.forward.insert(SparseIndexDelimiter::Start, id);
             data.reverse.insert(id, SparseIndexDelimiter::Start);
+            let old_count = data
+                .counts
+                .remove(&key_copy)
+                .expect("Invariant violation. This should always be populated if forward is");
+            data.counts.insert(SparseIndexDelimiter::Start, old_count);
         }
     }
 
-    pub(super) fn to_delta<K: ArrowWriteableKey>(
-        &self,
-    ) -> Result<BlockDelta, Box<dyn ChromaError>> {
+    #[cfg(test)]
+    fn to_reader(&self) -> Result<SparseIndexReader, ToReaderError> {
         let data = self.data.lock();
-        if data.forward.is_empty() {
-            panic!("Invariant violation. No blocks in the sparse index");
+        if data.forward.len() != data.counts.len() {
+            return Err(ToReaderError::CountsNotSet);
         }
 
-        // TODO: we could save the uuid not as a string to be more space efficient
-        // but given the scale is relatively small, this is fine for now
-        let delta = BlockDelta::new::<K, String>(self.id);
-        for (key, block_id) in data.forward.iter() {
-            match key {
-                SparseIndexDelimiter::Start => {
-                    delta.add("START", K::default(), block_id.to_string());
-                }
-                SparseIndexDelimiter::Key(k) => match &k.key {
-                    KeyWrapper::String(s) => {
-                        delta.add(&k.prefix, s.as_str(), block_id.to_string());
-                    }
-                    KeyWrapper::Float32(f) => {
-                        delta.add(&k.prefix, *f, block_id.to_string());
-                    }
-                    KeyWrapper::Bool(b) => {
-                        delta.add(&k.prefix, *b, block_id.to_string());
-                    }
-                    KeyWrapper::Uint32(u) => {
-                        delta.add(&k.prefix, *u, block_id.to_string());
-                    }
-                },
-            }
-        }
-        Ok(delta)
+        let zipped = data.forward.iter().zip(data.counts.iter());
+        let new_forward = zipped.map(|((key, block_id), (_, count))| {
+            (key.clone(), SparseIndexValue::new(*block_id, *count))
+        });
+        let new_forward = BTreeMap::from_iter(new_forward);
+        Ok(SparseIndexReader::new(new_forward))
     }
 }
 
 impl Debug for SparseIndexWriter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SparseIndexWriter")
-            .field("id", &self.id)
-            .finish()
+        f.debug_struct("SparseIndexWriter").finish()
     }
+}
+
+#[cfg(test)]
+#[derive(Error, Debug)]
+enum ToReaderError {
+    #[error("Counts not set to be the same length as forward")]
+    CountsNotSet,
 }
 
 // ============
@@ -220,41 +234,51 @@ impl Debug for SparseIndexWriter {
 // ============
 
 /// A sparse index is used by a Blockfile to map a range of keys to a block id
-/// # Methods
-/// - `new` - Create a new sparse index with a single block
-/// - `from` - Create a new sparse index from an existing sparse index
-/// - `get_target_block_id` - Get the block id for a given key
-/// - `add_block` - Add a new block to the sparse index
-/// - `replace_block` - Replace an existing block with a new one
-/// - `len` - Get the number of blocks in the sparse index
-/// - `is_valid` - Check if the sparse index is valid, useful for debugging and testing
-// #[derive(Clone, Serialize, Deserialize)]
-// pub struct SparseIndex {
-//     pub(super) data: Arc<Mutex<SparseIndexData>>,
-//     pub(super) id: Uuid,
-// }
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct SparseIndexReader {
     pub(super) data: Arc<SparseIndexReaderData>,
-    pub(super) id: Uuid,
 }
 
 #[derive(Serialize, Deserialize)]
 pub(super) struct SparseIndexReaderData {
-    pub(super) forward: BTreeMap<SparseIndexDelimiter, Uuid>,
+    pub(super) forward: BTreeMap<SparseIndexDelimiter, SparseIndexValue>,
+}
+
+/// A value in the sparse index.
+/// # Fields
+/// * `id` - The block id that contains the keys in the range
+/// * `count` - The number of keys in the block
+#[derive(Serialize, Deserialize)]
+pub(super) struct SparseIndexValue {
+    pub(super) id: Uuid,
+    pub(super) count: u32,
+}
+
+impl SparseIndexValue {
+    pub(super) fn new(id: Uuid, count: u32) -> Self {
+        Self { id, count }
+    }
 }
 
 impl SparseIndexReader {
+    pub(super) fn new(data: BTreeMap<SparseIndexDelimiter, SparseIndexValue>) -> Self {
+        Self {
+            data: Arc::new(SparseIndexReaderData { forward: data }),
+        }
+    }
+
+    /// Get the number of keys in the sparse index
     pub(super) fn len(&self) -> usize {
         self.data.forward.len()
     }
 
+    /// Get the block id for a given key
     pub(super) fn get_target_block_id(&self, search_key: &CompositeKey) -> Uuid {
         let forward = &self.data.forward;
-        get_target_block_id(search_key, forward)
+        get_target_block(search_key, forward).id
     }
 
+    /// Get all the block ids that contain keys in the given input search keys
     pub(super) fn get_all_target_block_ids(&self, mut search_keys: Vec<CompositeKey>) -> Vec<Uuid> {
         // Sort so that we can search in one iteration.
         let data = &self.data;
@@ -264,7 +288,7 @@ impl SparseIndexReader {
         let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut search_iter = search_keys.iter().peekable();
-        for (curr_key, curr_block_id) in curr_iter {
+        for (curr_key, curr_block_value) in curr_iter {
             let search_key = match search_iter.peek() {
                 Some(key) => SparseIndexDelimiter::Key((**key).clone()),
                 None => {
@@ -273,7 +297,7 @@ impl SparseIndexReader {
             };
             if let Some((next_key, _)) = next_iter.next() {
                 if search_key >= *curr_key && search_key < *next_key {
-                    result_uuids.push(*curr_block_id);
+                    result_uuids.push(curr_block_value.id);
                     // Move forward all search keys that match this block.
                     search_iter.next();
                     while let Some(key) = search_iter.peek() {
@@ -287,20 +311,21 @@ impl SparseIndexReader {
                 }
             } else {
                 // last block. All the remaining keys should be satisfied by this.
-                result_uuids.push(*curr_block_id);
+                result_uuids.push(curr_block_value.id);
                 break;
             }
         }
         result_uuids
     }
 
+    /// Get all block ids that have keys with the given prefix
     pub(super) fn get_block_ids_prefix(&self, prefix: &str) -> Vec<Uuid> {
         let data = &self.data;
         let forward = &data.forward;
         let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut block_ids = vec![];
-        for (curr_key, curr_uuid) in curr_iter {
+        for (curr_key, curr_block_value) in curr_iter {
             let non_start_curr_key: Option<&CompositeKey> = match curr_key {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -318,7 +343,7 @@ impl SparseIndexReader {
                 if non_start_curr_key.is_some()
                     && prefix == non_start_curr_key.unwrap().prefix.as_str()
                 {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
                 // If prefix is between the current delim and next delim then there could
                 // be keys in this block that have this prefix.
@@ -326,20 +351,21 @@ impl SparseIndexReader {
                     || prefix > non_start_curr_key.unwrap().prefix.as_str())
                     && (prefix <= non_start_next_key.unwrap().prefix.as_str())
                 {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
             } else {
                 // Last block.
                 if non_start_curr_key.is_none()
                     || prefix >= non_start_curr_key.unwrap().prefix.as_str()
                 {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
             }
         }
         block_ids
     }
 
+    /// Get all block ids that have keys with the given prefix and key greater than the given key
     pub(super) fn get_block_ids_gt<'a, K: ArrowReadableKey<'a> + Into<KeyWrapper>>(
         &self,
         prefix: &str,
@@ -350,7 +376,7 @@ impl SparseIndexReader {
         let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut block_ids = vec![];
-        for (curr_delim, curr_uuid) in curr_iter {
+        for (curr_delim, curr_block_value) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -367,20 +393,21 @@ impl SparseIndexReader {
             if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
                 && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
             {
-                block_ids.push(*curr_uuid);
+                block_ids.push(curr_block_value.id);
             }
             if let Some(curr_key) = curr_key {
                 if (curr_key.key > key.clone().into())
                     || next_key.is_none()
                     || next_key.unwrap().key > key.clone().into()
                 {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
             }
         }
         block_ids
     }
 
+    /// Get all block ids that have keys with the given prefix and key less than the given key
     pub(super) fn get_block_ids_lt<'a, K: ArrowReadableKey<'a> + Into<KeyWrapper>>(
         &self,
         prefix: &str,
@@ -391,7 +418,7 @@ impl SparseIndexReader {
         let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut block_ids = vec![];
-        for (curr_delim, curr_uuid) in curr_iter {
+        for (curr_delim, curr_block_value) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -408,17 +435,18 @@ impl SparseIndexReader {
             if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
                 && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
             {
-                block_ids.push(*curr_uuid);
+                block_ids.push(curr_block_value.id);
             }
             if let Some(curr_key) = curr_key {
                 if curr_key.prefix.as_str() == prefix && curr_key.key < key.clone().into() {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
             }
         }
         block_ids
     }
 
+    /// Get all block ids that have keys with the given prefix and key greater than or equal to the given key
     pub(super) fn get_block_ids_gte<'a, K: ArrowReadableKey<'a> + Into<KeyWrapper>>(
         &self,
         prefix: &str,
@@ -429,7 +457,7 @@ impl SparseIndexReader {
         let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut block_ids = vec![];
-        for (curr_delim, curr_uuid) in curr_iter {
+        for (curr_delim, curr_block_value) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -446,20 +474,21 @@ impl SparseIndexReader {
             if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
                 && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
             {
-                block_ids.push(*curr_uuid);
+                block_ids.push(curr_block_value.id);
             }
             if let Some(curr_key) = curr_key {
                 if curr_key.key >= key.clone().into()
                     || next_key.is_none()
                     || next_key.unwrap().key >= key.clone().into()
                 {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
             }
         }
         block_ids
     }
 
+    /// Get all block ids that have keys with the given prefix and key less than or equal to the given key
     pub(super) fn get_block_ids_lte<'a, K: ArrowReadableKey<'a> + Into<KeyWrapper>>(
         &self,
         prefix: &str,
@@ -470,7 +499,7 @@ impl SparseIndexReader {
         let curr_iter = forward.iter();
         let mut next_iter = forward.iter().skip(1);
         let mut block_ids = vec![];
-        for (curr_delim, curr_uuid) in curr_iter {
+        for (curr_delim, curr_block_value) in curr_iter {
             let curr_key = match curr_delim {
                 SparseIndexDelimiter::Start => None,
                 SparseIndexDelimiter::Key(k) => Some(k),
@@ -487,32 +516,37 @@ impl SparseIndexReader {
             if (curr_key.is_none() || curr_key.unwrap().prefix.as_str() < prefix)
                 && (next_key.is_none() || next_key.unwrap().prefix.as_str() >= prefix)
             {
-                block_ids.push(*curr_uuid);
+                block_ids.push(curr_block_value.id);
             }
             if let Some(curr_key) = curr_key {
                 if curr_key.prefix.as_str() == prefix && curr_key.key <= key.clone().into() {
-                    block_ids.push(*curr_uuid);
+                    block_ids.push(curr_block_value.id);
                 }
             }
         }
         block_ids
     }
 
-    pub(super) fn fork(&self, new_id: Uuid) -> SparseIndexWriter {
+    /// Fork the sparse index to create a new sparse index
+    /// with the same data as the current sparse index
+    pub(super) fn fork(&self) -> SparseIndexWriter {
         let mut new_forward = BTreeMap::new();
         let mut new_reverse = HashMap::new();
+        let mut new_counts = BTreeMap::new();
         let old_data = &self.data;
         let old_forward = &old_data.forward;
-        for (key, block_id) in old_forward.iter() {
-            new_forward.insert(key.clone(), *block_id);
-            new_reverse.insert(*block_id, key.clone());
+        for (key, curr_block_value) in old_forward.iter() {
+            new_forward.insert(key.clone(), curr_block_value.id);
+            new_reverse.insert(curr_block_value.id, key.clone());
+            new_counts.insert(key.clone(), curr_block_value.count);
         }
+
         SparseIndexWriter {
             data: Arc::new(Mutex::new(SparseIndexWriterData {
                 forward: new_forward,
                 reverse: new_reverse,
+                counts: new_counts,
             })),
-            id: new_id,
         }
     }
 
@@ -539,61 +573,24 @@ impl SparseIndexReader {
         }
         true
     }
-
-    pub(super) fn from_block<'block, K: ArrowReadableKey<'block> + 'block>(
-        block: &'block Block,
-    ) -> Result<Self, uuid::Error> {
-        let mut forward = BTreeMap::new();
-        let id = block.id;
-        let mut i = 0;
-        while let Some((prefix, key, value)) = block.get_at_index::<K, &str>(i) {
-            let (delimiter, block_id) = match prefix {
-                "START" => {
-                    let block_id = Uuid::parse_str(value);
-                    match block_id {
-                        Ok(block_id) => (SparseIndexDelimiter::Start, block_id),
-                        Err(e) => return Err(e),
-                    }
-                }
-                _ => {
-                    let block_id = Uuid::parse_str(value);
-                    match block_id {
-                        Ok(block_id) => (
-                            SparseIndexDelimiter::Key(CompositeKey::new(prefix.to_string(), key)),
-                            block_id,
-                        ),
-                        Err(e) => return Err(e),
-                    }
-                }
-            };
-            forward.insert(delimiter.clone(), block_id);
-            i += 1;
-        }
-        Ok(Self {
-            data: Arc::new(SparseIndexReaderData { forward }),
-            id,
-        })
-    }
 }
 
 impl Debug for SparseIndexReader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SparseIndexReader")
-            .field("id", &self.id)
-            .finish()
+        f.debug_struct("SparseIndexReader").finish()
     }
 }
 
 // Helper function to get the target block id for a given key
-fn get_target_block_id(
+fn get_target_block<'data, T>(
     search_key: &CompositeKey,
-    forward: &BTreeMap<SparseIndexDelimiter, Uuid>,
-) -> Uuid {
+    forward: &'data BTreeMap<SparseIndexDelimiter, T>,
+) -> &'data T {
     match forward
         .range(..=SparseIndexDelimiter::Key(search_key.clone()))
         .next_back()
     {
-        Some((_, block_id)) => *block_id,
+        Some((_, data)) => data,
         None => {
             panic!("No blocks in the sparse index");
         }
@@ -606,11 +603,11 @@ mod tests {
 
     #[test]
     fn test_sparse_index() {
-        let file_id = uuid::Uuid::new_v4();
         let block_id_1 = uuid::Uuid::new_v4();
-        let sparse_index = SparseIndexWriter::new(file_id, block_id_1);
+        let sparse_index = SparseIndexWriter::new(block_id_1);
         let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
         sparse_index.add_block(blockfile_key.clone(), block_id_1);
+        sparse_index.set_count(block_id_1, 10);
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_1);
 
         blockfile_key = CompositeKey::new("prefix".to_string(), "b");
@@ -620,6 +617,7 @@ mod tests {
         let block_id_2 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "c");
         sparse_index.add_block(blockfile_key.clone(), block_id_2);
+        sparse_index.set_count(block_id_2, 20);
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_2);
 
         // d should fall into the second block
@@ -630,6 +628,7 @@ mod tests {
         let block_id_3 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "f");
         sparse_index.add_block(blockfile_key.clone(), block_id_3);
+        sparse_index.set_count(block_id_3, 30);
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_3);
 
         // g should fall into the third block
@@ -642,27 +641,25 @@ mod tests {
     }
 
     #[test]
-    fn test_to_from_block() {
-        let file_id = uuid::Uuid::new_v4();
+    fn test_to_reader() {
         let block_id_0 = uuid::Uuid::new_v4();
 
         // Add an initial block to the sparse index
-        let sparse_index = SparseIndexWriter::new(file_id, block_id_0);
+        let sparse_index = SparseIndexWriter::new(block_id_0);
+        sparse_index.set_count(block_id_0, 5);
 
         // Add some more blocks
         let blockfile_key = CompositeKey::new("prefix".to_string(), "a");
         let block_id_1 = uuid::Uuid::new_v4();
         sparse_index.add_block(blockfile_key.clone(), block_id_1);
+        sparse_index.set_count(block_id_1, 10);
 
         let blockfile_key = CompositeKey::new("prefix".to_string(), "c");
         let block_id_2 = uuid::Uuid::new_v4();
         sparse_index.add_block(blockfile_key.clone(), block_id_2);
+        sparse_index.set_count(block_id_2, 20);
 
-        let block_delta = sparse_index.to_delta::<&str>().unwrap();
-        let block =
-            Block::from_record_batch(block_delta.id, block_delta.finish::<&str, String>(None));
-        let new_sparse_index = SparseIndexReader::from_block::<&str>(&block).unwrap();
-
+        let new_sparse_index = sparse_index.to_reader().expect("Conversion should succeed");
         let old_data = sparse_index.data.lock();
 
         assert_eq!(old_data.forward.len(), old_data.reverse.len());
@@ -672,8 +669,7 @@ mod tests {
         }
 
         // Test fork for reverse map
-        let new_id = uuid::Uuid::new_v4();
-        let forked_sparse_index = new_sparse_index.fork(new_id);
+        let forked_sparse_index = new_sparse_index.fork();
         let forked_data = forked_sparse_index.data.lock();
         assert_eq!(old_data.reverse.len(), forked_data.reverse.len());
         for (old_block_id, old_key) in old_data.reverse.iter() {
@@ -684,21 +680,25 @@ mod tests {
 
     #[test]
     fn test_get_all_block_ids() {
-        let file_id = uuid::Uuid::new_v4();
-        let block_id_1 = uuid::Uuid::new_v4();
-        let sparse_index = SparseIndexWriter::new(file_id, block_id_1);
+        let block_id_0 = uuid::Uuid::new_v4();
+        let writer = SparseIndexWriter::new(block_id_0);
+        writer.set_count(block_id_0, 5);
         let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
-        sparse_index.add_block(blockfile_key.clone(), block_id_1);
+        let block_id_1 = uuid::Uuid::new_v4();
+        writer.add_block(blockfile_key.clone(), block_id_1);
+        writer.set_count(block_id_1, 10);
 
         // Split the range into two blocks (start, c), and (c, end)
         let block_id_2 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "d");
-        sparse_index.add_block(blockfile_key.clone(), block_id_2);
+        writer.add_block(blockfile_key.clone(), block_id_2);
+        writer.set_count(block_id_2, 10);
 
         // Split the second block into (c, f) and (f, end)
         let block_id_3 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "f");
-        sparse_index.add_block(blockfile_key.clone(), block_id_3);
+        writer.add_block(blockfile_key.clone(), block_id_3);
+        writer.set_count(block_id_3, 10);
         let composite_keys = vec![
             CompositeKey::new("prefix".to_string(), "b"),
             CompositeKey::new("prefix".to_string(), "c"),
@@ -706,11 +706,7 @@ mod tests {
             CompositeKey::new("prefix".to_string(), "e"),
         ];
 
-        let as_block = sparse_index.to_delta::<&str>().unwrap();
-        let as_block = Block::from_record_batch(as_block.id, as_block.finish::<&str, String>(None));
-        let reader = SparseIndexReader::from_block::<&str>(&as_block)
-            .expect("Should be able to create reader");
-
+        let reader = writer.to_reader().expect("Conversion should succeed");
         let blocks = reader.get_all_target_block_ids(composite_keys);
         assert_eq!(blocks.len(), 2);
         assert!(blocks.contains(&block_id_1));
@@ -728,21 +724,22 @@ mod tests {
 
     #[test]
     fn test_serde() {
-        let sparse_index_id = uuid::Uuid::new_v4();
-        let block_id_1 = uuid::Uuid::new_v4();
-        let sparse_index = SparseIndexWriter::new(sparse_index_id, block_id_1);
-        let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
-        sparse_index.add_block(blockfile_key.clone(), block_id_1);
+        let ids = [uuid::Uuid::new_v4(), uuid::Uuid::new_v4()];
+        let counts = [10, 20];
+        let keys = [
+            CompositeKey::new("prefix".to_string(), "a"),
+            CompositeKey::new("prefix".to_string(), "c"),
+        ];
+
+        let sparse_index = SparseIndexWriter::new(ids[0]);
+        // sparse_index.add_block(keys[0].clone(), ids[0]);
+        sparse_index.set_count(ids[0], counts[0]);
 
         // Split the range into two blocks (start, c), and (c, end)
-        let block_id_2 = uuid::Uuid::new_v4();
-        blockfile_key = CompositeKey::new("prefix".to_string(), "c");
-        sparse_index.add_block(blockfile_key.clone(), block_id_2);
+        sparse_index.add_block(keys[1].clone(), ids[1]);
+        sparse_index.set_count(ids[1], counts[1]);
 
-        let as_block = sparse_index.to_delta::<&str>().unwrap();
-        let as_block = Block::from_record_batch(as_block.id, as_block.finish::<&str, String>(None));
-        let reader = SparseIndexReader::from_block::<&str>(&as_block)
-            .expect("Should be able to create reader");
+        let reader = sparse_index.to_reader().expect("Conversion should succeed");
 
         let serialized = bincode::serialize(&reader).unwrap();
         let deserialized: SparseIndexReader = bincode::deserialize(&serialized).unwrap();
@@ -750,7 +747,16 @@ mod tests {
         let old_data = sparse_index.data.lock();
         let new_data = deserialized.data;
         for (key, block_id) in old_data.forward.iter() {
-            assert_eq!(new_data.forward.get(key).unwrap(), block_id);
+            assert_eq!(new_data.forward.get(key).unwrap().id, *block_id);
+        }
+
+        for i in 0..ids.len() {
+            let target_key = match i {
+                0 => SparseIndexDelimiter::Start,
+                _ => SparseIndexDelimiter::Key(keys[i].clone()),
+            };
+            assert_eq!(new_data.forward.get(&target_key).unwrap().count, counts[i]);
+            assert_eq!(new_data.forward.get(&target_key).unwrap().id, ids[i]);
         }
     }
 }

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -1,5 +1,6 @@
 use super::types::ArrowReadableKey;
 use crate::key::{CompositeKey, KeyWrapper};
+use chroma_error::ChromaError;
 use core::panic;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -81,6 +82,20 @@ impl SparseIndexWriterData {
     }
 }
 
+#[derive(Error, Debug)]
+pub enum AddError {
+    #[error("Block id already exists in the sparse index")]
+    BlockIdExists,
+}
+
+impl ChromaError for AddError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            AddError::BlockIdExists => chroma_error::ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
 impl SparseIndexWriter {
     pub(super) fn new(initial_block_id: Uuid) -> Self {
         let mut forward = BTreeMap::new();
@@ -101,12 +116,23 @@ impl SparseIndexWriter {
         }
     }
 
-    pub(super) fn add_block(&self, start_key: CompositeKey, block_id: Uuid) {
+    pub(super) fn add_block(
+        &self,
+        start_key: CompositeKey,
+        block_id: Uuid,
+    ) -> Result<(), AddError> {
         let mut data = self.data.lock();
+
+        if data.reverse.contains_key(&block_id) {
+            return Err(AddError::BlockIdExists);
+        }
+
         data.forward
             .insert(SparseIndexDelimiter::Key(start_key.clone()), block_id);
         data.reverse
             .insert(block_id, SparseIndexDelimiter::Key(start_key));
+
+        Ok(())
     }
 
     pub(super) fn replace_block(&self, old_block_id: Uuid, new_block_id: Uuid) {
@@ -606,7 +632,6 @@ mod tests {
         let block_id_1 = uuid::Uuid::new_v4();
         let sparse_index = SparseIndexWriter::new(block_id_1);
         let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
-        sparse_index.add_block(blockfile_key.clone(), block_id_1);
         sparse_index.set_count(block_id_1, 10);
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_1);
 
@@ -616,7 +641,9 @@ mod tests {
         // Split the range into two blocks (start, c), and (c, end)
         let block_id_2 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "c");
-        sparse_index.add_block(blockfile_key.clone(), block_id_2);
+        sparse_index
+            .add_block(blockfile_key.clone(), block_id_2)
+            .expect("No error");
         sparse_index.set_count(block_id_2, 20);
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_2);
 
@@ -627,7 +654,9 @@ mod tests {
         // Split the second block into (c, f) and (f, end)
         let block_id_3 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "f");
-        sparse_index.add_block(blockfile_key.clone(), block_id_3);
+        sparse_index
+            .add_block(blockfile_key.clone(), block_id_3)
+            .expect("No error");
         sparse_index.set_count(block_id_3, 30);
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_3);
 
@@ -651,12 +680,16 @@ mod tests {
         // Add some more blocks
         let blockfile_key = CompositeKey::new("prefix".to_string(), "a");
         let block_id_1 = uuid::Uuid::new_v4();
-        sparse_index.add_block(blockfile_key.clone(), block_id_1);
+        sparse_index
+            .add_block(blockfile_key.clone(), block_id_1)
+            .expect("No error");
         sparse_index.set_count(block_id_1, 10);
 
         let blockfile_key = CompositeKey::new("prefix".to_string(), "c");
         let block_id_2 = uuid::Uuid::new_v4();
-        sparse_index.add_block(blockfile_key.clone(), block_id_2);
+        sparse_index
+            .add_block(blockfile_key.clone(), block_id_2)
+            .expect("No error");
         sparse_index.set_count(block_id_2, 20);
 
         let new_sparse_index = sparse_index.to_reader().expect("Conversion should succeed");
@@ -685,19 +718,25 @@ mod tests {
         writer.set_count(block_id_0, 5);
         let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
         let block_id_1 = uuid::Uuid::new_v4();
-        writer.add_block(blockfile_key.clone(), block_id_1);
+        writer
+            .add_block(blockfile_key.clone(), block_id_1)
+            .expect("No error");
         writer.set_count(block_id_1, 10);
 
         // Split the range into two blocks (start, c), and (c, end)
         let block_id_2 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "d");
-        writer.add_block(blockfile_key.clone(), block_id_2);
+        writer
+            .add_block(blockfile_key.clone(), block_id_2)
+            .expect("No error");
         writer.set_count(block_id_2, 10);
 
         // Split the second block into (c, f) and (f, end)
         let block_id_3 = uuid::Uuid::new_v4();
         blockfile_key = CompositeKey::new("prefix".to_string(), "f");
-        writer.add_block(blockfile_key.clone(), block_id_3);
+        writer
+            .add_block(blockfile_key.clone(), block_id_3)
+            .expect("No error");
         writer.set_count(block_id_3, 10);
         let composite_keys = vec![
             CompositeKey::new("prefix".to_string(), "b"),
@@ -732,12 +771,12 @@ mod tests {
         ];
 
         let sparse_index = SparseIndexWriter::new(ids[0]);
-        // sparse_index.add_block(keys[0].clone(), ids[0]);
-        // TODO: WHY THE FUCK IS THIS BUGGING!? IF UNCOMMENT LINE ABOVE
         sparse_index.set_count(ids[0], counts[0]);
 
         // Split the range into two blocks (start, c), and (c, end)
-        sparse_index.add_block(keys[1].clone(), ids[1]);
+        sparse_index
+            .add_block(keys[1].clone(), ids[1])
+            .expect("No error");
         sparse_index.set_count(ids[1], counts[1]);
 
         let reader = sparse_index.to_reader().expect("Conversion should succeed");

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -10,9 +10,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[cfg(test)]
-use thiserror::Error;
-
 // ============
 // Sparse Index Delimeter
 // ============

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -733,6 +733,7 @@ mod tests {
 
         let sparse_index = SparseIndexWriter::new(ids[0]);
         // sparse_index.add_block(keys[0].clone(), ids[0]);
+        // TODO: WHY THE FUCK IS THIS BUGGING!? IF UNCOMMENT LINE ABOVE
         sparse_index.set_count(ids[0], counts[0]);
 
         // Split the range into two blocks (start, c), and (c, end)

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::sync::Arc;
+use thiserror::Error;
 use uuid::Uuid;
 
 #[cfg(test)]
@@ -96,6 +97,20 @@ impl ChromaError for AddError {
     }
 }
 
+#[derive(Error, Debug)]
+pub enum SetCountError {
+    #[error("Block id does not exist in the sparse index")]
+    BlockIdDoesNotExist,
+}
+
+impl ChromaError for SetCountError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            SetCountError::BlockIdDoesNotExist => chroma_error::ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
 impl SparseIndexWriter {
     pub(super) fn new(initial_block_id: Uuid) -> Self {
         let mut forward = BTreeMap::new();
@@ -155,11 +170,16 @@ impl SparseIndexWriter {
     /// # Arguments
     /// * `block_id` - The block id to set the count for
     /// * `count` - The number of keys in the block
-    pub(super) fn set_count(&self, block_id: Uuid, count: u32) {
+    pub(super) fn set_count(&self, block_id: Uuid, count: u32) -> Result<(), SetCountError> {
         let mut data = self.data.lock();
-        // TODO: error if block_id does not exist
-        let start_key = data.reverse.get(&block_id).unwrap().clone();
-        data.counts.insert(start_key, count);
+        let start_key = data.reverse.get(&block_id);
+        match start_key.cloned() {
+            Some(start_key) => {
+                data.counts.insert(start_key, count);
+                Ok(())
+            }
+            None => Err(SetCountError::BlockIdDoesNotExist),
+        }
     }
 
     pub(super) fn get_target_block_id(&self, search_key: &CompositeKey) -> Uuid {
@@ -632,7 +652,9 @@ mod tests {
         let block_id_1 = uuid::Uuid::new_v4();
         let sparse_index = SparseIndexWriter::new(block_id_1);
         let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
-        sparse_index.set_count(block_id_1, 10);
+        sparse_index
+            .set_count(block_id_1, 10)
+            .expect("Set count should succeed");
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_1);
 
         blockfile_key = CompositeKey::new("prefix".to_string(), "b");
@@ -644,7 +666,9 @@ mod tests {
         sparse_index
             .add_block(blockfile_key.clone(), block_id_2)
             .expect("No error");
-        sparse_index.set_count(block_id_2, 20);
+        sparse_index
+            .set_count(block_id_2, 20)
+            .expect("Set count should succeed");
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_2);
 
         // d should fall into the second block
@@ -657,7 +681,9 @@ mod tests {
         sparse_index
             .add_block(blockfile_key.clone(), block_id_3)
             .expect("No error");
-        sparse_index.set_count(block_id_3, 30);
+        sparse_index
+            .set_count(block_id_3, 30)
+            .expect("Set count should succeed");
         assert_eq!(sparse_index.get_target_block_id(&blockfile_key), block_id_3);
 
         // g should fall into the third block
@@ -670,12 +696,64 @@ mod tests {
     }
 
     #[test]
+    fn test_count() {
+        let ids = [
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+        ];
+        let keys = [
+            CompositeKey::new("prefix".to_string(), "a"),
+            CompositeKey::new("prefix".to_string(), "c"),
+            CompositeKey::new("prefix".to_string(), "e"),
+        ];
+        let counts = [10, 20, 30];
+
+        let sparse_index = SparseIndexWriter::new(ids[0]);
+        sparse_index
+            .set_count(ids[0], counts[0])
+            .expect("Set count should succeed");
+        sparse_index
+            .add_block(keys[1].clone(), ids[1])
+            .expect("No error");
+        sparse_index
+            .set_count(ids[1], counts[1])
+            .expect("Set count should succeed");
+        sparse_index
+            .add_block(keys[2].clone(), ids[2])
+            .expect("No error");
+        sparse_index
+            .set_count(ids[2], counts[2])
+            .expect("Set count should succeed");
+
+        // Check that the counts are set correctly
+        assert_eq!(sparse_index.data.lock().counts.len(), 3);
+        for i in 0..ids.len() {
+            let target_key = match i {
+                0 => SparseIndexDelimiter::Start,
+                _ => SparseIndexDelimiter::Key(keys[i].clone()),
+            };
+            assert_eq!(
+                sparse_index.data.lock().counts.get(&target_key).unwrap(),
+                &counts[i]
+            );
+        }
+
+        // Check that we can't insert count for block not in map
+        let non_existent_id = uuid::Uuid::new_v4();
+        let result = sparse_index.set_count(non_existent_id, 10);
+        assert!(matches!(result, Err(SetCountError::BlockIdDoesNotExist)));
+    }
+
+    #[test]
     fn test_to_reader() {
         let block_id_0 = uuid::Uuid::new_v4();
 
         // Add an initial block to the sparse index
         let sparse_index = SparseIndexWriter::new(block_id_0);
-        sparse_index.set_count(block_id_0, 5);
+        sparse_index
+            .set_count(block_id_0, 5)
+            .expect("Set count should succeed");
 
         // Add some more blocks
         let blockfile_key = CompositeKey::new("prefix".to_string(), "a");
@@ -683,14 +761,18 @@ mod tests {
         sparse_index
             .add_block(blockfile_key.clone(), block_id_1)
             .expect("No error");
-        sparse_index.set_count(block_id_1, 10);
+        sparse_index
+            .set_count(block_id_1, 10)
+            .expect("Set count should succeed");
 
         let blockfile_key = CompositeKey::new("prefix".to_string(), "c");
         let block_id_2 = uuid::Uuid::new_v4();
         sparse_index
             .add_block(blockfile_key.clone(), block_id_2)
             .expect("No error");
-        sparse_index.set_count(block_id_2, 20);
+        sparse_index
+            .set_count(block_id_2, 20)
+            .expect("Set count should succeed");
 
         let new_sparse_index = sparse_index.to_reader().expect("Conversion should succeed");
         let old_data = sparse_index.data.lock();
@@ -715,13 +797,17 @@ mod tests {
     fn test_get_all_block_ids() {
         let block_id_0 = uuid::Uuid::new_v4();
         let writer = SparseIndexWriter::new(block_id_0);
-        writer.set_count(block_id_0, 5);
+        writer
+            .set_count(block_id_0, 5)
+            .expect("Set count should succeed");
         let mut blockfile_key = CompositeKey::new("prefix".to_string(), "a");
         let block_id_1 = uuid::Uuid::new_v4();
         writer
             .add_block(blockfile_key.clone(), block_id_1)
             .expect("No error");
-        writer.set_count(block_id_1, 10);
+        writer
+            .set_count(block_id_1, 10)
+            .expect("Set count should succeed");
 
         // Split the range into two blocks (start, c), and (c, end)
         let block_id_2 = uuid::Uuid::new_v4();
@@ -729,7 +815,11 @@ mod tests {
         writer
             .add_block(blockfile_key.clone(), block_id_2)
             .expect("No error");
-        writer.set_count(block_id_2, 10);
+        writer
+            .set_count(block_id_2, 10)
+            .expect("Set count should succeed");
+
+        //
 
         // Split the second block into (c, f) and (f, end)
         let block_id_3 = uuid::Uuid::new_v4();
@@ -737,7 +827,9 @@ mod tests {
         writer
             .add_block(blockfile_key.clone(), block_id_3)
             .expect("No error");
-        writer.set_count(block_id_3, 10);
+        writer
+            .set_count(block_id_3, 10)
+            .expect("Set count should succeed");
         let composite_keys = vec![
             CompositeKey::new("prefix".to_string(), "b"),
             CompositeKey::new("prefix".to_string(), "c"),
@@ -771,13 +863,17 @@ mod tests {
         ];
 
         let sparse_index = SparseIndexWriter::new(ids[0]);
-        sparse_index.set_count(ids[0], counts[0]);
+        sparse_index
+            .set_count(ids[0], counts[0])
+            .expect("Set count should succeed");
 
         // Split the range into two blocks (start, c), and (c, end)
         sparse_index
             .add_block(keys[1].clone(), ids[1])
             .expect("No error");
-        sparse_index.set_count(ids[1], counts[1]);
+        sparse_index
+            .set_count(ids[1], counts[1])
+            .expect("Set count should succeed");
 
         let reader = sparse_index.to_reader().expect("Conversion should succeed");
 

--- a/rust/blockstore/src/types.rs
+++ b/rust/blockstore/src/types.rs
@@ -139,7 +139,7 @@ pub enum BlockfileWriter {
 }
 
 impl BlockfileWriter {
-    pub fn commit<
+    pub async fn commit<
         K: Key + Into<KeyWrapper> + ArrowWriteableKey,
         V: Value + Writeable + ArrowWriteableValue,
     >(
@@ -150,7 +150,7 @@ impl BlockfileWriter {
                 Ok(flusher) => Ok(BlockfileFlusher::MemoryBlockfileFlusher(flusher)),
                 Err(e) => Err(e),
             },
-            BlockfileWriter::ArrowBlockfileWriter(writer) => match writer.commit::<K, V>() {
+            BlockfileWriter::ArrowBlockfileWriter(writer) => match writer.commit::<K, V>().await {
                 Ok(flusher) => Ok(BlockfileFlusher::ArrowBlockfileFlusher(flusher)),
                 Err(e) => Err(e),
             },

--- a/rust/index/benches/full_text.rs
+++ b/rust/index/benches/full_text.rs
@@ -55,7 +55,7 @@ where
     }
 
     full_text_index_writer.write_to_blockfiles().await.unwrap();
-    let flusher = full_text_index_writer.commit().unwrap();
+    let flusher = full_text_index_writer.commit().await.unwrap();
     flusher.flush().await.unwrap();
 
     let postings_blockfile_reader = blockfile_provider

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -573,7 +573,7 @@ mod tests {
         let mut index_writer =
             FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -602,7 +602,7 @@ mod tests {
             FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
         index_writer.add_document("hello world", 1).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -641,7 +641,7 @@ mod tests {
             FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
         index_writer.add_document("helo", 1).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -675,7 +675,7 @@ mod tests {
         index_writer.add_document("aaa", 1).await.unwrap();
         index_writer.add_document("aaaaa", 2).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -708,7 +708,7 @@ mod tests {
             FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
         index_writer.add_document("hello", 1).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -741,7 +741,7 @@ mod tests {
             FullTextIndexWriter::new(None, pl_blockfile_writer, freq_blockfile_writer, tokenizer);
         index_writer.add_document("hello world", 1).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -778,7 +778,7 @@ mod tests {
             .unwrap();
         index_writer.add_document("    hello ", 2).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -815,7 +815,7 @@ mod tests {
         index_writer.add_document("hello world", 1).await.unwrap();
         index_writer.add_document("hello", 2).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -854,7 +854,7 @@ mod tests {
         index_writer.add_document("world", 3).await.unwrap();
         index_writer.add_document("world hello", 4).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -903,7 +903,7 @@ mod tests {
             .await
             .unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -947,7 +947,7 @@ mod tests {
             .unwrap();
         index_writer.add_document(".!.!.!", 3).await.unwrap();
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -990,7 +990,7 @@ mod tests {
         index_writer.add_document("world", 3).await.unwrap();
 
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -1033,7 +1033,7 @@ mod tests {
         index_writer.add_document("world", 3).await.unwrap();
 
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -1080,7 +1080,7 @@ mod tests {
             .unwrap();
 
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
@@ -1121,7 +1121,7 @@ mod tests {
         index_writer.delete_document("world", 3).await.unwrap();
 
         index_writer.write_to_blockfiles().await.unwrap();
-        let flusher = index_writer.commit().unwrap();
+        let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -319,13 +319,16 @@ impl<'me> FullTextIndexWriter<'me> {
         Ok(())
     }
 
-    pub fn commit(self) -> Result<FullTextIndexFlusher, FullTextIndexError> {
+    pub async fn commit(self) -> Result<FullTextIndexFlusher, FullTextIndexError> {
         // TODO should we be `await?`ing these? Or can we just return the futures?
         let posting_lists_blockfile_flusher = self
             .posting_lists_blockfile_writer
-            .commit::<u32, Vec<u32>>()?;
-        let frequencies_blockfile_flusher =
-            self.frequencies_blockfile_writer.commit::<u32, String>()?;
+            .commit::<u32, Vec<u32>>()
+            .await?;
+        let frequencies_blockfile_flusher = self
+            .frequencies_blockfile_writer
+            .commit::<u32, String>()
+            .await?;
         Ok(FullTextIndexFlusher {
             posting_lists_blockfile_flusher,
             frequencies_blockfile_flusher,

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -386,28 +386,28 @@ impl<'me> MetadataIndexWriter<'me> {
         Ok(())
     }
 
-    pub fn commit(self) -> Result<MetadataIndexFlusher, MetadataIndexError> {
+    pub async fn commit(self) -> Result<MetadataIndexFlusher, MetadataIndexError> {
         match self {
             MetadataIndexWriter::StringMetadataIndexWriter(blockfile_writer, _, _) => {
-                match blockfile_writer.commit::<&str, RoaringBitmap>() {
+                match blockfile_writer.commit::<&str, RoaringBitmap>().await {
                     Ok(flusher) => Ok(MetadataIndexFlusher::StringMetadataIndexFlusher(flusher)),
                     Err(e) => Err(MetadataIndexError::BlockfileError(e)),
                 }
             }
             MetadataIndexWriter::U32MetadataIndexWriter(blockfile_writer, _, _) => {
-                match blockfile_writer.commit::<u32, RoaringBitmap>() {
+                match blockfile_writer.commit::<u32, RoaringBitmap>().await {
                     Ok(flusher) => Ok(MetadataIndexFlusher::U32MetadataIndexFlusher(flusher)),
                     Err(e) => Err(MetadataIndexError::BlockfileError(e)),
                 }
             }
             MetadataIndexWriter::F32MetadataIndexWriter(blockfile_writer, _, _) => {
-                match blockfile_writer.commit::<f32, RoaringBitmap>() {
+                match blockfile_writer.commit::<f32, RoaringBitmap>().await {
                     Ok(flusher) => Ok(MetadataIndexFlusher::F32MetadataIndexFlusher(flusher)),
                     Err(e) => Err(MetadataIndexError::BlockfileError(e)),
                 }
             }
             MetadataIndexWriter::BoolMetadataIndexWriter(blockfile_writer, _, _) => {
-                match blockfile_writer.commit::<bool, RoaringBitmap>() {
+                match blockfile_writer.commit::<bool, RoaringBitmap>().await {
                     Ok(flusher) => Ok(MetadataIndexFlusher::BoolMetadataIndexFlusher(flusher)),
                     Err(e) => Err(MetadataIndexError::BlockfileError(e)),
                 }

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -764,7 +764,7 @@ mod test {
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_string(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
-        let flusher = md_writer.commit().unwrap();
+        let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -781,7 +781,7 @@ mod test {
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
-        let flusher = md_writer.commit().unwrap();
+        let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -798,7 +798,7 @@ mod test {
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
-        let flusher = md_writer.commit().unwrap();
+        let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -815,7 +815,7 @@ mod test {
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_bool(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
-        let flusher = md_writer.commit().unwrap();
+        let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -833,7 +833,7 @@ mod test {
         let mut writer = MetadataIndexWriter::new_string(blockfile_writer, None);
         writer.set("key", "value", 1).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -854,7 +854,7 @@ mod test {
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key", 1, 1).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -875,7 +875,7 @@ mod test {
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key", 1.0, 1).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -896,7 +896,7 @@ mod test {
         let mut writer = MetadataIndexWriter::new_bool(blockfile_writer, None);
         writer.set("key", true, 1).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -920,7 +920,7 @@ mod test {
         writer.set("key2", "value", 3).await.unwrap();
         writer.set("key2", "value2", 4).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -949,7 +949,7 @@ mod test {
         writer.set("key2", 1, 3).await.unwrap();
         writer.set("key2", 2, 4).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -978,7 +978,7 @@ mod test {
         writer.set("key2", 1.0, 3).await.unwrap();
         writer.set("key2", 2.0, 4).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1007,7 +1007,7 @@ mod test {
         writer.set("key2", true, 3).await.unwrap();
         writer.set("key2", false, 4).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1037,7 +1037,7 @@ mod test {
         writer.set("key1", 4, 4).await.unwrap();
         writer.set("key2", 5, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1070,7 +1070,7 @@ mod test {
         writer.set("key1", 4, 4).await.unwrap();
         writer.set("key2", 5, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1104,7 +1104,7 @@ mod test {
         writer.set("key1", 4, 4).await.unwrap();
         writer.set("key2", 5, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1137,7 +1137,7 @@ mod test {
         writer.set("key1", 4, 4).await.unwrap();
         writer.set("key2", 5, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1171,7 +1171,7 @@ mod test {
         writer.set("key1", 4.0, 4).await.unwrap();
         writer.set("key2", 5.0, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1205,7 +1205,7 @@ mod test {
         writer.set("key1", 4.0, 4).await.unwrap();
         writer.set("key2", 5.0, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1240,7 +1240,7 @@ mod test {
         writer.set("key1", 4.0, 4).await.unwrap();
         writer.set("key2", 5.0, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1273,7 +1273,7 @@ mod test {
         writer.set("key1", 4.0, 4).await.unwrap();
         writer.set("key2", 5.0, 5).await.unwrap();
         writer.write_to_blockfile().await.unwrap();
-        let flusher = writer.commit().unwrap();
+        let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
@@ -1304,7 +1304,7 @@ mod test {
     //     let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
     //     writer.set("key1", 1, 1).await.unwrap();
     //     writer.write_to_blockfile().await.unwrap();
-    //     let flusher = writer.commit().unwrap();
+    //     let flusher = writer.commit().await.unwrap();
     //     flusher.flush().await.unwrap();
 
     //     let blockfile_reader = provider
@@ -1323,7 +1323,7 @@ mod test {
     //     let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, Some(reader));
     //     writer.set("key1", 1, 2).await.unwrap();
     //     writer.write_to_blockfile().await.unwrap();
-    //     let flusher = writer.commit().unwrap();
+    //     let flusher = writer.commit().await.unwrap();
     //     flusher.flush().await.unwrap();
 
     //     let blockfile_reader = provider

--- a/rust/test/src/segment.rs
+++ b/rust/test/src/segment.rs
@@ -62,6 +62,7 @@ impl CompactSegment {
             .expect("Should be able to write to blockfile.");
         self.metadata.file_path = metadata_writer
             .commit()
+            .await
             .expect("Should be able to commit metadata.")
             .flush()
             .await
@@ -78,6 +79,7 @@ impl CompactSegment {
 
         self.record.file_path = record_writer
             .commit()
+            .await
             .expect("Should be able to commit metadata.")
             .flush()
             .await

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -296,6 +296,7 @@ mod tests {
                 .expect("Apply materializated log failed");
             let flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
         }

--- a/rust/worker/src/execution/operators/flush_s3.rs
+++ b/rust/worker/src/execution/operators/flush_s3.rs
@@ -77,7 +77,7 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
                 return Err(Box::new(e));
             }
         }
-        let record_segment_flusher = input.record_segment_writer.clone().commit();
+        let record_segment_flusher = input.record_segment_writer.clone().commit().await;
         let record_segment_flush_info = match record_segment_flusher {
             Ok(flusher) => {
                 let segment_id = input.record_segment_writer.id;
@@ -105,7 +105,7 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
             }
         };
 
-        let hnsw_segment_flusher = input.hnsw_segment_writer.clone().commit();
+        let hnsw_segment_flusher = input.hnsw_segment_writer.clone().commit().await;
         let hnsw_segment_flush_info = match hnsw_segment_flusher {
             Ok(flusher) => {
                 let segment_id = input.hnsw_segment_writer.id;
@@ -133,7 +133,7 @@ impl Operator<FlushS3Input, FlushS3Output> for FlushS3Operator {
             }
         };
 
-        let metadata_segment_flusher = metadata_segment_writer.commit();
+        let metadata_segment_flusher = metadata_segment_writer.commit().await;
         let metadata_segment_flush_info = match metadata_segment_flusher {
             Ok(flusher) => {
                 let segment_id = input.metadata_segment_writer.id;

--- a/rust/worker/src/execution/operators/hydrate_metadata_results.rs
+++ b/rust/worker/src/execution/operators/hydrate_metadata_results.rs
@@ -350,9 +350,11 @@ mod test {
                 .expect("Metadata writer: write to blockfile failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()

--- a/rust/worker/src/execution/operators/metadata_filtering.rs
+++ b/rust/worker/src/execution/operators/metadata_filtering.rs
@@ -706,9 +706,11 @@ mod test {
                 .expect("Metadata writer: write to blockfile failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -914,9 +916,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -1094,9 +1098,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -1282,9 +1288,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -229,7 +229,7 @@ impl<'a> SegmentWriter<'a> for DistributedHNSWSegmentWriter {
         Ok(())
     }
 
-    fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
+    async fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
         let res = self.hnsw_index_provider.commit(self.index.clone());
         match res {
             Ok(_) => Ok(self),

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -821,9 +821,9 @@ impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
         Ok(())
     }
 
-    fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
+    async fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
         let full_text_flusher = match self.full_text_index_writer {
-            Some(flusher) => match flusher.commit() {
+            Some(flusher) => match flusher.commit().await {
                 Ok(flusher) => flusher,
                 Err(e) => return Err(Box::new(e)),
             },
@@ -831,7 +831,7 @@ impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
         };
 
         let string_metadata_flusher = match self.string_metadata_index_writer {
-            Some(flusher) => match flusher.commit() {
+            Some(flusher) => match flusher.commit().await {
                 Ok(flusher) => flusher,
                 Err(e) => return Err(Box::new(e)),
             },
@@ -839,7 +839,7 @@ impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
         };
 
         let bool_metadata_flusher = match self.bool_metadata_index_writer {
-            Some(flusher) => match flusher.commit() {
+            Some(flusher) => match flusher.commit().await {
                 Ok(flusher) => flusher,
                 Err(e) => return Err(Box::new(e)),
             },
@@ -847,7 +847,7 @@ impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
         };
 
         let f32_metadata_flusher = match self.f32_metadata_index_writer {
-            Some(flusher) => match flusher.commit() {
+            Some(flusher) => match flusher.commit().await {
                 Ok(flusher) => flusher,
                 Err(e) => return Err(Box::new(e)),
             },
@@ -855,7 +855,7 @@ impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
         };
 
         let u32_metadata_flusher = match self.u32_metadata_index_writer {
-            Some(flusher) => match flusher.commit() {
+            Some(flusher) => match flusher.commit().await {
                 Ok(flusher) => flusher,
                 Err(e) => return Err(Box::new(e)),
             },
@@ -1390,9 +1390,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -1460,9 +1462,11 @@ mod test {
             .expect("Apply materialized log to record segment failed");
         let record_flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         record_segment.file_path = record_flusher
             .flush()
@@ -1540,9 +1544,11 @@ mod test {
             .expect("Apply materialized log to record segment failed");
         let record_flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         record_segment.file_path = record_flusher
             .flush()
@@ -1672,9 +1678,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -1749,9 +1757,11 @@ mod test {
             .expect("Apply materialized log to record segment failed");
         let record_flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         record_segment.file_path = record_flusher
             .flush()
@@ -1915,9 +1925,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -1974,9 +1986,11 @@ mod test {
             .expect("Apply materialized log to record segment failed");
         let record_flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         record_segment.file_path = record_flusher
             .flush()
@@ -2127,9 +2141,11 @@ mod test {
                 .expect("Apply materialized log to record segment failed");
             let record_flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             record_segment.file_path = record_flusher
                 .flush()
@@ -2184,9 +2200,11 @@ mod test {
             .expect("Apply materialized log to record segment failed");
         let record_flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         record_segment.file_path = record_flusher
             .flush()

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -461,12 +461,32 @@ impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
         Ok(())
     }
 
-    fn commit(mut self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
+    async fn commit(mut self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>> {
         // Commit all the blockfiles
-        let flusher_user_id_to_id = self.user_id_to_id.take().unwrap().commit::<&str, u32>();
-        let flusher_id_to_user_id = self.id_to_user_id.take().unwrap().commit::<u32, String>();
-        let flusher_id_to_data = self.id_to_data.take().unwrap().commit::<u32, &DataRecord>();
-        let flusher_max_offset_id = self.max_offset_id.take().unwrap().commit::<&str, u32>();
+        let flusher_user_id_to_id = self
+            .user_id_to_id
+            .take()
+            .unwrap()
+            .commit::<&str, u32>()
+            .await;
+        let flusher_id_to_user_id = self
+            .id_to_user_id
+            .take()
+            .unwrap()
+            .commit::<u32, String>()
+            .await;
+        let flusher_id_to_data = self
+            .id_to_data
+            .take()
+            .unwrap()
+            .commit::<u32, &DataRecord>()
+            .await;
+        let flusher_max_offset_id = self
+            .max_offset_id
+            .take()
+            .unwrap()
+            .commit::<&str, u32>()
+            .await;
 
         let flusher_user_id_to_id = match flusher_user_id_to_id {
             Ok(f) => f,

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -811,7 +811,7 @@ pub trait SegmentWriter<'a> {
         &self,
         records: Chunk<MaterializedLogRecord<'a>>,
     ) -> Result<(), ApplyMaterializedLogError>;
-    fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>>;
+    async fn commit(self) -> Result<impl SegmentFlusher, Box<dyn ChromaError>>;
 }
 
 // This needs to be public for testing
@@ -940,9 +940,11 @@ mod tests {
                 .expect("Apply materialized log failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             let flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             metadata_segment.file_path = metadata_flusher
                 .flush()
@@ -1036,10 +1038,12 @@ mod tests {
             .expect("Write to blockfiles for metadata writer failed");
         let flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         metadata_segment.file_path = metadata_flusher
             .flush()
@@ -1229,9 +1233,11 @@ mod tests {
                 .expect("Apply materialized log failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             let flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             metadata_segment.file_path = metadata_flusher
                 .flush()
@@ -1316,10 +1322,12 @@ mod tests {
             .expect("Write to blockfiles for metadata writer failed");
         let flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         metadata_segment.file_path = metadata_flusher
             .flush()
@@ -1510,9 +1518,11 @@ mod tests {
                 .expect("Apply materialized log failed");
             let metadata_flusher = metadata_writer
                 .commit()
+                .await
                 .expect("Commit for metadata writer failed");
             let flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             metadata_segment.file_path = metadata_flusher
                 .flush()
@@ -1617,10 +1627,12 @@ mod tests {
             .expect("Write to blockfiles for metadata writer failed");
         let flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
         let metadata_flusher = metadata_writer
             .commit()
+            .await
             .expect("Commit for metadata writer failed");
         metadata_segment.file_path = metadata_flusher
             .flush()
@@ -1802,6 +1814,7 @@ mod tests {
                 .expect("Apply materialized log failed");
             let flusher = segment_writer
                 .commit()
+                .await
                 .expect("Commit for segment writer failed");
             record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
         }
@@ -1967,6 +1980,7 @@ mod tests {
             .expect("Error applying materialized log chunk");
         let flusher = segment_writer
             .commit()
+            .await
             .expect("Commit for segment writer failed");
         record_segment.file_path = flusher.flush().await.expect("Flush segment writer failed");
         // Read.


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Adds a count index to sparse index. On the writer this is kept in its own dict so that we can set it ONLY at the end to avoid having to set another map in the hot path.
	 - Changes to raw arrow based serialization instead block-based for root since we need to have multiple columns. Once BF supports this we can move back. 

## Test plan
*How are these changes tested?*
Added tests for old version migration and new functionality

A V1 RootWriter will not serialize counts. 
A V1 BlockfileWriter will ALWAYS upgrade to V1.1 and set all its counts at commit()

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
