### PR TITLE
[ENH] Implement rank() for blockfile

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -277,7 +277,7 @@ impl Block {
     /// Finds the partition point of the prefix and key.
     /// Returns the index of the first element that matches the target prefix and key. If no element matches, returns the index at which the target prefix and key could be inserted to maintain sorted order.
     #[inline]
-    fn binary_search_prefix_key<'me, K: ArrowReadableKey<'me>>(
+    pub(crate) fn binary_search_prefix_key<'me, K: ArrowReadableKey<'me>>(
         &'me self,
         prefix: &str,
         key: &K,

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -657,6 +657,54 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         self.root.id
     }
 
+    pub(crate) async fn rank(
+        &'me self,
+        prefix: &'me str,
+        key: K,
+    ) -> Result<usize, Box<dyn ChromaError>> {
+        let mut rank = 0;
+
+        // This should be sorted by offset id ranges
+        let block_ids = self
+            .root
+            .sparse_index
+            .get_block_ids_range(..=prefix, ..=key.clone());
+
+        // The block that may contain the prefix-key pair
+        if let Some(last_id) = block_ids.last() {
+            if self.root.version >= Version::V1_1 {
+                rank += self
+                    .root
+                    .sparse_index
+                    .data
+                    .forward
+                    .values()
+                    .take(block_ids.len() - 1)
+                    .map(|meta| meta.count)
+                    .sum::<u32>() as usize;
+            } else {
+                self.load_blocks(&block_ids).await;
+                for block_id in block_ids.iter().take(block_ids.len() - 1) {
+                    let block =
+                        self.get_block(*block_id)
+                            .await
+                            .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?
+                            .ok_or(Box::new(ArrowBlockfileError::BlockNotFound)
+                                as Box<dyn ChromaError>)?;
+                    rank += block.len();
+                }
+            }
+            let last_block = self
+                .get_block(*last_id)
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?
+                .ok_or(Box::new(ArrowBlockfileError::BlockNotFound) as Box<dyn ChromaError>)?;
+            rank += last_block.binary_search_prefix_key(prefix, &key);
+        }
+
+        Ok(rank)
+    }
+
     /// Check if the blockfile is valid.
     /// Validates that the sparse index is valid and that no block exceeds the max block size.
     pub async fn is_valid(&self) -> bool {
@@ -1547,6 +1595,45 @@ mod tests {
             assert_eq!(res.0, "key");
             assert_eq!(res.1, expected_key);
             assert_eq!(res.2, expected_value);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rank() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let block_cache = new_cache_for_test();
+        let sparse_index_cache = new_cache_for_test();
+        let blockfile_provider = ArrowBlockfileProvider::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            block_cache,
+            sparse_index_cache,
+        );
+        let writer = blockfile_provider
+            .write::<&str, Vec<u32>>(BlockfileWriterOptions::default())
+            .await
+            .unwrap();
+        let id_1 = writer.id();
+
+        let n = 1200;
+        for i in 0..n {
+            let key = format!("{:04}", i);
+            let value = vec![i];
+            writer.set("key", key.as_str(), value).await.unwrap();
+        }
+        let flusher = writer.commit::<&str, Vec<u32>>().await.unwrap();
+        flusher.flush::<&str, Vec<u32>>().await.unwrap();
+
+        let reader = blockfile_provider
+            .read::<&str, &[u32]>(&id_1)
+            .await
+            .unwrap();
+
+        for i in 0..n {
+            let rank_key = format!("{:04}", i);
+            let rank = reader.rank("key", &rank_key).await.unwrap();
+            assert_eq!(rank, i as usize);
         }
     }
 

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -657,6 +657,8 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         self.root.id
     }
 
+    /// Returns the number of elements strictly less than the given prefix-key pair in the blockfile
+    /// In other words, the rank is the position where the given prefix-key pair can be inserted while maintaining the order of the blockfile
     pub(crate) async fn rank(
         &'me self,
         prefix: &'me str,

--- a/rust/blockstore/src/memory/storage.rs
+++ b/rust/blockstore/src/memory/storage.rs
@@ -37,6 +37,8 @@ pub trait Readable<'referred_data>: Sized {
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>>;
 
     fn contains(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> bool;
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize;
 }
 
 impl Writeable for String {
@@ -125,6 +127,18 @@ impl<'referred_data> Readable<'referred_data> for &'referred_data str {
                 key,
             })
             .is_some()
+    }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .string_value_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
     }
 }
 
