### PR TITLE
[CLN] Send rust telemetry to otel_collector by default

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -5,7 +5,7 @@
 
 query_service:
     service_name: "query-service"
-    otel_endpoint: "http://jaeger:4317"
+    otel_endpoint: "http://otel-collector:4317"
     my_member_id: "query-service-0"
     my_port: 50051
     assignment_policy:
@@ -63,7 +63,7 @@ query_service:
 
 compaction_service:
     service_name: "compaction-service"
-    otel_endpoint: "http://jaeger:4317"
+    otel_endpoint: "http://otel-collector:4317"
     my_member_id: "compaction-service-0"
     my_port: 50051
     assignment_policy:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Send telemetry to otel_collector not jaeger. Fixing the left over in #3018 deemed out of scope by @codetheweb in https://github.com/chroma-core/chroma/pull/3018#issuecomment-2442919746
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None