### PR TITLE
[ENH]  Metrics-only support.

### DIFF
--- a/rust/load/src/opentelemetry_config.rs
+++ b/rust/load/src/opentelemetry_config.rs
@@ -112,7 +112,7 @@ pub(crate) fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     // Layer for adding our configured tracer.
     // Export everything at this layer. The backend i.e. honeycomb or jaeger will filter at its end.
     let exporter_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer)
-        .with_filter(tracing_subscriber::filter::LevelFilter::TRACE);
+        .with_filter(tracing_subscriber::filter::LevelFilter::ERROR);
     // Layer for printing spans to stdout. Only print INFO logs by default.
     let stdout_layer =
         BunyanFormattingLayer::new(service_name.clone().to_string(), std::io::stdout)


### PR DESCRIPTION
To fend off the possibility of overloading honeycomb budgets, I've
implemented metrics visibility.  Tracing relegated to ERROR and above
via open telemetry and INFO via stdout.
