### PR TITLE
[BLD]: Added chomadb dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ tqdm>=4.65.0
 typer>=0.9.0
 typing_extensions>=4.5.0
 uvicorn[standard]>=0.18.3
+chromadb==0.6.3


### PR DESCRIPTION
## Description of changes
I added `chromadb` python dependency to this PR is order to resolve the issue that I was facing - 
#3493 - importlib.metadata.PackageNotFoundError: No package metadata was found for chromadb

I faced this issue while running the docker image and accessing Swagger docs.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
