### PR TITLE
[TST]: fix Rust frontend for test_logservice.py

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -149,7 +149,6 @@ jobs:
                    "chromadb/test/property/test_collections_with_database_tenant.py",
                    "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
                    "chromadb/test/property/test_sysdb.py",
-                   "chromadb/test/ingest/test_producer_consumer.py",
                    "chromadb/test/segment/distributed/test_memberlist_provider.py",
                    "chromadb/test/test_logservice.py",
                    "chromadb/test/distributed/test_sanity.py"]

--- a/chromadb/proto/.gitignore
+++ b/chromadb/proto/.gitignore
@@ -1,0 +1,2 @@
+*_pb2.py*
+*_pb2_grpc.py

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -72,31 +72,36 @@ fn to_records<
     MetadataValue: Into<UpdateMetadataValue>,
     M: IntoIterator<Item = (String, MetadataValue)>,
 >(
-    mut ids: Vec<String>,
-    mut embeddings: Option<Vec<Vec<f32>>>,
-    mut documents: Option<Vec<String>>,
-    mut uris: Option<Vec<String>>,
-    mut metadatas: Option<Vec<M>>,
+    ids: Vec<String>,
+    embeddings: Option<Vec<Vec<f32>>>,
+    documents: Option<Vec<String>>,
+    uris: Option<Vec<String>>,
+    metadatas: Option<Vec<M>>,
     operation: Operation,
 ) -> Result<Vec<OperationRecord>, ToRecordsError> {
-    let mut records: Vec<OperationRecord> = vec![];
-    while let Some(id) = ids.pop() {
-        let embedding = embeddings
-            .as_mut()
-            .map(|v| v.pop().ok_or(ToRecordsError::InconsistentLength))
-            .transpose()?;
-        let document = documents
-            .as_mut()
-            .map(|v| v.pop().ok_or(ToRecordsError::InconsistentLength))
-            .transpose()?;
-        let uri = uris
-            .as_mut()
-            .map(|v| v.pop().ok_or(ToRecordsError::InconsistentLength))
-            .transpose()?;
-        let metadata = metadatas
-            .as_mut()
-            .map(|v| v.pop().ok_or(ToRecordsError::InconsistentLength))
-            .transpose()?;
+    let len = ids.len();
+
+    // Check that every present vector has the same length as `ids`.
+    if embeddings.as_ref().is_some_and(|v| v.len() != len)
+        || documents.as_ref().is_some_and(|v| v.len() != len)
+        || uris.as_ref().is_some_and(|v| v.len() != len)
+        || metadatas.as_ref().is_some_and(|v| v.len() != len)
+    {
+        return Err(ToRecordsError::InconsistentLength);
+    }
+
+    let mut embeddings_iter = embeddings.into_iter().flat_map(|v| v.into_iter());
+    let mut documents_iter = documents.into_iter().flat_map(|v| v.into_iter());
+    let mut uris_iter = uris.into_iter().flat_map(|v| v.into_iter());
+    let mut metadatas_iter = metadatas.into_iter().flat_map(|v| v.into_iter());
+
+    let mut records = Vec::with_capacity(len);
+
+    for id in ids {
+        let embedding = embeddings_iter.next();
+        let document = documents_iter.next();
+        let uri = uris_iter.next();
+        let metadata = metadatas_iter.next();
 
         let encoding = embedding.as_ref().map(|_| ScalarEncoding::FLOAT32);
 
@@ -126,8 +131,6 @@ fn to_records<
             operation,
         });
     }
-
-    records.reverse();
 
     Ok(records)
 }

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -127,6 +127,8 @@ fn to_records<
         });
     }
 
+    records.reverse();
+
     Ok(records)
 }
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Description of changes

Previously, records were reversed before being pushed to the log.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

`test_logservice.py` now passes.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a