### PR TITLE
[ENH]  Add a simple rate limiter for async.

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -5,7 +5,7 @@ from chromadb.auth import UserIdentity
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
 from chromadb.db.system import SysDB
 from chromadb.quota import QuotaEnforcer, Action
-from chromadb.rate_limit import RateLimitEnforcer
+from chromadb.rate_limit import RateLimitEnforcer, AsyncRateLimitEnforcer
 from chromadb.segment import SegmentManager
 from chromadb.execution.executor.abstract import Executor
 from chromadb.execution.expression.operator import Scan, Filter, Limit, KNN, Projection
@@ -117,6 +117,7 @@ class SegmentAPI(ServerAPI):
     _opentelemetry_client: OpenTelemetryClient
     _tenant_id: str
     _topic_ns: str
+    _rate_limit_enforcer: RateLimitEnforcer
 
     def __init__(self, system: System):
         super().__init__(system)

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -82,6 +82,7 @@ _abstract_type_keys: Dict[str, str] = {
     "chromadb.ingest.Producer": "chroma_producer_impl",
     "chromadb.quota.QuotaEnforcer": "chroma_quota_enforcer_impl",
     "chromadb.rate_limit.RateLimitEnforcer": "chroma_rate_limit_enforcer_impl",
+    "chromadb.rate_limit.AsyncRateLimitEnforcer": "chroma_async_rate_limit_enforcer_impl",
     "chromadb.segment.SegmentManager": "chroma_segment_manager_impl",
     "chromadb.segment.distributed.SegmentDirectory": "chroma_segment_directory_impl",
     "chromadb.segment.distributed.MemberlistProvider": "chroma_memberlist_provider_impl",
@@ -255,6 +256,10 @@ class Settings(BaseSettings):  # type: ignore
 
     chroma_rate_limit_enforcer_impl: str = (
         "chromadb.rate_limit.simple_rate_limit.SimpleRateLimitEnforcer"
+    )
+
+    chroma_async_rate_limit_enforcer_impl: str = (
+        "chromadb.rate_limit.simple_rate_limit.SimpleAsyncRateLimitEnforcer"
     )
 
     # ==========

--- a/chromadb/rate_limit/__init__.py
+++ b/chromadb/rate_limit/__init__.py
@@ -1,14 +1,16 @@
 from abc import abstractmethod
-from typing import Callable, TypeVar, Any
+from typing import Awaitable, Callable, TypeVar, Any
 from chromadb.config import Component, System
 
 T = TypeVar("T", bound=Callable[..., Any])
+A = TypeVar("A", bound=Awaitable[Any])
 
 
 class RateLimitEnforcer(Component):
     """
-    Rate limit enforcer. Implemented as a wrapper around server functions to
-    block requests if rate limits are exceeded.
+    Rate limit enforcer.
+
+    Implemented as a wrapper around server functions to block requests if rate limits are exceeded.
     """
 
     def __init__(self, system: System) -> None:
@@ -16,4 +18,19 @@ class RateLimitEnforcer(Component):
 
     @abstractmethod
     def rate_limit(self, func: T) -> T:
+        pass
+
+
+class AsyncRateLimitEnforcer(Component):
+    """
+    Rate limit enforcer.
+
+    Implemented as a wrapper around async functions to block requests if rate limits are exceeded.
+    """
+
+    def __init__(self, system: System) -> None:
+        super().__init__(system)
+
+    @abstractmethod
+    def rate_limit(self, func: A) -> A:
         pass

--- a/chromadb/rate_limit/simple_rate_limit/__init__.py
+++ b/chromadb/rate_limit/simple_rate_limit/__init__.py
@@ -1,11 +1,12 @@
 from overrides import override
-from typing import Any, Callable, TypeVar
+from typing import Any, Awaitable, Callable, TypeVar
 from functools import wraps
 
 from chromadb.rate_limit import RateLimitEnforcer
 from chromadb.config import System
 
 T = TypeVar("T", bound=Callable[..., Any])
+A = TypeVar("A", bound=Awaitable[Any])
 
 
 class SimpleRateLimitEnforcer(RateLimitEnforcer):
@@ -22,4 +23,20 @@ class SimpleRateLimitEnforcer(RateLimitEnforcer):
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             return func(*args, **kwargs)
 
+        return wrapper  # type: ignore
+
+
+class SimpleAsyncRateLimitEnforcer(RateLimitEnforcer):
+    """
+    A naive implementation of a rate limit enforcer that allows all requests.
+    """
+
+    def __init__(self, system: System) -> None:
+        super().__init__(system)
+
+    @override
+    def rate_limit(self, func: T) -> T:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return await func(*args, **kwargs)
         return wrapper  # type: ignore

--- a/chromadb/rate_limit/simple_rate_limit/__init__.py
+++ b/chromadb/rate_limit/simple_rate_limit/__init__.py
@@ -35,7 +35,7 @@ class SimpleAsyncRateLimitEnforcer(RateLimitEnforcer):
         super().__init__(system)
 
     @override
-    def rate_limit(self, func: T) -> T:
+    def rate_limit(self, func: A) -> A:
         @wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             return await func(*args, **kwargs)

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Awaitable,
     Callable,
     cast,
     Dict,
@@ -21,6 +22,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
 from fastapi.routing import APIRoute
 from fastapi import HTTPException, status
+from functools import wraps
 
 from chromadb.api.configuration import CollectionConfigurationInternal
 from pydantic import BaseModel
@@ -48,6 +50,7 @@ from chromadb.errors import (
     QuotaError,
 )
 from chromadb.quota import QuotaEnforcer
+from chromadb.rate_limit import AsyncRateLimitEnforcer
 from chromadb.server import Server
 from chromadb.server.fastapi.types import (
     AddEmbedding,
@@ -80,6 +83,18 @@ from chromadb.telemetry.opentelemetry import (
 from chromadb.types import Collection as CollectionModel
 
 logger = logging.getLogger(__name__)
+
+
+A = TypeVar("A", bound=Awaitable[Any])
+
+
+def rate_limit(func: A) -> A:
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        self = args[0]
+        return await self._async_rate_limit_enforcer.rate_limit(func)(*args, **kwargs)
+
+    return wrapper  # type: ignore
 
 
 def use_route_names_as_operation_ids(app: _FastAPI) -> None:
@@ -203,6 +218,7 @@ class FastAPI(Server):
         self._app.add_exception_handler(
             RateLimitError, self.rate_limit_exception_handler
         )
+        self._async_rate_limit_enforcer = self._system.require(AsyncRateLimitEnforcer)
 
         self._app.on_event("shutdown")(self.shutdown)
 
@@ -449,6 +465,7 @@ class FastAPI(Server):
         "auth_request",
         OpenTelemetryGranularity.OPERATION,
     )
+    @rate_limit
     async def auth_request(
         self,
         headers: Headers,
@@ -504,6 +521,7 @@ class FastAPI(Server):
         return
 
     @trace_method("FastAPI.get_user_identity", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_user_identity(
         self,
         request: Request,
@@ -521,6 +539,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_database", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def create_database(
         self,
         request: Request,
@@ -552,6 +571,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_database", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_database(
         self,
         request: Request,
@@ -599,6 +619,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def create_tenant(
         self,
         request: Request,
@@ -625,6 +646,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_tenant(
         self,
         request: Request,
@@ -648,6 +670,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.list_databases", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def list_databases(
         self,
         request: Request,
@@ -675,6 +698,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.list_collections", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def list_collections(
         self,
         request: Request,
@@ -716,6 +740,7 @@ class FastAPI(Server):
         return api_collection_models
 
     @trace_method("FastAPI.count_collections", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def count_collections(
         self,
         request: Request,
@@ -743,6 +768,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_collection", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def create_collection(
         self,
         request: Request,
@@ -794,6 +820,7 @@ class FastAPI(Server):
         return api_collection_model
 
     @trace_method("FastAPI.get_collection", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_collection(
         self,
         request: Request,
@@ -824,6 +851,7 @@ class FastAPI(Server):
         return api_collection_model
 
     @trace_method("FastAPI.update_collection", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def update_collection(
         self,
         tenant: str,
@@ -861,6 +889,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.delete_collection", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def delete_collection(
         self,
         request: Request,
@@ -886,6 +915,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.add", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def add(
         self,
         request: Request,
@@ -935,6 +965,7 @@ class FastAPI(Server):
             raise HTTPException(status_code=500, detail=str(e))
 
     @trace_method("FastAPI.update", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def update(
         self,
         request: Request,
@@ -976,6 +1007,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.upsert", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def upsert(
         self,
         request: Request,
@@ -1020,6 +1052,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get(
         self,
         collection_id: str,
@@ -1070,6 +1103,7 @@ class FastAPI(Server):
         return get_result
 
     @trace_method("FastAPI.delete", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def delete(
         self,
         collection_id: str,
@@ -1105,6 +1139,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.count", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def count(
         self,
         request: Request,
@@ -1133,6 +1168,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.reset", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def reset(
         self,
         request: Request,
@@ -1154,6 +1190,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_nearest_neighbors", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_nearest_neighbors(
         self,
         tenant: str,
@@ -1357,6 +1394,7 @@ class FastAPI(Server):
         "auth_and_get_tenant_and_database_for_request_v1",
         OpenTelemetryGranularity.OPERATION,
     )
+    @rate_limit
     async def auth_and_get_tenant_and_database_for_request(
         self,
         headers: Headers,
@@ -1432,6 +1470,7 @@ class FastAPI(Server):
         return (tenant, database)
 
     @trace_method("FastAPI.create_database_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def create_database_v1(
         self,
         request: Request,
@@ -1468,6 +1507,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_database_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_database_v1(
         self,
         request: Request,
@@ -1500,6 +1540,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_tenant_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def create_tenant_v1(
         self,
         request: Request,
@@ -1527,6 +1568,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_tenant_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_tenant_v1(
         self,
         request: Request,
@@ -1552,6 +1594,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.list_collections_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def list_collections_v1(
         self,
         request: Request,
@@ -1590,6 +1633,7 @@ class FastAPI(Server):
         return api_collection_models
 
     @trace_method("FastAPI.count_collections_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def count_collections_v1(
         self,
         request: Request,
@@ -1622,6 +1666,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_collection_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def create_collection_v1(
         self,
         request: Request,
@@ -1676,6 +1721,7 @@ class FastAPI(Server):
         return api_collection_model
 
     @trace_method("FastAPI.get_collection_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_collection_v1(
         self,
         request: Request,
@@ -1714,6 +1760,7 @@ class FastAPI(Server):
         return await inner()
 
     @trace_method("FastAPI.update_collection_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def update_collection_v1(
         self,
         collection_id: str,
@@ -1745,6 +1792,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.delete_collection_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def delete_collection_v1(
         self,
         request: Request,
@@ -1776,6 +1824,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.add_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def add_v1(
         self,
         request: Request,
@@ -1854,6 +1903,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.upsert_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def upsert_v1(
         self,
         request: Request,
@@ -1892,6 +1942,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def get_v1(
         self,
         collection_id: str,
@@ -1936,6 +1987,7 @@ class FastAPI(Server):
         return get_result
 
     @trace_method("FastAPI.delete_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def delete_v1(
         self,
         collection_id: str,
@@ -1965,6 +2017,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.count_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def count_v1(
         self,
         request: Request,
@@ -1988,6 +2041,7 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.reset_v1", OpenTelemetryGranularity.OPERATION)
+    @rate_limit
     async def reset_v1(
         self,
         request: Request,
@@ -2011,6 +2065,7 @@ class FastAPI(Server):
     @trace_method(
         "FastAPI.get_nearest_neighbors_v1", OpenTelemetryGranularity.OPERATION
     )
+    @rate_limit
     async def get_nearest_neighbors_v1(
         self,
         collection_id: str,

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -517,7 +517,6 @@ class FastAPI(Server):
         return
 
     @trace_method("FastAPI.get_user_identity", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def get_user_identity(
         self,
         request: Request,
@@ -535,7 +534,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_database", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def create_database(
         self,
         request: Request,
@@ -567,7 +565,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_database", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def get_database(
         self,
         request: Request,
@@ -615,7 +612,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def create_tenant(
         self,
         request: Request,
@@ -642,7 +638,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def get_tenant(
         self,
         request: Request,
@@ -666,7 +661,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.list_databases", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def list_databases(
         self,
         request: Request,
@@ -694,7 +688,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.list_collections", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def list_collections(
         self,
         request: Request,
@@ -736,7 +729,6 @@ class FastAPI(Server):
         return api_collection_models
 
     @trace_method("FastAPI.count_collections", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def count_collections(
         self,
         request: Request,
@@ -764,7 +756,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.create_collection", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def create_collection(
         self,
         request: Request,
@@ -816,7 +807,6 @@ class FastAPI(Server):
         return api_collection_model
 
     @trace_method("FastAPI.get_collection", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def get_collection(
         self,
         request: Request,
@@ -847,7 +837,6 @@ class FastAPI(Server):
         return api_collection_model
 
     @trace_method("FastAPI.update_collection", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def update_collection(
         self,
         tenant: str,
@@ -885,7 +874,6 @@ class FastAPI(Server):
         )
 
     @trace_method("FastAPI.delete_collection", OpenTelemetryGranularity.OPERATION)
-    @rate_limit
     async def delete_collection(
         self,
         request: Request,

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -85,16 +85,12 @@ from chromadb.types import Collection as CollectionModel
 logger = logging.getLogger(__name__)
 
 
-A = TypeVar("A", bound=Awaitable[Any])
-
-
-def rate_limit(func: A) -> A:
+def rate_limit(func):
     @wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         self = args[0]
         return await self._async_rate_limit_enforcer.rate_limit(func)(*args, **kwargs)
-
-    return wrapper  # type: ignore
+    return wrapper
 
 
 def use_route_names_as_operation_ids(app: _FastAPI) -> None:


### PR DESCRIPTION
This adds a rate limiter at the level of the fast api async code.  The
reason for doing this is that by the time stuff gets to the pool,
there's a queue.  We want to try and make the rate limiter async so that
we can avoid said queue.
