### PR TITLE
[BUG] Fix NAC getting stuck

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -120,35 +120,42 @@ impl AdmissionControlledS3Storage {
         let mut output_slices = output_buffer.chunks_mut(part_size).collect::<Vec<_>>();
         let range_and_output_slices = ranges.iter().zip(output_slices.drain(..));
         let mut futures = Vec::new();
-        let mut permits = Vec::new();
         let num_parts = range_and_output_slices.len();
         for (range, output_slice) in range_and_output_slices {
-            // Acquire permit.
-            permits.push(rate_limiter.enter().await);
-            let range_str = format!("bytes={}-{}", range.0, range.1);
-            let fut = storage
-                .fetch_range(key.clone(), range_str)
-                .then(|res| async move {
-                    match res {
-                        Ok(output) => {
-                            let body = output.body;
-                            let mut reader = body.into_async_read();
-                            match reader.read_exact(output_slice).await {
-                                Ok(_) => Ok(()),
-                                Err(e) => {
-                                    tracing::error!("Error reading from s3: {}", e);
-                                    Err(AdmissionControlledS3StorageError::S3GetError(
-                                        S3GetError::ByteStreamError(e.to_string()),
-                                    ))
+            let rate_limiter_clone = rate_limiter.clone();
+            let storage_clone = storage.clone();
+            let key_clone = key.clone();
+            let fut = async move {
+                // Acquire permit.
+                let token = rate_limiter_clone.enter().await;
+                let range_str = format!("bytes={}-{}", range.0, range.1);
+                storage_clone
+                    .fetch_range(key_clone, range_str)
+                    .then(|res| async move {
+                        let _token = token;
+                        match res {
+                            Ok(output) => {
+                                let body = output.body;
+                                let mut reader = body.into_async_read();
+                                match reader.read_exact(output_slice).await {
+                                    Ok(_) => Ok(()),
+                                    Err(e) => {
+                                        tracing::error!("Error reading from s3: {}", e);
+                                        Err(AdmissionControlledS3StorageError::S3GetError(
+                                            S3GetError::ByteStreamError(e.to_string()),
+                                        ))
+                                    }
                                 }
                             }
+                            Err(e) => {
+                                tracing::error!("Error reading from s3: {}", e);
+                                Err(AdmissionControlledS3StorageError::S3GetError(e))
+                            }
                         }
-                        Err(e) => {
-                            tracing::error!("Error reading from s3: {}", e);
-                            Err(AdmissionControlledS3StorageError::S3GetError(e))
-                        }
-                    }
-                });
+                        // _token gets dropped due to RAII and we've released the permit.
+                    })
+                    .await
+            };
             futures.push(fut);
         }
         // Await all futures and return the result.
@@ -157,7 +164,6 @@ impl AdmissionControlledS3Storage {
             .collect::<Vec<_>>()
             .await;
         Ok(Arc::new(output_buffer))
-        // All the permits get dropped due to RAII here.
     }
 
     async fn read_from_storage(

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -64,7 +64,7 @@ impl AdmissionControlledS3Storage {
         Self {
             storage,
             outstanding_requests: Arc::new(Mutex::new(HashMap::new())),
-            rate_limiter: Arc::new(RateLimitPolicy::CountBasedPolicy(CountBasedPolicy::new(5))),
+            rate_limiter: Arc::new(RateLimitPolicy::CountBasedPolicy(CountBasedPolicy::new(2))),
         }
     }
 
@@ -449,8 +449,8 @@ mod tests {
         // At < 8 MB.
         test_multipart_get_for_size(1024 * 1024 * 7).await;
         // At > 8 MB.
-        test_multipart_get_for_size(1024 * 1024 * 19).await;
-        // Greater than NAC limit i.e. > 5*8 MB = 40 MB.
-        test_multipart_get_for_size(1024 * 1024 * 100).await;
+        test_multipart_get_for_size(1024 * 1024 * 10).await;
+        // Greater than NAC limit i.e. > 2*8 MB = 16 MB.
+        test_multipart_get_for_size(1024 * 1024 * 18).await;
     }
 }

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -64,7 +64,7 @@ impl AdmissionControlledS3Storage {
         Self {
             storage,
             outstanding_requests: Arc::new(Mutex::new(HashMap::new())),
-            rate_limiter: Arc::new(RateLimitPolicy::CountBasedPolicy(CountBasedPolicy::new(15))),
+            rate_limiter: Arc::new(RateLimitPolicy::CountBasedPolicy(CountBasedPolicy::new(5))),
         }
     }
 
@@ -382,7 +382,7 @@ mod tests {
             .take(16)
             .map(char::from)
             .collect();
-        // Randomly generate 19 MB of data.
+        // Randomly generate data of size equaling value_size.
         let test_data_value_string: String = rand::thread_rng()
             .sample_iter(Alphanumeric)
             .take(value_size)
@@ -450,5 +450,7 @@ mod tests {
         test_multipart_get_for_size(1024 * 1024 * 7).await;
         // At > 8 MB.
         test_multipart_get_for_size(1024 * 1024 * 19).await;
+        // Greater than NAC limit i.e. > 5*8 MB = 40 MB.
+        test_multipart_get_for_size(1024 * 1024 * 100).await;
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - NAC would just get stuck if all tokens are exhausted by a single request in a low concurrency setting. There is a bug in the code that defers the release of all tokens for a request to the very end, this PR fixes that. Verified through a local repro.
## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
