### PR TITLE
[ENH] Brute force distances for a posting list operator

### DIFF
--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -9,6 +9,7 @@ pub(super) mod partition;
 pub(super) mod pull_log;
 pub(super) mod record_segment_prefetch;
 pub(super) mod register;
+pub(super) mod spann_bf_pl;
 pub(super) mod spann_centers_search;
 pub(super) mod spann_fetch_pl;
 pub(super) mod write_segments;

--- a/rust/worker/src/execution/operators/spann_bf_pl.rs
+++ b/rust/worker/src/execution/operators/spann_bf_pl.rs
@@ -1,0 +1,81 @@
+use chroma_distance::DistanceFunction;
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_types::SignedRoaringBitmap;
+use thiserror::Error;
+use tonic::async_trait;
+
+use crate::{
+    execution::operator::Operator,
+    segment::spann_segment::{SpannSegmentReader, SpannSegmentReaderContext},
+};
+
+use super::knn::RecordDistance;
+
+#[derive(Debug)]
+pub struct SpannBfPlInput {
+    // Needed for checking if a particular version is outdated.
+    reader_context: SpannSegmentReaderContext,
+    // Posting list data.
+    doc_offset_ids: Vec<u32>,
+    doc_versions: Vec<u32>,
+    doc_embeddings: Vec<f32>,
+    // Number of results to return.
+    k: usize,
+    // Bitmap of records to include/exclude.
+    filter: SignedRoaringBitmap,
+    // Distance function.
+    distance_function: DistanceFunction,
+    // Dimension of the embeddings.
+    dimension: usize,
+}
+
+#[derive(Debug)]
+pub struct SpannBfPlOutput {
+    records: Vec<RecordDistance>,
+}
+
+#[derive(Error, Debug)]
+pub enum SpannBfPlError {
+    #[error("Error creating spann segment reader")]
+    SpannSegmentReaderCreationError,
+    #[error("Error querying reader")]
+    SpannSegmentReaderError,
+}
+
+impl ChromaError for SpannBfPlError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            Self::SpannSegmentReaderCreationError => ErrorCodes::Internal,
+            Self::SpannSegmentReaderError => ErrorCodes::Internal,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SpannBfPlOperator {}
+
+impl SpannBfPlOperator {
+    pub fn new() -> Box<Self> {
+        Box::new(SpannBfPlOperator {})
+    }
+}
+
+#[async_trait]
+impl Operator<SpannBfPlInput, SpannBfPlOutput> for SpannBfPlOperator {
+    type Error = SpannBfPlError;
+
+    async fn run(&self, input: &SpannBfPlInput) -> Result<SpannBfPlOutput, SpannBfPlError> {
+        let spann_reader = SpannSegmentReader::from_segment(
+            &input.reader_context.segment,
+            &input.reader_context.blockfile_provider,
+            &input.reader_context.hnsw_provider,
+            input.reader_context.dimension,
+        )
+        .await
+        .map_err(|_| SpannBfPlError::SpannSegmentReaderCreationError)?;
+
+        Ok(SpannBfPlOutput {
+            records: Vec::new(),
+        })
+    }
+}

--- a/rust/worker/src/execution/operators/spann_bf_pl.rs
+++ b/rust/worker/src/execution/operators/spann_bf_pl.rs
@@ -13,6 +13,7 @@ use super::knn::RecordDistance;
 
 #[derive(Debug)]
 pub struct SpannBfPlInput {
+    // TODO(Sanket): We might benefit from a flat structure which might be more cache friendly.
     // Posting list data.
     posting_list: Vec<SpannPosting>,
     // Number of results to return.
@@ -25,6 +26,7 @@ pub struct SpannBfPlInput {
     query: Vec<f32>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct SpannBfPlOutput {
     records: Vec<RecordDistance>,
@@ -42,6 +44,7 @@ impl ChromaError for SpannBfPlError {
 #[derive(Debug)]
 pub struct SpannBfPlOperator {}
 
+#[allow(dead_code)]
 impl SpannBfPlOperator {
     pub fn new() -> Box<Self> {
         Box::new(SpannBfPlOperator {})


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - None
 - New functionality
   -  Goes over the posting list, filters out the allowed set, sorts and returns the top k.

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
