### PR TITLE
[BLD] Sync internal log service changes to OSS

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -7,19 +7,11 @@ docker_build(
 )
 
 docker_build(
-  'local:log-service',
+  'local:logservice',
   '.',
   only=['go/'],
   dockerfile='./go/Dockerfile',
-  target='log-service'
-)
-
-docker_build(
-  'local:sysdb-migration',
-  '.',
-  only=['go/'],
-  dockerfile='./go/Dockerfile.migration',
-  target='sysdb-migration'
+  target='logservice'
 )
 
 docker_build(
@@ -36,6 +28,14 @@ docker_build(
   only=['go/', 'idl/'],
   dockerfile='./go/Dockerfile',
   target='sysdb'
+)
+
+docker_build(
+  'local:sysdb-migration',
+  '.',
+  only=['go/'],
+  dockerfile='./go/Dockerfile.migration',
+  target='sysdb-migration'
 )
 
 docker_build(

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,9 +11,8 @@ docker_build(
   '.',
   only=['go/'],
   dockerfile='./go/Dockerfile',
-  target='logservice'
+  target='log-service'
 )
-
 
 docker_build(
   'local:sysdb-migration',

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -10,7 +10,7 @@ ADD ./go/ ./
 ENV GOCACHE=/root/.cache/go-build
 RUN --mount=type=cache,target="/root/.cache/go-build" make
 
-FROM debian:bookworm-slim AS log-service
+FROM debian:bookworm-slim AS logservice
 COPY --from=builder /build-dir/bin/logservice .
 ENV PATH=$PATH:./
 CMD ["./logservice"]

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:bookworm as builder
+FROM golang:bookworm AS builder
 WORKDIR /build-dir
 RUN apt-get update && apt-get install -y make git bash
 
@@ -10,12 +10,12 @@ ADD ./go/ ./
 ENV GOCACHE=/root/.cache/go-build
 RUN --mount=type=cache,target="/root/.cache/go-build" make
 
-FROM debian:bookworm-slim as log
+FROM debian:bookworm-slim AS log-service
 COPY --from=builder /build-dir/bin/logservice .
 ENV PATH=$PATH:./
 CMD ["./logservice"]
 
-FROM debian:bookworm-slim as sysdb
+FROM debian:bookworm-slim AS sysdb
 COPY --from=builder /build-dir/bin/coordinator .
 ENV PATH=$PATH:./
 CMD /bin/bash

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -10,14 +10,12 @@ ADD ./go/ ./
 ENV GOCACHE=/root/.cache/go-build
 RUN --mount=type=cache,target="/root/.cache/go-build" make
 
+FROM debian:bookworm-slim as log
+COPY --from=builder /build-dir/bin/logservice .
+ENV PATH=$PATH:./
+CMD ["./logservice"]
+
 FROM debian:bookworm-slim as sysdb
 COPY --from=builder /build-dir/bin/coordinator .
 ENV PATH=$PATH:./
-
 CMD /bin/bash
-
-
-FROM debian:bookworm-slim as logservice
-WORKDIR /app
-COPY --from=builder /build-dir/bin/logservice .
-CMD ["./logservice"]

--- a/go/Dockerfile.migration
+++ b/go/Dockerfile.migration
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as sysdb-migration
+FROM debian:bookworm-slim AS sysdb-migration
 
 RUN apt update
 RUN apt upgrade -y
@@ -8,6 +8,6 @@ RUN curl -sSf https://atlasgo.sh | sh -s -- --community
 COPY ./go/pkg/sysdb/metastore/db/migrations migrations
 COPY ./go/pkg/sysdb/metastore/db/atlas.hcl atlas.hcl
 
-FROM arigaio/atlas:latest as logservice-migration
+FROM arigaio/atlas:latest AS logservice-migration
 COPY ./go/pkg/log/store/migrations migrations
 COPY ./go/pkg/log/store/atlas.hcl atlas.hcl

--- a/go/cmd/logservice/main.go
+++ b/go/cmd/logservice/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/utils"
 	libs "github.com/chroma-core/chroma/go/shared/libs"
 	"github.com/chroma-core/chroma/go/shared/otel"
+	sharedOtel "github.com/chroma-core/chroma/go/shared/otel"
 	"github.com/pingcap/log"
 	"github.com/rs/zerolog"
 	"go.uber.org/automaxprocs/maxprocs"
@@ -52,7 +53,7 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to listen", zap.Error(err))
 	}
-	s := grpc.NewServer(grpc.UnaryInterceptor(otel.ServerGrpcInterceptor))
+	s := grpc.NewServer(grpc.UnaryInterceptor(sharedOtel.ServerGrpcInterceptor))
 	logservicepb.RegisterLogServiceServer(s, server)
 	log.Info("log service started", zap.String("address", listener.Addr().String()))
 	go leader.AcquireLeaderLock(ctx, func(ctx context.Context) {

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -51,10 +51,11 @@ sysdb:
       memory: '512Mi'
   flags:
 
+
 logService:
   image:
     repository: 'local'
-    tag: 'log-service'
+    tag: 'logservice'
   env:
   - name: OPTL_TRACING_ENDPOINT
     value: 'value: "otel-collector:4317"'
@@ -72,7 +73,6 @@ queryService:
     hostPath: '/local/cache/chroma'
     mountPath: '/cache/'
   replicaCount: 2
-
 
 compactionService:
   image:


### PR DESCRIPTION
## Description of changes

Currently, we build the log service from a `main.go` that lives in our private repository. This `main` package imports code from here in `./go`. Instead of having this weird split world, this syncs the few differences from the private repository (those from the `./go/Dockerfile` and using a "sharedOtel" import for the gRPC service) to here. There is also a change in the private repository to remove all the dead/duplicated code that we no longer need. This other change also updates the build to use this code entirely instead of the `main` package that was defined over there. 


## Test plan
- Manual `docker build` and `docker run`
- `tilt up`

- [ ] ~Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust~ not relevant

## Documentation Changes
- not needed
