### PR TITLE
[BUG] Cache should use weight

### DIFF
--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -402,6 +402,7 @@ where
     ) -> Result<FoyerPlainCache<K, V>, Box<dyn ChromaError>> {
         let cache = CacheBuilder::new(config.capacity)
             .with_shards(config.shards)
+            .with_weighter(|_: &_, v: &V| v.weight())
             .build();
         let meter = global::meter("chroma");
         let insert_latency = meter.u64_histogram("insert_latency").init();
@@ -447,6 +448,7 @@ where
 
         let cache = CacheBuilder::new(config.capacity)
             .with_shards(config.shards)
+            .with_weighter(|_: &_, v: &V| v.weight())
             .with_event_listener(Arc::new(evl))
             .build();
         let get_latency = global::meter("chroma").u64_histogram("get_latency").init();


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - https://github.com/chroma-core/chroma/pull/2697 Introduced a weighted cache. https://github.com/chroma-core/chroma/pull/2890/files#diff-2aee13d252376073188831aad803a50727d44fbf45f73e31106eab7e326de93dR348 Deleted it and smothered the setting, making "weighted_lru" not actually be weighted. (https://github.com/chroma-core/chroma/pull/2890/files#diff-6195692a271c580d5af2ce130f2b5a99b0e478a12271b1ba7bca2ed9572f7f3cR54) .
	- This PR enables weighting by default. As we can set the weight to 1 for types we don't want weighting for. We don't have any types that we want the ability to support both for and we can add that trivially in the future if needed.
 - New functionality
	 - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
