### PR TITLE
[ENH]  Sinusoid and sawtooth load patterns for chroma-load.

### DIFF
--- a/rust/load/src/bin/chroma-load-start.rs
+++ b/rust/load/src/bin/chroma-load-start.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 
 use chroma_load::rest::StartRequest;
-use chroma_load::{humanize_expires, Workload};
+use chroma_load::{humanize_expires, Throughput, Workload};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -18,19 +18,78 @@ struct Args {
     #[arg(long)]
     workload: String,
     #[arg(long)]
-    throughput: f64,
+    constant_throughput: Option<f64>,
+    #[arg(long)]
+    sinusoid_throughput: Option<String>,
+    #[arg(long)]
+    sawtooth_throughput: Option<String>,
+}
+
+impl Args {
+    fn throughput(&self) -> chroma_load::Throughput {
+        let mut count = 0;
+        if self.constant_throughput.is_some() {
+            count += 1;
+        }
+        if self.sinusoid_throughput.is_some() {
+            count += 1;
+        }
+        if self.sawtooth_throughput.is_some() {
+            count += 1;
+        }
+        if count > 1 {
+            eprintln!("Cannot specify multiple throughput types");
+            std::process::exit(1);
+        }
+        if let Some(throughput) = self.constant_throughput {
+            Throughput::Constant(throughput)
+        } else if let Some(throughput) = self.sinusoid_throughput.as_ref() {
+            let mut parts = throughput.split(',');
+            let min = parts.next().expect("sinusoidal throughput must have base");
+            let min: f64 = min.parse().expect("base must be a floating point number");
+            let max = parts.next().expect("sinusoidal throughput must have base");
+            let max: f64 = max.parse().expect("base must be a floating point number");
+            let periodicity = parts
+                .next()
+                .expect("sinusoidal throughput must have period");
+            let periodicity: usize = periodicity.parse().expect("period must be an integer");
+            Throughput::Sinusoidal {
+                min,
+                max,
+                periodicity,
+            }
+        } else if let Some(throughput) = self.sawtooth_throughput.as_ref() {
+            let mut parts = throughput.split(',');
+            let min = parts.next().expect("sinusoidal throughput must have base");
+            let min: f64 = min.parse().expect("base must be a floating point number");
+            let max = parts.next().expect("sinusoidal throughput must have base");
+            let max: f64 = max.parse().expect("base must be a floating point number");
+            let periodicity = parts
+                .next()
+                .expect("sinusoidal throughput must have period");
+            let periodicity: usize = periodicity.parse().expect("period must be an integer");
+            Throughput::Sawtooth {
+                min,
+                max,
+                periodicity,
+            }
+        } else {
+            Throughput::Constant(std::f64::consts::PI)
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
     let client = reqwest::Client::new();
+    let throughput = args.throughput();
     let req = StartRequest {
         name: args.name,
         expires: humanize_expires(&args.expires).unwrap_or(args.expires),
         data_set: args.data_set,
         workload: Workload::ByName(args.workload),
-        throughput: args.throughput,
+        throughput,
     };
     match client
         .post(format!("{}/start", args.host))

--- a/rust/load/src/rest.rs
+++ b/rust/load/src/rest.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-use crate::{Workload, WorkloadSummary};
+use crate::{Throughput, Workload, WorkloadSummary};
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Description {
@@ -33,7 +33,7 @@ pub struct StartRequest {
     pub workload: Workload,
     pub data_set: String,
     pub expires: String,
-    pub throughput: f64,
+    pub throughput: Throughput,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
This PR introduces a "Throughput" type for configurable workload
oscillations.  By setting sinusoid or sawtooth throughputs, you can vary
the workload automatically as a function of its runtime.
