### PR TITLE
[ENH]  Add a config param for active_io_tasks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "serde",
+ "serial_test",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/rust/garbage_collector/garbage_collector_config.yaml
+++ b/rust/garbage_collector/garbage_collector_config.yaml
@@ -14,6 +14,7 @@ dispatcher_config:
   dispatcher_queue_size: 100
   worker_queue_size: 100
   task_queue_limit: 1000
+  active_io_tasks: 100
 storage_config:
   s3:
     bucket: "chroma-storage"

--- a/rust/system/Cargo.toml
+++ b/rust/system/Cargo.toml
@@ -21,3 +21,4 @@ tempfile = { workspace = true }
 
 chroma-error = { workspace = true }
 chroma-config = { workspace = true }
+serial_test = "3.2.0"

--- a/rust/system/src/execution/config.rs
+++ b/rust/system/src/execution/config.rs
@@ -6,4 +6,5 @@ pub struct DispatcherConfig {
     pub task_queue_limit: usize,
     pub dispatcher_queue_size: usize,
     pub worker_queue_size: usize,
+    pub active_io_tasks: usize,
 }

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -221,6 +221,7 @@ mod tests {
 
     use super::*;
     use crate::{operator::*, ComponentHandle};
+    use serial_test::serial;
     use std::{
         collections::HashSet,
         sync::{
@@ -411,6 +412,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatcher_io_tasks() {
         let system = System::new();
         let dispatcher = Dispatcher::new(DispatcherConfig {
@@ -418,6 +420,7 @@ mod tests {
             task_queue_limit: 1000,
             dispatcher_queue_size: 1000,
             worker_queue_size: 1000,
+            active_io_tasks: 1000,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         let counter = Arc::new(AtomicUsize::new(0));
@@ -444,6 +447,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatcher_non_io_tasks() {
         let system = System::new();
         let dispatcher = Dispatcher::new(DispatcherConfig {
@@ -451,6 +455,7 @@ mod tests {
             task_queue_limit: 1000,
             dispatcher_queue_size: 1000,
             worker_queue_size: 1000,
+            active_io_tasks: 1000,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         let counter = Arc::new(AtomicUsize::new(0));
@@ -477,6 +482,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatcher_non_io_tasks_reject() {
         let system = System::new();
         let dispatcher = Dispatcher::new(DispatcherConfig {
@@ -485,6 +491,7 @@ mod tests {
             task_queue_limit: 0,
             dispatcher_queue_size: 1,
             worker_queue_size: 1,
+            active_io_tasks: 1,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         let counter = Arc::new(AtomicUsize::new(0));

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -329,6 +329,7 @@ mod tests {
             task_queue_limit: 1000,
             dispatcher_queue_size: 1000,
             worker_queue_size: 1000,
+            active_io_tasks: 1000,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -45,6 +45,7 @@ query_service:
         dispatcher_queue_size: 100
         worker_queue_size: 100
         task_queue_limit: 1000
+        active_io_tasks: 100
     blockfile_provider:
         Arrow:
             block_manager_config:
@@ -105,6 +106,7 @@ compaction_service:
         dispatcher_queue_size: 100
         worker_queue_size: 100
         task_queue_limit: 1000
+        active_io_tasks: 100
     compactor:
         compaction_manager_queue_size: 1000
         max_concurrent_jobs: 100

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -366,11 +366,13 @@ mod tests {
     use chroma_types::SegmentUuid;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord, Segment};
     use serde_json::Value;
+    use serial_test::serial;
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::str::FromStr;
 
     #[tokio::test]
+    #[serial]
     async fn test_compaction_manager() {
         let mut log = Box::new(Log::InMemory(InMemoryLog::new()));
         let in_memory_log = match *log {
@@ -595,6 +597,7 @@ mod tests {
             task_queue_limit: 10,
             dispatcher_queue_size: 10,
             worker_queue_size: 10,
+            active_io_tasks: 10,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         manager.set_dispatcher(dispatcher_handle);

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -199,6 +199,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -259,6 +260,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     compactor:
                         compaction_manager_queue_size: 1000
                         max_concurrent_jobs: 100
@@ -295,6 +297,14 @@ mod tests {
                 "compaction-service-0"
             );
             assert_eq!(config.compaction_service.my_port, 50051);
+            assert_eq!(config.compaction_service.dispatcher.num_worker_threads, 4);
+            assert_eq!(config.compaction_service.dispatcher.task_queue_limit, 100);
+            assert_eq!(
+                config.compaction_service.dispatcher.dispatcher_queue_size,
+                100
+            );
+            assert_eq!(config.compaction_service.dispatcher.worker_queue_size, 100);
+            assert_eq!(config.compaction_service.dispatcher.active_io_tasks, 100);
             assert_eq!(
                 config
                     .compaction_service
@@ -366,6 +376,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -426,6 +437,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     compactor:
                         compaction_manager_queue_size: 1000
                         max_concurrent_jobs: 100
@@ -486,6 +498,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_missing_default_field() {
         Jail::expect_with(|jail| {
             let _ = jail.create_file(
@@ -533,6 +546,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -593,6 +607,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     compactor:
                         compaction_manager_queue_size: 1000
                         max_concurrent_jobs: 100
@@ -706,6 +721,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -751,6 +767,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     compactor:
                         compaction_manager_queue_size: 1000
                         max_concurrent_jobs: 100
@@ -800,6 +817,14 @@ mod tests {
                 }
                 _ => panic!("Invalid storage config"),
             }
+            assert_eq!(config.compaction_service.dispatcher.num_worker_threads, 4);
+            assert_eq!(config.compaction_service.dispatcher.task_queue_limit, 100);
+            assert_eq!(
+                config.compaction_service.dispatcher.dispatcher_queue_size,
+                100
+            );
+            assert_eq!(config.compaction_service.dispatcher.worker_queue_size, 100);
+            assert_eq!(config.compaction_service.dispatcher.active_io_tasks, 100);
             assert_eq!(
                 config
                     .compaction_service
@@ -878,6 +903,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     blockfile_provider:
                         Arrow:
                             block_manager_config:
@@ -934,6 +960,7 @@ mod tests {
                         dispatcher_queue_size: 100
                         worker_queue_size: 100
                         task_queue_limit: 100
+                        active_io_tasks: 100
                     compactor:
                         compaction_manager_queue_size: 1000
                         max_concurrent_jobs: 100

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -431,6 +431,7 @@ mod tests {
             task_queue_limit: 10,
             dispatcher_queue_size: 10,
             worker_queue_size: 10,
+            active_io_tasks: 10,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 


### PR DESCRIPTION
We need to bound the I/O.  This PR separates out bounding the I/O from
the configuration for doing so because it's currently failing.
