### PR TITLE
[TST] Retry rust integration tests

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/rust
+        uses: Wandalen/wretry.action@v3.7.0
+        with:
+          action: ./.github/actions/rust
       - name: Build
         run: cargo build --verbose
       - name: Test
@@ -31,7 +33,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/rust
+        uses: Wandalen/wretry.action@v3.7.0
+        with:
+          action: ./.github/actions/rust
       - name: Start services in Tilt
         uses: ./.github/actions/tilt
       - name: Run tests


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Noticed on https://github.com/chroma-core/chroma/actions/runs/11710709672/job/32617687922 that we failed due to protoc transient install issue. This will retry
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None