### PR TITLE
[ENH]: add `push_logs()` to log interface

### DIFF
--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -3,7 +3,8 @@ use crate::in_memory_log::InMemoryLog;
 use crate::types::{
     CollectionInfo, GetCollectionsWithNewDataError, PullLogsError, UpdateCollectionLogOffsetError,
 };
-use chroma_types::{CollectionUuid, LogRecord};
+use crate::PushLogsError;
+use chroma_types::{CollectionUuid, LogRecord, OperationRecord};
 use std::fmt::Debug;
 
 #[derive(Clone, Debug)]
@@ -41,6 +42,17 @@ impl Log {
                 log.read(collection_id, offset, batch_size, end_timestamp)
                     .await
             }
+        }
+    }
+
+    pub async fn push_logs(
+        &mut self,
+        collection_id: CollectionUuid,
+        records: Vec<OperationRecord>,
+    ) -> Result<(), PushLogsError> {
+        match self {
+            Log::Grpc(log) => log.push_logs(collection_id, records).await,
+            Log::InMemory(_) => unimplemented!(),
         }
     }
 

--- a/rust/log/src/types.rs
+++ b/rust/log/src/types.rs
@@ -36,12 +36,15 @@ impl ChromaError for PullLogsError {
 pub enum PushLogsError {
     #[error("Failed to push logs")]
     FailedToPushLogs(#[from] tonic::Status),
+    #[error("Failed to convert records to proto")]
+    ConversionError(#[from] RecordConversionError),
 }
 
 impl ChromaError for PushLogsError {
     fn code(&self) -> ErrorCodes {
         match self {
             PushLogsError::FailedToPushLogs(_) => ErrorCodes::Internal,
+            PushLogsError::ConversionError(_) => ErrorCodes::Internal,
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Does what it says on the tin.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a