### PR TITLE
[BUG] Using `export` instead of `export type` for CommonJS compat

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -2,7 +2,7 @@ export { ChromaClient } from "./ChromaClient";
 export { AdminClient } from "./AdminClient";
 export { CloudClient } from "./CloudClient";
 export { Collection } from "./Collection";
-export type { IEmbeddingFunction } from "./embeddings/IEmbeddingFunction";
+export { IEmbeddingFunction } from "./embeddings/IEmbeddingFunction";
 export { OpenAIEmbeddingFunction } from "./embeddings/OpenAIEmbeddingFunction";
 export { CohereEmbeddingFunction } from "./embeddings/CohereEmbeddingFunction";
 export { TransformersEmbeddingFunction } from "./embeddings/TransformersEmbeddingFunction";

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -12,7 +12,7 @@ export { JinaEmbeddingFunction } from "./embeddings/JinaEmbeddingFunction";
 export { GoogleGenerativeAiEmbeddingFunction } from "./embeddings/GoogleGeminiEmbeddingFunction";
 export { OllamaEmbeddingFunction } from "./embeddings/OllamaEmbeddingFunction";
 
-export type {
+export {
   IncludeEnum,
   GetParams,
   CollectionMetadata,


### PR DESCRIPTION
## Description of changes

Closes #3661
Closes #3551

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Turns out that in CJS projects, the use of `export type` erases runtime info, which causes failure in user projects when importing our types

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
