### PR TITLE
[TST] Fix NAC test failure due to minio storage runout

### DIFF
--- a/k8s/test/minio.yaml
+++ b/k8s/test/minio.yaml
@@ -1,3 +1,17 @@
+# Add a PVC to the minio deployment
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+  namespace: chroma
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 60Gi
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,7 +30,8 @@ spec:
     spec:
       volumes:
         - name: minio
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: minio-pvc
       containers:
         - name: minio
           image: minio/minio:latest

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -451,6 +451,6 @@ mod tests {
         // At > 8 MB.
         test_multipart_get_for_size(1024 * 1024 * 19).await;
         // Greater than NAC limit i.e. > 5*8 MB = 40 MB.
-        test_multipart_get_for_size(1024 * 1024 * 100).await;
+        test_multipart_get_for_size(1024 * 1024 * 50).await;
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - I suspect storage exhaustion in runners due to emptyDir using memory. This will mount a PVC to minio and allocate more space.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None