### PR TITLE
[BUG]: Add Segment Caches thread-safety

### DIFF
--- a/chromadb/segment/impl/manager/cache/cache.py
+++ b/chromadb/segment/impl/manager/cache/cache.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 from typing import Any, Callable
 from chromadb.types import Segment
@@ -27,22 +28,27 @@ class SegmentCache(ABC):
 class BasicCache(SegmentCache):
     def __init__(self):
         self.cache: Dict[uuid.UUID, Segment] = {}
+        self.lock = threading.RLock()
 
     @override
     def get(self, key: uuid.UUID) -> Optional[Segment]:
-        return self.cache.get(key)
+        with self.lock:
+            return self.cache.get(key)
 
     @override
     def pop(self, key: uuid.UUID) -> Optional[Segment]:
-        return self.cache.pop(key, None)
+        with self.lock:
+            return self.cache.pop(key, None)
 
     @override
     def set(self, key: uuid.UUID, value: Segment) -> None:
-        self.cache[key] = value
+        with self.lock:
+            self.cache[key] = value
 
     @override
     def reset(self) -> None:
-        self.cache = {}
+        with self.lock:
+            self.cache = {}
 
 
 class SegmentLRUCache(BasicCache):
@@ -60,6 +66,7 @@ class SegmentLRUCache(BasicCache):
         self.cache: Dict[uuid.UUID, Segment] = {}
         self.history = []
         self.callback = callback
+        self.lock = threading.RLock()
 
     def _upsert_key(self, key: uuid.UUID):
         if key in self.history:
@@ -70,39 +77,43 @@ class SegmentLRUCache(BasicCache):
 
     @override
     def get(self, key: uuid.UUID) -> Optional[Segment]:
-        self._upsert_key(key)
-        if key in self.cache:
-            return self.cache[key]
-        else:
-            return None
+        with self.lock:
+            self._upsert_key(key)
+            if key in self.cache:
+                return self.cache[key]
+            else:
+                return None
 
     @override
     def pop(self, key: uuid.UUID) -> Optional[Segment]:
-        if key in self.history:
-            self.history.remove(key)
-        return self.cache.pop(key, None)
+        with self.lock:
+            if key in self.history:
+                self.history.remove(key)
+            return self.cache.pop(key, None)
 
     @override
     def set(self, key: uuid.UUID, value: Segment) -> None:
-        if key in self.cache:
-            return
-        item_size = self.size_func(key)
-        key_sizes = {key: self.size_func(key) for key in self.cache}
-        total_size = sum(key_sizes.values())
-        index = 0
-        # Evict items if capacity is exceeded
-        while total_size + item_size > self.capacity and len(self.history) > index:
-            key_delete = self.history[index]
-            if key_delete in self.cache:
-                self.callback(key_delete, self.cache[key_delete])
-                del self.cache[key_delete]
-                total_size -= key_sizes[key_delete]
-            index += 1
+        with self.lock:
+            if key in self.cache:
+                return
+            item_size = self.size_func(key)
+            key_sizes = {key: self.size_func(key) for key in self.cache}
+            total_size = sum(key_sizes.values())
+            index = 0
+            # Evict items if capacity is exceeded
+            while total_size + item_size > self.capacity and len(self.history) > index:
+                key_delete = self.history[index]
+                if key_delete in self.cache:
+                    self.callback(key_delete, self.cache[key_delete])
+                    del self.cache[key_delete]
+                    total_size -= key_sizes[key_delete]
+                index += 1
 
-        self.cache[key] = value
-        self._upsert_key(key)
+            self.cache[key] = value
+            self._upsert_key(key)
 
     @override
     def reset(self):
-        self.cache = {}
-        self.history = []
+        with self.lock:
+            self.cache = {}
+            self.history = []

