### PR TITLE
Revert "[ENH] Add fastapi middleware for http.disconnect (#3038)"

### DIFF
--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -3,6 +3,7 @@ import os
 from functools import wraps
 from enum import Enum
 from typing import Any, Callable, Dict, Optional, Sequence, Union, TypeVar
+
 from opentelemetry import trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -10,6 +11,7 @@ from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
 )
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
 from chromadb.config import Component
 from chromadb.config import System
 
@@ -98,7 +100,7 @@ def otel_init(
     granularity = otel_granularity
 
 
-T = TypeVar("T", bound=Callable)  # type: ignore[type-arg]
+T = TypeVar("T", bound=Callable)
 
 
 def trace_method(
@@ -126,7 +128,7 @@ def trace_method(
         if asyncio.iscoroutinefunction(f):
 
             @wraps(f)
-            async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            async def async_wrapper(*args, **kwargs):
                 global tracer, granularity
                 add_attributes_to_current_span({"pod_name": os.environ.get("HOSTNAME")})
                 if trace_granularity < granularity:
@@ -140,7 +142,7 @@ def trace_method(
         else:
 
             @wraps(f)
-            def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            def wrapper(*args, **kwargs):
                 global tracer, granularity
                 add_attributes_to_current_span({"pod_name": os.environ.get("HOSTNAME")})
                 if trace_granularity < granularity:
@@ -152,7 +154,7 @@ def trace_method(
 
             return wrapper  # type: ignore
 
-    return decorator
+    return decorator  # type: ignore
 
 
 def add_attributes_to_current_span(

--- a/chromadb/telemetry/opentelemetry/fastapi.py
+++ b/chromadb/telemetry/opentelemetry/fastapi.py
@@ -1,43 +1,10 @@
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import List, Optional
 from fastapi import FastAPI
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-from opentelemetry import trace
 
 
 def instrument_fastapi(app: FastAPI, excluded_urls: Optional[List[str]] = None) -> None:
     """Instrument FastAPI to emit OpenTelemetry spans."""
-
-    # FastAPI calls middleware in reverse order, we want our filter disconnect
-    # middleware to be called first to ensure that we have a chance to mark
-    # spans as disconnected before they are ended by the instrumentation
-    # middleware.
-    app.add_middleware(FilterDisconnectMiddleware)
     FastAPIInstrumentor.instrument_app(
         app, excluded_urls=",".join(excluded_urls) if excluded_urls else None
     )
-
-
-class FilterDisconnectMiddleware:
-    def __init__(self, app: Any):
-        self.app = app
-
-    async def __call__(
-        self,
-        scope: Dict[str, Any],
-        receive: Callable[[], Awaitable[Dict[str, Any]]],
-        send: Callable[[Dict[str, Any]], Awaitable[None]],
-    ) -> None:
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-
-        request_span = trace.get_current_span()
-
-        async def process() -> Dict[str, Any]:
-            message = await receive()
-            if message["type"] == "http.disconnect":
-                request_span.set_attribute("http.disconnect", True)
-
-            return message
-
-        await self.app(scope, process, send)


### PR DESCRIPTION
This reverts commit fc54f702f3244d67283e241b614bbbd8d01c18d3. Which does not quite work the way I'd like because I can't disambiguate between a real disconnect and a fake one.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - None
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None