### PR TITLE
[CLN]: remove offset ID atomic from record segment reader

### DIFF
--- a/rust/worker/src/execution/operators/limit.rs
+++ b/rust/worker/src/execution/operators/limit.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, num::TryFromIntError, sync::atomic};
+use std::{cmp::Ordering, num::TryFromIntError};
 
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
@@ -120,8 +120,7 @@ impl<'me> SeekScanner<'me> {
 
         let mut size = self
             .record_segment
-            .get_current_max_offset_id()
-            .load(atomic::Ordering::Relaxed)
+            .get_max_offset_id()
             .max(self.log_offset_ids.max().unwrap_or(0));
         if size == 0 {
             return Ok(0);

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -290,7 +290,8 @@ impl CompactOrchestrator {
             match RecordSegmentReader::from_segment(&record_segment, &self.blockfile_provider).await
             {
                 Ok(reader) => {
-                    let current_max_offset_id = reader.get_current_max_offset_id();
+                    let current_max_offset_id =
+                        Arc::new(AtomicU32::new(reader.get_max_offset_id()));
                     current_max_offset_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     Ok(current_max_offset_id)
                 }


### PR DESCRIPTION
## Description of changes

Small cleanup to clarify usage of offset ID on reader.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
n/a