### PR TITLE
[ENH] Rendezvous hashing support replication

### DIFF
--- a/chromadb/segment/impl/distributed/segment_directory.py
+++ b/chromadb/segment/impl/distributed/segment_directory.py
@@ -242,7 +242,9 @@ class RendezvousHashSegmentDirectory(SegmentDirectory, EnforceOverrides):
     def get_segment_endpoint(self, segment: Segment) -> str:
         if self._curr_memberlist is None or len(self._curr_memberlist) == 0:
             raise ValueError("Memberlist is not initialized")
-        assignment = assign(segment["id"].hex, self._curr_memberlist, murmur3hasher)
+        assignment = assign(segment["id"].hex, self._curr_memberlist, murmur3hasher, 1)[
+            0
+        ]
         service_name = self.extract_service_name(assignment)
         assignment = f"{assignment}.{service_name}.{KUBERNETES_NAMESPACE}.{HEADLESS_SERVICE}:50051"  # TODO: make port configurable
         return assignment

--- a/chromadb/test/segment/distributed/test_rendezvous_hash.py
+++ b/chromadb/test/segment/distributed/test_rendezvous_hash.py
@@ -28,3 +28,27 @@ def test_even_distribution() -> None:
     # Check if keys are somewhat evenly distributed
     for node in nodes:
         assert abs(key_distribution[node] - num_keys / len(nodes)) < tolerance
+
+
+def test_multi_assign_even_distribution() -> None:
+    member_count = 10
+    tolerance = 75
+    nodes = [str(i) for i in range(member_count)]
+
+    # Test if keys are evenly distributed across nodes
+    key_distribution = {node: 0 for node in nodes}
+    num_keys = 10000
+    replication = 3
+    for i in range(num_keys):
+        key = f"key_{i}"
+        nodes_assigned = assign(key, nodes, murmur3hasher, replication)
+        # Should be three unique nodes
+        assert len(set(nodes_assigned)) == replication
+        for node in nodes_assigned:
+            key_distribution[node] += 1
+
+    # Check if keys are somewhat evenly distributed
+    for node in nodes:
+        # 3k keys expected for each node (10000 keys / 10 nodes * 3 replication)
+        expected = num_keys / len(nodes) * replication
+        assert abs(key_distribution[node] - expected) < tolerance

--- a/chromadb/test/segment/distributed/test_rendezvous_hash.py
+++ b/chromadb/test/segment/distributed/test_rendezvous_hash.py
@@ -9,7 +9,7 @@ def test_rendezvous_hash() -> None:
     def mock_hasher(member: str, key: str) -> int:
         return members.index(member)  # Highest index wins
 
-    assert assign(key, members, mock_hasher) == "c"
+    assert assign(key, members, mock_hasher, 1)[0] == "c"
 
 
 def test_even_distribution() -> None:
@@ -22,7 +22,7 @@ def test_even_distribution() -> None:
     num_keys = 1000
     for i in range(num_keys):
         key = f"key_{i}"
-        node = assign(key, nodes, murmur3hasher)
+        node = assign(key, nodes, murmur3hasher, 1)[0]
         key_distribution[node] += 1
 
     # Check if keys are somewhat evenly distributed


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - /
 - New functionality
	 - Adds support for multiple assignment in HWRH. This works by taking the top-K scores instead of the top 1

## Test plan
*How are these changes tested?*
Added a test for uniformity
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
