### PR TITLE
[ENH]: stricter release/* & rc/* branch trigger

### DIFF
--- a/.github/workflows/trigger-deploy.yaml
+++ b/.github/workflows/trigger-deploy.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       # main is not included here because it is handled by the release-chromadb.yaml workflow
-      - rc/**
-      - release/**
+      - rc/**-**-**
+      - release/**-**-**
 
 jobs:
   deploy:


### PR DESCRIPTION
## Description of changes

Prevents distributed Chroma workflows from being triggered by release/$version_number.

## Test plan
*How are these changes tested?*

Tested in private repo.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
