### PR TITLE
[ENH] Atomically delete Collection w segments

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -386,9 +386,8 @@ class SegmentAPI(ServerAPI):
         if not existing:
             raise ValueError(f"Collection {name} does not exist.")
 
-        segments = [s for s in self._manager.delete_segments(existing[0].id)]
         self._sysdb.delete_collection(
-            existing[0].id, tenant=tenant, database=database, segments=segments
+            existing[0].id, tenant=tenant, database=database,
         )
 
     @trace_method("SegmentAPI._add", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -383,12 +383,13 @@ class SegmentAPI(ServerAPI):
             name=name, tenant=tenant, database=database
         )
 
-        if not existing:
+        if existing:
+            self._sysdb.delete_collection(
+                existing[0].id, tenant=tenant, database=database
+            )
+            self._manager.delete_segments(existing[0].id)
+        else:
             raise ValueError(f"Collection {name} does not exist.")
-
-        self._sysdb.delete_collection(
-            existing[0].id, tenant=tenant, database=database,
-        )
 
     @trace_method("SegmentAPI._add", OpenTelemetryGranularity.OPERATION)
     @override

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -383,14 +383,13 @@ class SegmentAPI(ServerAPI):
             name=name, tenant=tenant, database=database
         )
 
-        if existing:
-            self._sysdb.delete_collection(
-                existing[0].id, tenant=tenant, database=database
-            )
-            for s in self._manager.delete_segments(existing[0].id):
-                self._sysdb.delete_segment(existing[0].id, s)
-        else:
+        if not existing:
             raise ValueError(f"Collection {name} does not exist.")
+
+        segments = [s for s in self._manager.delete_segments(existing[0].id)]
+        self._sysdb.delete_collection(
+            existing[0].id, tenant=tenant, database=database, segments=segments
+        )
 
     @trace_method("SegmentAPI._add", OpenTelemetryGranularity.OPERATION)
     @override

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -292,14 +292,12 @@ class GrpcSysDB(SysDB):
         id: UUID,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-        segments: Optional[Sequence[UUID]] = None,
     ) -> None:
         try:
             request = DeleteCollectionRequest(
                 id=id.hex,
                 tenant=tenant,
                 database=database,
-                segment_ids=[segment.hex for segment in segments] if segments else None,
             )
             response = self._sys_db_stub.DeleteCollection(
                 request, timeout=self._request_timeout_seconds

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -288,13 +288,18 @@ class GrpcSysDB(SysDB):
 
     @overrides
     def delete_collection(
-        self, id: UUID, tenant: str = DEFAULT_TENANT, database: str = DEFAULT_DATABASE
+        self,
+        id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+        segments: Optional[Sequence[UUID]] = None,
     ) -> None:
         try:
             request = DeleteCollectionRequest(
                 id=id.hex,
                 tenant=tenant,
                 database=database,
+                segment_ids=[segment.hex for segment in segments] if segments else None,
             )
             response = self._sys_db_stub.DeleteCollection(
                 request, timeout=self._request_timeout_seconds

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -191,7 +191,9 @@ class SqlSysDB(SqlDB, SysDB):
                     segment["metadata"],
                 )
             except Exception as e:
+                logger.error(f"Error inserting segment metadata: {e}")
                 raise
+
 
     # TODO(rohit): Investigate and remove this method completely.
     @trace_method("SqlSysDB.create_segment", OpenTelemetryGranularity.ALL)
@@ -503,8 +505,8 @@ class SqlSysDB(SqlDB, SysDB):
             .delete()
         )
         with self.tx() as cur:
-            sql, params = get_sql(q, self.parameter_format())
             # no need for explicit del from metadata table because of ON DELETE CASCADE
+            sql, params = get_sql(q, self.parameter_format())
             sql = sql + " RETURNING id"
             result = cur.execute(sql, params).fetchone()
             if not result:

