### PR TITLE
Add Testcontainers documentations

### DIFF
--- a/docs/docs.trychroma.com/pages/integrations/_sidenav.js
+++ b/docs/docs.trychroma.com/pages/integrations/_sidenav.js
@@ -25,4 +25,10 @@ export const items = [
           { href: '/integrations/openlit', children: 'OpenLIT' },
       ]
     },
+    {
+      title: 'Libraries',
+      links: [
+        { href: '/integrations/testcontainers', children: 'Testcontainers' },
+      ]
+    }
   ];

--- a/docs/docs.trychroma.com/pages/integrations/index.md
+++ b/docs/docs.trychroma.com/pages/integrations/index.md
@@ -46,3 +46,9 @@ We welcome pull requests to add new Integrations to the community.
 | [🎈 Streamlit](/integrations/streamlit) | ✅     | ➖ |
 | [💙 Haystack](/integrations/haystack) | ✅     | ➖ |
 | [🔭 OpenLIT](/integrations/openlit) | ✅     | 🔜 |
+
+### 📦 Libraries
+
+|                       | Java |
+|-----------------------|------|
+| [Testcontainers](/integrations/testcontainers) | ✅   |

--- a/docs/docs.trychroma.com/pages/integrations/testcontainers.md
+++ b/docs/docs.trychroma.com/pages/integrations/testcontainers.md
@@ -1,0 +1,91 @@
+---
+title: Testcontainers
+---
+
+Testcontainers provides a Chroma module that allows to run ChromaDB in a container for testing purposes.
+
+## Java
+
+Install Chroma Java module:
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>chromadb</artifactId>
+    <version>1.20.4</version>
+    <scope>test</scope>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+testImplementation 'org.testcontainers:chromadb:1.20.4'
+```
+
+Declare the `ChromaDBContainer` in your test:
+
+```java
+ChromaDBContainer chromadb = new ChromaDBContainer("chromadb/chroma:0.4.22");
+chromadb.start();
+```
+
+Use `chroma.getEndpoint()` to connect your client library to the ChromaDB container.
+
+## Go
+
+Install Chroma Go module:
+
+```bash
+go get github.com/testcontainers/testcontainers-go/modules/chroma
+```
+
+Declare testcontainers `chroma` module in your test:
+
+```go
+ctr, err := chroma.Run(ctx, "chromadb/chroma:0.4.22")
+```
+
+Use `ctr.RESTEndpoint(context.Background())` to connect your client library to the ChromaDB container.
+
+
+## Node.js
+
+Install Chroma Node.js module:
+
+```bash
+npm install @testcontainers/chromadb --save-dev
+```
+
+Declare the `ChromaDBContainer` in your test:
+
+```typescript
+const container = await new ChromaDBContainer("chromadb/chroma:0.4.22").start();
+```
+
+Use `container.getHttpUrl()` to connect your client library to the ChromaDB container.
+
+## Python
+
+Install Chroma Python module:
+
+```bash
+pip install testcontainers[chroma]
+```
+
+Declare `ChromaContainer` and configure your client library: 
+
+```python
+with ChromaContainer() as chroma:
+    config = chroma.get_config()
+    client = chromadb.HttpClient(host=config["host"], port=config["port"])
+    collection = client.get_or_create_collection("test")
+    print(collection.name)
+```
+
+# Resources
+
+* [Testcontainers](https://testcontainers.com/)
+* [Testcontainers Chroma module](https://testcontainers.com/modules/chroma/)


### PR DESCRIPTION
Testcontainers implementations provide a Chroma module in order
to run docker images as part of their test suites.
