### PR TITLE
[ENH]  Bump to the latest chromadb-rs pr.

### DIFF
--- a/rust/load/Cargo.toml
+++ b/rust/load/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry_sdk = { workspace = true }
 
 # Unlikely to be used in the workspace.
 axum = "0.7"
-chromadb = { git = "https://github.com/rescrv/chromadb-rs", rev = "3b2a9c96bf99cd0f9bd4e09ea983df335d6bbf68" }
+chromadb = { git = "https://github.com/rescrv/chromadb-rs", rev = "a88e5a83e27e168362262308f62a34065b19e067" }
 guacamole = { version = "0.9", default-features = false }
 tower-http = { version = "0.6.2", features = ["trace"] }
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
This updates the client to not contend within libssl.
