### PR TITLE
[ENH] Fetch posting list operator

### DIFF
--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -1402,7 +1402,6 @@ impl ChromaError for SpannIndexReaderError {
 #[derive(Debug)]
 pub struct SpannPosting {
     pub doc_offset_id: u32,
-    pub doc_version: u32,
     pub doc_embedding: Vec<f32>,
 }
 
@@ -1540,7 +1539,6 @@ impl<'me> SpannIndexReader<'me> {
             }
             posting_lists.push(SpannPosting {
                 doc_offset_id: *doc_offset_id,
-                doc_version: res.doc_versions[index],
                 doc_embedding: res.doc_embeddings
                     [index * self.dimensionality..(index + 1) * self.dimensionality]
                     .to_vec(),

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -1384,6 +1384,8 @@ pub enum SpannIndexReaderError {
     BlockfileReaderConstructionError,
     #[error("Spann index uninitialized")]
     UninitializedIndex,
+    #[error("Error reading posting list")]
+    PostingListReadError,
 }
 
 impl ChromaError for SpannIndexReaderError {
@@ -1392,8 +1394,16 @@ impl ChromaError for SpannIndexReaderError {
             Self::HnswIndexConstructionError => ErrorCodes::Internal,
             Self::BlockfileReaderConstructionError => ErrorCodes::Internal,
             Self::UninitializedIndex => ErrorCodes::Internal,
+            Self::PostingListReadError => ErrorCodes::Internal,
         }
     }
+}
+
+#[derive(Debug)]
+pub struct SpannPosting {
+    pub doc_offset_id: u32,
+    pub doc_version: u32,
+    pub doc_embedding: Vec<f32>,
 }
 
 #[derive(Clone)]
@@ -1401,6 +1411,7 @@ pub struct SpannIndexReader<'me> {
     pub posting_lists: BlockfileReader<'me, u32, SpannPostingList<'me>>,
     pub hnsw_index: HnswIndexRef,
     pub versions_map: BlockfileReader<'me, u32, u32>,
+    pub dimensionality: usize,
 }
 
 impl<'me> SpannIndexReader<'me> {
@@ -1490,7 +1501,52 @@ impl<'me> SpannIndexReader<'me> {
             posting_lists: postings_list_reader,
             hnsw_index: hnsw_reader,
             versions_map: versions_map_reader,
+            dimensionality,
         })
+    }
+
+    async fn is_outdated(
+        &self,
+        doc_offset_id: u32,
+        doc_version: u32,
+    ) -> Result<bool, SpannIndexReaderError> {
+        let actual_version = self
+            .versions_map
+            .get("", doc_offset_id)
+            .await
+            .map_err(|_| SpannIndexReaderError::PostingListReadError)?
+            .ok_or(SpannIndexReaderError::PostingListReadError)?;
+        Ok(actual_version == 0 || doc_version < actual_version)
+    }
+
+    pub async fn fetch_posting_list(
+        &self,
+        head_id: u32,
+    ) -> Result<Vec<SpannPosting>, SpannIndexReaderError> {
+        let res = self
+            .posting_lists
+            .get("", head_id)
+            .await
+            .map_err(|_| SpannIndexReaderError::PostingListReadError)?
+            .ok_or(SpannIndexReaderError::PostingListReadError)?;
+
+        let mut posting_lists = Vec::with_capacity(res.doc_offset_ids.len());
+        for (index, doc_offset_id) in res.doc_offset_ids.iter().enumerate() {
+            if self
+                .is_outdated(*doc_offset_id, res.doc_versions[index])
+                .await?
+            {
+                continue;
+            }
+            posting_lists.push(SpannPosting {
+                doc_offset_id: *doc_offset_id,
+                doc_version: res.doc_versions[index],
+                doc_embedding: res.doc_embeddings
+                    [index * self.dimensionality..(index + 1) * self.dimensionality]
+                    .to_vec(),
+            });
+        }
+        Ok(posting_lists)
     }
 }
 

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -10,6 +10,7 @@ pub(super) mod pull_log;
 pub(super) mod record_segment_prefetch;
 pub(super) mod register;
 pub(super) mod spann_centers_search;
