### PR TITLE
[ENH] Add collection_id param to QuotaEnforcer enforce func

### DIFF
--- a/chromadb/quota/__init__.py
+++ b/chromadb/quota/__init__.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from enum import Enum
 from typing import Dict, Any, Optional
+from uuid import UUID
 
 from chromadb.api.types import (
     Embeddings,
@@ -62,6 +63,7 @@ class QuotaEnforcer(Component):
         where_document: Optional[WhereDocument] = None,
         n_results: Optional[int] = None,
         query_embeddings: Optional[Embeddings] = None,
+        collection_id: Optional[UUID] = None,
     ) -> None:
         """
         Enforces a quota.

--- a/chromadb/quota/simple_quota_enforcer/__init__.py
+++ b/chromadb/quota/simple_quota_enforcer/__init__.py
@@ -1,5 +1,6 @@
 from overrides import override
 from typing import Any, Callable, TypeVar, Dict, Optional
+from uuid import UUID
 
 from chromadb.api.types import (
     Embeddings,
@@ -48,5 +49,6 @@ class SimpleQuotaEnforcer(QuotaEnforcer):
         where_document: Optional[WhereDocument] = None,
         n_results: Optional[int] = None,
         query_embeddings: Optional[Embeddings] = None,
+        collection_id: Optional[UUID] = None,
     ) -> None:
         pass


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
   - Updates `QuotaEnforcer.enforce` abstract class to receive a `collection_id` UUID

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
