### PR TITLE
[ENH]: hook up /reset for Rust frontend

### DIFF
--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -1,3 +1,4 @@
+allow_reset: true
 service_name: "rust-frontend-service"
 otel_endpoint: "http://otel-collector:4317"
 sysdb:
@@ -8,7 +9,7 @@ sysdb:
     request_timeout_ms: 60000
 collections_with_segments_provider:
   cache:
-    nop: 
+    nop:
   permitted_parallelism: 180
 log:
   Grpc:
@@ -27,12 +28,12 @@ executor:
         hasher: Murmur3
     memberlist_provider:
       CustomResource:
-          kube_namespace: "chroma"
-          memberlist_name: "query-service-memberlist"
-          queue_size: 100
+        kube_namespace: "chroma"
+        memberlist_name: "query-service-memberlist"
+        queue_size: 100
 scorecard_enabled: true
 scorecard:
-- patterns:
-  - 'op:*'
-  - 'collection_id:*'
-  score: 100
+  - patterns:
+      - "op:*"
+      - "collection_id:*"
+    score: 100

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -13,6 +13,8 @@ pub struct ScorecardRule {
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct FrontendConfig {
+    #[serde(default)]
+    pub allow_reset: bool,
     pub sysdb: SysDbConfig,
     #[serde(default = "CircuitBreakerConfig::default")]
     pub circuit_breaker: CircuitBreakerConfig,

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -135,10 +135,9 @@ async fn pre_flight_checks() -> Result<Json<ChecklistResponse>, ServerError> {
     }))
 }
 
-async fn reset(State(mut _server): State<FrontendServer>) -> Result<(), ServerError> {
-    // TODO: Allow reset based on config
-    // server.frontend.reset().await?;
-    Ok(())
+async fn reset(State(mut server): State<FrontendServer>) -> Result<Json<bool>, ServerError> {
+    server.frontend.reset().await?;
+    Ok(Json(true))
 }
 
 async fn version() -> &'static str {

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -9,8 +9,8 @@ use chroma_types::{
     chroma_proto, CollectionAndSegments, CollectionMetadataUpdate, CreateDatabaseError,
     CreateDatabaseResponse, CreateTenantError, CreateTenantResponse, Database, DeleteDatabaseError,
     DeleteDatabaseResponse, GetDatabaseError, GetDatabaseResponse, GetTenantError,
-    GetTenantResponse, ListDatabasesError, ListDatabasesResponse, Metadata, SegmentFlushInfo,
-    SegmentFlushInfoConversionError, SegmentUuid,
+    GetTenantResponse, ListDatabasesError, ListDatabasesResponse, Metadata, ResetError,
+    SegmentFlushInfo, SegmentFlushInfoConversionError, SegmentUuid,
 };
 use chroma_types::{
     Collection, CollectionConversionError, CollectionUuid, FlushCompactionResponse,
@@ -267,6 +267,13 @@ impl SysDb {
                 )
                 .await
             }
+        }
+    }
+
+    pub async fn reset(&mut self) -> Result<(), ResetError> {
+        match self {
+            SysDb::Grpc(grpc) => grpc.reset().await,
+            SysDb::Test(_) => todo!(),
         }
     }
 }
@@ -813,6 +820,11 @@ impl GrpcSysDb {
             }
             Err(e) => Err(FlushCompactionError::FailedToFlushCompaction(e)),
         }
+    }
+
+    async fn reset(&mut self) -> Result<(), ResetError> {
+        self.client.reset_state(()).await?;
+        Ok(())
     }
 }
 

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -19,15 +19,24 @@ use uuid::Uuid;
 
 #[derive(Debug, Error)]
 pub enum ResetError {
-    #[error("Unable to reset cache")]
+    #[error("Error resetting cache")]
     Cache,
+    #[error("Reset is not allowed")]
+    NotAllowed,
     #[error("Rate limited")]
     RateLimited,
+    #[error("Error resetting SysDB: {0}")]
+    SysDB(#[from] Status),
 }
 
 impl ChromaError for ResetError {
     fn code(&self) -> ErrorCodes {
-        ErrorCodes::Internal
+        match self {
+            ResetError::Cache => ErrorCodes::Internal,
+            ResetError::NotAllowed => ErrorCodes::PermissionDenied,
+            ResetError::RateLimited => ErrorCodes::ResourceExhausted,
+            ResetError::SysDB(_) => ErrorCodes::Internal,
+        }
     }
 }
 


### PR DESCRIPTION
## Description of changes

See title.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a