### PR TITLE
[CHORE]  Set service.name correctly for metrics.

### DIFF
--- a/rust/worker/src/tracing/opentelemetry_config.rs
+++ b/rust/worker/src/tracing/opentelemetry_config.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;


### PR DESCRIPTION
Confirmed in tilt, not just by looking at code.

We see, e.g. the following metricsz:

    default_get_latency_bucket{job="compaction-service",le="250"} 529
