### PR TITLE
[PERF]: enable thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,12 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 arrow = "52.0.0"
 thiserror = "1.0.50"
-uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
+uuid = { version = "1.6.1", features = [
+   "v4",
+   "fast-rng",
+   "macro-diagnostics",
+   "serde",
+] }
 async-trait = "0.1.74"
 roaring = "0.10.3"
 futures = "0.3"
@@ -60,3 +65,4 @@ tempfile = "3.8.1"
 
 [profile.release]
 debug = 2
+lto = "thin"


### PR DESCRIPTION
## Description of changes

Increases full-text query performance (as measured by its benchmark) by 20-30% "for free". Does not seem to affect the limit/filter benchmarks.

Cold builds take the same amount of time with LTO enabled/disabled. Incremental builds take about 2x as long (25s -> 1m). (These changes only apply when building for the release profile.)

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a