### PR TITLE
[ENH] Dedup get_collections_with_segments sysdb rpc

### DIFF
--- a/rust/cache/src/async_partitioned_mutex.rs
+++ b/rust/cache/src/async_partitioned_mutex.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AysncPartitionedMutex<K, V = (), H = DefaultHasher>
 where
     K: Hash + Eq,

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -6,7 +6,7 @@ sysdb:
     port: 50051
     connect_timeout_ms: 60000
     request_timeout_ms: 60000
-cache_config:
+cache:
   lru:
     capacity: 1000
 log:

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -6,9 +6,11 @@ sysdb:
     port: 50051
     connect_timeout_ms: 60000
     request_timeout_ms: 60000
-cache:
-  lru:
-    capacity: 1000
+collections_with_segments_provider:
+  cache:
+    lru:
+      capacity: 1000
+  permitted_parallelism: 180
 log:
   Grpc:
     host: "logservice.chroma"

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -17,7 +17,7 @@ pub struct FrontendConfig {
     pub sysdb: SysDbConfig,
     #[serde(default = "CircuitBreakerConfig::default")]
     pub circuit_breaker: CircuitBreakerConfig,
-    pub cache_config: CacheConfig,
+    pub cache: CacheConfig,
     pub service_name: String,
     pub otel_endpoint: String,
     pub log: LogConfig,
@@ -66,10 +66,16 @@ mod tests {
         assert_eq!(sysdb_config.connect_timeout_ms, 60000);
         assert_eq!(sysdb_config.request_timeout_ms, 60000);
         assert_eq!(sysdb_config.num_channels, 5);
-        if let CacheConfig::Memory(cache_config) = config.cache_config {
-            assert_eq!(cache_config.capacity, 1000);
-        } else {
-            panic!("Expected Memory cache config");
+        match config.cache {
+            CacheConfig::Memory(c) => {
+                assert_eq!(c.capacity, 1000);
+            }
+            CacheConfig::Disk(c) => {
+                assert_eq!(c.capacity, 1000);
+            }
+            _ => {
+                panic!("Cache config is not memory or disk");
+            }
         }
     }
 }

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -1,5 +1,4 @@
-use crate::executor::config::ExecutorConfig;
-use chroma_cache::CacheConfig;
+use crate::{executor::config::ExecutorConfig, CollectionsWithSegmentsProviderConfig};
 use chroma_log::config::LogConfig;
 use chroma_sysdb::SysDbConfig;
 use figment::providers::{Env, Format, Yaml};
@@ -17,7 +16,7 @@ pub struct FrontendConfig {
     pub sysdb: SysDbConfig,
     #[serde(default = "CircuitBreakerConfig::default")]
     pub circuit_breaker: CircuitBreakerConfig,
-    pub cache: CacheConfig,
+    pub collections_with_segments_provider: CollectionsWithSegmentsProviderConfig,
     pub service_name: String,
     pub otel_endpoint: String,
     pub log: LogConfig,
@@ -66,7 +65,13 @@ mod tests {
         assert_eq!(sysdb_config.connect_timeout_ms, 60000);
         assert_eq!(sysdb_config.request_timeout_ms, 60000);
         assert_eq!(sysdb_config.num_channels, 5);
-        match config.cache {
+        assert_eq!(
+            config
+                .collections_with_segments_provider
+                .permitted_parallelism,
+            180
+        );
+        match config.collections_with_segments_provider.cache {
             CacheConfig::Memory(c) => {
                 assert_eq!(c.capacity, 1000);
             }

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use chroma_cache::{AysncPartitionedMutex, Cache};
+use chroma_config::Configurable;
+use chroma_error::ChromaError;
+use chroma_sysdb::{sysdb, SysDb};
+use chroma_types::{operator::Scan, CollectionAndSegments, CollectionUuid, QueryError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Clone, Serialize)]
+pub struct CollectionsWithSegmentsProviderConfig {
+    pub cache: chroma_cache::CacheConfig,
+    pub permitted_parallelism: u32,
+}
+
+#[async_trait::async_trait]
+impl Configurable<(CollectionsWithSegmentsProviderConfig, Box<SysDb>)>
+    for CollectionsWithSegmentsProvider
+{
+    async fn try_from_config(
+        (config, sysdb_client): &(CollectionsWithSegmentsProviderConfig, Box<SysDb>),
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let collections_with_segments_cache =
+            chroma_cache::from_config::<CollectionUuid, CollectionAndSegments>(&config.cache)
+                .await?;
+        let sysdb_rpc_lock =
+            AysncPartitionedMutex::with_parallelism(config.permitted_parallelism as usize, ());
+
+        Ok(Self {
+            sysdb_client: sysdb_client.clone(),
+            collections_with_segments_cache: collections_with_segments_cache.into(),
+            sysdb_rpc_lock,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CollectionsWithSegmentsProvider {
+    pub(crate) sysdb_client: Box<sysdb::SysDb>,
+    pub(crate) collections_with_segments_cache:
+        Arc<dyn Cache<CollectionUuid, CollectionAndSegments>>,
+    pub(crate) sysdb_rpc_lock: chroma_cache::AysncPartitionedMutex<CollectionUuid>,
+}
+
+impl CollectionsWithSegmentsProvider {
+    pub(crate) async fn get_collection_with_segments(
+        &mut self,
+        collection_id: CollectionUuid,
+    ) -> Result<Scan, QueryError> {
+        let collection_and_segments = match self
+            .collections_with_segments_cache
+            .get(&collection_id)
+            .await
+            .map_err(|_| QueryError::CollectionSegments)?
+        {
+            Some(collection_and_segments) => collection_and_segments,
+            None => {
+                let _guard = self.sysdb_rpc_lock.lock(&collection_id).await;
+                // Double checked locking pattern to avoid lock contention in the
+                // happy path when the collection is already cached.
+                match self
+                    .collections_with_segments_cache
+                    .get(&collection_id)
+                    .await
+                    .map_err(|_| QueryError::CollectionSegments)?
+                {
+                    Some(collection_and_segments) => collection_and_segments,
+                    None => {
+                        let collection_and_segments_sysdb = self
+                            .sysdb_client
+                            .get_collection_with_segments(collection_id)
+                            .await
+                            .map_err(|_| QueryError::CollectionSegments)?;
+                        self.collections_with_segments_cache
+                            .insert(collection_id, collection_and_segments_sysdb.clone())
+                            .await;
+                        collection_and_segments_sysdb
+                    }
+                }
+            }
+        };
+        Ok(Scan {
+            collection_and_segments,
+        })
+    }
+}

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -55,6 +55,9 @@ impl CollectionsWithSegmentsProvider {
         {
             Some(collection_and_segments) => collection_and_segments,
             None => {
+                // We acquire a lock to prevent the sysdb from experiencing a thundering herd.
+                // This can happen when a large number of threads try to get the same collection
+                // at the same time.
                 let _guard = self.sysdb_rpc_lock.lock(&collection_id).await;
                 // Double checked locking pattern to avoid lock contention in the
                 // happy path when the collection is already cached.

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 #[allow(dead_code)]
 mod executor;
 mod frontend;
+mod get_collection_with_segments_provider;
 mod server;
 mod tower_tracing;
 mod types;
@@ -10,6 +11,7 @@ mod types;
 use chroma_config::Configurable;
 use chroma_system::System;
 use frontend::Frontend;
+use get_collection_with_segments_provider::*;
 use server::FrontendServer;
 
 pub use config::{FrontendConfig, ScorecardRule};


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Uses partitioned mutex to avoid thundering herd on the sysdb
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
