### PR TITLE
[BUG] HTTP Clients unique ID based on hashed settings

### DIFF
--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -62,7 +62,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
 
         self._session = httpx.Client(timeout=None)
 
-        self._header = system.settings.chroma_server_headers or {}
+        self._header = (self._settings.chroma_server_headers or {}).copy()
         self._header["Content-Type"] = "application/json"
 
         if self._header is not None:

--- a/chromadb/api/shared_system_client.py
+++ b/chromadb/api/shared_system_client.py
@@ -62,8 +62,8 @@ class SharedSystemClient:
             "chromadb.api.fastapi.FastAPI",
             "chromadb.api.async_fastapi.AsyncFastAPI",
         ]:
-            # FastAPI clients can all use unique system identifiers since their configurations can be independent, e.g. different auth tokens
-            identifier = str(uuid.uuid4())
+            # FastAPI clients can all use hash-based identifier over all settings since their configurations can be independent, e.g. different auth tokens
+            identifier = settings.hash()
         else:
             raise ValueError(f"Unsupported Chroma API implementation {api_impl}")
 

--- a/chromadb/test/client/test_http_client.py
+++ b/chromadb/test/client/test_http_client.py
@@ -1,0 +1,47 @@
+import json
+import uuid
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+import chromadb
+from chromadb import DEFAULT_TENANT, DEFAULT_DATABASE
+from chromadb.auth import UserIdentity
+from chromadb.types import Tenant, Database
+
+
+@pytest.fixture
+def mock_server(httpserver: HTTPServer):
+    identity = UserIdentity(
+        user_id="", tenant=DEFAULT_TENANT, databases=[DEFAULT_DATABASE]
+    )
+    default_tenant = Tenant(name=DEFAULT_TENANT)
+    default_database = Database(
+        name=DEFAULT_DATABASE, tenant=DEFAULT_TENANT, id=uuid.uuid4()
+    )
+    httpserver.expect_request("/api/v2/auth/identity").respond_with_data(
+        json.dumps(identity.__dict__)
+    )
+    httpserver.expect_request("/api/v2/tenants/default_tenant").respond_with_data(
+        json.dumps(default_tenant)
+    )
+    httpserver.expect_request(
+        "/api/v2/tenants/default_tenant/databases/default_database"
+    ).respond_with_data(json.dumps({k: str(v) for k, v in default_database.items()}))
+    return httpserver
+
+
+def test_http_client_cardinality_with_same_settings(mock_server: HTTPServer):
+    client: chromadb.HttpClient = None
+    for _ in range(10):
+        client = chromadb.HttpClient(host=mock_server.host, port=mock_server.port)
+    assert len(client._identifier_to_system.keys()) == 1
+
+
+def test_http_client_cardinality_with_different_settings(mock_server: HTTPServer):
+    client: chromadb.HttpClient = None
+    for i in range(10):
+        client = chromadb.HttpClient(
+            host=mock_server.host, port=mock_server.port, headers={"header": str(i)}
+        )
+    assert len(client._identifier_to_system.keys()) == 10

--- a/chromadb/test/client/test_http_client.py
+++ b/chromadb/test/client/test_http_client.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 
 import pytest
@@ -33,6 +34,8 @@ def mock_server(httpserver: HTTPServer):
 
 
 def test_http_client_cardinality_with_same_settings(mock_server: HTTPServer):
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Skipping test for integration test")
     SharedSystemClient._identifier_to_system.clear()
     for _ in range(10):
         chromadb.HttpClient(host=f"http://{mock_server.host}:{mock_server.port}")
@@ -40,10 +43,15 @@ def test_http_client_cardinality_with_same_settings(mock_server: HTTPServer):
 
 
 def test_http_client_cardinality_with_different_settings(mock_server: HTTPServer):
+    if os.environ.get("CHROMA_INTEGRATION_TEST_ONLY"):
+        pytest.skip("Skipping test for integration test")
     SharedSystemClient._identifier_to_system.clear()
     expected_clients_count = 10
     for i in range(expected_clients_count):
         chromadb.HttpClient(
-            host=f"http://{mock_server.host}:{mock_server.port}", headers={"header": str(i)}
+            host=f"http://{mock_server.host}:{mock_server.port}",
+            headers={"header": str(i)},
         )
-    assert len(SharedSystemClient._identifier_to_system.keys()) == expected_clients_count
+    assert (
+        len(SharedSystemClient._identifier_to_system.keys()) == expected_clients_count
+    )

--- a/chromadb/test/client/test_http_client.py
+++ b/chromadb/test/client/test_http_client.py
@@ -35,7 +35,7 @@ def mock_server(httpserver: HTTPServer):
 def test_http_client_cardinality_with_same_settings(mock_server: HTTPServer):
     SharedSystemClient._identifier_to_system.clear()
     for _ in range(10):
-        chromadb.HttpClient(host=mock_server.host, port=mock_server.port)
+        chromadb.HttpClient(host=f"http://{mock_server.host}:{mock_server.port}")
     assert len(SharedSystemClient._identifier_to_system.keys()) == 1
 
 
@@ -44,6 +44,6 @@ def test_http_client_cardinality_with_different_settings(mock_server: HTTPServer
     expected_clients_count = 10
     for i in range(expected_clients_count):
         chromadb.HttpClient(
-            host=mock_server.host, port=mock_server.port, headers={"header": str(i)}
+            host=f"http://{mock_server.host}:{mock_server.port}", headers={"header": str(i)}
         )
     assert len(SharedSystemClient._identifier_to_system.keys()) == expected_clients_count

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ protobuf==5.28.0 # Later version not compatible with opentelemetry 1.27.0
 psutil
 pytest
 pytest-asyncio
+pytest-httpserver
 pytest-xdist
 setuptools_scm
 types-protobuf


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Added hash method to settings for creating unique HTTP client IDs
   - Fixed an issue where Sync http client was mutating headers

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
