### PR TITLE
[ENH] Update Python Collection with total_records_post_compaction field

### DIFF
--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -60,7 +60,9 @@ def to_proto_vector(vector: Vector, encoding: ScalarEncoding) -> chroma_pb.Vecto
             or {ScalarEncoding.INT32}"
         )
 
-    return chroma_pb.Vector(dimension=vector.size, vector=as_bytes, encoding=proto_encoding)
+    return chroma_pb.Vector(
+        dimension=vector.size, vector=as_bytes, encoding=proto_encoding
+    )
 
 
 def from_proto_vector(vector: chroma_pb.Vector) -> Tuple[Embedding, ScalarEncoding]:
@@ -161,7 +163,10 @@ def from_proto_segment(segment: chroma_pb.Segment) -> Segment:
         metadata=from_proto_metadata(segment.metadata)
         if segment.HasField("metadata")
         else None,
-        file_paths={name: [path for path in paths.paths] for name, paths in segment.file_paths.items()}
+        file_paths={
+            name: [path for path in paths.paths]
+            for name, paths in segment.file_paths.items()
+        },
     )
 
 
@@ -174,7 +179,10 @@ def to_proto_segment(segment: Segment) -> chroma_pb.Segment:
         metadata=None
         if segment["metadata"] is None
         else to_proto_update_metadata(segment["metadata"]),
-        file_paths={name: chroma_pb.FilePaths(paths=paths) for name, paths in segment["file_paths"].items()}
+        file_paths={
+            name: chroma_pb.FilePaths(paths=paths)
+            for name, paths in segment["file_paths"].items()
+        },
     )
 
 
@@ -241,6 +249,7 @@ def from_proto_collection(collection: chroma_pb.Collection) -> Collection:
         tenant=collection.tenant,
         version=collection.version,
         log_position=collection.log_position,
+        total_records_post_compaction=collection.total_records_post_compaction,
     )
 
 
@@ -257,6 +266,7 @@ def to_proto_collection(collection: Collection) -> chroma_pb.Collection:
         database=collection["database"],
         log_position=collection["log_position"],
         version=collection["version"],
+        total_records_post_compaction=collection["total_records_post_compaction"],
     )
 
 
@@ -581,7 +591,9 @@ def to_proto_scan(scan: Scan) -> query_pb.ScanOperator:
 
 def to_proto_filter(filter: Filter) -> query_pb.FilterOperator:
     return query_pb.FilterOperator(
-        ids=chroma_pb.UserIds(ids=filter.user_ids) if filter.user_ids is not None else None,
+        ids=chroma_pb.UserIds(ids=filter.user_ids)
+        if filter.user_ids is not None
+        else None,
         where=to_proto_where(filter.where) if filter.where else None,
         where_document=to_proto_where_document(filter.where_document)
         if filter.where_document

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -73,6 +73,7 @@ class Collection(
     # in single-node chroma, this field is always 0
     version: int
     log_position: int
+    total_records_post_compaction: int
 
     def __init__(
         self,
@@ -85,6 +86,7 @@ class Collection(
         database: str,
         version: int = 0,
         log_position: int = 0,
+        total_records_post_compaction: int = 0,
     ):
         super().__init__(
             id=id,
@@ -96,6 +98,7 @@ class Collection(
             database=database,
             version=version,
             log_position=log_position,
+            total_records_post_compaction=total_records_post_compaction,
         )
 
     # TODO: This throws away type information.
@@ -178,9 +181,11 @@ class Segment(TypedDict):
     metadata: Optional[Metadata]
     file_paths: Mapping[str, Sequence[str]]
 
+
 class CollectionAndSegments(TypedDict):
     collection: Collection
     segments: Sequence[Segment]
+
 
 # SeqID can be one of three types of value in our current and future plans:
 # 1. A Pulsar MessageID encoded as a 192-bit integer - This is no longer used as we removed pulsar


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
   - Updates Python `Collection` type to have new field, `total_records_post_compaction`, in line with proto changes

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
