### PR TITLE
[BUG] Remove protobuf from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   'importlib-resources',
   'graphlib_backport >= 1.0.3; python_version < "3.9"',
   'grpcio >= 1.58.0',
-  'protobuf >= 5.26.1, < 6.0dev',
   'bcrypt >= 4.0.1',
   'typer >= 0.9.0',
   'kubernetes>=28.1.0',


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- Attempt to fix protobuf versioning incompatibility by removing the requirement from pyproject.toml

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