+pub(super) mod spann_fetch_pl;
 pub(super) mod write_segments;
 
 // Required for benchmark

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -1,4 +1,5 @@
 use chroma_error::{ChromaError, ErrorCodes};
+use chroma_index::spann::types::SpannPosting;
 use thiserror::Error;
 use tonic::async_trait;
 
@@ -15,9 +16,7 @@ pub struct SpannFetchPlInput {
 
 #[derive(Debug)]
 pub struct SpannFetchPlOutput {
-    doc_offset_ids: Vec<u32>,
-    doc_versions: Vec<u32>,
-    doc_embeddings: Vec<f32>,
+    posting_list: Vec<SpannPosting>,
 }
 
 #[derive(Error, Debug)]
@@ -62,14 +61,10 @@ impl Operator<SpannFetchPlInput, SpannFetchPlOutput> for SpannFetchPlOperator {
         )
         .await
         .map_err(|_| SpannFetchPlError::SpannSegmentReaderCreationError)?;
-        let pl = spann_reader
+        let posting_list = spann_reader
             .fetch_posting_list(input.head_id)
             .await
             .map_err(|_| SpannFetchPlError::SpannSegmentReaderError)?;
-        Ok(SpannFetchPlOutput {
-            doc_offset_ids: pl.doc_offset_ids.to_vec(),
-            doc_versions: pl.doc_versions.to_vec(),
-            doc_embeddings: pl.doc_embeddings.to_vec(),
-        })
+        Ok(SpannFetchPlOutput { posting_list })
     }
 }

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -1,0 +1,75 @@
+use chroma_error::{ChromaError, ErrorCodes};
+use thiserror::Error;
+use tonic::async_trait;
+
+use crate::{
+    execution::operator::Operator,
+    segment::spann_segment::{SpannSegmentReader, SpannSegmentReaderContext},
+};
+
+#[derive(Debug)]
+pub struct SpannFetchPlInput {
+    reader_context: SpannSegmentReaderContext,
+    head_id: u32,
+}
+
+#[derive(Debug)]
+pub struct SpannFetchPlOutput {
+    doc_offset_ids: Vec<u32>,
+    doc_versions: Vec<u32>,
+    doc_embeddings: Vec<f32>,
+}
+
+#[derive(Error, Debug)]
+pub enum SpannFetchPlError {
+    #[error("Error creating spann segment reader")]
+    SpannSegmentReaderCreationError,
+    #[error("Error querying reader")]
+    SpannSegmentReaderError,
+}
+
+impl ChromaError for SpannFetchPlError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            Self::SpannSegmentReaderCreationError => ErrorCodes::Internal,
+            Self::SpannSegmentReaderError => ErrorCodes::Internal,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SpannFetchPlOperator {}
+
+impl SpannFetchPlOperator {
+    pub fn new() -> Box<Self> {
+        Box::new(SpannFetchPlOperator {})
+    }
+}
+
+#[async_trait]
+impl Operator<SpannFetchPlInput, SpannFetchPlOutput> for SpannFetchPlOperator {
+    type Error = SpannFetchPlError;
+
+    async fn run(
+        &self,
+        input: &SpannFetchPlInput,
+    ) -> Result<SpannFetchPlOutput, SpannFetchPlError> {
+        let spann_reader = SpannSegmentReader::from_segment(
+            &input.reader_context.segment,
+            &input.reader_context.blockfile_provider,
+            &input.reader_context.hnsw_provider,
+            input.reader_context.dimension,
+        )
+        .await
+        .map_err(|_| SpannFetchPlError::SpannSegmentReaderCreationError)?;
+        let pl = spann_reader
+            .fetch_posting_list(input.head_id)
+            .await
+            .map_err(|_| SpannFetchPlError::SpannSegmentReaderError)?;
+        Ok(SpannFetchPlOutput {
+            doc_offset_ids: pl.doc_offset_ids.to_vec(),
+            doc_versions: pl.doc_versions.to_vec(),
+            doc_embeddings: pl.doc_embeddings.to_vec(),
+        })
+    }
+}

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use tonic::async_trait;
 
 use crate::{
-    execution::operator::Operator,
+    execution::operator::{Operator, OperatorType},
     segment::spann_segment::{SpannSegmentReader, SpannSegmentReaderContext},
 };
 
