### PR TITLE
[ENH]  Latency histograms for get/insert/remove/clear of cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "chroma-types",
  "clap",
  "foyer",
+ "opentelemetry",
  "parking_lot",
  "serde",
  "serde_yaml",

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -10,6 +10,11 @@ path = "src/lib.rs"
 clap = { version = "4", features = ["derive"] }
 foyer = "0.12"
 anyhow = "1.0"
+opentelemetry = { version = "0.26.0", default-features = false, features = [
+  "trace",
+  "metrics",
+] }
+
 # TODO(rescrv):  Deprecated.  Find a suitable replacement for such things.
 serde_yaml = "0.9"
 

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -42,7 +42,7 @@ impl opentelemetry_sdk::trace::ShouldSample for ChromaShouldSample {
         if (name != "get" && name != "insert") || is_slow(attributes) {
             opentelemetry::trace::SamplingResult {
                 decision: opentelemetry::trace::SamplingDecision::RecordAndSample,
-                attributes: attributes.to_vec(),
+                attributes: vec![],
                 trace_state: opentelemetry::trace::TraceState::default(),
             }
         } else {

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -33,6 +33,9 @@ impl opentelemetry_sdk::trace::ShouldSample for ChromaShouldSample {
         attributes: &[opentelemetry::KeyValue],
         _: &[opentelemetry::trace::Link],
     ) -> opentelemetry::trace::SamplingResult {
+        // NOTE(rescrv):  THIS IS A HACK!  If you find yourself seriously extending it, it's time
+        // to investigate honeycomb's sampling capabilities.
+
         // If the name is not get and not insert, or the request is slow, sample it.
         // Otherwise, drop.
         // This filters filters foyer calls in-process so they won't be overwhelming the tracing.
@@ -84,6 +87,10 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     let stdout_layer =
         BunyanFormattingLayer::new(service_name.clone().to_string(), std::io::stdout)
             .with_filter(tracing_subscriber::filter::FilterFn::new(|metadata| {
+                // NOTE(rescrv):  This is a hack, too.  Not an uppercase hack, just a hack.  This
+                // one's localized to the cache module.  There's not much to do to unify it with
+                // the otel filter because these are different output layers from the tracing.
+
                 // This filter ensures that we don't cache calls for get/insert on stdout, but will
                 // still see the clear call.
                 !(metadata

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -26,12 +26,12 @@ fn is_slow(attributes: &[opentelemetry::KeyValue]) -> bool {
 impl opentelemetry_sdk::trace::ShouldSample for ChromaShouldSample {
     fn should_sample(
         &self,
-        parent_context: Option<&opentelemetry::Context>,
-        trace_id: opentelemetry::trace::TraceId,
+        _: Option<&opentelemetry::Context>,
+        _: opentelemetry::trace::TraceId,
         name: &str,
-        span_kind: &opentelemetry::trace::SpanKind,
+        _: &opentelemetry::trace::SpanKind,
         attributes: &[opentelemetry::KeyValue],
-        links: &[opentelemetry::trace::Link],
+        _: &[opentelemetry::trace::Link],
     ) -> opentelemetry::trace::SamplingResult {
         if (name != "get" && name != "insert") || is_slow(attributes) {
             opentelemetry::trace::SamplingResult {

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -5,6 +5,50 @@ use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing_bunyan_formatter::BunyanFormattingLayer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
+#[derive(Clone, Debug, Default)]
+struct ChromaShouldSample;
+
+const BUSY_NS: opentelemetry::Key = opentelemetry::Key::from_static_str("busy_ns");
+const IDLE_NS: opentelemetry::Key = opentelemetry::Key::from_static_str("idle_ns");
+
+fn is_slow(attributes: &[opentelemetry::KeyValue]) -> bool {
+    let mut nanos = 0i64;
+    for attr in attributes {
+        if attr.key == BUSY_NS || attr.key == IDLE_NS {
+            if let opentelemetry::Value::I64(ns) = attr.value {
+                nanos += ns;
+            }
+        }
+    }
+    nanos > 1_000_000
+}
+
+impl opentelemetry_sdk::trace::ShouldSample for ChromaShouldSample {
+    fn should_sample(
+        &self,
+        parent_context: Option<&opentelemetry::Context>,
+        trace_id: opentelemetry::trace::TraceId,
+        name: &str,
+        span_kind: &opentelemetry::trace::SpanKind,
+        attributes: &[opentelemetry::KeyValue],
+        links: &[opentelemetry::trace::Link],
+    ) -> opentelemetry::trace::SamplingResult {
+        if (name != "get" && name != "insert") || is_slow(attributes) {
+            opentelemetry::trace::SamplingResult {
+                decision: opentelemetry::trace::SamplingDecision::RecordAndSample,
+                attributes: attributes.to_vec(),
+                trace_state: opentelemetry::trace::TraceState::default(),
+            }
+        } else {
+            opentelemetry::trace::SamplingResult {
+                decision: opentelemetry::trace::SamplingDecision::Drop,
+                attributes: vec![],
+                trace_state: opentelemetry::trace::TraceState::default(),
+            }
+        }
+    }
+}
+
 pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     println!(
         "Registering jaeger subscriber for {} at endpoint {}",
@@ -16,7 +60,7 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     )]);
     // Prepare trace config.
     let trace_config = opentelemetry_sdk::trace::Config::default()
-        .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+        .with_sampler(ChromaShouldSample)
         .with_resource(resource);
     // Prepare exporter.
     let exporter = opentelemetry_otlp::new_exporter()
@@ -36,14 +80,23 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     // Layer for printing spans to stdout. Only print INFO logs by default.
     let stdout_layer =
         BunyanFormattingLayer::new(service_name.clone().to_string(), std::io::stdout)
+            .with_filter(tracing_subscriber::filter::FilterFn::new(|metadata| {
+                !(metadata
+                    .module_path()
+                    .unwrap_or("")
+                    .starts_with("chroma_cache")
+                    && metadata.name() != "clear")
+            }))
             .with_filter(tracing_subscriber::filter::LevelFilter::INFO);
     // global filter layer. Don't filter anything at above trace at the global layer for chroma.
     // And enable errors for every other library.
     let global_layer = EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| {
         "error,".to_string()
             + &vec![
+                "chroma",
                 "chroma-blockstore",
                 "chroma-config",
+                "chroma-cache",
                 "chroma-distance",
                 "chroma-error",
                 "chroma-index",

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -161,4 +161,13 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
 
         prev_hook(panic_info);
     }));
+    let exporter = opentelemetry_otlp::new_exporter()
+        .tonic()
+        .with_endpoint(otel_endpoint);
+    let provider = opentelemetry_otlp::new_pipeline()
+        .metrics(opentelemetry_sdk::runtime::Tokio)
+        .with_exporter(exporter)
+        .build()
+        .expect("Failed to build metrics provider");
+    global::set_meter_provider(provider);
 }


### PR DESCRIPTION
## Description of changes

* This wires up the cache to give us latency metrics for all operations.

## Test plan

I manually verified that the traces are exported if I change the otel_endpoint to otel-collector:4317 instead of jaeger:4317

- [ X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
