### PR TITLE
[CHORE] suppress filter too much health check from ef

### DIFF
--- a/chromadb/test/ef/test_default_ef.py
+++ b/chromadb/test/ef/test_default_ef.py
@@ -41,6 +41,9 @@ def test_unavailable_provider_multiple(providers: List[str]) -> None:
         ),
         min_size=1,
         unique_by=unique_by,
+        suppress_health_check=[
+            hypothesis.HealthCheck.filter_too_much
+        ],
     )
 )
 def test_available_provider(providers: List[str]) -> None:

--- a/chromadb/test/ef/test_default_ef.py
+++ b/chromadb/test/ef/test_default_ef.py
@@ -2,6 +2,7 @@ import shutil
 import os
 from typing import List, Hashable
 
+import hypothesis
 import hypothesis.strategies as st
 import onnxruntime
 import pytest


### PR DESCRIPTION
This test flaked because it took too many tries to generate "good" data.  Suppress that warning, but not others.
