### PR TITLE
[ENH]  End-to-end StorageConfig generating valid object stores.

### DIFF
--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -25,6 +25,8 @@ pub enum ObjectStoreType {
     Minio,
     #[serde(alias = "s3")]
     S3,
+    #[serde(alias = "local")]
+    Local,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -39,6 +41,7 @@ pub struct ObjectStoreConfig {
     pub upload_part_size_bytes: u64,
     pub download_part_size_bytes: u64,
     pub max_concurrent_requests: usize,
+    pub cache: Option<Box<ObjectStoreConfig>>,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/rust/storage/src/non_destructive.rs
+++ b/rust/storage/src/non_destructive.rs
@@ -20,12 +20,11 @@ use super::SafeObjectStore;
 
 #[derive(Clone)]
 pub struct NonDestructiveObjectStore {
-    object_store: Arc<dyn ObjectStore>,
+    object_store: Arc<dyn SafeObjectStore>,
 }
 
 impl NonDestructiveObjectStore {
-    pub fn new<O: ObjectStore>(object_store: O) -> Self {
-        let object_store = Arc::new(object_store);
+    pub fn new(object_store: Arc<dyn SafeObjectStore>) -> Self {
         Self { object_store }
     }
 }
@@ -108,6 +107,8 @@ impl SafeObjectStore for NonDestructiveObjectStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use object_store::path::Path;
     use object_store::{ObjectStore, PutMode};
 
@@ -118,14 +119,14 @@ mod tests {
     #[tokio::test]
     async fn empty() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(!non_destructive.supports_delete());
     }
 
     #[tokio::test]
     async fn insert() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(non_destructive
             .put_opts(
                 &Path::from("test"),
@@ -150,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn overwrite_fails() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(non_destructive
             .put_opts(
                 &Path::from("test"),
@@ -164,7 +165,7 @@ mod tests {
     #[tokio::test]
     async fn delete_fails() {
         let backing = object_store::memory::InMemory::new();
-        let non_destructive = NonDestructiveObjectStore::new(backing);
+        let non_destructive = NonDestructiveObjectStore::new(Arc::new(backing));
         assert!(non_destructive
             .put_opts(
                 &Path::from("test"),


### PR DESCRIPTION
This test wires up to make sure that every object store with a cache
that gets constructed is non-destructive, and also doesn't trip the
asserts for non-destructive behavior.
