### PR TITLE
[ENH] Include tenant in request headers

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -52,6 +52,11 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         database: str = DEFAULT_DATABASE,
         settings: Settings = Settings(),
     ) -> "AsyncClient":
+        # Always include the tenant in the headers
+        headers = settings.chroma_server_headers or {}
+        headers["Chroma-ID"] = tenant
+        settings.chroma_server_headers = headers
+
         # Create an admin client for verifying that databases and tenants exist
         self = cls(settings=settings)
         SharedSystemClient._populate_data_from_system(self._system)

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -53,6 +53,11 @@ class Client(SharedSystemClient, ClientAPI):
         database: str = DEFAULT_DATABASE,
         settings: Settings = Settings(),
     ) -> None:
+        # Always include the tenant in the headers
+        headers = settings.chroma_server_headers or {}
+        headers["Chroma-ID"] = tenant
+        settings.chroma_server_headers = headers
+
         super().__init__(settings=settings)
         self.tenant = tenant
         self.database = database

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -70,6 +70,7 @@ def test_http_client(http_api: ClientAPI) -> None:
         settings.chroma_api_impl == "chromadb.api.fastapi.FastAPI"
         or settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI"
     )
+    assert settings.chroma_server_headers == {"Chroma-ID": "default_tenant"}
 
 
 def test_http_client_with_inconsistent_host_settings(


### PR DESCRIPTION
## Description of changes
 - Include tenant in the headers of all requests originated by a `Client`. This allows for any load balancer to easily access it.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
