### PR TITLE
[CHORE]  Set tonic to http binary for chroma-load

### DIFF
--- a/rust/load/src/opentelemetry_config.rs
+++ b/rust/load/src/opentelemetry_config.rs
@@ -73,6 +73,7 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     // Prepare tracer.
     let span_exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
+        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
         .with_endpoint(otel_endpoint)
         .build()
         .expect("could not build span exporter");
@@ -90,6 +91,7 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     // Prepare meter.
     let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_tonic()
+        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
         .with_endpoint(otel_endpoint)
         .build()
         .expect("could not build metric exporter");


### PR DESCRIPTION
HTTP2 (gRPC) is not supported by whatever chroma-load is talking to for exporting tracing.  Use http
with the binary format instead.
