### PR TITLE
[ENH]  Improve the grpc used to contact knn.

### DIFF
--- a/chromadb/execution/executor/distributed.py
+++ b/chromadb/execution/executor/distributed.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Dict, Optional
 import grpc
 from overrides import overrides


### PR DESCRIPTION
Auth is no longer a bottleneck.  This PR fixes two problems:
- Max concurrent streams is 100 by default and we need it to be higher.
- I'm unfamiliar with Python threading, but I don't think a dictionary
  add is atomic in that putting into a dictionary is a release and
  reading from a dictionary an acquire.  Add a mutex for safety.
