### PR TITLE
[ENH] Comment about integer division.

### DIFF
--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -93,6 +93,7 @@ class LocalSegmentManager(SegmentManager):
                 self._max_file_handles = ctypes.windll.msvcrt._getmaxstdio()  # type: ignore
             segment_limit = (
                 self._max_file_handles
+                # This is integer division in Python 3, and not a comment.
                 // PersistentLocalHnswSegment.get_file_handle_count()
             )
             self._vector_instances_file_handle_cache = LRUCache(


### PR DESCRIPTION
In Python // is integer division, but sometimes people see it as a comment.  Add a note for anyone applying patches downstream so that they will have to re-evaluate their patch (and hopefully drop it).