### PR TITLE
[BUG] Fix hnsw concurrent loads

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -22,6 +22,7 @@ use std::mem::transmute;
 use std::ops::RangeBounds;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
+use tracing::Span;
 use uuid::Uuid;
 
 #[derive(Clone)]

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -22,7 +22,6 @@ use std::mem::transmute;
 use std::ops::RangeBounds;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
-use tracing::Span;
 use uuid::Uuid;
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fixes a race on concurrent hnsw loads. The goal is to allow multiple different files to write at the same time. 
 - New functionality
   - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None