### PR TITLE
[BUG] Fix HNSW resize conditions to exclude deleted items

### DIFF
--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -430,6 +430,7 @@ extern "C"
     }
 
     // Can not throw std::exception
+    // Note: includes deleted items
     int len(Index<float> *index)
     {
         if (!index->index_inited)
@@ -438,6 +439,18 @@ extern "C"
         }
 
         return index->appr_alg->getCurrentElementCount() - index->appr_alg->getDeletedCount();
+    }
+
+    // Can not throw std::exception
+    // Note: does not include deleted items
+    int len_with_deleted(Index<float> *index)
+    {
+        if (!index->index_inited)
+        {
+            return 0;
+        }
+
+        return index->appr_alg->getCurrentElementCount();
     }
 
     // Can not throw std::exception


### PR DESCRIPTION
## Description of changes

We were seeing errors in compaction that looked like:

```
WriteSegments(ApplyMaterializatedLogsError(HnswIndex(FFIException(\"The number of elements exceeds the specified limit\"))))
```
This is because the resize logic uses `len` which removes deleted elements which then causes the conditional for resizing to be skipped. This adds a new method `len_with_deleted` to return the length of the index including the elements that have been deleted so that the resize is not skipped. See: https://github.com/chroma-core/chroma/blob/27564afa0e82d184a0fa853a7384d00861d8e9dc/rust/worker/src/segment/distributed_hnsw_segment.rs#L212-L222

## Test plan
A test was added. It will fail when using the existing `len` method, but passes when using the newly added `len_with_deleted` method.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A

Thanks to @sanketkedia for helping root cause this. 

Fixes https://github.com/chroma-core/hosted-chroma/issues/855