### PR TITLE
[ENH]  Wire up config to scorecard with default rules

### DIFF
--- a/rust/config/src/assignment/config.rs
+++ b/rust/config/src/assignment/config.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 /// The type of hasher to use.
 /// # Options
 /// - Murmur3: The murmur3 hasher.
@@ -8,7 +8,7 @@ pub(crate) enum HasherType {
     Murmur3,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 /// The configuration for the assignment policy.
 /// # Options
 /// - RendezvousHashing: The rendezvous hashing assignment policy.
@@ -19,7 +19,7 @@ pub enum AssignmentPolicyConfig {
     RendezvousHashing(RendezvousHashingAssignmentPolicyConfig),
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 /// The configuration for the rendezvous hashing assignment policy.
 /// # Fields
 /// - hasher: The type of hasher to use.

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -29,3 +29,9 @@ executor:
           kube_namespace: "chroma"
           memberlist_name: "query-service-memberlist"
           queue_size: 100
+scorecard_enabled: true
+scorecard:
+- patterns:
+  - 'op:*'
+  - 'collection_id:*'
+  score: 100

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -4,28 +4,37 @@ use chroma_log::config::LogConfig;
 use chroma_sysdb::SysDbConfig;
 use figment::providers::{Env, Format, Yaml};
 use mdac::CircuitBreakerConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Clone)]
