### PR TITLE
[ENH]: disable Posthog profiles

### DIFF
--- a/chromadb/telemetry/product/posthog.py
+++ b/chromadb/telemetry/product/posthog.py
@@ -11,6 +11,8 @@ from overrides import override
 
 logger = logging.getLogger(__name__)
 
+POSTHOG_EVENT_SETTINGS = {"$process_person_profile": False}
+
 
 class Posthog(ProductTelemetryClient):
     def __init__(self, system: System):
@@ -53,7 +55,7 @@ class Posthog(ProductTelemetryClient):
             posthog.capture(
                 self.user_id,
                 event.name,
-                {**event.properties, **self.context},
+                {**event.properties, **POSTHOG_EVENT_SETTINGS, **self.context},
             )
         except Exception as e:
             logger.error(f"Failed to send telemetry event {event.name}: {e}")


### PR DESCRIPTION
## Description of changes

Our telemetry is anonymous, so this will save money.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
