### PR TITLE
[BUG] Ensure tenant/database are threaded through everywhere

### DIFF
--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -304,6 +304,8 @@ class Client(SharedSystemClient, ClientAPI):
     def _count(self, collection_id: UUID) -> int:
         return self._server._count(
             collection_id=collection_id,
+            tenant=self.tenant,
+            database=self.database,
         )
 
     @override
@@ -311,6 +313,8 @@ class Client(SharedSystemClient, ClientAPI):
         return self._server._peek(
             collection_id=collection_id,
             n=n,
+            tenant=self.tenant,
+            database=self.database,
         )
 
     @override

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -372,5 +372,10 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         )
 
         await self._client._delete(
-            collection_id=self.id, ids=ids, where=where, where_document=where_document
+            collection_id=self.id,
+            ids=ids,
+            where=where,
+            where_document=where_document,
+            tenant=self.tenant,
+            database=self.database,
         )

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -700,6 +700,8 @@ class FastAPI(Server):
                 id=_uuid(collection_id),
                 new_name=update.new_name,
                 new_metadata=update.new_metadata,
+                tenant=tenant,
+                database=database_name,
             )
 
         await to_thread.run_sync(
@@ -768,6 +770,8 @@ class FastAPI(Server):
                     metadatas=add.metadatas,  # type: ignore
                     documents=add.documents,  # type: ignore
                     uris=add.uris,  # type: ignore
+                    tenant=tenant,
+                    database=database_name,
                 )
 
             return cast(
@@ -812,6 +816,8 @@ class FastAPI(Server):
                 metadatas=update.metadatas,  # type: ignore
                 documents=update.documents,  # type: ignore
                 uris=update.uris,  # type: ignore
+                tenant=tenant,
+                database=database_name,
             )
 
         await to_thread.run_sync(
@@ -854,6 +860,8 @@ class FastAPI(Server):
                 metadatas=upsert.metadatas,  # type: ignore
                 documents=upsert.documents,  # type: ignore
                 uris=upsert.uris,  # type: ignore
+                tenant=tenant,
+                database=database_name,
             )
 
         await to_thread.run_sync(
@@ -891,6 +899,8 @@ class FastAPI(Server):
                 offset=get.offset,
                 where_document=get.where_document,
                 include=get.include,
+                tenant=tenant,
+                database=database_name,
             )
 
         get_result = cast(
@@ -935,6 +945,8 @@ class FastAPI(Server):
                 ids=delete.ids,
                 where=delete.where,
                 where_document=delete.where_document,
+                tenant=tenant,
+                database=database_name,
             )
 
         await to_thread.run_sync(
@@ -966,6 +978,8 @@ class FastAPI(Server):
             await to_thread.run_sync(
                 self._api._count,
                 _uuid(collection_id),
+                tenant,
+                database_name,
                 limiter=self._capacity_limiter,
             ),
         )
@@ -1024,6 +1038,8 @@ class FastAPI(Server):
                 where=query.where,  # type: ignore
                 where_document=query.where_document,  # type: ignore
                 include=query.include,
+                tenant=tenant,
+                database=database_name,
             )
 
         nnresult = cast(


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- After an audit of everywhere that uses an instance of `ServerAPI`, there were a few places where `tenant`/`database` were not being threaded all the way through. This PR fixes that.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
