### PR TITLE
[ENH] Invalidate collection cache appropriately

### DIFF
--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -473,6 +473,9 @@ impl Frontend {
             .is_some()
         {
             tracing::error!("Collection was just created. It should not be in the cache.");
+            return Err(CreateCollectionError::Validation(
+                "Collection found in cache when it shouldn't be".to_string(),
+            ));
         }
         self.collections_with_segments_provider
             .collections_with_segments_cache

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -462,6 +462,18 @@ impl Frontend {
                 _ => CreateCollectionError::SysDB(err.to_string()),
             })?;
         // This is purely defensive and should never happen.
+        if self
+            .collections_with_segments_provider
+            .collections_with_segments_cache
+            .get(&collection_id)
+            .await
+            .map_err(|_| {
+                CreateCollectionError::Validation("collection found in cache".to_string())
+            })?
+            .is_some()
+        {
+            tracing::error!("Collection was just created. It should not be in the cache.");
+        }
         self.collections_with_segments_provider
             .collections_with_segments_cache
             .remove(&collection_id)

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -106,9 +106,12 @@ impl CollectionsWithSegmentsProvider {
                             .get_collection_with_segments(collection_id)
                             .await
                             .map_err(|_| QueryError::CollectionSegments)?;
-                        self.collections_with_segments_cache
-                            .insert(collection_id, collection_and_segments_sysdb.clone())
-                            .await;
+                        // Insert only if the collection dimension is set.
+                        if collection_and_segments_sysdb.collection.dimension.is_some() {
+                            self.collections_with_segments_cache
+                                .insert(collection_id, collection_and_segments_sysdb.clone())
+                                .await;
+                        }
                         collection_and_segments_sysdb
                     }
                 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Invalidates the frontend cache whenever the collection is updated. This could happen when dimension is set, when collection is updated by user, when collection is deleted by user.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
