### PR TITLE
[ENH]: better error handlilng for Axum routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2363,9 +2363,10 @@ dependencies = [
  "figment",
  "mdac",
  "serde",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
- "tower 0.5.2",
+ "tower 0.5.1",
  "tracing",
  "uuid",
 ]
@@ -6272,14 +6273,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tower-layer",
  "tower-service",

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -17,6 +17,7 @@ uuid = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tower = { workspace = true }
+thiserror = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-types = { workspace = true }

--- a/rust/frontend/src/errors.rs
+++ b/rust/frontend/src/errors.rs
@@ -1,0 +1,69 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use chroma_error::ChromaError;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub(crate) enum ValidationError {
+    #[error("Collection ID is not a valid UUIDv4")]
+    InvalidCollectionId,
+}
+
+impl ChromaError for ValidationError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            ValidationError::InvalidCollectionId => chroma_error::ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
+/// Wrapper around `dyn ChromaError` that implements `IntoResponse`. This means that route handlers can return `Result<_, ServerError>` and use the `?` operator to return arbitrary errors.
+pub(crate) struct ServerError(Box<dyn ChromaError>);
+
+impl<E: ChromaError + 'static> From<E> for ServerError {
+    fn from(e: E) -> Self {
+        ServerError(Box::new(e))
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    message: String,
+}
+
+impl IntoResponse for ServerError {
+    fn into_response(self) -> Response {
+        let status_code = match self.0.code() {
+            chroma_error::ErrorCodes::Success => StatusCode::OK,
+            chroma_error::ErrorCodes::Cancelled => StatusCode::BAD_REQUEST,
+            chroma_error::ErrorCodes::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
+            chroma_error::ErrorCodes::InvalidArgument => StatusCode::BAD_REQUEST,
+            chroma_error::ErrorCodes::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+            chroma_error::ErrorCodes::NotFound => StatusCode::NOT_FOUND,
+            chroma_error::ErrorCodes::AlreadyExists => StatusCode::CONFLICT,
+            chroma_error::ErrorCodes::PermissionDenied => StatusCode::FORBIDDEN,
+            chroma_error::ErrorCodes::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+            chroma_error::ErrorCodes::FailedPrecondition => StatusCode::PRECONDITION_FAILED,
+            chroma_error::ErrorCodes::Aborted => StatusCode::BAD_REQUEST,
+            chroma_error::ErrorCodes::OutOfRange => StatusCode::BAD_REQUEST,
+            chroma_error::ErrorCodes::Unimplemented => StatusCode::NOT_IMPLEMENTED,
+            chroma_error::ErrorCodes::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+            chroma_error::ErrorCodes::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+            chroma_error::ErrorCodes::DataLoss => StatusCode::INTERNAL_SERVER_ERROR,
+            chroma_error::ErrorCodes::Unauthenticated => StatusCode::UNAUTHORIZED,
+            chroma_error::ErrorCodes::VersionMismatch => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+        let error = ErrorResponse {
+            error: status_code.to_string(),
+            message: self.0.to_string(),
+        };
+
+        (status_code, Json(error)).into_response()
+    }
+}

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -1,5 +1,6 @@
 mod ac;
 mod config;
+mod errors;
 #[allow(dead_code)]
 mod executor;
 mod frontend;


### PR DESCRIPTION
## Description of changes

Route handlers can now use `?` on methods that return `Result<_, E> where E: ChromaError`.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Tested by calling a route that threw.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a