### PR TITLE
[ENH]: make `get_range()` a lazy Stream

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -356,7 +356,7 @@ impl Block {
         &'me self,
         prefix_range: PrefixRange,
         key_range: KeyRange,
-    ) -> Vec<(K, V)>
+    ) -> impl Iterator<Item = (K, V)> + 'me
     where
         PrefixRange: RangeBounds<&'prefix str>,
         KeyRange: RangeBounds<K>,
@@ -405,15 +405,12 @@ impl Block {
             Bound::Unbounded => self.len(),
         };
 
-        let mut result = Vec::new();
-
-        for index in start_index..end_index {
-            result.push((
+        (start_index..end_index).map(move |index| {
+            (
                 K::get(self.data.column(1), index),
                 V::get(self.data.column(2), index),
-            ));
-        }
-        result
+            )
+        })
     }
 
     /// Get all the values for a given prefix in the block where the key is between the given keys

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -14,6 +14,7 @@ use crate::BlockfileError;
 use chroma_error::ChromaError;
 use chroma_error::ErrorCodes;
 use futures::future::join_all;
+use futures::{Stream, StreamExt, TryStreamExt};
 use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::mem::transmute;
@@ -37,12 +38,15 @@ pub struct ArrowBlockfileWriter {
 pub enum ArrowBlockfileError {
     #[error("Block not found")]
     BlockNotFound,
+    #[error("Could not fetch block")]
+    BlockFetchError(#[from] GetError),
 }
 
 impl ChromaError for ArrowBlockfileError {
     fn code(&self) -> ErrorCodes {
         match self {
             ArrowBlockfileError::BlockNotFound => ErrorCodes::Internal,
+            ArrowBlockfileError::BlockFetchError(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -478,42 +482,41 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     }
 
     // Returns all Arrow records in the specified range.
-    pub(crate) async fn get_range<'prefix, PrefixRange, KeyRange>(
+    pub(crate) fn get_range<'prefix, PrefixRange, KeyRange>(
         &'me self,
         prefix_range: PrefixRange,
         key_range: KeyRange,
-    ) -> Result<Vec<(K, V)>, Box<dyn ChromaError>>
+    ) -> impl Stream<Item = Result<(K, V), Box<dyn ChromaError>>> + Send + 'me
     where
-        PrefixRange: RangeBounds<&'prefix str> + Clone,
-        KeyRange: RangeBounds<K> + Clone,
+        PrefixRange: RangeBounds<&'prefix str> + Clone + Send + 'me,
+        KeyRange: RangeBounds<K> + Clone + Send + 'me,
+        K: Sync,
+        V: Sync,
     {
-        let block_ids = self
-            .root
-            .sparse_index
-            .get_block_ids_range(prefix_range.clone(), key_range.clone());
-
-        let mut result: Vec<(K, V)> = vec![];
-        for block_id in block_ids {
-            let block_opt = match self.get_block(block_id).await {
-                Ok(Some(block)) => Some(block),
-                Ok(None) => {
-                    return Err(Box::new(ArrowBlockfileError::BlockNotFound));
-                }
-                Err(e) => {
-                    return Err(Box::new(e));
-                }
-            };
-
-            let block = match block_opt {
-                Some(b) => b,
-                None => {
-                    return Err(Box::new(ArrowBlockfileError::BlockNotFound));
-                }
-            };
-            result.extend(block.get_range(prefix_range.clone(), key_range.clone()));
-        }
-
-        Ok(result)
+        futures::stream::iter(
+            self.root
+                .sparse_index
+                .get_block_ids_range(prefix_range.clone(), key_range.clone())
+                .into_iter()
+                .map(Ok),
+        )
+        .try_filter_map(move |block_id| async move {
+            // todo: does this load all blocks at once?
+            match self.get_block(block_id).await {
+                Ok(Some(block)) => Ok(Some(block)),
+                Ok(None) => Err(Box::new(ArrowBlockfileError::BlockNotFound)),
+                Err(e) => Err(Box::new(ArrowBlockfileError::BlockFetchError(e))),
+            }
+        })
+        .map(move |block| {
+            futures::stream::iter(
+                block
+                    .unwrap() // todo
+                    .get_range::<K, V, _, _>(prefix_range.clone(), key_range.clone()),
+            )
+            .map(Ok)
+        })
+        .flatten()
     }
 
     pub(crate) async fn contains(
@@ -596,6 +599,7 @@ mod tests {
     use chroma_cache::new_cache_for_test;
     use chroma_storage::{local::LocalStorage, Storage};
     use chroma_types::{DataRecord, MetadataValue};
+    use futures::TryStreamExt;
     use parking_lot::Mutex;
     use proptest::prelude::*;
     use proptest::test_runner::Config;
@@ -672,9 +676,8 @@ mod tests {
             let reader = blockfile_provider.open::<&str, u32>(&id).await.unwrap();
             let prefix_query = format!("{}/{}", "prefix", prefix_for_query);
             println!("Query {}, num_keys {}", prefix_query, num_keys);
-            let res = reader
-                .get_range(prefix_query.as_str()..=prefix_query.as_str(), ..)
-                .await;
+            let range_iter = reader.get_range(prefix_query.as_str()..=prefix_query.as_str(), ..);
+            let res = range_iter.try_collect::<Vec<_>>().await;
             match res {
                 Ok(c) => {
                     let mut kv_map = HashMap::new();
@@ -742,16 +745,26 @@ mod tests {
                             prefix..=prefix,
                             (Bound::Excluded(query.as_str()), Bound::Unbounded),
                         )
+                        .try_collect::<Vec<_>>()
                         .await
                 }
                 ComparisonOperation::GreaterThanOrEquals => {
-                    reader.get_range(prefix..=prefix, query.as_str()..).await
+                    reader
+                        .get_range(prefix..=prefix, query.as_str()..)
+                        .try_collect::<Vec<_>>()
+                        .await
                 }
                 ComparisonOperation::LessThan => {
-                    reader.get_range(prefix..=prefix, ..query.as_str()).await
+                    reader
+                        .get_range(prefix..=prefix, ..query.as_str())
+                        .try_collect::<Vec<_>>()
+                        .await
                 }
                 ComparisonOperation::LessThanOrEquals => {
-                    reader.get_range(prefix..=prefix, ..=query.as_str()).await
+                    reader
+                        .get_range(prefix..=prefix, ..=query.as_str())
+                        .try_collect::<Vec<_>>()
+                        .await
                 }
             };
             match greater_than {

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -141,7 +141,7 @@ impl Configurable<(ArrowBlockfileProviderConfig, Storage)> for ArrowBlockfilePro
 }
 
 #[derive(Error, Debug)]
-pub(super) enum GetError {
+pub enum GetError {
     #[error(transparent)]
     BlockLoadError(#[from] BlockLoadError),
     #[error(transparent)]

--- a/rust/blockstore/src/blockfile_writer_test.rs
+++ b/rust/blockstore/src/blockfile_writer_test.rs
@@ -7,6 +7,7 @@ mod tests {
     use chroma_storage::local::LocalStorage;
     use chroma_storage::Storage;
     use futures::executor::block_on;
+    use futures::TryStreamExt;
     use proptest::prelude::*;
     use proptest::test_runner::Config;
     use proptest_state_machine::prop_state_machine;
@@ -177,7 +178,8 @@ mod tests {
             assert_eq!(block_on(reader.count()).unwrap(), ref_last_commit.len());
 
             // Check that entries are ordered and match expected
-            let all_entries = block_on(reader.get_range(.., ..)).unwrap();
+            let all_entries = block_on(reader.get_range(.., ..).try_collect::<Vec<_>>()).unwrap();
+            assert_eq!(all_entries.len(), ref_last_commit.len());
 
             for (blockfile_entry, expected_entry) in all_entries.iter().zip(ref_last_commit.iter())
             {

--- a/rust/blockstore/src/blockfile_writer_test.rs
+++ b/rust/blockstore/src/blockfile_writer_test.rs
@@ -178,7 +178,7 @@ mod tests {
             assert_eq!(block_on(reader.count()).unwrap(), ref_last_commit.len());
 
             // Check that entries are ordered and match expected
-            let all_entries = block_on(reader.get_range(.., ..).try_collect::<Vec<_>>()).unwrap();
+            let all_entries = block_on(reader.get_range_stream(.., ..).try_collect::<Vec<_>>()).unwrap();
             assert_eq!(all_entries.len(), ref_last_commit.len());
 
             for (blockfile_entry, expected_entry) in all_entries.iter().zip(ref_last_commit.iter())

--- a/rust/blockstore/src/memory/reader_writer.rs
+++ b/rust/blockstore/src/memory/reader_writer.rs
@@ -97,7 +97,7 @@ impl<
         }
     }
 
-    pub(crate) fn get_range<'prefix, PrefixRange, KeyRange>(
+    pub(crate) fn get_range_iter<'prefix, PrefixRange, KeyRange>(
         &'storage self,
         prefix_range: PrefixRange,
         key_range: KeyRange,
@@ -311,7 +311,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<&str, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values
@@ -333,7 +333,8 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", (Bound::Excluded(3), Bound::Unbounded));
+        let values =
+            reader.get_range_iter("prefix"..="prefix", (Bound::Excluded(3), Bound::Unbounded));
         assert!(values.is_err());
     }
 
@@ -349,7 +350,7 @@ mod tests {
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
         let range_iter = reader
-            .get_range("prefix"..="prefix", (Bound::Excluded(0), Bound::Unbounded))
+            .get_range_iter("prefix"..="prefix", (Bound::Excluded(0), Bound::Unbounded))
             .unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
@@ -376,7 +377,7 @@ mod tests {
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
         let range_iter = reader
-            .get_range("prefix"..="prefix", (Bound::Excluded(1), Bound::Unbounded))
+            .get_range_iter("prefix"..="prefix", (Bound::Excluded(1), Bound::Unbounded))
             .unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
@@ -399,7 +400,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range(
+        let values = reader.get_range_iter(
             "prefix"..="prefix",
             (Bound::Excluded(3.0), Bound::Unbounded),
         );
@@ -418,7 +419,7 @@ mod tests {
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
         let range_iter = reader
-            .get_range(
+            .get_range_iter(
                 "prefix"..="prefix",
                 (Bound::Excluded(0.0), Bound::Unbounded),
             )
@@ -448,7 +449,7 @@ mod tests {
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
         let range_iter = reader
-            .get_range(
+            .get_range_iter(
                 "prefix"..="prefix",
                 (Bound::Excluded(1.0), Bound::Unbounded),
             )
@@ -474,7 +475,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", 4..);
+        let values = reader.get_range_iter("prefix"..="prefix", 4..);
         assert!(values.is_err());
     }
 
@@ -489,7 +490,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", 1..).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", 1..).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
         assert!(values
@@ -514,7 +515,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", 2..).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", 2..).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values
@@ -536,7 +537,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", 3.5..);
+        let values = reader.get_range_iter("prefix"..="prefix", 3.5..);
         assert!(values.is_err());
     }
 
@@ -551,7 +552,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", 0.5..).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", 0.5..).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
         assert!(values
@@ -576,7 +577,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", 1.5..).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", 1.5..).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values
@@ -598,7 +599,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", ..1);
+        let values = reader.get_range_iter("prefix"..="prefix", ..1);
         assert!(values.is_err());
     }
 
@@ -613,7 +614,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..4).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..4).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
         assert!(values
@@ -638,7 +639,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..3).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..3).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values
@@ -660,7 +661,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", ..0.5);
+        let values = reader.get_range_iter("prefix"..="prefix", ..0.5);
         assert!(values.is_err());
     }
 
@@ -675,7 +676,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..3.5).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..3.5).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
         assert!(values
@@ -700,7 +701,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..2.5).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..2.5).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values
@@ -722,7 +723,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", ..=0);
+        let values = reader.get_range_iter("prefix"..="prefix", ..=0);
         assert!(values.is_err());
     }
 
@@ -737,7 +738,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..=3).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..=3).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
         assert!(values
@@ -762,7 +763,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<u32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..=2).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..=2).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values
@@ -784,7 +785,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let values = reader.get_range("prefix"..="prefix", ..=0.5);
+        let values = reader.get_range_iter("prefix"..="prefix", ..=0.5);
         assert!(values.is_err());
     }
 
