### PR TITLE
[ENH] Implement an object-store backend for storage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chroma"
 version = "0.1.0"
 
@@ -1333,6 +1339,7 @@ dependencies = [
  "chroma-config",
  "chroma-error",
  "futures",
+ "object_store",
  "parking_lot",
  "rand",
  "rand_xorshift",
@@ -2597,6 +2604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,7 +2665,7 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -2668,6 +2681,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.13",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3577,6 +3591,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper 1.4.1",
+ "itertools 0.13.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4164,6 +4208,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.13",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.13",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,7 +4466,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4371,6 +4478,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -4446,6 +4554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -4500,6 +4615,32 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -4911,6 +5052,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5060,7 +5222,7 @@ dependencies = [
  "rayon",
  "regex",
  "rust-stemmers",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "sketches-ddsketch",

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -16,7 +16,6 @@ use chroma_cache::{CacheError, PersistentCache};
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
-use futures::StreamExt;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{Instrument, Span};
@@ -409,34 +408,14 @@ impl RootManager {
                 // This will be replaced with a full prefix-based storage shortly
                 let key = format!("sparse_index/{}", id);
                 tracing::debug!("Reading root from storage with key: {}", key);
-                // TODO: This should pass through NAC as well.
-                let stream = self.storage.get_stream(&key).await;
-                let mut buf: Vec<u8> = Vec::new();
-                match stream {
-                    Ok(mut bytes) => {
-                        while let Some(res) = bytes.next().await {
-                            match res {
-                                Ok(chunk) => {
-                                    buf.extend(chunk);
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error reading root from storage: {}", e);
-                                    return Err(RootManagerError::StorageGetError(e));
-                                }
-                            }
+                match self.storage.get(&key).await {
+                    Ok(bytes) => match RootReader::from_bytes::<K>(&bytes, *id) {
+                        Ok(root) => Ok(Some(root)),
+                        Err(e) => {
+                            tracing::error!("Error turning bytes into root: {}", e);
+                            Err(RootManagerError::FromBytesError(e))
                         }
-                        let root = RootReader::from_bytes::<K>(&buf, *id);
-                        match root {
-                            Ok(root) => {
-                                self.cache.insert(*id, root.clone()).await;
-                                Ok(Some(root))
-                            }
-                            Err(e) => {
-                                tracing::error!("Error turning bytes into root: {}", e);
-                                Err(RootManagerError::FromBytesError(e))
-                            }
-                        }
-                    }
+                    },
                     Err(e) => {
                         tracing::error!("Error reading root from storage: {}", e);
                         Err(RootManagerError::StorageGetError(e))

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1.5.0"
 aws-sdk-s3 = "1.5.0"
 aws-smithy-types = "1.1.0"
 aws-config = { version = "1.1.2", features = ["behavior-version-latest"] }
+object_store = { version = "0.11", features = ["aws"] }
 
 serde = { workspace = true }
 futures = { workspace = true }

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -9,12 +9,36 @@ use serde::Deserialize;
 /// config files to configure the worker.
 pub enum StorageConfig {
     // case-insensitive
+    #[serde(alias = "object_store")]
+    ObjectStore(ObjectStoreConfig),
     #[serde(alias = "s3")]
     S3(S3StorageConfig),
     #[serde(alias = "local")]
     Local(LocalStorageConfig),
     #[serde(alias = "admissioncontrolleds3")]
     AdmissionControlledS3(AdmissionControlledS3StorageConfig),
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub enum ObjectStoreType {
+    #[serde(alias = "minio")]
+    Minio,
+    #[serde(alias = "s3")]
+    S3,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ObjectStoreBucketConfig {
+    pub name: String,
+    pub r#type: ObjectStoreType,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ObjectStoreConfig {
+    pub bucket: ObjectStoreBucketConfig,
+    pub upload_part_size_bytes: u64,
+    pub download_part_size_bytes: u64,
+    pub max_concurrent_requests: usize,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use self::config::StorageConfig;
 use self::s3::S3GetError;
-use self::stream::ByteStreamItem;
 use admissioncontrolleds3::AdmissionControlledS3StorageError;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
@@ -10,15 +9,16 @@ use chroma_error::{ChromaError, ErrorCodes};
 pub mod admissioncontrolleds3;
 pub mod config;
 pub mod local;
+pub mod object_store;
 pub mod s3;
 pub mod stream;
-use futures::Stream;
 use local::LocalStorage;
 use tempfile::TempDir;
 use thiserror::Error;
 
 #[derive(Clone)]
 pub enum Storage {
+    ObjectStore(object_store::ObjectStore),
     S3(s3::S3Storage),
     Local(local::LocalStorage),
     AdmissionControlledS3(admissioncontrolleds3::AdmissionControlledS3Storage),
@@ -28,6 +28,8 @@ pub enum Storage {
 pub enum GetError {
     #[error("No such key: {0}")]
     NoSuchKey(String),
+    #[error("ObjectStore error: {0}")]
+    ObjectStoreError(Arc<::object_store::Error>),
     #[error("S3 error: {0}")]
     S3Error(#[from] S3GetError),
     #[error("Local storage error: {0}")]
@@ -38,14 +40,28 @@ impl ChromaError for GetError {
     fn code(&self) -> ErrorCodes {
         match self {
             GetError::NoSuchKey(_) => ErrorCodes::NotFound,
+            GetError::ObjectStoreError(_) => ErrorCodes::Internal,
             GetError::S3Error(_) => ErrorCodes::Internal,
             GetError::LocalError(_) => ErrorCodes::Internal,
         }
     }
 }
 
+impl From<::object_store::Error> for GetError {
+    fn from(e: ::object_store::Error) -> Self {
+        match e {
+            ::object_store::Error::NotFound { path, source: _ } => {
+                GetError::NoSuchKey(path.to_string())
+            }
+            _ => GetError::ObjectStoreError(Arc::new(e)),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum PutError {
+    #[error("ObjectStore error: {0}")]
+    ObjectStoreError(Arc<::object_store::Error>),
     #[error("S3 error: {0}")]
     S3Error(#[from] s3::S3PutError),
     #[error("Local storage error: {0}")]
@@ -55,8 +71,38 @@ pub enum PutError {
 impl ChromaError for PutError {
     fn code(&self) -> ErrorCodes {
         match self {
+            PutError::ObjectStoreError(_) => ErrorCodes::Internal,
             PutError::S3Error(_) => ErrorCodes::Internal,
             PutError::LocalError(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+impl From<std::io::Error> for PutError {
+    fn from(e: std::io::Error) -> Self {
+        Self::LocalError(e.to_string())
+    }
+}
+
+impl From<::object_store::Error> for PutError {
+    fn from(e: ::object_store::Error) -> Self {
+        Self::ObjectStoreError(Arc::new(e))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum StorageConfigError {
+    #[error("Invalid storage config")]
+    InvalidStorageConfig,
+    #[error("Failed to create bucket: {0}")]
+    FailedToCreateBucket(String),
+}
+
+impl ChromaError for StorageConfigError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            StorageConfigError::InvalidStorageConfig => ErrorCodes::InvalidArgument,
+            StorageConfigError::FailedToCreateBucket(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -64,6 +110,7 @@ impl ChromaError for PutError {
 impl Storage {
     pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
         match self {
+            Storage::ObjectStore(object_store) => object_store.get(key).await,
             Storage::S3(s3) => {
                 let res = s3.get(key).await;
                 match res {
@@ -98,6 +145,7 @@ impl Storage {
 
     pub async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
         match self {
+            Storage::ObjectStore(object_store) => object_store.get_parallel(key).await,
             Storage::S3(s3) => {
                 let res = s3.get_parallel(key).await;
                 match res {
@@ -132,46 +180,9 @@ impl Storage {
         }
     }
 
-    // TODO: Remove this once the upstream switches to consume non-streaming.
-    pub async fn get_stream(
-        &self,
-        key: &str,
-    ) -> Result<Box<dyn Stream<Item = ByteStreamItem> + Unpin + Send>, GetError> {
-        match self {
-            Storage::S3(s3) => {
-                let res = s3.get_stream(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                        _ => Err(GetError::S3Error(e)),
-                    },
-                }
-            }
-            Storage::Local(local) => {
-                let res = local.get_stream(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => Err(GetError::LocalError(e)),
-                }
-            }
-            Storage::AdmissionControlledS3(admission_controlled_storage) => {
-                let res = admission_controlled_storage.get_stream(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        AdmissionControlledS3StorageError::S3GetError(e) => match e {
-                            S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                            _ => Err(GetError::S3Error(e)),
-                        },
-                    },
-                }
-            }
-        }
-    }
-
     pub async fn put_file(&self, key: &str, path: &str) -> Result<(), PutError> {
         match self {
+            Storage::ObjectStore(object_store) => object_store.put_file(key, path).await,
             Storage::S3(s3) => s3.put_file(key, path).await.map_err(PutError::S3Error),
             Storage::Local(local) => local
                 .put_file(key, path)
@@ -185,6 +196,7 @@ impl Storage {
 
     pub async fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> Result<(), PutError> {
         match self {
+            Storage::ObjectStore(object_store) => object_store.put_bytes(key, bytes).await,
             Storage::S3(s3) => s3.put_bytes(key, bytes).await.map_err(PutError::S3Error),
             Storage::Local(local) => local
                 .put_bytes(key, &bytes)
@@ -199,6 +211,9 @@ impl Storage {
 
 pub async fn from_config(config: &StorageConfig) -> Result<Storage, Box<dyn ChromaError>> {
     match &config {
+        StorageConfig::ObjectStore(config) => Ok(Storage::ObjectStore(
+            object_store::ObjectStore::try_from_config(config).await?,
+        )),
         StorageConfig::S3(_) => Ok(Storage::S3(s3::S3Storage::try_from_config(config).await?)),
         StorageConfig::Local(_) => Ok(Storage::Local(
             local::LocalStorage::try_from_config(config).await?,

--- a/rust/storage/src/object_store.rs
+++ b/rust/storage/src/object_store.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+
+use chroma_error::ChromaError;
+use object_store::path::Path;
+use object_store::{GetOptions, ObjectStore as ObjectStoreTrait, PutOptions};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::sync::Mutex;
+
+use super::{GetError, PutError, StorageConfigError};
+
+#[derive(Clone)]
+pub struct ObjectStore {
+    object_store: Arc<dyn ObjectStoreTrait>,
+    upload_part_size_bytes: u64,
+    #[allow(dead_code)]
+    download_part_size_bytes: u64,
+}
+
+impl ObjectStore {
+    pub async fn try_from_config(
+        config: &super::config::ObjectStoreConfig,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        match &config.bucket.r#type {
+            super::config::ObjectStoreType::Minio => {
+                let object_store = object_store::aws::AmazonS3Builder::new()
+                    .with_region("us-east-1")
+                    .with_endpoint("http://minio.chroma:9000")
+                    .with_bucket_name(&config.bucket.name)
+                    .with_access_key_id("minio")
+                    .with_secret_access_key("minio123")
+                    .build()
+                    .map_err(|err| {
+                        tracing::error! {"Failed to create object store: {:?}", err};
+                        Box::new(StorageConfigError::InvalidStorageConfig) as _
+                    })?;
+                let object_store = object_store::limit::LimitStore::new(
+                    object_store,
+                    config.max_concurrent_requests,
+                );
+                Ok(ObjectStore {
+                    object_store: Arc::new(object_store),
+                    upload_part_size_bytes: config.upload_part_size_bytes,
+                    download_part_size_bytes: config.download_part_size_bytes,
+                })
+            }
+            super::config::ObjectStoreType::S3 => {
+                let object_store = object_store::aws::AmazonS3Builder::from_env()
+                    .with_bucket_name(&config.bucket.name)
+                    .build()
+                    .map_err(|err| {
+                        tracing::error! {"Failed to create object store: {:?}", err};
+                        Box::new(StorageConfigError::InvalidStorageConfig) as _
+                    })?;
+                let object_store = object_store::limit::LimitStore::new(
+                    object_store,
+                    config.max_concurrent_requests,
+                );
+                Ok(ObjectStore {
+                    object_store: Arc::new(object_store),
+                    upload_part_size_bytes: config.upload_part_size_bytes,
+                    download_part_size_bytes: config.download_part_size_bytes,
+                })
+            }
+        }
+    }
+
+    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
+        Ok(self
+            .object_store
+            .get_opts(&Path::from(key), GetOptions::default())
+            .await?
+            .bytes()
+            .await?
+            .to_vec()
+            .into())
+    }
+
+    pub async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
+        // TODO(rescrv, NOCOMMIT): Implement parallel get for object store
+        Ok(self
+            .object_store
+            .get_opts(&Path::from(key), GetOptions::default())
+            .await?
+            .bytes()
+            .await?
+            .to_vec()
+            .into())
+    }
+
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), PutError> {
+        let multipart = self.object_store.put_multipart(&Path::from(key)).await?;
+        let multipart = Arc::new(Mutex::new(multipart));
+        let file_size = tokio::fs::metadata(path).await?.len();
+        let path = path.to_string();
+        async fn read_from_part_of_file(
+            path: &str,
+            offset: u64,
+            length: u64,
+        ) -> Result<Vec<u8>, std::io::Error> {
+            let mut file = tokio::fs::File::open(path).await?;
+            let mut buffer = vec![0; length as usize];
+            file.seek(std::io::SeekFrom::Start(offset)).await?;
+            file.read_exact(&mut buffer).await?;
+            Ok(buffer)
+        }
+        let part_count =
+            (file_size + self.upload_part_size_bytes - 1) / self.upload_part_size_bytes;
+        let mut pieces = vec![];
+        for i in 0..part_count {
+            let path = path.clone();
+            let limit = std::cmp::min(
+                file_size - i * self.upload_part_size_bytes,
+                self.upload_part_size_bytes,
+            );
+            let multipart = Arc::clone(&multipart);
+            pieces.push(async move {
+                let bytes =
+                    match read_from_part_of_file(&path, i * self.upload_part_size_bytes, limit)
+                        .await
+                    {
+                        Ok(bytes) => bytes,
+                        Err(e) => {
+                            return Err::<(), PutError>(e.into());
+                        }
+                    };
+                let mut multipart = multipart.lock().await;
+                multipart.put_part(bytes.into()).await?;
+                Ok(())
+            })
+        }
+        futures::future::try_join_all(pieces).await?;
+        let mut multipart = multipart.lock().await;
+        multipart.complete().await?;
+        Ok(())
+    }
+
+    pub async fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> Result<(), PutError> {
+        self.object_store
+            .put_opts(&Path::from(key), bytes.into(), PutOptions::default())
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_object_store() -> ObjectStore {
+        ObjectStore {
+            object_store: Arc::new(object_store::memory::InMemory::new()),
+            upload_part_size_bytes: 1024 * 1024 * 5,
+            download_part_size_bytes: 1024 * 1024 * 5,
+        }
+    }
+
+    #[tokio::test]
+    async fn put_get() {
+        let object_store = get_object_store();
+        let key = "test";
+        let bytes = b"test data".to_vec();
+        object_store.put_bytes(key, bytes.clone()).await.unwrap();
+        let result = object_store.get(key).await.unwrap();
+        assert_eq!(result, bytes.into());
+    }
+
+    #[tokio::test]
+    async fn get_parallel() {
+        let object_store = get_object_store();
+        let key = "test";
+        let bytes = b"test data AaAaZzZz"
+            .iter()
+            .copied()
+            .cycle()
+            .take(1024 * 1024 * 50)
+            .collect::<Vec<_>>();
+        object_store.put_bytes(key, bytes.clone()).await.unwrap();
+        let result = object_store.get(key).await.unwrap();
+        assert_eq!(result, bytes.into());
+    }
+
+    #[tokio::test]
+    async fn put_file() {
+        let object_store = get_object_store();
+        let key = "test";
+        let bytes = b"test data".to_vec();
+        let path = "test_file";
+        tokio::fs::write(path, &bytes).await.unwrap();
+        object_store.put_file(key, path).await.unwrap();
+        let result = object_store.get(key).await.unwrap();
+        assert_eq!(result, bytes.into());
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/rust/storage/src/object_store.rs
+++ b/rust/storage/src/object_store.rs
@@ -98,7 +98,7 @@ impl ObjectStore {
                 ..Default::default()
             };
             let object_store = Arc::clone(&self.object_store);
-            let path = Path::from(key.clone()).to_owned();
+            let path = Path::from(key).to_owned();
             let fut = async move { object_store.get_opts(&path, options).await };
             pieces.push(fut);
         }


### PR DESCRIPTION
The `object_store` crate implements a backend-agnostic version of object
storage that is capable of accessing gcp, azure, aws, local filesystem
and other implementations.

Tested against tilt.
