### PR TITLE
[TST]: run tests against Rust frontend

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -12,6 +12,11 @@ on:
         description: 'Property testing preset'
         required: true
         type: string
+      run_rust_frontend_tests:
+        description: 'Whether to run the rust frontend tests'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   test:
@@ -149,6 +154,7 @@ jobs:
                    "chromadb/test/test_logservice.py",
                    "chromadb/test/distributed/test_sanity.py"]
     runs-on: ${{ matrix.platform }}
+    if: ${{ inputs.run_rust_frontend_tests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -128,6 +128,50 @@ jobs:
         ENV_FILE: ${{ matrix.env-file }}
         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
+  test-cluster-rust-frontend:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{fromJson(inputs.python_versions)}}
+        platform: ["depot-ubuntu-22.04-4"]
+        test-globs: ["chromadb/test/db/test_system.py",
+                   "chromadb/test/api/test_collection.py",
+                   "chromadb/test/api/test_limit_offset.py",
+                   "chromadb/test/property/test_collections.py",
+                   "chromadb/test/property/test_add.py",
+                   "chromadb/test/property/test_filtering.py",
+                   "chromadb/test/property/test_embeddings.py",
+                   "chromadb/test/property/test_collections_with_database_tenant.py",
+                   "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
+                   "chromadb/test/property/test_sysdb.py",
+                   "chromadb/test/ingest/test_producer_consumer.py",
+                   "chromadb/test/segment/distributed/test_memberlist_provider.py",
+                   "chromadb/test/test_logservice.py",
+                   "chromadb/test/distributed/test_sanity.py"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/python
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: ./.github/actions/tilt
+      - name: Test
+        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}"'
+        shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+          CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
+          CHROMA_SERVER_HOST: "localhost:3000"
+      - name: Compute artifact name
+        if: always()
+        id: compute-artifact-name
+        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
+      - name: Save service logs to artifact
+        if: always()
+        uses: ./.github/actions/export-tilt-logs
+        with:
+          artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
+
   test-cluster-integration:
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -119,6 +119,7 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     with:
       property_testing_preset: 'fast'
+      run_rust_frontend_tests: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'rust-frontend') }}
 
   python-vulnerability-scan:
     name: Python vulnerability scan

--- a/bin/cluster-test.sh
+++ b/bin/cluster-test.sh
@@ -3,8 +3,8 @@ set -e
 
 # TODO make url configuration consistent.
 export CHROMA_CLUSTER_TEST_ONLY=1
-export CHROMA_SERVER_HOST=localhost:8000
-export CHROMA_COORDINATOR_HOST=localhost
+export CHROMA_SERVER_HOST="${CHROMA_SERVER_HOST:-localhost:8000}"
+export CHROMA_COORDINATOR_HOST="${CHROMA_COORDINATOR_HOST:-localhost}"
 
 echo "Chroma Server is running at port $CHROMA_SERVER_HOST"
 echo "Chroma Coordinator is running at port $CHROMA_COORDINATOR_HOST"

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -106,9 +106,12 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             loop_hash = 0
 
         if loop_hash not in self._clients:
+            headers = (self._settings.chroma_server_headers or {}).copy()
+            headers["Content-Type"] = "application/json"
+
             self._clients[loop_hash] = httpx.AsyncClient(
                 timeout=None,
-                headers=self._settings.chroma_server_headers,
+                headers=headers,
                 verify=self._settings.chroma_server_ssl_verify or False,
             )
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -62,7 +62,9 @@ class FastAPI(BaseHTTPClient, ServerAPI):
 
         self._session = httpx.Client(timeout=None)
 
-        self._header = system.settings.chroma_server_headers
+        self._header = system.settings.chroma_server_headers or {}
+        self._header["Content-Type"] = "application/json"
+
         if self._header is not None:
             self._session.headers.update(self._header)
         if self._settings.chroma_server_ssl_verify is not None:

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -809,7 +809,6 @@ def client_factories(system: System) -> Generator[ClientFactories, None, None]:
 
 @pytest.fixture(scope="function")
 def client(system: System) -> Generator[ClientAPI, None, None]:
-    print("Resetting state")
     system.reset_state()
 
     if system.settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -375,10 +375,17 @@ def fastapi_ssl() -> Generator[System, None, None]:
 
 
 def basic_http_client() -> Generator[System, None, None]:
+    port = 8000
+    host = "localhost"
+
+    if os.getenv("CHROMA_SERVER_HOST"):
+        host = os.getenv("CHROMA_SERVER_HOST", "").split(":")[0]
+        port = int(os.getenv("CHROMA_SERVER_HOST", "").split(":")[1])
+
     settings = Settings(
         chroma_api_impl="chromadb.api.fastapi.FastAPI",
-        chroma_server_http_port=8000,
-        chroma_server_host="localhost",
+        chroma_server_http_port=port,
+        chroma_server_host=host,
         allow_reset=True,
     )
     system = System(settings)
@@ -802,6 +809,7 @@ def client_factories(system: System) -> Generator[ClientFactories, None, None]:
 
 @pytest.fixture(scope="function")
 def client(system: System) -> Generator[ClientAPI, None, None]:
