### PR TITLE
[CHORE]  Snip a log line that's happy-path and too verbose.

### DIFF
--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -211,8 +211,6 @@ func (s *Server) GetCollectionWithSegments(ctx context.Context, req *coordinator
 	}
 
 	res.Segments = segmentpbList
-
-	log.Info("GetCollectionWithSegments succeeded", zap.String("request", req.String()), zap.String("response", res.String()))
 	return res, nil
 }
 


### PR DESCRIPTION
This one log line generates 2kiB of log for each get.  Probably not
worth keeping around right now.
