### PR TITLE
[CLN]: rename blockfile `open()` -> `read()` and remove `create()`/`fork()`

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -686,7 +686,7 @@ mod tests {
         let flusher = writer.commit::<&str, Vec<u32>>().await.unwrap();
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &[u32]>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &[u32]>(&id).await.unwrap();
 
         let count = reader.count().await;
         match count {
@@ -724,7 +724,7 @@ mod tests {
             let flusher = writer.commit::<&str, u32>().await.unwrap();
             flusher.flush::<&str, u32>().await.unwrap();
 
-            let reader = blockfile_provider.open::<&str, u32>(&id).await.unwrap();
+            let reader = blockfile_provider.read::<&str, u32>(&id).await.unwrap();
             let prefix_query = format!("{}/{}", "prefix", prefix_for_query);
             println!("Query {}, num_keys {}", prefix_query, num_keys);
             let range_iter =
@@ -789,7 +789,7 @@ mod tests {
             let flusher = writer.commit::<&str, u32>().await.unwrap();
             flusher.flush::<&str, u32>().await.unwrap();
 
-            let reader = blockfile_provider.open::<&str, u32>(&id).await.unwrap();
+            let reader = blockfile_provider.read::<&str, u32>(&id).await.unwrap();
             let query = format!("{}/{}", "key", query_key);
             println!("Query {}", query);
             println!("Operation {:?}", operation);
@@ -950,7 +950,7 @@ mod tests {
         let flusher = writer.commit::<&str, Vec<u32>>().await.unwrap();
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &[u32]>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &[u32]>(&id).await.unwrap();
 
         let value = reader.get(prefix_1, key1).await.unwrap();
         assert_eq!(value, [1, 2, 3]);
@@ -988,7 +988,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_1)
+            .read::<&str, &[u32]>(&id_1)
             .await
             .unwrap();
 
@@ -1023,7 +1023,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_2)
+            .read::<&str, &[u32]>(&id_2)
             .await
             .unwrap();
         for i in 0..5 {
@@ -1057,7 +1057,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_3)
+            .read::<&str, &[u32]>(&id_3)
             .await
             .unwrap();
         for i in n..n * 2 {
@@ -1110,7 +1110,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_1)
+            .read::<&str, &[u32]>(&id_1)
             .await
             .unwrap();
 
@@ -1153,7 +1153,7 @@ mod tests {
         let flusher = writer.commit::<&str, String>().await.unwrap();
         flusher.flush::<&str, String>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         for i in 0..n {
             let key = format!("{:04}", i);
             let value = reader.get("key", &key).await.unwrap();
@@ -1190,7 +1190,7 @@ mod tests {
         let flusher = writer.commit::<f32, String>().await.unwrap();
         flusher.flush::<f32, String>().await.unwrap();
 
-        let reader = provider.open::<f32, &str>(&id).await.unwrap();
+        let reader = provider.read::<f32, &str>(&id).await.unwrap();
         for i in 0..n {
             let key = i as f32;
             let value = reader.get("key", key).await.unwrap();
@@ -1234,7 +1234,7 @@ mod tests {
             .unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, roaring::RoaringBitmap>(&id)
+            .read::<&str, roaring::RoaringBitmap>(&id)
             .await
             .unwrap();
         for i in 0..n {
@@ -1277,7 +1277,7 @@ mod tests {
         let flusher = writer.commit::<u32, u32>().await.unwrap();
         flusher.flush::<u32, u32>().await.unwrap();
 
-        let reader = blockfile_provider.open::<u32, u32>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<u32, u32>(&id).await.unwrap();
         for i in 0..n {
             let key = i as u32;
             let value = reader.get("key", key).await.unwrap();
@@ -1322,7 +1322,7 @@ mod tests {
         flusher.flush::<&str, &DataRecord>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, DataRecord>(&id)
+            .read::<&str, DataRecord>(&id)
             .await
             .unwrap();
         for i in 0..n {
@@ -1373,7 +1373,7 @@ mod tests {
         let flusher = writer.commit::<&str, String>().await.unwrap();
         flusher.flush::<&str, String>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         let val_1 = reader.get("key", "1").await.unwrap();
         let val_2 = reader.get("key", "2").await.unwrap();
 
@@ -1412,7 +1412,7 @@ mod tests {
         let flusher = writer.commit::<&str, String>().await.unwrap();
         flusher.flush::<&str, String>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         for i in 0..n {
             let key = format!("{:04}", i);
             let value = reader.get("key", &key).await.unwrap();
@@ -1439,7 +1439,7 @@ mod tests {
         flusher.flush::<&str, String>().await.unwrap();
 
         // Check that the deleted keys are gone
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         for i in 0..n {
             let key = format!("{:04}", i);
             if deleted_keys.contains(&i) {
@@ -1479,7 +1479,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_1)
+            .read::<&str, &[u32]>(&id_1)
             .await
             .unwrap();
 
@@ -1544,7 +1544,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_2)
+            .read::<&str, &[u32]>(&id_2)
             .await
             .unwrap();
 
@@ -1577,7 +1577,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_3)
+            .read::<&str, &[u32]>(&id_3)
             .await
             .unwrap();
 
@@ -1617,7 +1617,7 @@ mod tests {
         let flusher = writer.commit::<&str, u32>().await.unwrap();
         flusher.flush::<&str, u32>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, u32>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, u32>(&id).await.unwrap();
         let value = reader.get("prefix", fixed_key).await.unwrap();
         assert_eq!(value, n - 1);
     }
@@ -1742,7 +1742,7 @@ mod tests {
         );
 
         let reader = blockfile_provider
-            .open::<&str, &str>(&first_write_id)
+            .read::<&str, &str>(&first_write_id)
             .await
             .unwrap();
         let reader = match reader {
@@ -1798,7 +1798,7 @@ mod tests {
         // Verify that the counts were correctly migrated
 
         let blockfile_reader = blockfile_provider
-            .open::<&str, &str>(&second_write_id)
+            .read::<&str, &str>(&second_write_id)
             .await
             .unwrap();
 

--- a/rust/blockstore/src/arrow/concurrency_test.rs
+++ b/rust/blockstore/src/arrow/concurrency_test.rs
@@ -67,7 +67,7 @@ mod tests {
                 });
 
                 let reader = future::block_on(async {
-                    blockfile_provider.open::<&str, u32>(&id).await.unwrap()
+                    blockfile_provider.read::<&str, u32>(&id).await.unwrap()
                 });
                 // Read the data back
                 for i in 0..n {

--- a/rust/blockstore/src/arrow/ordered_blockfile_writer.rs
+++ b/rust/blockstore/src/arrow/ordered_blockfile_writer.rs
@@ -351,7 +351,7 @@ mod tests {
         let flusher = writer.commit::<&str, Vec<u32>>().await.unwrap();
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &[u32]>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &[u32]>(&id).await.unwrap();
 
         let count = reader.count().await;
         match count {
@@ -391,7 +391,7 @@ mod tests {
         let flusher = writer.commit::<&str, Vec<u32>>().await.unwrap();
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &[u32]>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &[u32]>(&id).await.unwrap();
 
         let value = reader.get(prefix_1, key1).await.unwrap();
         assert_eq!(value, [1, 2, 3]);
@@ -429,7 +429,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_1)
+            .read::<&str, &[u32]>(&id_1)
             .await
             .unwrap();
 
@@ -464,7 +464,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_2)
+            .read::<&str, &[u32]>(&id_2)
             .await
             .unwrap();
         for i in 0..5 {
@@ -497,7 +497,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_3)
+            .read::<&str, &[u32]>(&id_3)
             .await
             .unwrap();
         for i in n..n * 2 {
@@ -550,7 +550,7 @@ mod tests {
         let flusher = writer.commit::<&str, String>().await.unwrap();
         flusher.flush::<&str, String>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         let val_1 = reader.get("key", "1").await.unwrap();
         let val_2 = reader.get("key", "2").await.unwrap();
 
@@ -588,7 +588,7 @@ mod tests {
         let flusher = writer.commit::<&str, String>().await.unwrap();
         flusher.flush::<&str, String>().await.unwrap();
 
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         for i in 0..n {
             let key = format!("{:04}", i);
             let value = reader.get("key", &key).await.unwrap();
@@ -616,7 +616,7 @@ mod tests {
         flusher.flush::<&str, String>().await.unwrap();
 
         // Check that the deleted keys are gone
-        let reader = blockfile_provider.open::<&str, &str>(&id).await.unwrap();
+        let reader = blockfile_provider.read::<&str, &str>(&id).await.unwrap();
         for i in 0..n {
             let key = format!("{:04}", i);
             if deleted_keys.contains(&i) {
@@ -674,7 +674,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_2)
+            .read::<&str, &[u32]>(&id_2)
             .await
             .unwrap();
 
@@ -707,7 +707,7 @@ mod tests {
         flusher.flush::<&str, Vec<u32>>().await.unwrap();
 
         let reader = blockfile_provider
-            .open::<&str, &[u32]>(&id_3)
+            .read::<&str, &[u32]>(&id_3)
             .await
             .unwrap();
 
@@ -835,7 +835,7 @@ mod tests {
         );
 
         let reader = blockfile_provider
-            .open::<&str, &str>(&first_write_id)
+            .read::<&str, &str>(&first_write_id)
             .await
             .unwrap();
         let reader = match reader {
@@ -895,7 +895,7 @@ mod tests {
         // Verify that the counts were correctly migrated
 
         let blockfile_reader = blockfile_provider
-            .open::<&str, &str>(&second_write_id)
+            .read::<&str, &str>(&second_write_id)
             .await
             .unwrap();
 

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -45,7 +45,7 @@ impl ArrowBlockfileProvider {
         }
     }
 
-    pub async fn open<
+    pub async fn read<
         'new,
         K: Key + Into<KeyWrapper> + ArrowReadableKey<'new> + 'new,
         V: Value + Readable<'new> + ArrowReadableValue<'new> + 'new,

--- a/rust/blockstore/src/memory/provider.rs
+++ b/rust/blockstore/src/memory/provider.rs
@@ -26,7 +26,7 @@ impl MemoryBlockfileProvider {
         }
     }
 
-    pub(crate) fn open<
+    pub(crate) fn read<
         'new,
         K: Key
             + Into<KeyWrapper>

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -60,7 +60,7 @@ impl BlockfileProvider {
         ))
     }
 
-    pub async fn open<
+    pub async fn read<
         'new,
         K: Key
             + Into<KeyWrapper>
@@ -74,8 +74,8 @@ impl BlockfileProvider {
         id: &uuid::Uuid,
     ) -> Result<BlockfileReader<'new, K, V>, Box<OpenError>> {
         match self {
-            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.open::<K, V>(id),
-            BlockfileProvider::ArrowBlockfileProvider(provider) => provider.open::<K, V>(id).await,
+            BlockfileProvider::HashMapBlockfileProvider(provider) => provider.read::<K, V>(id),
+            BlockfileProvider::ArrowBlockfileProvider(provider) => provider.read::<K, V>(id).await,
         }
     }
 

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -100,45 +100,6 @@ impl BlockfileProvider {
         };
         Ok(())
     }
-
-    // todo: deprecate
-    pub async fn create<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(
-        &self,
-    ) -> Result<BlockfileWriter, Box<CreateError>> {
-        match self {
-            BlockfileProvider::HashMapBlockfileProvider(provider) => {
-                provider.write(BlockfileWriterOptions::default())
-            }
-            BlockfileProvider::ArrowBlockfileProvider(provider) => {
-                provider
-                    .write::<K, V>(BlockfileWriterOptions::default())
-                    .await
-            }
-        }
-    }
-
-    // todo: deprecate
-    pub async fn fork<K: Key + ArrowWriteableKey, V: Value + ArrowWriteableValue>(
-        &self,
-        id: &uuid::Uuid,
-    ) -> Result<BlockfileWriter, Box<CreateError>> {
-        match self {
-            BlockfileProvider::HashMapBlockfileProvider(provider) => {
-                provider.write(BlockfileWriterOptions {
-                    fork_from: Some(*id),
-                    ..Default::default()
-                })
-            }
-            BlockfileProvider::ArrowBlockfileProvider(provider) => {
-                provider
-                    .write::<K, V>(BlockfileWriterOptions {
-                        fork_from: Some(*id),
-                        ..Default::default()
-                    })
-                    .await
-            }
-        }
-    }
 }
 
 // =================== Configurable ===================

--- a/rust/blockstore/tests/blockfile_writer_test.rs
+++ b/rust/blockstore/tests/blockfile_writer_test.rs
@@ -411,7 +411,7 @@ mod tests {
             let ref_last_commit = ref_state.last_commit.as_ref().unwrap();
             let last_blockfile_id = state.last_blockfile_id.unwrap();
 
-            let reader = block_on(state.provider.open::<&str, &str>(&last_blockfile_id)).unwrap();
+            let reader = block_on(state.provider.read::<&str, &str>(&last_blockfile_id)).unwrap();
 
             // Check count
             assert_eq!(block_on(reader.count()).unwrap(), ref_last_commit.len());

--- a/rust/index/benches/full_text.rs
+++ b/rust/index/benches/full_text.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use chroma_benchmark::datasets::{
     ms_marco_queries::MicrosoftMarcoQueriesDataset, scidocs::SciDocsDataset, types::RecordDataset,
 };
-use chroma_blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider};
+use chroma_blockstore::{
+    arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider, BlockfileWriterOptions,
+};
 use chroma_cache::UnboundedCacheConfig;
 use chroma_index::fulltext::{
     tokenizer::TantivyChromaTokenizer,
@@ -25,8 +27,14 @@ async fn compact_log_and_get_reader<'a, T>(
 where
     T: RecordDataset,
 {
-    let postings_blockfile_writer = blockfile_provider.create::<u32, Vec<u32>>().await.unwrap();
-    let frequencies_blockfile_writer = blockfile_provider.create::<u32, u32>().await.unwrap();
+    let postings_blockfile_writer = blockfile_provider
+        .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+        .await
+        .unwrap();
+    let frequencies_blockfile_writer = blockfile_provider
+        .write::<u32, u32>(BlockfileWriterOptions::default())
+        .await
+        .unwrap();
     let postings_blockfile_id = postings_blockfile_writer.id();
     let frequencies_blockfile_id = frequencies_blockfile_writer.id();
 

--- a/rust/index/benches/full_text.rs
+++ b/rust/index/benches/full_text.rs
@@ -59,11 +59,11 @@ where
     flusher.flush().await.unwrap();
 
     let postings_blockfile_reader = blockfile_provider
-        .open::<u32, &[u32]>(&postings_blockfile_id)
+        .read::<u32, &[u32]>(&postings_blockfile_id)
         .await
         .unwrap();
     let frequencies_blockfile_reader = blockfile_provider
-        .open::<u32, u32>(&frequencies_blockfile_id)
+        .read::<u32, u32>(&frequencies_blockfile_id)
         .await
         .unwrap();
 

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -576,9 +576,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -605,9 +605,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -644,9 +644,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -678,9 +678,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -711,9 +711,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -744,9 +744,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -781,9 +781,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -818,9 +818,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -857,9 +857,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -906,9 +906,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -950,9 +950,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -993,9 +993,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -1036,9 +1036,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -1083,9 +1083,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
@@ -1124,9 +1124,9 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let freq_blockfile_reader = provider.open::<u32, u32>(&freq_blockfile_id).await.unwrap();
+        let freq_blockfile_reader = provider.read::<u32, u32>(&freq_blockfile_id).await.unwrap();
         let pl_blockfile_reader = provider
-            .open::<u32, &[u32]>(&pl_blockfile_id)
+            .read::<u32, &[u32]>(&pl_blockfile_id)
             .await
             .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -544,14 +544,20 @@ impl<'me> FullTextIndexReader<'me> {
 mod tests {
     use super::*;
     use crate::fulltext::tokenizer::TantivyChromaTokenizer;
-    use chroma_blockstore::provider::BlockfileProvider;
+    use chroma_blockstore::{provider::BlockfileProvider, BlockfileWriterOptions};
     use tantivy::tokenizer::NgramTokenizer;
 
     #[tokio::test]
     async fn test_new_writer() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let tokenizer = Box::new(TantivyChromaTokenizer::new(
             NgramTokenizer::new(1, 1, false).unwrap(),
         ));
@@ -562,8 +568,14 @@ mod tests {
     #[tokio::test]
     async fn test_new_writer_then_reader() {
         let provider = BlockfileProvider::new_memory();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let freq_blockfile_id = freq_blockfile_writer.id();
         let pl_blockfile_id = pl_blockfile_writer.id();
 
@@ -590,8 +602,14 @@ mod tests {
     #[tokio::test]
     async fn test_index_and_search_single_document() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -629,8 +647,14 @@ mod tests {
     #[tokio::test]
     async fn test_repeating_character_in_query() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -662,8 +686,14 @@ mod tests {
     #[tokio::test]
     async fn test_query_of_repeating_character() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -696,8 +726,14 @@ mod tests {
     #[tokio::test]
     async fn test_repeating_character_in_document() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -729,8 +765,14 @@ mod tests {
     #[tokio::test]
     async fn test_search_absent_token() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -762,8 +804,14 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_candidates_within_document() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -802,8 +850,14 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_simple_documents() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -839,8 +893,14 @@ mod tests {
     #[tokio::test]
     async fn test_multiple_complex_documents() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -884,8 +944,14 @@ mod tests {
     #[tokio::test]
     async fn test_index_multiple_character_repeating() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -930,8 +996,14 @@ mod tests {
     #[tokio::test]
     async fn test_index_special_characters() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -974,8 +1046,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_frequencies_for_token() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -1017,8 +1095,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_all_results_for_token() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -1060,8 +1144,14 @@ mod tests {
     #[tokio::test]
     async fn test_update_document() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 
@@ -1104,8 +1194,14 @@ mod tests {
     #[tokio::test]
     async fn test_delete_document() {
         let provider = BlockfileProvider::new_memory();
-        let pl_blockfile_writer = provider.create::<u32, Vec<u32>>().await.unwrap();
-        let freq_blockfile_writer = provider.create::<u32, String>().await.unwrap();
+        let pl_blockfile_writer = provider
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let freq_blockfile_writer = provider
+            .write::<u32, String>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
         let freq_blockfile_id = freq_blockfile_writer.id();
 

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -687,40 +687,55 @@ impl<'me> MetadataIndexReader<'me> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chroma_blockstore::provider::BlockfileProvider;
+    use chroma_blockstore::{provider::BlockfileProvider, BlockfileWriterOptions};
 
     #[tokio::test]
     async fn test_new_string_writer() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<&str, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let _writer = MetadataIndexWriter::new_string(blockfile_writer, None);
     }
 
     #[tokio::test]
     async fn test_new_u32_writer() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let _writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
     }
 
     #[tokio::test]
     async fn test_new_f32_writer() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let _writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
     }
 
     #[tokio::test]
     async fn test_new_bool_writer() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<bool, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let _writer = MetadataIndexWriter::new_bool(blockfile_writer, None);
     }
 
     #[tokio::test]
     async fn test_new_string_writer_then_reader() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<&str, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_string(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
@@ -737,7 +752,10 @@ mod test {
     #[tokio::test]
     async fn test_new_u32_writer_then_reader() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
@@ -754,7 +772,10 @@ mod test {
     #[tokio::test]
     async fn test_new_f32_writer_then_reader() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
@@ -771,7 +792,10 @@ mod test {
     #[tokio::test]
     async fn test_new_bool_writer_then_reader() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<bool, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut md_writer = MetadataIndexWriter::new_bool(blockfile_writer, None);
         md_writer.write_to_blockfile().await.unwrap();
@@ -788,7 +812,10 @@ mod test {
     #[tokio::test]
     async fn test_string_metadata_index_set_get() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<&str, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_string(blockfile_writer, None);
         writer.set("key", "value", 1).await.unwrap();
@@ -809,7 +836,10 @@ mod test {
     #[tokio::test]
     async fn test_u32_metadata_index_set_get() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key", 1, 1).await.unwrap();
@@ -830,7 +860,10 @@ mod test {
     #[tokio::test]
     async fn test_f32_metadata_index_set_get() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key", 1.0, 1).await.unwrap();
@@ -851,7 +884,10 @@ mod test {
     #[tokio::test]
     async fn test_bool_value_metadata_index_set_get() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<bool, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_bool(blockfile_writer, None);
         writer.set("key", true, 1).await.unwrap();
@@ -872,7 +908,10 @@ mod test {
     #[tokio::test]
     async fn test_string_metadata_multiple_keys() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<&str, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_string(blockfile_writer, None);
         writer.set("key1", "value", 1).await.unwrap();
@@ -901,7 +940,10 @@ mod test {
     #[tokio::test]
     async fn test_u32_metadata_multiple_keys() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key1", 1, 1).await.unwrap();
@@ -930,7 +972,10 @@ mod test {
     #[tokio::test]
     async fn test_f32_metadata_multiple_keys() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key1", 1.0, 1).await.unwrap();
@@ -959,7 +1004,10 @@ mod test {
     #[tokio::test]
     async fn test_bool_metadata_multiple_keys() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<bool, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_bool(blockfile_writer, None);
         writer.set("key1", true, 1).await.unwrap();
@@ -988,7 +1036,10 @@ mod test {
     #[tokio::test]
     async fn test_u32_metadata_lt_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key1", 1, 1).await.unwrap();
@@ -1021,7 +1072,10 @@ mod test {
     #[tokio::test]
     async fn test_u32_value_metadata_lte_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key1", 1, 1).await.unwrap();
@@ -1055,7 +1109,10 @@ mod test {
     #[tokio::test]
     async fn test_u32_value_metadata_gt_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key1", 1, 1).await.unwrap();
@@ -1088,7 +1145,10 @@ mod test {
     #[tokio::test]
     async fn test_u32_value_metadata_gte_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<u32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_u32(blockfile_writer, None);
         writer.set("key1", 1, 1).await.unwrap();
@@ -1122,7 +1182,10 @@ mod test {
     #[tokio::test]
     async fn test_f32_metadata_lt_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key1", 1.0, 1).await.unwrap();
@@ -1156,7 +1219,10 @@ mod test {
     #[tokio::test]
     async fn test_f32_metadata_lte_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key1", 1.0, 1).await.unwrap();
@@ -1191,7 +1257,10 @@ mod test {
     #[tokio::test]
     async fn test_f32_metadata_gt_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key1", 1.0, 1).await.unwrap();
@@ -1224,7 +1293,10 @@ mod test {
     #[tokio::test]
     async fn test_f32_metadata_gte_operator() {
         let provider = BlockfileProvider::new_memory();
-        let blockfile_writer = provider.create::<f32, RoaringBitmap>().await.unwrap();
+        let blockfile_writer = provider
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
         let writer_id = blockfile_writer.id();
         let mut writer = MetadataIndexWriter::new_f32(blockfile_writer, None);
         writer.set("key1", 1.0, 1).await.unwrap();

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -728,7 +728,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<&str, RoaringBitmap>(&writer_id)
+            .read::<&str, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_string(blockfile_reader);
@@ -745,7 +745,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -762,7 +762,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -779,7 +779,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<bool, RoaringBitmap>(&writer_id)
+            .read::<bool, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_bool(blockfile_reader);
@@ -797,7 +797,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<&str, RoaringBitmap>(&writer_id)
+            .read::<&str, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_string(blockfile_reader);
@@ -818,7 +818,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -839,7 +839,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -860,7 +860,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<bool, RoaringBitmap>(&writer_id)
+            .read::<bool, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_bool(blockfile_reader);
@@ -884,7 +884,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<&str, RoaringBitmap>(&writer_id)
+            .read::<&str, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_string(blockfile_reader);
@@ -913,7 +913,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -942,7 +942,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -971,7 +971,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<bool, RoaringBitmap>(&writer_id)
+            .read::<bool, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_bool(blockfile_reader);
@@ -1001,7 +1001,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1034,7 +1034,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1068,7 +1068,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1101,7 +1101,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1135,7 +1135,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1169,7 +1169,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1204,7 +1204,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1237,7 +1237,7 @@ mod test {
         flusher.flush().await.unwrap();
 
         let blockfile_reader = provider
-            .open::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(&writer_id)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -137,7 +137,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                         Ok(writer) => writer,
                         Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                     };
-                    let pls_reader = match blockfile_provider.open::<u32, &[u32]>(&pls_uuid).await {
+                    let pls_reader = match blockfile_provider.read::<u32, &[u32]>(&pls_uuid).await {
                         Ok(reader) => reader,
                         Err(e) => return Err(MetadataSegmentError::BlockfileOpenError(*e)),
                     };
@@ -166,7 +166,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                         Ok(writer) => writer,
                         Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                     };
-                    let freqs_reader = match blockfile_provider.open::<u32, u32>(&freqs_uuid).await
+                    let freqs_reader = match blockfile_provider.read::<u32, u32>(&freqs_uuid).await
                     {
                         Ok(reader) => reader,
                         Err(e) => return Err(MetadataSegmentError::BlockfileOpenError(*e)),
@@ -225,7 +225,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                             Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                         };
                         let string_metadata_index_reader = match blockfile_provider
-                            .open::<&str, RoaringBitmap>(&string_metadata_uuid)
+                            .read::<&str, RoaringBitmap>(&string_metadata_uuid)
                             .await
                         {
                             Ok(reader) => MetadataIndexReader::new_string(reader),
@@ -263,7 +263,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                             Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                         };
                         let bool_metadata_index_writer = match blockfile_provider
-                            .open::<bool, RoaringBitmap>(&bool_metadata_uuid)
+                            .read::<bool, RoaringBitmap>(&bool_metadata_uuid)
                             .await
                         {
                             Ok(reader) => MetadataIndexReader::new_bool(reader),
@@ -301,7 +301,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                             Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                         };
                         let f32_metadata_index_reader = match blockfile_provider
-                            .open::<f32, RoaringBitmap>(&f32_metadata_uuid)
+                            .read::<f32, RoaringBitmap>(&f32_metadata_uuid)
                             .await
                         {
                             Ok(reader) => MetadataIndexReader::new_f32(reader),
@@ -339,7 +339,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                             Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                         };
                         let u32_metadata_index_reader = match blockfile_provider
-                            .open::<u32, RoaringBitmap>(&u32_metadata_uuid)
+                            .read::<u32, RoaringBitmap>(&u32_metadata_uuid)
                             .await
                         {
                             Ok(reader) => MetadataIndexReader::new_u32(reader),
@@ -958,7 +958,7 @@ impl MetadataSegmentReader<'_> {
                         }
                     };
 
-                    match blockfile_provider.open::<u32, &[u32]>(&pls_uuid).await {
+                    match blockfile_provider.read::<u32, &[u32]>(&pls_uuid).await {
                         Ok(reader) => Some(reader),
                         Err(e) => return Err(MetadataSegmentError::BlockfileOpenError(*e)),
                     }
@@ -978,7 +978,7 @@ impl MetadataSegmentReader<'_> {
                             ))
                         }
                     };
-                    match blockfile_provider.open::<u32, u32>(&freqs_uuid).await {
+                    match blockfile_provider.read::<u32, u32>(&freqs_uuid).await {
                         Ok(reader) => Some(reader),
                         Err(e) => return Err(MetadataSegmentError::BlockfileOpenError(*e)),
                     }
@@ -1015,7 +1015,7 @@ impl MetadataSegmentReader<'_> {
                         }
                     };
                     match blockfile_provider
-                        .open::<&str, RoaringBitmap>(&string_metadata_uuid)
+                        .read::<&str, RoaringBitmap>(&string_metadata_uuid)
                         .await
                     {
                         Ok(reader) => Some(reader),
@@ -1041,7 +1041,7 @@ impl MetadataSegmentReader<'_> {
                         }
                     };
                     match blockfile_provider
-                        .open::<bool, RoaringBitmap>(&bool_metadata_uuid)
+                        .read::<bool, RoaringBitmap>(&bool_metadata_uuid)
                         .await
                     {
                         Ok(reader) => Some(reader),
@@ -1065,7 +1065,7 @@ impl MetadataSegmentReader<'_> {
                         }
                     };
                     match blockfile_provider
-                        .open::<u32, RoaringBitmap>(&u32_metadata_uuid)
+                        .read::<u32, RoaringBitmap>(&u32_metadata_uuid)
                         .await
                     {
                         Ok(reader) => Some(reader),
@@ -1089,7 +1089,7 @@ impl MetadataSegmentReader<'_> {
                         }
                     };
                     match blockfile_provider
-                        .open::<f32, RoaringBitmap>(&f32_metadata_uuid)
+                        .read::<f32, RoaringBitmap>(&f32_metadata_uuid)
                         .await
                     {
                         Ok(reader) => Some(reader),

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -6,6 +6,7 @@ use super::types::{MaterializedLogRecord, SegmentWriter};
 use super::SegmentFlusher;
 use async_trait::async_trait;
 use chroma_blockstore::provider::{BlockfileProvider, CreateError, OpenError};
+use chroma_blockstore::BlockfileWriterOptions;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::fulltext::tokenizer::TantivyChromaTokenizer;
 use chroma_index::fulltext::types::{
@@ -132,7 +133,9 @@ impl<'me> MetadataSegmentWriter<'me> {
                             return Err(MetadataSegmentError::UuidParseError(pls_uuid.to_string()))
                         }
                     };
-                    let pls_writer = match blockfile_provider.fork::<u32, Vec<u32>>(&pls_uuid).await
+                    let pls_writer = match blockfile_provider
+                        .write::<u32, Vec<u32>>(BlockfileWriterOptions::new().fork(pls_uuid))
+                        .await
                     {
                         Ok(writer) => writer,
                         Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
@@ -145,7 +148,10 @@ impl<'me> MetadataSegmentWriter<'me> {
                 }
                 None => return Err(MetadataSegmentError::EmptyPathVector),
             },
-            None => match blockfile_provider.create::<u32, Vec<u32>>().await {
+            None => match blockfile_provider
+                .write::<u32, Vec<u32>>(BlockfileWriterOptions::default())
+                .await
+            {
                 Ok(writer) => (writer, None),
                 Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
             },
@@ -161,7 +167,9 @@ impl<'me> MetadataSegmentWriter<'me> {
                             ))
                         }
                     };
-                    let freqs_writer = match blockfile_provider.fork::<u32, u32>(&freqs_uuid).await
+                    let freqs_writer = match blockfile_provider
+                        .write::<u32, u32>(BlockfileWriterOptions::new().fork(freqs_uuid))
+                        .await
                     {
                         Ok(writer) => writer,
                         Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
@@ -175,7 +183,10 @@ impl<'me> MetadataSegmentWriter<'me> {
                 }
                 None => return Err(MetadataSegmentError::EmptyPathVector),
             },
-            None => match blockfile_provider.create::<u32, u32>().await {
+            None => match blockfile_provider
+                .write::<u32, u32>(BlockfileWriterOptions::default())
+                .await
+            {
                 Ok(writer) => (writer, None),
                 Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
             },
@@ -218,7 +229,9 @@ impl<'me> MetadataSegmentWriter<'me> {
                             }
                         };
                         let string_metadata_writer = match blockfile_provider
-                            .fork::<&str, RoaringBitmap>(&string_metadata_uuid)
+                            .write::<&str, RoaringBitmap>(
+                                BlockfileWriterOptions::new().fork(string_metadata_uuid),
+                            )
                             .await
                         {
                             Ok(writer) => writer,
@@ -235,7 +248,10 @@ impl<'me> MetadataSegmentWriter<'me> {
                     }
                     None => return Err(MetadataSegmentError::EmptyPathVector),
                 },
-                None => match blockfile_provider.create::<&str, RoaringBitmap>().await {
+                None => match blockfile_provider
+                    .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new())
+                    .await
+                {
                     Ok(writer) => (writer, None),
                     Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                 },
@@ -256,7 +272,9 @@ impl<'me> MetadataSegmentWriter<'me> {
                             }
                         };
                         let bool_metadata_writer = match blockfile_provider
-                            .fork::<bool, RoaringBitmap>(&bool_metadata_uuid)
+                            .write::<bool, RoaringBitmap>(
+                                BlockfileWriterOptions::new().fork(bool_metadata_uuid),
+                            )
                             .await
                         {
                             Ok(writer) => writer,
@@ -273,7 +291,10 @@ impl<'me> MetadataSegmentWriter<'me> {
                     }
                     None => return Err(MetadataSegmentError::EmptyPathVector),
                 },
-                None => match blockfile_provider.create::<bool, RoaringBitmap>().await {
+                None => match blockfile_provider
+                    .write::<bool, RoaringBitmap>(BlockfileWriterOptions::default())
+                    .await
+                {
                     Ok(writer) => (writer, None),
                     Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                 },
@@ -294,7 +315,9 @@ impl<'me> MetadataSegmentWriter<'me> {
                             }
                         };
                         let f32_metadata_writer = match blockfile_provider
-                            .fork::<f32, RoaringBitmap>(&f32_metadata_uuid)
+                            .write::<f32, RoaringBitmap>(
+                                BlockfileWriterOptions::new().fork(f32_metadata_uuid),
+                            )
                             .await
                         {
                             Ok(writer) => writer,
@@ -311,7 +334,10 @@ impl<'me> MetadataSegmentWriter<'me> {
                     }
                     None => return Err(MetadataSegmentError::EmptyPathVector),
                 },
-                None => match blockfile_provider.create::<f32, RoaringBitmap>().await {
+                None => match blockfile_provider
+                    .write::<f32, RoaringBitmap>(BlockfileWriterOptions::default())
+                    .await
+                {
                     Ok(writer) => (writer, None),
                     Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                 },
@@ -332,7 +358,9 @@ impl<'me> MetadataSegmentWriter<'me> {
                             }
                         };
                         let u32_metadata_writer = match blockfile_provider
-                            .fork::<u32, RoaringBitmap>(&u32_metadata_uuid)
+                            .write::<u32, RoaringBitmap>(
+                                BlockfileWriterOptions::new().fork(u32_metadata_uuid),
+                            )
                             .await
                         {
                             Ok(writer) => writer,
@@ -349,7 +377,10 @@ impl<'me> MetadataSegmentWriter<'me> {
                     }
                     None => return Err(MetadataSegmentError::EmptyPathVector),
                 },
-                None => match blockfile_provider.create::<u32, RoaringBitmap>().await {
+                None => match blockfile_provider
+                    .write::<u32, RoaringBitmap>(BlockfileWriterOptions::default())
+                    .await
+                {
                     Ok(writer) => (writer, None),
                     Err(e) => return Err(MetadataSegmentError::BlockfileError(*e)),
                 },

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -660,7 +660,7 @@ impl RecordSegmentReader<'_> {
                 };
 
                 let max_offset_id_bf_reader = match max_offset_id_bf_uuid {
-                    Some(bf_uuid) => match blockfile_provider.open::<&str, u32>(&bf_uuid).await {
+                    Some(bf_uuid) => match blockfile_provider.read::<&str, u32>(&bf_uuid).await {
                         Ok(max_offset_id_bf_reader) => Some(max_offset_id_bf_reader),
                         Err(_) => None,
                     },
@@ -675,7 +675,7 @@ impl RecordSegmentReader<'_> {
                 };
 
                 let user_id_to_id = match blockfile_provider
-                    .open::<&str, u32>(&Uuid::parse_str(user_id_to_id_bf_id).unwrap())
+                    .read::<&str, u32>(&Uuid::parse_str(user_id_to_id_bf_id).unwrap())
                     .await
                 {
                     Ok(user_id_to_id) => user_id_to_id,
@@ -687,7 +687,7 @@ impl RecordSegmentReader<'_> {
                 };
 
                 let id_to_user_id = match blockfile_provider
-                    .open::<u32, &str>(&Uuid::parse_str(id_to_user_id_bf_id).unwrap())
+                    .read::<u32, &str>(&Uuid::parse_str(id_to_user_id_bf_id).unwrap())
                     .await
                 {
                     Ok(id_to_user_id) => id_to_user_id,
@@ -699,7 +699,7 @@ impl RecordSegmentReader<'_> {
                 };
 
                 let id_to_data = match blockfile_provider
-                    .open::<u32, DataRecord>(&Uuid::parse_str(id_to_data_bf_id).unwrap())
+                    .read::<u32, DataRecord>(&Uuid::parse_str(id_to_data_bf_id).unwrap())
                     .await
                 {
                     Ok(id_to_data) => id_to_data,

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -2,7 +2,9 @@ use super::types::{MaterializedLogRecord, SegmentWriter};
 use super::SegmentFlusher;
 use async_trait::async_trait;
 use chroma_blockstore::provider::{BlockfileProvider, CreateError, OpenError};
-use chroma_blockstore::{BlockfileFlusher, BlockfileReader, BlockfileWriter};
+use chroma_blockstore::{
+    BlockfileFlusher, BlockfileReader, BlockfileWriter, BlockfileWriterOptions,
+};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::{Chunk, DataRecord, MaterializedLogOperation, Segment, SegmentType};
 use std::cmp::Ordering;
@@ -100,173 +102,189 @@ impl RecordSegmentWriter {
             return Err(RecordSegmentWriterCreationError::InvalidSegmentType);
         }
 
-        let (user_id_to_id, id_to_user_id, id_to_data, max_offset_id) =
-            match segment.file_path.len() {
-                0 => {
-                    tracing::debug!("No files found, creating new blockfiles for record segment");
-                    let user_id_to_id = match blockfile_provider.create::<&str, u32>().await {
-                        Ok(user_id_to_id) => user_id_to_id,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    let id_to_user_id = match blockfile_provider.create::<u32, String>().await {
-                        Ok(id_to_user_id) => id_to_user_id,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    let id_to_data = match blockfile_provider.create::<u32, &DataRecord>().await {
-                        Ok(id_to_data) => id_to_data,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    let max_offset_id = match blockfile_provider.create::<&str, u32>().await {
-                        Ok(max_offset_id) => max_offset_id,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
+        let (user_id_to_id, id_to_user_id, id_to_data, max_offset_id) = match segment
+            .file_path
+            .len()
+        {
+            0 => {
+                tracing::debug!("No files found, creating new blockfiles for record segment");
+                let user_id_to_id = match blockfile_provider
+                    .write::<&str, u32>(BlockfileWriterOptions::default())
+                    .await
+                {
+                    Ok(user_id_to_id) => user_id_to_id,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                let id_to_user_id = match blockfile_provider
+                    .write::<u32, String>(BlockfileWriterOptions::default())
+                    .await
+                {
+                    Ok(id_to_user_id) => id_to_user_id,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                let id_to_data = match blockfile_provider
+                    .write::<u32, &DataRecord>(BlockfileWriterOptions::default())
+                    .await
+                {
+                    Ok(id_to_data) => id_to_data,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                let max_offset_id = match blockfile_provider
+                    .write::<&str, u32>(BlockfileWriterOptions::default())
+                    .await
+                {
+                    Ok(max_offset_id) => max_offset_id,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
 
-                    (user_id_to_id, id_to_user_id, id_to_data, max_offset_id)
-                }
-                4 => {
-                    tracing::debug!("Found files, loading blockfiles for record segment");
-                    let user_id_to_id_bf_id = match segment.file_path.get(USER_ID_TO_OFFSET_ID) {
-                        Some(user_id_to_id_bf_id) => match user_id_to_id_bf_id.first() {
-                            Some(user_id_to_id_bf_id) => user_id_to_id_bf_id,
-                            None => {
-                                return Err(RecordSegmentWriterCreationError::MissingFile(
-                                    USER_ID_TO_OFFSET_ID.to_string(),
-                                ))
-                            }
-                        },
+                (user_id_to_id, id_to_user_id, id_to_data, max_offset_id)
+            }
+            4 => {
+                tracing::debug!("Found files, loading blockfiles for record segment");
+                let user_id_to_id_bf_id = match segment.file_path.get(USER_ID_TO_OFFSET_ID) {
+                    Some(user_id_to_id_bf_id) => match user_id_to_id_bf_id.first() {
+                        Some(user_id_to_id_bf_id) => user_id_to_id_bf_id,
                         None => {
                             return Err(RecordSegmentWriterCreationError::MissingFile(
                                 USER_ID_TO_OFFSET_ID.to_string(),
                             ))
                         }
-                    };
-                    let id_to_user_id_bf_id = match segment.file_path.get(OFFSET_ID_TO_USER_ID) {
-                        Some(id_to_user_id_bf_id) => match id_to_user_id_bf_id.first() {
-                            Some(id_to_user_id_bf_id) => id_to_user_id_bf_id,
-                            None => {
-                                return Err(RecordSegmentWriterCreationError::MissingFile(
-                                    OFFSET_ID_TO_USER_ID.to_string(),
-                                ))
-                            }
-                        },
+                    },
+                    None => {
+                        return Err(RecordSegmentWriterCreationError::MissingFile(
+                            USER_ID_TO_OFFSET_ID.to_string(),
+                        ))
+                    }
+                };
+                let id_to_user_id_bf_id = match segment.file_path.get(OFFSET_ID_TO_USER_ID) {
+                    Some(id_to_user_id_bf_id) => match id_to_user_id_bf_id.first() {
+                        Some(id_to_user_id_bf_id) => id_to_user_id_bf_id,
                         None => {
                             return Err(RecordSegmentWriterCreationError::MissingFile(
                                 OFFSET_ID_TO_USER_ID.to_string(),
                             ))
                         }
-                    };
-                    let id_to_data_bf_id = match segment.file_path.get(OFFSET_ID_TO_DATA) {
-                        Some(id_to_data_bf_id) => match id_to_data_bf_id.first() {
-                            Some(id_to_data_bf_id) => id_to_data_bf_id,
-                            None => {
-                                return Err(RecordSegmentWriterCreationError::MissingFile(
-                                    OFFSET_ID_TO_DATA.to_string(),
-                                ))
-                            }
-                        },
+                    },
+                    None => {
+                        return Err(RecordSegmentWriterCreationError::MissingFile(
+                            OFFSET_ID_TO_USER_ID.to_string(),
+                        ))
+                    }
+                };
+                let id_to_data_bf_id = match segment.file_path.get(OFFSET_ID_TO_DATA) {
+                    Some(id_to_data_bf_id) => match id_to_data_bf_id.first() {
+                        Some(id_to_data_bf_id) => id_to_data_bf_id,
                         None => {
                             return Err(RecordSegmentWriterCreationError::MissingFile(
                                 OFFSET_ID_TO_DATA.to_string(),
                             ))
                         }
-                    };
-                    let max_offset_id_bf_id = match segment.file_path.get(MAX_OFFSET_ID) {
-                        Some(max_offset_id_file_id) => match max_offset_id_file_id.first() {
-                            Some(max_offset_id_file_id) => max_offset_id_file_id,
-                            None => {
-                                return Err(RecordSegmentWriterCreationError::MissingFile(
-                                    MAX_OFFSET_ID.to_string(),
-                                ))
-                            }
-                        },
+                    },
+                    None => {
+                        return Err(RecordSegmentWriterCreationError::MissingFile(
+                            OFFSET_ID_TO_DATA.to_string(),
+                        ))
+                    }
+                };
+                let max_offset_id_bf_id = match segment.file_path.get(MAX_OFFSET_ID) {
+                    Some(max_offset_id_file_id) => match max_offset_id_file_id.first() {
+                        Some(max_offset_id_file_id) => max_offset_id_file_id,
                         None => {
                             return Err(RecordSegmentWriterCreationError::MissingFile(
                                 MAX_OFFSET_ID.to_string(),
                             ))
                         }
-                    };
+                    },
+                    None => {
+                        return Err(RecordSegmentWriterCreationError::MissingFile(
+                            MAX_OFFSET_ID.to_string(),
+                        ))
+                    }
+                };
 
-                    let user_id_to_bf_uuid = match Uuid::parse_str(user_id_to_id_bf_id) {
-                        Ok(user_id_to_bf_uuid) => user_id_to_bf_uuid,
-                        Err(_) => {
-                            return Err(RecordSegmentWriterCreationError::InvalidUuid(
-                                USER_ID_TO_OFFSET_ID.to_string(),
-                            ))
-                        }
-                    };
-                    let id_to_user_id_bf_uuid = match Uuid::parse_str(id_to_user_id_bf_id) {
-                        Ok(id_to_user_id_bf_uuid) => id_to_user_id_bf_uuid,
-                        Err(_) => {
-                            return Err(RecordSegmentWriterCreationError::InvalidUuid(
-                                OFFSET_ID_TO_USER_ID.to_string(),
-                            ))
-                        }
-                    };
-                    let id_to_data_bf_uuid = match Uuid::parse_str(id_to_data_bf_id) {
-                        Ok(id_to_data_bf_uuid) => id_to_data_bf_uuid,
-                        Err(_) => {
-                            return Err(RecordSegmentWriterCreationError::InvalidUuid(
-                                OFFSET_ID_TO_DATA.to_string(),
-                            ))
-                        }
-                    };
-                    let max_offset_id_bf_uuid = match Uuid::parse_str(max_offset_id_bf_id) {
-                        Ok(max_offset_id_bf_uuid) => max_offset_id_bf_uuid,
-                        Err(_) => {
-                            return Err(RecordSegmentWriterCreationError::InvalidUuid(
-                                MAX_OFFSET_ID.to_string(),
-                            ))
-                        }
-                    };
+                let user_id_to_bf_uuid = match Uuid::parse_str(user_id_to_id_bf_id) {
+                    Ok(user_id_to_bf_uuid) => user_id_to_bf_uuid,
+                    Err(_) => {
+                        return Err(RecordSegmentWriterCreationError::InvalidUuid(
+                            USER_ID_TO_OFFSET_ID.to_string(),
+                        ))
+                    }
+                };
+                let id_to_user_id_bf_uuid = match Uuid::parse_str(id_to_user_id_bf_id) {
+                    Ok(id_to_user_id_bf_uuid) => id_to_user_id_bf_uuid,
+                    Err(_) => {
+                        return Err(RecordSegmentWriterCreationError::InvalidUuid(
+                            OFFSET_ID_TO_USER_ID.to_string(),
+                        ))
+                    }
+                };
+                let id_to_data_bf_uuid = match Uuid::parse_str(id_to_data_bf_id) {
+                    Ok(id_to_data_bf_uuid) => id_to_data_bf_uuid,
+                    Err(_) => {
+                        return Err(RecordSegmentWriterCreationError::InvalidUuid(
+                            OFFSET_ID_TO_DATA.to_string(),
+                        ))
+                    }
+                };
+                let max_offset_id_bf_uuid = match Uuid::parse_str(max_offset_id_bf_id) {
+                    Ok(max_offset_id_bf_uuid) => max_offset_id_bf_uuid,
+                    Err(_) => {
+                        return Err(RecordSegmentWriterCreationError::InvalidUuid(
+                            MAX_OFFSET_ID.to_string(),
+                        ))
+                    }
+                };
 
-                    let user_id_to_id = match blockfile_provider
-                        .fork::<&str, u32>(&user_id_to_bf_uuid)
-                        .await
-                    {
-                        Ok(user_id_to_id) => user_id_to_id,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    let id_to_user_id = match blockfile_provider
-                        .fork::<u32, String>(&id_to_user_id_bf_uuid)
-                        .await
-                    {
-                        Ok(id_to_user_id) => id_to_user_id,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    let id_to_data = match blockfile_provider
-                        .fork::<u32, &DataRecord>(&id_to_data_bf_uuid)
-                        .await
-                    {
-                        Ok(id_to_data) => id_to_data,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    let max_offset_id_bf = match blockfile_provider
-                        .fork::<&str, u32>(&max_offset_id_bf_uuid)
-                        .await
-                    {
-                        Ok(max_offset_id) => max_offset_id,
-                        Err(e) => {
-                            return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
-                        }
-                    };
-                    (user_id_to_id, id_to_user_id, id_to_data, max_offset_id_bf)
-                }
-                _ => return Err(RecordSegmentWriterCreationError::IncorrectNumberOfFiles),
-            };
+                let user_id_to_id = match blockfile_provider
+                    .write::<&str, u32>(BlockfileWriterOptions::new().fork(user_id_to_bf_uuid))
+                    .await
+                {
+                    Ok(user_id_to_id) => user_id_to_id,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                let id_to_user_id = match blockfile_provider
+                    .write::<u32, String>(BlockfileWriterOptions::new().fork(id_to_user_id_bf_uuid))
+                    .await
+                {
+                    Ok(id_to_user_id) => id_to_user_id,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                let id_to_data = match blockfile_provider
+                    .write::<u32, &DataRecord>(
+                        BlockfileWriterOptions::new().fork(id_to_data_bf_uuid),
+                    )
+                    .await
+                {
+                    Ok(id_to_data) => id_to_data,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                let max_offset_id_bf = match blockfile_provider
+                    .write::<&str, u32>(BlockfileWriterOptions::new().fork(max_offset_id_bf_uuid))
+                    .await
+                {
+                    Ok(max_offset_id) => max_offset_id,
+                    Err(e) => {
+                        return Err(RecordSegmentWriterCreationError::BlockfileCreateError(e))
+                    }
+                };
+                (user_id_to_id, id_to_user_id, id_to_data, max_offset_id_bf)
+            }
+            _ => return Err(RecordSegmentWriterCreationError::IncorrectNumberOfFiles),
+        };
 
         Ok(RecordSegmentWriter {
             user_id_to_id: Some(user_id_to_id),


### PR DESCRIPTION
## Description of changes

Follow up from https://github.com/chroma-core/chroma/pull/2952. Renames `open()` on the blockfile provider to `read()` (semantically consistent with `write()`) and removes the deprecated `create()` & `fork()` methods.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a