### PR TITLE
[ENH] Set up QuotaEnforcer on API

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -140,9 +140,7 @@ class SegmentAPI(ServerAPI):
         if len(name) < 3:
             raise ValueError("Database name must be at least 3 characters long")
 
-        self._quota_enforcer.enforce(
-            action="create_database", tenant=tenant, **locals()
-        )
+        self._quota_enforcer.enforce(action="create_database", **locals())
 
         self._sysdb.create_database(
             id=uuid4(),
@@ -199,9 +197,7 @@ class SegmentAPI(ServerAPI):
         # TODO: remove backwards compatibility in naming requirements
         check_index_name(name)
 
-        self._quota_enforcer.enforce(
-            action="create_collection", tenant=tenant, **locals()
-        )
+        self._quota_enforcer.enforce(action="create_collection", **locals())
 
         id = uuid4()
 
@@ -303,9 +299,7 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
-        self._quota_enforcer.enforce(
-            action="list_collections", tenant=tenant, **locals()
-        )
+        self._quota_enforcer.enforce(action="list_collections", **locals())
 
         return self._sysdb.get_collections(
             limit=limit, offset=offset, tenant=tenant, database=database
@@ -346,9 +340,7 @@ class SegmentAPI(ServerAPI):
         # Ensure the collection exists
         _ = self._get_collection(id)
 
-        self._quota_enforcer.enforce(
-            action="update_collection", tenant=tenant, **locals()
-        )
+        self._quota_enforcer.enforce(action="update_collection", **locals())
 
         # TODO eventually we'll want to use OptionalArgument and Unspecified in the
         # signature of `_modify` but not changing the API right now.
@@ -413,7 +405,7 @@ class SegmentAPI(ServerAPI):
         )
         self._validate_embedding_record_set(coll, records_to_submit)
 
-        self._quota_enforcer.enforce(action="add", tenant=tenant, **locals())
+        self._quota_enforcer.enforce(action="add", **locals())
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
@@ -460,7 +452,7 @@ class SegmentAPI(ServerAPI):
         )
         self._validate_embedding_record_set(coll, records_to_submit)
 
-        self._quota_enforcer.enforce(action="update", tenant=tenant, **locals())
+        self._quota_enforcer.enforce(action="update", **locals())
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
@@ -509,7 +501,7 @@ class SegmentAPI(ServerAPI):
         )
         self._validate_embedding_record_set(coll, records_to_submit)
 
-        self._quota_enforcer.enforce(action="upsert", tenant=tenant, **locals())
+        self._quota_enforcer.enforce(action="upsert", **locals())
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
@@ -555,7 +547,7 @@ class SegmentAPI(ServerAPI):
         if where_document is not None:
             validate_where_document(where_document)
 
-        self._quota_enforcer.enforce(action="get", tenant=tenant, **locals())
+        self._quota_enforcer.enforce(action="get", **locals())
 
         if sort is not None:
             raise NotImplementedError("Sorting is not yet supported")
@@ -637,7 +629,7 @@ class SegmentAPI(ServerAPI):
 
         coll = self._get_collection(collection_id)
 
-        self._quota_enforcer.enforce(action="delete", tenant=tenant, **locals())
+        self._quota_enforcer.enforce(action="delete", **locals())
 
         self._manager.hint_use_collection(collection_id, t.Operation.DELETE)
 
@@ -742,7 +734,7 @@ class SegmentAPI(ServerAPI):
         for embedding in query_embeddings:
             self._validate_dimension(coll, len(embedding), update=False)
 
