### PR TITLE
[BLD] Update Golang README and Makefile for generating protobuf dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 go/bin/
 go/**/testdata/
 go/coordinator/bin/
+go/pkg/proto/
 
 clients/js/package-lock.json
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,12 +1,13 @@
 .PHONY: build test lint clean docker proto log_db_clean log_db_generate log_db_migration
 
+PROTOC_BIN_PATH=$(if $(shell which protoc),$(shell which protoc),"${GOPATH}/bin/protoc")
 PROTOC_GEN_GO_BIN_PATH := $(if $(shell which protoc-gen-go),$(shell which protoc-gen-go),"${GOPATH}/bin/protoc-gen-go")
 PROTOC_GEN_GO_GRPC_BIN_PATH := $(if $(shell which protoc-gen-go-grpc),$(shell which protoc-gen-go-grpc),"${GOPATH}/bin/protoc-gen-go-grpc")
 
 proto:
 	@echo "Generating gRPC code for Golang..."
 	@mkdir -p pkg/proto/coordinatorpb pkg/proto/logservicepb
-	@protoc \
+	@$(PROTOC_BIN_PATH) \
 		-I../idl/ \
 		--go_out=pkg/proto/coordinatorpb \
 		--go_opt paths=source_relative \

--- a/go/README.md
+++ b/go/README.md
@@ -28,7 +28,7 @@ The biggest challenge to getting the project to build correctly is ensuring you 
 - `protoc-gen-go`
 - `protoc-gen-go-grpc`
 
-For MacOS users, you can download the version of `protoc` from the [release page](https://github.com/protocolbuffers/protobuf/releases). Ensure that you copy the `protoc` binary to `/usr/local/bin` or add it to your `GOPATH/bin`.
+You can start by downloading the version of `protoc` from the [release page](https://github.com/protocolbuffers/protobuf/releases). Ensure that you copy the `protoc` binary to `/usr/local/bin` or add it to your `GOPATH/bin`.
 
 ALSO, ensure you have copied the `/include` directory of the release to `../include` relative to wherever you installed the binary.
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,19 +1,35 @@
-# Set up Local Postgres
+# Chroma Golang Codebase
+
+## Set up Local Postgres
 
 - Install Postgres on Mac
-    - `brew install postgresql@14`
+  - `brew install postgresql@14`
 - Start & Stop
-    - `brew services start postgresql`
-    - `brew services stop postgresql`
+  - `brew services start postgresql`
+  - `brew services stop postgresql`
 - create testing db
-    - terminal: `psql postgres`
-    - postgres=# `create role chroma with login password 'chroma';`
-    - postgres=# `alter role chroma with superuser;`
-    - postgres=# `create database chroma;`
+  - terminal: `psql postgres`
+  - postgres=# `create role chroma with login password 'chroma';`
+  - postgres=# `alter role chroma with superuser;`
+  - postgres=# `create database chroma;`
 - Set postgres ENV Vars
     Several tests (such as record_log_service_test.go) require the following environment variables to be set:
-    - `export POSTGRES_HOST=localhost`
-    - `export POSTGRES_PORT=5432`
+  - `export POSTGRES_HOST=localhost`
+  - `export POSTGRES_PORT=5432`
 - Atlas schema migration
-    - [~/chroma/go]: `atlas migrate diff --env dev`
-    - [~/chroma/go]: `atlas --env dev migrate apply --url "postgres://chroma:chroma@localhost:5432/chroma?sslmode=disable"`
+  - [~/chroma/go]: `atlas migrate diff --env dev`
+  - [~/chroma/go]: `atlas --env dev migrate apply --url "postgres://chroma:chroma@localhost:5432/chroma?sslmode=disable"`
+
+## Building
+
+The biggest challenge to getting the project to build correctly is ensuring you have the correct versions for Protobuf. Refer to the "source of truth" for the version in `Dockerfile`. Note, you need all three of these:
+
+- `protoc`
+- `protoc-gen-go`
+- `protoc-gen-go-grpc`
+
+For MacOS users, you can download the version of `protoc` from the [release page](https://github.com/protocolbuffers/protobuf/releases). Ensure that you copy the `protoc` binary to `/usr/local/bin` or add it to your `GOPATH/bin`.
+
+ALSO, ensure you have copied the `/include` directory of the release to `../include` relative to wherever you installed the binary.
+
+Once those are installed, you can run `make build` to build the project and most importantly, the generated protobuf files which your IDE will complain about until they are generated.

--- a/go/README.md
+++ b/go/README.md
@@ -32,4 +32,6 @@ For MacOS users, you can download the version of `protoc` from the [release page
 
 ALSO, ensure you have copied the `/include` directory of the release to `../include` relative to wherever you installed the binary.
 
-Once those are installed, you can run `make build` to build the project and most importantly, the generated protobuf files which your IDE will complain about until they are generated.
+Then, to install the plugins, run the `go install` commands from the `Dockerfile`. The exact commands are not here because we would be duplicating where versions live if we did. The `Dockerfile` is the source of truth for the versions.
+
+Once those are all installed, you can run `make build` to build the project and most importantly, the generated protobuf files which your IDE will complain about until they are generated.


### PR DESCRIPTION
## Description of changes

These are all improvements to the local development environment, specifically for our Golang code. 

We recently removed generated protobuf files from the repository (see #3222). This resulted in needing to build these for my IDE to be happy. I eventually fixed what was a painful experience getting all this set up, so I added some details about getting it set up in the `README.md` and tweaked one thing in the `Makefile` for consistency with the other dependencies.

Note: there is some noise in the `README.md` diff that is from my linter.

We also weren't ignoring generated files, so I added them to `.gitignore` so they don't get re-added accidentally. 

## Test plan
Run `make build`

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