+    print("Resetting state")
     system.reset_state()
 
     if system.settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -21,14 +21,14 @@ use chroma_types::{
     DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse, GetCollectionError,
     GetCollectionRequest, GetCollectionResponse, GetDatabaseError, GetDatabaseRequest,
     GetDatabaseResponse, GetRequest, GetResponse, GetTenantError, GetTenantRequest,
-    GetTenantResponse, Include, ListCollectionsRequest, ListCollectionsResponse,
-    ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, Operation, OperationRecord,
-    QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse, ScalarEncoding, Segment,
-    SegmentScope, SegmentType, SegmentUuid, UpdateCollectionError, UpdateCollectionRecordsError,
-    UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse, UpdateCollectionRequest,
-    UpdateCollectionResponse, UpdateMetadata, UpdateMetadataValue, UpsertCollectionRecordsError,
-    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, CHROMA_DOCUMENT_KEY,
-    CHROMA_URI_KEY,
+    GetTenantResponse, HeartbeatError, HeartbeatResponse, Include, ListCollectionsRequest,
+    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
+    Operation, OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
+    ScalarEncoding, Segment, SegmentScope, SegmentType, SegmentUuid, UpdateCollectionError,
+    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateCollectionRequest, UpdateCollectionResponse, UpdateMetadata, UpdateMetadataValue,
+    UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
+    CHROMA_DOCUMENT_KEY, CHROMA_URI_KEY,
 };
 use mdac::{Pattern, Rule, Scorecard, ScorecardTicket};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -178,6 +178,14 @@ impl Frontend {
                 ticket: None,
             })
         }
+    }
+
+    pub async fn heartbeat(&self) -> Result<HeartbeatResponse, HeartbeatError> {
+        Ok(HeartbeatResponse {
+            nanosecond_heartbeat: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_nanos(),
+        })
     }
 
     async fn get_collection_dimension(

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -12,9 +12,10 @@ use chroma_types::{
     CreateTenantResponse, DeleteCollectionRecordsResponse, DeleteDatabaseRequest,
     DeleteDatabaseResponse, GetCollectionRequest, GetDatabaseRequest, GetDatabaseResponse,
     GetRequest, GetResponse, GetTenantRequest, GetTenantResponse, GetUserIdentityResponse,
-    IncludeList, ListCollectionsRequest, ListCollectionsResponse, ListDatabasesRequest,
-    ListDatabasesResponse, Metadata, QueryRequest, QueryResponse, UpdateCollectionRecordsResponse,
-    UpdateCollectionResponse, UpdateMetadata, UpsertCollectionRecordsResponse,
+    HealthCheckResponse, IncludeList, ListCollectionsRequest, ListCollectionsResponse,
+    ListDatabasesRequest, ListDatabasesResponse, Metadata, QueryRequest, QueryResponse,
+    UpdateCollectionRecordsResponse, UpdateCollectionResponse, UpdateMetadata,
+    UpsertCollectionRecordsResponse,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -124,8 +125,13 @@ async fn root() -> &'static str {
     "Chroma Rust Frontend"
 }
 
-async fn heartbeat() -> &'static str {
-    "<Heartbeat.wav>"
+async fn heartbeat() -> Json<HealthCheckResponse> {
+    Json(HealthCheckResponse {
+        nanosecond_heartbeat: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    })
 }
 
 // Dummy implementation for now

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -12,7 +12,7 @@ use chroma_types::{
     CreateTenantResponse, DeleteCollectionRecordsResponse, DeleteDatabaseRequest,
     DeleteDatabaseResponse, GetCollectionRequest, GetDatabaseRequest, GetDatabaseResponse,
     GetRequest, GetResponse, GetTenantRequest, GetTenantResponse, GetUserIdentityResponse,
-    HealthCheckResponse, IncludeList, ListCollectionsRequest, ListCollectionsResponse,
+    HeartbeatResponse, IncludeList, ListCollectionsRequest, ListCollectionsResponse,
     ListDatabasesRequest, ListDatabasesResponse, Metadata, QueryRequest, QueryResponse,
     UpdateCollectionRecordsResponse, UpdateCollectionResponse, UpdateMetadata,
     UpsertCollectionRecordsResponse,
@@ -125,13 +125,10 @@ async fn root() -> &'static str {
     "Chroma Rust Frontend"
 }
 
-async fn heartbeat() -> Json<HealthCheckResponse> {
-    Json(HealthCheckResponse {
-        nanosecond_heartbeat: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos(),
-    })
+async fn heartbeat(
+    State(server): State<FrontendServer>,
+) -> Result<Json<HeartbeatResponse>, ServerError> {
+    Ok(Json(server.frontend.heartbeat().await?))
 }
 
 // Dummy implementation for now

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -48,6 +48,12 @@ pub struct ChecklistResponse {
 }
 
 #[derive(Serialize)]
+pub struct HealthCheckResponse {
+    #[serde(rename(serialize = "nanosecond heartbeat"))]
+    pub nanosecond_heartbeat: u128,
+}
+
+#[derive(Serialize)]
 pub struct GetUserIdentityResponse {
     pub user_id: String,
     pub tenant: String,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -48,9 +48,21 @@ pub struct ChecklistResponse {
 }
 
 #[derive(Serialize)]
-pub struct HealthCheckResponse {
+pub struct HeartbeatResponse {
     #[serde(rename(serialize = "nanosecond heartbeat"))]
     pub nanosecond_heartbeat: u128,
+}
+
+#[derive(Debug, Error)]
+pub enum HeartbeatError {
+    #[error("Could not get time: {0}")]
+    CouldNotGetTime(#[from] std::time::SystemTimeError),
+}
+
+impl ChromaError for HeartbeatError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Description of changes

Runs the Rust frontend tests when a PR is tagged with `rust-frontend`.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a