### PR TITLE
[ENH]: suppress prefetch errors when the sender no longer exists

### DIFF
--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -29,6 +29,8 @@ where
     fn get_type(&self) -> OperatorType {
         OperatorType::Other
     }
+    /// By default operators will log an error event if their sender is dropped when sending the result.
+    /// This is not always desired, e.g. when creating a "fire-and-forget" operator (data prefetching); so this method can be overridden to return false.
     fn errors_when_sender_dropped(&self) -> bool {
         true
     }

--- a/rust/worker/src/execution/operators/prefetch_record.rs
+++ b/rust/worker/src/execution/operators/prefetch_record.rs
@@ -89,4 +89,9 @@ impl Operator<PrefetchRecordInput, PrefetchRecordOutput> for PrefetchRecordOpera
 
         Ok(())
     }
+
+    // We don't care if the sender is dropped since this is a prefetch
+    fn errors_when_sender_dropped(&self) -> bool {
+        false
+    }
 }

--- a/rust/worker/src/execution/operators/prefetch_segment.rs
+++ b/rust/worker/src/execution/operators/prefetch_segment.rs
@@ -106,6 +106,11 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
     fn get_type(&self) -> OperatorType {
         OperatorType::IO
     }
+
+    // We don't care if the sender is dropped since this is a prefetch
+    fn errors_when_sender_dropped(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes

Prefetch operators are "fire and forget"; we don't care if the sender is no longer available to receive the result of the prefetch.

## Test plan
*How are these changes tested?*

Tested by adding a sleep to a prefetch operator and observing that the logged event was at the debug level, not error level.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
