### PR TITLE
[BUG] Fix hnsw malloc of 0 bytes

### DIFF
--- a/rust/index/bindings.cpp
+++ b/rust/index/bindings.cpp
@@ -87,13 +87,13 @@ public:
         index_inited = true;
     }
 
-    void load_index(const std::string &path_to_index, const bool allow_replace_deleted, const bool is_persistent_index)
+    void load_index(const std::string &path_to_index, const bool allow_replace_deleted, const bool is_persistent_index, const size_t max_elements)
     {
         if (index_inited)
         {
             throw std::runtime_error("Index already inited");
         }
-        appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, 0, allow_replace_deleted, normalize, is_persistent_index);
+        appr_alg = new hnswlib::HierarchicalNSW<dist_t>(l2space, path_to_index, false, max_elements, allow_replace_deleted, normalize, is_persistent_index);
         // TODO(rescrv,sicheng): check integrity
         // appr_alg->checkIntegrity();
         index_inited = true;
@@ -278,11 +278,11 @@ extern "C"
     }
 
     // Can throw std::exception
-    void load_index(Index<float> *index, const char *path_to_index, const bool allow_replace_deleted, const bool is_persistent_index)
+    void load_index(Index<float> *index, const char *path_to_index, const bool allow_replace_deleted, const bool is_persistent_index, const size_t max_elements)
     {
         try
         {
-            index->load_index(path_to_index, allow_replace_deleted, is_persistent_index);
+            index->load_index(path_to_index, allow_replace_deleted, is_persistent_index, max_elements);
         }
         catch (std::exception &e)
         {

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -284,7 +284,7 @@ impl PersistentIndex<HnswIndexConfig> for HnswIndex {
             Err(e) => return Err(Box::new(HnswIndexInitError::InvalidPath(e.to_string()))),
         };
         unsafe {
-            load_index(ffi_ptr, path.as_ptr(), true, true);
+            load_index(ffi_ptr, path.as_ptr(), true, true, DEFAULT_MAX_ELEMENTS);
         }
         read_and_return_hnsw_error(ffi_ptr)?;
 
@@ -379,6 +379,7 @@ extern "C" {
         path: *const c_char,
         allow_replace_deleted: bool,
         is_persistent_index: bool,
+        max_elements: usize,
     );
 
     fn persist_dirty(index: *const IndexPtrFFI);


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - If you load an empty hnsw index, the index capacity is set to 0. Fixes this

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
