### PR TITLE
[TST]: add proptest Arbitrary impl for OperationRecord and UpdateMetadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,8 @@ version = "0.1.0"
 dependencies = [
  "chroma-config",
  "chroma-error",
+ "proptest",
+ "proptest-derive",
  "prost 0.13.3",
  "prost-types",
  "roaring",
@@ -4793,6 +4795,17 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ bincode = "1.3.3"
 indicatif = "0.17.9"
 proptest = "1.5.0"
 proptest-state-machine = "0.3.0"
+proptest-derive = "0.5.1"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
 rayon = "1.10.0"
@@ -80,3 +81,9 @@ serial_test = "3.2.0"
 [profile.release]
 debug = 2
 lto = "thin"
+
+[profile.test.package.proptest]
+opt-level = 3
+
+[profile.test.package.rand_chacha]
+opt-level = 3

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -17,8 +17,15 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 
+# (Cross-crate testing dependencies)
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
+
 chroma-error = { workspace = true }
 chroma-config = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.10"
+
+[features]
+testing = ["dep:proptest", "dep:proptest-derive"]

--- a/rust/types/src/lib.rs
+++ b/rust/types/src/lib.rs
@@ -14,6 +14,8 @@ mod segment;
 mod segment_scope;
 mod signed_rbm;
 mod spann_posting_list;
+#[cfg(feature = "testing")]
+pub mod strategies;
 mod tenant;
 
 // Re-export the types module, so that we can use it as a single import in other modules.

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -256,6 +256,35 @@ UpdateMetadata
 */
 pub type UpdateMetadata = HashMap<String, UpdateMetadataValue>;
 
+/**
+ * Check if two metadata are close to equal. Ignores small differences in float values.
+ */
+pub fn are_metadatas_close_to_equal(
+    metadata1: &UpdateMetadata,
+    metadata2: &UpdateMetadata,
+) -> bool {
+    assert_eq!(metadata1.len(), metadata2.len());
+
+    for (key, value) in metadata1.iter() {
+        if !metadata2.contains_key(key) {
+            return false;
+        }
+        let other_value = metadata2.get(key).unwrap();
+
+        if let (UpdateMetadataValue::Float(value), UpdateMetadataValue::Float(other_value)) =
+            (value, other_value)
+        {
+            if (value - other_value).abs() > 1e-6 {
+                return false;
+            }
+        } else if value != other_value {
+            return false;
+        }
+    }
+
+    true
+}
+
 impl TryFrom<chroma_proto::UpdateMetadata> for UpdateMetadata {
     type Error = UpdateMetadataValueConversionError;
 

--- a/rust/types/src/strategies.rs
+++ b/rust/types/src/strategies.rs
@@ -1,0 +1,114 @@
+use crate::{Operation, OperationRecord, ScalarEncoding, UpdateMetadata, UpdateMetadataValue};
+use proptest::prelude::*;
+
+/**
+ * Strategy for metadata.
+ */
+fn arbitrary_update_metadata(
+    min_pairs: usize,
+    max_pairs: usize,
+) -> impl Strategy<Value = UpdateMetadata> {
+    let num_pairs = (min_pairs..=max_pairs).boxed();
+
+    num_pairs
+        .clone()
+        .prop_flat_map(|num_pairs| {
+            let keys = proptest::collection::vec(proptest::arbitrary::any::<String>(), num_pairs);
+
+            let values = proptest::collection::vec(
+                prop_oneof![
+                    proptest::strategy::Just(UpdateMetadataValue::None),
+                    proptest::bool::ANY.prop_map(UpdateMetadataValue::Bool),
+                    proptest::arbitrary::any::<i64>().prop_map(UpdateMetadataValue::Int),
+                    (-1e6..1e6f64).prop_map(UpdateMetadataValue::Float),
+                    proptest::arbitrary::any::<String>()
+                        .prop_map(|v| { UpdateMetadataValue::Str(v) }),
+                ],
+                num_pairs,
+            );
+
+            (keys, values)
+        })
+        .prop_map(|(keys, values)| keys.into_iter().zip(values).collect::<UpdateMetadata>())
+}
+
+/**
+ * Strategy for operation record.
+ */
+pub struct OperationRecordStrategyParams {
+    pub min_embedding_size: usize,
+    pub max_embedding_size: usize,
+    pub min_metadata_pairs: usize,
+    pub max_metadata_pairs: usize,
+}
+
+impl Default for OperationRecordStrategyParams {
+    fn default() -> Self {
+        Self {
+            min_embedding_size: 3,
+            max_embedding_size: 1024,
+            min_metadata_pairs: 0,
+            max_metadata_pairs: 10,
+        }
+    }
+}
+
+impl Arbitrary for OperationRecord {
+    type Parameters = OperationRecordStrategyParams;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        let id = proptest::arbitrary::any::<String>();
+        let embedding = proptest::collection::vec(
+            proptest::arbitrary::any::<f32>(),
+            args.min_embedding_size..=args.max_embedding_size,
+        );
+        let metadata = proptest::option::of(arbitrary_update_metadata(
+            args.min_metadata_pairs,
+            args.max_metadata_pairs,
+        ));
+        let document = proptest::option::of(proptest::arbitrary::any::<String>());
+        let operation = prop_oneof![
+            proptest::strategy::Just(Operation::Add),
+            proptest::strategy::Just(Operation::Delete),
+            proptest::strategy::Just(Operation::Update),
+            proptest::strategy::Just(Operation::Upsert)
+        ];
+
+        (
+            id,
+            embedding,
+            metadata,
+            document,
+            operation,
+            proptest::bool::ANY,
+        )
+            .prop_map(
+                |(id, embedding, metadata, document, operation, discard_embedding)| {
+                    let embedding = match operation {
+                        Operation::Add => Some(embedding),
+                        Operation::Upsert => Some(embedding),
+                        Operation::Update => {
+                            if discard_embedding {
+                                None
+                            } else {
+                                Some(embedding)
+                            }
+                        }
+                        Operation::Delete => None,
+                    };
+                    let encoding = embedding.as_ref().map(|_| ScalarEncoding::FLOAT32);
+
+                    OperationRecord {
+                        id,
+                        embedding,
+                        metadata,
+                        document,
+                        operation,
+                        encoding,
+                    }
+                },
+            )
+            .boxed()
+    }
+}


### PR DESCRIPTION
## Description of changes

Adds an Arbitrary impl for OperationRecord and UpdateMetadata. Used in the next PR upstack.

## Test plan
*How are these changes tested?*

Spent a lot of time testing shrinking to ensure failures shrink fast.