### PR TITLE
[BUG]: Local segment manager memory leak fix

### DIFF
--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -97,7 +97,7 @@ class LocalSegmentManager(SegmentManager):
                 // PersistentLocalHnswSegment.get_file_handle_count()
             )
             self._vector_instances_file_handle_cache = LRUCache(
-                segment_limit, callback=lambda _, v: v.close_persistent_index()
+                segment_limit, callback=lambda _, v: v.stop()
             )
 
     @trace_method(
@@ -156,6 +156,7 @@ class LocalSegmentManager(SegmentManager):
     def delete_segments(self, segments: Sequence[Segment]) -> Sequence[UUID]:
         for segment in segments:
             collection_id = segment["collection"]
+            self._vector_instances_file_handle_cache.evict(collection_id)
             if segment["id"] in self._instances:
                 if segment["type"] == SegmentType.HNSW_LOCAL_PERSISTED.value:
                     instance = self.get_segment(collection_id, VectorReader)


### PR DESCRIPTION
## Description of changes

Closes #3336

Summarize the changes made by this PR.

- Improvements & Bug fixes
   - Fixes the memory leak issue by replacing close_persistent_index with close which also unsubscribes the segment from Embeddings Queue
   - Makes the LRUCache thread-safe
   - Adds an evict func to manually remove segments that have been deleted

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A

