### PR TITLE
[ENH]: make log materialization result owned

### DIFF
--- a/rust/types/src/data_record.rs
+++ b/rust/types/src/data_record.rs
@@ -10,6 +10,29 @@ pub struct DataRecord<'a> {
     pub document: Option<&'a str>,
 }
 
+#[derive(Debug, Clone)]
+pub struct OwnedDataRecord {
+    pub id: String,
+    pub embedding: Vec<f32>,
+    pub metadata: Option<Metadata>,
+    pub document: Option<String>,
+}
+
+impl<'a> From<&DataRecord<'a>> for OwnedDataRecord {
+    fn from(data_record: &DataRecord<'a>) -> Self {
+        let id = data_record.id.to_string();
+        let embedding = data_record.embedding.to_vec();
+        let metadata = data_record.metadata.clone();
+        let document = data_record.document.map(|doc| doc.to_string());
+        OwnedDataRecord {
+            id,
+            embedding,
+            metadata,
+            document,
+        }
+    }
+}
+
 impl DataRecord<'_> {
     pub fn get_size(&self) -> usize {
         let id_size = self.id.len();
@@ -27,5 +50,9 @@ impl DataRecord<'_> {
             None => 0,
         };
         id_size + embedding_size + metadata_size + document_size
+    }
+
+    pub fn to_owned(&self) -> OwnedDataRecord {
+        self.into()
     }
 }

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -106,7 +106,7 @@ pub(crate) struct MetadataLogReader<'me> {
 }
 
 impl<'me> MetadataLogReader<'me> {
-    pub(crate) fn new(logs: &'me Chunk<MaterializedLogRecord<'me>>) -> Self {
+    pub(crate) fn new(logs: &'me Chunk<MaterializedLogRecord>) -> Self {
         let mut compact_metadata: HashMap<_, BTreeMap<&MetadataValue, RoaringBitmap>> =
             HashMap::new();
         let mut document = HashMap::new();

--- a/rust/worker/src/execution/operators/hnsw_knn.rs
+++ b/rust/worker/src/execution/operators/hnsw_knn.rs
@@ -65,7 +65,7 @@ impl ChromaError for HnswKnnOperatorError {
 impl HnswKnnOperator {
     async fn get_disallowed_ids<'referred_data>(
         &self,
-        logs: Chunk<MaterializedLogRecord<'_>>,
+        logs: Chunk<MaterializedLogRecord>,
         record_segment_reader: &RecordSegmentReader<'_>,
     ) -> Result<Vec<u32>, Box<dyn ChromaError>> {
         let mut disallowed_ids = Vec::new();

--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -238,10 +238,10 @@ impl DistributedHNSWSegmentWriter {
     }
 }
 
-impl<'a> SegmentWriter<'a> for DistributedHNSWSegmentWriter {
+impl SegmentWriter for DistributedHNSWSegmentWriter {
     async fn apply_materialized_log_chunk(
         &self,
-        records: chroma_types::Chunk<super::MaterializedLogRecord<'a>>,
+        records: chroma_types::Chunk<super::MaterializedLogRecord>,
     ) -> Result<(), ApplyMaterializedLogError> {
         for (record, _) in records.iter() {
             match record.final_operation {

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -542,7 +542,7 @@ impl SegmentWriter for MetadataSegmentWriter<'_> {
                 .0
                 .data_record
                 .as_ref()
-                .and_then(|r| r.document.as_ref().map(|d| d.as_str()));
+                .and_then(|r| r.document.as_deref());
             let new_document = &record.0.final_document;
 
             if matches!(

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -539,7 +539,7 @@ impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
         let full_text_writer_batch = records.iter().filter_map(|record| {
             let offset_id = record.0.offset_id;
             let old_document = record.0.data_record.as_ref().and_then(|r| r.document);
-            let new_document = record.0.final_document;
+            let new_document = &record.0.final_document;
 
             if matches!(
                 record.0.final_operation,

--- a/rust/worker/src/segment/metadata_segment.rs
+++ b/rust/worker/src/segment/metadata_segment.rs
@@ -530,15 +530,19 @@ impl<'me> MetadataSegmentWriter<'me> {
     }
 }
 
-impl<'log_records> SegmentWriter<'log_records> for MetadataSegmentWriter<'_> {
+impl SegmentWriter for MetadataSegmentWriter<'_> {
     async fn apply_materialized_log_chunk(
         &self,
-        records: Chunk<MaterializedLogRecord<'log_records>>,
+        records: Chunk<MaterializedLogRecord>,
     ) -> Result<(), ApplyMaterializedLogError> {
         let mut count = 0u64;
         let full_text_writer_batch = records.iter().filter_map(|record| {
             let offset_id = record.0.offset_id;
-            let old_document = record.0.data_record.as_ref().and_then(|r| r.document);
+            let old_document = record
+                .0
+                .data_record
+                .as_ref()
+                .and_then(|r| r.document.as_ref().map(|d| d.as_str()));
             let new_document = &record.0.final_document;
 
             if matches!(

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -357,7 +357,11 @@ impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
                         .user_id_to_id
                         .as_ref()
                         .unwrap()
-                        .set::<&str, u32>("", log_record.user_id.unwrap(), log_record.offset_id)
+                        .set::<&str, u32>(
+                            "",
+                            log_record.user_id.as_ref().unwrap(),
+                            log_record.offset_id,
+                        )
                         .await
                     {
                         Ok(()) => (),
@@ -370,7 +374,11 @@ impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
                         .id_to_user_id
                         .as_ref()
                         .unwrap()
-                        .set::<u32, String>("", log_record.offset_id, log_record.user_id.unwrap().to_string())
+                        .set::<u32, String>(
+                            "",
+                            log_record.offset_id,
+                            log_record.user_id.clone().unwrap(),
+                        )
                         .await
                     {
                         Ok(()) => (),
@@ -382,7 +390,7 @@ impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
                     match self
                         .construct_and_set_data_record(
                             log_record,
-                            log_record.user_id.unwrap(),
+                            log_record.user_id.as_ref().unwrap(),
                             log_record.offset_id,
                         )
                         .await

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -61,9 +61,9 @@ pub enum RecordSegmentWriterCreationError {
 }
 
 impl RecordSegmentWriter {
-    async fn construct_and_set_data_record<'a>(
+    async fn construct_and_set_data_record(
         &self,
-        mat_record: &MaterializedLogRecord<'a>,
+        mat_record: &MaterializedLogRecord,
         user_id: &str,
         offset_id: u32,
     ) -> Result<(), ApplyMaterializedLogError> {
@@ -337,10 +337,10 @@ impl ChromaError for ApplyMaterializedLogError {
     }
 }
 
-impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
+impl SegmentWriter for RecordSegmentWriter {
     async fn apply_materialized_log_chunk(
         &self,
-        records: Chunk<MaterializedLogRecord<'a>>,
+        records: Chunk<MaterializedLogRecord>,
     ) -> Result<(), ApplyMaterializedLogError> {
         // The max new offset id introduced by materialized logs is initialized as zero
         // Since offset id should start from 1, we use this to indicate no new offset id
@@ -423,7 +423,7 @@ impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
                     match self
                         .construct_and_set_data_record(
                             log_record,
-                            log_record.data_record.as_ref().unwrap().id,
+                            &log_record.data_record.as_ref().unwrap().id,
                             log_record.offset_id,
                         )
                         .await
@@ -440,7 +440,7 @@ impl<'a> SegmentWriter<'a> for RecordSegmentWriter {
                         .user_id_to_id
                         .as_ref()
                         .unwrap()
-                        .delete::<&str, u32>("", log_record.data_record.as_ref().unwrap().id)
+                        .delete::<&str, u32>("", &log_record.data_record.as_ref().unwrap().id)
                         .await
                     {
                         Ok(()) => (),

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -602,8 +602,12 @@ pub async fn materialize_logs<'me>(
                                 return Err(LogMaterializerError::MetadataMaterialization(e));
                             }
                         };
-                        record_from_map.final_document = log_record.record.document.clone();
-                        record_from_map.final_embedding = log_record.record.embedding.clone();
+                        if let Some(doc) = &log_record.record.document {
+                            record_from_map.final_document = Some(doc.clone());
+                        }
+                        if let Some(emb) = &log_record.record.embedding {
+                            record_from_map.final_embedding = Some(emb.clone());
+                        }
                         match record_from_map.final_operation {
                             MaterializedLogOperation::Initial => {
                                 record_from_map.final_operation =
@@ -661,8 +665,12 @@ pub async fn materialize_logs<'me>(
                                             return Err(LogMaterializerError::MetadataMaterialization(e));
                                         }
                                     };
-                                    record_from_map.final_document = log_record.record.document.clone();
-                                    record_from_map.final_embedding = log_record.record.embedding.clone();
+                                    if let Some(doc) = &log_record.record.document {
+                                        record_from_map.final_document = Some(doc.clone());
+                                    }
+                                    if let Some(emb) = &log_record.record.embedding {
+                                        record_from_map.final_embedding = Some(emb.clone());
+                                    }
                                     match record_from_map.final_operation {
                                         MaterializedLogOperation::Initial => {
                                             record_from_map.final_operation =
@@ -699,8 +707,12 @@ pub async fn materialize_logs<'me>(
                                     return Err(LogMaterializerError::MetadataMaterialization(e));
                                 }
                             };
-                            record_from_map.final_document = log_record.record.document.clone();
-                            record_from_map.final_embedding = log_record.record.embedding.clone();
+                            if let Some(doc) = &log_record.record.document {
+                                record_from_map.final_document = Some(doc.clone());
+                            }
+                            if let Some(emb) = &log_record.record.embedding {
+                                record_from_map.final_embedding = Some(emb.clone());
+                            }
                             // This record is not present on storage yet hence final operation is
                             // AddNew and not UpdateExisting.
                             record_from_map.final_operation = MaterializedLogOperation::AddNew;

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -125,7 +125,7 @@ pub struct MaterializedLogRecord<'referred_data> {
     // Set only for the records that are being inserted for the first time
     // in the log since data_record will be None in such cases. For other
     // cases, just read from data record.
-    pub(crate) user_id: Option<&'referred_data str>,
+    pub(crate) user_id: Option<String>,
     // There can be several entries in the log for an id. This is the final
     // operation that needs to be done on it. For e.g.
     // If log has [Update, Update, Delete] then final operation is Delete.
@@ -200,8 +200,8 @@ impl<'referred_data> MaterializedLogRecord<'referred_data> {
     // Performs a deep copy of the user id so only use it if really
     // needed. If you only need reference then use merged_user_id_ref below.
     pub(crate) fn merged_user_id(&self) -> String {
-        match self.user_id {
-            Some(id) => id.to_string(),
+        match &self.user_id {
+            Some(id) => id.clone(),
             None => match &self.data_record {
                 Some(data_record) => data_record.id.to_string(),
                 None => panic!("Expected at least one user id to be set"),
@@ -209,9 +209,10 @@ impl<'referred_data> MaterializedLogRecord<'referred_data> {
         }
     }
 
+    // todo: needed?
     pub(crate) fn merged_user_id_ref(&self) -> &str {
-        match self.user_id {
-            Some(id) => id,
+        match &self.user_id {
+            Some(id) => id.as_str(),
             None => match &self.data_record {
                 Some(data_record) => data_record.id,
                 None => panic!("Expected at least one user id to be set"),
@@ -398,7 +399,7 @@ impl<'referred_data> TryFrom<(&'referred_data OperationRecord, u32, &'referred_d
         Ok(Self {
             data_record: None,
             offset_id,
-            user_id: Some(user_id),
+            user_id: Some(user_id.to_string()),
             final_operation: MaterializedLogOperation::AddNew,
             metadata_to_be_merged: merged_metadata,
             metadata_to_be_deleted: deleted_metadata,
@@ -1836,7 +1837,7 @@ mod tests {
             // Embedding 3.
             if log.user_id.is_some() {
                 id3_found += 1;
-                assert_eq!("embedding_id_3", log.user_id.unwrap());
+                assert_eq!("embedding_id_3", log.user_id.clone().unwrap());
                 assert!(log.data_record.is_none());
                 assert_eq!("doc3", log.final_document.unwrap());
                 assert_eq!(vec![7.0, 8.0, 9.0], log.final_embedding.unwrap());


### PR DESCRIPTION
## Description of changes

The log materialization function now returns an owned result instead of one containing references. This will allow us to move materialization into an operator.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a