### PR TITLE
[CLN]: add new_test_storage() helper

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/delta.rs
@@ -139,7 +139,7 @@ mod test {
     use crate::arrow::{block::Block, config::TEST_MAX_BLOCK_SIZE_BYTES, provider::BlockManager};
     #[cfg(test)]
     use chroma_cache::new_cache_for_test;
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::Storage;
     use chroma_types::{DataRecord, MetadataValue};
     use rand::{random, Rng};
     use roaring::RoaringBitmap;
@@ -164,7 +164,7 @@ mod test {
     async fn test_sizing_int_arr_val() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(path));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let delta = block_manager.create::<&str, Vec<u32>>();
@@ -206,7 +206,7 @@ mod test {
     async fn test_sizing_string_val() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let delta = block_manager.create::<&str, String>();
@@ -267,7 +267,7 @@ mod test {
     async fn test_sizing_float_key() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(path));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let delta = block_manager.create::<f32, String>();
@@ -306,7 +306,7 @@ mod test {
     async fn test_sizing_roaring_bitmap_val() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(path));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let delta = block_manager.create::<&str, RoaringBitmap>();
@@ -342,7 +342,7 @@ mod test {
     async fn test_data_record() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(path));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let ids = ["embedding_id_2", "embedding_id_0", "embedding_id_1"];
@@ -406,7 +406,7 @@ mod test {
     async fn test_sizing_uint_key_string_val() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(path));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let delta = block_manager.create::<u32, String>();
@@ -434,7 +434,7 @@ mod test {
     async fn test_sizing_uint_key_val() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let path = tmp_dir.path().to_str().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let cache = new_cache_for_test();
         let block_manager = BlockManager::new(storage, TEST_MAX_BLOCK_SIZE_BYTES, cache);
         let delta = block_manager.create::<u32, u32>();

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -635,7 +635,7 @@ mod tests {
     };
     use crate::{BlockfileReader, BlockfileWriter, BlockfileWriterOptions};
     use chroma_cache::new_cache_for_test;
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::Storage;
     use chroma_types::{DataRecord, MetadataValue};
     use futures::{StreamExt, TryStreamExt};
     use parking_lot::Mutex;
@@ -650,8 +650,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_count() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -690,8 +689,7 @@ mod tests {
 
     fn test_prefix(num_keys: u32, prefix_for_query: u32) {
         Runtime::new().unwrap().block_on(async {
-            let tmp_dir = tempfile::tempdir().unwrap();
-            let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+            let storage = Storage::new_test_storage();
             let block_cache = new_cache_for_test();
             let sparse_index_cache = new_cache_for_test();
             let blockfile_provider = ArrowBlockfileProvider::new(
@@ -757,8 +755,7 @@ mod tests {
 
     fn blockfile_comparisons(operation: ComparisonOperation, num_keys: u32, query_key: u32) {
         Runtime::new().unwrap().block_on(async {
-            let tmp_dir = tempfile::tempdir().unwrap();
-            let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+            let storage = Storage::new_test_storage();
             let block_cache = new_cache_for_test();
             let sparse_index_cache = new_cache_for_test();
             let blockfile_provider = ArrowBlockfileProvider::new(
@@ -914,8 +911,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_blockfile() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -954,8 +950,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_splitting() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1071,8 +1066,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_splitting_boundary() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1116,8 +1110,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_string_value() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1156,8 +1149,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_float_key() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let provider = ArrowBlockfileProvider::new(
@@ -1193,8 +1185,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_roaring_bitmap_value() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1243,8 +1234,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_uint_key_val() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1280,8 +1270,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_data_record_val() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1335,8 +1324,7 @@ mod tests {
     #[tokio::test]
     async fn test_large_split_value() {
         // Tests the case where a value is larger than half the block size
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1376,8 +1364,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1446,8 +1433,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_at_index() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1488,8 +1474,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_first_block_removal() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1583,8 +1568,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_to_same_key_many_times() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let blockfile_provider = ArrowBlockfileProvider::new(
@@ -1617,8 +1601,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_v1_to_v1_1_migration_all_new() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let root_cache = new_cache_for_test();
         let root_manager = RootManager::new(storage.clone(), root_cache);
@@ -1672,8 +1655,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_v1_to_v1_1_migration_partially_new() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let root_cache = new_cache_for_test();
         let root_manager = RootManager::new(storage.clone(), root_cache);

--- a/rust/blockstore/src/arrow/concurrency_test.rs
+++ b/rust/blockstore/src/arrow/concurrency_test.rs
@@ -5,7 +5,7 @@ mod tests {
         BlockfileWriterOptions,
     };
     use chroma_cache::new_cache_for_test;
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::Storage;
     use rand::Rng;
     use shuttle::{future, thread};
 
@@ -13,8 +13,7 @@ mod tests {
     fn test_blockfile_shuttle() {
         shuttle::check_random(
             || {
-                let tmp_dir = tempfile::tempdir().unwrap();
-                let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+                let storage = Storage::new_test_storage();
                 // NOTE(rescrv):  I chose to use non-persistent caches here to maximize chance of a
                 // race condition outside the cache.
                 let block_cache = new_cache_for_test();

--- a/rust/blockstore/src/blockfile_writer_test.rs
+++ b/rust/blockstore/src/blockfile_writer_test.rs
@@ -4,7 +4,6 @@
 mod tests {
     use std::collections::BTreeMap;
 
-    use chroma_storage::local::LocalStorage;
     use chroma_storage::Storage;
     use futures::executor::block_on;
     use futures::TryStreamExt;
@@ -112,8 +111,7 @@ mod tests {
         fn init_test(
             ref_state: &<Self::Reference as proptest_state_machine::ReferenceStateMachine>::State,
         ) -> Self::SystemUnderTest {
-            let tmp_dir = tempfile::tempdir().unwrap();
-            let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+            let storage = Storage::new_test_storage();
             let block_cache = new_cache_for_test();
             let sparse_index_cache = new_cache_for_test();
             let provider = ArrowBlockfileProvider::new(

--- a/rust/blockstore/src/lib.rs
+++ b/rust/blockstore/src/lib.rs
@@ -8,13 +8,13 @@ pub mod key;
 pub mod memory;
 pub mod provider;
 use chroma_cache::new_cache_for_test;
-use chroma_storage::test_storage;
+use chroma_storage::Storage;
 use provider::BlockfileProvider;
 pub use types::*;
 
 pub fn test_arrow_blockfile_provider(size: usize) -> BlockfileProvider {
     BlockfileProvider::new_arrow(
-        test_storage(),
+        Storage::new_test_storage(),
         size,
         new_cache_for_test(),
         new_cache_for_test(),

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -613,7 +613,6 @@ pub enum HnswIndexProviderFileError {
 mod tests {
     use super::*;
     use chroma_cache::new_non_persistent_cache_for_test;
-    use chroma_storage::local::LocalStorage;
     use chroma_types::SegmentType;
     use std::collections::HashMap;
 
@@ -625,7 +624,7 @@ mod tests {
         // Create the directories needed
         tokio::fs::create_dir_all(&hnsw_tmp_path).await.unwrap();
 
-        let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
+        let storage = Storage::new_test_storage_at(storage_dir);
         let cache = new_non_persistent_cache_for_test();
         let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache, rx);

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -9,7 +9,7 @@ pub mod utils;
 // Re-export types
 
 use chroma_cache::new_non_persistent_cache_for_test;
-use chroma_storage::test_storage;
+use chroma_storage::Storage;
 pub use hnsw::*;
 use hnsw_provider::HnswIndexProvider;
 use tempfile::tempdir;
@@ -18,7 +18,7 @@ pub use types::*;
 pub fn test_hnsw_index_provider() -> HnswIndexProvider {
     let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
     HnswIndexProvider::new(
-        test_storage(),
+        Storage::new_test_storage(),
         tempdir()
             .expect("Should be able to create a temporary directory")
             .into_path(),

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use self::config::StorageConfig;
 use self::s3::S3GetError;
 use self::stream::ByteStreamItem;
@@ -14,6 +12,7 @@ pub mod s3;
 pub mod stream;
 use futures::Stream;
 use local::LocalStorage;
+use std::{path::Path, sync::Arc};
 use tempfile::TempDir;
 use thiserror::Error;
 
@@ -62,6 +61,24 @@ impl ChromaError for PutError {
 }
 
 impl Storage {
+    pub fn new_test_storage() -> Self {
+        Storage::Local(LocalStorage::new(
+            TempDir::new()
+                .expect("Should be able to create a temporary directory.")
+                .into_path()
+                .to_str()
+                .expect("Should be able to convert temporary directory path to string"),
+        ))
+    }
+
+    pub fn new_test_storage_at<P: AsRef<Path>>(path: P) -> Self {
+        Storage::Local(LocalStorage::new(
+            path.as_ref()
+                .to_str()
+                .expect("Should be able to convert path to string"),
+        ))
+    }
+
     pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
         match self {
             Storage::S3(s3) => {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -342,7 +342,6 @@ mod tests {
     use crate::sysdb::test_sysdb::TestSysDb;
     use chroma_blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
     use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
-    use chroma_storage::local::LocalStorage;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord, Segment};
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -357,7 +356,7 @@ mod tests {
             _ => panic!("Expected InMemoryLog"),
         };
         let tmpdir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmpdir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
 
         let collection_uuid_1 =
             CollectionUuid::from_str("00000000-0000-0000-0000-000000000001").unwrap();

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -1242,7 +1242,7 @@ mod test {
         provider::BlockfileProvider,
     };
     use chroma_cache::new_cache_for_test;
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::Storage;
     use chroma_types::{
         Chunk, CollectionUuid, DirectDocumentComparison, DirectWhereComparison, LogRecord,
         MetadataValue, Operation, OperationRecord, PrimitiveOperator, UpdateMetadataValue, Where,
@@ -1253,8 +1253,7 @@ mod test {
 
     #[tokio::test]
     async fn empty_blocks() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
@@ -1545,8 +1544,7 @@ mod test {
 
     #[tokio::test]
     async fn metadata_update_same_key_different_type() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
@@ -1801,8 +1799,7 @@ mod test {
 
     #[tokio::test]
     async fn metadata_deletes() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
@@ -2026,8 +2023,7 @@ mod test {
 
     #[tokio::test]
     async fn document_updates() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -804,7 +804,7 @@ mod tests {
         provider::BlockfileProvider,
     };
     use chroma_cache::new_cache_for_test;
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::Storage;
     use chroma_types::{
         CollectionUuid, DirectDocumentComparison, DirectWhereComparison, PrimitiveOperator, Where,
         WhereComparison,
@@ -814,8 +814,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_materializer_add_delete_upsert() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
@@ -1107,8 +1106,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_materializer_add_upsert() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
@@ -1392,8 +1390,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_materializer_add_delete_upsert_update() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(
@@ -1696,8 +1693,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_materializer_basic() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let arrow_blockfile_provider = ArrowBlockfileProvider::new(

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -680,7 +680,7 @@ mod tests {
     #[cfg(debug_assertions)]
     use chroma_proto::debug_client::DebugClient;
     #[cfg(debug_assertions)]
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::Storage;
     #[cfg(debug_assertions)]
     use tempfile::tempdir;
 
@@ -690,7 +690,7 @@ mod tests {
         let sysdb = TestSysDb::new();
         let log = InMemoryLog::new();
         let tmp_dir = tempdir().unwrap();
-        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let storage = Storage::new_test_storage();
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let hnsw_index_cache = new_non_persistent_cache_for_test();


### PR DESCRIPTION
## Description of changes

Adds a helper to the `Storage` wrapper, `new_test_storage()`, which creates a `LocalStorage` instance on a temporary directory. Simplifies usage for tests and makes grabbing test storage instances much easier after the upstack PR changes.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a