### PR TITLE
[ENH]  First cut at a caching object store.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrrg"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a350fe7fd683a2b1c781ffc8e88b2a3888812fabbc327770828882f0b40fea"
+dependencies = [
+ "arrrg_derive",
+ "getopts",
+]
+
+[[package]]
+name = "arrrg_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "289198f9de45cef3ee361c783b8104497e8ef648c853407ebc91aa45750f0721"
+dependencies = [
+ "derive_util",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "assoc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "biometrics"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a50124c9be28b92ff57aa4f0d14744de4053b253d3d451b7bc08f989dba6a4"
+checksum = "d497470bfb1e5ade63ac03cd2871ed7ef7c7cc8657ee43b1469e4988e1bafc97"
 dependencies = [
  "sig_fig_histogram",
 ]
@@ -1353,6 +1375,8 @@ dependencies = [
  "chroma-config",
  "chroma-error",
  "futures",
+ "futures-core",
+ "guacamole",
  "object_store",
  "parking_lot",
  "rand",
@@ -1831,6 +1855,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_util"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc793ff4fee33f08b7305ace0b2b5642f7c3000fd111b7c0af3533572494284"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_utils"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -2381,6 +2416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2458,17 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "guacamole"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edce4d0c9e2a7e7fb7d037cf82a57e26379be4e453dd55c813953ba405fb1d1"
+dependencies = [
+ "arrrg",
+ "arrrg_derive",
+ "getopts",
 ]
 
 [[package]]
@@ -5176,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "sync42"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f142b8e692a4cc7d1988d8280c5507f5e43a198b4f774aa2b5660632906e212"
+checksum = "89b13d9260de381373a792e01e070de9106315639c38f95b13cd4f93da33e0c6"
 dependencies = [
  "biometrics",
 ]

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -11,8 +11,10 @@ bytes = "1.5.0"
 aws-sdk-s3 = "1.5.0"
 aws-smithy-types = "1.1.0"
 aws-config = { version = "1.1.2", features = ["behavior-version-latest"] }
+futures-core = "0.3"
+guacamole = "0.9"
 object_store = { version = "0.11", features = ["aws"] }
-sync42 = "0.11"
+sync42 = "0.12"
 
 serde = { workspace = true }
 futures = { workspace = true }

--- a/rust/storage/src/caching.rs
+++ b/rust/storage/src/caching.rs
@@ -1,0 +1,327 @@
+//! Our use of object storage is very specific in that we never overwrite objects and we think in
+//! blocks.  This module relies on this pattern to implement an object store that wraps two other
+//! object stores, one for the cache and one for the backing store.  Data is written to the backing
+//! store and then to the cache.  Reads are attempted from the cache and then from the backing
+//! store.  There is no effort made to dedupe writes, because it's assumed that a single writer is
+//! working on a single block at a time.  No one should write the same block to the same location
+//! at the same time, and the cost of doing so is cache inefficiency.
+
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+use std::ops::Range;
+use std::sync::Arc;
+
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOpts, PutOptions, PutPayload, PutResult, Result,
+};
+use sync42::state_hash_table::{Key, StateHashTable, Value};
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct DedupeKey {
+    path: Path,
+}
+
+impl Key for DedupeKey {}
+
+#[derive(Debug, Default)]
+pub struct DedupeValue {
+    one_in_flight: tokio::sync::Mutex<()>,
+}
+
+impl Value for DedupeValue {
+    fn finished(&self) -> bool {
+        true
+    }
+}
+
+impl From<DedupeKey> for DedupeValue {
+    fn from(_: DedupeKey) -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Clone)]
+pub struct CachingObjectStore {
+    cache: Arc<dyn ObjectStore>,
+    backing: Arc<dyn ObjectStore>,
+    dedupe: Arc<StateHashTable<DedupeKey, DedupeValue>>,
+}
+
+impl CachingObjectStore {
+    pub fn new<C: ObjectStore, B: ObjectStore>(cache: C, backing: B) -> Self {
+        Self {
+            cache: Arc::new(cache),
+            backing: Arc::new(backing),
+            dedupe: Arc::new(StateHashTable::new()),
+        }
+    }
+
+    async fn warm_cache(&self, location: &Path) -> Result<GetResult> {
+        let get = self
+            .backing
+            .get_opts(location, GetOptions::default())
+            .await?;
+        let meta = get.meta.clone();
+        let range = get.range.clone();
+        let attributes = get.attributes.clone();
+        let bytes = get.bytes().await?;
+        if let Err(err) = self
+            .cache
+            .put_opts(
+                location,
+                PutPayload::from(bytes.clone()),
+                PutOptions::default(),
+            )
+            .await
+        {
+            tracing::error!("failed to proactively warm the cache: {}", err);
+        }
+        let payload: GetResultPayload =
+            GetResultPayload::Stream(Box::pin(futures::stream::once(async move { Ok(bytes) })));
+        Ok(GetResult {
+            meta,
+            range,
+            attributes,
+            payload,
+        })
+    }
+}
+
+impl Debug for CachingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CachingObjectStore")
+    }
+}
+
+impl Display for CachingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CachingObjectStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for CachingObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        let res = self
+            .backing
+            .put_opts(location, payload.clone(), opts.clone())
+            .await?;
+        if let Err(err) = self
+            .cache
+            .put_opts(location, payload.clone(), opts.clone())
+            .await
+        {
+            tracing::error!("failed to proactively warm the cache: {}", err);
+        }
+        Ok(res)
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.backing.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        if options.range.is_some() || options.head {
+            return self.backing.get_opts(location, options).await;
+        }
+        // SAFETY(rescrv):  This uses double checked-locking to initialize the cache.  First, it
+        // checks the linearizable cache.  If that fails, it locks the dedupe state and checks the
+        // cache again.  If the cache fails again, it returns the result of warming the cache.
+        //
+        // This makes sure that we don't have the same file request the same path in flight twice.
+        //
+        // The second thread to acquire the mutex will see the warm_cache call be atomic w.r.t.
+        // their call to cache.get_opts.
+        if let Ok(get) = self.cache.get_opts(location, options.clone()).await {
+            return Ok(get);
+        }
+        let dedupe_key = DedupeKey {
+            path: location.clone(),
+        };
+        let dedupe_state = self.dedupe.get_or_create_state(dedupe_key);
+        let _dedupe_mutex = dedupe_state.one_in_flight.lock().await;
+        if let Ok(get) = self.cache.get_opts(location, options.clone()).await {
+            return Ok(get);
+        }
+        return self.warm_cache(location).await;
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+        // TODO(rescrv):  Perhaps find a way to encode partial fetches.
+        self.backing.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        match self.cache.head(location).await {
+            Ok(meta) => Ok(meta),
+            Err(err) => {
+                if !matches!(err, object_store::Error::NotFound { .. }) {
+                    tracing::error!("failed to read from cache: {}", err);
+                }
+                self.backing.head(location).await
+            }
+        }
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        if let Err(err) = self.cache.delete(location).await {
+            tracing::error!("failed to delete from cache: {}", err);
+        }
+        self.backing.delete(location).await
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.backing.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.backing.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.backing.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.backing.copy_if_not_exists(from, to).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+
+    use super::CachingObjectStore;
+
+    #[tokio::test]
+    async fn empty() {
+        let cache = object_store::memory::InMemory::new();
+        let backing = object_store::memory::InMemory::new();
+        let cached = CachingObjectStore::new(cache, backing);
+        assert!(cached
+            .get_opts(&Path::from("test"), Default::default())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn insert() {
+        let cache = object_store::memory::InMemory::new();
+        let backing = object_store::memory::InMemory::new();
+        let cached = CachingObjectStore::new(cache, backing);
+        assert!(cached
+            .put_opts(&Path::from("test"), "hello 42".into(), Default::default(),)
+            .await
+            .is_ok());
+
+        assert_eq!(
+            "hello 42".as_bytes(),
+            cached
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn not_in_cache_but_populates() {
+        let cache = object_store::memory::InMemory::new();
+        let backing = object_store::memory::InMemory::new();
+        let cached = CachingObjectStore::new(cache, backing);
+        assert!(cached
+            .backing
+            .put_opts(&Path::from("test"), "hello 42".into(), Default::default(),)
+            .await
+            .is_ok());
+
+        assert!(cached
+            .cache
+            .get_opts(&Path::from("test"), Default::default())
+            .await
+            .is_err());
+
+        assert_eq!(
+            "hello 42".as_bytes(),
+            cached
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            "hello 42".as_bytes(),
+            cached
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn in_cache_only_still_serves() {
+        let cache = object_store::memory::InMemory::new();
+        let backing = object_store::memory::InMemory::new();
+        let cached = CachingObjectStore::new(cache, backing);
+        assert!(cached
+            .cache
+            .put_opts(&Path::from("test"), "hello 42".into(), Default::default(),)
+            .await
+            .is_ok());
+
+        assert!(cached
+            .backing
+            .get_opts(&Path::from("test"), Default::default())
+            .await
+            .is_err());
+
+        assert_eq!(
+            "hello 42".as_bytes(),
+            cached
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            "hello 42".as_bytes(),
+            cached
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+
+        assert!(cached
+            .backing
+            .get_opts(&Path::from("test"), Default::default())
+            .await
+            .is_err());
+    }
+}

--- a/rust/storage/src/caching.rs
+++ b/rust/storage/src/caching.rs
@@ -21,6 +21,8 @@ use sync42::state_hash_table::{Key, StateHashTable, Value};
 use bytes::Bytes;
 use futures::stream::BoxStream;
 
+use super::SafeObjectStore;
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DedupeKey {
     path: Path,
@@ -47,16 +49,18 @@ impl From<DedupeKey> for DedupeValue {
 
 #[derive(Clone)]
 pub struct CachingObjectStore {
-    cache: Arc<dyn ObjectStore>,
-    backing: Arc<dyn ObjectStore>,
+    cache: Arc<dyn SafeObjectStore>,
+    backing: Arc<dyn SafeObjectStore>,
     dedupe: Arc<StateHashTable<DedupeKey, DedupeValue>>,
 }
 
 impl CachingObjectStore {
-    pub fn new<C: ObjectStore, B: ObjectStore>(cache: C, backing: B) -> Self {
+    pub fn new(cache: Arc<dyn SafeObjectStore>, backing: Arc<dyn SafeObjectStore>) -> Self {
+        assert!(cache.supports_delete());
+        assert!(!backing.supports_delete());
         Self {
-            cache: Arc::new(cache),
-            backing: Arc::new(backing),
+            cache,
+            backing,
             dedupe: Arc::new(StateHashTable::new()),
         }
     }
@@ -195,10 +199,7 @@ impl ObjectStore for CachingObjectStore {
 
     /// Delete an object.
     async fn delete(&self, location: &Path) -> Result<()> {
-        if let Err(err) = self.cache.delete(location).await {
-            tracing::error!("failed to delete from cache: {}", err);
-        }
-        self.backing.delete(location).await
+        Err(object_store::Error::NotImplemented)
     }
 
     /// List objects.
@@ -230,18 +231,30 @@ impl ObjectStore for CachingObjectStore {
     }
 }
 
+impl SafeObjectStore for CachingObjectStore {
+    fn supports_delete(&self) -> bool {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use object_store::path::Path;
-    use object_store::ObjectStore;
+    use object_store::{ObjectStore, PutMode};
 
     use super::CachingObjectStore;
+
+    use crate::non_destructive::NonDestructiveObjectStore;
+    use crate::SafeObjectStore;
 
     #[tokio::test]
     async fn empty() {
         let cache = object_store::memory::InMemory::new();
-        let backing = object_store::memory::InMemory::new();
-        let cached = CachingObjectStore::new(cache, backing);
+        let backing =
+            NonDestructiveObjectStore::new(Arc::new(object_store::memory::InMemory::new()));
+        let cached = CachingObjectStore::new(Arc::new(cache), Arc::new(backing));
         assert!(cached
             .get_opts(&Path::from("test"), Default::default())
             .await
@@ -251,10 +264,15 @@ mod tests {
     #[tokio::test]
     async fn insert() {
         let cache = object_store::memory::InMemory::new();
-        let backing = object_store::memory::InMemory::new();
-        let cached = CachingObjectStore::new(cache, backing);
+        let backing =
+            NonDestructiveObjectStore::new(Arc::new(object_store::memory::InMemory::new()));
+        let cached = CachingObjectStore::new(Arc::new(cache), Arc::new(backing));
         assert!(cached
-            .put_opts(&Path::from("test"), "hello 42".into(), Default::default(),)
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
             .await
             .is_ok());
 
@@ -273,11 +291,16 @@ mod tests {
     #[tokio::test]
     async fn not_in_cache_but_populates() {
         let cache = object_store::memory::InMemory::new();
-        let backing = object_store::memory::InMemory::new();
-        let cached = CachingObjectStore::new(cache, backing);
+        let backing =
+            NonDestructiveObjectStore::new(Arc::new(object_store::memory::InMemory::new()));
+        let cached = CachingObjectStore::new(Arc::new(cache), Arc::new(backing));
         assert!(cached
             .backing
-            .put_opts(&Path::from("test"), "hello 42".into(), Default::default(),)
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
             .await
             .is_ok());
 
@@ -312,11 +335,16 @@ mod tests {
     #[tokio::test]
     async fn in_cache_only_still_serves() {
         let cache = object_store::memory::InMemory::new();
-        let backing = object_store::memory::InMemory::new();
-        let cached = CachingObjectStore::new(cache, backing);
+        let backing =
+            NonDestructiveObjectStore::new(Arc::new(object_store::memory::InMemory::new()));
+        let cached = CachingObjectStore::new(Arc::new(cache), Arc::new(backing));
         assert!(cached
             .cache
-            .put_opts(&Path::from("test"), "hello 42".into(), Default::default(),)
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
             .await
             .is_ok());
 
@@ -352,5 +380,32 @@ mod tests {
             .get_opts(&Path::from("test"), Default::default())
             .await
             .is_err());
+    }
+
+    // This test verifies invariants necessary to prevent false successes in caching_cannot_delete.
+    #[test]
+    fn caching_cannot_delete_aux() {
+        let backing = object_store::memory::InMemory::new();
+        assert!(backing.supports_delete());
+    }
+
+    #[test]
+    #[should_panic]
+    fn caching_cannot_delete() {
+        let cache = object_store::memory::InMemory::new();
+        // Use a destructive store and it will panic.
+        let backing = object_store::memory::InMemory::new();
+        if backing.supports_delete() {
+            let _cached = CachingObjectStore::new(Arc::new(cache), Arc::new(backing));
+        }
+    }
+
+    #[tokio::test]
+    async fn caching_impls_safe() {
+        let cache = object_store::memory::InMemory::new();
+        let backing =
+            NonDestructiveObjectStore::new(Arc::new(object_store::memory::InMemory::new()));
+        let cached = CachingObjectStore::new(Arc::new(cache), Arc::new(backing));
+        assert!(!cached.supports_delete());
     }
 }

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -25,6 +25,8 @@ pub enum ObjectStoreType {
     Minio,
     #[serde(alias = "s3")]
     S3,
+    #[serde(alias = "local")]
+    Local,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -39,6 +41,7 @@ pub struct ObjectStoreConfig {
     pub upload_part_size_bytes: u64,
     pub download_part_size_bytes: u64,
     pub max_concurrent_requests: usize,
+    pub cache: Option<Box<ObjectStoreConfig>>,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/rust/storage/src/evicting.rs
+++ b/rust/storage/src/evicting.rs
@@ -1,0 +1,246 @@
+//! Our use of object storage is very specific in that we never overwrite objects and we think in
+//! blocks.  This module relies on this pattern to implement an object store that wraps two other
+//! object stores, one for the cache and one for the backing store.  Data is written to the backing
+//! store and then to the cache.  Reads are attempted from the cache and then from the backing
+//! store.  There is no effort made to dedupe writes, because it's assumed that a single writer is
+//! working on a single block at a time.  No one should write the same block to the same location
+//! at the same time, and the cost of doing so is cache inefficiency.
+
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+use std::sync::Arc;
+
+use futures::stream::StreamExt;
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts,
+    PutOptions, PutPayload, PutResult, Result,
+};
+use sync42::lru::{LeastRecentlyUsedCache, Value};
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+
+use super::SafeObjectStore;
+
+#[derive(Debug, Clone)]
+struct EvictionStub {
+    size: usize,
+}
+
+impl Value for EvictionStub {
+    fn approximate_size(&self) -> usize {
+        self.size
+    }
+}
+
+pub struct EvictingObjectStore {
+    target_disk_usage: usize,
+    object_store: Arc<dyn SafeObjectStore>,
+    lru: Arc<LeastRecentlyUsedCache<Path, EvictionStub>>,
+}
+
+impl EvictingObjectStore {
+    pub async fn new<O: SafeObjectStore>(
+        object_store: O,
+        target_disk_usage: usize,
+    ) -> Result<Self, object_store::Error> {
+        assert!(object_store.supports_delete());
+        let object_store = Arc::new(object_store);
+        let lru = Arc::new(LeastRecentlyUsedCache::new(1024));
+        let mut all_objects = object_store.list(None);
+        while let Some(meta) = all_objects.next().await {
+            let meta = meta?;
+            lru.insert_no_evict(meta.location.clone(), EvictionStub { size: meta.size });
+        }
+        drop(all_objects);
+        while lru.approximate_size() > target_disk_usage {
+            let Some((key, _)) = lru.pop() else {
+                break;
+            };
+            object_store.delete(&key).await?;
+        }
+        Ok(Self {
+            target_disk_usage,
+            object_store,
+            lru,
+        })
+    }
+}
+
+impl Debug for EvictingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EvictingObjectStore")
+    }
+}
+
+impl Display for EvictingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EvictingObjectStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for EvictingObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        self.lru.insert_no_evict(
+            location.clone(),
+            EvictionStub {
+                size: payload.content_length(),
+            },
+        );
+        while self.lru.approximate_size() > self.target_disk_usage {
+            let Some((key, _)) = self.lru.pop() else {
+                break;
+            };
+            self.object_store.delete(&key).await?;
+        }
+        self.object_store.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _: &Path,
+        _: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        // NOTE(rescrv):  The caching object store does not insert multipart uploads into the
+        // cache.  Because the evicting object store is intended to be used only around the
+        // caching object store, we can fail this call.
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.object_store.get_opts(location, options).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+        self.object_store.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.object_store.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.lru.remove(location);
+        self.object_store.delete(location).await
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.object_store.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.object_store.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.object_store.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.object_store.copy_if_not_exists(from, to).await
+    }
+}
+
+impl SafeObjectStore for EvictingObjectStore {
+    fn supports_delete(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::path::Path;
+    use object_store::{Error, ObjectStore};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn empty() {
+        let object_store = object_store::memory::InMemory::new();
+        let evicting = EvictingObjectStore::new(object_store, 1024).await.unwrap();
+        assert!(evicting
+            .get_opts(&Path::from("noexist"), Default::default())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn fill_it_and_see_it_evict() {
+        let object_store = object_store::memory::InMemory::new();
+        let evicting = EvictingObjectStore::new(object_store, 1024).await.unwrap();
+        for idx in 0..1024 {
+            assert!(evicting
+                .put_opts(
+                    &Path::from(format!("key{}", idx)),
+                    PutPayload::from(Bytes::from(format!("value{}", idx))),
+                    Default::default()
+                )
+                .await
+                .is_ok());
+        }
+        let mut expect_to_see = true;
+        for idx in (0..1024).rev() {
+            let key = Path::from(format!("key{}", idx));
+            let res = evicting.get_opts(&key, Default::default()).await;
+            if expect_to_see && matches!(res, Err(Error::NotFound { .. })) {
+                expect_to_see = false;
+            }
+            if expect_to_see {
+                assert!(res.is_ok());
+            } else {
+                assert!(matches!(res, Err(Error::NotFound { .. })));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_start() {
+        let object_store = object_store::memory::InMemory::new();
+        for idx in 0..1024 {
+            assert!(object_store
+                .put_opts(
+                    &Path::from(format!("key{}", idx)),
+                    PutPayload::from(Bytes::from(format!("value{}", idx))),
+                    Default::default()
+                )
+                .await
+                .is_ok());
+        }
+        let evicting = EvictingObjectStore::new(object_store, 1024).await.unwrap();
+        let mut not_found = 0;
+        let mut found = 0;
+        for idx in 0..1024 {
+            let key = Path::from(format!("key{}", idx));
+            let res = evicting.get_opts(&key, Default::default()).await;
+            if matches!(res, Err(Error::NotFound { .. })) {
+                not_found += 1;
+            } else if res.is_ok() {
+                found += 1;
+            } else {
+                panic!("unexpected result: {:?}", res);
+            }
+        }
+        println!(
+            "found: {}, not_found: {}, approx_size: {}",
+            found,
+            not_found,
+            evicting.lru.approximate_size()
+        );
+        assert!(found >= 64, "{}", found);
+    }
+
+    #[tokio::test]
+    async fn eviction_impls_safe() {
+        let object_store = object_store::memory::InMemory::new();
+        let evicting: &dyn SafeObjectStore =
+            &EvictingObjectStore::new(object_store, 1024).await.unwrap();
+        assert!(evicting.supports_delete());
+    }
+}

--- a/rust/storage/src/latency.rs
+++ b/rust/storage/src/latency.rs
@@ -1,0 +1,240 @@
+use std::ops::Range;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures_core::stream::BoxStream;
+use guacamole::combinators::*;
+use guacamole::Guacamole;
+use object_store::multipart::{MultipartStore, PartId};
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOpts, PutOptions, PutPayload, PutResult, Result,
+};
+
+///////////////////////////////////////// SimulationOptions ////////////////////////////////////////
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulationOptions {
+    put_opts_ms: u64,
+    put_multipart_opts_ms: u64,
+    get_opts_ms: u64,
+    get_ranges_ms: u64,
+    head_ms: u64,
+    delete_ms: u64,
+    list_ms: u64,
+    list_with_delimiter_ms: u64,
+    copy_ms: u64,
+    copy_if_not_exists_ms: u64,
+    create_multipart_ms: u64,
+    put_part_ms: u64,
+    complete_multipart_ms: u64,
+    abort_multipart_ms: u64,
+}
+
+impl Default for SimulationOptions {
+    fn default() -> Self {
+        SimulationOptions {
+            put_opts_ms: 100u64,
+            put_multipart_opts_ms: 100u64,
+            get_opts_ms: 100u64,
+            get_ranges_ms: 100u64,
+            head_ms: 100u64,
+            delete_ms: 100u64,
+            list_ms: 100u64,
+            list_with_delimiter_ms: 100u64,
+            copy_ms: 100u64,
+            copy_if_not_exists_ms: 100u64,
+            create_multipart_ms: 100u64,
+            put_part_ms: 100u64,
+            complete_multipart_ms: 100u64,
+            abort_multipart_ms: 100u64,
+        }
+    }
+}
+
+/////////////////////////////////// LatencyControlledObjectStore ///////////////////////////////////
+
+pub struct LatencyControlledObjectStore<O: ObjectStore> {
+    object_store: O,
+    guacamole: Mutex<Guacamole>,
+    options: SimulationOptions,
+}
+
+impl<O: ObjectStore> LatencyControlledObjectStore<O> {
+    pub fn new(options: SimulationOptions, object_store: O, guacamole: Guacamole) -> Self {
+        let guacamole = Mutex::new(guacamole);
+        Self {
+            object_store,
+            guacamole,
+            options,
+        }
+    }
+}
+
+impl<O: ObjectStore> std::fmt::Debug for LatencyControlledObjectStore<O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LatencyControlledObjectStore({:?})", self.object_store)
+    }
+}
+
+impl<O: ObjectStore> std::fmt::Display for LatencyControlledObjectStore<O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LatencyControlledObjectStore({})", self.object_store)
+    }
+}
+
+macro_rules! slow_operation {
+    ($this:ident, $interarrival_ms:expr, $operation:expr) => {{
+        // Exponentially distributed interarrival times
+        let interarrival_rate = 1_000.0 / ($interarrival_ms as f64);
+        let duration = {
+            let mut guac = $this.guacamole.lock().unwrap();
+            interarrival_duration(interarrival_rate)(&mut guac)
+        };
+        let start = Instant::now();
+        let res = $operation;
+        let elapsed = start.elapsed();
+        if elapsed < duration {
+            tokio::time::sleep(duration - elapsed).await;
+        }
+        res
+    }};
+}
+
+#[async_trait::async_trait]
+impl<O: ObjectStore> ObjectStore for LatencyControlledObjectStore<O> {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        slow_operation!(
+            self,
+            self.options.put_opts_ms,
+            self.object_store.put_opts(location, payload, opts).await
+        )
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        slow_operation!(
+            self,
+            self.options.put_multipart_opts_ms,
+            self.object_store.put_multipart_opts(location, opts).await
+        )
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        slow_operation!(
+            self,
+            self.options.get_opts_ms,
+            self.object_store.get_opts(location, options).await
+        )
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+        slow_operation!(
+            self,
+            self.options.get_ranges_ms,
+            self.object_store.get_ranges(location, ranges).await
+        )
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        slow_operation!(
+            self,
+            self.options.head_ms,
+            self.object_store.head(location).await
+        )
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        slow_operation!(
+            self,
+            self.options.delete_ms,
+            self.object_store.delete(location).await
+        )
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.object_store.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        slow_operation!(
+            self,
+            self.options.list_with_delimiter_ms,
+            self.object_store.list_with_delimiter(prefix).await
+        )
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        slow_operation!(
+            self,
+            self.options.copy_ms,
+            self.object_store.copy(from, to).await
+        )
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        slow_operation!(
+            self,
+            self.options.copy_if_not_exists_ms,
+            self.object_store.copy_if_not_exists(from, to).await
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl<O: MultipartStore + ObjectStore> MultipartStore for LatencyControlledObjectStore<O> {
+    async fn create_multipart(&self, path: &Path) -> Result<MultipartId> {
+        slow_operation!(
+            self,
+            self.options.create_multipart_ms,
+            self.object_store.create_multipart(path).await
+        )
+    }
+
+    async fn put_part(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        part_idx: usize,
+        payload: PutPayload,
+    ) -> Result<PartId> {
+        slow_operation!(
+            self,
+            self.options.put_part_ms,
+            self.object_store
+                .put_part(path, id, part_idx, payload)
+                .await
+        )
+    }
+
+    async fn complete_multipart(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        parts: Vec<PartId>,
+    ) -> Result<PutResult> {
+        slow_operation!(
+            self,
+            self.options.complete_multipart_ms,
+            self.object_store.complete_multipart(path, id, parts).await
+        )
+    }
+
+    async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> Result<()> {
+        slow_operation!(
+            self,
+            self.options.abort_multipart_ms,
+            self.object_store.abort_multipart(path, id).await
+        )
+    }
+}

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
-use self::config::StorageConfig;
-use self::s3::S3GetError;
-use admissioncontrolleds3::AdmissionControlledS3StorageError;
+use local::LocalStorage;
+use tempfile::TempDir;
+use thiserror::Error;
+
+use ::object_store::ObjectStore;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 
@@ -10,13 +12,17 @@ pub mod admission_controller;
 pub mod admissioncontrolleds3;
 pub mod caching;
 pub mod config;
+pub mod evicting;
+pub mod latency;
 pub mod local;
+pub mod non_destructive;
 pub mod object_store;
 pub mod s3;
 pub mod stream;
-use local::LocalStorage;
-use tempfile::TempDir;
-use thiserror::Error;
+
+use admissioncontrolleds3::AdmissionControlledS3StorageError;
+use config::StorageConfig;
+use s3::S3GetError;
 
 #[derive(Clone)]
 pub enum Storage {
@@ -24,6 +30,17 @@ pub enum Storage {
     S3(s3::S3Storage),
     Local(local::LocalStorage),
     AdmissionControlledS3(admissioncontrolleds3::AdmissionControlledS3Storage),
+}
+
+impl std::fmt::Debug for Storage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Storage::ObjectStore(_) => write!(f, "ObjectStore"),
+            Storage::S3(_) => write!(f, "S3"),
+            Storage::Local(_) => write!(f, "Local"),
+            Storage::AdmissionControlledS3(_) => write!(f, "AdmissionControlledS3"),
+        }
+    }
 }
 
 #[derive(Error, Debug, Clone)]
@@ -209,6 +226,15 @@ impl Storage {
             }
         }
     }
+
+    pub fn supports_delete(&self) -> bool {
+        match self {
+            Storage::ObjectStore(object_store) => object_store.supports_delete(),
+            Storage::S3(_) => true,
+            Storage::Local(_) => true,
+            Storage::AdmissionControlledS3(_) => true,
+        }
+    }
 }
 
 pub async fn from_config(config: &StorageConfig) -> Result<Storage, Box<dyn ChromaError>> {
@@ -234,4 +260,36 @@ pub fn test_storage() -> Storage {
             .to_str()
             .expect("Should be able to convert temporary directory path to string"),
     ))
+}
+
+/// This trait is for advertising capabilities of an object store so that we can write safe(r)
+/// code.
+///
+/// Specifically, I want to advertise whether an object store supports the `delete` call.  Delete
+/// is destructive.  Delete is a for loop, even more so.  And delete in a for loop over list is the
+/// fastest way I know of to delete data one round trip at a time.
+///
+/// To that end:  I'd like to make it so that object stores that wrap other object stores (like the
+/// evicting object store does) will make sure that there is at least one object store that does
+/// not implement delete.
+pub trait SafeObjectStore: ObjectStore {
+    fn supports_delete(&self) -> bool;
+}
+
+impl SafeObjectStore for ::object_store::memory::InMemory {
+    fn supports_delete(&self) -> bool {
+        true
+    }
+}
+
+impl SafeObjectStore for ::object_store::local::LocalFileSystem {
+    fn supports_delete(&self) -> bool {
+        true
+    }
+}
+
+impl SafeObjectStore for ::object_store::aws::AmazonS3 {
+    fn supports_delete(&self) -> bool {
+        true
+    }
 }

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -8,6 +8,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 
 pub mod admission_controller;
 pub mod admissioncontrolleds3;
+pub mod caching;
 pub mod config;
 pub mod local;
 pub mod object_store;

--- a/rust/storage/src/non_destructive.rs
+++ b/rust/storage/src/non_destructive.rs
@@ -1,0 +1,190 @@
+//! A non-destructive wrapper around object store.  It turns `delete` operations into
+//! `not-implemented` errors.  It makes sure the put mode is create for all block writes.
+//! Unfortunately the multi-part upload cannot exhibit this same safety.  Copy will be silently
+//! transformed to a copy-if-not-exist.
+
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+use std::sync::Arc;
+
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMode,
+    PutMultipartOpts, PutOptions, PutPayload, PutResult, Result,
+};
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+
+use super::SafeObjectStore;
+
+#[derive(Clone)]
+pub struct NonDestructiveObjectStore {
+    object_store: Arc<dyn SafeObjectStore>,
+}
+
+impl NonDestructiveObjectStore {
+    pub fn new(object_store: Arc<dyn SafeObjectStore>) -> Self {
+        Self { object_store }
+    }
+}
+
+impl Debug for NonDestructiveObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NonDestructiveObjectStore")
+    }
+}
+
+impl Display for NonDestructiveObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NonDestructiveObjectStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for NonDestructiveObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        match opts.mode {
+            PutMode::Overwrite => {
+                return Err(object_store::Error::NotImplemented);
+            }
+            PutMode::Create | PutMode::Update(_) => {}
+        };
+        self.object_store.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.object_store.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.object_store.get_opts(location, options).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+        self.object_store.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.object_store.head(location).await
+    }
+
+    async fn delete(&self, _: &Path) -> Result<()> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.object_store.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.object_store.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.object_store.copy_if_not_exists(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.object_store.copy_if_not_exists(from, to).await
+    }
+}
+
+impl SafeObjectStore for NonDestructiveObjectStore {
+    fn supports_delete(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use object_store::path::Path;
+    use object_store::{ObjectStore, PutMode};
+
+    use super::NonDestructiveObjectStore;
+
+    use crate::SafeObjectStore;
+
+    #[tokio::test]
+    async fn empty() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
+        assert!(!non_destructive.supports_delete());
+    }
+
+    #[tokio::test]
+    async fn insert() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
+        assert!(non_destructive
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
+            .await
+            .is_ok());
+        assert_eq!(
+            "hello 42".as_bytes(),
+            non_destructive
+                .object_store
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn overwrite_fails() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
+        assert!(non_destructive
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Overwrite.into()
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_fails() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
+        assert!(non_destructive
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
+            .await
+            .is_ok());
+        assert_eq!(
+            "hello 42".as_bytes(),
+            non_destructive
+                .object_store
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+        assert!(non_destructive.delete(&Path::from("test")).await.is_err());
+    }
+}


### PR DESCRIPTION
The object store takes two object stores, one as the canonical data
source and one as a cache.  It will then manage the cache to dedupe
traffic to the backend store for get_opts calls (whole files) only.
