### PR TITLE
[ENH] Nop cache for FE + Rwlock for memberlist

### DIFF
--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -8,8 +8,7 @@ sysdb:
     request_timeout_ms: 60000
 collections_with_segments_provider:
   cache:
-    lru:
-      capacity: 1000
+    nop: 
   permitted_parallelism: 180
 log:
   Grpc:

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -78,9 +78,8 @@ mod tests {
             CacheConfig::Disk(c) => {
                 assert_eq!(c.capacity, 1000);
             }
-            _ => {
-                panic!("Cache config is not memory or disk");
-            }
+            CacheConfig::Nop => {}
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Turning off FE cache until we have cache invalidation
   -  Memberlist access is synchronized by a r/w lock instead of a mutex
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
