### PR TITLE
[ENH]: add config to inject latency into storage API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "derive_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1337,6 +1337,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "serde",
+ "serde_with",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1429,7 +1430,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1752,7 +1753,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1774,7 +1775,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1816,7 +1817,7 @@ checksum = "65f152f4b8559c4da5d574bafc7af85454d706b4c5fe8b530d508cacbb6807ea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1983,7 +1984,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2278,7 +2279,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2782,6 +2783,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2792,6 +2794,7 @@ checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -3015,7 +3018,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3620,7 +3623,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3829,7 +3832,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3879,7 +3882,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3920,7 +3923,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4004,7 +4007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4026,14 +4029,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4046,7 +4049,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
  "version_check",
  "yansi",
 ]
@@ -4117,7 +4120,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types",
  "regex",
- "syn 2.0.52",
+ "syn 2.0.87",
  "tempfile",
  "which",
 ]
@@ -4132,7 +4135,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4145,7 +4148,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4708,9 +4711,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
@@ -4727,13 +4730,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4780,6 +4783,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling 0.20.8",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,7 +4847,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4982,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5202,7 +5235,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5335,7 +5368,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5496,7 +5529,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5572,7 +5605,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5802,7 +5835,7 @@ checksum = "7abb14ae1a50dad63eaa768a458ef43d298cd1bd44951677bd10b732a9ba2a2d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5884,7 +5917,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -5918,7 +5951,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6323,7 +6356,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.dependencies]
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.108"
 arrow = "52.0.0"
 thiserror = "1.0.50"

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -24,6 +24,7 @@ parking_lot = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
+serde_with = "3.11.0"
 
 [dev-dependencies]
 "rand" = { workspace = true}

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{RateLimitingConfig, StorageConfig},
+    config::{RateLimitingConfig, StorageConfig, StorageConfigKind},
     s3::{S3GetError, S3PutError, S3Storage, StorageConfigError},
     stream::ByteStreamItem,
 };
