### PR TITLE
[ENH]: add /delete to Rust frontend

### DIFF
--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -10,16 +10,15 @@ use chroma_system::System;
 use chroma_types::{
     operator::{Filter, KnnBatch, KnnProjection, Limit, Projection},
     plan::{Count, Get, Knn},
-    AddToCollectionError, AddToCollectionRequest, AddToCollectionResponse, CountCollectionsRequest,
-    CountCollectionsResponse, CountRequest, CountResponse, CreateDatabaseError,
-    CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantError, CreateTenantRequest,
-    CreateTenantResponse, DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse,
-    GetCollectionError, GetCollectionRequest, GetCollectionResponse, GetDatabaseError,
-    GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse, GetTenantError,
-    GetTenantRequest, GetTenantResponse, Include, ListCollectionsRequest, ListCollectionsResponse,
-    ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, QueryError, QueryRequest,
-    QueryResponse, ResetError, UpdateCollectionError, UpdateCollectionRequest,
-    UpdateCollectionResponse, CHROMA_DOCUMENT_KEY, CHROMA_URI_KEY,
+    CountCollectionsRequest, CountCollectionsResponse, CountRequest, CountResponse,
+    CreateDatabaseError, CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantError,
+    CreateTenantRequest, CreateTenantResponse, DeleteDatabaseError, DeleteDatabaseRequest,
+    DeleteDatabaseResponse, GetCollectionError, GetCollectionRequest, GetCollectionResponse,
+    GetDatabaseError, GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse,
+    GetTenantError, GetTenantRequest, GetTenantResponse, Include, ListCollectionsRequest,
+    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
+    QueryError, QueryRequest, QueryResponse, ResetError, UpdateCollectionError,
+    UpdateCollectionRequest, UpdateCollectionResponse, CHROMA_DOCUMENT_KEY, CHROMA_URI_KEY,
 };
 use chroma_types::{
     Operation, OperationRecord, ScalarEncoding, UpdateMetadata, UpdateMetadataValue,
@@ -340,9 +339,10 @@ impl Frontend {
 
     pub async fn add(
         &mut self,
-        request: AddToCollectionRequest,
-    ) -> Result<AddToCollectionResponse, AddToCollectionError> {
-        let chroma_types::AddToCollectionRequest {
+        request: chroma_types::AddCollectionRecordsRequest,
+    ) -> Result<chroma_types::AddCollectionRecordsResponse, chroma_types::AddCollectionRecordsError>
+    {
+        let chroma_types::AddCollectionRecordsRequest {
             ids,
             embeddings,
             documents,
@@ -354,7 +354,7 @@ impl Frontend {
         let records = to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)
             .map_err(|err| match err {
                 ToRecordsError::InconsistentLength => {
-                    chroma_types::AddToCollectionError::InconsistentLength
+                    chroma_types::AddCollectionRecordsError::InconsistentLength
                 }
             })?;
         self.log_client
@@ -362,7 +362,7 @@ impl Frontend {
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        Ok(chroma_types::AddToCollectionResponse {})
+        Ok(chroma_types::AddCollectionRecordsResponse {})
     }
 
     pub async fn update(
@@ -405,9 +405,12 @@ impl Frontend {
 
     pub async fn upsert(
         &mut self,
-        request: chroma_types::UpsertCollectionRequest,
-    ) -> Result<chroma_types::UpsertCollectionResponse, chroma_types::UpsertCollectionError> {
-        let chroma_types::UpsertCollectionRequest {
+        request: chroma_types::UpsertCollectionRecordsRequest,
+    ) -> Result<
+        chroma_types::UpsertCollectionRecordsResponse,
+        chroma_types::UpsertCollectionRecordsError,
+    > {
+        let chroma_types::UpsertCollectionRecordsRequest {
             ids,
             embeddings,
             documents,
@@ -426,7 +429,7 @@ impl Frontend {
         )
         .map_err(|err| match err {
             ToRecordsError::InconsistentLength => {
-                chroma_types::UpsertCollectionError::InconsistentLength
+                chroma_types::UpsertCollectionRecordsError::InconsistentLength
             }
         })?;
 
@@ -435,7 +438,7 @@ impl Frontend {
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        Ok(chroma_types::UpsertCollectionResponse {})
+        Ok(chroma_types::UpsertCollectionRecordsResponse {})
     }
 
     pub async fn delete(

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -6,7 +6,7 @@ use axum::{
     Json, Router, ServiceExt,
 };
 use chroma_types::{
-    AddToCollectionResponse, ChecklistResponse, Collection, CollectionMetadataUpdate,
+    AddCollectionRecordsResponse, ChecklistResponse, Collection, CollectionMetadataUpdate,
     CollectionUuid, CountCollectionsRequest, CountCollectionsResponse, CountRequest, CountResponse,
     CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantRequest, CreateTenantResponse,
     DeleteCollectionRecordsResponse, DeleteDatabaseRequest, DeleteDatabaseResponse,
@@ -14,7 +14,7 @@ use chroma_types::{
     GetTenantRequest, GetTenantResponse, GetUserIdentityResponse, IncludeList,
     ListCollectionsRequest, ListCollectionsResponse, ListDatabasesRequest, ListDatabasesResponse,
     Metadata, QueryRequest, QueryResponse, UpdateCollectionRecordsResponse,
-    UpdateCollectionResponse, UpdateMetadata, UpsertCollectionResponse,
+    UpdateCollectionResponse, UpdateMetadata, UpsertCollectionRecordsResponse,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -347,7 +347,7 @@ async fn update_collection(
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct AddToCollectionPayload {
+pub struct AddCollectionRecordsPayload {
     ids: Vec<String>,
     embeddings: Option<Vec<Vec<f32>>>,
     documents: Option<Vec<String>>,
@@ -358,15 +358,14 @@ pub struct AddToCollectionPayload {
 async fn collection_add(
     Path((tenant_id, database_name, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
-    Json(payload): Json<AddToCollectionPayload>,
-) -> Result<Json<AddToCollectionResponse>, ServerError> {
-    tracing::info!("Adding records to collection [{collection_id}] in database [{database_name}] for tenant [{tenant_id}]");
+    Json(payload): Json<AddCollectionRecordsPayload>,
+) -> Result<Json<AddCollectionRecordsResponse>, ServerError> {
     let collection_id =
         CollectionUuid(Uuid::parse_str(&collection_id).map_err(|_| ValidationError::CollectionId)?);
 
     let res = server
         .frontend
-        .add(chroma_types::AddToCollectionRequest {
+        .add(chroma_types::AddCollectionRecordsRequest {
             tenant_id,
             database_name,
             collection_id,
@@ -416,7 +415,7 @@ async fn collection_update(
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct UpsertCollectionPayload {
+pub struct UpsertCollectionRecordsPayload {
     ids: Vec<String>,
     embeddings: Option<Vec<Vec<f32>>>,
     documents: Option<Vec<String>>,
@@ -427,15 +426,15 @@ pub struct UpsertCollectionPayload {
 async fn collection_upsert(
     Path((tenant_id, database_name, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
-    Json(payload): Json<UpsertCollectionPayload>,
-) -> Result<Json<UpsertCollectionResponse>, ServerError> {
+    Json(payload): Json<UpsertCollectionRecordsPayload>,
+) -> Result<Json<UpsertCollectionRecordsResponse>, ServerError> {
     let collection_id =
         CollectionUuid(Uuid::parse_str(&collection_id).map_err(|_| ValidationError::CollectionId)?);
 
     Ok(Json(
         server
             .frontend
-            .upsert(chroma_types::UpsertCollectionRequest {
+            .upsert(chroma_types::UpsertCollectionRecordsRequest {
                 tenant_id,
                 database_name,
                 collection_id,

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -83,6 +83,14 @@ impl FrontendServer {
                 post(collection_upsert),
             )
             .route(
+                "/api/v2/tenants/:tenant/databases/:database_name/collections/:collection_id/update",
+                post(collection_update),
+            )
+            .route(
+                "/api/v2/tenants/:tenant/databases/:database_name/collections/:collection_id/upsert",
+                post(collection_upsert),
+            )
+            .route(
                 "/api/v2/tenants/:tenant_id/databases/:database_name/collections/:collection_id/count",
                 get(collection_count),
             )

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -289,7 +289,7 @@ impl ChromaError for UpdateCollectionError {
     }
 }
 
-pub struct AddToCollectionRequest {
+pub struct AddCollectionRecordsRequest {
     pub tenant_id: String,
     pub database_name: String,
     pub collection_id: CollectionUuid,
@@ -301,21 +301,21 @@ pub struct AddToCollectionRequest {
 }
 
 #[derive(Serialize)]
-pub struct AddToCollectionResponse {}
+pub struct AddCollectionRecordsResponse {}
 
 #[derive(Error, Debug)]
-pub enum AddToCollectionError {
+pub enum AddCollectionRecordsError {
     #[error("Inconsistent number of IDs, embeddings, documents, URIs and metadatas")]
     InconsistentLength,
     #[error("Failed to push logs: {0}")]
     FailedToPushLogs(#[from] Box<dyn ChromaError>),
 }
 
-impl ChromaError for AddToCollectionError {
+impl ChromaError for AddCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            AddToCollectionError::InconsistentLength => ErrorCodes::InvalidArgument,
-            AddToCollectionError::FailedToPushLogs(_) => ErrorCodes::Internal,
+            AddCollectionRecordsError::InconsistentLength => ErrorCodes::InvalidArgument,
+            AddCollectionRecordsError::FailedToPushLogs(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -351,7 +351,7 @@ impl ChromaError for UpdateCollectionRecordsError {
     }
 }
 
-pub struct UpsertCollectionRequest {
+pub struct UpsertCollectionRecordsRequest {
     pub tenant_id: String,
     pub database_name: String,
     pub collection_id: CollectionUuid,
@@ -363,21 +363,21 @@ pub struct UpsertCollectionRequest {
 }
 
 #[derive(Serialize)]
-pub struct UpsertCollectionResponse {}
+pub struct UpsertCollectionRecordsResponse {}
 
 #[derive(Error, Debug)]
-pub enum UpsertCollectionError {
+pub enum UpsertCollectionRecordsError {
     #[error("Inconsistent number of IDs, embeddings, documents, URIs and metadatas")]
     InconsistentLength,
     #[error("Failed to push logs: {0}")]
     FailedToPushLogs(#[from] Box<dyn ChromaError>),
 }
 
-impl ChromaError for UpsertCollectionError {
+impl ChromaError for UpsertCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            UpsertCollectionError::InconsistentLength => ErrorCodes::InvalidArgument,
-            UpsertCollectionError::FailedToPushLogs(_) => ErrorCodes::Internal,
+            UpsertCollectionRecordsError::InconsistentLength => ErrorCodes::InvalidArgument,
+            UpsertCollectionRecordsError::FailedToPushLogs(_) => ErrorCodes::Internal,
         }
     }
 }

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -292,7 +292,7 @@ impl ChromaError for UpdateCollectionError {
 pub struct AddToCollectionRequest {
     pub tenant_id: String,
     pub database_name: String,
-    pub collection_id: Uuid,
+    pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
     pub embeddings: Option<Vec<Vec<f32>>>,
     pub documents: Option<Vec<String>>,
@@ -323,7 +323,7 @@ impl ChromaError for AddToCollectionError {
 pub struct UpdateCollectionRecordsRequest {
     pub tenant_id: String,
     pub database_name: String,
-    pub collection_id: Uuid,
+    pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
     pub embeddings: Option<Vec<Vec<f32>>>,
     pub documents: Option<Vec<String>>,
@@ -354,7 +354,7 @@ impl ChromaError for UpdateCollectionRecordsError {
 pub struct UpsertCollectionRequest {
     pub tenant_id: String,
     pub database_name: String,
-    pub collection_id: Uuid,
+    pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
     pub embeddings: Option<Vec<Vec<f32>>>,
     pub documents: Option<Vec<String>>,
@@ -378,6 +378,37 @@ impl ChromaError for UpsertCollectionError {
         match self {
             UpsertCollectionError::InconsistentLength => ErrorCodes::InvalidArgument,
             UpsertCollectionError::FailedToPushLogs(_) => ErrorCodes::Internal,
+        }
+    }
+}
+
+pub struct DeleteCollectionRecordsRequest {
+    pub tenant_id: String,
+    pub database_name: String,
+    pub collection_id: CollectionUuid,
+    pub ids: Option<Vec<String>>,
+    pub r#where: Option<Where>,
+}
+
+#[derive(Serialize)]
+pub struct DeleteCollectionRecordsResponse {}
+
+#[derive(Error, Debug)]
+pub enum DeleteCollectionRecordsError {
+    #[error("Failed to get collection snapshot")]
+    FetchCollectionSnapshot(#[from] QueryError),
+    #[error("Failed to resolve IDs: {0}")]
+    GetFailed(#[from] ExecutorError),
+    #[error("Failed to push logs: {0}")]
+    FailedToPushLogs(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for DeleteCollectionRecordsError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            DeleteCollectionRecordsError::FetchCollectionSnapshot(err) => err.code(),
+            DeleteCollectionRecordsError::GetFailed(err) => err.code(),
+            DeleteCollectionRecordsError::FailedToPushLogs(_) => ErrorCodes::Internal,
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Adds support for deleting collection records to the Rust frontend.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Tested locally with a simple script.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a