### PR TITLE
[CLN] Remove quota_rules from QuotaProvider

### DIFF
--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Callable, TypeVar, Any, Dict
+from typing import Callable, TypeVar, Any
 from chromadb.config import Component, System
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -13,14 +13,6 @@ class QuotaProvider(Component):
     def __init__(self, system: System) -> None:
         super().__init__(system)
 
-    @property
-    @abstractmethod
-    def quota_rules(self) -> Dict[str, int]:
-        """
-        A dictionary mapping a quota rule to its integer value.
-        """
-        pass
-
 
 class QuotaEnforcer(Component):
     """
@@ -32,7 +24,7 @@ class QuotaEnforcer(Component):
         super().__init__(system)
 
     @abstractmethod
-    def enforce(self) -> None:
+    def enforce(self, tenant: str, action: str) -> None:
         """
         Enforces general quota rules.
         """

--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -16,16 +16,15 @@ class QuotaProvider(Component):
 
 class QuotaEnforcer(Component):
     """
-    Exposes hooks to enforce quota rules. A distinction is drawn between
-    general quotas and rate limits, which are a specific type of quota.
+    Exposes hooks to enforce quotas.
     """
 
     def __init__(self, system: System) -> None:
         super().__init__(system)
 
     @abstractmethod
-    def enforce(self, tenant: str, action: str) -> None:
+    def enforce(self) -> None:
         """
-        Enforces general quota rules.
+        Enforces a quota.
         """
         pass


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- Removes `quota_rules` property from `QuotaProvider` as it is not implemented within OSS

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
