### PR TITLE
[BLD]: always run Rust frontend tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -12,11 +12,6 @@ on:
         description: 'Property testing preset'
         required: true
         type: string
-      run_rust_frontend_tests:
-        description: 'Whether to run the rust frontend tests'
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   test:
@@ -152,7 +147,6 @@ jobs:
                    "chromadb/test/test_logservice.py",
                    "chromadb/test/distributed/test_sanity.py"]
     runs-on: ${{ matrix.platform }}
-    if: ${{ inputs.run_rust_frontend_tests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -119,7 +119,6 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     with:
       property_testing_preset: 'fast'
-      run_rust_frontend_tests: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'rust-frontend') }}
 
   python-vulnerability-scan:
     name: Python vulnerability scan


### PR DESCRIPTION
## Description of changes

Rust frontend tests are now green, so we can enable them to run against all PRs without being gated by a label.