### PR TITLE
[DOC]: Fix anchors in links to docs.trychroma.com

### DIFF
--- a/docs/docs.trychroma.com/context/app-context.tsx
+++ b/docs/docs.trychroma.com/context/app-context.tsx
@@ -2,7 +2,6 @@ import React, {
   createContext,
   useState,
   ReactNode,
-  useContext,
   useEffect,
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -26,12 +25,14 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
   );
   const router = useRouter();
   const pathname = usePathname();
+  // Don't consider the hash if the user is going to a differnet path.
+  const anchor = (pathname == window.location.pathname) ? window.location.hash : "";
 
   useEffect(() => {
     if (language === "typescript") {
-      router.replace(`${pathname}?lang=typescript`);
+      router.replace(pathname + "?lang=typescript" + anchor);
     } else {
-      router.replace(pathname);
+      router.replace(pathname + anchor);
     }
   }, [language]);
 

--- a/docs/docs.trychroma.com/context/app-context.tsx
+++ b/docs/docs.trychroma.com/context/app-context.tsx
@@ -13,7 +13,7 @@ export interface AppContextValue {
 
 const AppContextDefaultValue: AppContextValue = {
   language: "python",
-  setLanguage: () => {},
+  setLanguage: () => { },
 };
 
 const AppContext = createContext<AppContextValue>(AppContextDefaultValue);
@@ -25,16 +25,17 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
   );
   const router = useRouter();
   const pathname = usePathname();
-  // Don't consider the hash if the user is going to a differnet path.
-  const anchor = (pathname == window.location.pathname) ? window.location.hash : "";
 
   useEffect(() => {
+    // Don't consider the hash if the user is going to a differnet path.
+    const anchor = (pathname === window.location.pathname) ? window.location.hash : "";
+
     if (language === "typescript") {
       router.replace(pathname + "?lang=typescript" + anchor);
     } else {
       router.replace(pathname + anchor);
     }
-  }, [language]);
+  }, [language, pathname]);
 
   return (
     <AppContext.Provider value={{ language, setLanguage }}>


### PR DESCRIPTION
Closes #3395


## Description of changes
- The app context responsible of redirecting pages to either the JS docs or python docs was stripping out the hash (anchor) if you're navigating to a documentation page with an anchor such as [https://docs.trychroma.com/reference/python/client#deletecollection](https://docs.trychroma.com/reference/python/client#deletecollection).
- This PR fixes this issue by appending the hash to the URL being redirected to if it's valid to append the hash.
- Also cleaning up a bit by removing a not used import of react `useContext`.

## Test plan
 N/A

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
N/A
