### PR TITLE
[ENH] Add collection_id to quota_enforcer calls

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -5,7 +5,7 @@ from chromadb.auth import UserIdentity
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
 from chromadb.db.system import SysDB
 from chromadb.quota import QuotaEnforcer, Action
-from chromadb.rate_limit import RateLimitEnforcer, AsyncRateLimitEnforcer
+from chromadb.rate_limit import RateLimitEnforcer
 from chromadb.segment import SegmentManager
 from chromadb.execution.executor.abstract import Executor
 from chromadb.execution.expression.operator import Scan, Filter, Limit, KNN, Projection
@@ -447,6 +447,7 @@ class SegmentAPI(ServerAPI):
             metadatas=metadatas,
             documents=documents,
             uris=uris,
+            collection_id=collection_id,
         )
 
         self._producer.submit_embeddings(collection_id, records_to_submit)
@@ -559,6 +560,7 @@ class SegmentAPI(ServerAPI):
             metadatas=metadatas,
             documents=documents,
             uris=uris,
+            collection_id=collection_id,
         )
 
         self._producer.submit_embeddings(collection_id, records_to_submit)


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - None
 - New functionality
   - Update calls to `quota_enforcer.enforce` to include `collection_id` for `ADD` and `UPSERT`

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
