### PR TITLE
[BUG]  Building and running tests builds twice.

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/rust
-      - name: Build
-        run: cargo build --verbose
       - name: Test
         run: cargo nextest run
   test-integration:


### PR DESCRIPTION
I've noticed that the tests will build everything and then recompile many things with nexttest
(presumably rustc config).  This seems unnecessary.  Running the tests should be enough.
