### PR TITLE
[BLD]: use Depot to build chromadb image

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -68,6 +68,10 @@ jobs:
   release-docker:
     name: Publish to DockerHub and GHCR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     needs:
       - check-tag
       - get-version
@@ -89,20 +93,22 @@ jobs:
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push prerelease Docker image
         if: ${{ needs.check-tag.outputs.tag_matches != 'true' }}
-        uses: docker/build-push-action@v3.2.0
+        uses: depot/build-push-action@v1
         with:
           context: .
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: "${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version}},${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }}"
+          project: ${{ vars.DEPOT_PROJECT_ID }}
       - name: Build and push release Docker image
         if: ${{ needs.check-tag.outputs.tag_matches == 'true' }}
-        uses: docker/build-push-action@v3.2.0
+        uses: depot/build-push-action@v1
         with:
           context: .
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: "${{ env.GHCR_IMAGE_NAME }}:${{ needs.get-version.outputs.version }},${{ env.DOCKERHUB_IMAGE_NAME }}:${{ needs.get-version.outputs.version }},${{ env.GHCR_IMAGE_NAME }}:latest,${{ env.DOCKERHUB_IMAGE_NAME }}:latest"
+          project: ${{ vars.DEPOT_PROJECT_ID }}
 
   release-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## Description of changes

chromadb currently takes ~6m to build. Now that this build is blocking staging deploys, we should make it as fast as possible.

I'll add the var before merging.

## Test plan
*How are these changes tested?*

n/a

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
