### PR TITLE
[BUG] Bound tokenizers, patch CVP test

### DIFF
--- a/chromadb/test/client/test_http_client_v1_compatability.py
+++ b/chromadb/test/client/test_http_client_v1_compatability.py
@@ -41,7 +41,7 @@ def test_http_client_bw_compatibility() -> None:
     port = sys.settings.chroma_server_http_port
 
     old_version = "0.5.11"  # Module with known v1 client
-    install_version(old_version)
+    install_version(old_version, {})
 
     ctx = multiprocessing.get_context("spawn")
     conn1, conn2 = multiprocessing.Pipe()

--- a/chromadb/test/utils/cross_version.py
+++ b/chromadb/test/utils/cross_version.py
@@ -61,31 +61,13 @@ def install(pkg: str, path: str, dep_overrides: Dict[str, str]) -> int:
         ]
     )
 
+    command = [sys.executable, "-m", "pip", "-q", "-q", "install", pkg]
+
     for dep, operator_version in dep_overrides.items():
-        print(f"Installing {dep} version {operator_version}")
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "-q",
-                "-q",
-                "install",
-                f"{dep}{operator_version}",
-            ]
-        )
+        command.append(f"{dep}{operator_version}")
+
+    command.append("--no-binary=chroma-hnswlib")
+    command.append(f"--target={path}")
 
     print(f"Installing chromadb version {pkg} to {path}")
-    return subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "-q",
-            "-q",
-            "install",
-            pkg,
-            "--no-binary=chroma-hnswlib",
-            "--target={}".format(path),
-        ]
-    )
+    return subprocess.check_call(command)

--- a/chromadb/test/utils/cross_version.py
+++ b/chromadb/test/utils/cross_version.py
@@ -71,7 +71,7 @@ def install(pkg: str, path: str, dep_overrides: Dict[str, str]) -> int:
                 "-q",
                 "-q",
                 "install",
-                f"'{dep}{operator_version}'",
+                f"{dep}{operator_version}",
             ]
         )
 

--- a/chromadb/test/utils/cross_version.py
+++ b/chromadb/test/utils/cross_version.py
@@ -3,7 +3,7 @@ import subprocess
 import os
 import tempfile
 from types import ModuleType
-from typing import List
+from typing import Dict, List
 
 base_install_dir = tempfile.gettempdir() + "/persistence_test_chromadb_versions"
 
@@ -38,16 +38,16 @@ def get_path_to_version_library(version: str) -> str:
     return get_path_to_version_install(version) + "/chromadb/__init__.py"
 
 
-def install_version(version: str) -> None:
+def install_version(version: str, dep_overrides: Dict[str, str]) -> None:
     # Check if already installed
     version_library = get_path_to_version_library(version)
     if os.path.exists(version_library):
         return
     path = get_path_to_version_install(version)
-    install(f"chromadb=={version}", path)
+    install(f"chromadb=={version}", path, dep_overrides)
 
 
-def install(pkg: str, path: str) -> int:
+def install(pkg: str, path: str, dep_overrides: Dict[str, str]) -> int:
     # -q -q to suppress pip output to ERROR level
     # https://pip.pypa.io/en/stable/cli/pip/#quiet
     print("Purging pip cache")
@@ -60,6 +60,21 @@ def install(pkg: str, path: str) -> int:
             "purge",
         ]
     )
+
+    for dep, operator_version in dep_overrides.items():
+        print(f"Installing {dep} version {operator_version}")
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "-q",
+                "-q",
+                "install",
+                f"'{dep}{operator_version}'",
+            ]
+        )
+
     print(f"Installing chromadb version {pkg} to {path}")
     return subprocess.check_call(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
   'opentelemetry-instrumentation-fastapi>=0.41b0',
   'opentelemetry-sdk>=1.2.0',
-  'tokenizers >= 0.13.2',
+  'tokenizers >= 0.13.2, <= 0.20.3',
   'pypika >= 0.48.9',
   'tqdm >= 4.65.0',
   'overrides >= 7.3.1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pypika>=0.48.9
 PyYAML>=6.0.0
 rich>=10.11.0
 tenacity>=8.2.3
-tokenizers>=0.13.2
+tokenizers>=0.13.2,<=0.20.3
 tqdm>=4.65.0
 typer>=0.9.0
 typing_extensions>=4.5.0


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Bounds tokenizers as in #3202 
   - Includes a change to CVP test to install an old version of a dep in case of b/w incompat like this has. 
 - New functionality
   - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None