### PR TITLE
[ENH] Plumb ML into fe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1478,6 +1478,7 @@ dependencies = [
 name = "chroma-types"
 version = "0.1.0"
 dependencies = [
+ "chroma-config",
  "chroma-error",
  "prost 0.13.3",
  "prost-types",
@@ -2377,17 +2378,21 @@ dependencies = [
  "chroma-config",
  "chroma-error",
  "chroma-log",
+ "chroma-memberlist",
  "chroma-sysdb",
+ "chroma-system",
  "chroma-tracing",
  "chroma-types",
  "figment",
  "mdac",
+ "parking_lot",
+ "rand",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
- "tower 0.5.1",
+ "tower 0.4.13",
  "tracing",
  "uuid",
 ]
@@ -6294,14 +6299,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -10,6 +10,7 @@ use foyer::{
 };
 use opentelemetry::global;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Duration;
@@ -257,6 +258,16 @@ where
     clear_latency: opentelemetry::metrics::Histogram<u64>,
 }
 
+impl<K, V> Debug for FoyerHybridCache<K, V>
+where
+    K: Clone + Send + Sync + StorageKey + Eq + PartialEq + Hash + 'static,
+    V: Clone + Send + Sync + StorageValue + Weighted + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FoyerHybridCache").finish()
+    }
+}
+
 impl<K, V> FoyerHybridCache<K, V>
 where
     K: Clone + Send + Sync + StorageKey + Eq + PartialEq + Hash + 'static,
@@ -410,6 +421,16 @@ where
     insert_latency: opentelemetry::metrics::Histogram<u64>,
     remove_latency: opentelemetry::metrics::Histogram<u64>,
     clear_latency: opentelemetry::metrics::Histogram<u64>,
+}
+
+impl<K, V> Debug for FoyerPlainCache<K, V>
+where
+    K: Clone + Send + Sync + Eq + PartialEq + Hash + 'static,
+    V: Clone + Send + Sync + Weighted + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FoyerPlainCache").finish()
+    }
 }
 
 impl<K, V> FoyerPlainCache<K, V>

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::hash::Hash;
 
 use ::foyer::{StorageKey, StorageValue};
@@ -58,7 +59,7 @@ pub enum CacheConfig {
 
 /// A cache offers async access.  It's unspecified whether this cache is persistent or not.
 #[async_trait::async_trait]
-pub trait Cache<K, V>: Send + Sync
+pub trait Cache<K, V>: Send + Sync + Debug
 where
     K: Clone + Send + Sync + Eq + PartialEq + Hash + 'static,
     V: Clone + Send + Sync + Weighted + 'static,

--- a/rust/cache/src/nop.rs
+++ b/rust/cache/src/nop.rs
@@ -1,6 +1,6 @@
-use std::hash::Hash;
-
 use super::{CacheError, StorageKey, StorageValue, Weighted};
+use std::fmt::Debug;
+use std::hash::Hash;
 
 /// A zero-configuration cache that doesn't evict.
 pub struct NopCache;
@@ -21,6 +21,12 @@ where
 
     async fn clear(&self) -> Result<(), CacheError> {
         Ok(())
+    }
+}
+
+impl Debug for NopCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NopCache")
     }
 }
 

--- a/rust/cache/src/unbounded.rs
+++ b/rust/cache/src/unbounded.rs
@@ -1,10 +1,9 @@
+use super::{CacheError, StorageKey, StorageValue, Weighted};
+use parking_lot::RwLock;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
-
-use parking_lot::RwLock;
-
-use super::{CacheError, StorageKey, StorageValue, Weighted};
 
 /// A zero-configuration cache that doesn't evict.
 /// Mostly useful for testing.
@@ -65,6 +64,16 @@ where
     async fn clear(&self) -> Result<(), CacheError> {
         self.cache.write().clear();
         Ok(())
+    }
+}
+
+impl<K, V> Debug for UnboundedCache<K, V>
+where
+    K: Clone + Send + Sync + Eq + PartialEq + Hash + 'static,
+    V: Clone + Send + Sync + Clone + Weighted + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UnboundedCache")
     }
 }
 

--- a/rust/config/src/assignment/config.rs
+++ b/rust/config/src/assignment/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 /// The type of hasher to use.
 /// # Options
 /// - Murmur3: The murmur3 hasher.
