### PR TITLE
[PERF] Performance Optimizations for MemberList and Ready Pod Lookup (Go)

### DIFF
--- a/go/pkg/memberlist_manager/memberlist_manager.go
+++ b/go/pkg/memberlist_manager/memberlist_manager.go
@@ -150,11 +150,11 @@ func (m *MemberlistManager) getOldMemberlist() (Memberlist, *string, error) {
 	if memberlist == nil {
 		return nil, nil, errors.New("Memberlist recieved is nil")
 	}
-	return *memberlist, &resourceVersion, nil
+	return memberlist, &resourceVersion, nil
 }
 
 func (m *MemberlistManager) updateMemberlist(memberlist Memberlist, resourceVersion string) error {
-	return m.memberlistStore.UpdateMemberlist(context.Background(), &memberlist, resourceVersion)
+	return m.memberlistStore.UpdateMemberlist(context.Background(), memberlist, resourceVersion)
 }
 
 func (m *MemberlistManager) SetReconcileInterval(interval time.Duration) {

--- a/go/pkg/memberlist_manager/memberlist_manager.go
+++ b/go/pkg/memberlist_manager/memberlist_manager.go
@@ -2,7 +2,6 @@ package memberlist_manager
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
@@ -147,9 +146,7 @@ func (m *MemberlistManager) getOldMemberlist() (Memberlist, *string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	if memberlist == nil {
-		return nil, nil, errors.New("Memberlist recieved is nil")
-	}
+
 	return memberlist, &resourceVersion, nil
 }
 

--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -93,7 +93,7 @@ func TestNodeWatcher(t *testing.T) {
 func TestMemberlistStore(t *testing.T) {
 	memberlistName := "test-memberlist"
 	namespace := "chroma"
-	memberlist := &Memberlist{}
+	memberlist := Memberlist{}
 	cr_memberlist := memberlistToCr(memberlist, namespace, memberlistName, "0")
 
 	// Following the assumptions of the real system, we initialize the CR with no members.
@@ -105,16 +105,16 @@ func TestMemberlistStore(t *testing.T) {
 		t.Fatalf("Error getting memberlist: %v", err)
 	}
 	// assert the memberlist is empty
-	assert.Equal(t, Memberlist{}, *memberlist)
+	assert.Equal(t, Memberlist{}, memberlist)
 
 	// Add a member to the memberlist
-	memberlist_store.UpdateMemberlist(context.Background(), &Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}, "0")
+	memberlist_store.UpdateMemberlist(context.Background(), Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}, "0")
 	memberlist, _, err = memberlist_store.GetMemberlist(context.Background())
 	if err != nil {
 		t.Fatalf("Error getting memberlist: %v", err)
 	}
 	// assert the memberlist has the correct members
-	if !memberlistSame(*memberlist, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}) {
+	if !memberlistSame(memberlist, Memberlist{Member{id: "test-pod-0"}, Member{id: "test-pod-1"}}) {
 		t.Fatalf("Memberlist did not update after adding a member")
 	}
 }
@@ -150,7 +150,7 @@ func deleteFakePod(name string, clientset kubernetes.Interface) {
 func TestMemberlistManager(t *testing.T) {
 	memberlist_name := "test-memberlist"
 	namespace := "chroma"
-	initialMemberlist := &Memberlist{}
+	initialMemberlist := Memberlist{}
 	initialCrMemberlist := memberlistToCr(initialMemberlist, namespace, memberlist_name, "0")
 
 	// Create a fake kubernetes client
@@ -253,5 +253,5 @@ func getMemberlistAndCompare(t *testing.T, memberlistStore IMemberlistStore, exp
 	if err != nil {
 		t.Fatalf("Error getting memberlist: %v", err)
 	}
-	return memberlistSame(*memberlist, expected_memberlist)
+	return memberlistSame(memberlist, expected_memberlist)
 }

--- a/go/pkg/memberlist_manager/memberlist_manager_test.go
+++ b/go/pkg/memberlist_manager/memberlist_manager_test.go
@@ -94,7 +94,7 @@ func TestMemberlistStore(t *testing.T) {
 	memberlistName := "test-memberlist"
 	namespace := "chroma"
 	memberlist := Memberlist{}
-	cr_memberlist := memberlistToCr(memberlist, namespace, memberlistName, "0")
+	cr_memberlist := memberlist.toCr(namespace, memberlistName, "0")
 
 	// Following the assumptions of the real system, we initialize the CR with no members.
 	dynamicClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), cr_memberlist)
@@ -151,7 +151,7 @@ func TestMemberlistManager(t *testing.T) {
 	memberlist_name := "test-memberlist"
 	namespace := "chroma"
 	initialMemberlist := Memberlist{}
-	initialCrMemberlist := memberlistToCr(initialMemberlist, namespace, memberlist_name, "0")
+	initialCrMemberlist := initialMemberlist.toCr(namespace, memberlist_name, "0")
 
 	// Create a fake kubernetes client
 	clientset, err := utils.GetTestKubenertesInterface()

--- a/go/pkg/memberlist_manager/node_watcher.go
+++ b/go/pkg/memberlist_manager/node_watcher.go
@@ -162,13 +162,12 @@ func (w *KubernetesWatcher) ListReadyMembers() (Memberlist, error) {
 	}
 	memberlist := make(Memberlist, 0, len(pods))
 	for _, pod := range pods {
-		conditions := pod.Status.Conditions
-		for _, condition := range conditions {
-			if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
-				member := Member{
-					id: pod.Name,
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == v1.PodReady {
+				if condition.Status == v1.ConditionTrue {
+					memberlist = append(memberlist, Member{pod.Name})
 				}
-				memberlist = append(memberlist, member)
+				break
 			}
 		}
 	}

--- a/go/pkg/memberlist_manager/node_watcher.go
+++ b/go/pkg/memberlist_manager/node_watcher.go
@@ -160,7 +160,7 @@ func (w *KubernetesWatcher) ListReadyMembers() (Memberlist, error) {
 	if err != nil {
 		return nil, err
 	}
-	memberlist := Memberlist{}
+	memberlist := make(Memberlist, 0, len(pods))
 	for _, pod := range pods {
 		conditions := pod.Status.Conditions
 		for _, condition := range conditions {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Removes unnecessary pointer indirection from MemberList, reducing indirection overhead
	 - Preallocates slices for MemberList to minimize memory allocations.
	 - Optimizes ready pod lookup during member listing, improving efficiency.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
Existing Test
- [ x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
