### PR TITLE
[CLN] Deprecate blockfile get_at_index()

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -418,31 +418,6 @@ impl Block {
         })
     }
 
-    /// Get all the values for a given prefix in the block where the key is between the given keys
-    /// ### Notes
-    /// - Returns a tuple of (prefix, key, value)
-    /// - Returns None if the requested index is out of bounds
-    /// ### Panics
-    /// - If the underlying data types are not the same as the types specified in the function signature
-    pub fn get_at_index<'me, K: ArrowReadableKey<'me>, V: ArrowReadableValue<'me>>(
-        &'me self,
-        index: usize,
-    ) -> Option<(&'me str, K, V)> {
-        if index >= self.data.num_rows() {
-            return None;
-        }
-        let prefix_arr = self
-            .data
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let prefix = prefix_arr.value(index);
-        let key = K::get(self.data.column(1), index);
-        let value = V::get(self.data.column(2), index);
-        Some((prefix, key, value))
-    }
-
     /*
         ===== Block Metadata =====
     */

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -311,6 +311,8 @@ impl SparseIndexReader {
     }
 
     /// Get the number of keys in the sparse index
+    /// Used in unit test
+    #[allow(dead_code)]
     pub(super) fn len(&self) -> usize {
         self.data.forward.len()
     }

--- a/rust/blockstore/src/memory/reader_writer.rs
+++ b/rust/blockstore/src/memory/reader_writer.rs
@@ -123,18 +123,6 @@ impl<
             .map(|(key, value)| (K::try_from(&key.key).unwrap(), value)))
     }
 
-    pub(crate) fn get_at_index(
-        &'storage self,
-        index: usize,
-    ) -> Result<(&'storage str, K, V), Box<dyn ChromaError>> {
-        let res = V::get_at_index(&self.storage, index);
-        let (key, value) = match res {
-            Some((key, value)) => (key, value),
-            None => return Err(Box::new(BlockfileError::NotFoundError)),
-        };
-        Ok((key.prefix.as_str(), K::try_from(&key.key).unwrap(), value))
-    }
-
     pub(crate) fn count(&self) -> Result<usize, Box<dyn ChromaError>> {
         V::count(&self.storage)
     }
@@ -861,33 +849,6 @@ mod tests {
 
         let key_1 = reader.get("prefix", "key1");
         assert!(matches!(key_1, Ok(None)));
-    }
-
-    #[tokio::test]
-    async fn test_get_by_index() {
-        let storage_manager = StorageManager::new();
-        let writer = MemoryBlockfileWriter::new(storage_manager.clone());
-        let id = writer.id;
-
-        let n = 2000;
-        for i in 0..n {
-            let key = format!("key{:04}", i);
-            let value = format!("value{:04}", i);
-            let _ = writer.set("prefix", key.as_str(), value.to_string());
-        }
-        let _ = writer.commit();
-
-        let reader: MemoryBlockfileReader<&str, &str> =
-            MemoryBlockfileReader::open(id, storage_manager.clone());
-        for i in 0..n {
-            let expected_key = format!("key{:04}", i);
-            let expected_value = format!("value{:04}", i);
-            let (prefix, key, value) =
-                MemoryBlockfileReader::<&str, &str>::get_at_index(&reader, i).unwrap();
-            assert_eq!(prefix, "prefix");
-            assert_eq!(key, expected_key.as_str());
-            assert_eq!(value, expected_value.as_str());
-        }
     }
 
     #[tokio::test]

--- a/rust/blockstore/src/memory/storage.rs
+++ b/rust/blockstore/src/memory/storage.rs
@@ -29,11 +29,6 @@ pub trait Readable<'referred_data>: Sized {
         PrefixRange: std::ops::RangeBounds<&'prefix str>,
         KeyRange: std::ops::RangeBounds<KeyWrapper>;
 
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)>;
-
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>>;
 
     fn contains(prefix: &str, key: KeyWrapper, storage: &'referred_data Storage) -> bool;
@@ -102,17 +97,6 @@ impl<'referred_data> Readable<'referred_data> for &'referred_data str {
             })
             .map(|(k, v)| (k, v.as_str()))
             .collect()
-    }
-
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        storage
-            .string_value_storage
-            .iter()
-            .nth(index)
-            .map(|(k, v)| (k, v.as_str()))
     }
 
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
@@ -206,17 +190,6 @@ impl<'referred_data> Readable<'referred_data> for &'referred_data [u32] {
             .collect()
     }
 
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        storage
-            .uint32_array_storage
-            .iter()
-            .nth(index)
-            .map(|(k, v)| (k, v.as_slice()))
-    }
-
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
         Ok(storage.uint32_array_storage.iter().len())
     }
@@ -303,17 +276,6 @@ impl<'referred_data> Readable<'referred_data> for RoaringBitmap {
             .collect()
     }
 
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        storage
-            .roaring_bitmap_storage
-            .iter()
-            .nth(index)
-            .map(|(k, v)| (k, v.clone()))
-    }
-
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
         Ok(storage.roaring_bitmap_storage.iter().len())
     }
@@ -395,13 +357,6 @@ impl<'referred_data> Readable<'referred_data> for f32 {
             .collect()
     }
 
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        storage.f32_storage.iter().nth(index).map(|(k, v)| (k, *v))
-    }
-
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
         Ok(storage.f32_storage.iter().len())
     }
@@ -481,13 +436,6 @@ impl<'referred_data> Readable<'referred_data> for u32 {
             })
             .map(|(k, v)| (k, *v))
             .collect()
-    }
-
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        storage.u32_storage.iter().nth(index).map(|(k, v)| (k, *v))
     }
 
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
@@ -573,13 +521,6 @@ impl<'referred_data> Readable<'referred_data> for bool {
             })
             .map(|(k, v)| (k, *v))
             .collect()
-    }
-
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        storage.bool_storage.iter().nth(index).map(|(k, v)| (k, *v))
     }
 
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
@@ -721,24 +662,6 @@ impl<'referred_data> Readable<'referred_data> for DataRecord<'referred_data> {
             .collect()
     }
 
-    fn get_at_index(
-        storage: &'referred_data Storage,
-        index: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
-        let (k, v) = storage.data_record_id_storage.iter().nth(index).unwrap();
-        let embedding = storage.data_record_embedding_storage.get(k).unwrap();
-        let id = v;
-        Some((
-            k,
-            DataRecord {
-                id,
-                embedding,
-                metadata: None,
-                document: None,
-            },
-        ))
-    }
-
     fn count(storage: &Storage) -> Result<usize, Box<dyn ChromaError>> {
         Ok(storage.data_record_id_storage.iter().len())
     }
@@ -780,13 +703,6 @@ impl<'referred_data> Readable<'referred_data> for SpannPostingList<'referred_dat
         PrefixRange: std::ops::RangeBounds<&'prefix str>,
         KeyRange: std::ops::RangeBounds<KeyWrapper>,
     {
-        todo!()
-    }
-
-    fn get_at_index(
-        _: &'referred_data Storage,
-        _: usize,
-    ) -> Option<(&'referred_data CompositeKey, Self)> {
         todo!()
     }
 

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -106,16 +106,6 @@ impl<
         }
     }
 
-    pub async fn get_at_index(
-        &'referred_data self,
-        index: usize,
-    ) -> Result<(&'referred_data str, K, V), Box<dyn ChromaError>> {
-        match self {
-            BlockfileReader::MemoryBlockfileReader(reader) => reader.get_at_index(index),
-            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_at_index(index).await,
-        }
-    }
-
     pub fn id(&self) -> uuid::Uuid {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader.id(),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Deprecate blockfile `get_at_index` method
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
