### PR TITLE
[ENH]  Safer object store interface.

### DIFF
--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -25,6 +25,8 @@ pub enum ObjectStoreType {
     Minio,
     #[serde(alias = "s3")]
     S3,
+    #[serde(alias = "local")]
+    Local,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -39,6 +41,7 @@ pub struct ObjectStoreConfig {
     pub upload_part_size_bytes: u64,
     pub download_part_size_bytes: u64,
     pub max_concurrent_requests: usize,
+    pub cache: Option<Box<ObjectStoreConfig>>,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
-use self::config::StorageConfig;
-use self::s3::S3GetError;
-use admissioncontrolleds3::AdmissionControlledS3StorageError;
+use local::LocalStorage;
+use tempfile::TempDir;
+use thiserror::Error;
+
+use ::object_store::ObjectStore;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 
@@ -12,12 +14,14 @@ pub mod caching;
 pub mod config;
 pub mod evicting;
 pub mod local;
+pub mod non_destructive;
 pub mod object_store;
 pub mod s3;
 pub mod stream;
-use local::LocalStorage;
-use tempfile::TempDir;
-use thiserror::Error;
+
+use admissioncontrolleds3::AdmissionControlledS3StorageError;
+use config::StorageConfig;
+use s3::S3GetError;
 
 #[derive(Clone)]
 pub enum Storage {
@@ -235,4 +239,30 @@ pub fn test_storage() -> Storage {
             .to_str()
             .expect("Should be able to convert temporary directory path to string"),
     ))
+}
+
+/// This trait is for advertising capabilities of an object store so that we can write safe(r)
+/// code.
+///
+/// Specifically, I want to advertise whether an object store supports the `delete` call.  Delete
+/// is destructive.  Delete is a for loop, even more so.  And delete in a for loop over list is the
+/// fastest way I know of to delete data one round trip at a time.
+///
+/// To that end:  I'd like to make it so that object stores that wrap other object stores (like the
+/// evicting object store does) will make sure that there is at least one object store that does
+/// not implement delete.
+pub trait SafeObjectStore: ObjectStore {
+    fn supports_delete(&self) -> bool;
+}
+
+impl SafeObjectStore for ::object_store::memory::InMemory {
+    fn supports_delete(&self) -> bool {
+        true
+    }
+}
+
+impl SafeObjectStore for ::object_store::local::LocalFileSystem {
+    fn supports_delete(&self) -> bool {
+        true
+    }
 }

--- a/rust/storage/src/non_destructive.rs
+++ b/rust/storage/src/non_destructive.rs
@@ -20,12 +20,11 @@ use super::SafeObjectStore;
 
 #[derive(Clone)]
 pub struct NonDestructiveObjectStore {
-    object_store: Arc<dyn ObjectStore>,
+    object_store: Arc<dyn SafeObjectStore>,
 }
 
 impl NonDestructiveObjectStore {
-    pub fn new<O: ObjectStore>(object_store: O) -> Self {
-        let object_store = Arc::new(object_store);
+    pub fn new(object_store: Arc<dyn SafeObjectStore>) -> Self {
         Self { object_store }
     }
 }
@@ -108,6 +107,8 @@ impl SafeObjectStore for NonDestructiveObjectStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use object_store::path::Path;
     use object_store::{ObjectStore, PutMode};
 
@@ -118,14 +119,14 @@ mod tests {
     #[tokio::test]
     async fn empty() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(!non_destructive.supports_delete());
     }
 
     #[tokio::test]
     async fn insert() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(non_destructive
             .put_opts(
                 &Path::from("test"),
@@ -150,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn overwrite_fails() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(non_destructive
             .put_opts(
                 &Path::from("test"),
@@ -164,7 +165,7 @@ mod tests {
     #[tokio::test]
     async fn delete_fails() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(non_destructive
             .put_opts(
                 &Path::from("test"),

--- a/rust/storage/src/non_destructive.rs
+++ b/rust/storage/src/non_destructive.rs
@@ -1,0 +1,189 @@
+//! A non-destructive wrapper around object store.  It turns `delete` operations into
+//! `not-implemented` errors.  It makes sure the put mode is create for all block writes.
+//! Unfortunately the multi-part upload cannot exhibit this same safety.  Copy will be silently
+//! transformed to a copy-if-not-exist.
+
+use std::fmt::{Debug, Display};
+use std::ops::Range;
+use std::sync::Arc;
+
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMode,
+    PutMultipartOpts, PutOptions, PutPayload, PutResult, Result,
+};
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+
+use super::SafeObjectStore;
+
+#[derive(Clone)]
+pub struct NonDestructiveObjectStore {
+    object_store: Arc<dyn ObjectStore>,
+}
+
+impl NonDestructiveObjectStore {
+    pub fn new<O: ObjectStore>(object_store: O) -> Self {
+        let object_store = Arc::new(object_store);
+        Self { object_store }
+    }
+}
+
+impl Debug for NonDestructiveObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NonDestructiveObjectStore")
+    }
+}
+
+impl Display for NonDestructiveObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NonDestructiveObjectStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for NonDestructiveObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        match opts.mode {
+            PutMode::Overwrite => {
+                return Err(object_store::Error::NotImplemented);
+            }
+            PutMode::Create | PutMode::Update(_) => {}
+        };
+        self.object_store.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.object_store.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.object_store.get_opts(location, options).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> Result<Vec<Bytes>> {
+        self.object_store.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.object_store.head(location).await
+    }
+
+    async fn delete(&self, _: &Path) -> Result<()> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta>> {
+        self.object_store.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.object_store.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.object_store.copy_if_not_exists(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.object_store.copy_if_not_exists(from, to).await
+    }
+}
+
+impl SafeObjectStore for NonDestructiveObjectStore {
+    fn supports_delete(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::path::Path;
+    use object_store::{ObjectStore, PutMode};
+
+    use super::NonDestructiveObjectStore;
+
+    use crate::SafeObjectStore;
+
+    #[tokio::test]
+    async fn empty() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(backing);
+        assert!(!non_destructive.supports_delete());
+    }
+
+    #[tokio::test]
+    async fn insert() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(backing);
+        assert!(non_destructive
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
+            .await
+            .is_ok());
+        assert_eq!(
+            "hello 42".as_bytes(),
+            non_destructive
+                .object_store
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn overwrite_fails() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(backing);
+        assert!(non_destructive
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Overwrite.into()
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_fails() {
+        let backing = object_store::memory::InMemory::new();
+        let non_destructive = NonDestructiveObjectStore::new(backing);
+        assert!(non_destructive
+            .put_opts(
+                &Path::from("test"),
+                "hello 42".into(),
+                PutMode::Create.into()
+            )
+            .await
+            .is_ok());
+        assert_eq!(
+            "hello 42".as_bytes(),
+            non_destructive
+                .object_store
+                .get_opts(&Path::from("test"), Default::default())
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+        );
+        assert!(non_destructive.delete(&Path::from("test")).await.is_err());
+    }
+}


### PR DESCRIPTION
We already wrap up the object store in an interface that doesn't expose
delete.  This allows us to wrap an object store in a non-destructive
interface that advertises when it is non-destructive.  The cache has
been updated to mandate that the cache be destructive and the backing
store be non-destructive.
