### PR TITLE
[ENH]  Add flags to the go binary for concurrency and stream processing.

### DIFF
--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -29,6 +29,8 @@ func init() {
 
 	// GRPC
 	flag.GRPCAddr(Cmd, &conf.GrpcConfig.BindAddress)
+	Cmd.Flags().IntVar(&conf.MaxConcurrentStreams, "max-concurrent-streams", 100, "Max concurrent streams")
+	Cmd.Flags().IntVar(&conf.MaxConcurrentStreams, "num-stream-workers", 100, "Number of stream workers")
 
 	// System Catalog
 	Cmd.Flags().StringVar(&conf.SystemCatalogProvider, "system-catalog-provider", "database", "System catalog provider")

--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -29,8 +29,8 @@ func init() {
 
 	// GRPC
 	flag.GRPCAddr(Cmd, &conf.GrpcConfig.BindAddress)
-	Cmd.Flags().IntVar(&conf.MaxConcurrentStreams, "max-concurrent-streams", 100, "Max concurrent streams")
-	Cmd.Flags().IntVar(&conf.MaxConcurrentStreams, "num-stream-workers", 100, "Number of stream workers")
+	Cmd.Flags().Uint32Var(&conf.GrpcConfig.MaxConcurrentStreams, "max-concurrent-streams", 100, "Max concurrent streams")
+	Cmd.Flags().Uint32Var(&conf.GrpcConfig.NumStreamWorkers, "num-stream-workers", 100, "Number of stream workers")
 
 	// System Catalog
 	Cmd.Flags().StringVar(&conf.SystemCatalogProvider, "system-catalog-provider", "database", "System catalog provider")

--- a/go/pkg/grpcutils/config.go
+++ b/go/pkg/grpcutils/config.go
@@ -4,6 +4,9 @@ type GrpcConfig struct {
 	// BindAddress is the address to bind the GRPC server to.
 	BindAddress string
 
+	MaxConcurrentStreams uint32
+	NumStreamWorkers uint32
+
 	// GRPC mTLS config
 	CertPath string
 	KeyPath  string

--- a/go/pkg/grpcutils/service.go
+++ b/go/pkg/grpcutils/service.go
@@ -49,8 +49,12 @@ type defaultGrpcServer struct {
 func newDefaultGrpcProvider(name string, grpcConfig *GrpcConfig, registerFunc func(grpc.ServiceRegistrar)) (GrpcServer, error) {
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.MaxRecvMsgSize(maxGrpcFrameSize))
-	opts = append(opts, grpc.NumStreamWorkers(grpcConfig.NumStreamWorkers))
-	opts = append(opts, grpc.MaxConcurrentStreams(grpcConfig.MaxConcurrentStreams))
+	if grpcConfig.NumStreamWorkers > 0 {
+		opts = append(opts, grpc.NumStreamWorkers(grpcConfig.NumStreamWorkers))
+	}
+	if grpcConfig.MaxConcurrentStreams > 0 {
+		opts = append(opts, grpc.MaxConcurrentStreams(grpcConfig.MaxConcurrentStreams))
+	}
 	if grpcConfig.MTLSEnabled() {
 		cert, err := tls.LoadX509KeyPair(grpcConfig.CertPath, grpcConfig.KeyPath)
 		if err != nil {

--- a/go/pkg/grpcutils/service.go
+++ b/go/pkg/grpcutils/service.go
@@ -49,6 +49,8 @@ type defaultGrpcServer struct {
 func newDefaultGrpcProvider(name string, grpcConfig *GrpcConfig, registerFunc func(grpc.ServiceRegistrar)) (GrpcServer, error) {
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.MaxRecvMsgSize(maxGrpcFrameSize))
+	opts = append(opts, grpc.NumStreamWorkers(grpcConfig.NumStreamWorkers))
+	opts = append(opts, grpc.MaxConcurrentStreams(grpcConfig.MaxConcurrentStreams))
 	if grpcConfig.MTLSEnabled() {
 		cert, err := tls.LoadX509KeyPair(grpcConfig.CertPath, grpcConfig.KeyPath)
 		if err != nil {


### PR DESCRIPTION
By default, most grpc implementations allow up to 100 concurrent
streams.  We have 200 concurrent requests, basically guaranteeing
queueing.  Expose the two gRPC options in Go that will allow us to tune.
