### PR TITLE
[ENH] Stand up @rate_limit in front of all operations

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -179,6 +179,7 @@ class SegmentAPI(ServerAPI):
     # causes the system to somehow convert all values to strings.
     @trace_method("SegmentAPI.create_collection", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def create_collection(
         self,
         name: str,
@@ -245,6 +246,7 @@ class SegmentAPI(ServerAPI):
         "SegmentAPI.get_or_create_collection", OpenTelemetryGranularity.OPERATION
     )
     @override
+    @rate_limit
     def get_or_create_collection(
         self,
         name: str,
@@ -267,6 +269,7 @@ class SegmentAPI(ServerAPI):
     # causes the system to somehow convert all values to strings
     @trace_method("SegmentAPI.get_collection", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def get_collection(
         self,
         name: Optional[str] = None,
@@ -287,6 +290,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI.list_collection", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def list_collections(
         self,
         limit: Optional[int] = None,
@@ -300,6 +304,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI.count_collections", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def count_collections(
         self,
         tenant: str = DEFAULT_TENANT,
@@ -313,6 +318,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI._modify", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def _modify(
         self,
         id: UUID,
@@ -342,6 +348,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI.delete_collection", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def delete_collection(
         self,
         name: str,
@@ -408,6 +415,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI._update", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def _update(
         self,
         collection_id: UUID,
@@ -454,6 +462,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI._upsert", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def _upsert(
         self,
         collection_id: UUID,
@@ -495,6 +504,7 @@ class SegmentAPI(ServerAPI):
         reraise=True,
     )
     @override
+    @rate_limit
     def _get(
         self,
         collection_id: UUID,
@@ -561,6 +571,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI._delete", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def _delete(
         self,
         collection_id: UUID,
@@ -635,6 +646,7 @@ class SegmentAPI(ServerAPI):
         reraise=True,
     )
     @override
+    @rate_limit
     def _count(
         self,
         collection_id: UUID,
@@ -723,6 +735,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI._peek", OpenTelemetryGranularity.OPERATION)
     @override
+    @rate_limit
     def _peek(
         self,
         collection_id: UUID,


### PR DESCRIPTION
## Description of changes
 Improvements & Bug fixes
- Add `@rate_limit` decorator in front of all server-side operations for the HTTP API

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
