### PR TITLE
[ENH]: fix Go Dockerfile build time regression

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -11,28 +11,22 @@ RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v28.2
 # Set the PATH to include Go binaries
 ENV PATH=$PATH:/root/go/bin
 
-# Copy the Go source code and protobuf files
-ADD ./go/ ./go
-ADD ./idl/ ./idl
-ADD ./go/go.mod ./go/go.mod
-ADD ./go/go.sum ./go/go.sum
-WORKDIR /build-dir/go
-RUN go mod download
-
 # Install protoc Go plugins
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.2
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 
 ENV GOCACHE=/root/.cache/go-build
 
+ADD ./go /build-dir/go
+ADD ./idl /build-dir/idl
+
 WORKDIR /build-dir/go
+
 # Generate protobuf files
-# RUN --mount=type=cache,target="/root/.cache/go-build" go generate ./...
-# Run 'make proto' to generate protobuf files
-RUN --mount=type=cache,target="/root/.cache/go-build" make proto
+RUN make proto
 
 # Build the Go binaries
-RUN --mount=type=cache,target="/root/.cache/go-build" make build
+RUN --mount=type=cache,target="/root/.cache/go-build" --mount=type=cache,target="/go/pkg/mod" make build
 
 FROM debian:bookworm-slim AS logservice
 COPY --from=builder /build-dir/go/bin/logservice .


### PR DESCRIPTION
## Description of changes

Significantly decreases incremental build time of Go images. See https://github.com/chroma-core/hosted-chroma/issues/981 for context.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Container builds.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
