### PR TITLE
Update local.py

### DIFF
--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -93,7 +93,7 @@ class LocalSegmentManager(SegmentManager):
                 self._max_file_handles = ctypes.windll.msvcrt._getmaxstdio()  # type: ignore
             segment_limit = (
                 self._max_file_handles
-                // PersistentLocalHnswSegment.get_file_handle_count()
+                # PersistentLocalHnswSegment.get_file_handle_count()
             )
             self._vector_instances_file_handle_cache = LRUCache(
                 segment_limit, callback=lambda _, v: v.close_persistent_index()


### PR DESCRIPTION
There seems to be a trivial bug with a wrong comment sign from another programming language. I stumbled upon it when testing nano-graphrag with Kotaemon (https://github.com/Cinnamon/kotaemon). After fixing it locally, it worked again. 

Other mentions of this bug:
https://github.com/Cinnamon/kotaemon/issues/440
https://github.com/chroma-core/chroma/issues/931

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Change "//" to "#"
