### PR TITLE
[ENH] Add fastapi middleware for http.disconnect

### DIFF
--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -2,7 +2,6 @@ import asyncio
 from functools import wraps
 from enum import Enum
 from typing import Any, Callable, Dict, Optional, Sequence, Union, TypeVar
-
 from opentelemetry import trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -10,7 +9,6 @@ from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
 )
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-
 from chromadb.config import Component
 from chromadb.config import System
 
@@ -99,7 +97,7 @@ def otel_init(
     granularity = otel_granularity
 
 
-T = TypeVar("T", bound=Callable)
+T = TypeVar("T", bound=Callable)  # type: ignore[type-arg]
 
 
 def trace_method(
@@ -127,7 +125,7 @@ def trace_method(
         if asyncio.iscoroutinefunction(f):
 
             @wraps(f)
-            async def async_wrapper(*args, **kwargs):
+            async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
                 global tracer, granularity
                 if trace_granularity < granularity:
                     return await f(*args, **kwargs)
@@ -140,7 +138,7 @@ def trace_method(
         else:
 
             @wraps(f)
-            def wrapper(*args, **kwargs):
+            def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
                 global tracer, granularity
                 if trace_granularity < granularity:
                     return f(*args, **kwargs)
@@ -151,7 +149,7 @@ def trace_method(
 
             return wrapper  # type: ignore
 
-    return decorator  # type: ignore
+    return decorator
 
 
 def add_attributes_to_current_span(

--- a/chromadb/telemetry/opentelemetry/fastapi.py
+++ b/chromadb/telemetry/opentelemetry/fastapi.py
@@ -1,10 +1,43 @@
-from typing import List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 from fastapi import FastAPI
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry import trace
 
 
 def instrument_fastapi(app: FastAPI, excluded_urls: Optional[List[str]] = None) -> None:
     """Instrument FastAPI to emit OpenTelemetry spans."""
+
+    # FastAPI calls middleware in reverse order, we want our filter disconnect
+    # middleware to be called first to ensure that we have a chance to mark
+    # spans as disconnected before they are ended by the instrumentation
+    # middleware.
+    app.add_middleware(FilterDisconnectMiddleware)
     FastAPIInstrumentor.instrument_app(
         app, excluded_urls=",".join(excluded_urls) if excluded_urls else None
     )
+
+
+class FilterDisconnectMiddleware:
+    def __init__(self, app: Any):
+        self.app = app
+
+    async def __call__(
+        self,
+        scope: Dict[str, Any],
+        receive: Callable[[], Awaitable[Dict[str, Any]]],
+        send: Callable[[Dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_span = trace.get_current_span()
+
+        async def process() -> Dict[str, Any]:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                request_span.set_attribute("http.disconnect", True)
+
+            return message
+
+        await self.app(scope, process, send)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - This change adds the ASGI http.disconnect tag to the root span so that we can filter out disconnects from errors
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*
I manually ran a disconnect script and checked the events were tagged appropriately. I ensured requests with no disconnect were not tagged.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None