### PR TITLE
[CHORE] Update host path for disk cache

### DIFF
--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -69,7 +69,7 @@ queryService:
     tag: 'query-service'
   env:
   cache:
-    hostPath: '/var/cache/chroma'
+    hostPath: '/local/cache/chroma'
     mountPath: '/cache/'
 
 
@@ -79,7 +79,7 @@ compactionService:
     tag: 'compaction-service'
   env:
   cache:
-    hostPath: '/var/cache/chroma'
+    hostPath: '/local/cache/chroma'
     mountPath: '/cache/'
   replicaCount: 1
 


### PR DESCRIPTION
## Description of changes
 - Improvements & Bug fixes
	 - We are providing a "fast" storage path on our cloud instances at `/local` so this needs to be reflected in our Helm charts as the `hostPath` for our cache directory.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

`tilt up` builds and updates the charts in the expected way. 

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
