### PR TITLE
[ENH] Full garbage collection

### DIFF
--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -129,6 +129,34 @@ public:
         }
     }
 
+    void get_all_ids_sizes(size_t *ids_sizes)
+    {
+        if (!index_inited)
+        {
+            throw std::runtime_error("Index not inited");
+        }
+        auto res = appr_alg->getLabelCounts();
+        ids_sizes[0] = res.first;
+        ids_sizes[1] = res.second;
+    }
+
+    void get_all_ids(hnswlib::labeltype *non_deleted_ids, hnswlib::labeltype *deleted_ids)
+    {
+        if (!index_inited)
+        {
+            throw std::runtime_error("Index not inited");
+        }
+        auto res = appr_alg->getAllLabels();
+        for (int i = 0; i < res.first.size(); i++)
+        {
+            non_deleted_ids[i] = res.first[i];
+        }
+        for (int i = 0; i < res.second.size(); i++)
+        {
+            deleted_ids[i] = res.second[i];
+        }
+    }
+
     void mark_deleted(const hnswlib::labeltype id)
     {
         if (!index_inited)
@@ -298,6 +326,34 @@ extern "C"
         try
         {
             index->get_item(id, data);
+        }
+        catch (std::exception &e)
+        {
+            last_error = e.what();
+            return;
+        }
+        last_error.clear();
+    }
+
+    void get_all_ids_sizes(Index<float> *index, size_t *ids_sizes)
+    {
+        try
+        {
+            index->get_all_ids_sizes(ids_sizes);
+        }
+        catch (std::exception &e)
+        {
+            last_error = e.what();
+            return;
+        }
+        last_error.clear();
+    }
+
+    void get_all_ids(Index<float> *index, hnswlib::labeltype *non_deleted_ids, hnswlib::labeltype *deleted_ids)
+    {
+        try
+        {
+            index->get_all_ids(non_deleted_ids, deleted_ids);
         }
         catch (std::exception &e)
         {

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -233,7 +233,7 @@ impl Index<HnswIndexConfig> for HnswIndex {
 
     fn get_all_ids_sizes(&self) -> Result<Vec<usize>, Box<dyn ChromaError>> {
         let mut sizes = vec![0usize; 2];
-        unsafe { get_all_ids_size(self.ffi_ptr, sizes.as_mut_ptr()) };
+        unsafe { get_all_ids_sizes(self.ffi_ptr, sizes.as_mut_ptr()) };
         read_and_return_hnsw_error(self.ffi_ptr)?;
         Ok(sizes)
     }
@@ -381,7 +381,7 @@ extern "C" {
     fn add_item(index: *const IndexPtrFFI, data: *const f32, id: usize, replace_deleted: bool);
     fn mark_deleted(index: *const IndexPtrFFI, id: usize);
     fn get_item(index: *const IndexPtrFFI, id: usize, data: *mut f32);
-    fn get_all_ids_size(index: *const IndexPtrFFI, sizes: *mut usize);
+    fn get_all_ids_sizes(index: *const IndexPtrFFI, sizes: *mut usize);
     fn get_all_ids(index: *const IndexPtrFFI, non_deleted_ids: *mut usize, deleted_ids: *mut usize);
     fn knn_query(
         index: *const IndexPtrFFI,

--- a/rust/index/src/types.rs
+++ b/rust/index/src/types.rs
@@ -44,6 +44,8 @@ pub trait Index<C> {
         disallow_ids: &[usize],
     ) -> Result<(Vec<usize>, Vec<f32>), Box<dyn ChromaError>>;
     fn get(&self, id: usize) -> Result<Option<Vec<f32>>, Box<dyn ChromaError>>;
+    fn get_all_ids(&self) -> Result<(Vec<usize>, Vec<usize>), Box<dyn ChromaError>>;
+    fn get_all_ids_sizes(&self) -> Result<Vec<usize>, Box<dyn ChromaError>>;
 }
 
 /// The persistent index trait.


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
	 - Full garbage collection in spann

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
