### PR TITLE
[BLD] Make artifact names unique for the job being run

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -46,5 +46,5 @@ jobs:
       - name: Merge
         uses: actions/upload-artifact/merge@v4
         with:
-          name: cluster_test_logs-${{ github.run_id }}
+          name: cluster_test_logs
           pattern: cluster_logs_*

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -31,7 +31,7 @@ jobs:
         if: always()
         uses: ./.github/actions/export-tilt-logs
         with:
-          artifact-name: "tilt-logs-${{ github.run_id }}-${{ github.job }}"
+          artifact-name: "tilt-logs-${{ github.run_id }}-${{ matrix.test-globs }}"
       - name: Send PagerDuty alert on failure
         if: ${{ failure() }}
         uses: Entle/action-pagerduty-alert@0.2.0
@@ -46,5 +46,5 @@ jobs:
       - name: Merge
         uses: actions/upload-artifact/merge@v4
         with:
-          name: cluster_test_logs-${{ github.run_id }}-${{ github.job }}
+          name: cluster_test_logs-${{ github.run_id }}
           pattern: cluster_logs_*

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -31,7 +31,7 @@ jobs:
         if: always()
         uses: ./.github/actions/export-tilt-logs
         with:
-          artifact-name: "tilt-logs"
+          artifact-name: "tilt-logs-${{ github.run_id }}-${{ github.job }}"
       - name: Send PagerDuty alert on failure
         if: ${{ failure() }}
         uses: Entle/action-pagerduty-alert@0.2.0
@@ -46,5 +46,5 @@ jobs:
       - name: Merge
         uses: actions/upload-artifact/merge@v4
         with:
-          name: cluster_test_logs
+          name: cluster_test_logs-${{ github.run_id }}-${{ github.job }}
           pattern: cluster_logs_*

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -27,11 +27,16 @@ jobs:
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: slow
+      - name: Create artifact name
+        id: create-artifact-name
+        run: |
+          ARTIFACT_NAME=$(echo "${{ matrix.test-globs }}" | tr '/' '_' | tr '.' '_')
+          echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs
         with:
-          artifact-name: "tilt-logs-${{ github.run_id }}-${{ matrix.test-globs }}"
+          artifact-name: "tilt-logs-${{ steps.create-artifact-name.outputs.artifact_name }}"
       - name: Send PagerDuty alert on failure
         if: ${{ failure() }}
         uses: Entle/action-pagerduty-alert@0.2.0


### PR DESCRIPTION
## Description of changes

We often see failures in this workflow that look like:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

## Test plan
I linted the action, but will need to test it live to see that artifacts are getting generated appropriately. Expect that many of the failure conditions we are currently seeing go away. 