### PR TITLE
[BLD]: invalidate the layer cache for git clone hnswlib when there's a new commit to the repo

### DIFF
--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -3,6 +3,9 @@ FROM rust:1.81.0 AS builder
 ARG RELEASE_MODE=
 
 WORKDIR /
+
+# ADD with an external URL is always run, so this will trigger a cache invalidation (and thus run the below git clone) if the latest commit changes
+ADD "https://api.github.com/repos/chroma-core/hnswlib/commits?per_page=1" hnswlib_commits.json
 RUN git clone https://github.com/chroma-core/hnswlib.git
 
 WORKDIR /chroma/


### PR DESCRIPTION
## Description of changes

Rust image builds are currently failing because an older, cached version of hnswlib is being used.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
