### PR TITLE
[BUG]  Fix a panic when splitting a block at the first key.

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/data_record.rs
+++ b/rust/blockstore/src/arrow/block/delta/data_record.rs
@@ -238,6 +238,7 @@ impl DataRecordStorage {
 
         let inner = self.inner.read();
         let mut iter = inner.storage.iter();
+        let mut first = true;
 
         while let Some((key, (id, embedding, metadata, document))) = iter.next() {
             prefix_size += key.prefix.len();
@@ -275,7 +276,7 @@ impl DataRecordStorage {
                 + document_offset
                 + validity_bytes;
 
-            if total_size > split_size {
+            if !first && total_size > split_size {
                 split_key = match iter.next() {
                     Some((key, _)) => Some(key.clone()),
                     None => {
@@ -291,6 +292,7 @@ impl DataRecordStorage {
                 };
                 break;
             }
+            first = false;
         }
 
         SplitInformation {

--- a/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
@@ -145,6 +145,7 @@ impl<T: ArrowWriteableValue> SingleColumnStorage<T> {
 
             let mut item_count = 0;
             let mut iter = storage.iter();
+            let mut first = true;
             while let Some((key, value)) = iter.next() {
                 prefix_size += key.prefix.len();
                 key_size += key.key.get_size();
@@ -167,7 +168,7 @@ impl<T: ArrowWriteableValue> SingleColumnStorage<T> {
                     + value_offset_bytes
                     + value_validity_bytes;
 
-                if total_size > split_size {
+                if !first && total_size > split_size {
                     split_key = match iter.next() {
                         None => {
                             // Remove the last item since we are splitting at the end
@@ -180,6 +181,7 @@ impl<T: ArrowWriteableValue> SingleColumnStorage<T> {
                     };
                     break;
                 }
+                first = false;
             }
         }
 


### PR DESCRIPTION
It doesn't make sense to ever split a block at the first key.  If one key cannot fit a block, it's just going to be bumped to the next block. This will repeat indefinitely without a base case.

Therefore, do not split on the first key.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