--- a/chromadb/db/system.py
+++ b/chromadb/db/system.py
@@ -106,7 +106,11 @@ class SysDB(Component):
 
     @abstractmethod
     def delete_collection(
-        self, id: UUID, tenant: str = DEFAULT_TENANT, database: str = DEFAULT_DATABASE
+        self,
+        id: UUID,
+        tenant: str = DEFAULT_TENANT,
+        database: str = DEFAULT_DATABASE,
+        segments: Optional[Sequence[UUID]] = None,
     ) -> None:
         """Delete a collection, all associated segments and any associate resources (log stream)
         from the SysDB and the system at large."""

--- a/chromadb/db/system.py
+++ b/chromadb/db/system.py
@@ -110,7 +110,6 @@ class SysDB(Component):
         id: UUID,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-        segments: Optional[Sequence[UUID]] = None,
     ) -> None:
         """Delete a collection, all associated segments and any associate resources (log stream)
         from the SysDB and the system at large."""

--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -844,14 +844,9 @@ def test_create_get_delete_segments(sysdb: SysDB) -> None:
 
     # Delete Segments will be a NoOp due to atomic delete of collection and segments.
     # See comments in coordinator.go for more details.
+    # Execute the call and expect no error or exception.
     s1 = segments_created_with_collection[0]
     sysdb.delete_segment(s1["collection"], s1["id"])
