### PR TITLE
[ENH] Remove collection_id from get_collection

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -407,7 +407,6 @@ class ClientAPI(BaseAPI, ABC):
     def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
@@ -415,7 +414,6 @@ class ClientAPI(BaseAPI, ABC):
     ) -> Collection:
         """Get a collection with the given name.
         Args:
-            id: The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
             name: The name of the collection to get
             embedding_function: Optional function to use to embed documents.
                                 Uses the default embedding function if not provided.
@@ -577,7 +575,6 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
     def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -398,7 +398,6 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
     async def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
@@ -406,7 +405,6 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
     ) -> AsyncCollection:
         """Get a collection with the given name.
         Args:
-            id: The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
             name: The name of the collection to get
             embedding_function: Optional function to use to embed documents.
                                 Uses the default embedding function if not provided.
@@ -568,7 +566,6 @@ class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
     async def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -201,14 +201,12 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     async def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
         model = await self._server.get_collection(
-            id=id,
             name=name,
             tenant=self.tenant,
             database=self.database,

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -257,21 +257,12 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     async def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
-        if (name is None and id is None) or (name is not None and id is not None):
-            raise ValueError("Name or id must be specified, but not both")
-
-        params: Dict[str, str] = {}
-        if id is not None:
-            params["type"] = str(id)
-
         resp_json = await self._make_request(
             "get",
             f"/tenants/{tenant}/databases/{database}/collections/{name}",
-            params=params,
         )
 
         model = CollectionModel.from_json(resp_json)

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -163,14 +163,12 @@ class Client(SharedSystemClient, ClientAPI):
     def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
         ] = ef.DefaultEmbeddingFunction(),  # type: ignore
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
         model = self._server.get_collection(
-            id=id,
             name=name,
             tenant=self.tenant,
             database=self.database,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -213,22 +213,13 @@ class FastAPI(BaseHTTPClient, ServerAPI):
     def get_collection(
         self,
         name: str,
-        id: Optional[UUID] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
         """Returns a collection"""
-        if (name is None and id is None) or (name is not None and id is not None):
-            raise ValueError("Name or id must be specified, but not both")
-
-        _params: Dict[str, str] = {}
-        if id is not None:
-            _params["type"] = str(id)
-
         resp_json = self._make_request(
             "get",
             f"/tenants/{tenant}/databases/{database}/collections/{name}",
-            params=_params,
         )
 
         model = CollectionModel.from_json(resp_json)

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -173,7 +173,7 @@ class CollectionCommon(Generic[ClientT]):
         )
 
     def __repr__(self) -> str:
-        return f"Collection(id={self.id}, name={self.name})"
+        return f"Collection(name={self.name})"
 
     def get_model(self) -> CollectionModel:
         return self._model

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -273,14 +273,11 @@ class SegmentAPI(ServerAPI):
     def get_collection(
         self,
         name: Optional[str] = None,
-        id: Optional[UUID] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
-        if id is None and name is None or (id is not None and name is not None):
-            raise ValueError("Name or id must be specified, but not both")
         existing = self._sysdb.get_collections(
-            id=id, name=name, tenant=tenant, database=database
+            name=name, tenant=tenant, database=database
         )
 
         if existing:

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -674,7 +674,6 @@ class FastAPI(Server):
             await to_thread.run_sync(
                 self._api.get_collection,
                 collection_name,
-                None,  # id
                 tenant,
                 database_name,
                 limiter=self._capacity_limiter,
@@ -1042,8 +1041,8 @@ class FastAPI(Server):
                     else None,
                 ),
                 n_results=query.n_results,
-                where=query.where,  # type: ignore
-                where_document=query.where_document,  # type: ignore
+                where=query.where,
+                where_document=query.where_document,
                 include=query.include,
                 tenant=tenant,
                 database=database_name,
@@ -1542,7 +1541,6 @@ class FastAPI(Server):
             await to_thread.run_sync(
                 self._api.get_collection,
                 collection_name,
-                None,  # id
                 tenant,
                 database,
                 limiter=self._capacity_limiter,
@@ -1862,8 +1860,8 @@ class FastAPI(Server):
                     else None,
                 ),
                 n_results=query.n_results,
-                where=query.where,  # type: ignore
-                where_document=query.where_document,  # type: ignore
+                where=query.where,
+                where_document=query.where_document,
                 include=query.include,
             )
 

--- a/docs/docs.trychroma.com/pages/reference/py-client.md
+++ b/docs/docs.trychroma.com/pages/reference/py-client.md
@@ -330,7 +330,6 @@ Create a new collection with the given name and metadata.
 ```python
 def get_collection(
         name: str,
-        id: Optional[UUID] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None) -> Collection


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- Removes id from the signature of `get_collection()`. Removes from the `__repr__()` of `Collection`.
  - This is a patch for the bug of not being able to get a `Collection` by its id. It is the precursor to a much larger/breaking change where we are planning to completely scrub `collection_id` from client-facing code.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
- Documentation is updated but this is a breaking changes so needs to be communicated in the next release.
