### PR TITLE
[BLD]: use lower core count for Python cluster tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: ["depot-ubuntu-22.04-16"]
+        platform: ["depot-ubuntu-22.04-4"]
         test-globs: ["chromadb/test/db/test_system.py",
                    "chromadb/test/api/test_collection.py",
                    "chromadb/test/property/test_collections.py",


### PR DESCRIPTION
## Description of changes

Increases wall time by about 2m for cluster tests, however they're still relatively fast. Say the average cluster test is 8m before this change and 10m after this change. With the minute multipler, the total # of minutes before was 64 and is now 20 (-3.2x).

## Test plan
*How are these changes tested?*

n/a

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a