### PR TITLE
Update validation to handle empty filter dict

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -594,8 +594,8 @@ def validate_where(where: Where) -> None:
     """
     if not isinstance(where, dict):
         raise ValueError(f"Expected where to be a dict, got {where}")
-    if len(where) != 1:
-        raise ValueError(f"Expected where to have exactly one operator, got {where}")
+    if len(where) > 1:
+        raise ValueError(f"Expected where to have at most one operator, got {where}")
     for key, value in where.items():
         if not isinstance(key, str):
             raise ValueError(f"Expected where key to be a str, got {key}")

--- a/chromadb/segment/impl/metadata/grpc_segment.py
+++ b/chromadb/segment/impl/metadata/grpc_segment.py
@@ -142,9 +142,9 @@ class GrpcMetadataSegment(MetadataReader):
         response = pb.Where()
         if where is None:
             return response
-        if len(where) != 1:
+        if len(where) > 1:
             raise ValueError(
-                f"Expected where to have exactly one operator, got {where}"
+                f"Expected where to have at most one operator, got {where}"
             )
 
         for key, value in where.items():


### PR DESCRIPTION
## Description of changes
Support empty dict to undo backwards incompatible changes in https://github.com/chroma-core/chroma/pull/2899


## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
