### PR TITLE
[ENH] Bump chroma-load to version that caches get_collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,8 +1364,8 @@ dependencies = [
 
 [[package]]
 name = "chromadb"
-version = "1.1.0"
-source = "git+https://github.com/rescrv/chromadb-rs?rev=3b2a9c96bf99cd0f9bd4e09ea983df335d6bbf68#3b2a9c96bf99cd0f9bd4e09ea983df335d6bbf68"
+version = "2.0.0"
+source = "git+https://github.com/rescrv/chromadb-rs?rev=70c79feb220c3f75c345916f6dfa073b88f8f16a#70c79feb220c3f75c345916f6dfa073b88f8f16a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/load/Cargo.toml
+++ b/rust/load/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry_sdk = { workspace = true }
 
 # Unlikely to be used in the workspace.
 axum = "0.7"
-chromadb = { git = "https://github.com/rescrv/chromadb-rs", rev = "a88e5a83e27e168362262308f62a34065b19e067" }
+chromadb = { git = "https://github.com/rescrv/chromadb-rs", rev = "70c79feb220c3f75c345916f6dfa073b88f8f16a" }
 guacamole = { version = "0.9", default-features = false }
 tower-http = { version = "0.6.2", features = ["trace"] }
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
The chromadb-rs client called to the server to hit sysdb for each time a
collection is instantiated.  Add a collection cache.
