### PR TITLE
[BUG] Share the same HNSW reader for KNNOrchestrator

### DIFF
--- a/rust/worker/src/execution/operators/knn_hnsw.rs
+++ b/rust/worker/src/execution/operators/knn_hnsw.rs
@@ -1,24 +1,18 @@
 use chroma_distance::{normalize, DistanceFunction};
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_index::hnsw_provider::HnswIndexProvider;
-use chroma_types::{Segment, SignedRoaringBitmap};
+use chroma_types::SignedRoaringBitmap;
 use thiserror::Error;
 use tonic::async_trait;
 
 use crate::{
-    execution::operator::Operator,
-    segment::distributed_hnsw_segment::{
-        DistributedHNSWSegmentFromSegmentError, DistributedHNSWSegmentReader,
-    },
+    execution::operator::Operator, segment::distributed_hnsw_segment::DistributedHNSWSegmentReader,
 };
 
 use super::knn::{KnnOperator, RecordDistance};
 
 #[derive(Debug)]
 pub struct KnnHnswInput {
-    pub hnsw_provider: HnswIndexProvider,
-    pub hnsw_segment: Segment,
-    pub collection_dimension: u32,
+    pub(crate) hnsw_reader: Box<DistributedHNSWSegmentReader>,
     pub compact_offset_ids: SignedRoaringBitmap,
     pub distance_function: DistanceFunction,
 }
@@ -32,14 +26,11 @@ pub struct KnnHnswOutput {
 pub enum KnnHnswError {
     #[error("Error querying hnsw index: {0}")]
     HnswIndex(#[from] Box<dyn ChromaError>),
-    #[error("Error creating hnsw segment reader: {0}")]
-    HnswReader(#[from] DistributedHNSWSegmentFromSegmentError),
 }
 
 impl ChromaError for KnnHnswError {
     fn code(&self) -> ErrorCodes {
         match self {
-            KnnHnswError::HnswReader(e) => e.code(),
             KnnHnswError::HnswIndex(e) => e.code(),
         }
     }
@@ -74,31 +65,17 @@ impl Operator<KnnHnswInput, KnnHnswOutput> for KnnOperator {
             &self.embedding
         };
 
-        match DistributedHNSWSegmentReader::from_segment(
-            &input.hnsw_segment,
-            input.collection_dimension as usize,
-            input.hnsw_provider.clone(),
-        )
-        .await
-        {
-            Ok(reader) => {
-                let (offset_ids, distances) =
-                    reader.query(embedding, self.fetch as usize, &allowed, &disallowed)?;
-                Ok(KnnHnswOutput {
-                    record_distances: offset_ids
-                        .into_iter()
-                        .map(|offset_id| offset_id as u32)
-                        .zip(distances)
-                        .map(|(offset_id, measure)| RecordDistance { offset_id, measure })
-                        .collect(),
-                })
-            }
-            Err(e) if matches!(*e, DistributedHNSWSegmentFromSegmentError::Uninitialized) => {
-                Ok(KnnHnswOutput {
-                    record_distances: Vec::new(),
-                })
-            }
-            Err(e) => Err((*e).into()),
-        }
+        let (offset_ids, distances) =
+            input
+                .hnsw_reader
+                .query(embedding, self.fetch as usize, &allowed, &disallowed)?;
+        Ok(KnnHnswOutput {
+            record_distances: offset_ids
+                .into_iter()
+                .map(|offset_id| offset_id as u32)
+                .zip(distances)
+                .map(|(offset_id, measure)| RecordDistance { offset_id, measure })
+                .collect(),
+        })
     }
 }

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -2,11 +2,11 @@ mod common;
 mod compact;
 mod count;
 mod get_vectors;
-pub(crate) mod hnsw;
+#[allow(dead_code)]
+mod hnsw;
 pub(crate) use compact::*;
 pub(crate) use count::*;
 pub(crate) use get_vectors::*;
 
 pub mod get;
-#[allow(dead_code)]
 pub mod knn;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
	 - Previously a single `<collection>.query(...)` will spawn multiple `KnnOrchestrator` concurrently, leading to multiple instances of HNSW readers. Each HNSW reader will load the index data to the same locations in the file system, resulting in a high probability of concurrent read and write on the same index files. This PR moves the logic to create HNSW reader into `KnnFilterOrchestrator`, so all `KnnOrchestrator` will share the same HNSW reader.
 - New functionality
	 - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
