### PR TITLE
[CLN]: make materialization function rather than struct

### DIFF
--- a/rust/worker/src/execution/operators/brute_force_knn.rs
+++ b/rust/worker/src/execution/operators/brute_force_knn.rs
@@ -1,8 +1,7 @@
 use crate::execution::operator::Operator;
 use crate::execution::operators::normalize_vectors::normalize;
 use crate::segment::record_segment::RecordSegmentReader;
-use crate::segment::LogMaterializer;
-use crate::segment::LogMaterializerError;
+use crate::segment::{materialize_logs, LogMaterializerError};
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_distance::DistanceFunction;
@@ -134,9 +133,7 @@ impl Operator<BruteForceKnnOperatorInput, BruteForceKnnOperatorOutput> for Brute
                 }
             }
         };
-        let log_materializer = LogMaterializer::new(record_segment_reader, input.log.clone(), None);
-        let logs = match log_materializer
-            .materialize()
+        let logs = match materialize_logs(&record_segment_reader, &input.log, None)
             .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
             .await
         {

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -199,9 +199,9 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
 
 #[cfg(test)]
 mod tests {
+    use crate::segment::materialize_logs;
     use crate::segment::record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError};
     use crate::segment::types::SegmentFlusher;
-    use crate::segment::LogMaterializer;
     use crate::{
         execution::{
             operator::Operator,
@@ -293,9 +293,7 @@ mod tests {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
                 .await
                 .expect("Log materialization failed");

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -1,5 +1,5 @@
 use crate::segment::record_segment::RecordSegmentReaderCreationError;
-use crate::segment::{LogMaterializer, LogMaterializerError, MaterializedLogRecord};
+use crate::segment::{materialize_logs, LogMaterializerError, MaterializedLogRecord};
 use crate::{
     execution::operator::Operator,
     segment::{
@@ -147,13 +147,8 @@ impl Operator<HnswKnnOperatorInput, HnswKnnOperatorOutput> for HnswKnnOperator {
                 }
             },
         };
-        let log_materializer = LogMaterializer::new(
-            Some(record_segment_reader.clone()),
-            input.logs.clone(),
-            None,
-        );
-        let logs = match log_materializer
-            .materialize()
+        let some_reader = Some(record_segment_reader.clone());
+        let logs = match materialize_logs(&some_reader, &input.logs, None)
             .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
             .await
         {

--- a/rust/worker/src/execution/operators/knn_log.rs
+++ b/rust/worker/src/execution/operators/knn_log.rs
@@ -10,8 +10,9 @@ use tonic::async_trait;
 use crate::{
     execution::operator::Operator,
     segment::{
+        materialize_logs,
         record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
-        LogMaterializer, LogMaterializerError,
+        LogMaterializerError,
     },
 };
 
@@ -72,8 +73,7 @@ impl Operator<KnnLogInput, KnnLogOutput> for KnnOperator {
             Err(e) => Err(*e),
         }?;
 
-        let materializer = LogMaterializer::new(record_segment_reader, input.logs.clone(), None);
-        let logs = materializer.materialize().await?;
+        let logs = materialize_logs(&record_segment_reader, &input.logs, None).await?;
 
         let target_vector;
         let target_embedding = if let DistanceFunction::Cosine = input.distance_function {

--- a/rust/worker/src/execution/operators/limit.rs
+++ b/rust/worker/src/execution/operators/limit.rs
@@ -11,8 +11,9 @@ use tracing::{trace, Instrument, Span};
 use crate::{
     execution::operator::Operator,
     segment::{
+        materialize_logs,
         record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
-        LogMaterializer, LogMaterializerError,
+        LogMaterializerError,
     },
 };
 
@@ -213,10 +214,7 @@ impl Operator<LimitInput, LimitOutput> for LimitOperator {
         let mut materialized_log_offset_ids = match &input.log_offset_ids {
             SignedRoaringBitmap::Include(rbm) => rbm.clone(),
             SignedRoaringBitmap::Exclude(rbm) => {
-                let materializer =
-                    LogMaterializer::new(record_segment_reader.clone(), input.logs.clone(), None);
-                let materialized_logs = materializer
-                    .materialize()
+                let materialized_logs = materialize_logs(&record_segment_reader, &input.logs, None)
                     .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
                     .await?;
 

--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -10,8 +10,9 @@ use tracing::{error, trace, Instrument, Span};
 use crate::{
     execution::operator::Operator,
     segment::{
+        materialize_logs,
         record_segment::{RecordSegmentReader, RecordSegmentReaderCreationError},
-        LogMaterializer, LogMaterializerError,
+        LogMaterializerError,
     },
 };
 
@@ -104,10 +105,8 @@ impl Operator<ProjectionInput, ProjectionOutput> for ProjectionOperator {
             }
             Err(e) => Err(*e),
         }?;
-        let materializer =
-            LogMaterializer::new(record_segment_reader.clone(), input.logs.clone(), None);
-        let materialized_logs = materializer
-            .materialize()
+
+        let materialized_logs = materialize_logs(&record_segment_reader, &input.logs, None)
             .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
             .await?;
 

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -1075,11 +1075,12 @@ mod test {
     #![allow(deprecated)]
 
     use crate::segment::{
+        materialize_logs,
         metadata_segment::{MetadataSegmentReader, MetadataSegmentWriter},
         record_segment::{
             RecordSegmentReader, RecordSegmentReaderCreationError, RecordSegmentWriter,
         },
-        LogMaterializer, SegmentFlusher, SegmentWriter,
+        SegmentFlusher, SegmentWriter,
     };
     use chroma_blockstore::{
         arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
@@ -1193,9 +1194,7 @@ mod test {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -1265,9 +1264,8 @@ mod test {
             MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
                 .await
                 .expect("Error creating segment writer");
-        let materializer = LogMaterializer::new(Some(record_segment_reader), data, None);
-        let mat_records = materializer
-            .materialize()
+        let some_reader = Some(record_segment_reader);
+        let mat_records = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Log materialization failed");
         metadata_writer
@@ -1347,9 +1345,8 @@ mod test {
             MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
                 .await
                 .expect("Error creating segment writer");
-        let materializer = LogMaterializer::new(Some(record_segment_reader), data, None);
-        let mat_records = materializer
-            .materialize()
+        let some_reader = Some(record_segment_reader);
+        let mat_records = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Log materialization failed");
         metadata_writer
@@ -1487,9 +1484,7 @@ mod test {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -1566,9 +1561,8 @@ mod test {
             MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
                 .await
                 .expect("Error creating segment writer");
-        let materializer = LogMaterializer::new(Some(record_segment_reader), data, None);
-        let mat_records = materializer
-            .materialize()
+        let some_reader = Some(record_segment_reader);
+        let mat_records = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Log materialization failed");
         metadata_writer
@@ -1740,9 +1734,7 @@ mod test {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -1801,9 +1793,8 @@ mod test {
             MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
                 .await
                 .expect("Error creating segment writer");
-        let materializer = LogMaterializer::new(Some(record_segment_reader), data, None);
-        let mat_records = materializer
-            .materialize()
+        let some_reader = Some(record_segment_reader);
+        let mat_records = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Log materialization failed");
         metadata_writer
@@ -1962,9 +1953,7 @@ mod test {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -2021,9 +2010,8 @@ mod test {
             MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
                 .await
                 .expect("Error creating segment writer");
-        let materializer = LogMaterializer::new(Some(record_segment_reader), data, None);
-        let mat_records = materializer
-            .materialize()
+        let some_reader = Some(record_segment_reader);
+        let mat_records = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Log materialization failed");
         metadata_writer

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -955,7 +955,7 @@ mod tests {
     use crate::{
         log::test::{upsert_generator, LogGenerator},
         segment::{
-            record_segment::MAX_OFFSET_ID, test::TestSegment, LogMaterializer, SegmentWriter,
+            materialize_logs, record_segment::MAX_OFFSET_ID, test::TestSegment, SegmentWriter,
         },
     };
 
@@ -999,10 +999,12 @@ mod tests {
                         .stack_size(stack_size)
                         .spawn(move || {
                             let log_chunk = Chunk::new(batch.into());
-                            let materializer =
-                                LogMaterializer::new(None, log_chunk, Some(curr_offset_id));
-                            let materialized_logs = future::block_on(materializer.materialize())
-                                .expect("Should be able to materialize log");
+                            let materialized_logs = future::block_on(materialize_logs(
+                                &None,
+                                &log_chunk,
+                                Some(curr_offset_id),
+                            ))
+                            .expect("Should be able to materialize log");
                             future::block_on(
                                 record_writer.apply_materialized_log_chunk(materialized_logs),
                             )

--- a/rust/worker/src/segment/test.rs
+++ b/rust/worker/src/segment/test.rs
@@ -9,7 +9,7 @@ use chroma_types::{
 use crate::log::test::{LogGenerator, TEST_EMBEDDING_DIMENSION};
 
 use super::{
-    metadata_segment::MetadataSegmentWriter, record_segment::RecordSegmentWriter, LogMaterializer,
+    materialize_logs, metadata_segment::MetadataSegmentWriter, record_segment::RecordSegmentWriter,
     SegmentFlusher, SegmentWriter,
 };
 
@@ -24,12 +24,13 @@ pub struct TestSegment {
 impl TestSegment {
     // WARN: The size of the log chunk should not be too large
     async fn compact_log(&mut self, logs: Chunk<LogRecord>, next_offset: usize) {
-        let materializer =
-            LogMaterializer::new(None, logs, Some(AtomicU32::new(next_offset as u32).into()));
-        let materialized_logs = materializer
-            .materialize()
-            .await
-            .expect("Should be able to materialize log.");
+        let materialized_logs = materialize_logs(
+            &None,
+            &logs,
+            Some(AtomicU32::new(next_offset as u32).into()),
+        )
+        .await
+        .expect("Should be able to materialize log.");
 
         let mut metadata_writer =
             MetadataSegmentWriter::from_segment(&self.metadata_segment, &self.blockfile_provider)

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -409,8 +409,13 @@ impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_d
 }
 
 pub async fn materialize_logs<'me>(
+    // Is None when record segment is uninitialized.
     record_segment_reader: &'me Option<RecordSegmentReader<'me>>,
     logs: &'me Chunk<LogRecord>,
+    // Is None for readers. In that case, the materializer reads
+    // the current maximum from the record segment and uses that
+    // for materializing. Writers pass this value to the materializer
+    // because they need to share this across all log partitions.
     next_offset_id: Option<Arc<AtomicU32>>,
 ) -> Result<Chunk<MaterializedLogRecord<'me>>, LogMaterializerError> {
     // Trace the total_len since len() iterates over the entire chunk

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -408,109 +408,82 @@ impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_d
     }
 }
 
-pub struct LogMaterializer<'me> {
-    // Is None when record segment is uninitialized.
-    pub(crate) record_segment_reader: Option<RecordSegmentReader<'me>>,
-    pub(crate) logs: Chunk<LogRecord>,
-    // Is None for readers. In that case, the materializer reads
-    // the current maximum from the record segment and uses that
-    // for materializing. Writers pass this value to the materializer
-    // because they need to share this across all log partitions.
-    pub(crate) next_offset_id: Option<Arc<AtomicU32>>,
-}
-
-impl<'me> LogMaterializer<'me> {
-    pub fn new(
-        record_segment_reader: Option<RecordSegmentReader<'me>>,
-        logs: Chunk<LogRecord>,
-        next_offset_id: Option<Arc<AtomicU32>>,
-    ) -> Self {
-        Self {
-            record_segment_reader,
-            logs,
-            next_offset_id,
-        }
-    }
-    pub async fn materialize(
-        &'me self,
-    ) -> Result<Chunk<MaterializedLogRecord<'me>>, LogMaterializerError> {
-        // Trace the total_len since len() iterates over the entire chunk
-        // and we don't want to do that just to trace the length.
-        tracing::info!(
-            "Total length of logs in materializer: {}",
-            self.logs.total_len()
-        );
-        let next_offset_id;
-        match self.next_offset_id.as_ref() {
-            Some(next_oid) => {
-                next_offset_id = next_oid.clone();
+pub async fn materialize_logs<'me>(
+    record_segment_reader: &'me Option<RecordSegmentReader<'me>>,
+    logs: &'me Chunk<LogRecord>,
+    next_offset_id: Option<Arc<AtomicU32>>,
+) -> Result<Chunk<MaterializedLogRecord<'me>>, LogMaterializerError> {
+    // Trace the total_len since len() iterates over the entire chunk
+    // and we don't want to do that just to trace the length.
+    tracing::info!("Total length of logs in materializer: {}", logs.total_len());
+    // The offset ID that should be used for the next record
+    let next_offset_id = match next_offset_id.as_ref() {
+        Some(next_offset_id) => next_offset_id.clone(),
+        None => {
+            match record_segment_reader.as_ref() {
+                Some(reader) => {
+                    let offset_id = reader.get_current_max_offset_id();
+                    offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    offset_id
+                }
+                // This means that the segment is uninitialized so counting starts from 1.
+                None => Arc::new(AtomicU32::new(1)),
             }
-            None => {
-                match self.record_segment_reader.as_ref() {
-                    Some(reader) => {
-                        next_offset_id = reader.get_current_max_offset_id();
-                        next_offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    }
-                    // This means that the segment is uninitialized so counting starts
-                    // from 1.
-                    None => {
-                        next_offset_id = Arc::new(AtomicU32::new(1));
+        }
+    };
+
+    // Populate entries that are present in the record segment.
+    let mut existing_id_to_materialized: HashMap<&str, MaterializedLogRecord> = HashMap::new();
+    let mut new_id_to_materialized: HashMap<&str, MaterializedLogRecord> = HashMap::new();
+    if let Some(reader) = &record_segment_reader {
+        async {
+            for (log_record, _) in logs.iter() {
+                let exists = match reader
+                    .data_exists_for_user_id(log_record.record.id.as_str())
+                    .await
+                {
+                    Ok(res) => res,
+                    Err(e) => {
+                        return Err(LogMaterializerError::RecordSegment(e));
                     }
                 };
-            }
-        }
-        // Populate entries that are present in the record segment.
-        let mut existing_id_to_materialized: HashMap<&str, MaterializedLogRecord> = HashMap::new();
-        let mut new_id_to_materialized: HashMap<&str, MaterializedLogRecord> = HashMap::new();
-        if let Some(reader) = &self.record_segment_reader {
-            async {
-                for (log_record, _) in self.logs.iter() {
-                    let exists = match reader
-                        .data_exists_for_user_id(log_record.record.id.as_str())
+                if exists {
+                    match reader
+                        .get_data_and_offset_id_for_user_id(log_record.record.id.as_str())
                         .await
                     {
-                        Ok(res) => res,
+                        Ok(Some((data_record, offset_id))) => {
+                            existing_id_to_materialized.insert(
+                                log_record.record.id.as_str(),
+                                MaterializedLogRecord::from((data_record, offset_id)),
+                            );
+                        }
+                        Ok(None) => {
+                            return Err(LogMaterializerError::RecordSegment(Box::new(
+                                RecordSegmentReaderCreationError::UserRecordNotFound(format!(
+                                    "not found: {}",
+                                    log_record.record.id,
+                                )),
+                            )
+                                as _));
+                        }
                         Err(e) => {
                             return Err(LogMaterializerError::RecordSegment(e));
                         }
-                    };
-                    if exists {
-                        match reader
-                            .get_data_and_offset_id_for_user_id(log_record.record.id.as_str())
-                            .await
-                        {
-                            Ok(Some((data_record, offset_id))) => {
-                                existing_id_to_materialized.insert(
-                                    log_record.record.id.as_str(),
-                                    MaterializedLogRecord::from((data_record, offset_id)),
-                                );
-                            }
-                            Ok(None) => {
-                                return Err(LogMaterializerError::RecordSegment(Box::new(
-                                    RecordSegmentReaderCreationError::UserRecordNotFound(format!(
-                                        "not found: {}",
-                                        log_record.record.id,
-                                    )),
-                                )
-                                    as _));
-                            }
-                            Err(e) => {
-                                return Err(LogMaterializerError::RecordSegment(e));
-                            }
-                        }
                     }
                 }
-                Ok(())
             }
-            .instrument(
-                tracing::info_span!(parent: Span::current(), "Materialization read from storage"),
-            )
-            .await?;
+            Ok(())
         }
-        // Populate updates to these and fresh records that are being
-        // inserted for the first time.
-        async {
-            for (log_record, _) in self.logs.iter() {
+        .instrument(
+            tracing::info_span!(parent: Span::current(), "Materialization read from storage"),
+        )
+        .await?;
+    }
+    // Populate updates to these and fresh records that are being
+    // inserted for the first time.
+    async {
+            for (log_record, _) in logs.iter() {
                 match log_record.record.operation {
                     Operation::Add => {
                         // If this is an add of a record present in the segment then add
@@ -768,20 +741,19 @@ impl<'me> LogMaterializer<'me> {
             }
             Ok(())
         }.instrument(tracing::info_span!(parent: Span::current(), "Materialization main iteration")).await?;
-        let mut res = vec![];
-        for (_key, value) in existing_id_to_materialized {
-            // Ignore records that only had invalid ADDS on the log.
-            if value.final_operation == MaterializedLogOperation::Initial {
-                continue;
-            }
-            res.push(value);
+    let mut res = vec![];
+    for (_key, value) in existing_id_to_materialized {
+        // Ignore records that only had invalid ADDS on the log.
+        if value.final_operation == MaterializedLogOperation::Initial {
+            continue;
         }
-        for (_key, value) in new_id_to_materialized {
-            res.push(value);
-        }
-        res.sort_by(|x, y| x.offset_id.cmp(&y.offset_id));
-        Ok(Chunk::new(res.into()))
+        res.push(value);
     }
+    for (_key, value) in new_id_to_materialized {
+        res.push(value);
+    }
+    res.sort_by(|x, y| x.offset_id.cmp(&y.offset_id));
+    Ok(Chunk::new(res.into()))
 }
 
 // This needs to be public for testing
@@ -907,9 +879,7 @@ mod tests {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -971,13 +941,8 @@ mod tests {
         let reader = RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
             .await
             .expect("Error creating segment reader");
-        let materializer = LogMaterializer {
-            record_segment_reader: Some(reader),
-            logs: data,
-            next_offset_id: None,
-        };
-        let res = materializer
-            .materialize()
+        let some_reader = Some(reader);
+        let res = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Error materializing logs");
         let mut res_vec = vec![];
@@ -1206,9 +1171,7 @@ mod tests {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -1257,13 +1220,8 @@ mod tests {
         let reader = RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
             .await
             .expect("Error creating segment reader");
-        let materializer = LogMaterializer {
-            record_segment_reader: Some(reader),
-            logs: data,
-            next_offset_id: None,
-        };
-        let res = materializer
-            .materialize()
+        let some_reader = Some(reader);
+        let res = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Error materializing logs");
         let mut res_vec = vec![];
@@ -1497,9 +1455,7 @@ mod tests {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             metadata_writer
@@ -1572,13 +1528,8 @@ mod tests {
         let reader = RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
             .await
             .expect("Error creating segment reader");
-        let materializer = LogMaterializer {
-            record_segment_reader: Some(reader),
-            logs: data,
-            next_offset_id: None,
-        };
-        let res = materializer
-            .materialize()
+        let some_reader = Some(reader);
+        let res = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Error materializing logs");
         let mut res_vec = vec![];
@@ -1807,9 +1758,7 @@ mod tests {
                         }
                     }
                 };
-            let materializer = LogMaterializer::new(record_segment_reader, data, None);
-            let mat_records = materializer
-                .materialize()
+            let mat_records = materialize_logs(&record_segment_reader, &data, None)
                 .await
                 .expect("Log materialization failed");
             segment_writer
@@ -1870,13 +1819,8 @@ mod tests {
         let reader = RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
             .await
             .expect("Error creating segment reader");
-        let materializer = LogMaterializer {
-            record_segment_reader: Some(reader),
-            logs: data,
-            next_offset_id: None,
-        };
-        let res = materializer
-            .materialize()
+        let some_reader = Some(reader);
+        let res = materialize_logs(&some_reader, &data, None)
             .await
             .expect("Error materializing logs");
         assert_eq!(3, res.len());


### PR DESCRIPTION
## Description of changes

Simplifies usage of log materialization logic & lifetimes in preparation for next PR in this stack. There are no actual logic changes.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a