@@ -272,11 +272,9 @@ impl AdmissionControlledS3Storage {
 #[async_trait]
 impl Configurable<StorageConfig> for AdmissionControlledS3Storage {
     async fn try_from_config(config: &StorageConfig) -> Result<Self, Box<dyn ChromaError>> {
-        match &config {
-            StorageConfig::AdmissionControlledS3(nacconfig) => {
-                let s3_storage =
-                    S3Storage::try_from_config(&StorageConfig::S3(nacconfig.s3_config.clone()))
-                        .await?;
+        match &config.kind {
+            StorageConfigKind::AdmissionControlledS3(nacconfig) => {
+                let s3_storage = S3Storage::try_from_config(&nacconfig.s3_config).await?;
                 let policy =
                     RateLimitPolicy::try_from_config(&nacconfig.rate_limiting_policy).await?;
                 return Ok(Self::new(s3_storage, policy));

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -1,13 +1,16 @@
 use serde::Deserialize;
+use serde_with::serde_as;
+use serde_with::DurationMilliSeconds;
+use std::time::Duration;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 /// The configuration for the chosen storage.
 /// # Options
 /// - S3: The configuration for the s3 storage.
 /// # Notes
 /// See config.rs in the root of the worker crate for an example of how to use
 /// config files to configure the worker.
-pub enum StorageConfig {
+pub enum StorageConfigKind {
     // case-insensitive
     #[serde(alias = "s3")]
     S3(S3StorageConfig),
@@ -17,12 +20,31 @@ pub enum StorageConfig {
     AdmissionControlledS3(AdmissionControlledS3StorageConfig),
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct StorageConfig {
+    #[serde(flatten)]
+    pub kind: StorageConfigKind,
+    pub inject_latency: Option<InjectedLatencyConfig>,
+}
+
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub enum S3CredentialsConfig {
     Minio,
     AWS,
 }
 
+#[serde_as]
+#[derive(Deserialize, Debug, Clone)]
+pub struct InjectedLatencyConfig {
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(rename = "min_put_latency_ms")]
+    pub min_put_latency: Duration,
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(rename = "min_get_latency_ms")]
+    pub min_get_latency: Duration,
+}
+
+#[serde_as]
 #[derive(Deserialize, Debug, Clone)]
 /// The configuration for the s3 storage type
 /// # Fields
@@ -30,8 +52,12 @@ pub enum S3CredentialsConfig {
 pub struct S3StorageConfig {
     pub bucket: String,
     pub credentials: S3CredentialsConfig,
-    pub connect_timeout_ms: u64,
-    pub request_timeout_ms: u64,
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(rename = "connect_timeout_ms")]
+    pub connect_timeout: Duration,
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(rename = "request_timeout_ms")]
+    pub request_timeout: Duration,
     pub upload_part_size_bytes: usize,
     pub download_part_size_bytes: usize,
 }

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod local;
 pub mod s3;
 pub mod stream;
+use config::{InjectedLatencyConfig, StorageConfigKind};
 use futures::Stream;
 use local::LocalStorage;
 use std::{path::Path, sync::Arc};
@@ -17,10 +18,16 @@ use tempfile::TempDir;
 use thiserror::Error;
 
 #[derive(Clone)]
-pub enum Storage {
+enum StorageKind {
     S3(s3::S3Storage),
     Local(local::LocalStorage),
     AdmissionControlledS3(admissioncontrolleds3::AdmissionControlledS3Storage),
+}
+
+#[derive(Clone)]
+pub struct Storage {
+    kind: StorageKind,
+    injected_latency: Option<InjectedLatencyConfig>,
 }
 
 #[derive(Error, Debug, Clone)]
@@ -62,26 +69,36 @@ impl ChromaError for PutError {
 
 impl Storage {
     pub fn new_test_storage() -> Self {
-        Storage::Local(LocalStorage::new(
-            TempDir::new()
-                .expect("Should be able to create a temporary directory.")
-                .into_path()
-                .to_str()
-                .expect("Should be able to convert temporary directory path to string"),
-        ))
+        Storage {
+            kind: StorageKind::Local(LocalStorage::new(
+                TempDir::new()
+                    .expect("Should be able to create a temporary directory.")
+                    .into_path()
+                    .to_str()
+                    .expect("Should be able to convert temporary directory path to string"),
+            )),
+            injected_latency: None,
+        }
     }
 
     pub fn new_test_storage_at<P: AsRef<Path>>(path: P) -> Self {
-        Storage::Local(LocalStorage::new(
-            path.as_ref()
-                .to_str()
-                .expect("Should be able to convert path to string"),
-        ))
+        Storage {
+            kind: StorageKind::Local(LocalStorage::new(
+                path.as_ref()
+                    .to_str()
+                    .expect("Should be able to convert path to string"),
+            )),
+            injected_latency: None,
+        }
     }
 
     pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
-        match self {
-            Storage::S3(s3) => {
+        if let Some(latency) = &self.injected_latency {
+            tokio::time::sleep(latency.min_put_latency).await;
+        }
+
+        match &self.kind {
+            StorageKind::S3(s3) => {
                 let res = s3.get(key).await;
                 match res {
                     Ok(res) => Ok(res),
@@ -91,14 +108,14 @@ impl Storage {
                     },
                 }
             }
-            Storage::Local(local) => {
+            StorageKind::Local(local) => {
                 let res = local.get(key).await;
                 match res {
                     Ok(res) => Ok(res),
                     Err(e) => Err(GetError::LocalError(e)),
                 }
             }
-            Storage::AdmissionControlledS3(admission_controlled_storage) => {
+            StorageKind::AdmissionControlledS3(admission_controlled_storage) => {
                 let res = admission_controlled_storage.get(key.to_string()).await;
                 match res {
                     Ok(res) => Ok(res),
@@ -114,8 +131,12 @@ impl Storage {
     }
 
     pub async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
-        match self {
-            Storage::S3(s3) => {
+        if let Some(latency) = &self.injected_latency {
+            tokio::time::sleep(latency.min_put_latency).await;
+        }
+
+        match &self.kind {
+            StorageKind::S3(s3) => {
                 let res = s3.get_parallel(key).await;
                 match res {
                     Ok(res) => Ok(res),
@@ -125,14 +146,14 @@ impl Storage {
                     },
                 }
             }
-            Storage::Local(local) => {
+            StorageKind::Local(local) => {
                 let res = local.get(key).await;
                 match res {
                     Ok(res) => Ok(res),
                     Err(e) => Err(GetError::LocalError(e)),
                 }
             }
-            Storage::AdmissionControlledS3(admission_controlled_storage) => {
+            StorageKind::AdmissionControlledS3(admission_controlled_storage) => {
                 let res = admission_controlled_storage
                     .get_parallel(key.to_string())
                     .await;
@@ -154,8 +175,12 @@ impl Storage {
         &self,
         key: &str,
     ) -> Result<Box<dyn Stream<Item = ByteStreamItem> + Unpin + Send>, GetError> {
-        match self {
-            Storage::S3(s3) => {
+        if let Some(latency) = &self.injected_latency {
+            tokio::time::sleep(latency.min_put_latency).await;
+        }
+
+        match &self.kind {
+            StorageKind::S3(s3) => {
                 let res = s3.get_stream(key).await;
                 match res {
                     Ok(res) => Ok(res),
@@ -165,14 +190,14 @@ impl Storage {
                     },
                 }
             }
-            Storage::Local(local) => {
+            StorageKind::Local(local) => {
                 let res = local.get_stream(key).await;
                 match res {
                     Ok(res) => Ok(res),
                     Err(e) => Err(GetError::LocalError(e)),
                 }
             }
-            Storage::AdmissionControlledS3(admission_controlled_storage) => {
+            StorageKind::AdmissionControlledS3(admission_controlled_storage) => {
                 let res = admission_controlled_storage.get_stream(key).await;
                 match res {
                     Ok(res) => Ok(res),
@@ -188,26 +213,34 @@ impl Storage {
     }
 
     pub async fn put_file(&self, key: &str, path: &str) -> Result<(), PutError> {
-        match self {
-            Storage::S3(s3) => s3.put_file(key, path).await.map_err(PutError::S3Error),
-            Storage::Local(local) => local
+        if let Some(latency) = &self.injected_latency {
+            tokio::time::sleep(latency.min_put_latency).await;
+        }
+
+        match &self.kind {
+            StorageKind::S3(s3) => s3.put_file(key, path).await.map_err(PutError::S3Error),
+            StorageKind::Local(local) => local
                 .put_file(key, path)
                 .await
                 .map_err(PutError::LocalError),
-            Storage::AdmissionControlledS3(as3) => {
+            StorageKind::AdmissionControlledS3(as3) => {
                 as3.put_file(key, path).await.map_err(PutError::S3Error)
             }
         }
     }
 
     pub async fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> Result<(), PutError> {
-        match self {
-            Storage::S3(s3) => s3.put_bytes(key, bytes).await.map_err(PutError::S3Error),
-            Storage::Local(local) => local
+        if let Some(latency) = &self.injected_latency {
+            tokio::time::sleep(latency.min_put_latency).await;
+        }
+
+        match &self.kind {
+            StorageKind::S3(s3) => s3.put_bytes(key, bytes).await.map_err(PutError::S3Error),
+            StorageKind::Local(local) => local
                 .put_bytes(key, &bytes)
                 .await
                 .map_err(PutError::LocalError),
-            Storage::AdmissionControlledS3(as3) => {
+            StorageKind::AdmissionControlledS3(as3) => {
                 as3.put_bytes(key, bytes).await.map_err(PutError::S3Error)
             }
         }
@@ -215,23 +248,126 @@ impl Storage {
 }
 
 pub async fn from_config(config: &StorageConfig) -> Result<Storage, Box<dyn ChromaError>> {
-    match &config {
-        StorageConfig::S3(_) => Ok(Storage::S3(s3::S3Storage::try_from_config(config).await?)),
-        StorageConfig::Local(_) => Ok(Storage::Local(
+    let kind = match &config.kind {
+        StorageConfigKind::S3(_) => Ok(StorageKind::S3(
+            s3::S3Storage::try_from_config(config).await?,
+        )),
+        StorageConfigKind::Local(_) => Ok(StorageKind::Local(
             local::LocalStorage::try_from_config(config).await?,
         )),
-        StorageConfig::AdmissionControlledS3(_) => Ok(Storage::AdmissionControlledS3(
+        StorageConfigKind::AdmissionControlledS3(_) => Ok(StorageKind::AdmissionControlledS3(
             admissioncontrolleds3::AdmissionControlledS3Storage::try_from_config(config).await?,
         )),
-    }
+    };
+
+    Ok(Storage {
+        kind: kind?,
+        injected_latency: config.inject_latency.clone(),
+    })
 }
 
-pub fn test_storage() -> Storage {
-    Storage::Local(LocalStorage::new(
-        TempDir::new()
-            .expect("Should be able to create a temporary directory.")
-            .into_path()
-            .to_str()
-            .expect("Should be able to convert temporary directory path to string"),
-    ))
+#[cfg(test)]
+mod tests {
+    use crate::config::InjectedLatencyConfig;
+
+    use super::*;
+    use config::LocalStorageConfig;
+    use futures::StreamExt;
+    use rand::{Rng, SeedableRng};
+    use std::{io::Write, time::Duration};
+    use tempfile::NamedTempFile;
+
+    fn generate_file(file_size: usize) -> NamedTempFile {
+        let mut temp_file = NamedTempFile::new().unwrap();
+
+        let mut rng = rand_xorshift::XorShiftRng::seed_from_u64(0);
+        let mut remaining_file_size = file_size;
+
+        while remaining_file_size > 0 {
+            let chunk_size = std::cmp::min(remaining_file_size, 4096);
+            let mut chunk = vec![0u8; chunk_size];
+            rng.try_fill(&mut chunk[..]).unwrap();
+            temp_file.write_all(&chunk).unwrap();
+            remaining_file_size -= chunk_size;
+        }
+
+        temp_file
+    }
+
+    #[tokio::test]
+    async fn test_latency_injection() {
+        let latency = InjectedLatencyConfig {
+            min_put_latency: Duration::from_millis(1000),
+            min_get_latency: Duration::from_millis(1000),
+        };
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config = StorageConfig {
+            kind: StorageConfigKind::Local(LocalStorageConfig {
+                root: temp_dir.path().to_str().unwrap().to_string(),
+            }),
+            inject_latency: Some(latency.clone()),
+        };
+
+        let storage = from_config(&config).await.unwrap();
+
+        let file = generate_file(1024);
+
+        // Test put_file()
+        let now = std::time::Instant::now();
+        storage
+            .put_file("test", file.path().to_str().unwrap())
+            .await
+            .unwrap();
+        let put_duration = now.elapsed();
+        assert!(
+            put_duration >= latency.min_put_latency,
+            "put_file() does not respect min_put_latency_ms: {:?}",
+            put_duration
+        );
+
+        // Test put_bytes()
+        let now = std::time::Instant::now();
+        storage
+            .put_bytes("test", "test".as_bytes().to_vec())
+            .await
+            .unwrap();
+        let put_duration = now.elapsed();
+        assert!(
+            put_duration >= latency.min_put_latency,
+            "put_bytes() does not respect min_put_latency_ms: {:?}",
+            put_duration
+        );
+
+        // Test get()
+        let now = std::time::Instant::now();
+        let _ = storage.get("test").await.unwrap();
+        let get_duration = now.elapsed();
+        assert!(
+            get_duration >= latency.min_get_latency,
+            "get() does not respect min_get_latency_ms: {:?}",
+            get_duration
+        );
+
+        // Test get_stream()
+        let now = std::time::Instant::now();
+        let mut stream = storage.get_stream("test").await.unwrap();
+        while stream.next().await.is_some() {}
+        let get_duration = now.elapsed();
+        assert!(
+            get_duration >= latency.min_get_latency,
+            "get_stream() does not respect min_get_latency_ms: {:?}",
+            get_duration
+        );
+
+        // Test get_parallel()
+        let now = std::time::Instant::now();
+        let _ = storage.get_parallel("test").await.unwrap();
+        let get_duration = now.elapsed();
+        assert!(
+            get_duration >= latency.min_get_latency,
+            "get_parallel() does not respect min_get_latency_ms: {:?}",
+            get_duration
+        );
+    }
 }

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -1,6 +1,8 @@
 use super::stream::ByteStream;
 use super::stream::ByteStreamItem;
-use super::{config::StorageConfig, s3::StorageConfigError};
+use crate::config::StorageConfig;
+use crate::config::StorageConfigKind;
+use crate::s3::StorageConfigError;
 use crate::GetError;
 use async_trait::async_trait;
 use chroma_config::Configurable;
@@ -105,8 +107,8 @@ impl LocalStorage {
 #[async_trait]
 impl Configurable<StorageConfig> for LocalStorage {
     async fn try_from_config(config: &StorageConfig) -> Result<Self, Box<dyn ChromaError>> {
-        match &config {
-            StorageConfig::Local(local_config) => {
+        match &config.kind {
+            StorageConfigKind::Local(local_config) => {
                 let storage = LocalStorage::new(&local_config.root);
                 Ok(storage)
             }

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -136,6 +136,8 @@ pub(crate) struct CompactionServiceConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use figment::Jail;
     use serial_test::serial;
@@ -742,15 +744,15 @@ mod tests {
                 "compaction-service-0"
             );
             assert_eq!(config.compaction_service.my_port, 50051);
-            match &config.compaction_service.storage {
-                chroma_storage::config::StorageConfig::S3(s) => {
+            match &config.compaction_service.storage.kind {
+                chroma_storage::config::StorageConfigKind::S3(s) => {
                     assert_eq!(s.bucket, "buckets!");
                     assert_eq!(
                         s.credentials,
                         chroma_storage::config::S3CredentialsConfig::AWS
                     );
-                    assert_eq!(s.connect_timeout_ms, 5000);
-                    assert_eq!(s.request_timeout_ms, 1000);
+                    assert_eq!(s.connect_timeout, Duration::from_millis(5000));
+                    assert_eq!(s.request_timeout, Duration::from_millis(1000));
                     assert_eq!(s.upload_part_size_bytes, 1024 * 1024 * 8);
                     assert_eq!(s.download_part_size_bytes, 1024 * 1024 * 8);
                 }


### PR DESCRIPTION
## Description of changes

Adds two new fields to the storage config that allows latency injection on any storage implementation. I added it to the top-level storage config rather than S3-specific config as this allows injecting latency on the local storage implementation as well (useful for benchmarks).

These config changes are fully backwards-compatible with existing configs.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a