### PR TITLE
[DOC] fix inconsistent variable names for the Python HttpClient

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/production/administration/auth.md
+++ b/docs/docs.trychroma.com/markdoc/content/production/administration/auth.md
@@ -76,7 +76,7 @@ We will use Chroma's `Settings` object to define the authentication method on th
 import chromadb
 from chromadb.config import Settings
 
-client = chromadb.HttpClient(
+chroma_client = chromadb.HttpClient(
     host="localhost",
     port=8000,
     settings=Settings(


### PR DESCRIPTION
fix inconsistent variable names for the Python HttpClient example on the Auth docs page

## Description of changes

*Summarize the changes made by this PR.*
- Edited typo in documentation that had a variable name for the Chroma Python HttpClient first named `client` but when calling the `heartbeat()` method on it, was called as `chroma_client`.

I changed the initially named `client` to `chroma_client` for full consistency/functionality if tested by a user.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes ✔︎
[Auth page to change](https://docs.trychroma.com/production/administration/auth)

*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
