### PR TITLE
[BUG] Fix property failure for soft delete.

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -390,7 +390,7 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 
 		// Generate new name with timestamp and random number
 		oldName := *collections[0].Collection.Name
-		newName := fmt.Sprintf("deleted_%s_%d_%d", oldName, time.Now().Unix(), rand.Intn(1000))
+		newName := fmt.Sprintf("_deleted_%s_%d_%d", oldName, time.Now().Unix(), rand.Intn(1000))
 
 		dbCollection := &dbmodel.Collection{
 			ID:        deleteCollection.ID.String(),


### PR DESCRIPTION
[BUG] Fix property failure for soft delete.

Renaming soft deleted collection at delete time
since modify and create can try to re-create
a collection with the same name.

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fix property failure for soft delete.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
n/a
