### PR TITLE
[TST]: improve blockfile writer proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,9 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-state-machine"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52a714915de2d16a5289616d2265a934780f50a9dd30359322b687403fa2ac2"
+checksum = "28278d6a11102264b0c569c33dbe5286ba00d2dd6d96ff2a94296e0e5b3d1e04"
 dependencies = [
  "proptest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ worker = { path = "rust/worker" }
 # Dev dependencies
 bincode = "1.3.3"
 indicatif = "0.17.8"
-proptest = "1.4.0"
-proptest-state-machine = "0.1.0"
+proptest = "1.5.0"
+proptest-state-machine = "0.3.0"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
 rayon = "1.8.0"


### PR DESCRIPTION
## Description of changes

Generates transitions on-demand instead of upfront. It seemed like generating transitions upfront was preventing proper shrinking for some reason. :(

My main motiviation was trying to convience proptest to catch a bug I knew about in another PR. It now catches the bug correctly.

I also changed the values being stored to `Vec<u32>` instead of Strings as they seem to be much faster to generate.

Execution time for this test went from 40s -> 16s for me and we're also running 4x as many cases now.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