@@ -8,7 +8,7 @@ pub(crate) enum HasherType {
     Murmur3,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 /// The configuration for the assignment policy.
 /// # Options
 /// - RendezvousHashing: The rendezvous hashing assignment policy.
@@ -19,7 +19,7 @@ pub enum AssignmentPolicyConfig {
     RendezvousHashing(RendezvousHashingAssignmentPolicyConfig),
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 /// The configuration for the rendezvous hashing assignment policy.
 /// # Fields
 /// - hasher: The type of hasher to use.

--- a/rust/config/src/assignment/rendezvous_hash.rs
+++ b/rust/config/src/assignment/rendezvous_hash.rs
@@ -95,6 +95,7 @@ fn merge_hashes(x: u64, y: u64) -> u64 {
     acc
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct Murmur3Hasher {}
 
 impl Hasher for Murmur3Hasher {

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -17,8 +17,10 @@ figment = { workspace = true }
 uuid = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
-tower = { workspace = true }
 thiserror = { workspace = true }
+parking_lot = { workspace = true }
+rand = { workspace = true }
+tower = { version = "0.4.13", features = ["discover"] }
 
 chroma-config = { workspace = true }
 chroma-types = { workspace = true }
@@ -28,3 +30,5 @@ chroma-tracing = { workspace = true }
 mdac = { workspace = true }
 chroma-cache = { workspace = true }
 chroma-log = { workspace = true }
+chroma-memberlist = { workspace = true }
+chroma-system = { workspace = true }

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -15,3 +15,15 @@ log:
     port: 50051
     connect_timeout_ms: 5000
     request_timeout_ms: 5000
+executor:
+  Distributed:
+    connections_per_node: 5
+    replication_factor: 2
+    assignment:
+      RendezvousHashing:
+        hasher: Murmur3
+    memberlist_provider:
+      CustomResource:
+          kube_namespace: "chroma"
+          memberlist_name: "query-service-memberlist"
+          queue_size: 100

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -19,6 +19,8 @@ executor:
   Distributed:
     connections_per_node: 5
     replication_factor: 2
+    connect_timeout_ms: 5000
+    request_timeout_ms: 5000
     assignment:
       RendezvousHashing:
         hasher: Murmur3

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -1,3 +1,4 @@
+use crate::executor::config::ExecutorConfig;
 use chroma_cache::CacheConfig;
 use chroma_log::config::LogConfig;
 use chroma_sysdb::SysDbConfig;
@@ -5,7 +6,7 @@ use figment::providers::{Env, Format, Yaml};
 use mdac::CircuitBreakerConfig;
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub(super) struct FrontendConfig {
     pub(super) sysdb: SysDbConfig,
     #[serde(default = "CircuitBreakerConfig::default")]
@@ -14,6 +15,7 @@ pub(super) struct FrontendConfig {
     pub service_name: String,
     pub otel_endpoint: String,
     pub(super) log: LogConfig,
+    pub(super) executor: ExecutorConfig,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "./frontend_config.yaml";

--- a/rust/frontend/src/executor/client_manager.rs
+++ b/rust/frontend/src/executor/client_manager.rs
@@ -1,0 +1,149 @@
+use async_trait::async_trait;
+use chroma_memberlist::memberlist_provider::Memberlist;
+use chroma_system::{Component, ComponentContext, Handler};
+use chroma_types::chroma_proto::query_executor_client::QueryExecutorClient;
+use parking_lot::Mutex;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use tonic::transport::{Channel, Endpoint};
+use tower::discover::Change;
+
+#[derive(Debug)]
+pub(super) struct ClientManager {
+    // The name of the node to the grpc client
+    node_name_to_client:
+        Arc<Mutex<HashMap<String, QueryExecutorClient<tonic::transport::Channel>>>>,
+    // The name of the node to the sender to the channel to add / remove the ip
+    node_name_to_change_sender:
+        HashMap<String, tokio::sync::mpsc::Sender<Change<String, Endpoint>>>,
+    connections_per_node: usize,
+    old_memberlist: Memberlist,
+}
+
+impl ClientManager {
+    pub(super) fn new(
+        node_name_to_client: Arc<
+            Mutex<HashMap<String, QueryExecutorClient<tonic::transport::Channel>>>,
+        >,
+        connections_per_node: usize,
+    ) -> Self {
+        ClientManager {
+            node_name_to_client,
+            node_name_to_change_sender: HashMap::new(),
+            connections_per_node,
+            old_memberlist: Memberlist::new(),
+        }
+    }
+
+    async fn remove_ip_for_node(&self, ip: String, node: &str) {
+        let sender = match self.node_name_to_change_sender.get(&ip) {
+            Some(sender) => sender,
+            None => {
+                // There is no one to return the error to, so just log it
+                tracing::error!("Failed to find sender for node: {:?}", node);
+                return;
+            }
+        };
+
+        match sender.send(Change::Remove(ip)).await {
+            Ok(_) => {}
+            Err(e) => {
+                // There is no one to return the error to, so just log it
+                tracing::error!("Failed to remove ip from client manager: {:?}", e);
+            }
+        }
+    }
+
+    async fn add_ip_for_node(&mut self, ip: String, node: &str) {
+        let endpoint = match Endpoint::from_shared(ip.clone()) {
+            Ok(endpoint) => endpoint,
+            Err(e) => {
+                // There is no one to return the error to, so just log it
+                tracing::error!("Failed to create endpoint from ip: {:?}", e);
+                return;
+            }
+        };
+
+        let sender = match self.node_name_to_change_sender.get(node) {
+            Some(sender) => sender.clone(),
+            None => {
+                // TODO(hammadb): configure timeouts and such
+                let (chan, channel_change_sender) =
+                    Channel::balance_channel::<String>(self.connections_per_node);
+                let client = QueryExecutorClient::new(chan);
+
+                // TODO: insert up to the max number of connections
+                let mut node_name_to_client_guard = self.node_name_to_client.lock();
+                node_name_to_client_guard.insert(node.to_string(), client);
+                self.node_name_to_change_sender
+                    .insert(node.to_string(), channel_change_sender.clone());
+                channel_change_sender
+            }
+        };
+
+        match sender.send(Change::Insert(ip, endpoint)).await {
+            Ok(_) => {}
+            Err(e) => {
+                // There is no one to return the error to, so just log it
+                tracing::error!("Failed to add ip to client manager: {:?}", e);
+            }
+        }
+    }
+}
+
+///////////////////////// Component Impl /////////////////////////
+
+impl Component for ClientManager {
+    fn get_name() -> &'static str {
+        "ClientManger"
+    }
+
+    fn queue_size(&self) -> usize {
+        1000
+    }
+}
+
+#[async_trait]
+impl Handler<Memberlist> for ClientManager {
+    type Result = ();
+
+    async fn handle(&mut self, new_members: Memberlist, _ctx: &ComponentContext<ClientManager>) {
+        let mut old_node_to_ip = HashMap::new();
+        for old_member in self.old_memberlist.iter() {
+            old_node_to_ip.insert(
+                old_member.member_node_name.to_string(),
+                old_member.member_ip.to_string(),
+            );
+        }
+
+        let mut seen_nodes = HashSet::new();
+        for new_member in new_members.iter() {
+            let node = new_member.member_node_name.as_str();
+            let ip = new_member.member_ip.as_str();
+
+            match old_node_to_ip.get(node) {
+                Some(old_ip) => {
+                    if *old_ip != ip {
+                        // The ip has changed
+                        self.remove_ip_for_node(old_ip.to_string(), node).await;
+                        self.add_ip_for_node(ip.to_string(), node).await;
+                    }
+                }
+                None => {
+                    // This is a new node
+                    self.add_ip_for_node(ip.to_string(), node).await;
+                }
+            }
+            seen_nodes.insert(node.to_string());
+        }
+
+        for (node, ip) in old_node_to_ip.iter() {
+            if !seen_nodes.contains(node) {
+                // This node has been removed
+                self.remove_ip_for_node(ip.to_string(), node).await;
+            }
+        }
+    }
+}

--- a/rust/frontend/src/executor/config.rs
+++ b/rust/frontend/src/executor/config.rs
@@ -1,0 +1,37 @@
+use super::{distributed::DistributedExecutor, Executor};
+use async_trait::async_trait;
+use chroma_config::Configurable;
+use chroma_error::ChromaError;
+use chroma_system::System;
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone)]
+pub(crate) struct DistributedExecutorConfig {
+    pub(crate) connections_per_node: usize,
+    pub(crate) replication_factor: usize,
+    pub(crate) assignment: chroma_config::assignment::config::AssignmentPolicyConfig,
+    pub(crate) memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
+}
+
+#[derive(Deserialize, Clone)]
+pub(crate) enum ExecutorConfig {
+    Distributed(DistributedExecutorConfig),
+}
+
+#[async_trait]
+impl Configurable<(ExecutorConfig, System)> for Executor {
+    async fn try_from_config(
+        (config, system): &(ExecutorConfig, System),
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        match config {
+            ExecutorConfig::Distributed(distributed_config) => {
+                let distributed_executor = DistributedExecutor::try_from_config(&(
+                    distributed_config.clone(),
+                    system.clone(),
+                ))
+                .await?;
+                Ok(Executor::Distributed(distributed_executor))
+            }
+        }
+    }
+}

--- a/rust/frontend/src/executor/config.rs
+++ b/rust/frontend/src/executor/config.rs
@@ -5,10 +5,20 @@ use chroma_error::ChromaError;
 use chroma_system::System;
 use serde::Deserialize;
 
+/// Configuration for the distributed executor.
+/// # Fields
+/// - `connections_per_node` - The number of connections to maintain per node
+/// - `replication_factor` - The target replication factor for the request
+/// - `connect_timeout_ms` - The timeout for connecting to a node
+/// - `request_timeout_ms` - The timeout for the request
+/// - `assignment` - The assignment policy to use for routing requests
+/// - `memberlist_provider` - The memberlist provider to use for getting the list of nodes
 #[derive(Deserialize, Clone)]
 pub(crate) struct DistributedExecutorConfig {
     pub(crate) connections_per_node: usize,
     pub(crate) replication_factor: usize,
+    pub(crate) connect_timeout_ms: u64,
+    pub(crate) request_timeout_ms: u64,
     pub(crate) assignment: chroma_config::assignment::config::AssignmentPolicyConfig,
     pub(crate) memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
 }

--- a/rust/frontend/src/executor/distributed.rs
+++ b/rust/frontend/src/executor/distributed.rs
@@ -1,25 +1,67 @@
-use std::{iter::once, time::Duration};
-
+use super::{client_manager::ClientManager, config};
+use async_trait::async_trait;
+use chroma_config::{
+    assignment::{self, assignment_policy::AssignmentPolicy},
+    Configurable,
+};
+use chroma_error::ChromaError;
+use chroma_memberlist::{
+    config::MemberlistProviderConfig,
+    memberlist_provider::{CustomResourceMemberlistProvider, MemberlistProvider},
+};
+use chroma_system::System;
 use chroma_types::{
     chroma_proto::query_executor_client::QueryExecutorClient,
     operator::{from_proto_knn_batch_result, CountResult, GetResult, KnnBatchResult},
     plan::{Count, Get, Knn},
-    ExecutorError,
+    CollectionUuid, ExecutorError,
 };
-use tonic::{
-    transport::{Channel, Endpoint},
-    Request,
-};
+use parking_lot::Mutex;
+use rand::Rng;
+use std::{collections::HashMap, sync::Arc};
+use tonic::Request;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DistributedExecutor {
-    client: QueryExecutorClient<tonic::transport::Channel>,
+    node_name_to_client:
+        Arc<Mutex<HashMap<String, QueryExecutorClient<tonic::transport::Channel>>>>,
+    assignment_policy: Box<dyn AssignmentPolicy>,
+    replication_factor: usize,
+}
+
+#[async_trait]
+impl Configurable<(config::DistributedExecutorConfig, System)> for DistributedExecutor {
+    async fn try_from_config(
+        (config, system): &(config::DistributedExecutorConfig, System),
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let assignment_policy = assignment::from_config(&config.assignment).await?;
+        let node_name_to_client = Arc::new(Mutex::new(HashMap::new()));
+        let client_manager =
+            ClientManager::new(node_name_to_client.clone(), config.connections_per_node);
+        let client_manager_handle = system.start_component(client_manager);
+
+        let mut memberlist_provider = match &config.memberlist_provider {
+            MemberlistProviderConfig::CustomResource(_memberlist_provider_config) => {
+                CustomResourceMemberlistProvider::try_from_config(&config.memberlist_provider)
+                    .await?
+            }
+        };
+        memberlist_provider.subscribe(client_manager_handle.receiver());
+        let _memberlist_provider_handle = system.start_component(memberlist_provider);
+
+        Ok(Self {
+            node_name_to_client,
+            assignment_policy,
+            replication_factor: config.replication_factor,
+        })
+    }
 }
 
 impl DistributedExecutor {
+    ///////////////////////// Plan Operations /////////////////////////
     pub async fn count(&mut self, plan: Count) -> Result<CountResult, ExecutorError> {
-        Ok(self
-            .client
+        let mut client = self.client(plan.scan.collection_and_segments.collection.collection_id)?;
+        Ok(client
             .count(Request::new(plan.into()))
             .await?
             .into_inner()
@@ -27,34 +69,47 @@ impl DistributedExecutor {
     }
 
     pub async fn get(&mut self, plan: Get) -> Result<GetResult, ExecutorError> {
-        Ok(self
-            .client
+        let mut client = self.client(plan.scan.collection_and_segments.collection.collection_id)?;
+        Ok(client
             .get(Request::new(plan.try_into()?))
             .await?
             .into_inner()
             .try_into()?)
     }
     pub async fn knn(&mut self, plan: Knn) -> Result<KnnBatchResult, ExecutorError> {
+        let mut client = self.client(plan.scan.collection_and_segments.collection.collection_id)?;
         Ok(from_proto_knn_batch_result(
-            self.client
+            client
                 .knn(Request::new(plan.try_into()?))
                 .await?
                 .into_inner(),
         )?)
     }
-}
 
-// WARN: This is a placeholder impl, which should be replaced by proper initialization from memberlist
-impl Default for DistributedExecutor {
-    fn default() -> Self {
-        let endpoint = Endpoint::from_shared(
-            "http://query-service-0.query-service.chroma.svc.cluster.local:50051",
-        )
-        .expect("This should be a valid endpoint for query service")
-        .connect_timeout(Duration::from_secs(6))
-        .timeout(Duration::from_secs(1));
-        Self {
-            client: QueryExecutorClient::new(Channel::balance_list(once(endpoint).cycle().take(6))),
-        }
+    ///////////////////////// Helpers /////////////////////////
+
+    /// Get the gRPC client for the given collection id by performing the assignment policy
+    /// # Arguments
+    /// - `collection_id` - The collection id for which the client is to be fetched
+    /// # Returns
+    /// - The gRPC client for the given collection id
+    /// # Errors
+    /// - If no client is found for the given collection id
+    /// - If the assignment policy fails to assign the collection id
+    fn client(
+        &mut self,
+        collection_id: CollectionUuid,
+    ) -> Result<QueryExecutorClient<tonic::transport::Channel>, ExecutorError> {
+        let node_name_to_client_guard = self.node_name_to_client.lock();
+        let members = node_name_to_client_guard.keys().cloned().collect();
+        self.assignment_policy.set_members(members);
+        let assigned = self
+            .assignment_policy
+            .assign(&collection_id.to_string(), self.replication_factor)?;
+        let random_index = rand::thread_rng().gen_range(0..assigned.len());
+        let client = node_name_to_client_guard
+            .get(&assigned[random_index])
+            .ok_or_else(|| ExecutorError::NoClientFound(assigned[0].clone()))?;
+        Ok(client.clone())
     }
 }

--- a/rust/frontend/src/executor/mod.rs
+++ b/rust/frontend/src/executor/mod.rs
@@ -5,10 +5,12 @@ use chroma_types::{
 };
 use distributed::DistributedExecutor;
 
+pub(super) mod client_manager;
+pub(crate) mod config;
 mod distributed;
 
-#[derive(Clone)]
-pub enum Executor {
+#[derive(Clone, Debug)]
+pub(crate) enum Executor {
     Distributed(DistributedExecutor),
 }
 
@@ -27,12 +29,5 @@ impl Executor {
         match self {
             Executor::Distributed(distributed_executor) => distributed_executor.knn(plan).await,
         }
-    }
-}
-
-// WARN: This is a placeholder impl, which should be replaced by proper initialization from config
-impl Default for Executor {
-    fn default() -> Self {
-        Self::Distributed(DistributedExecutor::default())
     }
 }

--- a/rust/frontend/src/executor/mod.rs
+++ b/rust/frontend/src/executor/mod.rs
@@ -5,10 +5,12 @@ use chroma_types::{
 };
 use distributed::DistributedExecutor;
 
+//////////////////////// Exposed Modules ////////////////////////
 pub(super) mod client_manager;
 pub(crate) mod config;
 mod distributed;
 
+//////////////////////// Main Types ////////////////////////
 #[derive(Clone, Debug)]
 pub(crate) enum Executor {
     Distributed(DistributedExecutor),

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct GrpcLogConfig {
     pub host: String,
     pub port: u16,
@@ -8,7 +8,7 @@ pub struct GrpcLogConfig {
     pub request_timeout_ms: u64,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub enum LogConfig {
     Grpc(GrpcLogConfig),
 }

--- a/rust/memberlist/src/config.rs
+++ b/rust/memberlist/src/config.rs
@@ -11,7 +11,7 @@ pub(crate) enum MemberlistProviderType {
 /// The configuration for the memberlist provider.
 /// # Options
 /// - CustomResource: Use a custom resource to get the memberlist
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub enum MemberlistProviderConfig {
     CustomResource(CustomResourceMemberlistProviderConfig),
 }
@@ -21,7 +21,7 @@ pub enum MemberlistProviderConfig {
 /// - kube_namespace: The namespace to use for the custom resource.
 /// - memberlist_name: The name of the custom resource to use for the memberlist.
 /// - queue_size: The size of the queue to use for the channel.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct CustomResourceMemberlistProviderConfig {
     pub kube_namespace: String,
     pub memberlist_name: String,

--- a/rust/memberlist/src/memberlist_provider.rs
+++ b/rust/memberlist/src/memberlist_provider.rs
@@ -307,7 +307,7 @@ mod tests {
         let memberlist = memberlist.as_ref().unwrap();
         // The query service memberlist in our test tilt config has two nodes
         assert_eq!(memberlist.len(), 2);
-        // The ids should be formmatted as "query-service-<node number>"
+        // The ids should be formatted as "query-service-<node number>"
         for member in memberlist.iter() {
             assert!(member.member_id.starts_with("query-service-"));
         }

--- a/rust/sysdb/src/config.rs
+++ b/rust/sysdb/src/config.rs
@@ -23,7 +23,7 @@ fn default_num_channels() -> usize {
 
 //////////////////////// SYSDB CONFIG ////////////////////////
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub enum SysDbConfig {
     Grpc(GrpcSysDbConfig),
 }

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 chroma-error = { workspace = true }
+chroma-config = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -177,7 +177,7 @@ impl Scheduler {
             let result = self
                 .assignment_policy
                 // NOTE(rescrv):  Need to use the untyped uuid here.
-                .assign(collection.collection_id.0.to_string().as_str());
+                .assign_one(collection.collection_id.0.to_string().as_str());
             match result {
                 Ok(member) => {
                     if member == self.my_member_id {

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -9,7 +9,6 @@ use chroma_memberlist::memberlist_provider::{
 use clap::Parser;
 use compactor::compaction_client::CompactionClient;
 use compactor::compaction_server::CompactionServer;
-
 use tokio::select;
 use tokio::signal::unix::{signal, SignalKind};
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Add clone to a bunch of config structs since we need it
 - New functionality
   - Adds a ClientManager to respond to the memberlist changes and update nodes
   - Introduces config for the executor num_connections, and timeouts
   - Performs top-k HWRH for assignment to query nodes and randomly load balances between them
   - Add assign many behavior into assignment policy

## Test plan
*How are these changes tested?*
Not well. Will add in future PR. Manually verified the connection pooling to query nodes

![signal-2025-01-29-075332_002](https://github.com/user-attachments/assets/8676ae3d-b8c2-44d7-9cd8-30ddc8278f14)


- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None