### PR TITLE
[ENH] Expose reader endpoint on SysDB coordinator

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -17,7 +17,8 @@ proto:
 		--plugin protoc-gen-go-grpc="$(PROTOC_GEN_GO_GRPC_BIN_PATH)" \
 		../idl/chromadb/proto/chroma.proto \
 		../idl/chromadb/proto/coordinator.proto \
-		../idl/chromadb/proto/logservice.proto
+		../idl/chromadb/proto/logservice.proto \
+		../idl/chromadb/proto/read_coordinator.proto
 	@mv pkg/proto/coordinatorpb/chromadb/proto/logservice*.go pkg/proto/logservicepb/
 	@mv pkg/proto/coordinatorpb/chromadb/proto/*.go pkg/proto/coordinatorpb/
 	@rm -rf pkg/proto/coordinatorpb/chromadb

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -33,6 +33,7 @@ type APIsTestSuite struct {
 	databaseId        string
 	sampleCollections []*model.Collection
 	coordinator       *Coordinator
+	readCoordinator   *ReadCoordinator
 }
 
 func (suite *APIsTestSuite) SetupSuite() {
@@ -57,7 +58,12 @@ func (suite *APIsTestSuite) SetupTest() {
 	if err != nil {
 		suite.T().Fatalf("error creating coordinator: %v", err)
 	}
+	read_c, err := NewReadCoordinator(ctx, suite.db)
+	if err != nil {
+		suite.T().Fatalf("error creating read coordinator: %v", err)
+	}
 	suite.coordinator = c
+	suite.readCoordinator = read_c
 	for _, collection := range suite.sampleCollections {
 		_, _, errCollectionCreation := c.CreateCollection(ctx, &model.CreateCollection{
 			ID:           collection.ID,

--- a/go/pkg/sysdb/coordinator/read_coordinator.go
+++ b/go/pkg/sysdb/coordinator/read_coordinator.go
@@ -1,0 +1,32 @@
+package coordinator
+
+import (
+	"context"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
+	"github.com/chroma-core/chroma/go/pkg/types"
+	"gorm.io/gorm"
+)
+
+type ReadCoordinator struct {
+	ctx     context.Context
+	catalog ReadCatalog
+}
+
+func NewReadCoordinator(ctx context.Context, db *gorm.DB) (*ReadCoordinator, error) {
+	s := &ReadCoordinator{
+		ctx: ctx,
+	}
+
+	// catalog
+	txnImpl := dbcore.NewTxImpl()
+	metaDomain := dao.NewMetaDomain()
+	s.catalog = *NewReadTableCatalog(txnImpl, metaDomain)
+	return s, nil
+}
+
+func (s *ReadCoordinator) GetCollectionsRead(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string) ([]*model.Collection, error) {
+	return s.catalog.GetCollectionsRead(ctx, collectionID, collectionName, tenantID, databaseName)
+}

--- a/go/pkg/sysdb/coordinator/read_coordinator.go
+++ b/go/pkg/sysdb/coordinator/read_coordinator.go
@@ -20,7 +20,6 @@ func NewReadCoordinator(ctx context.Context, db *gorm.DB) (*ReadCoordinator, err
 		ctx: ctx,
 	}
 
-	// catalog
 	txnImpl := dbcore.NewTxImpl()
 	metaDomain := dao.NewMetaDomain()
 	s.catalog = *NewReadTableCatalog(txnImpl, metaDomain)

--- a/go/pkg/sysdb/coordinator/read_coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/read_coordinator_test.go
@@ -1,0 +1,34 @@
+package coordinator
+
+import (
+	"context"
+	"sort"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
+	"github.com/chroma-core/chroma/go/pkg/types"
+)
+
+func (suite *APIsTestSuite) TestGetCollectionsRead() {
+	ctx := context.Background()
+	results, err := suite.readCoordinator.GetCollectionsRead(ctx, types.NilUniqueID(), nil, suite.tenantName, suite.databaseName)
+	suite.NoError(err)
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+	suite.Equal(suite.sampleCollections, results)
+
+	// Find by name
+	for _, collection := range suite.sampleCollections {
+		result, err := suite.readCoordinator.GetCollectionsRead(ctx, types.NilUniqueID(), &collection.Name, suite.tenantName, suite.databaseName)
+		suite.NoError(err)
+		suite.Equal([]*model.Collection{collection}, result)
+	}
+
+	// Find by id
+	for _, collection := range suite.sampleCollections {
+		result, err := suite.readCoordinator.GetCollectionsRead(ctx, collection.ID, nil, suite.tenantName, suite.databaseName)
+		suite.NoError(err)
+		suite.Equal([]*model.Collection{collection}, result)
+	}
+}

--- a/go/pkg/sysdb/coordinator/read_table_catalog.go
+++ b/go/pkg/sysdb/coordinator/read_table_catalog.go
@@ -1,0 +1,37 @@
+package coordinator
+
+import (
+	"context"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
+	"github.com/chroma-core/chroma/go/pkg/types"
+	"github.com/chroma-core/chroma/go/shared/otel"
+)
+
+type ReadCatalog struct {
+	metaDomain dbmodel.IMetaDomain
+	txImpl     dbmodel.ITransaction
+}
+
+func NewReadTableCatalog(txImpl dbmodel.ITransaction, metaDomain dbmodel.IMetaDomain) *ReadCatalog {
+	return &ReadCatalog{
+		txImpl:     txImpl,
+		metaDomain: metaDomain,
+	}
+}
+
+func (tc *ReadCatalog) GetCollectionsRead(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string) ([]*model.Collection, error) {
+	tracer := otel.Tracer
+	if tracer != nil {
+		_, span := tracer.Start(ctx, "Catalog.GetCollectionsRead")
+		defer span.End()
+	}
+
+	collectionAndMetadataList, err := tc.metaDomain.CollectionDb(ctx).GetCollections(types.FromUniqueID(collectionID), collectionName, tenantID, databaseName, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	collections := convertCollectionToModel(collectionAndMetadataList)
+	return collections, nil
+}

--- a/go/pkg/sysdb/coordinator/read_table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/read_table_catalog_test.go
@@ -1,0 +1,78 @@
+package coordinator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chroma-core/chroma/go/pkg/common"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel/mocks"
+	"github.com/chroma-core/chroma/go/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCatalog_GetCollectionsRead(t *testing.T) {
+	// create a mock meta domain implementation
+	mockMetaDomain := &mocks.IMetaDomain{}
+
+	// create a new catalog instance
+	catalog := NewReadTableCatalog(nil, mockMetaDomain)
+
+	// create a mock collection ID
+	collectionID := types.MustParse("00000000-0000-0000-0000-000000000001")
+
+	// create a mock collection name
+	collectionName := "test_collection"
+
+	// create a mock collection and metadata list
+	name := "test_collection"
+	testKey := "test_key"
+	testValue := "test_value"
+	collectionConfigurationJsonStr := "{\"a\": \"param\", \"b\": \"param2\", \"3\": true}"
+	collectionAndMetadataList := []*dbmodel.CollectionAndMetadata{
+		{
+			Collection: &dbmodel.Collection{
+				ID:                   "00000000-0000-0000-0000-000000000001",
+				Name:                 &name,
+				ConfigurationJsonStr: &collectionConfigurationJsonStr,
+				Ts:                   types.Timestamp(1234567890),
+			},
+			CollectionMetadata: []*dbmodel.CollectionMetadata{
+				{
+					CollectionID: "00000000-0000-0000-0000-000000000001",
+					Key:          &testKey,
+					StrValue:     &testValue,
+					Ts:           types.Timestamp(1234567890),
+				},
+			},
+		},
+	}
+
+	// mock the get collections method
+	mockMetaDomain.On("CollectionDb", context.Background()).Return(&mocks.ICollectionDb{})
+	var n *int32
+	mockMetaDomain.CollectionDb(context.Background()).(*mocks.ICollectionDb).On("GetCollections", types.FromUniqueID(collectionID), &collectionName, common.DefaultTenant, common.DefaultDatabase, n, n).Return(collectionAndMetadataList, nil)
+
+	// call the GetCollections method
+	collections, err := catalog.GetCollectionsRead(context.Background(), collectionID, &collectionName, defaultTenant, defaultDatabase)
+
+	// assert that the method returned no error
+	assert.NoError(t, err)
+
+	// assert that the collections were returned as expected
+	metadata := model.NewCollectionMetadata[model.CollectionMetadataValueType]()
+	metadata.Add("test_key", &model.CollectionMetadataValueStringType{Value: "test_value"})
+	assert.Equal(t, []*model.Collection{
+		{
+			ID:                   types.MustParse("00000000-0000-0000-0000-000000000001"),
+			Name:                 "test_collection",
+			ConfigurationJsonStr: collectionConfigurationJsonStr,
+			Ts:                   types.Timestamp(1234567890),
+			Metadata:             metadata,
+		},
+	}, collections)
+
+	// assert that the mock methods were called as expected
+	mockMetaDomain.AssertExpectations(t)
+}

--- a/go/pkg/sysdb/grpc/cleaup_test.go
+++ b/go/pkg/sysdb/grpc/cleaup_test.go
@@ -36,7 +36,7 @@ func (suite *CleanupTestSuite) SetupSuite() {
 		SoftDeleteCleanupInterval:  1 * time.Second,
 		SoftDeleteMaxAge:           0,
 		SoftDeleteCleanupBatchSize: 10,
-		Testing:                    true}, grpcutils.Default, suite.db)
+		Testing:                    true}, grpcutils.Default, suite.db, nil)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)
 	}

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -40,7 +40,7 @@ func (suite *CollectionServiceTestSuite) SetupSuite() {
 	suite.db = dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
-		Testing:               true}, grpcutils.Default, suite.db)
+		Testing:               true}, grpcutils.Default, suite.db, nil)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)
 	}
@@ -73,7 +73,7 @@ func testCollection(t *rapid.T) {
 	db := dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "memory",
-		Testing:               true}, grpcutils.Default, db)
+		Testing:               true}, grpcutils.Default, db, nil)
 	if err != nil {
 		t.Fatalf("error creating server: %v", err)
 	}
@@ -304,6 +304,15 @@ func (suite *CollectionServiceTestSuite) TestCreateCollection() {
 	suite.Len(getResp.Collections, 1)
 	suite.Equal(collectionID.String(), getResp.Collections[0].Id)
 	suite.Equal(collectionName, getResp.Collections[0].Name)
+
+	getReadReq := &coordinatorpb.GetCollectionsReadRequest{
+		Id: &collectionIDStr,
+	}
+	getReadResp, err := suite.s.GetCollectionsRead(context.Background(), getReadReq)
+	suite.NoError(err)
+	suite.Len(getReadResp.Collections, 1)
+	suite.Equal(collectionID.String(), getReadResp.Collections[0].Id)
+	suite.Equal(collectionName, getReadResp.Collections[0].Name)
 
 	// Verify the segments exist
 	getSegmentsResp, err := suite.s.GetSegments(context.Background(), &coordinatorpb.GetSegmentsRequest{

--- a/go/pkg/sysdb/grpc/tenant_database_service_test.go
+++ b/go/pkg/sysdb/grpc/tenant_database_service_test.go
@@ -33,7 +33,7 @@ func (suite *TenantDatabaseServiceTestSuite) SetupSuite() {
 	suite.db = dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
-		Testing:               true}, grpcutils.Default, suite.db)
+		Testing:               true}, grpcutils.Default, suite.db, nil)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)
 	}

--- a/idl/chromadb/proto/read_coordinator.proto
+++ b/idl/chromadb/proto/read_coordinator.proto
@@ -3,9 +3,7 @@ syntax = "proto3";
 package chroma;
 option go_package = "github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb";
 
-import "chromadb/proto/chroma.proto";
 import "chromadb/proto/coordinator.proto";
-import "google/protobuf/empty.proto";
 
 message GetCollectionsReadRequest {
   optional string id = 1;

--- a/idl/chromadb/proto/read_coordinator.proto
+++ b/idl/chromadb/proto/read_coordinator.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package chroma;
+option go_package = "github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb";
+
+import "chromadb/proto/chroma.proto";
+import "chromadb/proto/coordinator.proto";
+import "google/protobuf/empty.proto";
+
+message GetCollectionsReadRequest {
+  optional string id = 1;
+  optional string name = 2;
+  string tenant = 4;
+  string database = 5;
+}
+
+service ReadSysDB {
+  rpc GetCollectionsRead(GetCollectionsReadRequest) returns (GetCollectionsResponse) {}
+}

--- a/idl/makefile
+++ b/idl/makefile
@@ -9,7 +9,8 @@ proto_python:
 	    ./chromadb/proto/chroma.proto \
 	    ./chromadb/proto/coordinator.proto \
 	    ./chromadb/proto/logservice.proto \
-	    ./chromadb/proto/query_executor.proto
+	    ./chromadb/proto/query_executor.proto \
+		./chromadb/proto/read_coordinator.proto
 	@mv chromadb/proto/*.py ../chromadb/proto/
 	@mv chromadb/proto/*.pyi ../chromadb/proto/
 	@echo "Done"
@@ -25,7 +26,8 @@ proto_go:
     	--plugin protoc-gen-go-grpc="${PROTOC_GEN_GO_GRPC_BIN_PATH}" \
 			chromadb/proto/chroma.proto \
 			chromadb/proto/coordinator.proto \
-			chromadb/proto/logservice.proto
+			chromadb/proto/logservice.proto \
+			chromadb/proto/read_coordinator.proto
 	@mv ../go/pkg/proto/coordinatorpb/chromadb/proto/logservice*.go ../go/pkg/proto/logservicepb/
 	@mv ../go/pkg/proto/coordinatorpb/chromadb/proto/*.go ../go/pkg/proto/coordinatorpb/
 	@rm -rf ../go/pkg/proto/coordinatorpb/chromadb


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - None
 - New functionality
   - Hooks up `SysDB` Go coordinator to a reader endpoint of the database
   - Creates a `ReadCoordinator` and `ReadCatalog` in order to facilitate access to the reader
   - Exposes a new API endpoint, `GetCollectionsRead` to allow consumers to get collections via the reader

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
