### PR TITLE
[CHORE] Make block cache weight 8. Make cache config unit based.

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -630,7 +630,7 @@ impl Block {
 
 impl chroma_cache::Weighted for Block {
     fn weight(&self) -> usize {
-        1
+        8 // A block is at most 8 MB
     }
 }
 

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -88,12 +88,12 @@ pub struct FoyerCacheConfig {
     #[arg(short, long)]
     pub dir: Option<String>,
 
-    /// In-memory cache capacity. (items)
+    /// In-memory cache capacity. (weighted units)
     #[arg(long, default_value_t = 1048576)]
     #[serde(default = "default_capacity")]
     pub capacity: usize,
 
-    /// In-memory cache capacity. (items)
+    /// In-memory cache capacity. (weighted units)
     #[arg(long, default_value_t = 1024)]
     #[serde(default = "default_mem")]
     pub mem: usize,

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -1,8 +1,4 @@
-use opentelemetry::global;
-use std::hash::Hash;
-use std::sync::Arc;
-use std::time::Duration;
-
+use super::{CacheError, Weighted};
 use chroma_error::ChromaError;
 use clap::Parser;
 use foyer::{
@@ -10,9 +6,11 @@ use foyer::{
     InvalidRatioPicker, LargeEngineOptions, LfuConfig, LruConfig, RateLimitPicker, S3FifoConfig,
     StorageKey, StorageValue, TracingOptions,
 };
+use opentelemetry::global;
 use serde::{Deserialize, Serialize};
-
-use super::{CacheError, Weighted};
+use std::hash::Hash;
+use std::sync::Arc;
+use std::time::Duration;
 
 const MIB: usize = 1024 * 1024;
 
@@ -95,7 +93,7 @@ pub struct FoyerCacheConfig {
     #[serde(default = "default_capacity")]
     pub capacity: usize,
 
-    /// In-memory cache capacity. (MiB)
+    /// In-memory cache capacity. (items)
     #[arg(long, default_value_t = 1024)]
     #[serde(default = "default_mem")]
     pub mem: usize,
@@ -273,7 +271,7 @@ where
 
         let builder = HybridCacheBuilder::<K, V>::new()
             .with_tracing_options(tracing_options)
-            .memory(config.mem * MIB)
+            .memory(config.mem)
             .with_shards(config.shards);
 
         let builder = match config.eviction.as_str() {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - The cache code uses weighted capacity and specifies the capacity in MiB units. But we currently assume blocks are 1 MB.
	 - The underlying foyer cache is capacity and weight based. Fixing to MiB makes cache configuration indirect from the mechanics of the cache and results in it being cumbersome and potentially outright impossible to use. For example if I want to limit to 7000 items. I have to specify  a very small value as my capacity. This value may not be an integer but the configuration expects an integer capacity. Or alternatively, I can say that each item has some byte weight and choose a limit based on that. Rather than force these workarounds, it makes more sense for callers to think in whatever units they need and make the cache specification agnostic to that.  As is, if a cache does not want to think in MiB and instead wants to think in items, it cannot without complication.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None