### PR TITLE
[DOC] Fix install command in Getting Started doc: Replace 'yarn/pnpm install' with 'yarn/pnpm add'

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
@@ -41,7 +41,7 @@ npm install --save chromadb chromadb-default-embed
 
 {% Tab label="pnpm" %}
 ```terminal
-pnpm install chromadb chromadb-default-embed 
+pnpm add chromadb chromadb-default-embed 
 ```
 {% /Tab %}
 

--- a/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
@@ -29,7 +29,7 @@ pip install chromadb
 
 {% Tab label="yarn" %}
 ```terminal
-yarn install chromadb chromadb-default-embed 
+yarn add chromadb chromadb-default-embed 
 ```
 {% /Tab %}
 


### PR DESCRIPTION
## Description of changes

 This pull request addresses an issue in the Getting Started documentation, where the incorrect yarn install command was provided for installing packages. The correct command, `yarn add <package-name>`
 
 
![image](https://github.com/user-attachments/assets/fdb173c9-ef4d-45ee-bf0c-10fd0d0c61a3)

**Issue:**

![image](https://github.com/user-attachments/assets/45800118-9acf-4c36-9c66-d27ea30ba18b)


## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
