### PR TITLE
[BUG]  Instantiate http client for chroma-load tracing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,7 @@ dependencies = [
  "figment",
  "guacamole",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest 0.12.9",
@@ -3914,6 +3915,7 @@ dependencies = [
  "bytes",
  "http 1.1.0",
  "opentelemetry",
+ "reqwest 0.12.9",
 ]
 
 [[package]]
@@ -4714,6 +4716,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3"
 num_cpus = "1.16.0"
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.27", features = ["http-proto"] }
+opentelemetry-http = { version = "0.27", features = ["reqwest"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 parking_lot = { version = "0.12.3", features = ["serde"] }
 prost = "0.13"

--- a/rust/load/Cargo.toml
+++ b/rust/load/Cargo.toml
@@ -19,6 +19,7 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
+opentelemetry-http = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 
 # Unlikely to be used in the workspace.

--- a/rust/load/src/opentelemetry_config.rs
+++ b/rust/load/src/opentelemetry_config.rs
@@ -5,7 +5,7 @@
 
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider;
-use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing_bunyan_formatter::BunyanFormattingLayer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
@@ -71,8 +71,10 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     )]);
 
     // Prepare tracer.
+    let client = reqwest::Client::new();
     let span_exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
+        .with_http_client(client)
         .with_endpoint(otel_endpoint)
         .build()
         .expect("could not build span exporter");
@@ -88,8 +90,10 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     // global::set_tracer_provider(tracer_provider);
 
     // Prepare meter.
+    let client = reqwest::Client::new();
     let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_http()
+        .with_http_client(client)
         .with_endpoint(otel_endpoint)
         .build()
         .expect("could not build metric exporter");


### PR DESCRIPTION
Saying "with_http" isn't enough.  You need to then pass in a client.
