### PR TITLE
[ENH] Validate HNSW index integrity on load

### DIFF
--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -94,6 +94,7 @@ public:
             throw std::runtime_error("Index already inited");
         }
         appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, 0, allow_replace_deleted, normalize, is_persistent_index);
+        appr_alg->checkIntegrity();
         index_inited = true;
     }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - N/A
 - New functionality
   - We would like to verify HNSW index integrity on load. An additional call to `checkIntegrity()` method is added to the `load()` method in the binding.

## Test plan
*How are these changes tested?*
This should not break any existing test cases

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A