### PR TITLE
[BUG] Pass next offset id to log materializer

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -124,7 +124,7 @@ impl CompactionManager {
                     dispatcher,
                     None,
                     None,
-                    Arc::new(AtomicU32::new(0)),
+                    Arc::new(AtomicU32::new(1)),
                     self.max_compaction_size,
                     self.max_partition_size,
                 );

--- a/rust/worker/src/execution/operators/write_segments.rs
+++ b/rust/worker/src/execution/operators/write_segments.rs
@@ -68,7 +68,7 @@ pub struct WriteSegmentsInput {
     chunk: Chunk<LogRecord>,
     provider: BlockfileProvider,
     record_segment: Segment,
-    offset_id: Arc<AtomicU32>,
+    next_offset_id: Arc<AtomicU32>,
 }
 
 impl WriteSegmentsInput {
@@ -79,7 +79,7 @@ impl WriteSegmentsInput {
         chunk: Chunk<LogRecord>,
         provider: BlockfileProvider,
         record_segment: Segment,
-        offset_id: Arc<AtomicU32>,
+        next_offset_id: Arc<AtomicU32>,
     ) -> Self {
         WriteSegmentsInput {
             record_segment_writer,
@@ -88,7 +88,7 @@ impl WriteSegmentsInput {
             chunk,
             provider,
             record_segment,
-            offset_id,
+            next_offset_id,
         }
     }
 }
@@ -163,7 +163,7 @@ impl Operator<WriteSegmentsInput, WriteSegmentsOutput> for WriteSegmentsOperator
         let materializer = LogMaterializer::new(
             record_segment_reader,
             input.chunk.clone(),
-            Some(input.offset_id.clone()),
+            Some(input.next_offset_id.clone()),
         );
         // Materialize the logs.
         let res = match materializer

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -1043,9 +1043,7 @@ mod tests {
                 .expect("Get owned should not fail")
                 .expect("Max offset id should exist");
 
-                // TODO: Switch the expected log offset after log materializer bug fix
-                // assert_eq!(max_offset_id, max_log_offset as u32);
-                assert_eq!(max_offset_id as usize, max_log_offset + thread_count);
+                assert_eq!(max_offset_id, max_log_offset as u32);
             },
             60,
         );

--- a/rust/worker/src/segment/test.rs
+++ b/rust/worker/src/segment/test.rs
@@ -23,9 +23,9 @@ pub struct TestSegment {
 
 impl TestSegment {
     // WARN: The size of the log chunk should not be too large
-    async fn compact_log(&mut self, logs: Chunk<LogRecord>, offset: usize) {
+    async fn compact_log(&mut self, logs: Chunk<LogRecord>, next_offset: usize) {
         let materializer =
-            LogMaterializer::new(None, logs, Some(AtomicU32::new(offset as u32).into()));
+            LogMaterializer::new(None, logs, Some(AtomicU32::new(next_offset as u32).into()));
         let materialized_logs = materializer
             .materialize()
             .await
@@ -80,8 +80,7 @@ impl TestSegment {
                 chunk
                     .first()
                     .copied()
-                    .expect("The chunk of offset ids to generate should not be empty.")
-                    - 1,
+                    .expect("The chunk of offset ids to generate should not be empty."),
             )
             .await;
         }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Currently the materializer is initialized with an atomic integer representing current maximum offset, and increases it upon initialization so that it can be used to represent the next available offset id. If two materializers are sharing the same atomic integer, then the increment is duplicated upon initialization, leaving a hole in the offset id. This PR initializes the materializer directly with the next available offset id to resolve this scenario.
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A
