### PR TITLE
[ENH] BF writer support reads

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/builder_storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/builder_storage.rs
@@ -14,6 +14,13 @@ impl<V: ArrowWriteableValue> BTreeBuilderStorage<V> {
         self.storage.remove(key)
     }
 
+    fn get(&self, key: &CompositeKey) -> Option<V::PreparedValue> {
+        if !self.storage.contains_key(key) {
+            return None;
+        }
+        Some(V::prepare(self.storage.get(key).unwrap().clone()))
+    }
+
     fn min_key(&self) -> Option<&CompositeKey> {
         self.storage.keys().next()
     }
@@ -59,6 +66,10 @@ impl<V: ArrowWriteableValue> VecBuilderStorage<V> {
 
     fn delete(&mut self, _: &CompositeKey) -> Option<V> {
         None
+    }
+
+    fn get(&self, _: &CompositeKey) -> Option<V::PreparedValue> {
+        unimplemented!()
     }
 
     fn min_key(&self) -> Option<&CompositeKey> {
@@ -134,6 +145,13 @@ impl<V: ArrowWriteableValue> BuilderStorage<V> {
         match self {
             BuilderStorage::BTreeBuilderStorage(storage) => storage.delete(key),
             BuilderStorage::VecBuilderStorage(storage) => storage.delete(key),
+        }
+    }
+
+    pub fn get(&self, key: &CompositeKey) -> Option<V::PreparedValue> {
+        match self {
+            BuilderStorage::BTreeBuilderStorage(storage) => storage.get(key),
+            BuilderStorage::VecBuilderStorage(storage) => storage.get(key),
         }
     }
 

--- a/rust/blockstore/src/arrow/block/delta/data_record.rs
+++ b/rust/blockstore/src/arrow/block/delta/data_record.rs
@@ -49,7 +49,11 @@ impl DataRecordStorage {
         inner.size_tracker.get_key_size()
     }
 
-    pub fn get_owned_value(&self, prefix: &str, key: KeyWrapper) -> Option<DataRecordStorageEntry> {
+    pub fn get_owned_value(
+        &self,
+        prefix: &str,
+        key: KeyWrapper,
+    ) -> Option<(String, Vec<f32>, Option<Vec<u8>>, Option<String>)> {
         let inner = self.inner.read();
         let composite_key = CompositeKey {
             prefix: prefix.to_string(),

--- a/rust/blockstore/src/arrow/block/delta/data_record.rs
+++ b/rust/blockstore/src/arrow/block/delta/data_record.rs
@@ -1,5 +1,6 @@
 use super::data_record_size_tracker::DataRecordSizeTracker;
 use super::BlockKeyArrowBuilder;
+use crate::arrow::block::value::data_record_value::DataRecordStorageEntry;
 use crate::arrow::types::ArrowWriteableValue;
 use crate::{
     arrow::types::ArrowWriteableKey,
@@ -49,11 +50,7 @@ impl DataRecordStorage {
         inner.size_tracker.get_key_size()
     }
 
-    pub fn get_owned_value(
-        &self,
-        prefix: &str,
-        key: KeyWrapper,
-    ) -> Option<(String, Vec<f32>, Option<Vec<u8>>, Option<String>)> {
+    pub fn get_owned_value(&self, prefix: &str, key: KeyWrapper) -> Option<DataRecordStorageEntry> {
         let inner = self.inner.read();
         let composite_key = CompositeKey {
             prefix: prefix.to_string(),

--- a/rust/blockstore/src/arrow/block/delta/data_record.rs
+++ b/rust/blockstore/src/arrow/block/delta/data_record.rs
@@ -49,6 +49,15 @@ impl DataRecordStorage {
         inner.size_tracker.get_key_size()
     }
 
+    pub fn get_owned_value(&self, prefix: &str, key: KeyWrapper) -> Option<DataRecordStorageEntry> {
+        let inner = self.inner.read();
+        let composite_key = CompositeKey {
+            prefix: prefix.to_string(),
+            key,
+        };
+        inner.storage.get(&composite_key).cloned()
+    }
+
     pub fn add(&self, prefix: &str, key: KeyWrapper, value: &DataRecord<'_>) {
         let mut inner = self.inner.write();
         let composite_key = CompositeKey {

--- a/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
@@ -269,4 +269,15 @@ impl<V: ArrowWriteableValue<SizeTracker = SingleColumnSizeTracker>> SingleColumn
 
         (schema.into(), vec![prefix_arr, key_arr, value_arr])
     }
+
+    pub fn get_owned_value(&self, prefix: &str, key: KeyWrapper) -> Option<RoaringBitmap> {
+        let inner = self.inner.read();
+        inner
+            .storage
+            .get(&CompositeKey {
+                prefix: prefix.to_string(),
+                key,
+            })
+            .cloned()
+    }
 }

--- a/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
@@ -11,7 +11,6 @@ use crate::{
 use arrow::util::bit_util;
 use arrow::{array::Array, datatypes::Schema};
 use parking_lot::RwLock;
-use roaring::RoaringBitmap;
 use std::sync::Arc;
 use std::{collections::HashMap, vec};
 

--- a/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
+++ b/rust/blockstore/src/arrow/block/delta/single_column_storage.rs
@@ -11,6 +11,7 @@ use crate::{
 use arrow::util::bit_util;
 use arrow::{array::Array, datatypes::Schema};
 use parking_lot::RwLock;
+use roaring::RoaringBitmap;
 use std::sync::Arc;
 use std::{collections::HashMap, vec};
 
@@ -270,14 +271,11 @@ impl<V: ArrowWriteableValue<SizeTracker = SingleColumnSizeTracker>> SingleColumn
         (schema.into(), vec![prefix_arr, key_arr, value_arr])
     }
 
-    pub fn get_owned_value(&self, prefix: &str, key: KeyWrapper) -> Option<RoaringBitmap> {
-        let inner = self.inner.read();
-        inner
-            .storage
-            .get(&CompositeKey {
-                prefix: prefix.to_string(),
-                key,
-            })
-            .cloned()
+    pub fn get_owned_value(&self, prefix: &str, key: KeyWrapper) -> Option<V::PreparedValue> {
+        let composite_key = CompositeKey {
+            prefix: prefix.to_string(),
+            key,
+        };
+        self.inner.read().storage.get(&composite_key)
     }
 }

--- a/rust/blockstore/src/arrow/block/delta/spann_posting_list_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/spann_posting_list_delta.rs
@@ -5,7 +5,10 @@ use chroma_types::SpannPostingList;
 use parking_lot::RwLock;
 
 use crate::{
-    arrow::types::{ArrowWriteableKey, ArrowWriteableValue},
+    arrow::{
+        block::value::spann_posting_list_value::SpannPostingListDeltaEntry,
+        types::{ArrowWriteableKey, ArrowWriteableValue},
+    },
     key::{CompositeKey, KeyWrapper},
 };
 

--- a/rust/blockstore/src/arrow/block/delta/spann_posting_list_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/spann_posting_list_delta.rs
@@ -48,6 +48,19 @@ impl SpannPostingListDelta {
         self.inner.read().size_tracker.get_key_size()
     }
 
+    pub fn get_owned_value(
+        &self,
+        prefix: &str,
+        key: KeyWrapper,
+    ) -> Option<SpannPostingListDeltaEntry> {
+        let read_guard = self.inner.read();
+        let composite_key = CompositeKey {
+            prefix: prefix.to_string(),
+            key,
+        };
+        read_guard.storage.get(&composite_key).cloned()
+    }
+
     pub fn add(&self, prefix: &str, key: KeyWrapper, value: &SpannPostingList<'_>) {
         let mut lock_guard = self.inner.write();
         let composite_key = CompositeKey {

--- a/rust/blockstore/src/arrow/block/value/data_record_value.rs
+++ b/rust/blockstore/src/arrow/block/value/data_record_value.rs
@@ -20,9 +20,9 @@ use arrow::{
     array::{ArrayRef, BinaryArray},
     util::bit_util,
 };
-use chroma_types::{chroma_proto::UpdateMetadata, DataRecord, MetadataValue};
+use chroma_types::{chroma_proto::UpdateMetadata, DataRecord};
 use prost::Message;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 pub struct ValueBuilderWrapper {
     id_builder: StringBuilder,
@@ -31,11 +31,13 @@ pub struct ValueBuilderWrapper {
     document_builder: StringBuilder,
 }
 
+pub type DataRecordStorageEntry = (String, Vec<f32>, Option<Vec<u8>>, Option<String>);
+
 impl ArrowWriteableValue for &DataRecord<'_> {
     type ReadableValue<'referred_data> = DataRecord<'referred_data>;
     type ArrowBuilder = ValueBuilderWrapper;
     type SizeTracker = DataRecordSizeTracker;
-    type PreparedValue = (String, Vec<f32>, Option<Vec<u8>>, Option<String>);
+    type PreparedValue = DataRecordStorageEntry;
 
     fn offset_size(item_count: usize) -> usize {
         let id_offset = bit_util::round_upto_multiple_of_64((item_count + 1) * 4);

--- a/rust/blockstore/src/arrow/block/value/roaring_bitmap_value.rs
+++ b/rust/blockstore/src/arrow/block/value/roaring_bitmap_value.rs
@@ -81,6 +81,8 @@ impl ArrowWriteableValue for RoaringBitmap {
 }
 
 impl ArrowReadableValue<'_> for RoaringBitmap {
+    type OwnedReadableValue = RoaringBitmap;
+
     fn get(array: &std::sync::Arc<dyn Array>, index: usize) -> Self {
         let arr = array.as_any().downcast_ref::<BinaryArray>().unwrap();
         let bytes = arr.value(index);
@@ -95,5 +97,9 @@ impl ArrowReadableValue<'_> for RoaringBitmap {
         storage: &mut BlockStorage,
     ) {
         RoaringBitmap::add(prefix, key.into(), value, storage);
+    }
+
+    fn to_owned(self) -> Self::OwnedReadableValue {
+        self.clone()
     }
 }

--- a/rust/blockstore/src/arrow/block/value/roaring_bitmap_value.rs
+++ b/rust/blockstore/src/arrow/block/value/roaring_bitmap_value.rs
@@ -23,7 +23,6 @@ impl ArrowWriteableValue for RoaringBitmap {
     type ArrowBuilder = BinaryBuilder;
     type SizeTracker = SingleColumnSizeTracker;
     type PreparedValue = Vec<u8>;
-    type OwnedReadableValue = RoaringBitmap;
 
     fn offset_size(item_count: usize) -> usize {
         bit_util::round_upto_multiple_of_64((item_count + 1) * 4)
@@ -83,8 +82,8 @@ impl ArrowWriteableValue for RoaringBitmap {
     fn get_owned_value_from_delta(
         prefix: &str,
         key: KeyWrapper,
-        delta: &BlockDelta,
-    ) -> Option<Self::OwnedReadableValue> {
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue> {
         match &delta.builder {
             BlockStorage::RoaringBitmap(builder) => builder.get_owned_value(prefix, key),
             _ => panic!("Invalid builder type"),

--- a/rust/blockstore/src/arrow/block/value/roaring_bitmap_value.rs
+++ b/rust/blockstore/src/arrow/block/value/roaring_bitmap_value.rs
@@ -23,6 +23,7 @@ impl ArrowWriteableValue for RoaringBitmap {
     type ArrowBuilder = BinaryBuilder;
     type SizeTracker = SingleColumnSizeTracker;
     type PreparedValue = Vec<u8>;
+    type OwnedReadableValue = RoaringBitmap;
 
     fn offset_size(item_count: usize) -> usize {
         bit_util::round_upto_multiple_of_64((item_count + 1) * 4)
@@ -78,11 +79,20 @@ impl ArrowWriteableValue for RoaringBitmap {
         let value_arr = (&value_arr as &dyn Array).slice(0, value_arr.len());
         (value_field, value_arr)
     }
+
+    fn get_owned_value_from_delta(
+        prefix: &str,
+        key: KeyWrapper,
+        delta: &BlockDelta,
+    ) -> Option<Self::OwnedReadableValue> {
+        match &delta.builder {
+            BlockStorage::RoaringBitmap(builder) => builder.get_owned_value(prefix, key),
+            _ => panic!("Invalid builder type"),
+        }
+    }
 }
 
 impl ArrowReadableValue<'_> for RoaringBitmap {
-    type OwnedReadableValue = RoaringBitmap;
-
     fn get(array: &std::sync::Arc<dyn Array>, index: usize) -> Self {
         let arr = array.as_any().downcast_ref::<BinaryArray>().unwrap();
         let bytes = arr.value(index);
@@ -97,9 +107,5 @@ impl ArrowReadableValue<'_> for RoaringBitmap {
         storage: &mut BlockStorage,
     ) {
         RoaringBitmap::add(prefix, key.into(), value, storage);
-    }
-
-    fn to_owned(self) -> Self::OwnedReadableValue {
-        self.clone()
     }
 }

--- a/rust/blockstore/src/arrow/block/value/spann_posting_list_value.rs
+++ b/rust/blockstore/src/arrow/block/value/spann_posting_list_value.rs
@@ -22,7 +22,7 @@ use crate::{
     BlockfileWriterMutationOrdering,
 };
 
-type SpannPostingListDeltaEntry = (Vec<u32>, Vec<u32>, Vec<f32>);
+pub type SpannPostingListDeltaEntry = (Vec<u32>, Vec<u32>, Vec<f32>);
 
 pub struct SpannPostingListBuilderWrapper {
     doc_offset_ids_builder: ListBuilder<UInt32Builder>,
@@ -35,7 +35,6 @@ impl ArrowWriteableValue for &SpannPostingList<'_> {
     type PreparedValue = SpannPostingListDeltaEntry;
     type SizeTracker = SpannPostingListSizeTracker;
     type ArrowBuilder = SpannPostingListBuilderWrapper;
-    type OwnedReadableValue = SpannPostingListDeltaEntry;
 
     // This method is only called for SingleColumnStorage.
     fn offset_size(_: usize) -> usize {
@@ -185,8 +184,8 @@ impl ArrowWriteableValue for &SpannPostingList<'_> {
     fn get_owned_value_from_delta(
         prefix: &str,
         key: KeyWrapper,
-        delta: &BlockDelta,
-    ) -> Option<Self::OwnedReadableValue> {
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue> {
         match &delta.builder {
             BlockStorage::SpannPostingListDelta(builder) => builder.get_owned_value(prefix, key),
             _ => panic!("Invalid builder type"),

--- a/rust/blockstore/src/arrow/block/value/spann_posting_list_value.rs
+++ b/rust/blockstore/src/arrow/block/value/spann_posting_list_value.rs
@@ -183,6 +183,8 @@ impl ArrowWriteableValue for &SpannPostingList<'_> {
 }
 
 impl<'referred_data> ArrowReadableValue<'referred_data> for SpannPostingList<'referred_data> {
+    type OwnedReadableValue = SpannPostingListDeltaEntry;
+
     fn get(array: &'referred_data Arc<dyn Array>, index: usize) -> Self {
         let as_struct_array = array.as_any().downcast_ref::<StructArray>().unwrap();
 
@@ -252,5 +254,13 @@ impl<'referred_data> ArrowReadableValue<'referred_data> for SpannPostingList<'re
         storage: &mut BlockStorage,
     ) {
         <&SpannPostingList>::add(prefix, key.into(), &value, storage);
+    }
+
+    fn to_owned(self) -> Self::OwnedReadableValue {
+        (
+            self.doc_offset_ids.to_vec(),
+            self.doc_versions.to_vec(),
+            self.doc_embeddings.to_vec(),
+        )
     }
 }

--- a/rust/blockstore/src/arrow/block/value/str_value.rs
+++ b/rust/blockstore/src/arrow/block/value/str_value.rs
@@ -72,6 +72,8 @@ impl ArrowWriteableValue for String {
 }
 
 impl<'referred_data> ArrowReadableValue<'referred_data> for &'referred_data str {
+    type OwnedReadableValue = String;
+
     fn get(array: &'referred_data Arc<dyn Array>, index: usize) -> &'referred_data str {
         let array = array.as_any().downcast_ref::<StringArray>().unwrap();
         array.value(index)
@@ -83,5 +85,9 @@ impl<'referred_data> ArrowReadableValue<'referred_data> for &'referred_data str 
         storage: &mut BlockStorage,
     ) {
         String::add(prefix, key.into(), value.to_string(), storage);
+    }
+
+    fn to_owned(self) -> Self::OwnedReadableValue {
+        self.to_string()
     }
 }

--- a/rust/blockstore/src/arrow/block/value/str_value.rs
+++ b/rust/blockstore/src/arrow/block/value/str_value.rs
@@ -21,7 +21,6 @@ impl ArrowWriteableValue for String {
     type ArrowBuilder = StringBuilder;
     type SizeTracker = SingleColumnSizeTracker;
     type PreparedValue = String;
-    type OwnedReadableValue = String;
 
     fn offset_size(item_count: usize) -> usize {
         bit_util::round_upto_multiple_of_64((item_count + 1) * 4)
@@ -74,8 +73,8 @@ impl ArrowWriteableValue for String {
     fn get_owned_value_from_delta(
         prefix: &str,
         key: KeyWrapper,
-        delta: &BlockDelta,
-    ) -> Option<Self::OwnedReadableValue> {
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue> {
         match &delta.builder {
             BlockStorage::String(builder) => builder.get_owned_value(prefix, key),
             _ => panic!("Invalid builder type"),

--- a/rust/blockstore/src/arrow/block/value/u32_value.rs
+++ b/rust/blockstore/src/arrow/block/value/u32_value.rs
@@ -71,6 +71,8 @@ impl ArrowWriteableValue for u32 {
 }
 
 impl<'a> ArrowReadableValue<'a> for u32 {
+    type OwnedReadableValue = u32;
+
     fn get(array: &Arc<dyn Array>, index: usize) -> u32 {
         let array = array.as_any().downcast_ref::<UInt32Array>().unwrap();
         array.value(index)
@@ -82,5 +84,9 @@ impl<'a> ArrowReadableValue<'a> for u32 {
         storage: &mut BlockStorage,
     ) {
         u32::add(prefix, key.into(), value, storage);
+    }
+
+    fn to_owned(self) -> Self::OwnedReadableValue {
+        self
     }
 }

--- a/rust/blockstore/src/arrow/block/value/u32_value.rs
+++ b/rust/blockstore/src/arrow/block/value/u32_value.rs
@@ -20,7 +20,6 @@ impl ArrowWriteableValue for u32 {
     type ArrowBuilder = UInt32Builder;
     type SizeTracker = SingleColumnSizeTracker;
     type PreparedValue = u32;
-    type OwnedReadableValue = u32;
 
     fn offset_size(_item_count: usize) -> usize {
         0
@@ -73,8 +72,8 @@ impl ArrowWriteableValue for u32 {
     fn get_owned_value_from_delta(
         prefix: &str,
         key: KeyWrapper,
-        delta: &BlockDelta,
-    ) -> Option<Self::OwnedReadableValue> {
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue> {
         match &delta.builder {
             BlockStorage::UInt32(builder) => builder.get_owned_value(prefix, key),
             _ => panic!("Invalid builder type: {:?}", &delta.builder),
@@ -83,8 +82,6 @@ impl ArrowWriteableValue for u32 {
 }
 
 impl<'a> ArrowReadableValue<'a> for u32 {
-    type OwnedReadableValue = u32;
-
     fn get(array: &Arc<dyn Array>, index: usize) -> u32 {
         let array = array.as_any().downcast_ref::<UInt32Array>().unwrap();
         array.value(index)

--- a/rust/blockstore/src/arrow/block/value/uint32array_value.rs
+++ b/rust/blockstore/src/arrow/block/value/uint32array_value.rs
@@ -21,7 +21,6 @@ impl ArrowWriteableValue for Vec<u32> {
     type ArrowBuilder = ListBuilder<UInt32Builder>;
     type SizeTracker = SingleColumnSizeTracker;
     type PreparedValue = Vec<u32>;
-    type OwnedReadableValue = Vec<u32>;
 
     fn offset_size(item_count: usize) -> usize {
         bit_util::round_upto_multiple_of_64((item_count + 1) * size_of::<u32>())
@@ -91,8 +90,8 @@ impl ArrowWriteableValue for Vec<u32> {
     fn get_owned_value_from_delta(
         prefix: &str,
         key: KeyWrapper,
-        delta: &BlockDelta,
-    ) -> Option<Self::OwnedReadableValue> {
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue> {
         match &delta.builder {
             BlockStorage::VecUInt32(builder) => builder.get_owned_value(prefix, key),
             _ => panic!("Invalid builder type"),

--- a/rust/blockstore/src/arrow/block/value/uint32array_value.rs
+++ b/rust/blockstore/src/arrow/block/value/uint32array_value.rs
@@ -89,6 +89,8 @@ impl ArrowWriteableValue for Vec<u32> {
 }
 
 impl<'referred_data> ArrowReadableValue<'referred_data> for &'referred_data [u32] {
+    type OwnedReadableValue = Vec<u32>;
+
     fn get(array: &'referred_data Arc<dyn Array>, index: usize) -> Self {
         let list_array = array.as_any().downcast_ref::<ListArray>().unwrap();
         let start = list_array.value_offsets()[index] as usize;
@@ -132,5 +134,9 @@ impl<'referred_data> ArrowReadableValue<'referred_data> for &'referred_data [u32
         storage: &mut BlockStorage,
     ) {
         <Vec<u32>>::add(prefix, key.into(), value.to_vec(), storage);
+    }
+
+    fn to_owned(self) -> Self::OwnedReadableValue {
+        self.to_vec()
     }
 }

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -224,6 +224,7 @@ impl ArrowUnorderedBlockfileWriter {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn get_clone<K: ArrowWriteableKey, V: ArrowWriteableValue>(
         &self,
         prefix: &str,

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -228,7 +228,7 @@ impl ArrowUnorderedBlockfileWriter {
         &self,
         prefix: &str,
         key: K,
-    ) -> Result<Option<V::OwnedReadableValue>, Box<dyn ChromaError>> {
+    ) -> Result<Option<V::PreparedValue>, Box<dyn ChromaError>> {
         // TODO: for now the BF writer locks the entire write operation
         let _guard = self.write_mutex.lock().await;
 
@@ -258,7 +258,11 @@ impl ArrowUnorderedBlockfileWriter {
                         return Err(Box::new(e));
                     }
                 };
-                let new_delta = match self.block_manager.fork::<K, V>(&block.id).await {
+                let new_delta = match self
+                    .block_manager
+                    .fork::<K, V, UnorderedBlockDelta>(&block.id)
+                    .await
+                {
                     Ok(delta) => delta,
                     Err(e) => {
                         return Err(Box::new(e));

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -225,7 +225,7 @@ impl ArrowUnorderedBlockfileWriter {
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn get_clone<K: ArrowWriteableKey, V: ArrowWriteableValue>(
+    pub(crate) async fn get_owned<K: ArrowWriteableKey, V: ArrowWriteableValue>(
         &self,
         prefix: &str,
         key: K,

--- a/rust/blockstore/src/arrow/types.rs
+++ b/rust/blockstore/src/arrow/types.rs
@@ -22,8 +22,7 @@ pub trait ArrowWriteableValue: Value {
     /// Every writable value has a corresponding readable value type. For example, the readable value type for a `String` is `&str`.
     type ReadableValue<'referred_data>: ArrowReadableValue<'referred_data>;
     /// Some values are a reference type and need to be converted to an owned type or need to be prepared (e.g. serializing a RoaringBitmap) before they can be stored in a delta or Arrow array.
-    type PreparedValue;
-    type OwnedReadableValue;
+    type PreparedValue: Clone;
 
     /// Some values use an offsets array. This returns the size of the offsets array given the number of items in the array.
     fn offset_size(item_count: usize) -> usize;
@@ -49,8 +48,8 @@ pub trait ArrowWriteableValue: Value {
     fn get_owned_value_from_delta(
         prefix: &str,
         key: KeyWrapper,
-        delta: &BlockDelta,
-    ) -> Option<Self::OwnedReadableValue>;
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue>;
 }
 
 pub trait ArrowReadableKey<'referred_data>: Key + PartialOrd {

--- a/rust/blockstore/src/arrow/types.rs
+++ b/rust/blockstore/src/arrow/types.rs
@@ -58,6 +58,8 @@ pub trait ArrowReadableKey<'referred_data>: Key + PartialOrd {
 }
 
 pub trait ArrowReadableValue<'referred_data>: Sized {
+    type OwnedReadableValue;
+
     fn get(array: &'referred_data Arc<dyn Array>, index: usize) -> Self;
     fn add_to_delta<K: ArrowWriteableKey>(
         prefix: &str,
@@ -65,4 +67,5 @@ pub trait ArrowReadableValue<'referred_data>: Sized {
         value: Self,
         storage: &mut BlockStorage,
     );
+    fn to_owned(self) -> Self::OwnedReadableValue;
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Implemented `writer.get_clone()` that returns an owned value for the key

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