@@ -216,6 +230,18 @@ impl<'referred_data> Readable<'referred_data> for &'referred_data [u32] {
             })
             .is_some()
     }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .uint32_array_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
+    }
 }
 
 impl Writeable for RoaringBitmap {
@@ -301,6 +327,18 @@ impl<'referred_data> Readable<'referred_data> for RoaringBitmap {
             })
             .is_some()
     }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .roaring_bitmap_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
+    }
 }
 
 impl Writeable for f32 {
@@ -377,6 +415,18 @@ impl<'referred_data> Readable<'referred_data> for f32 {
             })
             .is_some()
     }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .f32_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
+    }
 }
 
 impl Writeable for u32 {
@@ -452,6 +502,18 @@ impl<'referred_data> Readable<'referred_data> for u32 {
                 key,
             })
             .is_some()
+    }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .u32_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
     }
 }
 
@@ -532,6 +594,18 @@ impl<'referred_data> Readable<'referred_data> for bool {
                 key,
             })
             .is_some()
+    }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .bool_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
     }
 }
 
@@ -678,6 +752,18 @@ impl<'referred_data> Readable<'referred_data> for DataRecord<'referred_data> {
             })
             .is_some()
     }
+
+    fn rank(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> usize {
+        storage
+            .data_record_id_storage
+            .range(
+                ..CompositeKey {
+                    prefix: prefix.to_string(),
+                    key,
+                },
+            )
+            .count()
+    }
 }
 
 impl<'referred_data> Readable<'referred_data> for SpannPostingList<'referred_data> {
@@ -709,6 +795,10 @@ impl<'referred_data> Readable<'referred_data> for SpannPostingList<'referred_dat
     }
 
     fn contains(_: &str, _: KeyWrapper, _: &'referred_data Storage) -> bool {
+        todo!()
+    }
+
+    fn rank(_: &str, _: KeyWrapper, _: &'referred_data Storage) -> usize {
         todo!()
     }
 }

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -131,4 +131,15 @@ impl<
             }
         }
     }
+
+    pub async fn rank(
+        &'referred_data self,
+        prefix: &'referred_data str,
+        key: K,
+    ) -> Result<usize, Box<dyn ChromaError>> {
+        match self {
+            BlockfileReader::MemoryBlockfileReader(reader) => Ok(reader.rank(prefix, key)),
+            BlockfileReader::ArrowBlockfileReader(reader) => reader.rank(prefix, key).await,
+        }
+    }
 }

--- a/rust/worker/src/execution/operators/limit.rs
+++ b/rust/worker/src/execution/operators/limit.rs
@@ -3,6 +3,7 @@ use std::{cmp::Ordering, num::TryFromIntError, sync::atomic};
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::{Chunk, LogRecord, MaterializedLogOperation, Segment, SignedRoaringBitmap};
+use futures::StreamExt;
 use roaring::RoaringBitmap;
 use thiserror::Error;
 use tonic::async_trait;
