### PR TITLE
[DOC] Making git clone command more accessible in Docker container instructions

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
+++ b/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
@@ -39,7 +39,7 @@ docker run -p 8000:8000 chromadb/chroma
 You can also build the Docker image yourself from the Dockerfile in the [Chroma GitHub repository](https://github.com/chroma-core/chroma)
 
 ```terminal
-git clone git@github.com:chroma-core/chroma.git
+git clone https://github.com/chroma-core/chroma.git
 cd chroma
 docker-compose up -d --build
 ```


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Moving to `git clone https://...` instead of the current `git clone git@...`, the latter requires users to have a GH account with SSH key added

## Test plan
*How are these changes tested?*

N/A

## Documentation Changes

