### PR TITLE
[ENH] multiple api keys support

### DIFF
--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -50,10 +50,9 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 "The openai python package is not installed. Please install it with `pip install openai`"
             )
 
-        if api_key is not None:
-            openai.api_key = api_key
+        self._api_key = api_key or openai.api_key
         # If the api key is still not set, raise an error
-        elif openai.api_key is None:
+        if self._api_key is None:
             raise ValueError(
                 "Please provide an OpenAI API key. You can get one at https://platform.openai.com/account/api-keys"
             )


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
 Allow multiple openAI API keys #2979 
 Removed direct assignment to global openai.api_key to prevent unintended side effects.


## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

It seems that `cargo test` is failing due to a build issue. #2294 
Both `pytest` and `yarn test` succeed.


## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
