### PR TITLE
[BUG] Conditionally hnsw write during compaction

### DIFF
--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -41,7 +41,7 @@ pub struct RegisterInput {
     collection_id: CollectionUuid,
     log_position: i64,
     collection_version: i32,
-    segment_flush_info: Arc<[SegmentFlushInfo]>,
+    segment_flush_info: Arc<Vec<SegmentFlushInfo>>,
     sysdb: Box<SysDb>,
     log: Box<Log>,
 }
@@ -53,7 +53,7 @@ impl RegisterInput {
         collection_id: CollectionUuid,
         log_position: i64,
         collection_version: i32,
-        segment_flush_info: Arc<[SegmentFlushInfo]>,
+        segment_flush_info: Arc<Vec<SegmentFlushInfo>>,
         sysdb: Box<SysDb>,
         log: Box<Log>,
     ) -> Self {

--- a/rust/worker/src/sysdb/sysdb.rs
+++ b/rust/worker/src/sysdb/sysdb.rs
@@ -75,7 +75,7 @@ impl SysDb {
         collection_id: CollectionUuid,
         log_position: i64,
         collection_version: i32,
-        segment_flush_info: Arc<[SegmentFlushInfo]>,
+        segment_flush_info: Arc<Vec<SegmentFlushInfo>>,
     ) -> Result<FlushCompactionResponse, FlushCompactionError> {
         match self {
             SysDb::Grpc(grpc) => {
@@ -272,7 +272,7 @@ impl GrpcSysDb {
         collection_id: CollectionUuid,
         log_position: i64,
         collection_version: i32,
-        segment_flush_info: Arc<[SegmentFlushInfo]>,
+        segment_flush_info: Arc<Vec<SegmentFlushInfo>>,
     ) -> Result<FlushCompactionResponse, FlushCompactionError> {
         let segment_compaction_info =
             segment_flush_info

--- a/rust/worker/src/sysdb/test_sysdb.rs
+++ b/rust/worker/src/sysdb/test_sysdb.rs
@@ -177,7 +177,7 @@ impl TestSysDb {
         collection_id: CollectionUuid,
         log_position: i64,
         collection_version: i32,
-        segment_flush_info: Arc<[SegmentFlushInfo]>,
+        segment_flush_info: Arc<Vec<SegmentFlushInfo>>,
     ) -> Result<FlushCompactionResponse, FlushCompactionError> {
         let mut inner = self.inner.lock();
         let collection = inner.collections.get(&collection_id);


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Previously, if we initialize an empty collection and a series of `<collection>.delete(...)`, the compaction service will attempt to initialize the hnsw writer, which panics because the dimensionality of the collection is missing
   - This PR conditionally initializes the hnsw writer only when the dimensionality is present. This serves a temporary workaround for this problem.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A