### PR TITLE
[BUG] Race condition when updating max offset id

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -225,7 +225,7 @@ impl ArrowUnorderedBlockfileWriter {
     }
 
     #[allow(dead_code)]
-    pub(crate) async fn get_owned<K: ArrowWriteableKey, V: ArrowWriteableValue>(
+    pub async fn get_owned<K: ArrowWriteableKey, V: ArrowWriteableValue>(
         &self,
         prefix: &str,
         key: K,

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -966,7 +966,7 @@ mod tests {
     fn test_max_offset_id_shuttle() {
         shuttle::check_random(
             || {
-                let log_partition_size = 1000;
+                let log_partition_size = 100;
                 let stack_size = 1 << 22;
                 let thread_count = 4;
                 let log_generator = LogGenerator {
@@ -1047,7 +1047,7 @@ mod tests {
                 // assert_eq!(max_offset_id, max_log_offset as u32);
                 assert_eq!(max_offset_id as usize, max_log_offset + thread_count);
             },
-            10,
+            60,
         );
     }
 }

--- a/rust/worker/src/segment/test.rs
+++ b/rust/worker/src/segment/test.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::AtomicU32;
 
 use chroma_blockstore::{provider::BlockfileProvider, test_arrow_blockfile_provider};
-use chroma_index::{hnsw_provider::HnswIndexProvider, test_hnsw_index_provider};
 use chroma_types::{
     test_segment, Chunk, Collection, CollectionUuid, LogRecord, OperationRecord, Segment,
     SegmentScope,
@@ -15,7 +14,6 @@ use super::{
 };
 
 pub struct TestSegment {
-    pub hnsw_provider: HnswIndexProvider,
     pub blockfile_provider: BlockfileProvider,
     pub collection: Collection,
     pub metadata_segment: Segment,
@@ -104,7 +102,6 @@ impl Default for TestSegment {
             version: 0,
         };
         Self {
-            hnsw_provider: test_hnsw_index_provider(),
             blockfile_provider: test_arrow_blockfile_provider(2 << 22),
             collection,
             metadata_segment: test_segment(collection_uuid, SegmentScope::METADATA),

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -417,6 +417,7 @@ mod tests {
     use crate::segment::test::TestSegment;
     use crate::sysdb::test_sysdb::TestSysDb;
     use crate::system;
+    use chroma_index::test_hnsw_index_provider;
     #[cfg(debug_assertions)]
     use chroma_proto::debug_client::DebugClient;
     use chroma_proto::query_executor_client::QueryExecutorClient;
@@ -433,7 +434,7 @@ mod tests {
             system: None,
             sysdb: Box::new(SysDb::Test(sysdb)),
             log: Box::new(Log::InMemory(log)),
-            hnsw_index_provider: segments.hnsw_provider,
+            hnsw_index_provider: test_hnsw_index_provider(),
             blockfile_provider: segments.blockfile_provider,
             port,
         };


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - The record segment writer has a race condition if multiple threads are concurrently applying materialized logs to it. Specifically, the maximum offset id will not be set properly. This PR introduce tests on the Rust side to replicate this bug and then aims to fix the bug.
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A