### PR TITLE
[BUG] Fix max seq ID incorrect bug by reducing state

### DIFF
--- a/chromadb/segment/impl/vector/batch.py
+++ b/chromadb/segment/impl/vector/batch.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Set, cast
-
-from chromadb.types import LogRecord, Operation, SeqId, Vector
+from chromadb.types import LogRecord, Operation, Vector
 
 
 class Batch:
@@ -12,7 +11,6 @@ class Batch:
     _upsert_add_ids: Set[str]  # IDs that are being added in an upsert
     add_count: int
     update_count: int
-    max_seq_id: SeqId
 
     def __init__(self) -> None:
         self._ids_to_records = {}
@@ -21,7 +19,6 @@ class Batch:
         self._upsert_add_ids = set()
         self.add_count = 0
         self.update_count = 0
-        self.max_seq_id = 0
 
     def __len__(self) -> int:
         """Get the number of changes in this batch"""
@@ -58,7 +55,6 @@ class Batch:
         For example, a delete or update presumes the ID exists in the index. An add presumes the ID does not exist in the index.
         The exists_already flag should be set to True if the ID does exist in the index, and False otherwise.
         """
-
         id = record["record"]["id"]
         if record["record"]["operation"] == Operation.DELETE:
             # If the ID was previously written, remove it from the written set
@@ -108,5 +104,3 @@ class Batch:
                 self.add_count += 1
             elif record["record"]["operation"] == Operation.UPDATE:
                 self.update_count += 1
-
-        self.max_seq_id = max(self.max_seq_id, record["log_offset"])

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -287,9 +287,6 @@ class LocalHnswSegment(VectorReader):
             # If that succeeds, update the total count
             self._total_elements_added += batch.add_count
 
-            # If that succeeds, finally the seq ID
-            self._max_seq_id = batch.max_seq_id
-
     @trace_method("LocalHnswSegment._write_records", OpenTelemetryGranularity.ALL)
     def _write_records(self, records: Sequence[LogRecord]) -> None:
         """Add a batch of embeddings to the index"""

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -444,7 +444,7 @@ def test_delete_add_after_persist(settings: Settings) -> None:
 
 
 def test_batch_size_less_than_sync_with_duplicate_adds_results_in_skipped_seq_ids(
-    _caplog: pytest.LogCaptureFixture, settings: Settings
+    caplog: pytest.LogCaptureFixture, settings: Settings
 ) -> None:
     # NOTE(hammadb) this test was autogenerate by hypothesis and added here to ensure that the test is run
     # in the future. It tests a case where the max seq id was incorrect in response to the same

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -3,7 +3,7 @@ import multiprocessing
 from multiprocessing.connection import Connection
 import multiprocessing.context
 import time
-from typing import Generator, Callable, List, Tuple
+from typing import Generator, Callable, List, Tuple, cast
 from uuid import UUID
 from hypothesis import given
 import hypothesis.strategies as st
@@ -11,9 +11,11 @@ import pytest
 import chromadb
 from chromadb.api import ClientAPI, ServerAPI
 from chromadb.config import Settings, System
-from chromadb.segment import SegmentManager, VectorReader
+from chromadb.segment import VectorReader
+from chromadb.segment.impl.manager.local import LocalSegmentManager
 import chromadb.test.property.strategies as strategies
 import chromadb.test.property.invariants as invariants
+from strategies import hashing_embedding_function
 from chromadb.test.property.test_embeddings import (
     EmbeddingStateMachineStates,
     trace,
@@ -24,6 +26,7 @@ from hypothesis.stateful import (
     rule,
     precondition,
     initialize,
+    MultipleResults,
 )
 import os
 import shutil
@@ -171,7 +174,7 @@ def test_sync_threshold(settings: Settings) -> None:
         name="test", metadata={"hnsw:batch_size": 3, "hnsw:sync_threshold": 3}
     )
 
-    manager = system.instance(SegmentManager)
+    manager = system.instance(LocalSegmentManager)
     segment = manager.get_segment(collection.id, VectorReader)
 
     def get_index_last_modified_at() -> float:
@@ -438,3 +441,279 @@ def test_delete_add_after_persist(settings: Settings) -> None:
 
     # At this point, the changes above are not fully persisted
     state.fields_match()
+
+
+def test_batch_size_less_than_sync_with_duplicate_adds_results_in_skipped_seq_ids(
+    _caplog: pytest.LogCaptureFixture, settings: Settings
+) -> None:
+    # NOTE(hammadb) this test was autogenerate by hypothesis and added here to ensure that the test is run
+    # in the future. It tests a case where the max seq id was incorrect in response to the same
+    # id being added multiple times in a bathc.
+    client = chromadb.Client(settings)
+    state = PersistEmbeddingsStateMachine(settings=settings, client=client)
+    state.initialize(
+        collection=strategies.Collection(
+            name="JqzMs4pPm14c\n",
+            metadata={
+                "hnsw:construction_ef": 128,
+                "hnsw:search_ef": 128,
+                "hnsw:M": 128,
+                "hnsw:sync_threshold": 9,
+                "hnsw:batch_size": 7,
+            },
+            embedding_function=hashing_embedding_function(dim=92, dtype=np.float64),
+            id=UUID("45c5c816-0a90-4293-8d01-4325ff860040"),
+            dimension=92,
+            dtype=np.float64,
+            known_metadata_keys={},
+            known_document_keywords=[],
+            has_documents=False,
+            has_embeddings=True,
+        )
+    )
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+    (
+        embedding_ids_0,
+        embedding_ids_1,
+        embedding_ids_2,
+        embedding_ids_3,
+        embedding_ids_4,
+        embedding_ids_5,
+        embedding_ids_6,
+    ) = cast(
+        MultipleResults[str],
+        state.add_embeddings(
+            record_set={
+                "ids": ["N", "e8r6", "4", "Yao", "qFjA2c", "jHCv", "2"],
+                "embeddings": [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 1.0, 1.0],
+                    [2.0, 2.0, 2.0],
+                    [3.0, 3.0, 3.0],
+                    [4.0, 4.0, 4.0],
+                    [5.0, 5.0, 5.0],
+                    [6.0, 6.0, 6.0],
+                ],
+                "metadatas": None,
+                "documents": None,
+            }
+        ),
+    )
+    state.ann_accuracy()
+    # recall: 1.0, missing 0 out of 7, accuracy threshold 1e-06
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    print("\n\n")
+    (_) = state.add_embeddings(
+        record_set={
+            "ids": ["MVu393QTc"],
+            "embeddings": [[7.0, 7.0, 7.0]],
+            "metadatas": None,
+            "documents": None,
+        }
+    )
+    state.ann_accuracy()
+    # recall: 1.0, missing 0 out of 8, accuracy threshold 1e-06
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    (
+        _,
+        _,
+        _,
+        _,
+        embedding_ids_12,
+        _,
+        _,
+        _,
+        _,
+        embedding_ids_17,
+        embedding_ids_18,
+        _,
+        _,
+        _,
+        embedding_ids_22,
+        _,
+        _,
+    ) = cast(
+        MultipleResults[str],
+        state.add_embeddings(
+            record_set={
+                "ids": [
+                    "CyF0Mk-",
+                    "q_Fwu",
+                    "2D2sQSFogDgPLkcfT",
+                    "SrwuQHQ6w4f51qWr2enLPQw8uKYs1",
+                    "G",
+                    "wdzt",
+                    "5W",
+                    "8tpsn",
+                    "fJbV7z",
+                    "5",
+                    "V",
+                    "1iFkoJX",
+                    "Zw4u",
+                    "Fc",
+                    "7",
+                    "vEEwrP",
+                    "Yf",
+                ],
+                "embeddings": [
+                    [8.0, 8.0, 8.0],
+                    [9.0, 9.0, 9.0],
+                    [10.0, 10.0, 10.0],
+                    [11.0, 11.0, 11.0],
+                    [12.0, 12.0, 12.0],
+                    [13.0, 13.0, 13.0],
+                    [14.0, 14.0, 14.0],
+                    [15.0, 15.0, 15.0],
+                    [16.0, 16.0, 16.0],
+                    [17.0, 17.0, 17.0],
+                    [18.0, 18.0, 18.0],
+                    [19.0, 19.0, 19.0],
+                    [20.0, 20.0, 20.0],
+                    [21.0, 21.0, 21.0],
+                    [22.0, 22.0, 22.0],
+                    [23.0, 23.0, 23.0],
+                    [24.0, 24.0, 24.0],
+                ],
+                "metadatas": None,
+                "documents": None,
+            }
+        ),
+    )
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    state.add_embeddings(
+        record_set={
+            "ids": ["0", "df_RWhR0HelOcv"],
+            "embeddings": [[25.0, 25.0, 25.0], [26.0, 26.0, 26.0]],
+            "metadatas": [None, None],
+            "documents": None,
+        }
+    )
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    state.add_embeddings(
+        record_set={
+            "ids": ["3R", "9_", "44u", "3B", "MZCXZDS", "Uelx"],
+            "embeddings": [
+                [27.0, 27.0, 27.0],
+                [28.0, 28.0, 28.0],
+                [29.0, 29.0, 29.0],
+                [30.0, 30.0, 30.0],
+                [31.0, 31.0, 31.0],
+                [32.0, 32.0, 32.0],
+            ],
+            "metadatas": None,
+            "documents": None,
+        }
+    )
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+    state.persist()
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    state.add_embeddings(
+        record_set={
+            "ids": "YlVm",
+            "embeddings": [[33.0, 33.0, 33.0]],
+            "metadatas": None,
+            "documents": None,
+        }
+    )
+    state.ann_accuracy()
+    # recall: 1.0, missing 0 out of 34, accuracy threshold 1e-06
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    state.add_embeddings(
+        record_set={
+            "ids": ["Rk1", "TPL"],
+            "embeddings": [[34.0, 34.0, 34.0], [35.0, 35.0, 35.0]],
+            "metadatas": [None, None],
+            "documents": None,
+        }
+    )
+    state.ann_accuracy()
+    # recall: 1.0, missing 0 out of 36, accuracy threshold 1e-06
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.no_duplicates()
+
+    state.add_embeddings(
+        record_set={
+            "ids": [
+                "CyF0Mk-",
+                "q_Fwu",
+                "2D2sQSFogDgPLkcfT",
+                "SrwuQHQ6w4f51qWr2enLPQw8uKYs1",
+                embedding_ids_12,
+                "wdzt",
+                "5W",
+                "8tpsn",
+                "fJbV7z",
+                embedding_ids_17,
+                embedding_ids_18,
+                "1iFkoJX",
+                "Zw4u",
+                "Fc",
+                embedding_ids_22,
+                "vEEwrP",
+                "Yf",
+            ],
+            "embeddings": [
+                [8.0, 8.0, 8.0],
+                [9.0, 9.0, 9.0],
+                [10.0, 10.0, 10.0],
+                [11.0, 11.0, 11.0],
+                [12.0, 12.0, 12.0],
+                [13.0, 13.0, 13.0],
+                [14.0, 14.0, 14.0],
+                [15.0, 15.0, 15.0],
+                [16.0, 16.0, 16.0],
+                [17.0, 17.0, 17.0],
+                [18.0, 18.0, 18.0],
+                [19.0, 19.0, 19.0],
+                [20.0, 20.0, 20.0],
+                [21.0, 21.0, 21.0],
+                [22.0, 22.0, 22.0],
+                [23.0, 23.0, 23.0],
+                [24.0, 24.0, 24.0],
+            ],
+            "metadatas": None,
+            "documents": None,
+        }
+    )
+    state.ann_accuracy()
+    state.count()
+    state.fields_match()
+    state.log_size_below_max()
+    state.teardown()


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - There was a bug where if the ID already existed the max seq id of the batch was not advanced. This results in storing more data than we need to on the log since the seq id is underreported. Not a huge issue, but breaks tests. This change removes `max_seq_id` from the batch entirely. `local_hnsw` will track it correctly in memory, and `local_persistent_hnsw` tracks it correctly on persist advances. For example, `add A` and then `add A` will result in the second add A to note advance the `batch` max_seq_id, by removing the needless redundant state we prevent the error.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
This is a test fix. I've included the hypothesis repro as a new test. I ran test_persist.py 15 times locally with cleared hypothesis generations.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None