@@ -14,6 +14,7 @@ pub struct SpannFetchPlInput {
     head_id: u32,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct SpannFetchPlOutput {
     posting_list: Vec<SpannPosting>,
@@ -40,6 +41,7 @@ impl ChromaError for SpannFetchPlError {
 pub struct SpannFetchPlOperator {}
 
 impl SpannFetchPlOperator {
+    #[allow(dead_code)]
     pub fn new() -> Box<Self> {
         Box::new(SpannFetchPlOperator {})
     }
@@ -66,5 +68,10 @@ impl Operator<SpannFetchPlInput, SpannFetchPlOutput> for SpannFetchPlOperator {
             .await
             .map_err(|_| SpannFetchPlError::SpannSegmentReaderError)?;
         Ok(SpannFetchPlOutput { posting_list })
+    }
+
+    // This operator is IO bound.
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
     }
 }

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -10,6 +10,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct SpannFetchPlInput {
+    // TODO(Sanket): Ship the reader instead of constructing here.
     reader_context: SpannSegmentReaderContext,
     head_id: u32,
 }

--- a/rust/worker/src/segment/spann_segment.rs
+++ b/rust/worker/src/segment/spann_segment.rs
@@ -8,8 +8,8 @@ use chroma_index::spann::types::{
 };
 use chroma_index::IndexUuid;
 use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::SpannIndexWriter};
+use chroma_types::SegmentUuid;
 use chroma_types::{MaterializedLogOperation, Segment, SegmentScope, SegmentType};
-use chroma_types::{SegmentUuid, SpannPostingList};
 use thiserror::Error;
 use tonic::async_trait;
 use uuid::Uuid;

--- a/rust/worker/src/segment/spann_segment.rs
+++ b/rust/worker/src/segment/spann_segment.rs
@@ -4,7 +4,7 @@ use chroma_blockstore::provider::BlockfileProvider;
 use chroma_distance::DistanceFunctionError;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::spann::types::{
-    SpannIndexFlusher, SpannIndexReader, SpannIndexReaderError, SpannIndexWriterError,
+    SpannIndexFlusher, SpannIndexReader, SpannIndexReaderError, SpannIndexWriterError, SpannPosting,
 };
 use chroma_index::IndexUuid;
 use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::SpannIndexWriter};
@@ -463,19 +463,11 @@ impl<'me> SpannSegmentReader<'me> {
     pub async fn fetch_posting_list(
         &self,
         head_id: u32,
-    ) -> Result<SpannPostingList<'_>, SpannSegmentReaderError> {
-        let res = self
-            .index_reader
-            .posting_lists
-            .get("", head_id)
+    ) -> Result<Vec<SpannPosting>, SpannSegmentReaderError> {
+        self.index_reader
+            .fetch_posting_list(head_id)
             .await
-            .map_err(|_| SpannSegmentReaderError::KeyReadError)?;
-        match res {
-            Some(pl) => Ok(pl),
-            None => {
-                panic!("Invariant violation. Key present in hnsw but not in posting list")
-            }
-        }
+            .map_err(|_| SpannSegmentReaderError::KeyReadError)
     }
 }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Operator for fetching the posting list for a given head. Currently clones the posting list. Can revisit in future if it ends up becoming a performance bottleneck.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
