### PR TITLE
[BLD] trigger hosted release workflow

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -104,6 +104,30 @@ jobs:
           push: true
           tags: "${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }},${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }},${{ env.GHCR_IMAGE_NAME }}:latest,${{ env.DOCKERHUB_IMAGE_NAME }}:latest"
 
+  release-hosted:
+    name: Release to Chroma Cloud
+    runs-on: ubuntu-latest
+    needs:
+      - release-docker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Trigger Hosted Chroma FE Release
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'chroma-core',
+              repo: 'hosted-chroma',
+              workflow_id: 'deploy-data-plane.yaml',
+              ref: 'main',
+              inputs: {
+                "oss-sha": "${{ github.sha }}",
+              }
+            })
+
   release-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -104,30 +104,6 @@ jobs:
           push: true
           tags: "${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }},${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }},${{ env.GHCR_IMAGE_NAME }}:latest,${{ env.DOCKERHUB_IMAGE_NAME }}:latest"
 
-  release-hosted:
-    name: Release to Chroma Cloud
-    runs-on: ubuntu-latest
-    needs:
-      - release-docker
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Trigger Hosted Chroma FE Release
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
-          script: |
-            const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'chroma-core',
-              repo: 'hosted-chroma',
-              workflow_id: 'deploy-data-plane.yaml',
-              ref: 'main',
-              inputs: {
-                "oss-sha": "${{ github.sha }}",
-              }
-            })
-
   release-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -267,6 +243,37 @@ jobs:
           allowUpdates: true
           removeArtifacts: true
           prerelease: true
+
+  release-hosted:
+    name: Release to Chroma Cloud
+    runs-on: ubuntu-latest
+    needs:
+      - release-github
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Dispatch deploy
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'chroma-core',
+              repo: 'hosted-chroma',
+              workflow_id: 'deploy.yaml',
+              ref: 'main',
+              inputs: {
+                // We intentionally *do not* provide the current commit SHA of chroma-core/chroma here. The workflow we dispatch defaults to the commit tagged with "latest" (which we update above).
+                // If we provided the current commit here, there's a potential race condition:
+                // - Commit history is A -> B
+                // - This CI workflow runs on both commits, but the second commit finishes first
+                // - B is deployed to Chroma Cloud
+                // - This workflow finishes for A and deploys A to Chroma Cloud
+                // Chroma Cloud is now running A, but the last commit was B.
+                "environment": "staging",
+                "planes": "data"
+              }
+            })
 
   release-docs:
     name: Deploy docs to Vercel


### PR DESCRIPTION
## Description of changes

Adds action to trigger deploy of Chroma Cloud after checks pass. After merging, our internal staging deployment of Distributed Chroma will be gated by our CI tests (Rust tests, Python tests, etc).

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a