### PR TITLE
[PERF] Use dimension cache in rust front

### DIFF
--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -192,14 +192,13 @@ impl Frontend {
         &mut self,
         collection_id: CollectionUuid,
     ) -> Result<Option<u32>, GetCollectionError> {
-        let mut collections = self
-            .sysdb_client
-            .get_collections(Some(collection_id), None, None, None)
+        Ok(self
+            .collections_with_segments_provider
+            .get_collection_with_segments(collection_id)
             .await
-            .map_err(|err| GetCollectionError::SysDB(err.to_string()))?;
-        Ok(collections
-            .pop()
-            .ok_or(GetCollectionError::NotFound)?
+            .map_err(|err| GetCollectionError::SysDB(err.to_string()))?
+            .collection_and_segments
+            .collection
             .dimension
             .map(|dim| dim as u32))
     }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - The dimension is write-once. So we can cache it with abandon.
 - New functionality
   - None

## Test plan
*How are these changes tested?*
None
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None