### PR TITLE
[ENH]  Use GITHUB_TOKEN for setup-protoc

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -15,7 +15,7 @@ runs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
       secrets:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Cache
       uses: Swatinem/rust-cache@v2
       with:

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
-      with:
+      secrets:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
-      secrets:
+      with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -14,6 +14,8 @@ runs:
       shell: bash
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: Cache
       uses: Swatinem/rust-cache@v2
       with:


### PR DESCRIPTION
The protoc setup uses the GH API.  It's rate limited.

Bump from 60/hour to 5000/hour by authenticating.