### PR TITLE
[ENH]: improve interface for `load_blocks_for_keys()`

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -435,16 +435,12 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         join_all(futures).await;
     }
 
-    pub(crate) async fn load_blocks_for_keys(&self, prefixes: &[&str], keys: &[K]) {
-        let mut composite_keys = Vec::new();
-        let prefix_iter = prefixes.iter();
-        let mut key_iter = keys.iter();
-        for prefix in prefix_iter {
-            if let Some(key) = key_iter.next() {
-                let composite_key = CompositeKey::new(prefix.to_string(), key.clone());
-                composite_keys.push(composite_key);
-            }
-        }
+    pub(crate) async fn load_blocks_for_keys(&self, keys: impl IntoIterator<Item = (String, K)>) {
+        let composite_keys = keys
+            .into_iter()
+            .map(|(prefix, key)| CompositeKey::new(prefix, key))
+            .collect::<Vec<_>>();
+
         let target_block_ids = self
             .root
             .sparse_index

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -113,11 +113,11 @@ impl<
         }
     }
 
-    pub async fn load_blocks_for_keys(&self, prefixes: &[&str], keys: &[K]) {
+    pub async fn load_blocks_for_keys(&self, keys: impl IntoIterator<Item = (String, K)>) {
         match self {
             BlockfileReader::MemoryBlockfileReader(_reader) => unimplemented!(),
             BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.load_blocks_for_keys(prefixes, keys).await
+                reader.load_blocks_for_keys(keys).await
             }
         }
     }

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -853,15 +853,15 @@ impl RecordSegmentReader<'_> {
     }
 
     pub async fn prefetch_id_to_data(&self, keys: &[u32]) {
-        let prefixes = vec![""; keys.len()];
-        self.id_to_data.load_blocks_for_keys(&prefixes, keys).await
+        self.id_to_data
+            .load_blocks_for_keys(keys.iter().map(|k| ("".to_string(), *k)))
+            .await
     }
 
     #[allow(dead_code)]
     pub(crate) async fn prefetch_user_id_to_id(&self, keys: Vec<&str>) {
-        let prefixes = vec![""; keys.len()];
         self.user_id_to_id
-            .load_blocks_for_keys(&prefixes, &keys)
+            .load_blocks_for_keys(keys.iter().map(|k| ("".to_string(), *k)))
             .await
     }
 }


### PR DESCRIPTION
## Description of changes

These changes were originally part of https://github.com/chroma-core/chroma/pull/3370 but decided to break them out as they're no longer needed for that PR.

Makes the interface slightly more flexible and puts the burden of owned data on the caller.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a