### PR TITLE
[ENH]  Allow reference work loads.

### DIFF
--- a/rust/load/src/data_sets.rs
+++ b/rust/load/src/data_sets.rs
@@ -1,13 +1,13 @@
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-use chromadb::collection::{GetOptions, QueryOptions};
+use chromadb::collection::{CollectionEntries, GetOptions, QueryOptions};
 use chromadb::ChromaClient;
 use guacamole::combinators::*;
 use guacamole::Guacamole;
 use tracing::Instrument;
 
-use crate::{bit_difference, DataSet, Error, GetQuery, QueryQuery, UpsertQuery};
+use crate::{bit_difference, DataSet, Error, GetQuery, KeySelector, QueryQuery, UpsertQuery};
 
 //////////////////////////////////////////////// Nop ///////////////////////////////////////////////
 
@@ -29,12 +29,16 @@ impl DataSet for NopDataSet {
         serde_json::json!("nop")
     }
 
+    fn cardinality(&self) -> usize {
+        0
+    }
+
     async fn get(
         &self,
         _: &ChromaClient,
         _: GetQuery,
         _: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         tracing::info!("nop get");
         Ok(())
     }
@@ -44,7 +48,7 @@ impl DataSet for NopDataSet {
         _: &ChromaClient,
         qq: QueryQuery,
         _: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         tracing::info!("nop query {qq:?}", qq = qq);
         Ok(())
     }
