### PR TITLE
[Doc] Fix for Python Params search_ef and construction_ef

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/collections/configure.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/collections/configure.md
@@ -10,8 +10,8 @@ You can configure the embedding space of a collection by setting special keys on
 | Inner product     |   `ip`    |                                                                                     {% Latex %} d = 1.0 - \\sum\\left(A_i \\times B_i\\right) {% /Latex %} |
 | Cosine similarity | `cosine`  | {% Latex %} d = 1.0 - \\frac{\\sum\\left(A_i \\times B_i\\right)}{\\sqrt{\\sum\\left(A_i^2\\right)} \\cdot \\sqrt{\\sum\\left(B_i^2\\right)}} {% /Latex %} |
 
-* `hnsw:ef_construction` determines the size of the candidate list used to select neighbors during index creation. A higher value improves index quality at the cost of more memory and time, while a lower value speeds up construction with reduced accuracy. The default value is `100`.
-* `hnsw:ef_search` determines the size of the dynamic candidate list used while searching for the nearest neighbors. A higher value improves recall and accuracy by exploring more potential neighbors but increases query time and computational cost, while a lower value results in faster but less accurate searches. The default value is `10`.
+* `hnsw:construction_ef` determines the size of the candidate list used to select neighbors during index creation. A higher value improves index quality at the cost of more memory and time, while a lower value speeds up construction with reduced accuracy. The default value is `100`.
+* `hnsw:search_ef` determines the size of the dynamic candidate list used while searching for the nearest neighbors. A higher value improves recall and accuracy by exploring more potential neighbors but increases query time and computational cost, while a lower value results in faster but less accurate searches. The default value is `10`.
 * `hnsw:M` is the maximum number of neighbors (connections) that each node in the graph can have during the construction of the index. A higher value results in a denser graph, leading to better recall and accuracy during searches but increases memory usage and construction time. A lower value creates a sparser graph, reducing memory usage and construction time but at the cost of lower search accuracy and recall. The default value is `16`.
 * `hnsw:num_threads` specifies the number of threads to use during index construction or search operations. The default value is `multiprocessing.cpu_count()` (available CPU cores).
 
@@ -26,7 +26,7 @@ collection = client.create_collection(
     embedding_function=emb_fn,
     metadata={
         "hnsw:space": "cosine",
-        "hnsw:ef_search": 100
+        "hnsw:search_ef": 100
     }
 )
 ```
@@ -39,7 +39,7 @@ let collection = await client.createCollection({
     embeddingFunction: emb_fn,
     metadata: {
         "hnsw:space": "cosine",
-        "hnsw:ef_search": 100
+        "hnsw:search_ef": 100
     }
 });
 ```


### PR DESCRIPTION
search_ef and construction_ef keys in doc for python updated, to reflect keys used by the python function create_collection, on the metadata parameter

## Description of changes
Parameters: `search_ef` and `construction_ef` in the doc file updated
https://github.com/chroma-core/chroma/blob/main/docs/docs.trychroma.com/markdoc/content/docs/collections/configure.md
to reflect their python keys

Mentioned as bug in https://github.com/chroma-core/chroma/issues/3381