### PR TITLE
[BLD] Add link to hotfix PR in action summary

### DIFF
--- a/.github/workflows/apply-hotfix.yaml
+++ b/.github/workflows/apply-hotfix.yaml
@@ -130,3 +130,7 @@ jobs:
               reviewers: [assignee]
             })
             core.info(`Requested review from ${assignee} on PR #${pr.number}`)
+
+            // Add a link to the hotfix PR in the action summary
+            core.summary.addHeading('Link to Hotfix PR', '2')
+            core.summary.addLink(`chroma-core/chroma #${pr.number}`, pr.html.url)


### PR DESCRIPTION
## Description of changes

When applying a hotfix, a PR gets generated. This PR is currently only in the output of the action, or can be found in the list of PRs. This adds a heading and a link to the PR in the action summary so that the developer can find it more easily.

## Test plan
I manually linted the action code to make sure I didn't break anything obvious. I may still want to tweak the output that gets generated, but at this point, the PR link will be much more easy to spot.