### PR TITLE
[BLD]: publish Helm chart to ECR

### DIFF
--- a/.github/workflows/copy-helm-chart.yml
+++ b/.github/workflows/copy-helm-chart.yml
@@ -1,0 +1,30 @@
+# TODO Once distributed chroma is operational, update this to update the
+# OSS helm chart we'll host. For now, just kick off the job which updates
+# hosted-chroma's version.
+
+name: Copy Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'k8s/**'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Hosted Chroma Coordinator Release
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
+        script: |
+          const result = await github.rest.actions.createWorkflowDispatch({
+            owner: 'chroma-core',
+            repo: 'hosted-chroma',
+            workflow_id: 'copy-oss-helm.yaml',
+            ref: 'main'
+          })
+          console.log(result)

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -61,4 +61,4 @@ jobs:
       - name: Package Helm chart
         run: helm package chart
       - name: Publish Helm chart
-        run: helm push distributed-chroma-${{ needs.detect-version-change.outputs.version }}.tgz oci://${{ vars.AWS_ECR_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/oss-charts
+        run: helm push distributed-chroma-${{ needs.detect-version-change.outputs.version }}.tgz oci://${{ vars.AWS_ECR_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/charts

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -1,30 +1,64 @@
-# TODO Once distributed chroma is operational, update this to update the
-# OSS helm chart we'll host. For now, just kick off the job which updates
-# hosted-chroma's version.
-
 name: 📦 Release Helm Chart
 
 on:
   push:
-    branches:
-      - main
     paths:
-      - 'k8s/**'
+      - k8s/distributed-chroma/Chart.yaml
   workflow_dispatch:
 
 jobs:
-  release:
+  detect-version-change:
+    name: Detect if version in Chart.yaml was changed
     runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.detect-version-change.outputs.version_changed }}
+      version: ${{ steps.detect-version-change.outputs.version }}
     steps:
-    - name: Trigger Hosted Chroma Coordinator Release
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
-        script: |
-          const result = await github.rest.actions.createWorkflowDispatch({
-            owner: 'chroma-core',
-            repo: 'hosted-chroma',
-            workflow_id: 'copy-oss-helm.yaml',
-            ref: 'main'
-          })
-          console.log(result)
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Detect if version field in Chart.yaml was changed
+        id: detect-version-change
+        shell: bash
+        run: |
+          current=$(git show HEAD:$file | yq ".version")
+          previous=$(git show HEAD^:$file | yq ".version")
+
+          echo "version=$current" >> $GITHUB_OUTPUT
+
+          if [ "$current" != "$previous" ]; then
+            echo "Version field in $file was changed from $previous to $current"
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version field in $file was not changed"
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          file: k8s/distributed-chroma/Chart.yaml
+
+  publish-helm:
+    name: Publish Helm chart
+    needs: detect-version-change
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: us-east-1
+    if: ${{ needs.detect-version-change.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ vars.AWS_ECR_OIDC_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+      - name: Package Helm chart
+        run: helm package chart
+      - name: Publish Helm chart
+        run: helm push distributed-chroma-${{ needs.detect-version-change.outputs.version }}.tgz oci://${{ vars.AWS_ECR_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/oss-charts


### PR DESCRIPTION
## Description of changes

Does what it says on the tin. Automatically publishes to ECR upon chart version change or manual workflow run.

Tested in a sandbox repo & AWS account.

Requires https://github.com/chroma-core/hosted-chroma/pull/691.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
n/a
