### PR TITLE
[ENH] GetCollectionSize on SysDB read replica

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/types"
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 )
 
 // DeleteMode represents whether to perform a soft or hard delete
@@ -33,7 +32,7 @@ type Coordinator struct {
 	deleteMode DeleteMode
 }
 
-func NewCoordinator(ctx context.Context, db *gorm.DB, deleteMode DeleteMode) (*Coordinator, error) {
+func NewCoordinator(ctx context.Context, deleteMode DeleteMode) (*Coordinator, error) {
 	s := &Coordinator{
 		ctx:        ctx,
 		deleteMode: deleteMode,
@@ -113,6 +112,10 @@ func (s *Coordinator) CreateCollection(ctx context.Context, createCollection *mo
 
 func (s *Coordinator) GetCollections(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*model.Collection, error) {
 	return s.catalog.GetCollections(ctx, collectionID, collectionName, tenantID, databaseName, limit, offset)
+}
+
+func (s *Coordinator) GetCollectionSize(ctx context.Context, collectionID types.UniqueID) (uint64, error) {
+	return s.catalog.GetCollectionSize(ctx, collectionID)
 }
 
 func (s *Coordinator) GetCollectionWithSegments(ctx context.Context, collectionID types.UniqueID) (*model.Collection, []*model.Segment, error) {

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -25,6 +25,7 @@ import (
 type APIsTestSuite struct {
 	suite.Suite
 	db                *gorm.DB
+	read_db           *gorm.DB
 	collectionId1     types.UniqueID
 	collectionId2     types.UniqueID
 	records           [][]byte
@@ -38,6 +39,7 @@ type APIsTestSuite struct {
 func (suite *APIsTestSuite) SetupSuite() {
 	log.Info("setup suite")
 	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
 }
 
 func (suite *APIsTestSuite) SetupTest() {

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -53,7 +53,7 @@ func (suite *APIsTestSuite) SetupTest() {
 		collection.Name = "collection_" + suite.T().Name() + strconv.Itoa(index)
 	}
 	ctx := context.Background()
-	c, err := NewCoordinator(ctx, suite.db, SoftDelete)
+	c, err := NewCoordinator(ctx, SoftDelete)
 	if err != nil {
 		suite.T().Fatalf("error creating coordinator: %v", err)
 	}
@@ -82,9 +82,9 @@ func (suite *APIsTestSuite) TearDownTest() {
 // TODO: This is not complete yet. We need to add more tests for the other APIs.
 // We will deprecate the example based tests once we have enough tests here.
 func testCollection(t *rapid.T) {
-	db := dbcore.ConfigDatabaseForTesting()
+	dbcore.ConfigDatabaseForTesting()
 	ctx := context.Background()
-	c, err := NewCoordinator(ctx, db, HardDelete)
+	c, err := NewCoordinator(ctx, HardDelete)
 	if err != nil {
 		t.Fatalf("error creating coordinator: %v", err)
 	}
@@ -135,9 +135,9 @@ func testCollection(t *rapid.T) {
 }
 
 func testSegment(t *rapid.T) {
-	db := dbcore.ConfigDatabaseForTesting()
+	dbcore.ConfigDatabaseForTesting()
 	ctx := context.Background()
-	c, err := NewCoordinator(ctx, db, HardDelete)
+	c, err := NewCoordinator(ctx, HardDelete)
 	if err != nil {
 		t.Fatalf("error creating coordinator: %v", err)
 	}

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -495,6 +495,16 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	suite.Empty(segments)
 }
 
+func (suite *APIsTestSuite) TestCollectionSize() {
+	ctx := context.Background()
+
+	for _, collection := range suite.sampleCollections {
+		result, err := suite.coordinator.GetCollectionSize(ctx, collection.ID)
+		suite.NoError(err)
+		suite.Equal(uint64(0), result)
+	}
+}
+
 func (suite *APIsTestSuite) TestUpdateCollections() {
 	ctx := context.Background()
 	coll := &model.Collection{

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -38,8 +38,7 @@ type APIsTestSuite struct {
 
 func (suite *APIsTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
-	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
+	suite.db, suite.read_db = dbcore.ConfigDatabaseForTesting()
 }
 
 func (suite *APIsTestSuite) SetupTest() {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -374,7 +374,7 @@ func (tc *Catalog) GetCollectionSize(ctx context.Context, collectionID types.Uni
 		defer span.End()
 	}
 
-	total_records_post_compaction, err := tc.metaDomain.CollectionDb(ctx).GetCollectionSize(*types.FromUniqueID(collectionID))
+	total_records_post_compaction, err := tc.metaDomain.CollectionDb(ctx).GetCollectionSize(collectionID.String())
 	if err != nil {
 		return 0, err
 	}

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -367,6 +367,20 @@ func (tc *Catalog) GetCollections(ctx context.Context, collectionID types.Unique
 	return collections, nil
 }
 
+func (tc *Catalog) GetCollectionSize(ctx context.Context, collectionID types.UniqueID) (uint64, error) {
+	tracer := otel.Tracer
+	if tracer != nil {
+		_, span := tracer.Start(ctx, "Catalog.GetCollectionSize")
+		defer span.End()
+	}
+
+	total_records_post_compaction, err := tc.metaDomain.CollectionDb(ctx).GetCollectionSize(*types.FromUniqueID(collectionID))
+	if err != nil {
+		return 0, err
+	}
+	return total_records_post_compaction, nil
+}
+
 func (tc *Catalog) GetCollectionWithSegments(ctx context.Context, collectionID types.UniqueID) (*model.Collection, []*model.Segment, error) {
 	tracer := otel.Tracer
 	if tracer != nil {

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -137,3 +137,17 @@ func TestCatalog_GetCollections(t *testing.T) {
 	// assert that the mock methods were called as expected
 	mockMetaDomain.AssertExpectations(t)
 }
+
+func TestCatalog_GetCollectionSize(t *testing.T) {
+	mockMetaDomain := &mocks.IMetaDomain{}
+	catalog := NewTableCatalog(nil, mockMetaDomain)
+	collectionID := types.MustParse("00000000-0000-0000-0000-000000000001")
+	mockMetaDomain.On("CollectionDb", context.Background()).Return(&mocks.ICollectionDb{})
+	var total_records_post_compaction uint64 = uint64(100)
+	mockMetaDomain.CollectionDb(context.Background()).(*mocks.ICollectionDb).On("GetCollectionSize", *types.FromUniqueID(collectionID)).Return(total_records_post_compaction, nil)
+	collection_size, err := catalog.GetCollectionSize(context.Background(), collectionID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, total_records_post_compaction, collection_size)
+	mockMetaDomain.AssertExpectations(t)
+}

--- a/go/pkg/sysdb/grpc/cleaup_test.go
+++ b/go/pkg/sysdb/grpc/cleaup_test.go
@@ -21,6 +21,7 @@ import (
 type CleanupTestSuite struct {
 	suite.Suite
 	db           *gorm.DB
+	read_db      *gorm.DB
 	s            *Server
 	tenantName   string
 	databaseName string
@@ -30,13 +31,14 @@ type CleanupTestSuite struct {
 func (suite *CleanupTestSuite) SetupSuite() {
 	log.Info("setup suite")
 	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider:      "database",
 		SoftDeleteEnabled:          true,
 		SoftDeleteCleanupInterval:  1 * time.Second,
 		SoftDeleteMaxAge:           0,
 		SoftDeleteCleanupBatchSize: 10,
-		Testing:                    true}, grpcutils.Default, suite.db)
+		Testing:                    true}, grpcutils.Default)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)
 	}

--- a/go/pkg/sysdb/grpc/cleaup_test.go
+++ b/go/pkg/sysdb/grpc/cleaup_test.go
@@ -30,8 +30,7 @@ type CleanupTestSuite struct {
 
 func (suite *CleanupTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
-	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
+	suite.db, suite.read_db = dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider:      "database",
 		SoftDeleteEnabled:          true,

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -148,6 +148,26 @@ func (s *Server) GetCollections(ctx context.Context, req *coordinatorpb.GetColle
 	return res, nil
 }
 
+func (s *Server) GetCollectionSize(ctx context.Context, req *coordinatorpb.GetCollectionSizeRequest) (*coordinatorpb.GetCollectionSizeResponse, error) {
+	collectionID := req.Id
+
+	res := &coordinatorpb.GetCollectionSizeResponse{}
+
+	parsedCollectionID, err := types.ToUniqueID(&collectionID)
+	if err != nil {
+		log.Error("GetCollectionSize failed. collection id format error", zap.Error(err), zap.Stringp("collection_id", &collectionID))
+		return res, grpcutils.BuildInternalGrpcError(err.Error())
+	}
+
+	total_records_post_compaction, err := s.coordinator.GetCollectionSize(ctx, parsedCollectionID)
+	if err != nil {
+		log.Error("GetCollectionSize failed. ", zap.Error(err), zap.Stringp("collection_id", &collectionID))
+		return res, grpcutils.BuildInternalGrpcError(err.Error())
+	}
+	res.TotalRecordsPostCompaction = total_records_post_compaction
+	return res, nil
+}
+
 func (s *Server) CheckCollections(ctx context.Context, req *coordinatorpb.CheckCollectionsRequest) (*coordinatorpb.CheckCollectionsResponse, error) {
 	res := &coordinatorpb.CheckCollectionsResponse{}
 	res.Deleted = make([]bool, len(req.CollectionIds))

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -479,7 +479,7 @@ func (suite *CollectionServiceTestSuite) TestServer_FlushCollectionCompaction() 
 }
 
 func (suite *CollectionServiceTestSuite) TestGetCollectionSize() {
-	collectionName := "collection_service_test_flush_collection_compaction"
+	collectionName := "collection_service_test_get_collection_size"
 	collectionID, err := dao.CreateTestCollection(suite.db, collectionName, 128, suite.databaseId)
 	suite.NoError(err)
 

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -29,6 +29,7 @@ type CollectionServiceTestSuite struct {
 	suite.Suite
 	catalog      *coordinator.Catalog
 	db           *gorm.DB
+	read_db      *gorm.DB
 	s            *Server
 	tenantName   string
 	databaseName string
@@ -38,9 +39,10 @@ type CollectionServiceTestSuite struct {
 func (suite *CollectionServiceTestSuite) SetupSuite() {
 	log.Info("setup suite")
 	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
-		Testing:               true}, grpcutils.Default, suite.db)
+		Testing:               true}, grpcutils.Default)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)
 	}
@@ -70,10 +72,10 @@ func (suite *CollectionServiceTestSuite) TearDownSuite() {
 // Collection created should have the right ID
 // Collection created should have the right timestamp
 func testCollection(t *rapid.T) {
-	db := dbcore.ConfigDatabaseForTesting()
+	dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "memory",
-		Testing:               true}, grpcutils.Default, db)
+		Testing:               true}, grpcutils.Default)
 	if err != nil {
 		t.Fatalf("error creating server: %v", err)
 	}
@@ -472,6 +474,22 @@ func (suite *CollectionServiceTestSuite) TestServer_FlushCollectionCompaction() 
 	validateDatabase(suite, collectionID, collection, filePaths)
 
 	// clean up
+	err = dao.CleanUpTestCollection(suite.db, collectionID)
+	suite.NoError(err)
+}
+
+func (suite *CollectionServiceTestSuite) TestGetCollectionSize() {
+	collectionName := "collection_service_test_flush_collection_compaction"
+	collectionID, err := dao.CreateTestCollection(suite.db, collectionName, 128, suite.databaseId)
+	suite.NoError(err)
+
+	req := coordinatorpb.GetCollectionSizeRequest{
+		Id: collectionID,
+	}
+	res, err := suite.s.GetCollectionSize(context.Background(), &req)
+	suite.NoError(err)
+	suite.Equal(uint64(100), res.TotalRecordsPostCompaction)
+
 	err = dao.CleanUpTestCollection(suite.db, collectionID)
 	suite.NoError(err)
 }

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -38,8 +38,7 @@ type CollectionServiceTestSuite struct {
 
 func (suite *CollectionServiceTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
-	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
+	suite.db, suite.read_db = dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
 		Testing:               true}, grpcutils.Default)

--- a/go/pkg/sysdb/grpc/tenant_database_service_test.go
+++ b/go/pkg/sysdb/grpc/tenant_database_service_test.go
@@ -33,7 +33,7 @@ func (suite *TenantDatabaseServiceTestSuite) SetupSuite() {
 	suite.db = dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
-		Testing:               true}, grpcutils.Default, suite.db)
+		Testing:               true}, grpcutils.Default)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)
 	}

--- a/go/pkg/sysdb/grpc/tenant_database_service_test.go
+++ b/go/pkg/sysdb/grpc/tenant_database_service_test.go
@@ -30,7 +30,7 @@ type TenantDatabaseServiceTestSuite struct {
 
 func (suite *TenantDatabaseServiceTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.db, _ = dbcore.ConfigDatabaseForTesting()
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
 		Testing:               true}, grpcutils.Default)

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -153,9 +153,7 @@ func (s *collectionDb) GetCollectionSize(id string) (uint64, error) {
 		return 0, err
 	}
 
-	var (
-		totalRecordsPostCompaction uint64
-	)
+	var totalRecordsPostCompaction uint64
 
 	for rows.Next() {
 		err := rows.Scan(&totalRecordsPostCompaction)

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -16,7 +16,8 @@ import (
 )
 
 type collectionDb struct {
-	db *gorm.DB
+	db      *gorm.DB
+	read_db *gorm.DB
 }
 
 var _ dbmodel.ICollectionDb = &collectionDb{}
@@ -140,6 +141,31 @@ func (s *collectionDb) getCollections(id *string, name *string, tenantID string,
 	}
 
 	return
+}
+
+func (s *collectionDb) GetCollectionSize(id string) (uint64, error) {
+	query := s.read_db.Table("collections").
+		Select("collections.total_records_post_compaction").
+		Where("collections.id = ?", id)
+
+	rows, err := query.Rows()
+	if err != nil {
+		return 0, err
+	}
+
+	var (
+		totalRecordsPostCompaction uint64
+	)
+
+	for rows.Next() {
+		err := rows.Scan(&totalRecordsPostCompaction)
+		if err != nil {
+			log.Error("scan collection failed", zap.Error(err))
+			return 0, err
+		}
+	}
+	rows.Close()
+	return totalRecordsPostCompaction, nil
 }
 
 func (s *collectionDb) GetSoftDeletedCollections(collectionID *string, tenantID string, databaseName string, limit int32) ([]*dbmodel.CollectionAndMetadata, error) {

--- a/go/pkg/sysdb/metastore/db/dao/collection_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_test.go
@@ -25,8 +25,7 @@ type CollectionDbTestSuite struct {
 
 func (suite *CollectionDbTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
-	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
+	suite.db, suite.read_db = dbcore.ConfigDatabaseForTesting()
 	suite.collectionDb = &collectionDb{
 		db:      suite.db,
 		read_db: suite.read_db,

--- a/go/pkg/sysdb/metastore/db/dao/collection_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_test.go
@@ -220,7 +220,6 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollectionSize() {
 	suite.NoError(err)
 	suite.Equal(uint64(100), total_records_post_compaction)
 
-	// clean up
 	err = CleanUpTestCollection(suite.db, collectionID)
 	suite.NoError(err)
 }

--- a/go/pkg/sysdb/metastore/db/dao/collection_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_test.go
@@ -16,6 +16,7 @@ import (
 type CollectionDbTestSuite struct {
 	suite.Suite
 	db           *gorm.DB
+	read_db      *gorm.DB
 	collectionDb *collectionDb
 	tenantName   string
 	databaseName string
@@ -25,8 +26,10 @@ type CollectionDbTestSuite struct {
 func (suite *CollectionDbTestSuite) SetupSuite() {
 	log.Info("setup suite")
 	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.read_db = dbcore.ConfigReadDatabaseForTesting()
 	suite.collectionDb = &collectionDb{
-		db: suite.db,
+		db:      suite.db,
+		read_db: suite.read_db,
 	}
 	suite.tenantName = "test_collection_tenant"
 	suite.databaseName = "test_collection_database"
@@ -75,7 +78,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	suite.Len(collections[0].CollectionMetadata, 1)
 	suite.Equal(metadata.Key, collections[0].CollectionMetadata[0].Key)
 	suite.Equal(metadata.StrValue, collections[0].CollectionMetadata[0].StrValue)
-	suite.Equal(uint64(0), collections[0].Collection.TotalRecordsPostCompaction)
+	suite.Equal(uint64(100), collections[0].Collection.TotalRecordsPostCompaction)
 
 	// Test when filtering by ID
 	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
@@ -205,6 +208,20 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_SoftDelete() {
 	err = CleanUpTestCollection(suite.db, collectionID1)
 	suite.NoError(err)
 	err = CleanUpTestCollection(suite.db, collectionID2)
+	suite.NoError(err)
+}
+
+func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollectionSize() {
+	collectionName := "test_collection_get_collection_size"
+	collectionID, err := CreateTestCollection(suite.db, collectionName, 128, suite.databaseId)
+	suite.NoError(err)
+
+	total_records_post_compaction, err := suite.collectionDb.GetCollectionSize(collectionID)
+	suite.NoError(err)
+	suite.Equal(uint64(100), total_records_post_compaction)
+
+	// clean up
+	err = CleanUpTestCollection(suite.db, collectionID)
 	suite.NoError(err)
 }
 

--- a/go/pkg/sysdb/metastore/db/dao/common.go
+++ b/go/pkg/sysdb/metastore/db/dao/common.go
@@ -22,7 +22,7 @@ func (*MetaDomain) TenantDb(ctx context.Context) dbmodel.ITenantDb {
 }
 
 func (*MetaDomain) CollectionDb(ctx context.Context) dbmodel.ICollectionDb {
-	return &collectionDb{dbcore.GetDB(ctx)}
+	return &collectionDb{dbcore.GetDB(ctx), dbcore.GetReadDB(ctx)}
 }
 
 func (*MetaDomain) CollectionMetadataDb(ctx context.Context) dbmodel.ICollectionMetadataDb {

--- a/go/pkg/sysdb/metastore/db/dao/segment_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/segment_test.go
@@ -23,7 +23,7 @@ type SegmentDbTestSuite struct {
 
 func (suite *SegmentDbTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.db, _ = dbcore.ConfigDatabaseForTesting()
 	suite.segmentDb = &segmentDb{
 		db: suite.db,
 	}

--- a/go/pkg/sysdb/metastore/db/dao/tenant_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/tenant_test.go
@@ -21,7 +21,7 @@ type TenantDbTestSuite struct {
 
 func (suite *TenantDbTestSuite) SetupSuite() {
 	log.Info("setup suite")
-	suite.db = dbcore.ConfigDatabaseForTesting()
+	suite.db, _ = dbcore.ConfigDatabaseForTesting()
 	suite.Db = &tenantDb{
 		db: suite.db,
 	}

--- a/go/pkg/sysdb/metastore/db/dao/test_utils.go
+++ b/go/pkg/sysdb/metastore/db/dao/test_utils.go
@@ -118,12 +118,13 @@ func CreateTestCollection(db *gorm.DB, collectionName string, dimension int32, d
 
 	defaultConfigurationJsonStr := "{\"a\": \"param\", \"b\": \"param2\", \"3\": true}"
 	err := collectionDb.Insert(&dbmodel.Collection{
-		ID:                   collectionId,
-		Name:                 &collectionName,
-		ConfigurationJsonStr: &defaultConfigurationJsonStr,
-		Dimension:            &dimension,
-		DatabaseID:           databaseID,
-		CreatedAt:            time.Now(),
+		ID:                         collectionId,
+		Name:                       &collectionName,
+		ConfigurationJsonStr:       &defaultConfigurationJsonStr,
+		Dimension:                  &dimension,
+		DatabaseID:                 databaseID,
+		CreatedAt:                  time.Now(),
+		TotalRecordsPostCompaction: uint64(100),
 	})
 	if err != nil {
 		return "", err

--- a/go/pkg/sysdb/metastore/db/dbcore/core.go
+++ b/go/pkg/sysdb/metastore/db/dbcore/core.go
@@ -99,15 +99,6 @@ func ConnectPostgres(address string, username string, password string, port int,
 	return db, nil
 }
 
-// SetGlobalDB Only for test
-func SetGlobalDB(db *gorm.DB) {
-	globalDB = db
-}
-
-func SetGlobalReadDB(db *gorm.DB) {
-	globalReadDB = db
-}
-
 type ctxTransactionKey struct{}
 
 func CtxWithTransaction(ctx context.Context, tx *gorm.DB) context.Context {
@@ -265,18 +256,15 @@ func GetDBConfigForTesting() DBConfig {
 	}
 }
 
-func ConfigDatabaseForTesting() *gorm.DB {
+func ConfigDatabaseForTesting() (*gorm.DB, *gorm.DB) {
 	cfg := GetDBConfigForTesting()
 	db, err := ConnectPostgres(cfg.Address, cfg.Username, cfg.Password, cfg.Port, cfg.DBName, cfg.SslMode, cfg.MaxIdleConns, cfg.MaxOpenConns)
 	if err != nil {
 		panic("failed to connect database")
 	}
-	SetGlobalDB(db)
+	globalDB = db
+	// For testing, we set the read_db to be the same as the db
+	globalReadDB = db
 	CreateTestTables(db)
-	return db
-}
-
-func ConfigReadDatabaseForTesting() *gorm.DB {
-	globalReadDB = globalDB
-	return globalReadDB
+	return globalDB, globalReadDB
 }

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -42,4 +42,5 @@ type ICollectionDb interface {
 	DeleteAll() error
 	UpdateLogPositionVersionAndTotalRecords(collectionID string, logPosition int64, currentCollectionVersion int32, totalRecordsPostCompaction uint64) (int32, error)
 	GetCollectionEntry(collectionID *string, databaseName *string) (*Collection, error)
+	GetCollectionSize(collectionID string) (uint64, error)
 }

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -88,6 +88,34 @@ func (_m *ICollectionDb) GetCollectionEntry(collectionID *string, databaseName *
 	return r0, r1
 }
 
+// GetCollectionSize provides a mock function with given fields: collectionID
+func (_m *ICollectionDb) GetCollectionSize(collectionID string) (uint64, error) {
+	ret := _m.Called(collectionID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCollectionSize")
+	}
+
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (uint64, error)); ok {
+		return rf(collectionID)
+	}
+	if rf, ok := ret.Get(0).(func(string) uint64); ok {
+		r0 = rf(collectionID)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(collectionID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetCollections provides a mock function with given fields: collectionID, collectionName, tenantID, databaseName, limit, offset
 func (_m *ICollectionDb) GetCollections(collectionID *string, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*dbmodel.CollectionAndMetadata, error) {
 	ret := _m.Called(collectionID, collectionName, tenantID, databaseName, limit, offset)

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -361,6 +361,14 @@ message RestoreCollectionResponse {
   int64 new_collection_version = 1;
 }
 
+message GetCollectionSizeRequest {
+  string id = 1;
+}
+
+message GetCollectionSizeResponse {
+  uint64 total_records_post_compaction = 1;
+}
+
 service SysDB {
   rpc CreateDatabase(CreateDatabaseRequest) returns (CreateDatabaseResponse) {}
   rpc GetDatabase(GetDatabaseRequest) returns (GetDatabaseResponse) {}
@@ -384,4 +392,5 @@ service SysDB {
   rpc FlushCollectionCompaction(FlushCollectionCompactionRequest) returns (FlushCollectionCompactionResponse) {}
   rpc RestoreCollection(RestoreCollectionRequest) returns (RestoreCollectionResponse) {}
   rpc ListCollectionVersions(ListCollectionVersionsRequest) returns (ListCollectionVersionsResponse) {}
+  rpc GetCollectionSize(GetCollectionSizeRequest) returns (GetCollectionSizeResponse) {}
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - None
 - New functionality
   - Hooks up `SysDB` Go coordinator to a DB read replica
   - Adds a new RPC, `GetCollectionSize`, to return the total records in a collection, pulling from the reader DB

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
