### PR TITLE
[ENH]: fix dynamic span names in Jaeger

### DIFF
--- a/k8s/test/otel-collector.yaml
+++ b/k8s/test/otel-collector.yaml
@@ -15,6 +15,10 @@ data:
 
     processors:
       batch:
+      # When using the tracing crate in Rust, we sometimes set the otel.name attribute for dynamic spans. Jaeger does not automatically override the span name with this attribute, so we do it manually here.
+      span/override-name:
+        name:
+          from_attributes: [name]
 
     exporters:
       prometheus:
@@ -29,6 +33,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
+          processors: [batch, span/override-name]
           exporters: [otlp/jaeger]
         metrics:
           receivers: [otlp]


### PR DESCRIPTION
## Description of changes

Before (note generic "component received message" and "task execution" spans):

<img width="2161" alt="Screenshot 2025-01-21 at 10 15 30" src="https://github.com/user-attachments/assets/6e420ba8-8d05-409e-a381-2adb0544632d" />

After:

<img width="2195" alt="Screenshot 2025-01-21 at 10 14 26" src="https://github.com/user-attachments/assets/c337522d-b5da-4f81-8d62-c2f3d6e1a822" />

## Test plan
*How are these changes tested?*

Looks correct in Jaeger.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a