### PR TITLE
[ENH] Update DBConfig to take read address

### DIFF
--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -37,6 +37,7 @@ func init() {
 	Cmd.Flags().StringVar(&conf.DBConfig.Username, "username", "chroma", "MetaTable username")
 	Cmd.Flags().StringVar(&conf.DBConfig.Password, "password", "chroma", "MetaTable password")
 	Cmd.Flags().StringVar(&conf.DBConfig.Address, "db-address", "postgres", "MetaTable db address")
+	Cmd.Flags().StringVar(&conf.DBConfig.ReadAddress, "read-db-address", "postgres", "MetaTable db read only address")
 	Cmd.Flags().IntVar(&conf.DBConfig.Port, "db-port", 5432, "MetaTable db port")
 	Cmd.Flags().StringVar(&conf.DBConfig.DBName, "db-name", "sysdb", "MetaTable db name")
 	Cmd.Flags().IntVar(&conf.DBConfig.MaxIdleConns, "max-idle-conns", 10, "MetaTable max idle connections")

--- a/go/pkg/sysdb/metastore/db/dbcore/core.go
+++ b/go/pkg/sysdb/metastore/db/dbcore/core.go
@@ -31,6 +31,7 @@ type DBConfig struct {
 	Username     string
 	Password     string
 	Address      string
+	ReadAddress  string
 	Port         int
 	DBName       string
 	MaxIdleConns int
@@ -225,6 +226,7 @@ func GetDBConfigForTesting() DBConfig {
 		MaxIdleConns: 10,
 		MaxOpenConns: 100,
 		SslMode:      "disable",
+		ReadAddress:  "localhost",
 	}
 }
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds `ReadAddress` to `DBConfig` for `SysDB` Go coordinator
 - New functionality
   - None

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
