### PR TITLE
[ENH] Implement compactor server interface

### DIFF
--- a/idl/chromadb/proto/compactor.proto
+++ b/idl/chromadb/proto/compactor.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package chroma;
+
+message CollectionIds {
+  repeated string ids = 1;
+}
+
+message CompactionRequest {
+  optional CollectionIds ids = 1;
+}
+
+message CompactionResponse {
+  // Empty
+}
+
+service Compactor {
+  rpc Compact(CompactionRequest) returns (CompactionResponse) {}
+}

--- a/idl/chromadb/proto/compactor.proto
+++ b/idl/chromadb/proto/compactor.proto
@@ -7,7 +7,7 @@ message CollectionIds {
 }
 
 message CompactionRequest {
-  optional CollectionIds ids = 1;
+  CollectionIds ids = 1;
 }
 
 message CompactionResponse {

--- a/rust/types/build.rs
+++ b/rust/types/build.rs
@@ -2,6 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Compile the protobuf files in the chromadb proto directory.
     let mut proto_paths = vec![
         "../../idl/chromadb/proto/chroma.proto",
+        "../../idl/chromadb/proto/compactor.proto",
         "../../idl/chromadb/proto/coordinator.proto",
         "../../idl/chromadb/proto/logservice.proto",
         "../../idl/chromadb/proto/query_executor.proto",

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use chroma_types::chroma_proto::{
+    compactor_server::{Compactor, CompactorServer},
+    CompactionRequest, CompactionResponse,
+};
+use tokio::signal::unix::{signal, SignalKind};
+use tonic::{transport::Server, Request, Response, Status};
+use tracing::trace_span;
+
+use crate::{compactor::OneOffCompactionMessage, system::ComponentHandle};
+
+use super::CompactionManager;
+
+pub struct CompactionServer {
+    pub manager: ComponentHandle<CompactionManager>,
+    pub port: u16,
+}
+
+impl CompactionServer {
+    pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        let addr = format!("[::]:{}", self.port).parse().unwrap();
+        tracing::info!("Compaction server listing at {addr}");
+        let server = Server::builder().add_service(CompactorServer::new(self));
+        server
+            .serve_with_shutdown(addr, async {
+                match signal(SignalKind::terminate()) {
+                    Ok(mut sigterm) => {
+                        sigterm.recv().await;
+                        tracing::info!("Received SIGTERM, shutting down")
+                    }
+                    Err(err) => {
+                        tracing::error!("Failed to create SIGTERM handler: {err}")
+                    }
+                }
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Compactor for CompactionServer {
+    async fn compact(
+        &self,
+        request: Request<CompactionRequest>,
+    ) -> Result<Response<CompactionResponse>, Status> {
+        let compaction_span = trace_span!("CompactionRequest", request = ?request);
+        self.manager
+            .receiver()
+            .send(
+                OneOffCompactionMessage::try_from(request.into_inner())
+                    .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                Some(compaction_span),
+            )
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(CompactionResponse {}))
+    }
+}

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     compactor_server::{Compactor, CompactorServer},
     CompactionRequest, CompactionResponse,
@@ -7,7 +8,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::trace_span;
 
-use crate::{compactor::OneOffCompactionMessage, system::ComponentHandle};
+use crate::compactor::OneOffCompactionMessage;
 
 use super::CompactionManager;
 

--- a/rust/worker/src/compactor/mod.rs
+++ b/rust/worker/src/compactor/mod.rs
@@ -6,3 +6,5 @@ mod types;
 
 pub(crate) use compaction_manager::*;
 pub(crate) use types::*;
+
+pub mod compaction_server;

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -14,5 +14,5 @@ pub struct ScheduledCompactionMessage {}
 #[derive(Clone, Debug)]
 pub struct OneOffCompactionMessage {
     #[allow(dead_code)]
-    pub collection_ids: Option<Vec<CollectionUuid>>,
+    pub collection_ids: Vec<CollectionUuid>,
 }

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -9,4 +9,9 @@ pub(crate) struct CompactionJob {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct ScheduleMessage {}
+pub struct ScheduledCompactionMessage {}
+
+#[derive(Clone, Debug)]
+pub struct OneOffCompactionMessage {
+    pub collection_ids: Option<Vec<CollectionUuid>>,
+}

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -13,5 +13,6 @@ pub struct ScheduledCompactionMessage {}
 
 #[derive(Clone, Debug)]
 pub struct OneOffCompactionMessage {
+    #[allow(dead_code)]
     pub collection_ids: Option<Vec<CollectionUuid>>,
 }

--- a/rust/worker/src/utils/convert.rs
+++ b/rust/worker/src/utils/convert.rs
@@ -167,13 +167,11 @@ impl TryFrom<chroma_proto::CompactionRequest> for OneOffCompactionMessage {
         Ok(Self {
             collection_ids: value
                 .ids
-                .map(|ids| {
-                    ids.ids
-                        .into_iter()
-                        .map(|id| CollectionUuid::from_str(&id))
-                        .collect::<Result<_, _>>()
-                })
-                .transpose()
+                .ok_or(ConversionError::DecodeError)?
+                .ids
+                .into_iter()
+                .map(|id| CollectionUuid::from_str(&id))
+                .collect::<Result<_, _>>()
                 .map_err(|_| ConversionError::DecodeError)?,
         })
     }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - N/A
 - New functionality
   - We would like to manually start a compaction on certain collections. This PR is the first in the stack to implement this feature. Specifically, it:
     - Introduces the grpc interface for compactor. Currently there is only a single variant of request that allows the user to specify an optional list of collection ids for compaction.
     - Implements the `CompactionServer` struct in rust that implements this interface. It receives the request and send it to the running `CompactionManager`
     - The next PRs will handle the request in `CompactionManager`.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
