### PR TITLE
[ENH] Configure tracing via RUST_LOG.

### DIFF
--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -39,7 +39,7 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
             .with_filter(tracing_subscriber::filter::LevelFilter::INFO);
     // global filter layer. Don't filter anything at above trace at the global layer for chroma.
     // And enable errors for every other library.
-    let global_layer = EnvFilter::new(
+    let global_layer = EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| {
         "error,".to_string()
             + &vec![
                 "chroma",
@@ -62,8 +62,8 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
             .into_iter()
             .map(|s| s.to_string() + "=trace")
             .collect::<Vec<String>>()
-            .join(","),
-    );
+            .join(",")
+    }));
 
     // Create subscriber.
     let subscriber = tracing_subscriber::registry()


### PR DESCRIPTION
The RUST_LOG environment variable will allow the environment to override the specifics of which crates log at what level.  The format of RUST_LOG is:  default_level,crate_name1=some_level,crate_name2=some_other_level

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - ...
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