@@ -54,9 +58,125 @@ impl DataSet for NopDataSet {
         _: &ChromaClient,
         _: UpsertQuery,
         _: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         tracing::info!("nop upsert");
         Ok(())
+    }
+}
+
+////////////////////////////////////// TinyStoriesDataSetType //////////////////////////////////////
+
+/// A type of tiny stories data set.
+///
+/// In the initial load (Classic), we loaded variable numbers of stories from the Tiny Stories data
+/// set in a variety of collections.  Some work, some don't.  They are handy to have around.  We'll
+/// use the for garbage collection and other tests in the limit.
+///
+/// In order to support writes, we needed to have a way to index the data set to e.g. return the
+/// N'th item.  The classic data sets use a set of random UUIDs to index the data set.  The
+/// reference data sets use a set of sequential numbers to index the data set.  This allows for a
+/// workload to create a new collection and write to it according to some hybrid workload, because
+/// the writer can select point-wise from the reference set and insert into the referred-to set.
+#[derive(Clone, Debug)]
+pub enum TinyStoriesDataSetType {
+    Classic {
+        name: &'static str,
+        model: &'static str,
+        size: usize,
+    },
+    Reference {
+        name: &'static str,
+        model: &'static str,
+        size: usize,
+    },
+}
+
+impl TinyStoriesDataSetType {
+    pub const fn classic(name: &'static str, model: &'static str, size: usize) -> Self {
+        Self::Classic { name, model, size }
+    }
+
+    pub const fn reference(name: &'static str, model: &'static str, size: usize) -> Self {
+        Self::Reference { name, model, size }
+    }
+
+    pub fn model_size(&self) -> Result<usize, Error> {
+        fn func_of_model(model: &str) -> Result<usize, Error> {
+            match model {
+                ALL_MINILM_L6_V2 => Ok(384),
+                DISTILUSE_BASE_MULTILINGUAL_CASED_V2 => Ok(512),
+                PARAPHRASE_MINILM_L3_V2 => Ok(384),
+                PARAPHRASE_ALBERT_SMALL_V2 => Ok(768),
+                _ => Err(Error::InvalidRequest(format!("Unknown model: {}", model)))?,
+            }
+        }
+        match self {
+            Self::Classic { model, .. } => func_of_model(model),
+            Self::Reference { model, .. } => func_of_model(model),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        fn humanize(size: usize) -> String {
+            match size {
+                100_000 => "100K".to_string(),
+                1_000_000 => "1M".to_string(),
+                25_000 => "25K".to_string(),
+                50_000 => "50K".to_string(),
+                _ => format!("{}", size),
+            }
+        }
+        match self {
+            Self::Classic { name, model, size } => {
+                format!("{}-{}-{}", name, model, humanize(*size))
+            }
+            Self::Reference { name, model, size } => {
+                format!("{}-{}-{}", name, model, humanize(*size))
+            }
+        }
+    }
+
+    pub fn description(&self) -> String {
+        match self {
+            Self::Classic { name, model, size } => {
+                format!(
+                    "{} tiny stories from {} with model {} (classic collection)",
+                    size, name, model
+                )
+            }
+            Self::Reference { name, model, size } => {
+                format!(
+                    "{} tiny stories from {} with model {} (reference collection)",
+                    size, name, model
+                )
+            }
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Classic { size, .. } => *size,
+            Self::Reference { size, .. } => *size,
+        }
+    }
+
+    pub fn json(&self) -> serde_json::Value {
+        match self {
+            Self::Classic { name, model, size } => serde_json::json!({
+                "tiny_stories": {
+                    "name": name,
+                    "model": model,
+                    "size": size,
+                }
+            }),
+            Self::Reference { name, model, size } => serde_json::json!({
+                "tiny_stories": {
+                    "name": name,
+                    "model": model,
+                    "size": size,
+                }
+            }),
+        }
     }
 }
 
@@ -65,45 +185,38 @@ impl DataSet for NopDataSet {
 /// A data set of tiny stories.
 #[derive(Clone, Debug)]
 pub struct TinyStoriesDataSet {
-    name: &'static str,
-    model: &'static str,
-    size: usize,
+    data_set_type: TinyStoriesDataSetType,
 }
 
 impl TinyStoriesDataSet {
-    pub const fn new(name: &'static str, model: &'static str, size: usize) -> Self {
-        Self { name, model, size }
+    pub const fn new(data_set_type: TinyStoriesDataSetType) -> Self {
+        Self { data_set_type }
+    }
+
+    fn model(&self) -> &str {
+        match self.data_set_type {
+            TinyStoriesDataSetType::Classic { model, .. } => model,
+            TinyStoriesDataSetType::Reference { model, .. } => model,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl DataSet for TinyStoriesDataSet {
     fn name(&self) -> String {
-        let size = match self.size {
-            100_000 => "100K".to_string(),
-            1_000_000 => "1M".to_string(),
-            25_000 => "25K".to_string(),
-            50_000 => "50K".to_string(),
-            _ => format!("{}", self.size),
-        };
-        format!("{}-{}-{}", self.name, self.model, size)
+        self.data_set_type.name()
     }
 
     fn description(&self) -> String {
-        format!(
-            "TinyStories dataset with {} stories and model {}",
-            self.size, self.model
-        )
+        self.data_set_type.description()
     }
 
     fn json(&self) -> serde_json::Value {
-        serde_json::json!({
-            "tiny_stories": {
-                "name": self.name,
-                "model": self.model,
-                "size": self.size,
-            }
-        })
+        self.data_set_type.json()
+    }
+
+    fn cardinality(&self) -> usize {
+        self.data_set_type.size()
     }
 
     async fn get(
@@ -111,7 +224,7 @@ impl DataSet for TinyStoriesDataSet {
         client: &ChromaClient,
         gq: GetQuery,
         guac: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         let collection = client.get_collection(&self.name()).await?;
         let limit = gq.limit.sample(guac);
         let where_metadata = gq.metadata.map(|m| m.to_json(guac));
@@ -136,19 +249,13 @@ impl DataSet for TinyStoriesDataSet {
         client: &ChromaClient,
         qq: QueryQuery,
         guac: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         let collection = client.get_collection(&self.name()).await?;
         let limit = qq.limit.sample(guac);
-        let size = match self.model {
-            ALL_MINILM_L6_V2 => 384,
-            DISTILUSE_BASE_MULTILINGUAL_CASED_V2 => 512,
-            PARAPHRASE_MINILM_L3_V2 => 384,
-            PARAPHRASE_ALBERT_SMALL_V2 => 768,
-            _ => Err(Error::InvalidRequest(format!(
-                "Unknown model: {}",
-                self.model
-            )))?,
-        };
+        let size = self
+            .data_set_type
+            .model_size()
+            .map_err(|err| -> Box<dyn std::error::Error + Send> { Box::new(err) as _ })?;
         let mut point = vec![0.0; size];
         for x in point.iter_mut() {
             *x = any(guac);
@@ -176,95 +283,575 @@ impl DataSet for TinyStoriesDataSet {
         _: &ChromaClient,
         _: UpsertQuery,
         _: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        Err(Error::InvalidRequest("Upsert not supported".into()).into())
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
+        Err(Box::new(Error::InvalidRequest(
+            "Upsert not supported".into(),
+        )))
     }
 }
 
-const ALL_MINILM_L6_V2: &str = "all-MiniLM-L6-v2";
-const DISTILUSE_BASE_MULTILINGUAL_CASED_V2: &str = "distiluse-base-multilingual-cased-v2";
-const PARAPHRASE_MINILM_L3_V2: &str = "paraphrase-MiniLM-L3-v2";
-const PARAPHRASE_ALBERT_SMALL_V2: &str = "paraphrase-albert-small-v2";
+pub const ALL_MINILM_L6_V2: &str = "all-MiniLM-L6-v2";
+pub const DISTILUSE_BASE_MULTILINGUAL_CASED_V2: &str = "distiluse-base-multilingual-cased-v2";
+pub const PARAPHRASE_MINILM_L3_V2: &str = "paraphrase-MiniLM-L3-v2";
+pub const PARAPHRASE_ALBERT_SMALL_V2: &str = "paraphrase-albert-small-v2";
 
 const TINY_STORIES_DATA_SETS: &[TinyStoriesDataSet] = &[
-    TinyStoriesDataSet::new("stories1", ALL_MINILM_L6_V2, 100_000),
-    TinyStoriesDataSet::new("stories1", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 100_000),
-    TinyStoriesDataSet::new("stories1", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 1_000_000),
-    TinyStoriesDataSet::new("stories1", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories1", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_MINILM_L3_V2, 100_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_MINILM_L3_V2, 1_000_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_ALBERT_SMALL_V2, 100_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_ALBERT_SMALL_V2, 1_000_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories1", PARAPHRASE_ALBERT_SMALL_V2, 100_000),
-    TinyStoriesDataSet::new("stories10", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories10", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories10", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories10", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories10", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories10", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories2", ALL_MINILM_L6_V2, 100_000),
-    TinyStoriesDataSet::new("stories2", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 100_000),
-    TinyStoriesDataSet::new("stories2", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 1_000_000),
-    TinyStoriesDataSet::new("stories2", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories2", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_MINILM_L3_V2, 100_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_MINILM_L3_V2, 1_000_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_ALBERT_SMALL_V2, 100_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_ALBERT_SMALL_V2, 1_000_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories2", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories3", ALL_MINILM_L6_V2, 100_000),
-    TinyStoriesDataSet::new("stories3", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories3", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories3", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories3", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories3", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories3", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories4", ALL_MINILM_L6_V2, 100_000),
-    TinyStoriesDataSet::new("stories4", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories4", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories4", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories4", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories4", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories4", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories5", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories5", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories5", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories5", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories5", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories5", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories6", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories6", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories6", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories6", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories6", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories6", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories7", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories7", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories7", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories7", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories7", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories7", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories8", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories8", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories8", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories8", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories8", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories8", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
-    TinyStoriesDataSet::new("stories9", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 25_000),
-    TinyStoriesDataSet::new("stories9", DISTILUSE_BASE_MULTILINGUAL_CASED_V2, 50_000),
-    TinyStoriesDataSet::new("stories9", PARAPHRASE_MINILM_L3_V2, 25_000),
-    TinyStoriesDataSet::new("stories9", PARAPHRASE_MINILM_L3_V2, 50_000),
-    TinyStoriesDataSet::new("stories9", PARAPHRASE_ALBERT_SMALL_V2, 25_000),
-    TinyStoriesDataSet::new("stories9", PARAPHRASE_ALBERT_SMALL_V2, 50_000),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        ALL_MINILM_L6_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        1_000_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_MINILM_L3_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_MINILM_L3_V2,
+        1_000_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        1_000_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories1",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories10",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories10",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories10",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories10",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories10",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories10",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        ALL_MINILM_L6_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        1_000_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_MINILM_L3_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_MINILM_L3_V2,
+        1_000_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        1_000_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories2",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        ALL_MINILM_L6_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories3",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        ALL_MINILM_L6_V2,
+        100_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories4",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories5",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories5",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories5",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories5",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories5",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories5",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories6",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories6",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories6",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories6",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories6",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories6",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories7",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories7",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories7",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories7",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories7",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories7",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories8",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories8",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories8",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories8",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories8",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories8",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories9",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories9",
+        DISTILUSE_BASE_MULTILINGUAL_CASED_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories9",
+        PARAPHRASE_MINILM_L3_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories9",
+        PARAPHRASE_MINILM_L3_V2,
+        50_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories9",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        25_000,
+    )),
+    TinyStoriesDataSet::new(TinyStoriesDataSetType::classic(
+        "stories9",
+        PARAPHRASE_ALBERT_SMALL_V2,
+        50_000,
+    )),
 ];
+
+//////////////////////////////////////// ReferencingDataSet ////////////////////////////////////////
+
+/// A referencing data set refers to some _other_ data set and re-uses its data.
+#[derive(Debug)]
+pub struct ReferencingDataSet {
+    references: Arc<dyn DataSet>,
+    operates_on: String,
+    cardinality: usize,
+}
+
+#[async_trait::async_trait]
+impl DataSet for ReferencingDataSet {
+    fn name(&self) -> String {
+        self.operates_on.clone()
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "referencing data set {}, operating on {}",
+            self.references.name(),
+            self.operates_on
+        )
+    }
+
+    fn json(&self) -> serde_json::Value {
+        serde_json::json! {
+            {
+                "references": self.references.json(),
+                "operates_on": self.operates_on,
+            }
+        }
+    }
+
+    fn cardinality(&self) -> usize {
+        self.cardinality
+    }
+
+    async fn get(
+        &self,
+        client: &ChromaClient,
+        gq: GetQuery,
+        guac: &mut Guacamole,
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
+        let mut keys = vec![];
+        let num_keys = gq.limit.sample(guac);
+        for _ in 0..num_keys {
+            keys.push(KeySelector::Random(gq.skew).select(guac, self));
+        }
+        let collection = client.get_collection(&self.operates_on).await?;
+        // TODO(rescrv):  from the reference collection, pull the documents and embeddings and
+        // generate where_document and where_metadata mixins.
+        collection
+            .get(GetOptions {
+                ids: keys,
+                where_metadata: None,
+                limit: None,
+                offset: None,
+                where_document: None,
+                include: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        client: &ChromaClient,
+        qq: QueryQuery,
+        guac: &mut Guacamole,
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
+        let mut keys = vec![];
+        let num_keys = qq.limit.sample(guac);
+        for _ in 0..num_keys {
+            keys.push(KeySelector::Random(qq.skew).select(guac, self));
+        }
+        let keys = keys.iter().map(|k| k.as_str()).collect::<Vec<_>>();
+        if let Some(res) = self.references.get_by_key(client, &keys).await? {
+            let mut embeddings = vec![];
+            if let Some(embeds) = res.embeddings {
+                for (idx, embed) in embeds.iter().enumerate() {
+                    if let Some(embed) = embed {
+                        embeddings.push(embed.clone());
+                    } else {
+                        return Err(Box::new(Error::InvalidRequest(format!(
+                            "Missing document for {}",
+                            idx
+                        ))));
+                    }
+                }
+            } else {
+                return Err(Box::new(Error::InvalidRequest("No documents".into())));
+            }
+            let collection = client.get_collection(&self.operates_on).await?;
+            collection
+                .query(
+                    QueryOptions {
+                        query_texts: None,
+                        query_embeddings: Some(embeddings),
+                        where_metadata: None,
+                        where_document: None,
+                        n_results: Some(num_keys),
+                        include: None,
+                    },
+                    None,
+                )
+                .await?;
+            Ok(())
+        } else {
+            return Err(Box::new(Error::InvalidRequest("No results".into())));
+        }
+    }
+
+    async fn upsert(
+        &self,
+        client: &ChromaClient,
+        uq: UpsertQuery,
+        guac: &mut Guacamole,
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
+        let collection = client.get_collection(&self.operates_on).await?;
+        let mut keys = vec![];
+        for _ in 0..uq.batch_size {
+            keys.push(uq.key.select(guac, self));
+        }
+        let keys = keys.iter().map(|k| k.as_str()).collect::<Vec<_>>();
+        if let Some(res) = self.references.get_by_key(client, &keys).await? {
+            let mut documents = vec![];
+            if let Some(docs) = res.documents {
+                for (idx, doc) in docs.into_iter().enumerate() {
+                    if let Some(doc) = doc {
+                        documents.push(doc);
+                    } else {
+                        return Err(Box::new(Error::InvalidRequest(format!(
+                            "Missing document for {}",
+                            idx
+                        ))));
+                    }
+                }
+            } else {
+                return Err(Box::new(Error::InvalidRequest("No documents".into())));
+            }
+            let documents = documents.iter().map(|d| d.as_str()).collect::<Vec<_>>();
+            let mut embeddings = vec![];
+            if let Some(embeds) = res.embeddings {
+                for (idx, embed) in embeds.iter().enumerate() {
+                    if let Some(embed) = embed {
+                        embeddings.push(embed.clone());
+                    } else {
+                        return Err(Box::new(Error::InvalidRequest(format!(
+                            "Missing document for {}",
+                            idx
+                        ))));
+                    }
+                }
+            } else {
+                return Err(Box::new(Error::InvalidRequest("No documents".into())));
+            }
+            let entries = CollectionEntries {
+                ids: keys,
+                metadatas: res.metadatas,
+                documents: Some(documents),
+                embeddings: Some(embeddings),
+            };
+            collection.upsert(entries, None).await?;
+        } else {
+            return Err(Box::new(Error::InvalidRequest("No results".into())));
+        }
+        Ok(())
+    }
+}
 
 //////////////////////////////////////////// RoundRobin ////////////////////////////////////////////
 
@@ -291,12 +878,16 @@ impl DataSet for RoundRobinDataSet {
         serde_json::json!("round-robin")
     }
 
+    fn cardinality(&self) -> usize {
+        self.data_sets.iter().map(|ds| ds.cardinality()).sum()
+    }
+
     async fn get(
         &self,
         client: &ChromaClient,
         gq: GetQuery,
         guac: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         let index = self
             .index
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -309,7 +900,7 @@ impl DataSet for RoundRobinDataSet {
         client: &ChromaClient,
         qq: QueryQuery,
         guac: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         let index = self
             .index
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -322,7 +913,7 @@ impl DataSet for RoundRobinDataSet {
         client: &ChromaClient,
         uq: UpsertQuery,
         guac: &mut Guacamole,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send>> {
         let index = self
             .index
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -338,6 +929,29 @@ pub fn all_data_sets() -> Vec<Arc<dyn DataSet>> {
     let mut data_sets = vec![Arc::new(NopDataSet) as _];
     for data_set in TINY_STORIES_DATA_SETS {
         data_sets.push(Arc::new(data_set.clone()) as _);
+    }
+    for model in &[
+        ALL_MINILM_L6_V2,
+        PARAPHRASE_MINILM_L3_V2,
+        PARAPHRASE_ALBERT_SMALL_V2,
+    ] {
+        let reference = Arc::new(TinyStoriesDataSet::new(TinyStoriesDataSetType::reference(
+            "reference",
+            model,
+            1_000_000,
+        )));
+        for cardinality in [10_000, 25_000, 50_000, 100_000, 1_000_000] {
+            for data_set in TINY_STORIES_DATA_SETS {
+                if data_set.model() != *model {
+                    continue;
+                }
+                data_sets.push(Arc::new(ReferencingDataSet {
+                    references: reference.clone(),
+                    operates_on: data_set.name() + "-writable",
+                    cardinality,
+                }) as _);
+            }
+        }
     }
     data_sets.push(Arc::new(RoundRobinDataSet {
         name: "tiny-stories".to_string(),
@@ -386,12 +1000,33 @@ pub fn all_data_sets() -> Vec<Arc<dyn DataSet>> {
     data_sets
 }
 
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct References {
+    references: serde_json::Value,
+    operates_on: String,
+    cardinality: usize,
+}
+
 /// Get a data set from a particular JSON value.
 pub fn from_json(json: &serde_json::Value) -> Option<Arc<dyn DataSet>> {
     // NOTE(rescrv):  I don't like that we use json attributes to identify data sets, but it's the
     // only robust way I can think of that's not encoding everything to strings or reworking the
     // data set type to be an enum.
-    all_data_sets()
+    if let Some(data_set) = all_data_sets()
         .into_iter()
         .find(|data_set| data_set.json() == *json)
+    {
+        Some(data_set)
+    } else {
+        let references: Result<References, _> = serde_json::from_value(json.clone());
+        if let Ok(references) = references {
+            Some(Arc::new(ReferencingDataSet {
+                references: from_json(&references.references)?,
+                operates_on: references.operates_on,
+                cardinality: references.cardinality,
+            }))
+        } else {
+            None
+        }
+    }
 }


### PR DESCRIPTION
A reference workload uses two collections.  It references one to get doc
ids and it writes/reads the other with queries, gets, and upserts.

This may sound strange, but it's because we need a canonical way of
knowing what data we're writing and can query so that we can verify
ground truth.

Options considered:
- Load the hugging face data sets to a volume.  Operationally tricky.
- Load the hugging face data sets to a different DB.  Operationally
  tricky.
- Use a reference chroma collection (this).
