### PR TITLE
[ENH] Config to disable compactor on collections

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -109,6 +109,7 @@ compaction_service:
         min_compaction_size: 10
         max_compaction_size: 10000
         max_partition_size: 5000
+        disabled_collections: [] # uuids to disable compaction for
     blockfile_provider:
         Arrow:
             block_manager_config:

--- a/rust/worker/src/compactor/config.rs
+++ b/rust/worker/src/compactor/config.rs
@@ -8,4 +8,5 @@ pub(crate) struct CompactorConfig {
     pub(crate) min_compaction_size: usize,
     pub(crate) max_compaction_size: usize,
     pub(crate) max_partition_size: usize,
+    pub(crate) disabled_collections: Vec<String>,
 }

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -1,3 +1,12 @@
+use std::collections::HashSet;
+use std::str::FromStr;
+
+use chroma_types::CollectionUuid;
+use figment::providers::Env;
+use figment::Figment;
+use serde::Deserialize;
+use uuid::Uuid;
+
 use crate::assignment::assignment_policy::AssignmentPolicy;
 use crate::compactor::scheduler_policy::SchedulerPolicy;
 use crate::compactor::types::CompactionJob;
@@ -17,9 +26,16 @@ pub(crate) struct Scheduler {
     min_compaction_size: usize,
     memberlist: Option<Memberlist>,
     assignment_policy: Box<dyn AssignmentPolicy>,
+    disabled_collections: HashSet<CollectionUuid>,
+}
+
+#[derive(Deserialize)]
+struct RunTimeConfig {
+    disabled_collections: Vec<String>,
 }
 
 impl Scheduler {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         my_ip: String,
         log: Box<Log>,
@@ -28,6 +44,7 @@ impl Scheduler {
         max_concurrent_jobs: usize,
         min_compaction_size: usize,
         assignment_policy: Box<dyn AssignmentPolicy>,
+        disabled_collections: HashSet<CollectionUuid>,
     ) -> Scheduler {
         Scheduler {
             my_ip,
@@ -39,6 +56,7 @@ impl Scheduler {
             max_concurrent_jobs,
             memberlist: None,
             assignment_policy,
+            disabled_collections,
         }
     }
 
@@ -63,6 +81,16 @@ impl Scheduler {
     ) -> Vec<CollectionRecord> {
         let mut collection_records = Vec::new();
         for collection_info in collections {
+            if self
+                .disabled_collections
+                .contains(&collection_info.collection_id)
+            {
+                tracing::info!(
+                    "Ignoring collection: {:?} because it disabled for compaction",
+                    collection_info.collection_id
+                );
+                continue;
+            }
             let collection_id = Some(collection_info.collection_id);
             // TODO: add a cache to avoid fetching the same collection multiple times
             let result = self
@@ -161,6 +189,22 @@ impl Scheduler {
         self.job_queue.extend(jobs);
     }
 
+    pub(crate) fn recompute_disabled_collections(&mut self) {
+        let config = Figment::new()
+            .merge(
+                Env::prefixed("CHROMA_COMPACTION_SERVICE__COMPACTOR__")
+                    .only(&["DISABLED_COLLECTIONS"]),
+            )
+            .extract::<RunTimeConfig>();
+        if let Ok(config) = config {
+            self.disabled_collections = config
+                .disabled_collections
+                .iter()
+                .map(|collection| CollectionUuid(Uuid::from_str(collection).unwrap()))
+                .collect();
+        }
+    }
+
     pub(crate) async fn schedule(&mut self) {
         // For now, we clear the job queue every time, assuming we will not have any pending jobs running
         self.job_queue.clear();
@@ -168,6 +212,8 @@ impl Scheduler {
             tracing::error!("Memberlist is not set or empty. Cannot schedule compaction jobs.");
             return;
         }
+        // Recompute disabled list.
+        self.recompute_disabled_collections();
         let collections = self.get_collections_with_new_data().await;
         if collections.is_empty() {
             return;
@@ -300,6 +346,7 @@ mod tests {
             max_concurrent_jobs,
             1,
             assignment_policy,
+            HashSet::new(),
         );
         // Scheduler does nothing without memberlist
         scheduler.schedule().await;
@@ -477,6 +524,7 @@ mod tests {
             max_concurrent_jobs,
             1,
             assignment_policy,
+            HashSet::new(),
         );
 
         scheduler.set_memberlist(vec![my_ip.clone()]);

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -261,6 +261,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
+                        disabled_collections: []
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -407,6 +408,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
+                        disabled_collections: []
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -571,6 +573,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
+                        disabled_collections: []
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -722,6 +725,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
+                        disabled_collections: []
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -884,6 +888,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
+                        disabled_collections: []
                     blockfile_provider:
                         Arrow:
                             block_manager_config:

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -146,6 +146,7 @@ mod tests {
     use super::*;
     use figment::Jail;
     use serial_test::serial;
+    use uuid::Uuid;
 
     #[test]
     #[serial]
@@ -261,7 +262,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
-                        disabled_collections: []
+                        disabled_collections: ["74b3240e-a2b0-43d7-8adb-f55a394964a1", "496db4aa-fbe1-498a-b60b-81ec0fe59792"]
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -290,6 +291,24 @@ mod tests {
                 "compaction-service-0"
             );
             assert_eq!(config.compaction_service.my_port, 50051);
+            assert_eq!(
+                config
+                    .compaction_service
+                    .compactor
+                    .disabled_collections
+                    .len(),
+                2
+            );
+            assert_eq!(
+                Uuid::parse_str(&config.compaction_service.compactor.disabled_collections[0])
+                    .unwrap(),
+                Uuid::parse_str("74b3240e-a2b0-43d7-8adb-f55a394964a1").unwrap()
+            );
+            assert_eq!(
+                Uuid::parse_str(&config.compaction_service.compactor.disabled_collections[1])
+                    .unwrap(),
+                Uuid::parse_str("496db4aa-fbe1-498a-b60b-81ec0fe59792").unwrap()
+            );
             Ok(())
         });
     }
@@ -632,6 +651,10 @@ mod tests {
                 "CHROMA_COMPACTION_SERVICE__STORAGE__S3__REQUEST_TIMEOUT_MS",
                 1000,
             );
+            jail.set_env(
+                "CHROMA_COMPACTION_SERVICE__COMPACTOR__DISABLED_COLLECTIONS",
+                "[\"74b3240e-a2b0-43d7-8adb-f55a394964a1\",\"496db4aa-fbe1-498a-b60b-81ec0fe59792\"]",
+            );
             let _ = jail.create_file(
                 "chroma_config.yaml",
                 r#"
@@ -725,7 +748,7 @@ mod tests {
                         min_compaction_size: 10
                         max_compaction_size: 10000
                         max_partition_size: 5000
-                        disabled_collections: []
+                        disabled_collections: ["c92e4d75-eb25-4295-82d8-7c53dbd33258"]
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -767,6 +790,24 @@ mod tests {
                 }
                 _ => panic!("Invalid storage config"),
             }
+            assert_eq!(
+                config
+                    .compaction_service
+                    .compactor
+                    .disabled_collections
+                    .len(),
+                2
+            );
+            assert_eq!(
+                Uuid::parse_str(&config.compaction_service.compactor.disabled_collections[0])
+                    .unwrap(),
+                Uuid::parse_str("74b3240e-a2b0-43d7-8adb-f55a394964a1").unwrap()
+            );
+            assert_eq!(
+                Uuid::parse_str(&config.compaction_service.compactor.disabled_collections[1])
+                    .unwrap(),
+                Uuid::parse_str("496db4aa-fbe1-498a-b60b-81ec0fe59792").unwrap()
+            );
             Ok(())
         });
     }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Can specify a list of collection ids that needs to disabled and compactor will respect that.
   - In runtime, can set the env `CHROMA_COMPACTION_SERVICE__COMPACTOR__DISABLED_COLLECTIONS=[list of collection ids]` or  `CHROMA_COMPACTION_SERVICE.COMPACTOR.DISABLED_COLLECTIONS=[list of collection ids]` and the changes will take effect without restarting the pod

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
