### PR TITLE
Make opentelemetry dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
   </a>
 </p>
 
-
 ```bash
 pip install chromadb # python client
+pip install chromadb[opentelemetry] # install with opentelemetry dependencies
 # for javascript, npm install chromadb!
 # for client-server mode, chroma run --path /chroma_db_path
 ```
@@ -56,6 +56,7 @@ results = collection.query(
 ```
 
 ## Features
+
 - __Simple__: Fully-typed, fully-tested, fully-documented == happiness
 - __Integrations__: [`🦜️🔗 LangChain`](https://blog.langchain.dev/langchain-chroma/) (python and js), [`🦙 LlamaIndex`](https://twitter.com/atroyn/status/1628557389762007040) and more soon
 - __Dev, Test, Prod__: the same API that runs in your python notebook, scales to your cluster
@@ -65,6 +66,7 @@ results = collection.query(
 ## Use case: ChatGPT for ______
 
 For example, the `"Chat your data"` use case:
+
 1. Add documents to your database. You can pass in your own embeddings, embedding function, or let Chroma embed them for you.
 2. Query relevant documents with natural language.
 3. Compose documents into the context window of an LLM like `GPT3` for additional summarization or analysis.
@@ -79,17 +81,18 @@ What are embeddings?
 - __Technical__: An embedding is the latent-space position of a document at a layer of a deep neural network. For models trained specifically to embed data, this is the last layer.
 - __A small example__: If you search your photos for "famous bridge in San Francisco". By embedding this query and comparing it to the embeddings of your photos and their metadata - it should return photos of the Golden Gate Bridge.
 
-Embeddings databases (also known as **vector databases**) store embeddings and allow you to search by nearest neighbors rather than by substrings like a traditional database. By default, Chroma uses [Sentence Transformers](https://docs.trychroma.com/guides/embeddings#default:-all-minilm-l6-v2) to embed for you but you can also use OpenAI embeddings, Cohere (multilingual) embeddings, or your own.
+Embeddings databases (also known as __vector databases__) store embeddings and allow you to search by nearest neighbors rather than by substrings like a traditional database. By default, Chroma uses [Sentence Transformers](https://docs.trychroma.com/guides/embeddings#default:-all-minilm-l6-v2) to embed for you but you can also use OpenAI embeddings, Cohere (multilingual) embeddings, or your own.
 
 ## Get involved
 
 Chroma is a rapidly developing project. We welcome PR contributors and ideas for how to improve the project.
+
 - [Join the conversation on Discord](https://discord.gg/MMeYNTmh3x) - `#contributing` channel
 - [Review the 🛣️ Roadmap and contribute your ideas](https://docs.trychroma.com/roadmap)
 - [Grab an issue and open a PR](https://github.com/chroma-core/chroma/issues) - [`Good first issue tag`](https://github.com/chroma-core/chroma/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [Read our contributing guide](https://docs.trychroma.com/contributing)
 
-**Release Cadence**
+__Release Cadence__
 We currently release new tagged versions of the `pypi` and `npm` packages on Mondays. Hotfixes go out at any time during the week.
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ dependencies = [
   'posthog >= 2.4.0',
   'typing_extensions >= 4.5.0',
   'onnxruntime >= 1.14.1',
-  'opentelemetry-api>=1.2.0',
-  'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
-  'opentelemetry-instrumentation-fastapi>=0.41b0',
-  'opentelemetry-sdk>=1.2.0',
   'tokenizers >= 0.13.2, <= 0.20.3',
   'pypika >= 0.48.9',
   'tqdm >= 4.65.0',
@@ -44,6 +40,14 @@ dependencies = [
   'orjson>=3.9.12',
   'httpx>=0.27.0',
   'rich>=10.11.0',
+]
+
+[project.optional-dependencies]
+opentelemetry = [
+  'opentelemetry-api>=1.2.0',
+  'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
+  'opentelemetry-instrumentation-fastapi>=0.41b0',
+  'opentelemetry-sdk>=1.2.0',
 ]
 
 [tool.black]


### PR DESCRIPTION
## Description of changes
 
This is just a DRAFT meant to discuss what it would take to provide a workaround for #2571 and any other potential issues with our protobuf files being inconsistent. The primary question we need to answer is:

> Does this provide enough value than the cost it imposes on installing Chroma's dependencies?

In other words, this is imperfect, so is it even worth doing versus making OTEL truly optional in our codebase by doing a huge refactor.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - This makes our `opentelemetry` _dependencies_ optional
   - We are _not_ doing anything magical here to turn off OTEL wholesale in the codebase by excluding these dependencies
   - We are doing this to avoid issues like #2571 where protos are built with incompatible versions external to Chroma
 - New functionality
   - This introduces the need to install OTEL dependencies with `pip install chromadb[opentelemetry]` 

## Test plan
- I tested that I can target the optional dependencies by doing `pip install '.[opentelemetry]'`

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
- README has been updated with a note about installing OTEL dependencies.
