### PR TITLE
[BUG]: fix NAC hang when pulling empty file

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -88,6 +88,12 @@ impl AdmissionControlledS3Storage {
                 return Err(AdmissionControlledS3StorageError::S3GetError(e));
             }
         };
+
+        // .buffer_unordered() below will hang if the range is empty (https://github.com/rust-lang/futures-rs/issues/2740), so we short-circuit here
+        if content_length == 0 {
+            return Ok(Arc::new(Vec::new()));
+        }
+
         let part_size = storage.download_part_size_bytes;
         tracing::info!(
             "[AdmissionControlledS3][Parallel fetch] Content length: {}, key ranges: {:?}",
@@ -433,5 +439,10 @@ mod tests {
         test_multipart_get_for_size(1024 * 1024 * 10).await;
         // Greater than NAC limit i.e. > 2*8 MB = 16 MB.
         test_multipart_get_for_size(1024 * 1024 * 18).await;
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_empty_file() {
+        test_multipart_get_for_size(0).await;
     }
 }


### PR DESCRIPTION
## Description of changes

Currently the NAC hangs when attempting to pull an empty file because of a bug in the futures crate. This adds a small check to work around the bug.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
