### PR TITLE
[ENH]: better span names in Jaeger

### DIFF
--- a/rust/worker/src/execution/dispatcher.rs
+++ b/rust/worker/src/execution/dispatcher.rs
@@ -96,7 +96,7 @@ impl Dispatcher {
     async fn enqueue_task(&mut self, task: TaskMessage) {
         match task.get_type() {
             OperatorType::IO => {
-                let child_span = trace_span!(parent: Span::current(), "IO task execution", name = task.get_name());
+                let child_span = trace_span!(parent: Span::current(), "IO task execution", otel.name = format!("IO task execution: {}", task.get_name()), name = task.get_name());
                 tokio::spawn(async move {
                     task.run().instrument(child_span).await;
                 });

--- a/rust/worker/src/execution/worker_thread.rs
+++ b/rust/worker/src/execution/worker_thread.rs
@@ -57,8 +57,7 @@ impl Handler<TaskMessage> for WorkerThread {
     type Result = ();
 
     async fn handle(&mut self, task: TaskMessage, ctx: &ComponentContext<WorkerThread>) {
-        let child_span =
-            trace_span!(parent: Span::current(), "Task execution", name = task.get_name());
+        let child_span = trace_span!(parent: Span::current(), "Task execution", otel.name = format!("Task execution: {}", task.get_name()), name = task.get_name());
         task.run().instrument(child_span).await;
         let req: TaskRequestMessage = TaskRequestMessage::new(ctx.receiver());
         let _res = self.dispatcher.send(req, None).await;

--- a/rust/worker/src/system/executor.rs
+++ b/rust/worker/src/system/executor.rs
@@ -76,7 +76,7 @@ where
                                     Span::current().clone()
                                 }
                             };
-                            let child_span = trace_span!(parent: parent_span, "Component received message", "name" =  C::get_name());
+                            let child_span = trace_span!(parent: parent_span, "Component received message", otel.name = format!("{} received message", C::get_name()), "name" =  C::get_name());
                             let component_context = ComponentContext {
                                     system: self.inner.system.clone(),
                                     sender: self.inner.sender.clone(),

--- a/rust/worker/src/system/system.rs
+++ b/rust/worker/src/system/system.rs
@@ -49,8 +49,7 @@ impl System {
 
         match C::runtime() {
             ComponentRuntime::Inherit => {
-                let child_span =
-                    trace_span!(parent: Span::current(), "component spawn", "name" = C::get_name());
+                let child_span = trace_span!(parent: Span::current(), "Spawning component", otel.name = format!("Spawning component {}", C::get_name()), "name" = C::get_name());
                 let task_future = async move { executor.run(rx).await };
                 let join_handle = tokio::spawn(task_future.instrument(child_span));
                 ComponentHandle::new(


### PR DESCRIPTION
## Description of changes

When using `trace_span!(X, name = Y)`, Honeycomb uses the name attribute (`Y`) in the trace view. Jaeger uses `X` in its trace view, which is much harder to debug as it doesn't include the name of the task/component.

This adds a `otel.name` attribute to applicable macro usages, which Jaeger picks up and renders:

<img width="2169" alt="Screenshot 2024-11-20 at 5 26 40 PM" src="https://github.com/user-attachments/assets/bf556197-9b96-4aa7-b3d2-0364f66f957e">

I'm not sure if Honeycomb will prefer `name` or `otel.name` (or if they have already collapsed to a single attribute by the time Honeycomb sees the trace).

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
