### PR TITLE
[TST]: Rust frontend fixes for test_sanity

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -30,5 +30,6 @@ runs:
         kubectl -n chroma port-forward svc/logservice 50052:50051 &
         kubectl -n chroma port-forward svc/query-service 50053:50051 &
         kubectl -n chroma port-forward svc/frontend-service 8000:8000 &
+        kubectl -n chroma port-forward svc/rust-frontend-service 3000:3000 &
         kubectl -n chroma port-forward svc/minio 9000:9000 &
         kubectl -n chroma port-forward svc/jaeger 16686:16686 &

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -749,7 +749,7 @@ impl Frontend {
                     where_clause: request.r#where,
                 },
                 limit: Limit {
-                    skip: request.offset,
+                    skip: request.offset.unwrap_or(0),
                     fetch: request.limit,
                 },
                 proj: Projection {

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -749,7 +749,7 @@ impl Frontend {
                     where_clause: request.r#where,
                 },
                 limit: Limit {
-                    skip: request.offset.unwrap_or(0),
+                    skip: request.offset,
                     fetch: request.limit,
                 },
                 proj: Projection {

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -550,7 +550,8 @@ pub struct GetRequestPayload {
     #[serde(flatten)]
     where_fields: RawWhereFields,
     limit: Option<u32>,
-    offset: Option<u32>,
+    #[serde(default)]
+    offset: u32,
     #[serde(default = "IncludeList::default_get")]
     include: IncludeList,
 }

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -550,7 +550,7 @@ pub struct GetRequestPayload {
     #[serde(flatten)]
     where_fields: RawWhereFields,
     limit: Option<u32>,
-    offset: u32,
+    offset: Option<u32>,
     #[serde(default = "IncludeList::default_get")]
     include: IncludeList,
 }

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -572,7 +572,7 @@ pub struct GetRequest {
     pub ids: Option<Vec<String>>,
     pub r#where: Option<Where>,
     pub limit: Option<u32>,
-    pub offset: Option<u32>,
+    pub offset: u32,
     pub include: IncludeList,
 }
 

--- a/rust/types/src/execution/plan.rs
+++ b/rust/types/src/execution/plan.rs
@@ -80,7 +80,7 @@ impl TryFrom<Get> for chroma_proto::GetPlan {
 }
 
 /// The `Knn` plan should output records nearest to the target embeddings that matches the specified filter
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Knn {
     pub scan: Scan,
     pub filter: Filter,


### PR DESCRIPTION
## Description of changes

Fixes the Rust frontend so that `chromadb/test/distributed/test_sanity.py` passes.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a