### PR TITLE
[ENH] Bump chroma-load dep on client to avoid connection pooling and be open loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "chromadb"
 version = "2.0.0"
-source = "git+https://github.com/rescrv/chromadb-rs?rev=630889ccd2f13b7c79489e9e8ec0272377e470af#630889ccd2f13b7c79489e9e8ec0272377e470af"
+source = "git+https://github.com/rescrv/chromadb-rs?rev=540c3e225e92ecea05039b73b69adf5875385c0e#540c3e225e92ecea05039b73b69adf5875385c0e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/load/Cargo.toml
+++ b/rust/load/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry-http = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 
 # Unlikely to be used in the workspace.
-chromadb = { git = "https://github.com/rescrv/chromadb-rs", rev = "630889ccd2f13b7c79489e9e8ec0272377e470af" }
+chromadb = { git = "https://github.com/rescrv/chromadb-rs", rev = "540c3e225e92ecea05039b73b69adf5875385c0e" }
 guacamole = { version = "0.9", default-features = false }
 tower-http = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }

--- a/rust/load/src/lib.rs
+++ b/rust/load/src/lib.rs
@@ -129,7 +129,6 @@ pub async fn client_for_url(url: String) -> ChromaClient {
                 header: ChromaTokenHeader::XChromaToken,
             },
             database: "hf-tiny-stories".to_string(),
-            connections: 32,
         })
         .await
         .unwrap()
@@ -138,7 +137,6 @@ pub async fn client_for_url(url: String) -> ChromaClient {
             url: Some(url),
             auth: ChromaAuthMethod::None,
             database: "hf-tiny-stories".to_string(),
-            connections: 32,
         })
         .await
         .unwrap()


### PR DESCRIPTION
The client no longer bounds the number of outstanding requests.  Up to a higher-level primitive to do so.
