### PR TITLE
[BUG]: FastAPI operations id are now unique

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -101,7 +101,8 @@ def use_route_names_as_operation_ids(app: _FastAPI) -> None:
     """
     for route in app.routes:
         if isinstance(route, APIRoute):
-            route.operation_id = route.name
+            print(route)
+            route.operation_id = route.name + ("-v2" if "v2" in route.path else "-v1")
 
 
 async def add_trace_id_to_response_middleware(

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -101,7 +101,6 @@ def use_route_names_as_operation_ids(app: _FastAPI) -> None:
     """
     for route in app.routes:
         if isinstance(route, APIRoute):
-            print(route)
             route.operation_id = route.name + ("-v2" if "v2" in route.path else "-v1")
 
 


### PR DESCRIPTION
## Description of changes
Closes #3521
*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fixes and issue where v1 and v2 operations were overlapping so when executed from Swagger UI v2 operations were hitting v1 api

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