@@ -141,26 +142,17 @@ impl<'me> SeekScanner<'me> {
 
     // Seek the start in the log and record segment, then scan for the specified number of offset ids
     async fn seek_and_scan(&self, skip: u64, mut fetch: u64) -> Result<RoaringBitmap, LimitError> {
-        let record_count = self.record_segment.count().await?;
         let starting_offset = self.seek_starting_offset(skip).await?;
         let mut log_index = self.log_offset_ids.rank(starting_offset)
             - self.log_offset_ids.contains(starting_offset) as u64;
-        let mut record_index = self
-            .record_segment
-            .get_offset_id_rank(starting_offset)
-            .await?;
+        let mut record_stream = self.record_segment.get_offset_stream(starting_offset..);
         let mut merged_result = Vec::new();
 
         while fetch > 0 {
             let log_offset_id = self.log_offset_ids.select(u32::try_from(log_index)?);
-            let record_offset_id = (record_index < record_count).then_some(
-                self.record_segment
-                    .get_offset_id_at_index(record_index)
-                    .await?,
-            );
+            let record_offset_id = record_stream.next().await.transpose()?;
             match (log_offset_id, record_offset_id) {
                 (_, Some(oid)) if self.mask.contains(oid) => {
-                    record_index += 1;
                     continue;
                 }
                 (Some(log_oid), Some(record_oid)) => {
@@ -169,12 +161,10 @@ impl<'me> SeekScanner<'me> {
                         log_index += 1;
                     } else {
                         merged_result.push(record_oid);
-                        record_index += 1;
                     }
                 }
                 (None, Some(oid)) => {
                     merged_result.push(oid);
-                    record_index += 1;
                 }
                 (Some(oid), None) => {
                     merged_result.push(oid);

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -11,9 +11,10 @@ use chroma_index::fulltext::types::FullTextIndexError;
 use chroma_types::{
     Chunk, DataRecord, MaterializedLogOperation, Segment, SegmentType, SegmentUuid,
 };
-use std::cmp::Ordering;
+use futures::{Stream, StreamExt};
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
+use std::ops::RangeBounds;
 use std::sync::atomic::{self, AtomicU32};
 use std::sync::Arc;
 use thiserror::Error;
@@ -831,50 +832,19 @@ impl RecordSegmentReader<'_> {
     /// embedding id
     #[allow(dead_code)]
     pub(crate) async fn get_all_data(&self) -> Result<Vec<DataRecord>, Box<dyn ChromaError>> {
-        let mut data = Vec::new();
-        let max_size = self.user_id_to_id.count().await?;
-        for i in 0..max_size {
-            let res = self.user_id_to_id.get_at_index(i).await;
-            match res {
-                Ok((_, _, offset_id)) => {
-                    if let Some(data_record) = self.id_to_data.get("", offset_id).await? {
-                        data.push(data_record);
-                    } else {
-                        return Err(
-                            Box::new(RecordSegmentReaderCreationError::DataRecordNotFound(
-                                offset_id,
-                            )) as _,
-                        );
-                    }
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "[GetAllData] Error getting data record for index {:?}: {:?}",
-                        i,
-                        e
-                    );
-                    return Err(e);
-                }
-            }
-        }
-        Ok(data)
+        self.id_to_data
+            .get_range(.., ..)
+            .await
+            .map(|vec| vec.into_iter().map(|(_, data)| data).collect())
     }
 
-    pub(crate) async fn get_offset_id_at_index(
-        &self,
-        index: usize,
-    ) -> Result<u32, Box<dyn ChromaError>> {
-        match self.id_to_user_id.get_at_index(index).await {
-            Ok((_, oid, _)) => Ok(oid),
-            Err(e) => {
-                tracing::error!(
-                    "[GetAllData] Error getting offset id for index {}: {}",
-                    index,
-                    e
-                );
-                Err(e)
-            }
-        }
+    pub(crate) fn get_offset_stream<'me>(
+        &'me self,
+        offset_range: impl RangeBounds<u32> + Clone + Send + 'me,
+    ) -> impl Stream<Item = Result<u32, Box<dyn ChromaError>>> + 'me {
+        self.id_to_user_id
+            .get_range_stream(.., offset_range)
+            .map(|res| res.map(|(offset_id, _)| offset_id))
     }
 
     // Find the rank of the given offset id in the record segment
@@ -883,27 +853,7 @@ impl RecordSegmentReader<'_> {
         &self,
         target_oid: u32,
     ) -> Result<usize, Box<dyn ChromaError>> {
-        let mut size = self.count().await?;
-        if size == 0 {
-            return Ok(0);
-        }
-        let mut base = 0;
-        while size > 1 {
-            let half = size / 2;
-            let mid = base + half;
-
-            let cmp = self.get_offset_id_at_index(mid).await?.cmp(&target_oid);
-            base = if cmp == Ordering::Greater { base } else { mid };
-            size -= half;
-        }
-
-        Ok(
-            match self.get_offset_id_at_index(base).await?.cmp(&target_oid) {
-                Ordering::Equal => base,
-                Ordering::Less => base + 1,
-                Ordering::Greater => base,
-            },
-        )
+        self.id_to_user_id.rank("", target_oid).await
     }
 
     pub(crate) async fn count(&self) -> Result<usize, Box<dyn ChromaError>> {

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -828,8 +828,7 @@ impl RecordSegmentReader<'_> {
         self.id_to_data.contains("", offset_id).await
     }
 
-    /// Returns all data in the record segment, sorted by
-    /// embedding id
+    /// Returns all data in the record segment, sorted by their offset ids
     #[allow(dead_code)]
     pub(crate) async fn get_all_data(&self) -> Result<Vec<DataRecord>, Box<dyn ChromaError>> {
         self.id_to_data
@@ -838,6 +837,7 @@ impl RecordSegmentReader<'_> {
             .map(|vec| vec.into_iter().map(|(_, data)| data).collect())
     }
 
+    /// Get a stream of offset ids from the smallest to the largest in the given range
     pub(crate) fn get_offset_stream<'me>(
         &'me self,
         offset_range: impl RangeBounds<u32> + Clone + Send + 'me,
@@ -847,8 +847,9 @@ impl RecordSegmentReader<'_> {
             .map(|res| res.map(|(offset_id, _)| offset_id))
     }
 
-    // Find the rank of the given offset id in the record segment
-    // The implemention is based on std binary search
+    /// Find the rank of the given offset id in the record segment
+    /// The rank of an offset id is the number of offset ids strictly smaller than it
+    /// In other words, it is the position where the given offset id can be inserted without breaking the order
     pub(crate) async fn get_offset_id_rank(
         &self,
         target_oid: u32,

--- a/rust/worker/src/segment/record_segment.rs
+++ b/rust/worker/src/segment/record_segment.rs
@@ -833,7 +833,7 @@ impl RecordSegmentReader<'_> {
     #[allow(dead_code)]
     pub(crate) async fn get_all_data(&self) -> Result<Vec<DataRecord>, Box<dyn ChromaError>> {
         self.id_to_data
-            .get_range(.., ..)
+            .get_range(""..="", ..)
             .await
             .map(|vec| vec.into_iter().map(|(_, data)| data).collect())
     }
@@ -843,7 +843,7 @@ impl RecordSegmentReader<'_> {
         offset_range: impl RangeBounds<u32> + Clone + Send + 'me,
     ) -> impl Stream<Item = Result<u32, Box<dyn ChromaError>>> + 'me {
         self.id_to_user_id
-            .get_range_stream(.., offset_range)
+            .get_range_stream(""..="", offset_range)
             .map(|res| res.map(|(offset_id, _)| offset_id))
     }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - N/A
 - New functionality
   - Implement `rank(prefix, key)` method for blockfile, which calculates the number of elements in the blockfile that is strictly less than the given prefix-key pair. In otherword, the given prefix-key pair can be inserted at its rank without breaking the order of the blockfile.
   - Use the `rank(prefix, key)` method to replace `get_at_index(index)` in `LimitOperator` and `RecordSegmentReader`.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
