### PR TITLE
[TST] Fix client compatibility test

### DIFF
--- a/chromadb/test/client/test_http_client_v1_compatability.py
+++ b/chromadb/test/client/test_http_client_v1_compatability.py
@@ -8,7 +8,7 @@ from chromadb.test.conftest import _fastapi_fixture
 from chromadb.api import ServerAPI
 from chromadb.test.utils.cross_version import switch_to_version, install_version
 
-VERSIONED_MODULES = ["pydantic", "numpy"]
+VERSIONED_MODULES = ["numpy"]
 
 
 def try_old_client(old_version: str, port: int, conn: Connection) -> None:


### PR DESCRIPTION
## Description of changes
 Improvements & Bug fixes
- Fixes failing `chromadb/test/client/test_http_client_v1_compatability.py` test. The `pydantic` version was incompatible with `Collection` in `chromadb==0.5.11`.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
