### PR TITLE
[ENH]: upgrade otel stack to 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,9 +3647,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3661,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -3675,13 +3675,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3691,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -3708,6 +3709,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -5716,9 +5718,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 clap = { version = "4", features = ["derive"] }
 foyer = "0.12"
 anyhow = "1.0"
-opentelemetry = { version = "0.26.0", default-features = false, features = [
+opentelemetry = { version = "0.27.0", default-features = false, features = [
   "trace",
   "metrics",
 ] }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -332,12 +332,12 @@ where
             TracingOptions::new().with_record_hybrid_get_threshold(Duration::from_millis(10)),
         );
         let meter = global::meter("chroma");
-        let cache_hit = meter.u64_counter("cache_hit").init();
-        let cache_miss = meter.u64_counter("cache_miss").init();
-        let get_latency = meter.u64_histogram("get_latency").init();
-        let insert_latency = meter.u64_histogram("insert_latency").init();
-        let remove_latency = meter.u64_histogram("remove_latency").init();
-        let clear_latency = meter.u64_histogram("clear_latency").init();
+        let cache_hit = meter.u64_counter("cache_hit").build();
+        let cache_miss = meter.u64_counter("cache_miss").build();
+        let get_latency = meter.u64_histogram("get_latency").build();
+        let insert_latency = meter.u64_histogram("insert_latency").build();
+        let remove_latency = meter.u64_histogram("remove_latency").build();
+        let clear_latency = meter.u64_histogram("clear_latency").build();
         Ok(FoyerHybridCache {
             cache,
             cache_hit,
@@ -423,12 +423,12 @@ where
             .with_weighter(|_: &_, v: &V| v.weight())
             .build();
         let meter = global::meter("chroma");
-        let cache_hit = meter.u64_counter("cache_hit").init();
-        let cache_miss = meter.u64_counter("cache_miss").init();
-        let get_latency = meter.u64_histogram("get_latency").init();
-        let insert_latency = meter.u64_histogram("insert_latency").init();
-        let remove_latency = meter.u64_histogram("remove_latency").init();
-        let clear_latency = meter.u64_histogram("clear_latency").init();
+        let cache_hit = meter.u64_counter("cache_hit").build();
+        let cache_miss = meter.u64_counter("cache_miss").build();
+        let get_latency = meter.u64_histogram("get_latency").build();
+        let insert_latency = meter.u64_histogram("insert_latency").build();
+        let remove_latency = meter.u64_histogram("remove_latency").build();
+        let clear_latency = meter.u64_histogram("clear_latency").build();
         Ok(FoyerPlainCache {
             cache,
             cache_hit,
@@ -474,12 +474,12 @@ where
             .with_event_listener(Arc::new(evl))
             .build();
         let meter = global::meter("chroma");
-        let cache_hit = meter.u64_counter("cache_hit").init();
-        let cache_miss = meter.u64_counter("cache_miss").init();
-        let get_latency = meter.u64_histogram("get_latency").init();
-        let insert_latency = meter.u64_histogram("insert_latency").init();
-        let remove_latency = meter.u64_histogram("remove_latency").init();
-        let clear_latency = meter.u64_histogram("clear_latency").init();
+        let cache_hit = meter.u64_counter("cache_hit").build();
+        let cache_miss = meter.u64_counter("cache_miss").build();
+        let get_latency = meter.u64_histogram("get_latency").build();
+        let insert_latency = meter.u64_histogram("insert_latency").build();
+        let remove_latency = meter.u64_histogram("remove_latency").build();
+        let clear_latency = meter.u64_histogram("clear_latency").build();
         Ok(FoyerPlainCache {
             cache,
             cache_hit,

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -18,14 +18,14 @@ schemars = "0.8.16"
 kube = { version = "0.87.1", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.20.0", features = ["latest"] }
 tracing-bunyan-formatter = "0.3"
-tracing-opentelemetry = "0.27.0"
+tracing-opentelemetry = "0.28.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-opentelemetry = { version = "0.26.0", default-features = false, features = [
+opentelemetry = { version = "0.27.0", default-features = false, features = [
   "trace",
   "metrics",
 ] }
-opentelemetry-otlp = "0.26"
-opentelemetry_sdk = { version = "0.26", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.27"
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 regex = "1.10.5"
 figment = { version = "0.10.12", features = ["env", "yaml", "test"] }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Upgrade otel stack from 0.26 to 0.27

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
