### PR TITLE
[ENH]: add ready probe to Rust frontend

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -17,11 +17,10 @@ spec:
         - name: rust-frontend-service
           image: "{{ .Values.rustFrontendService.image.repository }}:{{ .Values.rustFrontendService.image.tag }}"
           imagePullPolicy: IfNotPresent
-          livenessProbe:
+          readinessProbe:
             httpGet:
               port: 3000
               path: /api/v2/healthcheck
-            periodSeconds: 1
           ports:
             - containerPort: 3000
           {{ if .Values.rustFrontendService.resources }}

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -17,6 +17,11 @@ spec:
         - name: rust-frontend-service
           image: "{{ .Values.rustFrontendService.image.repository }}:{{ .Values.rustFrontendService.image.tag }}"
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              port: 3000
+              path: /api/v2/healthcheck
+            periodSeconds: 1
           ports:
             - containerPort: 3000
           {{ if .Values.rustFrontendService.resources }}

--- a/rust/frontend/src/executor/client_manager.rs
+++ b/rust/frontend/src/executor/client_manager.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use chroma_memberlist::memberlist_provider::{Member, Memberlist};
+use chroma_memberlist::memberlist_provider::Memberlist;
 use chroma_system::{Component, ComponentContext, Handler};
 use chroma_types::chroma_proto::query_executor_client::QueryExecutorClient;
 use parking_lot::RwLock;

--- a/rust/frontend/src/executor/distributed.rs
+++ b/rust/frontend/src/executor/distributed.rs
@@ -119,6 +119,10 @@ impl DistributedExecutor {
         Ok(from_proto_knn_batch_result(res.into_inner())?)
     }
 
+    pub async fn is_ready(&self) -> bool {
+        !self.node_name_to_client.read().is_empty()
+    }
+
     ///////////////////////// Helpers /////////////////////////
 
     /// Get the gRPC clients for the given collection id by performing the assignment policy

--- a/rust/frontend/src/executor/mod.rs
+++ b/rust/frontend/src/executor/mod.rs
@@ -32,4 +32,9 @@ impl Executor {
             Executor::Distributed(distributed_executor) => distributed_executor.knn(plan).await,
         }
     }
+    pub async fn is_ready(&self) -> bool {
+        match self {
+            Executor::Distributed(distributed_executor) => distributed_executor.is_ready().await,
+        }
+    }
 }

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -22,14 +22,15 @@ use chroma_types::{
     DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse, GetCollectionError,
     GetCollectionRequest, GetCollectionResponse, GetDatabaseError, GetDatabaseRequest,
     GetDatabaseResponse, GetRequest, GetResponse, GetTenantError, GetTenantRequest,
-    GetTenantResponse, HeartbeatError, HeartbeatResponse, Include, ListCollectionsRequest,
-    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
-    Operation, OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
-    ScalarEncoding, Segment, SegmentScope, SegmentType, SegmentUuid, UpdateCollectionError,
-    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
-    UpdateCollectionRequest, UpdateCollectionResponse, UpdateMetadata, UpdateMetadataValue,
-    UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
-    CHROMA_DOCUMENT_KEY, CHROMA_URI_KEY,
+    GetTenantResponse, HealthCheckResponse, HeartbeatError, HeartbeatResponse, Include,
+    ListCollectionsRequest, ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest,
+    ListDatabasesResponse, Operation, OperationRecord, QueryError, QueryRequest, QueryResponse,
+    ResetError, ResetResponse, ScalarEncoding, Segment, SegmentScope, SegmentType, SegmentUuid,
+    UpdateCollectionError, UpdateCollectionRecordsError, UpdateCollectionRecordsRequest,
+    UpdateCollectionRecordsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
+    UpdateMetadata, UpdateMetadataValue, UpsertCollectionRecordsError,
+    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, CHROMA_DOCUMENT_KEY,
+    CHROMA_URI_KEY,
 };
 use mdac::{Pattern, Rule, Scorecard, ScorecardTicket};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -912,6 +913,12 @@ impl Frontend {
             .retry(self.collections_with_segments_provider.get_retry_backoff())
             .when(|e| e.code() == ErrorCodes::NotFound)
             .await
+    }
+
+    pub async fn healthcheck(&self) -> HealthCheckResponse {
+        HealthCheckResponse {
+            is_executor_ready: self.executor.is_ready().await,
+        }
     }
 }
 

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -767,6 +767,21 @@ impl ChromaError for QueryError {
     }
 }
 
+#[derive(Serialize)]
+pub struct HealthCheckResponse {
+    pub is_executor_ready: bool,
+}
+
+impl HealthCheckResponse {
+    pub fn get_status_code(&self) -> tonic::Code {
+        if self.is_executor_ready {
+            tonic::Code::Ok
+        } else {
+            tonic::Code::Unavailable
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ExecutorError {
     #[error("Error converting: {0}")]


### PR DESCRIPTION
## Description of changes

The memberlist (used by the query executor) may not be available immediately upon startup.

Tilt displays the container in green even when the probe is failing, but the docs imply that `tilt ci` will properly wait for k8s probe checks:

<img width="920" alt="Screenshot 2025-01-31 at 21 20 51" src="https://github.com/user-attachments/assets/6a212781-1fd1-49ba-9b01-6ec814925403" />

## Test plan

*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
