### PR TITLE
[PERF] Mark `ProjectionOperator` as a regular operator

### DIFF
--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use tracing::{error, trace, Instrument, Span};
 
 use crate::{
-    execution::operator::{Operator, OperatorType},
+    execution::operator::Operator,
     segment::{
         record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
         LogMaterializer, LogMaterializerError,
@@ -88,10 +88,6 @@ impl ChromaError for ProjectionError {
 #[async_trait]
 impl Operator<ProjectionInput, ProjectionOutput> for ProjectionOperator {
     type Error = ProjectionError;
-
-    fn get_type(&self) -> OperatorType {
-        OperatorType::IO
-    }
 
     async fn run(&self, input: &ProjectionInput) -> Result<ProjectionOutput, ProjectionError> {
         trace!("[{}]: {:?}", self.get_name(), input);


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Mark the `ProjectionOperator` as `Other` type, which implies it uses both compute and IO
 - New functionality
	 - ...

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A