### PR TITLE
[BUG] Update quota exception handler to 400

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -366,7 +366,7 @@ class FastAPI(Server):
         self, request: Request, exc: QuotaError
     ) -> JSONResponse:
         return JSONResponse(
-            status_code=429,
+            status_code=400,
             content={"message": exc.message()},
         )
 


### PR DESCRIPTION
## Description of changes
Improvements & Bug fixes
- Update quota exception handler to return a `400` instead of a `429`

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
