### PR TITLE
Minor docs copyedits

### DIFF
--- a/docs/docs.trychroma.com/pages/deployment/aws.md
+++ b/docs/docs.trychroma.com/pages/deployment/aws.md
@@ -278,7 +278,7 @@ chromaClient.heartbeat()
 
 ## Observability with AWS
 
-Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only exports OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
+Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only export OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
 
 Tracing is configured with four environment variables:
 

--- a/docs/docs.trychroma.com/pages/deployment/azure.md
+++ b/docs/docs.trychroma.com/pages/deployment/azure.md
@@ -243,7 +243,7 @@ chromaClient.heartbeat()
 
 ## Observability with Azure
 
-Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only exports OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
+Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only export OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
 
 Tracing is configured with four environment variables:
 

--- a/docs/docs.trychroma.com/pages/deployment/docker.md
+++ b/docs/docs.trychroma.com/pages/deployment/docker.md
@@ -272,7 +272,7 @@ chromaClient.heartbeat()
 
 ## Observability with Docker
 
-Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only exports OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
+Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only export OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
 
 Tracing is configured with four environment variables:
 
@@ -309,7 +309,7 @@ service:
 ```
 
 This is the configuration file for the OpenTelemetry Collector:
-* The `recievers` section specifies that the OpenTelemetry protocol (OTLP) will be used to receive data over GRPC and HTTP.
+* The `receivers` section specifies that the OpenTelemetry protocol (OTLP) will be used to receive data over GRPC and HTTP.
 * `exporters` defines that telemetry data is logged to the console (`debug`), and sent to a `zipkin` server (defined bellow in `docker-compose.yml`).
 * The `service` section ties everything together, defining a `traces` pipeline receiving data through our `otlp` receiver and exporting data to `zipkin` and via logging.
 

--- a/docs/docs.trychroma.com/pages/deployment/gcp.md
+++ b/docs/docs.trychroma.com/pages/deployment/gcp.md
@@ -265,7 +265,7 @@ chromaClient.heartbeat()
 
 ## Observability with GCP
 
-Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only exports OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
+Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability. We currently only export OpenTelemetry [traces](https://opentelemetry.io/docs/concepts/signals/traces/). These should allow you to understand how requests flow through the system and quickly identify bottlenecks.
 
 Tracing is configured with four environment variables:
 

--- a/docs/docs.trychroma.com/pages/reference/js-client.md
+++ b/docs/docs.trychroma.com/pages/reference/js-client.md
@@ -14,13 +14,13 @@ title: JS Client
 
 Creates a new ChromaClient instance.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `ChromaClientParams` | The parameters for creating a new client |
 
-**`Example`**
+**Example**
 
 ```typescript
 const client = new ChromaClient({
@@ -36,17 +36,17 @@ const client = new ChromaClient({
 
 Counts all collections.
 
-#### Returns
+**Returns**
 
 `Promise`\<`number`\>
 
 A promise that resolves to the number of collections.
 
-**`Throws`**
+**Throws**
 
 If there is an issue counting the collections.
 
-**`Example`**
+**Example**
 
 ```typescript
 const collections = await client.countCollections();
@@ -60,27 +60,27 @@ ___
 
 Creates a new collection with the specified properties.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `CreateCollectionParams` | The parameters for creating a new collection. |
 
-#### Returns
+**Returns**
 
 `Promise`\<[`Collection`](Collection.Collection.md)\>
 
 A promise that resolves to the created collection.
 
-**`Throws`**
+**Throws**
 
 If the client is unable to connect to the server.
 
-**`Throws`**
+**Throws**
 
 If there is an issue creating the collection.
 
-**`Example`**
+**Example**
 
 ```typescript
 const collection = await client.createCollection({
@@ -99,23 +99,23 @@ ___
 
 Deletes a collection with the specified name.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `DeleteCollectionParams` | The parameters for deleting a collection. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`void`\>
 
 A promise that resolves when the collection is deleted.
 
-**`Throws`**
+**Throws**
 
 If there is an issue deleting the collection.
 
-**`Example`**
+**Example**
 
 ```typescript
 await client.deleteCollection({
@@ -131,23 +131,23 @@ ___
 
 Gets a collection with the specified name.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `GetCollectionParams` | The parameters for getting a collection. |
 
-#### Returns
+**Returns**
 
 `Promise`\<[`Collection`](Collection.Collection.md)\>
 
 A promise that resolves to the collection.
 
-**`Throws`**
+**Throws**
 
 If there is an issue getting the collection.
 
-**`Example`**
+**Example**
 
 ```typescript
 const collection = await client.getCollection({
@@ -163,23 +163,23 @@ ___
 
 Gets or creates a collection with the specified properties.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `CreateCollectionParams` | The parameters for creating a new collection. |
 
-#### Returns
+**Returns**
 
 `Promise`\<[`Collection`](Collection.Collection.md)\>
 
 A promise that resolves to the got or created collection.
 
-**`Throws`**
+**Throws**
 
 If there is an issue getting or creating the collection.
 
-**`Example`**
+**Example**
 
 ```typescript
 const collection = await client.getOrCreateCollection({
@@ -198,17 +198,17 @@ ___
 
 Returns a heartbeat from the Chroma API.
 
-#### Returns
+**Returns**
 
 `Promise`\<`number`\>
 
 A promise that resolves to the heartbeat from the Chroma API.
 
-**`Throws`**
+**Throws**
 
 If the client is unable to connect to the server.
 
-**`Example`**
+**Example**
 
 ```typescript
 const heartbeat = await client.heartbeat();
@@ -222,23 +222,23 @@ ___
 
 Lists all collections.
 
-#### Parameters
+**Parameters**
 
 | Name | Type |
 | :------ | :------ |
 | `«destructured»` | `ListCollectionsParams` |
 
-#### Returns
+**Returns**
 
 `Promise`\<`CollectionParams`[]\>
 
 A promise that resolves to a list of collection names.
 
-**`Throws`**
+**Throws**
 
 If there is an issue listing the collections.
 
-**`Example`**
+**Example**
 
 ```typescript
 const collections = await client.listCollections({
@@ -255,21 +255,21 @@ ___
 
 Resets the state of the object by making an API call to the reset endpoint.
 
-#### Returns
+**Returns**
 
 `Promise`\<`boolean`\>
 
 A promise that resolves when the reset operation is complete.
 
-**`Throws`**
+**Throws**
 
 If the client is unable to connect to the server.
 
-**`Throws`**
+**Throws**
 
 If the server experienced an error while the state.
 
-**`Example`**
+**Example**
 
 ```typescript
 await client.reset();
@@ -283,17 +283,17 @@ ___
 
 Returns the version of the Chroma API.
 
-#### Returns
+**Returns**
 
 `Promise`\<`string`\>
 
 A promise that resolves to the version of the Chroma API.
 
-**`Throws`**
+**Throws**
 
 If the client is unable to connect to the server.
 
-**`Example`**
+**Example**
 
 ```typescript
 const version = await client.version();

--- a/docs/docs.trychroma.com/pages/reference/js-collection.md
+++ b/docs/docs.trychroma.com/pages/reference/js-collection.md
@@ -32,19 +32,19 @@ ___
 
 Add items to the collection
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `AddRecordsParams` | The parameters for the query. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`void`\>
 
 - The response from the API. True if successful.
 
-**`Example`**
+**Example**
 
 ```typescript
 const response = await collection.add({
@@ -63,13 +63,13 @@ ___
 
 Count the number of items in the collection
 
-#### Returns
+**Returns**
 
 `Promise`\<`number`\>
 
 - The number of items in the collection.
 
-**`Example`**
+**Example**
 
 ```typescript
 const count = await collection.count();
@@ -83,23 +83,23 @@ ___
 
 Deletes items from the collection.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `DeleteParams` | The parameters for deleting items from the collection. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`string`[]\>
 
 A promise that resolves to the IDs of the deleted items.
 
-**`Throws`**
+**Throws**
 
 If there is an issue deleting items from the collection.
 
-**`Example`**
+**Example**
 
 ```typescript
 const results = await collection.delete({
@@ -117,19 +117,19 @@ ___
 
 Get items from the collection
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `BaseGetParams` | The parameters for the query. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`MultiGetResponse`\>
 
 - The response from the server.
 
-**`Example`**
+**Example**
 
 ```typescript
 const response = await collection.get({
@@ -150,7 +150,7 @@ ___
 
 Modify the collection name or metadata
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -158,13 +158,13 @@ Modify the collection name or metadata
 | `params.metadata?` | `CollectionMetadata` | Optional new metadata for the collection. |
 | `params.name?` | `string` | Optional new name for the collection. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`CollectionParams`\>
 
 - The response from the API.
 
-**`Example`**
+**Example**
 
 ```typescript
 const response = await client.updateCollection({
@@ -181,23 +181,23 @@ ___
 
 Peek inside the collection
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `PeekParams` | The parameters for the query. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`MultiGetResponse`\>
 
 A promise that resolves to the query results.
 
-**`Throws`**
+**Throws**
 
 If there is an issue executing the query.
 
-**`Example`**
+**Example**
 
 ```typescript
 const results = await collection.peek({
@@ -213,23 +213,23 @@ ___
 
 Performs a query on the collection using the specified parameters.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `QueryRecordsParams` | The parameters for the query. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`MultiQueryResponse`\>
 
 A promise that resolves to the query results.
 
-**`Throws`**
+**Throws**
 
 If there is an issue executing the query.
 
-**`Example`**
+**Example**
 
 ```ts
 // Query the collection using embeddings
@@ -241,7 +241,7 @@ const results = await collection.query({
 });
 ```
 
-**`Example`**
+**Example**
 
 ```js
 // Query the collection using query text
@@ -261,17 +261,17 @@ ___
 
 Update items in the collection
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `UpdateRecordsParams` | The parameters for the query. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`void`\>
 
-**`Example`**
+**Example**
 
 ```typescript
 const response = await collection.update({
@@ -290,17 +290,17 @@ ___
 
 Upsert items to the collection
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `params` | `AddRecordsParams` | The parameters for the query. |
 
-#### Returns
+**Returns**
 
 `Promise`\<`void`\>
 
-**`Example`**
+**Example**
 
 ```typescript
 const response = await collection.upsert({

--- a/docs/docs.trychroma.com/pages/reference/py-client.md
+++ b/docs/docs.trychroma.com/pages/reference/py-client.md
@@ -174,10 +174,10 @@ Count the number of collections.
 
 **Examples**:
 
-    ```python
-    client.count_collections()
-    # 1
-    ```
+```python
+client.count_collections()
+# 1
+```
 
 ## delete\_collection
 
@@ -199,9 +199,9 @@ Delete a collection with the given name.
 
 **Examples**:
 
-    ```python
-    client.delete_collection("my_collection")
-    ```
+```python
+client.delete_collection("my_collection")
+```
 
 ## reset
 
@@ -317,13 +317,13 @@ Create a new collection with the given name and metadata.
 
 **Examples**:
 
-    ```python
-    client.create_collection("my_collection")
-    # collection(name="my_collection", metadata={})
+```python
+client.create_collection("my_collection")
+# collection(name="my_collection", metadata={})
 
-    client.create_collection("my_collection", metadata={"foo": "bar"})
-    # collection(name="my_collection", metadata={"foo": "bar"})
-    ```
+client.create_collection("my_collection", metadata={"foo": "bar"})
+# collection(name="my_collection", metadata={"foo": "bar"})
+```
 
 ## get\_collection
 
@@ -358,10 +358,10 @@ Get a collection with the given name.
 
 **Examples**:
 
-    ```python
-    client.get_collection("my_collection")
-    # collection(name="my_collection", metadata={})
-    ```
+```python
+client.get_collection("my_collection")
+# collection(name="my_collection", metadata={})
+```
 
 ## get\_or\_create\_collection
 
@@ -394,10 +394,10 @@ Get or create a collection with the given name and metadata.
 
 **Examples**:
 
-    ```python
-    client.get_or_create_collection("my_collection")
-    # collection(name="my_collection", metadata={})
-    ```
+```python
+client.get_or_create_collection("my_collection")
+# collection(name="my_collection", metadata={})
+```
 
 ## set\_tenant
 

--- a/docs/docs.trychroma.com/pages/roadmap.md
+++ b/docs/docs.trychroma.com/pages/roadmap.md
@@ -43,7 +43,7 @@ Not an exhaustive list, but these are some of the core team’s biggest prioriti
 
 ## What areas are great for community contributions?
 
-This is where you have a lot more free reign to contribute (without having to sync with us first)!
+This is where you have a lot more free rein to contribute (without having to sync with us first)!
 
 If you're unsure about your contribution idea, feel free to chat with us (@chroma) in the `#general` channel in [our Discord](https://discord.gg/rahcMUU5XV)! We'd love to support you however we can.
 


### PR DESCRIPTION
Fixes some copyediting and markdown formatting issues I encountered while reading the chroma docs.

## Description of changes

*Summarize the changes made by this PR.*
1. Dedent example python code snippets in client docs
2. Remove code formatting on JS doc Returns section headers, and downgrade returns/parameters section headers to bolded text.
3. Minor spelling and copyedits.

## Test plan
*How are these changes tested?*
N/A

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
No updates required.
