### PR TITLE
[ENH] Implement compaction client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6865,6 +6865,7 @@ dependencies = [
  "chroma-sysdb",
  "chroma-system",
  "chroma-types",
+ "clap",
  "criterion",
  "fastrace",
  "fastrace-opentelemetry",

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -4,12 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "query_service"
-path = "src/bin/query_service.rs"
+name = "compaction_client"
+path = "src/bin/compaction_client.rs"
 
 [[bin]]
 name = "compaction_service"
 path = "src/bin/compaction_service.rs"
+
+[[bin]]
+name = "query_service"
+path = "src/bin/query_service.rs"
 
 [dependencies]
 rand = "0.8.5"
@@ -47,6 +51,7 @@ prost-types = { workspace = true }
 num_cpus = { workspace = true }
 flatbuffers = { workspace = true }
 tantivy = { workspace = true }
+clap = { workspace = true }
 
 chroma-blockstore = { workspace = true }
 chroma-error = { workspace = true }

--- a/rust/worker/src/bin/compaction_client.rs
+++ b/rust/worker/src/bin/compaction_client.rs
@@ -1,10 +1,3 @@
-#[cfg(not(target_env = "msvc"))]
-use tikv_jemallocator::Jemalloc;
-
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
-
 #[tokio::main]
 async fn main() {
     worker::compaction_client_entrypoint().await;

--- a/rust/worker/src/bin/compaction_client.rs
+++ b/rust/worker/src/bin/compaction_client.rs
@@ -1,0 +1,11 @@
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+#[tokio::main]
+async fn main() {
+    worker::compaction_client_entrypoint().await;
+}

--- a/rust/worker/src/compactor/compaction_client.rs
+++ b/rust/worker/src/compactor/compaction_client.rs
@@ -1,0 +1,66 @@
+use chroma_types::chroma_proto::{
+    compactor_client::CompactorClient, CollectionIds, CompactionRequest,
+};
+use clap::{Parser, Subcommand};
+use thiserror::Error;
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+/// Error for compaction client
+#[derive(Debug, Error)]
+pub enum CompactionClientError {
+    #[error("Compactor failed: {0}")]
+    Compactor(String),
+    #[error("Unable to connect to compactor: {0}")]
+    Connection(#[from] tonic::transport::Error),
+}
+
+/// Tool to control compaction service
+#[derive(Debug, Parser)]
+#[command(version, about, long_about = None)]
+pub struct CompactionClient {
+    /// Url of the target compactor
+    #[arg(short, long)]
+    url: String,
+    /// Subcommand for compaction
+    #[command(subcommand)]
+    command: CompactionCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CompactionCommand {
+    /// Trigger a one-off compaction
+    Compact {
+        /// Specify Uuids of the collections to compact. If unspecified, no compaction will occur unless --all flag is specified
+        #[arg(short, long)]
+        id: Vec<Uuid>,
+        /// Compact all collections available. If specified, the Uuids specified with --id will be ignored
+        #[arg(short, long)]
+        all: bool,
+    },
+}
+
+impl CompactionClient {
+    async fn grpc_client(&self) -> Result<CompactorClient<Channel>, CompactionClientError> {
+        Ok(CompactorClient::connect(self.url.clone()).await?)
+    }
+
+    pub async fn run(&self) -> Result<(), CompactionClientError> {
+        match &self.command {
+            CompactionCommand::Compact { id, all } => {
+                let mut client = self.grpc_client().await?;
+                let response = client
+                    .compact(CompactionRequest {
+                        ids: (!all).then_some(CollectionIds {
+                            ids: id.iter().map(ToString::to_string).collect(),
+                        }),
+                    })
+                    .await;
+                if let Err(status) = response {
+                    return Err(CompactionClientError::Compactor(status.to_string()));
+                }
+            }
+        };
+        Ok(())
+    }
+}

--- a/rust/worker/src/compactor/compaction_client.rs
+++ b/rust/worker/src/compactor/compaction_client.rs
@@ -34,9 +34,6 @@ pub enum CompactionCommand {
         /// Specify Uuids of the collections to compact. If unspecified, no compaction will occur unless --all flag is specified
         #[arg(short, long)]
         id: Vec<Uuid>,
-        /// Compact all collections available. If specified, the Uuids specified with --id will be ignored
-        #[arg(short, long)]
-        all: bool,
     },
 }
 
@@ -47,11 +44,11 @@ impl CompactionClient {
 
     pub async fn run(&self) -> Result<(), CompactionClientError> {
         match &self.command {
-            CompactionCommand::Compact { id, all } => {
+            CompactionCommand::Compact { id } => {
                 let mut client = self.grpc_client().await?;
                 let response = client
                     .compact(CompactionRequest {
-                        ids: (!all).then_some(CollectionIds {
+                        ids: Some(CollectionIds {
                             ids: id.iter().map(ToString::to_string).collect(),
                         }),
                     })

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -20,7 +20,7 @@ pub struct CompactionServer {
 impl CompactionServer {
     pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
         let addr = format!("[::]:{}", self.port).parse().unwrap();
-        tracing::info!("Compaction server listing at {addr}");
+        tracing::info!("Compaction server listening at {addr}");
         let server = Server::builder().add_service(CompactorServer::new(self));
         server
             .serve_with_shutdown(addr, async {

--- a/rust/worker/src/compactor/mod.rs
+++ b/rust/worker/src/compactor/mod.rs
@@ -7,4 +7,5 @@ mod types;
 pub(crate) use compaction_manager::*;
 pub(crate) use types::*;
 
+pub mod compaction_client;
 pub mod compaction_server;

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -6,6 +6,8 @@ mod tracing;
 mod utils;
 
 use chroma_config::Configurable;
+use clap::Parser;
+use compactor::compaction_client::CompactionClient;
 use compactor::compaction_server::CompactionServer;
 use memberlist::MemberlistProvider;
 
@@ -138,7 +140,7 @@ pub async fn compaction_service_entrypoint() {
     };
 
     let server_join_handle = tokio::spawn(async move {
-        let _ = CompactionServer::run(compaction_server).await;
+        let _ = compaction_server.run().await;
     });
 
     let mut sigterm = match signal(SignalKind::terminate()) {
@@ -165,4 +167,11 @@ pub async fn compaction_service_entrypoint() {
         },
     };
     println!("Server stopped");
+}
+
+pub async fn compaction_client_entrypoint() {
+    let client = CompactionClient::parse();
+    if let Err(e) = client.run().await {
+        eprintln!("{e}");
+    }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - N/A
 - New functionality
   - Implements the compaction client, which is a CLI tool that can be used to remotely control a compaction service.
   - For now it only allows for triggering an one-off compaction on selected collections (or all of available collections)

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
