### PR TITLE
[CHORE]  Configure service name for metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,40 +862,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -909,25 +881,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -947,7 +902,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -1237,7 +1192,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-state-machine",
- "prost 0.12.3",
+ "prost 0.13.3",
  "prost-types",
  "rand",
  "roaring",
@@ -1294,7 +1249,7 @@ dependencies = [
 name = "chroma-error"
 version = "0.1.0"
 dependencies = [
- "tonic 0.10.2",
+ "tonic",
 ]
 
 [[package]]
@@ -1361,11 +1316,11 @@ name = "chroma-types"
 version = "0.1.0"
 dependencies = [
  "chroma-error",
- "prost 0.12.3",
+ "prost 0.13.3",
  "prost-types",
  "roaring",
  "thiserror",
- "tonic 0.10.2",
+ "tonic",
  "tonic-build",
  "uuid",
 ]
@@ -3719,7 +3674,7 @@ dependencies = [
  "prost 0.13.3",
  "thiserror",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -3731,7 +3686,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.13.3",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -4479,7 +4434,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -5160,12 +5115,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -5598,40 +5547,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.12.3",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.5",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.6",
@@ -6426,7 +6348,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-state-machine",
- "prost 0.12.3",
+ "prost 0.13.3",
  "prost-types",
  "rand",
  "rand_xorshift",
@@ -6444,7 +6366,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
- "tonic 0.10.2",
+ "tonic",
  "tracing",
  "tracing-bunyan-formatter",
  "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ parking_lot = { version = "0.12.1", features = ["serde"] }
 tracing = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-util = "0.7.10"
-tonic = "0.10"
-prost = "0.12"
+tonic = "0.12"
+prost = "0.13"
 prost-types = "0.12"
 num_cpus = "1.16.0"
 flatbuffers = "24.3.25"

--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
@@ -67,7 +69,7 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     // Prepare trace config.
     let trace_config = opentelemetry_sdk::trace::Config::default()
         .with_sampler(ChromaShouldSample)
-        .with_resource(resource);
+        .with_resource(resource.clone());
     // Prepare exporter.
     let exporter = opentelemetry_otlp::new_exporter()
         .tonic()
@@ -161,8 +163,16 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
 
         prev_hook(panic_info);
     }));
+    let mut metadata = tonic::metadata::MetadataMap::new();
+    metadata.insert(
+        "service.name",
+        // SAFETY(rescrv):  This will always be ascii in practice.  If it fails we will have a
+        // clear path to fixing it.
+        tonic::metadata::AsciiMetadataValue::from_str(service_name).unwrap(),
+    );
     let exporter = opentelemetry_otlp::new_exporter()
         .tonic()
+        .with_metadata(metadata)
         .with_endpoint(otel_endpoint);
     let provider = opentelemetry_otlp::new_pipeline()
         .metrics(opentelemetry_sdk::runtime::Tokio)


### PR DESCRIPTION
This bumps the version of tonic and prost, eliminating two copies of
tonic.  It then configures a service name for metrics emitted from Rust.
