### PR TITLE
[ENH] Implement Get collections to GC + add to rust sysdb client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -226,3 +226,7 @@ func (s *Coordinator) GetTenantsLastCompactionTime(ctx context.Context, tenantID
 func (s *Coordinator) FlushCollectionCompaction(ctx context.Context, flushCollectionCompaction *model.FlushCollectionCompaction) (*model.FlushCollectionInfo, error) {
 	return s.catalog.FlushCollectionCompaction(ctx, flushCollectionCompaction)
 }
+
+func (s *Coordinator) ListCollectionsToGc(ctx context.Context) ([]*model.CollectionToGc, error) {
+	return s.catalog.ListCollectionsToGc(ctx)
+}

--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -19,6 +19,12 @@ type Collection struct {
 	TotalRecordsPostCompaction uint64
 }
 
+type CollectionToGc struct {
+	ID              types.UniqueID
+	Name            string
+	VersionFilePath string
+}
+
 type CreateCollection struct {
 	ID                   types.UniqueID
 	Name                 string

--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -33,6 +33,27 @@ func convertCollectionToModel(collectionAndMetadataList []*dbmodel.CollectionAnd
 	return collections
 }
 
+func convertCollectionToGcToModel(collectionToGc []*dbmodel.CollectionToGc) []*model.CollectionToGc {
+	if collectionToGc == nil {
+		return nil
+	}
+	collections := make([]*model.CollectionToGc, 0, len(collectionToGc))
+	// TODO(Sanket): Set version file path.
+	for _, collectionInfo := range collectionToGc {
+		// Skip collections that haven't been compacted even once.
+		if collectionInfo.Version == 0 {
+			continue
+		}
+		collection := model.CollectionToGc{
+			ID:              types.MustParse(collectionInfo.ID),
+			Name:            collectionInfo.Name,
+			VersionFilePath: "",
+		}
+		collections = append(collections, &collection)
+	}
+	return collections
+}
+
 func convertCollectionMetadataToModel(collectionMetadataList []*dbmodel.CollectionMetadata) *model.CollectionMetadata[model.CollectionMetadataValueType] {
 	metadata := model.NewCollectionMetadata[model.CollectionMetadataValueType]()
 	if collectionMetadataList == nil {

--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -40,10 +40,6 @@ func convertCollectionToGcToModel(collectionToGc []*dbmodel.CollectionToGc) []*m
 	collections := make([]*model.CollectionToGc, 0, len(collectionToGc))
 	// TODO(Sanket): Set version file path.
 	for _, collectionInfo := range collectionToGc {
-		// Skip collections that haven't been compacted even once.
-		if collectionInfo.Version == 0 {
-			continue
-		}
 		collection := model.CollectionToGc{
 			ID:              types.MustParse(collectionInfo.ID),
 			Name:            collectionInfo.Name,

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -381,6 +381,22 @@ func (tc *Catalog) GetCollectionSize(ctx context.Context, collectionID types.Uni
 	return total_records_post_compaction, nil
 }
 
+func (tc *Catalog) ListCollectionsToGc(ctx context.Context) ([]*model.CollectionToGc, error) {
+	tracer := otel.Tracer
+	if tracer != nil {
+		_, span := tracer.Start(ctx, "Catalog.ListCollectionsToGc")
+		defer span.End()
+	}
+
+	collectionsToGc, err := tc.metaDomain.CollectionDb(ctx).ListCollectionsToGc()
+
+	if err != nil {
+		return nil, err
+	}
+	collections := convertCollectionToGcToModel(collectionsToGc)
+	return collections, nil
+}
+
 func (tc *Catalog) GetCollectionWithSegments(ctx context.Context, collectionID types.UniqueID) (*model.Collection, []*model.Segment, error) {
 	tracer := otel.Tracer
 	if tracer != nil {

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -364,3 +364,21 @@ func (s *Server) FlushCollectionCompaction(ctx context.Context, req *coordinator
 	}
 	return res, nil
 }
+
+func (s *Server) ListCollectionsToGc(ctx context.Context, req *coordinatorpb.ListCollectionsToGcRequest) (*coordinatorpb.ListCollectionsToGcResponse, error) {
+	// Dumb implementation that just returns ALL the collections for now.
+	collectionsToGc, err := s.coordinator.ListCollectionsToGc(ctx)
+	if err != nil {
+		log.Error("ListCollectionsToGc failed", zap.Error(err))
+		return nil, grpcutils.BuildInternalGrpcError(err.Error())
+	}
+	res := &coordinatorpb.ListCollectionsToGcResponse{}
+	for _, collectionToGc := range collectionsToGc {
+		res.Collections = append(res.Collections, &coordinatorpb.CollectionToGcInfo{
+			Id:              collectionToGc.ID.String(),
+			Name:            collectionToGc.Name,
+			VersionFilePath: collectionToGc.VersionFilePath,
+		})
+	}
+	return res, nil
+}

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -51,6 +51,16 @@ func (s *collectionDb) GetCollections(id *string, name *string, tenantID string,
 	return s.getCollections(id, name, tenantID, databaseName, limit, offset, false)
 }
 
+func (s *collectionDb) ListCollectionsToGc() ([]*dbmodel.CollectionToGc, error) {
+	// TODO(Sanket): Read version file path.
+	var collections []*dbmodel.CollectionToGc
+	err := s.db.Table("collections").Select("id, name, version").Find(&collections).Error
+	if err != nil {
+		return nil, err
+	}
+	return collections, nil
+}
+
 func (s *collectionDb) getCollections(id *string, name *string, tenantID string, databaseName string, limit *int32, offset *int32, is_deleted bool) (collectionWithMetdata []*dbmodel.CollectionAndMetadata, err error) {
 	var collections []*dbmodel.Collection
 	query := s.db.Table("collections").

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -54,7 +54,9 @@ func (s *collectionDb) GetCollections(id *string, name *string, tenantID string,
 func (s *collectionDb) ListCollectionsToGc() ([]*dbmodel.CollectionToGc, error) {
 	// TODO(Sanket): Read version file path.
 	var collections []*dbmodel.CollectionToGc
-	err := s.db.Table("collections").Select("id, name, version").Find(&collections).Error
+	// Use the read replica for this so as to not overwhelm the writer.
+	// Skip collections that have not been compacted even once.
+	err := s.read_db.Table("collections").Select("id, name, version").Find(&collections).Where("version > 0").Error
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -21,6 +21,12 @@ type Collection struct {
 	TotalRecordsPostCompaction uint64          `gorm:"total_records_post_compaction;default:0"`
 }
 
+type CollectionToGc struct {
+	ID      string `gorm:"id;primaryKey"`
+	Name    string `gorm:"name;not null;index:idx_name,unique;"`
+	Version int32  `gorm:"version;default:0"`
+}
+
 func (v Collection) TableName() string {
 	return "collections"
 }
@@ -43,4 +49,5 @@ type ICollectionDb interface {
 	UpdateLogPositionVersionAndTotalRecords(collectionID string, logPosition int64, currentCollectionVersion int32, totalRecordsPostCompaction uint64) (int32, error)
 	GetCollectionEntry(collectionID *string, databaseName *string) (*Collection, error)
 	GetCollectionSize(collectionID string) (uint64, error)
+	ListCollectionsToGc() ([]*CollectionToGc, error)
 }

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -194,6 +194,36 @@ func (_m *ICollectionDb) Insert(in *dbmodel.Collection) error {
 	return r0
 }
 
+// ListCollectionsToGc provides a mock function with given fields:
+func (_m *ICollectionDb) ListCollectionsToGc() ([]*dbmodel.CollectionToGc, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListCollectionsToGc")
+	}
+
+	var r0 []*dbmodel.CollectionToGc
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]*dbmodel.CollectionToGc, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []*dbmodel.CollectionToGc); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*dbmodel.CollectionToGc)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Update provides a mock function with given fields: in
 func (_m *ICollectionDb) Update(in *dbmodel.Collection) error {
 	ret := _m.Called(in)

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IDatabaseDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IDatabaseDb.go
@@ -12,6 +12,24 @@ type IDatabaseDb struct {
 	mock.Mock
 }
 
+// Delete provides a mock function with given fields: databaseID
+func (_m *IDatabaseDb) Delete(databaseID string) error {
+	ret := _m.Called(databaseID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Delete")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(databaseID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteAll provides a mock function with given fields:
 func (_m *IDatabaseDb) DeleteAll() error {
 	ret := _m.Called()
@@ -106,6 +124,36 @@ func (_m *IDatabaseDb) Insert(in *dbmodel.Database) error {
 	}
 
 	return r0
+}
+
+// ListDatabases provides a mock function with given fields: limit, offset, tenantID
+func (_m *IDatabaseDb) ListDatabases(limit *int32, offset *int32, tenantID string) ([]*dbmodel.Database, error) {
+	ret := _m.Called(limit, offset, tenantID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListDatabases")
+	}
+
+	var r0 []*dbmodel.Database
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*int32, *int32, string) ([]*dbmodel.Database, error)); ok {
+		return rf(limit, offset, tenantID)
+	}
+	if rf, ok := ret.Get(0).(func(*int32, *int32, string) []*dbmodel.Database); ok {
+		r0 = rf(limit, offset, tenantID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*dbmodel.Database)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*int32, *int32, string) error); ok {
+		r1 = rf(limit, offset, tenantID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // NewIDatabaseDb creates a new instance of IDatabaseDb. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -369,6 +369,18 @@ message GetCollectionSizeResponse {
   uint64 total_records_post_compaction = 1;
 }
 
+message ListCollectionsToGcRequest {}
+
+message CollectionToGcInfo {
+  string id = 1;
+  string name = 2;
+  string version_file_path = 3;
+}
+
+message ListCollectionsToGcResponse {
+  repeated CollectionToGcInfo collections = 1;
+}
+
 service SysDB {
   rpc CreateDatabase(CreateDatabaseRequest) returns (CreateDatabaseResponse) {}
   rpc GetDatabase(GetDatabaseRequest) returns (GetDatabaseResponse) {}
@@ -393,4 +405,5 @@ service SysDB {
   rpc RestoreCollection(RestoreCollectionRequest) returns (RestoreCollectionResponse) {}
   rpc ListCollectionVersions(ListCollectionVersionsRequest) returns (ListCollectionVersionsResponse) {}
   rpc GetCollectionSize(GetCollectionSizeRequest) returns (GetCollectionSizeResponse) {}
+  rpc ListCollectionsToGc(ListCollectionsToGcRequest) returns (ListCollectionsToGcResponse) {}
 }

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -83,8 +83,13 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
         _message: GarbageCollectMessage,
         _ctx: &ComponentContext<Self>,
     ) -> Self::Result {
-        // TODO(Sanket): Implement the garbage collection logic.
-        todo!()
+        // Get all collections to gc and create gc orchestrator for each.
+        let _ = self
+            .sysdb_client
+            .get_collections_to_gc()
+            .await
+            .expect("Failed to get collections to gc");
+        // TODO(Sanket):  Implement the logic to create gc orchestrator for each collection.
     }
 }
 

--- a/rust/sysdb/Cargo.toml
+++ b/rust/sysdb/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
+uuid = { workspace = true }
 parking_lot = { workspace = true }
 
 chroma-config = { workspace = true }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - New functionality
   - Adds an rpc on Go side that is dumb and gets all collections
   - Adds this rpc to the rust sysdb client + uses this rpc from rust client in gc

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
