### PR TITLE
[BUG] Remove unnecessary call to `get_metadata` for query

### DIFF
--- a/chromadb/execution/executor/distributed.py
+++ b/chromadb/execution/executor/distributed.py
@@ -126,6 +126,10 @@ class DistributedExecutor(Executor):
             prefiltered_ids = [r["id"] for r in records]
 
         knns: Sequence[Sequence[VectorQueryResult]] = [[]] * len(plan.knn.embeddings)
+
+        # Query vectors only when the user did not specify a filter or when the filter
+        # yields non-empty ids. Otherwise, the user specified a filter but it yields
+        # no matching ids, in which case we can return an empty result.
         if prefiltered_ids is None or len(prefiltered_ids) > 0:
             query = VectorQuery(
                 vectors=plan.knn.embeddings,

--- a/chromadb/execution/executor/distributed.py
+++ b/chromadb/execution/executor/distributed.py
@@ -112,19 +112,21 @@ class DistributedExecutor(Executor):
 
     @overrides
     def knn(self, plan: KNNPlan) -> QueryResult:
-        records = self._metadata_segment(plan.scan.collection).get_metadata(
-            request_version_context=plan.scan.version,
-            where=plan.filter.where,
-            where_document=plan.filter.where_document,
-            ids=plan.filter.user_ids,
-            limit=None,
-            offset=0,
-            include_metadata=False,
-        )
+        prefiltered_ids = None
+        if plan.filter.user_ids or plan.filter.where or plan.filter.where_document:
+            records = self._metadata_segment(plan.scan.collection).get_metadata(
+                request_version_context=plan.scan.version,
+                where=plan.filter.where,
+                where_document=plan.filter.where_document,
+                ids=plan.filter.user_ids,
+                limit=None,
+                offset=0,
+                include_metadata=False,
+            )
+            prefiltered_ids = [r["id"] for r in records]
 
-        prefiltered_ids = [r["id"] for r in records]
         knns: Sequence[Sequence[VectorQueryResult]] = [[]] * len(plan.knn.embeddings)
-        if len(prefiltered_ids) > 0:
+        if prefiltered_ids is None or len(prefiltered_ids) > 0:
             query = VectorQuery(
                 vectors=plan.knn.embeddings,
                 k=plan.knn.fetch,

--- a/chromadb/execution/executor/local.py
+++ b/chromadb/execution/executor/local.py
@@ -123,6 +123,10 @@ class LocalExecutor(Executor):
             prefiltered_ids = [r["id"] for r in records]
 
         knns: Sequence[Sequence[VectorQueryResult]] = [[]] * len(plan.knn.embeddings)
+
+        # Query vectors only when the user did not specify a filter or when the filter
+        # yields non-empty ids. Otherwise, the user specified a filter but it yields
+        # no matching ids, in which case we can return an empty result.
         if prefiltered_ids is None or len(prefiltered_ids) > 0:
             query = VectorQuery(
                 vectors=plan.knn.embeddings,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Restore the logic to skip the filter when the user does not specify any in the `query`
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
