### PR TITLE
[BUG] Support all iterables in toArrayOfArrays

### DIFF
--- a/clients/js/src/utils.ts
+++ b/clients/js/src/utils.ts
@@ -23,13 +23,21 @@ export function toArray<T>(obj: T | T[]): Array<T> {
 
 // a function to convert an array to array of arrays
 export function toArrayOfArrays<T>(
-  obj: Array<Array<T>> | Array<T>,
+  obj: Array<Array<T>> | Array<T>
 ): Array<Array<T>> {
+  if (obj.length === 0) {
+    return [];
+  }
+
   if (Array.isArray(obj[0])) {
     return obj as Array<Array<T>>;
-  } else {
-    return [obj] as Array<Array<T>>;
   }
+
+  if (obj[0] && typeof (obj[0] as any)[Symbol.iterator] === 'function') {
+    return (obj as unknown as Array<Iterable<T>>).map(el => Array.from(el));
+  }
+
+  return [obj] as Array<Array<T>>;
 }
 
 /**


### PR DESCRIPTION
## Description of changes

Allows the utility `toArrayOfArrays` to support other input iterables that can be returned from embedding functions, as well as handle empty edge case.

Closes #2724 

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