-pub(super) struct FrontendConfig {
-    pub(super) sysdb: SysDbConfig,
+#[derive(Deserialize, Serialize, Clone)]
+pub struct ScorecardRule {
+    pub patterns: Vec<String>,
+    pub score: u32,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct FrontendConfig {
+    pub sysdb: SysDbConfig,
     #[serde(default = "CircuitBreakerConfig::default")]
     pub circuit_breaker: CircuitBreakerConfig,
-    pub(super) cache_config: CacheConfig,
+    pub cache_config: CacheConfig,
     pub service_name: String,
     pub otel_endpoint: String,
-    pub(super) log: LogConfig,
-    pub(super) executor: ExecutorConfig,
+    pub log: LogConfig,
+    pub executor: ExecutorConfig,
+    pub scorecard_enabled: bool,
+    #[serde(default)]
+    pub scorecard: Vec<ScorecardRule>,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "./frontend_config.yaml";
 
 impl FrontendConfig {
-    pub(super) fn load() -> Self {
+    pub fn load() -> Self {
         Self::load_from_path(DEFAULT_CONFIG_PATH)
     }
 
-    pub(super) fn load_from_path(path: &str) -> Self {
+    pub fn load_from_path(path: &str) -> Self {
         // Unfortunately, figment doesn't support environment variables with underscores. So we have to map and replace them.
         // Excluding our own environment variables, which are prefixed with CHROMA_.
         let mut f = figment::Figment::from(

--- a/rust/frontend/src/executor/config.rs
+++ b/rust/frontend/src/executor/config.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use chroma_system::System;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Configuration for the distributed executor.
 /// # Fields
@@ -13,18 +13,18 @@ use serde::Deserialize;
 /// - `request_timeout_ms` - The timeout for the request
 /// - `assignment` - The assignment policy to use for routing requests
 /// - `memberlist_provider` - The memberlist provider to use for getting the list of nodes
-#[derive(Deserialize, Clone)]
-pub(crate) struct DistributedExecutorConfig {
-    pub(crate) connections_per_node: usize,
-    pub(crate) replication_factor: usize,
-    pub(crate) connect_timeout_ms: u64,
-    pub(crate) request_timeout_ms: u64,
-    pub(crate) assignment: chroma_config::assignment::config::AssignmentPolicyConfig,
-    pub(crate) memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
+#[derive(Deserialize, Clone, Serialize)]
+pub struct DistributedExecutorConfig {
+    pub connections_per_node: usize,
+    pub replication_factor: usize,
+    pub connect_timeout_ms: u64,
+    pub request_timeout_ms: u64,
+    pub assignment: chroma_config::assignment::config::AssignmentPolicyConfig,
+    pub memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
 }
 
-#[derive(Deserialize, Clone)]
-pub(crate) enum ExecutorConfig {
+#[derive(Deserialize, Clone, Serialize)]
+pub enum ExecutorConfig {
     Distributed(DistributedExecutorConfig),
 }
 

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -1,4 +1,7 @@
-use crate::{config::FrontendConfig, executor::Executor};
+use crate::{
+    config::{FrontendConfig, ScorecardRule},
+    executor::Executor,
+};
 use chroma_cache::Cache;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
@@ -15,7 +18,7 @@ use chroma_types::{
 use chroma_types::{
     Operation, OperationRecord, ScalarEncoding, UpdateMetadata, UpdateMetadataValue,
 };
-use mdac::{Scorecard, ScorecardTicket};
+use mdac::{Pattern, Rule, Scorecard, ScorecardTicket};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -37,6 +40,20 @@ impl Drop for ScorecardGuard {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum ScorecardRuleError {
+    #[error("Invalid pattern: {0}")]
+    InvalidPattern(String),
+}
+
+impl ChromaError for ScorecardRuleError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            ScorecardRuleError::InvalidPattern(_) => chroma_error::ErrorCodes::InvalidArgument,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Frontend {
     #[allow(dead_code)]
@@ -54,12 +71,14 @@ impl Frontend {
         collections_with_segments_cache: Arc<dyn Cache<CollectionUuid, CollectionAndSegments>>,
         log_client: Box<chroma_log::Log>,
         executor: Executor,
+        scorecard_enabled: bool,
+        rules: Vec<Rule>,
     ) -> Self {
-        let scorecard_enabled = Arc::new(AtomicBool::new(false));
+        let scorecard_enabled = Arc::new(AtomicBool::new(scorecard_enabled));
         // NOTE(rescrv):  Assume statically no more than 128 threads because we won't deploy on
         // hardware with that many threads anytime soon for frontends, if ever.
         // SAFETY(rescrv):  This is safe because 128 is non-zero.
-        let scorecard = Arc::new(Scorecard::new(&(), vec![], 128.try_into().unwrap()));
+        let scorecard = Arc::new(Scorecard::new(&(), rules, 128.try_into().unwrap()));
         Frontend {
             executor,
             sysdb_client,
@@ -297,11 +316,32 @@ impl Configurable<(FrontendConfig, System)> for Frontend {
 
         let executor =
             Executor::try_from_config(&(config.executor.clone(), system.clone())).await?;
+        fn rule_to_rule(rule: &ScorecardRule) -> Result<Rule, ScorecardRuleError> {
+            let patterns = rule
+                .patterns
+                .iter()
+                .map(|p| {
+                    Pattern::new(p).ok_or_else(|| ScorecardRuleError::InvalidPattern(p.clone()))
+                })
+                .collect::<Result<Vec<_>, ScorecardRuleError>>()?;
+            Ok(Rule {
+                patterns,
+                limit: rule.score as usize,
+            })
+        }
+        let rules = config
+            .scorecard
+            .iter()
+            .map(rule_to_rule)
+            .collect::<Result<Vec<_>, ScorecardRuleError>>()
+            .map_err(|x| Box::new(x) as _)?;
         Ok(Frontend::new(
             sysdb_client,
             collections_with_segments_cache.into(),
             log_client,
             executor,
+            config.scorecard_enabled,
+            rules,
         ))
     }
 }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -8,9 +8,10 @@ mod server;
 
 use chroma_config::Configurable;
 use chroma_system::System;
-use config::FrontendConfig;
 use frontend::Frontend;
 use server::FrontendServer;
+
+pub use config::{FrontendConfig, ScorecardRule};
 
 const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
 
@@ -25,6 +26,6 @@ pub async fn frontend_service_entrypoint() {
     let frontend = Frontend::try_from_config(&(config.clone(), system))
         .await
         .expect("Error creating SegmentApi from config");
-    let server = FrontendServer::new(config.circuit_breaker, frontend);
+    let server = FrontendServer::new(config, frontend);
     FrontendServer::run(server).await;
 }

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -10,33 +10,29 @@ use chroma_types::{
     GetUserIdentityResponse, Include, IncludeList, Metadata, MetadataExpression, PrimitiveOperator,
     QueryRequest, QueryResponse, Where,
 };
-use mdac::CircuitBreakerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 
 use crate::ac::AdmissionControlledService;
+use crate::config::FrontendConfig;
 use crate::errors::{ServerError, ValidationError};
 use crate::frontend::Frontend;
 
 #[derive(Clone)]
 pub(crate) struct FrontendServer {
-    circuit_breaker_config: CircuitBreakerConfig,
+    config: FrontendConfig,
     frontend: Frontend,
 }
 
 impl FrontendServer {
-    pub fn new(circuit_breaker_config: CircuitBreakerConfig, frontend: Frontend) -> FrontendServer {
-        let frontend = frontend;
-        FrontendServer {
-            circuit_breaker_config,
-            frontend,
-        }
+    pub fn new(config: FrontendConfig, frontend: Frontend) -> FrontendServer {
+        FrontendServer { config, frontend }
     }
 
     #[allow(dead_code)]
     pub async fn run(server: FrontendServer) {
-        let circuit_breaker_config = server.circuit_breaker_config.clone();
+        let circuit_breaker_config = server.config.circuit_breaker.clone();
         let app = Router::new()
             // `GET /` goes to `root`
             .route("/", get(root))

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct GrpcLogConfig {
     pub host: String,
     pub port: u16,
@@ -8,7 +8,7 @@ pub struct GrpcLogConfig {
     pub request_timeout_ms: u64,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub enum LogConfig {
     Grpc(GrpcLogConfig),
 }

--- a/rust/memberlist/src/config.rs
+++ b/rust/memberlist/src/config.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 /// The type of memberlist provider to use
 /// # Options
 /// - CustomResource: Use a custom resource to get the memberlist
@@ -11,7 +11,7 @@ pub(crate) enum MemberlistProviderType {
 /// The configuration for the memberlist provider.
 /// # Options
 /// - CustomResource: Use a custom resource to get the memberlist
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub enum MemberlistProviderConfig {
     CustomResource(CustomResourceMemberlistProviderConfig),
 }
@@ -21,7 +21,7 @@ pub enum MemberlistProviderConfig {
 /// - kube_namespace: The namespace to use for the custom resource.
 /// - memberlist_name: The name of the custom resource to use for the memberlist.
 /// - queue_size: The size of the queue to use for the channel.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Serialize)]
 pub struct CustomResourceMemberlistProviderConfig {
     pub kube_namespace: String,
     pub memberlist_name: String,

--- a/rust/sysdb/src/config.rs
+++ b/rust/sysdb/src/config.rs
@@ -1,11 +1,11 @@
 use crate::{GrpcSysDb, SysDb};
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 //////////////////////// GRPC SYSDB CONFIG ////////////////////////
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Serialize)]
 pub struct GrpcSysDbConfig {
     pub host: String,
     pub port: u16,
@@ -23,7 +23,7 @@ fn default_num_channels() -> usize {
 
 //////////////////////// SYSDB CONFIG ////////////////////////
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Serialize)]
 pub enum SysDbConfig {
     Grpc(GrpcSysDbConfig),
 }


### PR DESCRIPTION
By default we limit to 100 of each op per collection, but we could do
something more.
