### PR TITLE
[TST]: fix float generation for where clause filtering

### DIFF
--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -526,9 +526,7 @@ def opposite_value(value: LiteralValue) -> SearchStrategy[Any]:
     Returns a strategy that will generate all valid values except the input value - testing of $nin
     """
     if isinstance(value, float):
-        return st.floats(allow_nan=False, allow_infinity=False).filter(
-            lambda x: x != value
-        )
+        return safe_floats.filter(lambda x: x != value)
     elif isinstance(value, str):
         return safe_text.filter(lambda x: x != value)
     elif isinstance(value, bool):


### PR DESCRIPTION
## Description of changes

This was previously generating f64 values, but we store these values internally in distributed Chroma as f32, leading to occasional flakes of test_filtering.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
