### PR TITLE
[BUG] Return early with empty query embeddings

### DIFF
--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -260,6 +260,10 @@ impl WorkerServer {
             .knn
             .ok_or(Status::invalid_argument("Invalid Scan Operator"))?;
 
+        if knn.embeddings.is_empty() {
+            return Ok(Response::new(to_proto_knn_batch_result(Vec::new())?));
+        }
+
         let knn_filter_orchestrator = KnnFilterOrchestrator::new(
             self.blockfile_provider.clone(),
             dispatcher.clone(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - #3145 suggests `<stream>.buffered` will hang infinitely if the stream is empty. Thus we should bail early if we receive no query embedding
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A