### PR TITLE
[ENH]: add /upsert & /update to Rust frontend

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -297,7 +297,7 @@ pub struct AddToCollectionRequest {
     pub ids: Vec<String>,
     pub embeddings: Option<Vec<Vec<f32>>>,
     pub documents: Option<Vec<String>>,
-    pub uri: Option<Vec<String>>,
+    pub uris: Option<Vec<String>>,
     pub metadatas: Option<Vec<Metadata>>,
 }
 
@@ -317,6 +317,68 @@ impl ChromaError for AddToCollectionError {
         match self {
             AddToCollectionError::InconsistentLength => ErrorCodes::InvalidArgument,
             AddToCollectionError::FailedToPushLogs(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+pub struct UpdateCollectionRecordsRequest {
+    pub tenant_id: String,
+    pub database_name: String,
+    pub collection_id: Uuid,
+    pub ids: Vec<String>,
+    pub embeddings: Option<Vec<Vec<f32>>>,
+    pub documents: Option<Vec<String>>,
+    pub uris: Option<Vec<String>>,
+    pub metadatas: Option<Vec<UpdateMetadata>>,
+}
+
+#[derive(Serialize)]
+pub struct UpdateCollectionRecordsResponse {}
+
+#[derive(Error, Debug)]
+pub enum UpdateCollectionRecordsError {
+    #[error("Inconsistent number of IDs, embeddings, documents, URIs and metadatas")]
+    InconsistentLength,
+    #[error("Failed to push logs: {0}")]
+    FailedToPushLogs(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for UpdateCollectionRecordsError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            UpdateCollectionRecordsError::InconsistentLength => ErrorCodes::InvalidArgument,
+            UpdateCollectionRecordsError::FailedToPushLogs(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+pub struct UpsertCollectionRequest {
+    pub tenant_id: String,
+    pub database_name: String,
+    pub collection_id: Uuid,
+    pub ids: Vec<String>,
+    pub embeddings: Option<Vec<Vec<f32>>>,
+    pub documents: Option<Vec<String>>,
+    pub uris: Option<Vec<String>>,
+    pub metadatas: Option<Vec<UpdateMetadata>>,
+}
+
+#[derive(Serialize)]
+pub struct UpsertCollectionResponse {}
+
+#[derive(Error, Debug)]
+pub enum UpsertCollectionError {
+    #[error("Inconsistent number of IDs, embeddings, documents, URIs and metadatas")]
+    InconsistentLength,
+    #[error("Failed to push logs: {0}")]
+    FailedToPushLogs(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for UpsertCollectionError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            UpsertCollectionError::InconsistentLength => ErrorCodes::InvalidArgument,
+            UpsertCollectionError::FailedToPushLogs(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -361,6 +423,7 @@ pub struct CountRequest {
 pub type CountResponse = u32;
 
 pub const CHROMA_KEY: &str = "chroma:";
+pub const CHROMA_DOCUMENT_KEY: &str = "chroma:document";
 pub const CHROMA_URI_KEY: &str = "chroma:uri";
 
 #[derive(Clone)]

--- a/rust/types/src/operation.rs
+++ b/rust/types/src/operation.rs
@@ -3,7 +3,7 @@ use crate::chroma_proto;
 use chroma_error::{ChromaError, ErrorCodes};
 use thiserror::Error;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Operation {
     Add,
     Update,

--- a/rust/types/src/record.rs
+++ b/rust/types/src/record.rs
@@ -3,7 +3,7 @@ use super::{
     ScalarEncodingConversionError, UpdateMetadata, UpdateMetadataValue,
     UpdateMetadataValueConversionError,
 };
-use crate::chroma_proto;
+use crate::{chroma_proto, CHROMA_DOCUMENT_KEY};
 use chroma_error::{ChromaError, ErrorCodes};
 use thiserror::Error;
 
@@ -102,7 +102,7 @@ impl TryFrom<chroma_proto::OperationRecord> for OperationRecord {
         let (metadata, document) = match operation_record_proto.metadata {
             Some(proto_metadata) => match UpdateMetadata::try_from(proto_metadata) {
                 Ok(mut metadata) => {
-                    let document = metadata.remove("chroma:document");
+                    let document = metadata.remove(CHROMA_DOCUMENT_KEY);
                     match document {
                         Some(UpdateMetadataValue::Str(document)) => {
                             (Some(metadata), Some(document))
@@ -297,7 +297,7 @@ impl From<MetadataEmbeddingRecord> for chroma_proto::MetadataEmbeddingRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{chroma_proto, UpdateMetadataValue};
+    use crate::{chroma_proto, UpdateMetadataValue, CHROMA_DOCUMENT_KEY};
     use std::collections::HashMap;
     use uuid::Uuid;
 
@@ -322,7 +322,7 @@ mod tests {
 
         // Insert a chroma:document field
         metadata.metadata.insert(
-            "chroma:document".to_string(),
+            CHROMA_DOCUMENT_KEY.to_string(),
             chroma_proto::UpdateMetadataValue {
                 value: Some(chroma_proto::update_metadata_value::Value::StringValue(
                     "document_contents".to_string(),
@@ -361,7 +361,7 @@ mod tests {
         assert_eq!(converted_operation_record.operation, Operation::Add);
 
         // Ensure metadata no longer has the document field
-        assert_eq!(metadata.get("chroma:document"), None);
+        assert_eq!(metadata.get(CHROMA_DOCUMENT_KEY), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Adds support for collection updates & upserts to Rust frontend.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Tested locally with a simple script.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a