### PR TITLE
[ENH] Use sparse index count in blockfile

### DIFF
--- a/rust/blockstore/src/arrow/root.rs
+++ b/rust/blockstore/src/arrow/root.rs
@@ -194,7 +194,7 @@ pub struct RootReader {
     pub(super) sparse_index: SparseIndexReader,
     // Metadata
     pub(super) id: Uuid,
-    version: Version,
+    pub(super) version: Version,
 }
 
 impl chroma_cache::Weighted for RootReader {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Use the count index if it exists to speed up search.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Existing count tests for BF hold
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None