-        self._quota_enforcer.enforce(action="query", tenant=tenant, **locals())
+        self._quota_enforcer.enforce(action="query", **locals())
 
         return self._executor.knn(
             KNNPlan(

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -140,7 +140,10 @@ class SegmentAPI(ServerAPI):
         if len(name) < 3:
             raise ValueError("Database name must be at least 3 characters long")
 
-        self._quota_enforcer.enforce(action="create_database", **locals())
+        self._quota_enforcer.enforce(
+            action="create_database",
+            **{k: v for k, v in locals().items() if k != "self"},
+        )
 
         self._sysdb.create_database(
             id=uuid4(),
@@ -197,7 +200,10 @@ class SegmentAPI(ServerAPI):
         # TODO: remove backwards compatibility in naming requirements
         check_index_name(name)
 
-        self._quota_enforcer.enforce(action="create_collection", **locals())
+        self._quota_enforcer.enforce(
+            action="create_collection",
+            **{k: v for k, v in locals().items() if k != "self"},
+        )
 
         id = uuid4()
 
@@ -299,7 +305,10 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
-        self._quota_enforcer.enforce(action="list_collections", **locals())
+        self._quota_enforcer.enforce(
+            action="list_collections",
+            **{k: v for k, v in locals().items() if k != "self"},
+        )
 
         return self._sysdb.get_collections(
             limit=limit, offset=offset, tenant=tenant, database=database
@@ -340,7 +349,10 @@ class SegmentAPI(ServerAPI):
         # Ensure the collection exists
         _ = self._get_collection(id)
 
-        self._quota_enforcer.enforce(action="update_collection", **locals())
+        self._quota_enforcer.enforce(
+            action="update_collection",
+            **{k: v for k, v in locals().items() if k != "self"},
+        )
 
         # TODO eventually we'll want to use OptionalArgument and Unspecified in the
         # signature of `_modify` but not changing the API right now.
@@ -405,7 +417,9 @@ class SegmentAPI(ServerAPI):
         )
         self._validate_embedding_record_set(coll, records_to_submit)
 
-        self._quota_enforcer.enforce(action="add", **locals())
+        self._quota_enforcer.enforce(
+            action="add", **{k: v for k, v in locals().items() if k != "self"}
+        )
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
@@ -452,7 +466,9 @@ class SegmentAPI(ServerAPI):
         )
         self._validate_embedding_record_set(coll, records_to_submit)
 
-        self._quota_enforcer.enforce(action="update", **locals())
+        self._quota_enforcer.enforce(
+            action="update", **{k: v for k, v in locals().items() if k != "self"}
+        )
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
@@ -501,7 +517,9 @@ class SegmentAPI(ServerAPI):
         )
         self._validate_embedding_record_set(coll, records_to_submit)
 
-        self._quota_enforcer.enforce(action="upsert", **locals())
+        self._quota_enforcer.enforce(
+            action="upsert", **{k: v for k, v in locals().items() if k != "self"}
+        )
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
 
@@ -547,7 +565,9 @@ class SegmentAPI(ServerAPI):
         if where_document is not None:
             validate_where_document(where_document)
 
-        self._quota_enforcer.enforce(action="get", **locals())
+        self._quota_enforcer.enforce(
+            action="get", **{k: v for k, v in locals().items() if k != "self"}
+        )
 
         if sort is not None:
             raise NotImplementedError("Sorting is not yet supported")
@@ -629,7 +649,9 @@ class SegmentAPI(ServerAPI):
 
         coll = self._get_collection(collection_id)
 
-        self._quota_enforcer.enforce(action="delete", **locals())
+        self._quota_enforcer.enforce(
+            action="delete", **{k: v for k, v in locals().items() if k != "self"}
+        )
 
         self._manager.hint_use_collection(collection_id, t.Operation.DELETE)
 
@@ -734,7 +756,9 @@ class SegmentAPI(ServerAPI):
         for embedding in query_embeddings:
             self._validate_dimension(coll, len(embedding), update=False)
 
-        self._quota_enforcer.enforce(action="query", **locals())
+        self._quota_enforcer.enforce(
+            action="query", **{k: v for k, v in locals().items() if k != "self"}
+        )
 
         return self._executor.knn(
             KNNPlan(

--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -1,7 +1,31 @@
 from abc import abstractmethod
-from typing import Dict, Any
+from enum import Enum
+from typing import Dict, Any, Optional
 
+from chromadb.api.types import (
+    Embeddings,
+    Metadatas,
+    Documents,
+    URIs,
+    IDs,
+    CollectionMetadata,
+    Where,
+    WhereDocument,
+)
 from chromadb.config import Component, System
+
+
+class Action(str, Enum):
+    CREATE_DATABASE = "create_database"
+    CREATE_COLLECTION = "create_collection"
+    LIST_COLLECTIONS = "list_collections"
+    UPDATE_COLLECTION = "update_collection"
+    ADD = "add"
+    GET = "get"
+    DELETE = "delete"
+    UPDATE = "update"
+    UPSERT = "upsert"
+    QUERY = "query"
 
 
 class QuotaEnforcer(Component):
@@ -20,7 +44,25 @@ class QuotaEnforcer(Component):
         pass
 
     @abstractmethod
-    def enforce(self, action: str, **kwargs: Dict[str, Any]) -> None:
+    def enforce(
+        self,
+        action: Action,
+        tenant: str,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        embeddings: Optional[Embeddings] = None,
+        uris: Optional[URIs] = None,
+        ids: Optional[IDs] = None,
+        name: Optional[str] = None,
+        new_name: Optional[str] = None,
+        metadata: Optional[CollectionMetadata] = None,
+        new_metadata: Optional[CollectionMetadata] = None,
+        limit: Optional[int] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        n_results: Optional[int] = None,
+        query_embeddings: Optional[Embeddings] = None,
+    ) -> None:
         """
         Enforces a quota.
         """

--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -1,4 +1,6 @@
 from abc import abstractmethod
+from typing import Dict, Any
+
 from chromadb.config import Component, System
 
 
@@ -11,7 +13,14 @@ class QuotaEnforcer(Component):
         super().__init__(system)
 
     @abstractmethod
-    def enforce(self) -> None:
+    def set_context(self, context: Dict[str, Any]) -> None:
+        """
+        Sets the context for a given request.
+        """
+        pass
+
+    @abstractmethod
+    def enforce(self, action: str, tenant: str, **kwargs: Dict[str, Any]) -> None:
         """
         Enforces a quota.
         """

--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -20,7 +20,7 @@ class QuotaEnforcer(Component):
         pass
 
     @abstractmethod
-    def enforce(self, action: str, tenant: str, **kwargs: Dict[str, Any]) -> None:
+    def enforce(self, action: str, **kwargs: Dict[str, Any]) -> None:
         """
         Enforces a quota.
         """

--- a/chromadb/quota/simple_quota_enforcer/__init__.py
+++ b/chromadb/quota/simple_quota_enforcer/__init__.py
@@ -1,5 +1,5 @@
 from overrides import override
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, Dict
 
 from chromadb.quota import QuotaEnforcer
 from chromadb.config import System
@@ -16,5 +16,9 @@ class SimpleQuotaEnforcer(QuotaEnforcer):
         super().__init__(system)
 
     @override
-    def enforce(self) -> None:
+    def set_context(self, context: Dict[str, Any]) -> None:
+        pass
+
+    @override
+    def enforce(self, action: str, tenant: str, **kwargs: Dict[str, Any]) -> None:
         pass

--- a/chromadb/quota/simple_quota_enforcer/__init__.py
+++ b/chromadb/quota/simple_quota_enforcer/__init__.py
@@ -20,5 +20,5 @@ class SimpleQuotaEnforcer(QuotaEnforcer):
         pass
 
     @override
-    def enforce(self, action: str, tenant: str, **kwargs: Dict[str, Any]) -> None:
+    def enforce(self, action: str, **kwargs: Dict[str, Any]) -> None:
         pass

--- a/chromadb/quota/simple_quota_enforcer/__init__.py
+++ b/chromadb/quota/simple_quota_enforcer/__init__.py
@@ -1,7 +1,17 @@
 from overrides import override
-from typing import Any, Callable, TypeVar, Dict
+from typing import Any, Callable, TypeVar, Dict, Optional
 
-from chromadb.quota import QuotaEnforcer
+from chromadb.api.types import (
+    Embeddings,
+    Metadatas,
+    Documents,
+    URIs,
+    IDs,
+    CollectionMetadata,
+    Where,
+    WhereDocument,
+)
+from chromadb.quota import QuotaEnforcer, Action
 from chromadb.config import System
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -20,5 +30,23 @@ class SimpleQuotaEnforcer(QuotaEnforcer):
         pass
 
     @override
-    def enforce(self, action: str, **kwargs: Dict[str, Any]) -> None:
+    def enforce(
+        self,
+        action: Action,
+        tenant: str,
+        metadatas: Optional[Metadatas] = None,
+        documents: Optional[Documents] = None,
+        embeddings: Optional[Embeddings] = None,
+        uris: Optional[URIs] = None,
+        ids: Optional[IDs] = None,
+        name: Optional[str] = None,
+        new_name: Optional[str] = None,
+        metadata: Optional[CollectionMetadata] = None,
+        new_metadata: Optional[CollectionMetadata] = None,
+        limit: Optional[int] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        n_results: Optional[int] = None,
+        query_embeddings: Optional[Embeddings] = None,
+    ) -> None:
         pass


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- Updates the signatures on `QuotaEnforcer` abstract class and `SimpleQuotaEnforcer` impl slightly to explicitly name the parameters on `enforce()`. Adds the `set_context()` method.
- Sets up the relevant context passing and quota enforcement within the API.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
