### PR TITLE
[BUG] `UniqueConstraintError` not included as a `ChromaError`

### DIFF
--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -194,4 +194,7 @@ error_types: Dict[str, Type[ChromaError]] = {
     "VersionMismatchError": VersionMismatchError,
     "RateLimitError": RateLimitError,
     "AuthError": ChromaAuthError,
+    "UniqueConstraintError": UniqueConstraintError,
+    "QuotaError": QuotaError,
+    "InternalError": InternalError,
 }

--- a/chromadb/test/api/test_collection.py
+++ b/chromadb/test/api/test_collection.py
@@ -1,4 +1,5 @@
 from chromadb.api import ClientAPI
+from chromadb.errors import UniqueConstraintError
 
 
 def test_duplicate_collection_create(
@@ -21,7 +22,7 @@ def test_duplicate_collection_create(
         assert False, "Expected exception"
     except Exception as e:
         print("Collection creation failed as expected with error ", e)
-        assert "already exists" in e.args[0] or "UniqueConstraintError" in e.args[0]
+        assert "already exists" in e.args[0] or isinstance(e, UniqueConstraintError)
 
 
 def test_not_existing_collection_delete(


### PR DESCRIPTION
## Description of changes

`UniqueConstraintError` was not included as the possible `ChromaError` types causing it to appear as a generic error.

Closes #2569 

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
