### PR TITLE
[ENH]: add `/add` route to Rust frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "chroma-cache",
  "chroma-config",
  "chroma-error",
+ "chroma-log",
  "chroma-sysdb",
  "chroma-tracing",
  "chroma-types",

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -27,3 +27,4 @@ chroma-error = { workspace = true }
 chroma-tracing = { workspace = true }
 mdac = { workspace = true }
 chroma-cache = { workspace = true }
+chroma-log = { workspace = true }

--- a/rust/frontend/Dockerfile
+++ b/rust/frontend/Dockerfile
@@ -4,6 +4,10 @@ ARG RELEASE_MODE=
 
 WORKDIR /
 
+# ADD with an external URL is always run, so this will trigger a cache invalidation (and thus run the below git clone) if the latest commit changes
+ADD "https://api.github.com/repos/chroma-core/hnswlib/commits?per_page=1" hnswlib_commits.json
+RUN git clone https://github.com/chroma-core/hnswlib.git
+
 WORKDIR /chroma/
 
 ENV PROTOC_ZIP=protoc-25.1-linux-x86_64.zip

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -9,3 +9,9 @@ sysdb:
 cache_config:
   lru:
     capacity: 1000
+log:
+  Grpc:
+    host: "logservice.chroma"
+    port: 50051
+    connect_timeout_ms: 5000
+    request_timeout_ms: 5000

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -1,4 +1,5 @@
 use chroma_cache::CacheConfig;
+use chroma_log::config::LogConfig;
 use chroma_sysdb::SysDbConfig;
 use figment::providers::{Env, Format, Yaml};
 use mdac::CircuitBreakerConfig;
@@ -12,6 +13,7 @@ pub(super) struct FrontendConfig {
     pub(super) cache_config: CacheConfig,
     pub service_name: String,
     pub otel_endpoint: String,
+    pub(super) log: LogConfig,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "./frontend_config.yaml";

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -137,6 +137,37 @@ pub struct QueryResponse {
     include: Vec<Include>,
 }
 
+pub struct AddToCollectionRequest {
+    pub tenant_id: String,
+    pub database_name: String,
+    pub collection_id: Uuid,
+    pub ids: Vec<String>,
+    pub embeddings: Option<Vec<Vec<f32>>>,
+    pub documents: Option<Vec<String>>,
+    pub uri: Option<Vec<String>>,
+    pub metadatas: Option<Vec<Metadata>>,
+}
+
+#[derive(Serialize)]
+pub struct AddToCollectionResponse {}
+
+#[derive(Error, Debug)]
+pub enum AddToCollectionError {
+    #[error("Inconsistent number of IDs, embeddings, documents, URIs and metadatas")]
+    InconsistentLength,
+    #[error("Failed to push logs: {0}")]
+    FailedToPushLogs(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for AddToCollectionError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            AddToCollectionError::InconsistentLength => ErrorCodes::InvalidArgument,
+            AddToCollectionError::FailedToPushLogs(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum Include {
     Distance,

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -161,6 +161,17 @@ impl TryFrom<&MetadataValue> for String {
     }
 }
 
+impl From<MetadataValue> for UpdateMetadataValue {
+    fn from(value: MetadataValue) -> Self {
+        match value {
+            MetadataValue::Bool(v) => UpdateMetadataValue::Bool(v),
+            MetadataValue::Int(v) => UpdateMetadataValue::Int(v),
+            MetadataValue::Float(v) => UpdateMetadataValue::Float(v),
+            MetadataValue::Str(v) => UpdateMetadataValue::Str(v),
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum MetadataValueConversionError {
     #[error("Invalid metadata value, valid values are: Int, Float, Str")]


### PR DESCRIPTION
## Description of changes

Adds write path to Rust frontend.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Tested with a small script that added records and then queried them.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a