### PR TITLE
[BUG]: Local segment manager memory leak fix

### DIFF
--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -97,7 +97,7 @@ class LocalSegmentManager(SegmentManager):
                 // PersistentLocalHnswSegment.get_file_handle_count()
             )
             self._vector_instances_file_handle_cache = LRUCache(
-                segment_limit, callback=lambda _, v: v.close_persistent_index()
+                segment_limit, callback=lambda _, v: v.stop()
             )
 
     @trace_method(
@@ -153,6 +153,7 @@ class LocalSegmentManager(SegmentManager):
     @override
     def delete_segments(self, collection_id: UUID) -> Sequence[UUID]:
         segments = self._sysdb.get_segments(collection=collection_id)
+        self._vector_instances_file_handle_cache.evict(collection_id)
         for segment in segments:
             if segment["id"] in self._instances:
                 if segment["type"] == SegmentType.HNSW_LOCAL_PERSISTED.value:

--- a/chromadb/utils/lru_cache.py
+++ b/chromadb/utils/lru_cache.py
@@ -1,6 +1,6 @@
+import threading
 from collections import OrderedDict
 from typing import Any, Callable, Generic, Optional, TypeVar
-
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -14,19 +14,32 @@ class LRUCache(Generic[K, V]):
         self.capacity = capacity
         self.cache: OrderedDict[K, V] = OrderedDict()
         self.callback = callback
+        self.lock = threading.Lock()
+
 
     def get(self, key: K) -> Optional[V]:
-        if key not in self.cache:
-            return None
-        value = self.cache.pop(key)
-        self.cache[key] = value
-        return value
+        with self.lock:
+            if key not in self.cache:
+                return None
+            value = self.cache.pop(key)
+            self.cache[key] = value
+            return value
+
 
     def set(self, key: K, value: V) -> None:
-        if key in self.cache:
-            self.cache.pop(key)
-        elif len(self.cache) == self.capacity:
-            evicted_key, evicted_value = self.cache.popitem(last=False)
-            if self.callback:
-                self.callback(evicted_key, evicted_value)
-        self.cache[key] = value
+        with self.lock:
+            if key in self.cache:
+                self.cache.pop(key)
+            elif len(self.cache) == self.capacity:
+                evicted_key, evicted_value = self.cache.popitem(last=False)
+                if self.callback:
+                    self.callback(evicted_key, evicted_value)
+            self.cache[key] = value
+
+
+    def evict(self, key: K) -> None:
+        with self.lock:
+            if key in self.cache:
+                value = self.cache.pop(key)
+                if self.callback:
+                    self.callback(key, value)


### PR DESCRIPTION
## Description of changes

Closes #3336

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fixes the memory leak issue by replacing `close_persistent_index` with `close` which also unsubscribes the segment from Embeddings Queue
   - Makes the LRUCache thread-safe
   - Adds an `evict` func to manually remove segments that have been deleted

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A

After this fix a prolonged test over 12h+ shows no memory leak:

![image](https://github.com/user-attachments/assets/745d7415-d77c-4d1d-b446-a41d912189fb)