-
-    results = []
-    for collection in sample_collections:
-        results.extend(sysdb.get_segments(collection=collection.id))
-    assert s1 in results
-
 
 def test_update_segment(sysdb: SysDB) -> None:
     metadata: Dict[str, Union[str, int, float]] = {

--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -842,22 +842,15 @@ def test_create_get_delete_segments(sysdb: SysDB) -> None:
     result = sysdb.get_segments(type="test_type_b", collection=sample_collections[0].id)
     assert len(result) == 0
 
-    # Delete
+    # Delete Segments will be a NoOp due to atomic delete of collection and segments.
+    # See comments in coordinator.go for more details.
     s1 = segments_created_with_collection[0]
     sysdb.delete_segment(s1["collection"], s1["id"])
 
     results = []
     for collection in sample_collections:
         results.extend(sysdb.get_segments(collection=collection.id))
-    assert s1 not in results
-    assert len(results) == len(segments_created_with_collection) - 1
-    assert sorted(results, key=lambda c: c["id"]) == sorted(
-        segments_created_with_collection[1:], key=lambda c: c["id"]
-    )
-
-    # Duplicate delete throws an exception
-    with pytest.raises(NotFoundError):
-        sysdb.delete_segment(s1["collection"], s1["id"])
+    assert s1 in results
 
 
 def test_update_segment(sysdb: SysDB) -> None:

--- a/chromadb/test/db/test_system.py
+++ b/chromadb/test/db/test_system.py
@@ -224,7 +224,7 @@ def test_create_get_delete_collections(sysdb: SysDB) -> None:
 
     # Delete
     c1 = sample_collections[0]
-    sysdb.delete_collection(id=c1.id, segments=[segments_created_with_collection[0]["id"]])
+    sysdb.delete_collection(id=c1.id)
 
     results = sysdb.get_collections()
     assert c1 not in results

--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -107,10 +107,6 @@ func (s *Coordinator) GetSoftDeletedCollections(ctx context.Context, collectionI
 	return s.catalog.GetSoftDeletedCollections(ctx, collectionID, tenantID, databaseName, limit)
 }
 
-// func (s *Coordinator) DeleteCollectionAndSegments(ctx context.Context, deleteCollection *model.DeleteCollection, segmentIDs []types.UniqueID) error {
-// 	return s.catalog.DeleteCollectionAndSegments(ctx, deleteCollection, segmentIDs)
-// }
-
 func (s *Coordinator) DeleteCollection(ctx context.Context, deleteCollection *model.DeleteCollection) error {
 	if s.deleteMode == SoftDelete {
 		return s.catalog.DeleteCollection(ctx, deleteCollection, true)

--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -107,6 +107,10 @@ func (s *Coordinator) GetSoftDeletedCollections(ctx context.Context, collectionI
 	return s.catalog.GetSoftDeletedCollections(ctx, collectionID, tenantID, databaseName, limit)
 }
 
+func (s *Coordinator) DeleteCollectionAndSegments(ctx context.Context, deleteCollection *model.DeleteCollection, segmentIDs []types.UniqueID) error {
+	return s.catalog.DeleteCollectionAndSegments(ctx, deleteCollection, segmentIDs)
+}
+
 func (s *Coordinator) DeleteCollection(ctx context.Context, deleteCollection *model.DeleteCollection) error {
 	if s.deleteMode == SoftDelete {
 		return s.catalog.DeleteCollection(ctx, deleteCollection, true)

--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -107,9 +107,9 @@ func (s *Coordinator) GetSoftDeletedCollections(ctx context.Context, collectionI
 	return s.catalog.GetSoftDeletedCollections(ctx, collectionID, tenantID, databaseName, limit)
 }
 
-func (s *Coordinator) DeleteCollectionAndSegments(ctx context.Context, deleteCollection *model.DeleteCollection, segmentIDs []types.UniqueID) error {
-	return s.catalog.DeleteCollectionAndSegments(ctx, deleteCollection, segmentIDs)
-}
+// func (s *Coordinator) DeleteCollectionAndSegments(ctx context.Context, deleteCollection *model.DeleteCollection, segmentIDs []types.UniqueID) error {
+// 	return s.catalog.DeleteCollectionAndSegments(ctx, deleteCollection, segmentIDs)
+// }
 
 func (s *Coordinator) DeleteCollection(ctx context.Context, deleteCollection *model.DeleteCollection) error {
 	if s.deleteMode == SoftDelete {

--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -137,6 +137,10 @@ func (s *Coordinator) GetSegments(ctx context.Context, segmentID types.UniqueID,
 	return s.catalog.GetSegments(ctx, segmentID, segmentType, scope, collectionID)
 }
 
+// DeleteSegment is a no-op.
+// Segments are deleted as part of atomic delete of collection.
+// Keeping this API so that older clients continue to work, since older clients will issue DeleteSegment
+// after a DeleteCollection.
 func (s *Coordinator) DeleteSegment(ctx context.Context, segmentID types.UniqueID, collectionID types.UniqueID) error {
 	return s.catalog.DeleteSegment(ctx, segmentID, collectionID)
 }

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -651,6 +651,9 @@ func (tc *Catalog) GetSegments(ctx context.Context, segmentID types.UniqueID, se
 	return segments, nil
 }
 
+// DeleteSegment is a no-op.
+// Segments are deleted as part of atomic delete of collection.
+// Keeping this API so that older clients continue to work.
 func (tc *Catalog) DeleteSegment(ctx context.Context, segmentID types.UniqueID, collectionID types.UniqueID) error {
 	return nil
 }

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -651,29 +651,6 @@ func (tc *Catalog) GetSegments(ctx context.Context, segmentID types.UniqueID, se
 	return segments, nil
 }
 
-// TODO: Remove this once tests pass.
-func (tc *Catalog) deleteSegmentImpl(txCtx context.Context, segmentID types.UniqueID, collectionID types.UniqueID) error {
-	segment, err := tc.metaDomain.SegmentDb(txCtx).GetSegments(segmentID, nil, nil, collectionID)
-	if err != nil {
-		return err
-	}
-	if len(segment) == 0 {
-		return common.ErrSegmentDeleteNonExistingSegment
-	}
-
-	err = tc.metaDomain.SegmentDb(txCtx).DeleteSegmentByID(segmentID.String())
-	if err != nil {
-		log.Error("error deleting segment", zap.Error(err))
-		return err
-	}
-	err = tc.metaDomain.SegmentMetadataDb(txCtx).DeleteBySegmentID(segmentID.String())
-	if err != nil {
-		log.Error("error deleting segment metadata", zap.Error(err))
-		return err
-	}
-	return nil
-}
-
 func (tc *Catalog) DeleteSegment(ctx context.Context, segmentID types.UniqueID, collectionID types.UniqueID) error {
 	return nil
 }

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -161,17 +161,6 @@ func (s *Server) DeleteCollection(ctx context.Context, req *coordinatorpb.Delete
 		TenantID:     req.GetTenant(),
 		DatabaseName: req.GetDatabase(),
 	}
-	// segmentIds := []types.UniqueID{}
-	// for _, segment := range req.SegmentIds {
-	// 	parsedSegmentID, err := types.Parse(segment)
-	// 	if err != nil {
-	// 		log.Error("Delete collection failed. Parsing error for segmendId",
-	// 			zap.Error(err), zap.String("collection_id", collectionID),
-	// 			zap.String("segmentID", segment))
-	// 		return res, grpcutils.BuildInternalGrpcError(err.Error())
-	// 	}
-	// 	segmentIds = append(segmentIds, parsedSegmentID)
-	// }
 
 	err = s.coordinator.DeleteCollection(ctx, deleteCollection)
 	if err != nil {

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -161,7 +161,19 @@ func (s *Server) DeleteCollection(ctx context.Context, req *coordinatorpb.Delete
 		TenantID:     req.GetTenant(),
 		DatabaseName: req.GetDatabase(),
 	}
-	err = s.coordinator.DeleteCollection(ctx, deleteCollection)
+	segmentIds := []types.UniqueID{}
+	for _, segment := range req.SegmentIds {
+		parsedSegmentID, err := types.Parse(segment)
+		if err != nil {
+			log.Error("Delete collection failed. Parsing error for segmendId",
+				zap.Error(err), zap.String("collection_id", collectionID),
+				zap.String("segmentID", segment))
+			return res, grpcutils.BuildInternalGrpcError(err.Error())
+		}
+		segmentIds = append(segmentIds, parsedSegmentID)
+	}
+
+	err = s.coordinator.DeleteCollectionAndSegments(ctx, deleteCollection, segmentIds)
 	if err != nil {
 		log.Error("DeleteCollection failed", zap.Error(err), zap.String("collection_id", collectionID))
 		if err == common.ErrCollectionDeleteNonExistingCollection {

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -161,7 +161,6 @@ func (s *Server) DeleteCollection(ctx context.Context, req *coordinatorpb.Delete
 		TenantID:     req.GetTenant(),
 		DatabaseName: req.GetDatabase(),
 	}
-
 	err = s.coordinator.DeleteCollection(ctx, deleteCollection)
 	if err != nil {
 		log.Error("DeleteCollection failed", zap.Error(err), zap.String("collection_id", collectionID))

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -161,19 +161,19 @@ func (s *Server) DeleteCollection(ctx context.Context, req *coordinatorpb.Delete
 		TenantID:     req.GetTenant(),
 		DatabaseName: req.GetDatabase(),
 	}
-	segmentIds := []types.UniqueID{}
-	for _, segment := range req.SegmentIds {
-		parsedSegmentID, err := types.Parse(segment)
-		if err != nil {
-			log.Error("Delete collection failed. Parsing error for segmendId",
-				zap.Error(err), zap.String("collection_id", collectionID),
-				zap.String("segmentID", segment))
-			return res, grpcutils.BuildInternalGrpcError(err.Error())
-		}
-		segmentIds = append(segmentIds, parsedSegmentID)
-	}
+	// segmentIds := []types.UniqueID{}
+	// for _, segment := range req.SegmentIds {
+	// 	parsedSegmentID, err := types.Parse(segment)
+	// 	if err != nil {
+	// 		log.Error("Delete collection failed. Parsing error for segmendId",
+	// 			zap.Error(err), zap.String("collection_id", collectionID),
+	// 			zap.String("segmentID", segment))
+	// 		return res, grpcutils.BuildInternalGrpcError(err.Error())
+	// 	}
+	// 	segmentIds = append(segmentIds, parsedSegmentID)
+	// }
 
-	err = s.coordinator.DeleteCollectionAndSegments(ctx, deleteCollection, segmentIds)
+	err = s.coordinator.DeleteCollection(ctx, deleteCollection)
 	if err != nil {
 		log.Error("DeleteCollection failed", zap.Error(err), zap.String("collection_id", collectionID))
 		if err == common.ErrCollectionDeleteNonExistingCollection {

--- a/go/pkg/sysdb/metastore/db/dao/segment.go
+++ b/go/pkg/sysdb/metastore/db/dao/segment.go
@@ -229,3 +229,12 @@ func (s *segmentDb) RegisterFilePaths(flushSegmentCompactions []*model.FlushSegm
 	}
 	return nil
 }
+
+func (s *segmentDb) GetSegmentsForCollection(collectionID types.UniqueID) ([]*dbmodel.Segment, error) {
+	var segments []*dbmodel.Segment
+	err := s.db.Where("collection_id = ?", collectionID.String()).Find(&segments).Error
+	if err != nil {
+		return nil, err
+	}
+	return segments, nil
+}

--- a/go/pkg/sysdb/metastore/db/dao/segment.go
+++ b/go/pkg/sysdb/metastore/db/dao/segment.go
@@ -230,9 +230,9 @@ func (s *segmentDb) RegisterFilePaths(flushSegmentCompactions []*model.FlushSegm
 	return nil
 }
 
-func (s *segmentDb) GetSegmentsForCollection(collectionID types.UniqueID) ([]*dbmodel.Segment, error) {
+func (s *segmentDb) GetSegmentsByCollectionID(collectionID string) ([]*dbmodel.Segment, error) {
 	var segments []*dbmodel.Segment
-	err := s.db.Where("collection_id = ?", collectionID.String()).Find(&segments).Error
+	err := s.db.Where("collection_id = ?", collectionID).Find(&segments).Error
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/sysdb/metastore/db/dbmodel/segment.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/segment.go
@@ -42,8 +42,8 @@ type UpdateSegment struct {
 //go:generate mockery --name=ISegmentDb
 type ISegmentDb interface {
 	GetSegments(id types.UniqueID, segmentType *string, scope *string, collectionID types.UniqueID) ([]*SegmentAndMetadata, error)
-	GetSegmentsForCollection(collectionID types.UniqueID) ([]*Segment, error)
 	DeleteSegmentByID(id string) error
+	GetSegmentsByCollectionID(collectionID string) ([]*Segment, error)
 	Insert(*Segment) error
 	Update(*UpdateSegment) error
 	DeleteAll() error

--- a/go/pkg/sysdb/metastore/db/dbmodel/segment.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/segment.go
@@ -42,6 +42,7 @@ type UpdateSegment struct {
 //go:generate mockery --name=ISegmentDb
 type ISegmentDb interface {
 	GetSegments(id types.UniqueID, segmentType *string, scope *string, collectionID types.UniqueID) ([]*SegmentAndMetadata, error)
+	GetSegmentsForCollection(collectionID types.UniqueID) ([]*Segment, error)
 	DeleteSegmentByID(id string) error
 	Insert(*Segment) error
 	Update(*UpdateSegment) error


### PR DESCRIPTION
## Atomically delete collection & segments in 1 transaction.
This PR only changes the backend GRPC/sysdb code.

*Summarize the changes made by this PR.*
 - Improvements
	 - Removes the state where orphaned segments could be lying around.

## Test plan
- [ ] Tests pass locally with `pytest` for python, `make test` for golang

## Documentation Changes
N/A