### PR TITLE
[BUG]: fix S3 hang when pulling empty file

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -253,6 +253,12 @@ impl S3Storage {
 
     pub(super) async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, S3GetError> {
         let (content_length, ranges) = self.get_key_ranges(key).await?;
+
+        // .buffer_unordered() below will hang if the range is empty (https://github.com/rust-lang/futures-rs/issues/2740), so we short-circuit here
+        if content_length == 0 {
+            return Ok(Arc::new(Vec::new()));
+        }
+
         let part_size = self.download_part_size_bytes;
         let mut output_buffer: Vec<u8> = vec![0; content_length as usize];
         let mut output_slices = output_buffer.chunks_mut(part_size).collect::<Vec<_>>();
@@ -564,7 +570,7 @@ impl Configurable<StorageConfig> for S3Storage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{Rng, SeedableRng};
+    use rand::{distributions::Alphanumeric, Rng, SeedableRng};
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -652,6 +658,49 @@ mod tests {
         assert_eq!(buf, file_contents.into());
     }
 
+    async fn test_multipart_get_for_size(value_size: usize) {
+        let client = get_s3_client();
+
+        let storage = S3Storage {
+            bucket: format!("test-{}", rand::thread_rng().gen::<u64>()),
+            client,
+            upload_part_size_bytes: 1024 * 1024 * 8,
+            download_part_size_bytes: 1024 * 1024 * 8,
+        };
+        storage.create_bucket().await.unwrap();
+
+        // Randomly generate a 16 byte utf8 string.
+        let test_data_key: String = rand::thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(16)
+            .map(char::from)
+            .collect();
+        // Randomly generate data of size equaling value_size.
+        let test_data_value_string: String = rand::thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(value_size)
+            .map(char::from)
+            .collect();
+        storage
+            .put_bytes(
+                test_data_key.as_str(),
+                test_data_value_string.as_bytes().to_vec(),
+            )
+            .await
+            .unwrap();
+        println!(
+            "Wrote key {} with value of size {}",
+            test_data_key,
+            test_data_value_string.len()
+        );
+
+        // Parallel fetch.
+        let buf = storage.get_parallel(&test_data_key).await.unwrap();
+
+        let buf = String::from_utf8(Arc::unwrap_or_clone(buf)).unwrap();
+        assert_eq!(buf, test_data_value_string);
+    }
+
     #[tokio::test]
     // Naming this "test_k8s_integration_" means that the Tilt stack is required. See rust/worker/README.md.
     async fn test_k8s_integration_put_file_scenarios() {
@@ -679,5 +728,23 @@ mod tests {
             test_download_part_size_bytes,
         )
         .await;
+    }
+
+    #[tokio::test]
+    // Naming this "test_k8s_integration_" means that the Tilt stack is required. See rust/worker/README.md.
+    async fn test_k8s_integration_multipart_get() {
+        // At 8 MB.
+        test_multipart_get_for_size(1024 * 1024 * 8).await;
+        // At < 8 MB.
+        test_multipart_get_for_size(1024 * 1024 * 7).await;
+        // At > 8 MB.
+        test_multipart_get_for_size(1024 * 1024 * 10).await;
+        // Greater than NAC limit i.e. > 2*8 MB = 16 MB.
+        test_multipart_get_for_size(1024 * 1024 * 18).await;
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_empty_file() {
+        test_multipart_get_for_size(0).await;
     }
 }


### PR DESCRIPTION
## Description of changes

Follow-up from https://github.com/chroma-core/chroma/pull/3143: I forgot that the same logic existed in the S3Storage struct.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
