### PR TITLE
Convert OpenCLIP embeddings to numpy arrays

### DIFF
--- a/chromadb/utils/embedding_functions/open_clip_embedding_function.py
+++ b/chromadb/utils/embedding_functions/open_clip_embedding_function.py
@@ -59,13 +59,13 @@ class OpenCLIPEmbeddingFunction(EmbeddingFunction[Union[Documents, Images]]):
                 self._preprocess(pil_image).unsqueeze(0)
             )
             image_features /= image_features.norm(dim=-1, keepdim=True)
-            return cast(Embedding, image_features.squeeze())
+            return cast(Embedding, image_features.squeeze().cpu().numpy())
 
     def _encode_text(self, text: Document) -> Embedding:
         with self._torch.no_grad():
             text_features = self._model.encode_text(self._tokenizer(text))
             text_features /= text_features.norm(dim=-1, keepdim=True)
-            return cast(Embedding, text_features.squeeze())
+            return cast(Embedding, text_features.squeeze().cpu().numpy())
 
     def __call__(self, input: Union[Documents, Images]) -> Embeddings:
         embeddings: Embeddings = []


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes

**fixes bug with `OpenCLIPEmbeddingFunction` when passing `device="cuda"`**

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
- none needed
