### PR TITLE
[BUG] Use len_with_deleted instead of len

### DIFF
--- a/rust/worker/src/segment/distributed_hnsw_segment.rs
+++ b/rust/worker/src/segment/distributed_hnsw_segment.rs
@@ -210,7 +210,7 @@ impl DistributedHNSWSegmentWriter {
                     let embedding = record.merged_embeddings_ref();
 
                     let mut index = self.index.inner.upgradable_read();
-                    let index_len = index.len();
+                    let index_len = index.len_with_deleted();
                     let index_capacity = index.capacity();
                     if index_len + 1 > index_capacity {
                         index.with_upgraded(|index| {


### PR DESCRIPTION
## Description of changes

This is a follow-up from #3424 - where I had added code to fix the bug in compaction but then forgot to replace the method at the actual callsite with the new method 🤦🏼 . 

This updates the problem code to use `len_with_deleted` instead of just `len` so that the resize actually gets triggered. 

Some additional context: we decided not to change the behavior of the existing `len` method in case other callers were depending on existing behavior. In other words, we didn't want to introduce accidentally introduce bugs that were relying on the "buggy" code.