### PR TITLE
[DOC] add bun example to docs

### DIFF
--- a/docs/docs.trychroma.com/pages/getting-started.md
+++ b/docs/docs.trychroma.com/pages/getting-started.md
@@ -48,6 +48,16 @@ pnpm add chromadb chromadb-default-embed # [!code $]
 ```
 
 {% /codetab %}
+{% codetab label="bun" %}
+
+```bash {% codetab=true %}
+bun install chromadb chromadb-default-embed # [!code $]
+
+# If you run into issues when connecting to default_tenant,
+# try using the latest version of Bun (>=1.1.38).
+```
+
+{% /codetab %}
 {% /codetabs %}
 
 Install chroma via `pypi` to easily run the backend server. ([Docker](./deployment/docker) also available)


### PR DESCRIPTION
## Description of changes


I ran into the following error when using Bun 1.1.20:
> error: Could not connect to tenant default_tenant. Are you sure it exists? Underlying error: SyntaxError: Unexpected end of JSON input

![image](https://github.com/user-attachments/assets/8219f2ad-0bc0-4f45-a0d5-3808725700ea)

This error was resolved by upgrading Bun.

This PR adds a Bun example to the docs and includes a suggestion to use the latest version of Bun:

<img width="834" alt="image" src="https://github.com/user-attachments/assets/13acdac2-5882-49a3-98a3-56d3299d8dba">
