### PR TITLE
[ENH]: get segment writers inside operator

### DIFF
--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -36,7 +36,7 @@ impl std::fmt::Display for SegmentUuid {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SegmentType {
     HnswDistributed,
     BlockfileMetadata,

--- a/rust/worker/src/execution/operators/get_segment_writer.rs
+++ b/rust/worker/src/execution/operators/get_segment_writer.rs
@@ -1,0 +1,156 @@
+use crate::segment::{
+    distributed_hnsw_segment::{
+        DistributedHNSWSegmentFromSegmentError, DistributedHNSWSegmentWriter,
+    },
+    metadata_segment::{MetadataSegmentError, MetadataSegmentWriter},
+    record_segment::{RecordSegmentWriter, RecordSegmentWriterCreationError},
+    ChromaSegmentWriter,
+};
+use chroma_blockstore::provider::BlockfileProvider;
+use chroma_error::ChromaError;
+use chroma_index::hnsw_provider::HnswIndexProvider;
+use chroma_sysdb::{GetCollectionsError, SysDb};
+use chroma_system::Operator;
+use chroma_types::{Segment, SegmentType};
+use thiserror::Error;
+use tonic::async_trait;
+
+#[derive(Debug, Default)]
+pub struct GetSegmentWriterOperator {}
+
+impl GetSegmentWriterOperator {
+    pub fn new() -> Self {
+        GetSegmentWriterOperator::default()
+    }
+}
+
+#[derive(Debug)]
+pub struct GetSegmentWriterInput {
+    blockfile_provider: BlockfileProvider,
+    hnsw_provider: HnswIndexProvider,
+    sysdb: SysDb,
+    segment: Segment,
+}
+
+impl GetSegmentWriterInput {
+    pub fn new(
+        blockfile_provider: BlockfileProvider,
+        hnsw_provider: HnswIndexProvider,
+        sysdb: SysDb,
+        segment: Segment,
+    ) -> Self {
+        GetSegmentWriterInput {
+            blockfile_provider,
+            hnsw_provider,
+            sysdb,
+            segment,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetSegmentWriterOutput {
+    pub writer: ChromaSegmentWriter<'static>,
+}
+
+#[derive(Debug, Error)]
+pub enum GetSegmentWriterError {
+    #[error("Unsupported segment type: {:?}", 0)]
+    UnsupportedSegmentType(SegmentType),
+    #[error("Failed to create metadata segment writer: {0}")]
+    MetadataSegmentWriter(#[from] MetadataSegmentError),
+    #[error("Failed to create record segment writer: {0}")]
+    RecordSegmentWriter(#[from] RecordSegmentWriterCreationError),
+    #[error("Collection not found")]
+    CollectionNotFound,
+    #[error("Failed to get collection: {0}")]
+    GetCollectionError(#[from] GetCollectionsError),
+    #[error("Error creating HNSW segment writer: {0}")]
+    HnswSegmentWriterError(#[from] Box<DistributedHNSWSegmentFromSegmentError>),
+    #[error("Collection missing dimension (cannot create HNSW writer)")]
+    CollectionMissingDimension,
+}
+
+impl ChromaError for GetSegmentWriterError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl Operator<GetSegmentWriterInput, GetSegmentWriterOutput> for GetSegmentWriterOperator {
+    type Error = GetSegmentWriterError;
+
+    fn get_name(&self) -> &'static str {
+        "GetSegmentWriterOperator"
+    }
+
+    async fn run(
+        &self,
+        input: &GetSegmentWriterInput,
+    ) -> Result<GetSegmentWriterOutput, Self::Error> {
+        let writer = match input.segment.r#type {
+            SegmentType::BlockfileMetadata => ChromaSegmentWriter::MetadataSegment(
+                MetadataSegmentWriter::from_segment(&input.segment, &input.blockfile_provider)
+                    .await?,
+            ),
+            SegmentType::BlockfileRecord => ChromaSegmentWriter::RecordSegment(
+                RecordSegmentWriter::from_segment(&input.segment, &input.blockfile_provider)
+                    .await?,
+            ),
+            SegmentType::HnswDistributed => {
+                let collection_res = input
+                    .sysdb
+                    .clone()
+                    .get_collections(Some(input.segment.collection), None, None, None)
+                    .await;
+
+                let collection_res = match collection_res {
+                    Ok(collections) => {
+                        if collections.is_empty() {
+                            return Err(GetSegmentWriterError::CollectionNotFound);
+                        }
+                        collections
+                    }
+                    Err(e) => {
+                        return Err(GetSegmentWriterError::GetCollectionError(e));
+                    }
+                };
+                let collection = &collection_res[0];
+
+                match collection.dimension {
+                    Some(dimension) => {
+                        let hnsw_segment_writer = match DistributedHNSWSegmentWriter::from_segment(
+                            &input.segment,
+                            dimension as usize,
+                            input.hnsw_provider.clone(),
+                        )
+                        .await
+                        {
+                            Ok(writer) => writer,
+                            Err(e) => {
+                                return Err(GetSegmentWriterError::HnswSegmentWriterError(e));
+                            }
+                        };
+
+                        ChromaSegmentWriter::DistributedHNSWSegment(hnsw_segment_writer)
+                    }
+                    None => {
+                        return Err(GetSegmentWriterError::CollectionMissingDimension);
+                    }
+                }
+            }
+            _ => {
+                return Err(GetSegmentWriterError::UnsupportedSegmentType(
+                    input.segment.r#type,
+                ))
+            }
+        };
+
+        Ok(GetSegmentWriterOutput { writer })
+    }
+
+    fn get_type(&self) -> chroma_system::OperatorType {
+        chroma_system::OperatorType::IO
+    }
+}

--- a/rust/worker/src/execution/operators/get_segments.rs
+++ b/rust/worker/src/execution/operators/get_segments.rs
@@ -1,0 +1,70 @@
+use crate::segment::metadata_segment::MetadataSegmentError;
+use chroma_sysdb::{sysdb, SysDb};
+use chroma_system::Operator;
+use chroma_types::{CollectionUuid, Segment, SegmentType};
+use thiserror::Error;
+use tonic::async_trait;
+
+#[derive(Debug, Default)]
+pub struct GetSegmentsOperator {}
+
+impl GetSegmentsOperator {
+    pub fn new() -> Self {
+        GetSegmentsOperator::default()
+    }
+}
+
+#[derive(Debug)]
+pub struct GetSegmentsInput {
+    sysdb: SysDb,
+    collection_id: CollectionUuid,
+}
+
+impl GetSegmentsInput {
+    pub fn new(sysdb: SysDb, collection_id: CollectionUuid) -> Self {
+        GetSegmentsInput {
+            sysdb,
+            collection_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GetSegmentsOutput {
+    pub segments: Vec<Segment>,
+}
+
+#[derive(Debug, Error)]
+pub enum GetSegmentsError {
+    #[error("Failed to get segments from SysDb: {0}")]
+    SysDb(#[from] sysdb::GetSegmentsError),
+    #[error("Segment type not found")]
+    SegmentTypeNotFound,
+    #[error("Writer unimplemented for segment type {:?}", 0)]
+    WriterUnimplemented(SegmentType),
+    #[error("Failed to create writer for metadata segment: {0}")]
+    MetadataSegmentWriter(#[from] MetadataSegmentError),
+}
+
+#[async_trait]
+impl Operator<GetSegmentsInput, GetSegmentsOutput> for GetSegmentsOperator {
+    type Error = GetSegmentsError;
+
+    fn get_name(&self) -> &'static str {
+        "GetSegmentsOperator"
+    }
+
+    async fn run(&self, input: &GetSegmentsInput) -> Result<GetSegmentsOutput, Self::Error> {
+        let segments = input
+            .sysdb
+            .clone()
+            .get_segments(None, None, None, input.collection_id)
+            .await?;
+
+        Ok(GetSegmentsOutput { segments })
+    }
+
+    fn get_type(&self) -> chroma_system::OperatorType {
+        chroma_system::OperatorType::IO
+    }
+}

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -2,6 +2,8 @@ pub mod apply_log_to_segment_writer;
 pub mod commit_segment_writer;
 pub(super) mod count_records;
 pub mod flush_segment_writer;
+pub mod get_segment_writers;
+pub mod get_segments;
 pub mod materialize_logs;
 pub(super) mod partition;
 pub(super) mod register;

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -2,7 +2,7 @@ pub mod apply_log_to_segment_writer;
 pub mod commit_segment_writer;
 pub(super) mod count_records;
 pub mod flush_segment_writer;
-pub mod get_segment_writers;
+pub mod get_segment_writer;
 pub mod get_segments;
 pub mod materialize_logs;
 pub(super) mod partition;

--- a/rust/worker/src/segment/types.rs
+++ b/rust/worker/src/segment/types.rs
@@ -1,8 +1,8 @@
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::{
     Chunk, DataRecord, DeletedMetadata, LogRecord, MaterializedLogOperation, Metadata,
-    MetadataDelta, MetadataValue, MetadataValueConversionError, Operation, SegmentUuid,
-    UpdateMetadata, UpdateMetadataValue,
+    MetadataDelta, MetadataValue, MetadataValueConversionError, Operation, SegmentType,
+    SegmentUuid, UpdateMetadata, UpdateMetadataValue,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicU32;
@@ -876,6 +876,14 @@ impl ChromaSegmentWriter<'_> {
         }
     }
 
+    pub fn get_segment_type(&self) -> SegmentType {
+        match self {
+            ChromaSegmentWriter::RecordSegment(_) => SegmentType::BlockfileRecord,
+            ChromaSegmentWriter::MetadataSegment(_) => SegmentType::BlockfileMetadata,
+            ChromaSegmentWriter::DistributedHNSWSegment(_) => SegmentType::HnswDistributed,
+        }
+    }
+
     pub fn get_name(&self) -> &'static str {
         match self {
             ChromaSegmentWriter::RecordSegment(_) => "RecordSegmentWriter",
@@ -947,6 +955,14 @@ impl ChromaSegmentFlusher {
             ChromaSegmentFlusher::RecordSegment(flusher) => flusher.id,
             ChromaSegmentFlusher::MetadataSegment(flusher) => flusher.id,
             ChromaSegmentFlusher::DistributedHNSWSegment(flusher) => flusher.id,
+        }
+    }
+
+    pub fn get_segment_type(&self) -> SegmentType {
+        match self {
+            ChromaSegmentFlusher::RecordSegment(_) => SegmentType::BlockfileRecord,
+            ChromaSegmentFlusher::MetadataSegment(_) => SegmentType::BlockfileMetadata,
+            ChromaSegmentFlusher::DistributedHNSWSegment(_) => SegmentType::HnswDistributed,
         }
     }
 


### PR DESCRIPTION
- **[ENH]: get segments inside operator**
- **[ENH]: get segment writers inside operator**

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