--- a/chromadb/test/cache/test_cache.py
+++ b/chromadb/test/cache/test_cache.py
@@ -1,0 +1,167 @@
+import threading
+import time
+from time import sleep
+
+import numpy as np
+import uuid
+from typing import Dict, Any, Optional
+from concurrent.futures import ThreadPoolExecutor
+import hypothesis.strategies as st
+from hypothesis.stateful import (
+    RuleBasedStateMachine,
+    Bundle,
+    rule,
+    run_state_machine_as_test,
+    consumes,
+    MultipleResults,
+    multiple,
+)
+from hypothesis import given, settings
+
+from chromadb.segment.impl.manager.cache.cache import SegmentLRUCache, SegmentCache
+from chromadb.types import Segment, SegmentScope
+
+
+class LRUCacheStateMachine(RuleBasedStateMachine):
+    _model: Dict[uuid.UUID, Segment]
+    collection_keys = Bundle("collection_keys")
+
+    def __init__(self, capacity: int):
+        super().__init__()
+        self.evicted_items = []
+        self._cache = SegmentLRUCache(
+            capacity=capacity,
+            size_func=lambda _: 10,
+            callback=lambda k, v: (self.evicted_items.append(k), self._model.pop(k)),
+        )
+        self._model = {}
+        self._capacity = capacity
+
+    @rule(collection_id=collection_keys)
+    def test_get(self, collection_id) -> None:
+        if collection_id not in self._model:
+            return
+        expected = self._model.get(collection_id)
+        assert self._cache.get(collection_id) == expected
+
+    @rule(collection_id=consumes(collection_keys))
+    def test_pop(self, collection_id) -> None:
+        if collection_id not in self._model:
+            return
+        expected = self._model.pop(collection_id)
+        assert self._cache.pop(collection_id) == expected
+
+    @rule(target=collection_keys)
+    def test_set(self) -> MultipleResults[uuid.UUID]:
+        segment = new_segment()
+        collection_id = segment["collection"]
+        self._model[collection_id] = segment
+        self._cache.set(collection_id, segment)
+        assert self._cache.get(collection_id) == segment
+        assert len(self._cache.cache) <= self._capacity
+        if self.evicted_items:
+            last_evicted = self.evicted_items[-1]
+            assert last_evicted not in self._cache.cache
+        return multiple(collection_id)
+
+    def teardown(self):
+        self._cache.reset()
+        self._model.clear()
+
+
+@given(capacity=st.integers(min_value=10, max_value=1000))
+@settings(max_examples=20)
+def test_caches(capacity: int) -> None:
+    run_state_machine_as_test(lambda: LRUCacheStateMachine(capacity=capacity))  # type: ignore
+
+
+def new_segment(collection_id: Optional[uuid.UUID] = None) -> Segment:
+    if collection_id is None:
+        collection_id = uuid.uuid4()
+    return Segment(
+        id=uuid.uuid4(),
+        type="test",
+        scope=SegmentScope.VECTOR,
+        collection=collection_id,
+        metadata=None,
+        file_paths={},
+    )
+
+
+class CacheSetup:
+    def __init__(
+        self,
+        cache: SegmentCache,
+        iterations: Optional[int] = 1000,
+        num_threads: Optional[int] = 50,
+    ):
+        self.cache: SegmentCache = cache
+        self.iterations = iterations
+        self.num_threads = num_threads
+        self.metrics: Dict[str, Any] = {
+            "errors": [],
+            "time_to_first_error": None,
+            "error_timings": [],
+        }
+        self.lock = threading.Lock()
+
+
+def _get_segment_disk_size(_: uuid.UUID) -> int:
+    return np.random.randint(1, 10)
+
+
+def callback_cache_evict(_: Segment) -> None:
+    pass
+
+
+@given(
+    capacity=st.integers(min_value=1, max_value=1000),
+    num_threads=st.integers(min_value=1, max_value=40),
+    iterations=st.integers(min_value=1, max_value=800),
+)
+@settings(max_examples=20)
+def test_thread_safety(capacity: int, num_threads: int, iterations: int) -> None:
+    """Test that demonstrates thread safety issues in the LRU cache"""
+
+    cache_setup = CacheSetup(
+        SegmentLRUCache(
+            capacity=capacity,
+            callback=lambda k, v: callback_cache_evict(v),
+            size_func=lambda k: _get_segment_disk_size(k),
+        ),
+        iterations=iterations,
+        num_threads=num_threads,
+    )
+
+    def worker():
+        """Worker that performs multiple cache operations"""
+        _iterations = 0
+        start_time = time.perf_counter()
+        try:
+            while _iterations <= cache_setup.iterations:
+                _iterations += 1
+                cache_keys = list(cache_setup.cache.cache.keys())
+                if np.random.uniform(0, 1) < 0.5 and len(cache_keys) > 0:
+                    cache_setup.cache.get(np.random.choice(cache_keys))
+                else:
+                    key = uuid.uuid4()
+                    segment = new_segment(key)
+                    cache_setup.cache.set(key, segment)
+                sleep(np.random.uniform(0, 0.01))
+                if np.random.uniform(0, 1) < 0.3 and len(cache_keys) > 0:
+                    cache_setup.cache.get(np.random.choice(cache_keys))
+                if np.random.uniform(0, 1) < 0.05:
+                    cache_setup.cache.reset()
+        except Exception as e:
+            with cache_setup.lock:
+                cache_setup.metrics["errors"].append(e)
+                time_to_error = time.perf_counter() - start_time
+                cache_setup.metrics["error_timings"].append(time_to_error)
+                if cache_setup.metrics["time_to_first_error"] is None:
+                    cache_setup.metrics["time_to_first_error"] = time_to_error
+
+    with ThreadPoolExecutor(max_workers=cache_setup.num_threads) as executor:
+        for _ in range(cache_setup.num_threads):
+            executor.submit(worker)
+    print(cache_setup.metrics)
+    assert len(cache_setup.metrics["errors"]) == 0, "Thread safety issues found"


### PR DESCRIPTION
## Description of changes

Closes #3334

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fixes the lack of thread-safety of Basic and LRU segment caches by adding RLocks.
   - Add tests to verify the thread-safety
   - Implement simple state-machine property test to verify the LRU cache implementation

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
