### PR TITLE
[BUG]: Removing numpy pinning from python client

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  'numpy >= 1.22.5, < 2.0.0',
+  'numpy >= 1.22.5',
   'opentelemetry-api>=1.2.0',
   'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
   'opentelemetry-sdk>=1.2.0',


### PR DESCRIPTION
## Description of changes

Ref: https://discord.com/channels/1073293645303795742/1329146423786213521/1329156629781942413

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Turns out we've forgot to remove the numpy pinning in python client

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