@@ -799,7 +800,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..=3.0).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..=3.0).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 3);
         assert!(values
@@ -824,7 +825,7 @@ mod tests {
 
         let reader: MemoryBlockfileReader<f32, &str> =
             MemoryBlockfileReader::open(writer.id, storage_manager);
-        let range_iter = reader.get_range("prefix"..="prefix", ..=2.0).unwrap();
+        let range_iter = reader.get_range_iter("prefix"..="prefix", ..=2.0).unwrap();
         let values = range_iter.collect::<Vec<_>>();
         assert_eq!(values.len(), 2);
         assert!(values

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -65,8 +65,9 @@ impl BlockfileProvider {
             + Into<KeyWrapper>
             + TryFrom<&'new KeyWrapper, Error = InvalidKeyConversion>
             + ArrowReadableKey<'new>
+            + Sync
             + 'new,
-        V: Value + Readable<'new> + ArrowReadableValue<'new> + 'new,
+        V: Value + Readable<'new> + ArrowReadableValue<'new> + Sync + 'new,
     >(
         &self,
         id: &uuid::Uuid,

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -412,7 +412,7 @@ impl<'me> FullTextIndexReader<'me> {
             .then(|token| async {
                 let positional_posting_list = self
                     .posting_lists_blockfile_reader
-                    .get_range(token.text.as_str()..=token.text.as_str(), ..)
+                    .get_range_stream(token.text.as_str()..=token.text.as_str(), ..)
                     .try_collect::<Vec<_>>()
                     .await?;
                 Ok::<_, FullTextIndexError>(positional_posting_list)
@@ -515,7 +515,7 @@ impl<'me> FullTextIndexReader<'me> {
     ) -> Result<Vec<(u32, Vec<u32>)>, FullTextIndexError> {
         let positional_posting_list = self
             .posting_lists_blockfile_reader
-            .get_range(token..=token, ..)
+            .get_range_stream(token..=token, ..)
             .try_collect::<Vec<_>>()
             .await?;
         let mut results = vec![];
@@ -530,7 +530,7 @@ impl<'me> FullTextIndexReader<'me> {
     async fn get_frequencies_for_token(&self, token: &str) -> Result<u32, FullTextIndexError> {
         let res = self
             .frequencies_blockfile_reader
-            .get_range(token..=token, ..)
+            .get_range_stream(token..=token, ..)
             .try_collect::<Vec<_>>()
             .await?;
         if res.is_empty() {

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -565,7 +565,7 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => blockfile_reader
-                    .get_range(metadata_key..=metadata_key, ..*k)
+                    .get_range_stream(metadata_key..=metadata_key, ..*k)
                     .try_fold(RoaringBitmap::new(), |result, record| async move {
                         Ok(result.bitor(&record.1))
                     })
@@ -575,7 +575,7 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => blockfile_reader
-                    .get_range(metadata_key..=metadata_key, ..*k)
+                    .get_range_stream(metadata_key..=metadata_key, ..*k)
                     .try_fold(RoaringBitmap::new(), |result, record| async move {
                         Ok(result.bitor(&record.1))
                     })
@@ -595,7 +595,7 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => blockfile_reader
-                    .get_range(metadata_key..=metadata_key, ..=*k)
+                    .get_range_stream(metadata_key..=metadata_key, ..=*k)
                     .try_fold(RoaringBitmap::new(), |result, record| async move {
                         Ok(result.bitor(&record.1))
                     })
@@ -605,7 +605,7 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => blockfile_reader
-                    .get_range(metadata_key..=metadata_key, ..=*k)
+                    .get_range_stream(metadata_key..=metadata_key, ..=*k)
                     .try_fold(RoaringBitmap::new(), |result, record| async move {
                         Ok(result.bitor(&record.1))
                     })
@@ -625,7 +625,7 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => blockfile_reader
-                    .get_range(
+                    .get_range_stream(
                         metadata_key..=metadata_key,
                         (Bound::Excluded(*k), Bound::Unbounded),
                     )
@@ -638,7 +638,7 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => blockfile_reader
-                    .get_range(
+                    .get_range_stream(
                         metadata_key..=metadata_key,
                         (Bound::Excluded(*k), Bound::Unbounded),
                     )
@@ -661,7 +661,7 @@ impl<'me> MetadataIndexReader<'me> {
         match self {
             MetadataIndexReader::U32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Uint32(k) => blockfile_reader
-                    .get_range(metadata_key..=metadata_key, *k..)
+                    .get_range_stream(metadata_key..=metadata_key, *k..)
                     .try_fold(RoaringBitmap::new(), |result, record| async move {
                         Ok(result.bitor(&record.1))
                     })
@@ -671,7 +671,7 @@ impl<'me> MetadataIndexReader<'me> {
             },
             MetadataIndexReader::F32MetadataIndexReader(blockfile_reader) => match metadata_value {
                 KeyWrapper::Float32(k) => blockfile_reader
-                    .get_range(metadata_key..=metadata_key, *k..)
+                    .get_range_stream(metadata_key..=metadata_key, *k..)
                     .try_fold(RoaringBitmap::new(), |result, record| async move {
                         Ok(result.bitor(&record.1))
                     })


### PR DESCRIPTION
## Description of changes

Enables a usecase from @Sicheng-Pan (scanning up to a given limit with an application filter) and makes some current operations slightly more efficient.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a