### PR TITLE
[ENH] Implement reference segment

### DIFF
--- a/rust/log/src/test.rs
+++ b/rust/log/src/test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use chroma_segment::test::TestSegment;
+use chroma_segment::test::TestDistributedSegment;
 use chroma_types::{Chunk, LogRecord, Operation, OperationRecord, UpdateMetadataValue};
 use rand::{
     distributions::{Alphanumeric, Open01},
@@ -121,7 +121,7 @@ pub trait LoadFromGenerator<L: LogGenerator> {
 }
 
 #[async_trait]
-impl<L: LogGenerator + Send + 'static> LoadFromGenerator<L> for TestSegment {
+impl<L: LogGenerator + Send + 'static> LoadFromGenerator<L> for TestDistributedSegment {
     async fn populate_with_generator(&mut self, log_count: usize, generator: L) {
         let ids: Vec<_> = (1..=log_count).collect();
         for chunk in ids.chunks(100) {

--- a/rust/segment/Cargo.toml
+++ b/rust/segment/Cargo.toml
@@ -29,6 +29,7 @@ chroma-sqlite = { workspace = true }
 chroma-types = { workspace = true }
 
 [dev-dependencies]
+proptest = { workspace = true }
 shuttle = { workspace = true }
 tokio = { workspace = true }
 tempfile = { workspace = true }
@@ -36,4 +37,5 @@ tempfile = { workspace = true }
 chroma-cache = { workspace = true }
 chroma-log = { workspace = true }
 chroma-storage = { workspace = true }
+chroma-types = { workspace = true, features = ["testing"] }
 

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -875,7 +875,9 @@ mod tests {
     use chroma_types::Chunk;
     use shuttle::{future, thread};
 
-    use crate::{blockfile_record::MAX_OFFSET_ID, test::TestSegment, types::materialize_logs};
+    use crate::{
+        blockfile_record::MAX_OFFSET_ID, test::TestDistributedSegment, types::materialize_logs,
+    };
 
     use super::RecordSegmentWriter;
 
@@ -886,7 +888,7 @@ mod tests {
             .enable_all()
             .build()
             .expect("Runtime creation should not fail")
-            .block_on(async { TestSegment::default() });
+            .block_on(async { TestDistributedSegment::default() });
         shuttle::check_random(
             move || {
                 let log_partition_size = 100;

--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -389,7 +389,7 @@ impl SqliteMetadataWriter {
         Ok(())
     }
 
-    pub async fn apply_materialized_logs(
+    pub async fn apply_logs(
         &self,
         logs: Vec<LogRecord>,
         segment_id: SegmentUuid,
@@ -754,7 +754,7 @@ mod tests {
         MetadataExpression, MetadataValue, PrimitiveOperator, Where,
     };
 
-    use crate::test::TestSegment;
+    use crate::test::TestDistributedSegment;
 
     use super::SqliteMetadataReader;
 
@@ -767,7 +767,7 @@ mod tests {
         metadata_reader
             .count(Count {
                 scan: Scan {
-                    collection_and_segments: TestSegment::default().into(),
+                    collection_and_segments: TestDistributedSegment::default().into(),
                 },
             })
             .await
@@ -782,7 +782,7 @@ mod tests {
         let _result = metadata_reader
             .get(Get {
                 scan: Scan {
-                    collection_and_segments: TestSegment::default().into(),
+                    collection_and_segments: TestDistributedSegment::default().into(),
                 },
                 filter: Filter {
                     query_ids: None,

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -288,6 +288,9 @@ impl TestReferenceSegment {
     }
 }
 
+/// Given a record, verify if the predicate evaluates to true on it
+/// This is intended to be used with the reference segment impl
+/// This should be implemented for all (sub)types of the where clause
 trait CheckRecord {
     fn eval(&self, record: &ProjectionRecord) -> bool;
 }

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -1,10 +1,20 @@
-use std::sync::atomic::AtomicU32;
+use std::{
+    collections::{HashMap, HashSet},
+    ops::{BitAnd, BitOr},
+    sync::atomic::AtomicU32,
+};
 
 use chroma_blockstore::{provider::BlockfileProvider, test_arrow_blockfile_provider};
 use chroma_index::{hnsw_provider::HnswIndexProvider, test_hnsw_index_provider};
 use chroma_types::{
-    test_segment, Chunk, Collection, CollectionAndSegments, LogRecord, Segment, SegmentScope,
+    operator::{CountResult, GetResult, Projection, ProjectionOutput, ProjectionRecord},
+    plan::{Count, Get},
+    test_segment, BooleanOperator, Chunk, Collection, CollectionAndSegments, CompositeExpression,
+    DocumentExpression, DocumentOperator, LogRecord, Metadata, MetadataComparison,
+    MetadataExpression, MetadataSetValue, MetadataValue, Operation, OperationRecord,
+    PrimitiveOperator, Segment, SegmentScope, SegmentUuid, SetOperator, Where,
 };
+use thiserror::Error;
 
 use super::{
     blockfile_metadata::MetadataSegmentWriter, blockfile_record::RecordSegmentWriter,
@@ -12,7 +22,7 @@ use super::{
 };
 
 #[derive(Clone)]
-pub struct TestSegment {
+pub struct TestDistributedSegment {
     pub blockfile_provider: BlockfileProvider,
     pub hnsw_provider: HnswIndexProvider,
     pub collection: Collection,
@@ -21,7 +31,7 @@ pub struct TestSegment {
     pub vector_segment: Segment,
 }
 
-impl TestSegment {
+impl TestDistributedSegment {
     pub fn new_with_dimension(dimension: usize) -> Self {
         let collection = Collection::test_collection(dimension as i32);
         let collection_uuid = collection.collection_id;
@@ -104,8 +114,8 @@ impl TestSegment {
     }
 }
 
-impl From<TestSegment> for CollectionAndSegments {
-    fn from(value: TestSegment) -> Self {
+impl From<TestDistributedSegment> for CollectionAndSegments {
+    fn from(value: TestDistributedSegment) -> Self {
         Self {
             collection: value.collection,
             metadata_segment: value.metadata_segment,
@@ -115,8 +125,255 @@ impl From<TestSegment> for CollectionAndSegments {
     }
 }
 
-impl Default for TestSegment {
+impl Default for TestDistributedSegment {
     fn default() -> Self {
         Self::new_with_dimension(128)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TestReferenceSegmentError {
+    #[error("Not found")]
+    NotFound,
+}
+
+#[derive(Default)]
+pub struct TestReferenceSegment {
+    max_id: u32,
+    record: HashMap<SegmentUuid, HashMap<String, (u32, ProjectionRecord)>>,
+}
+
+impl TestReferenceSegment {
+    fn merge_meta(old_meta: Option<Metadata>, new_meta: Option<Metadata>) -> Option<Metadata> {
+        match (old_meta, new_meta) {
+            (None, None) => None,
+            (None, Some(m)) | (Some(m), None) => Some(m),
+            (Some(o), Some(n)) => Some(o.into_iter().chain(n).collect()),
+        }
+    }
+
+    pub fn apply_logs(&mut self, logs: Vec<LogRecord>, segmemt_id: SegmentUuid) {
+        let coll = self.record.entry(segmemt_id).or_default();
+        for LogRecord {
+            log_offset: _,
+            record:
+                OperationRecord {
+                    id,
+                    embedding,
+                    encoding: _,
+                    metadata,
+                    document,
+                    operation,
+                },
+        } in logs
+        {
+            let (deleted_keys, new_meta) = if let Some(m) = metadata {
+                let mut dk = HashSet::new();
+                let mut nm = HashMap::new();
+                for (k, v) in m {
+                    match MetadataValue::try_from(&v) {
+                        Ok(mv) => {
+                            nm.insert(k, mv);
+                        }
+                        Err(_) => {
+                            dk.insert(k);
+                        }
+                    }
+                }
+                (dk, Some(nm))
+            } else {
+                (HashSet::new(), None)
+            };
+            let mut record = ProjectionRecord {
+                id: id.clone(),
+                document,
+                embedding,
+                metadata: None,
+            };
+            match operation {
+                Operation::Add => {
+                    if !coll.contains_key(&id) && deleted_keys.is_empty() {
+                        record.metadata = new_meta;
+                        coll.insert(id, (self.max_id, record));
+                        self.max_id += 1;
+                    }
+                }
+                Operation::Update => {
+                    if let Some((_, old_record)) = coll.get_mut(&id) {
+                        old_record.document = record.document;
+                        old_record.embedding = record.embedding;
+                        old_record.metadata =
+                            Self::merge_meta(old_record.metadata.clone(), new_meta);
+                    }
+                }
+                Operation::Upsert => {
+                    if let Some((_, old_record)) = coll.get_mut(&id) {
+                        old_record.document = record.document;
+                        old_record.embedding = record.embedding;
+                        old_record.metadata =
+                            Self::merge_meta(old_record.metadata.clone(), new_meta);
+                    } else {
+                        record.metadata = new_meta;
+                        coll.insert(id, (self.max_id, record));
+                        self.max_id += 1;
+                    }
+                }
+                Operation::Delete => {
+                    coll.remove(&id);
+                }
+            };
+        }
+    }
+
+    pub fn count(&self, plan: Count) -> Result<CountResult, TestReferenceSegmentError> {
+        let coll = self
+            .record
+            .get(&plan.scan.collection_and_segments.record_segment.id)
+            .ok_or(TestReferenceSegmentError::NotFound)?;
+        Ok(coll.len() as u32)
+    }
+
+    pub fn get(&self, plan: Get) -> Result<GetResult, TestReferenceSegmentError> {
+        let coll = self
+            .record
+            .get(&plan.scan.collection_and_segments.record_segment.id)
+            .ok_or(TestReferenceSegmentError::NotFound)?;
+        let mut records = coll
+            .iter()
+            .filter(|(k, (_, rec))| {
+                plan.filter
+                    .query_ids
+                    .as_ref()
+                    .map_or(true, |ids| ids.contains(k))
+                    && plan
+                        .filter
+                        .where_clause
+                        .as_ref()
+                        .map_or(true, |w| w.eval(rec))
+            })
+            .map(|(_, v)| v.clone())
+            .collect::<Vec<_>>();
+
+        records.sort_by_key(|(oid, _)| *oid);
+
+        Ok(ProjectionOutput {
+            records: records
+                .into_iter()
+                .skip(plan.limit.skip as usize)
+                .take(plan.limit.fetch.unwrap_or(u32::MAX) as usize)
+                .map(|(_, mut rec)| {
+                    let Projection {
+                        document,
+                        embedding,
+                        metadata,
+                    } = plan.proj;
+                    if !document {
+                        rec.document = None;
+                    }
+                    if !embedding {
+                        rec.embedding = None;
+                    }
+                    if !metadata {
+                        rec.metadata = None;
+                    }
+                    rec
+                })
+                .collect(),
+        })
+    }
+}
+
+trait CheckRecord {
+    fn eval(&self, record: &ProjectionRecord) -> bool;
+}
+
+impl CheckRecord for Where {
+    fn eval(&self, record: &ProjectionRecord) -> bool {
+        match self {
+            Where::Composite(composite_expression) => composite_expression.eval(record),
+            Where::Document(document_expression) => document_expression.eval(record),
+            Where::Metadata(metadata_expression) => metadata_expression.eval(record),
+        }
+    }
+}
+
+impl CheckRecord for CompositeExpression {
+    fn eval(&self, record: &ProjectionRecord) -> bool {
+        let children_evals = self.children.iter().map(|child| child.eval(record));
+        match self.operator {
+            BooleanOperator::And => children_evals.fold(true, BitAnd::bitand),
+            BooleanOperator::Or => children_evals.fold(false, BitOr::bitor),
+        }
+    }
+}
+
+impl CheckRecord for DocumentExpression {
+    fn eval(&self, record: &ProjectionRecord) -> bool {
+        let contains = record
+            .document
+            .as_ref()
+            .is_some_and(|doc| doc.contains(&self.text));
+        match self.operator {
+            DocumentOperator::Contains => contains,
+            DocumentOperator::NotContains => !contains,
+        }
+    }
+}
+
+impl CheckRecord for MetadataExpression {
+    fn eval(&self, record: &ProjectionRecord) -> bool {
+        let stored = record.metadata.as_ref().and_then(|m| m.get(&self.key));
+        match &self.comparison {
+            MetadataComparison::Primitive(primitive_operator, metadata_value) => {
+                let match_type = matches!(
+                    (stored, metadata_value),
+                    (Some(MetadataValue::Bool(_)), MetadataValue::Bool(_))
+                        | (Some(MetadataValue::Int(_)), MetadataValue::Int(_))
+                        | (Some(MetadataValue::Float(_)), MetadataValue::Float(_))
+                        | (Some(MetadataValue::Str(_)), MetadataValue::Str(_))
+                );
+                match primitive_operator {
+                    PrimitiveOperator::Equal => {
+                        match_type && stored.is_some_and(|v| v == metadata_value)
+                    }
+                    PrimitiveOperator::NotEqual => {
+                        !match_type || stored.is_some_and(|v| v != metadata_value)
+                    }
+                    PrimitiveOperator::GreaterThan => {
+                        match_type && stored.is_some_and(|v| v > metadata_value)
+                    }
+                    PrimitiveOperator::GreaterThanOrEqual => {
+                        match_type && stored.is_some_and(|v| v >= metadata_value)
+                    }
+                    PrimitiveOperator::LessThan => {
+                        match_type && stored.is_some_and(|v| v < metadata_value)
+                    }
+                    PrimitiveOperator::LessThanOrEqual => {
+                        match_type && stored.is_some_and(|v| v <= metadata_value)
+                    }
+                }
+            }
+            MetadataComparison::Set(set_operator, metadata_set_value) => {
+                let contains = match (stored, metadata_set_value) {
+                    (Some(MetadataValue::Bool(val)), MetadataSetValue::Bool(vec)) => {
+                        vec.contains(val)
+                    }
+                    (Some(MetadataValue::Int(val)), MetadataSetValue::Int(vec)) => {
+                        vec.contains(val)
+                    }
+                    (Some(MetadataValue::Float(val)), MetadataSetValue::Float(vec)) => {
+                        vec.contains(val)
+                    }
+                    (Some(MetadataValue::Str(val)), MetadataSetValue::Str(vec)) => {
+                        vec.contains(val)
+                    }
+                    _ => false,
+                };
+                match set_operator {
+                    SetOperator::In => contains,
+                    SetOperator::NotIn => !contains,
+                }
+            }
+        }
     }
 }

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -1,5 +1,5 @@
 use super::{Metadata, MetadataValueConversionError};
-use crate::{chroma_proto, Segment};
+use crate::{chroma_proto, test_segment, Segment, SegmentScope};
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -144,6 +144,19 @@ pub struct CollectionAndSegments {
     pub metadata_segment: Segment,
     pub record_segment: Segment,
     pub vector_segment: Segment,
+}
+
+impl CollectionAndSegments {
+    pub fn test(dim: i32) -> Self {
+        let collection = Collection::test_collection(dim);
+        let collection_uuid = collection.collection_id;
+        Self {
+            collection,
+            metadata_segment: test_segment(collection_uuid, SegmentScope::METADATA),
+            record_segment: test_segment(collection_uuid, SegmentScope::RECORD),
+            vector_segment: test_segment(collection_uuid, SegmentScope::VECTOR),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/worker/benches/filter.rs
+++ b/rust/worker/benches/filter.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};
 use chroma_log::test::{upsert_generator, LoadFromGenerator};
-use chroma_segment::test::TestSegment;
+use chroma_segment::test::TestDistributedSegment;
 use chroma_system::Operator;
 use chroma_types::{
     BooleanOperator, Chunk, CompositeExpression, MetadataComparison, MetadataExpression,
@@ -74,7 +74,7 @@ fn bench_filter(criterion: &mut Criterion) {
 
     for record_count in [1000, 10000, 100000] {
         let test_segment = runtime.block_on(async {
-            let mut segment = TestSegment::default();
+            let mut segment = TestDistributedSegment::default();
             segment
                 .populate_with_generator(record_count, upsert_generator)
                 .await;

--- a/rust/worker/benches/get.rs
+++ b/rust/worker/benches/get.rs
@@ -3,7 +3,7 @@ mod load;
 
 use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};
 use chroma_config::Configurable;
-use chroma_segment::test::TestSegment;
+use chroma_segment::test::TestDistributedSegment;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
 use criterion::{criterion_group, criterion_main, Criterion};
 use load::{
@@ -14,7 +14,7 @@ use load::{
 use worker::{config::RootConfig, execution::orchestration::get::GetOrchestrator};
 
 fn trivial_get(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> GetOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -32,7 +32,7 @@ fn trivial_get(
 }
 
 fn get_false_filter(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> GetOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -50,7 +50,7 @@ fn get_false_filter(
 }
 
 fn get_true_filter(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> GetOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -68,7 +68,7 @@ fn get_true_filter(
 }
 
 fn get_true_filter_limit(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> GetOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -86,7 +86,7 @@ fn get_true_filter_limit(
 }
 
 fn get_true_filter_limit_projection(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> GetOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();

--- a/rust/worker/benches/limit.rs
+++ b/rust/worker/benches/limit.rs
@@ -1,6 +1,6 @@
 use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};
 use chroma_log::test::{upsert_generator, LoadFromGenerator};
-use chroma_segment::test::TestSegment;
+use chroma_segment::test::TestDistributedSegment;
 use chroma_system::Operator;
 use chroma_types::{Chunk, SignedRoaringBitmap};
 use criterion::Criterion;
@@ -14,7 +14,7 @@ fn bench_limit(criterion: &mut Criterion) {
 
     for record_count in [1000, 10000, 100000] {
         let test_segment = runtime.block_on(async {
-            let mut segment = TestSegment::default();
+            let mut segment = TestDistributedSegment::default();
             segment
                 .populate_with_generator(record_count, upsert_generator)
                 .await;

--- a/rust/worker/benches/load.rs
+++ b/rust/worker/benches/load.rs
@@ -1,6 +1,6 @@
 use chroma_benchmark::datasets::sift::Sift1MData;
 use chroma_log::{in_memory_log::InMemoryLog, test::modulo_metadata, Log};
-use chroma_segment::test::TestSegment;
+use chroma_segment::test::TestDistributedSegment;
 use chroma_types::{
     Chunk, CollectionUuid, LogRecord, MetadataComparison, MetadataExpression, MetadataSetValue,
     Operation, OperationRecord, SetOperator, Where,
@@ -13,8 +13,8 @@ use worker::execution::operators::{
 
 const DATA_CHUNK_SIZE: usize = 10000;
 
-pub async fn sift1m_segments() -> TestSegment {
-    let mut segments = TestSegment::default();
+pub async fn sift1m_segments() -> TestDistributedSegment {
+    let mut segments = TestDistributedSegment::default();
     let mut sift1m = Sift1MData::init()
         .await
         .expect("Should be able to download Sift1M data");

--- a/rust/worker/benches/query.rs
+++ b/rust/worker/benches/query.rs
@@ -6,7 +6,7 @@ use chroma_benchmark::{
     datasets::sift::Sift1MData,
 };
 use chroma_config::Configurable;
-use chroma_segment::test::TestSegment;
+use chroma_segment::test::TestDistributedSegment;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::{stream, StreamExt, TryStreamExt};
@@ -27,7 +27,7 @@ use worker::{
 };
 
 fn trivial_knn_filter(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> KnnFilterOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -45,7 +45,7 @@ fn trivial_knn_filter(
 }
 
 fn always_true_knn_filter(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> KnnFilterOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -63,7 +63,7 @@ fn always_true_knn_filter(
 }
 
 fn always_false_knn_filter(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
 ) -> KnnFilterOrchestrator {
     let blockfile_provider = test_segments.blockfile_provider.clone();
@@ -81,7 +81,7 @@ fn always_false_knn_filter(
 }
 
 fn knn(
-    test_segments: TestSegment,
+    test_segments: TestDistributedSegment,
     dispatcher_handle: ComponentHandle<Dispatcher>,
     knn_filter_output: KnnFilterOutput,
     query: Vec<f32>,

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -499,7 +499,7 @@ impl Operator<FilterInput, FilterOutput> for FilterOperator {
 #[cfg(test)]
 mod tests {
     use chroma_log::test::{add_delete_generator, int_as_id, LoadFromGenerator, LogGenerator};
-    use chroma_segment::test::TestSegment;
+    use chroma_segment::test::TestDistributedSegment;
     use chroma_system::Operator;
     use chroma_types::{
         BooleanOperator, CompositeExpression, DocumentExpression, MetadataComparison,
@@ -516,7 +516,7 @@ mod tests {
     /// - Log: Delete [11..=20], add [51..=100]
     /// - Compacted: Delete [1..=10] deletion, add [11..=50]
     async fn setup_filter_input() -> FilterInput {
-        let mut test_segment = TestSegment::default();
+        let mut test_segment = TestDistributedSegment::default();
         test_segment
             .populate_with_generator(60, add_delete_generator)
             .await;

--- a/rust/worker/src/execution/operators/knn_log.rs
+++ b/rust/worker/src/execution/operators/knn_log.rs
@@ -130,7 +130,7 @@ mod tests {
     use chroma_log::test::{
         random_embedding, upsert_generator, LogGenerator, TEST_EMBEDDING_DIMENSION,
     };
-    use chroma_segment::test::TestSegment;
+    use chroma_segment::test::TestDistributedSegment;
     use chroma_system::Operator;
     use chroma_types::SignedRoaringBitmap;
 
@@ -144,7 +144,7 @@ mod tests {
         metric: DistanceFunction,
         log_offset_ids: SignedRoaringBitmap,
     ) -> KnnLogInput {
-        let test_segment = TestSegment::default();
+        let test_segment = TestDistributedSegment::default();
         KnnLogInput {
             logs: upsert_generator.generate_chunk(1..=100),
             blockfile_provider: test_segment.blockfile_provider,

--- a/rust/worker/src/execution/operators/knn_projection.rs
+++ b/rust/worker/src/execution/operators/knn_projection.rs
@@ -121,7 +121,7 @@ impl Operator<KnnProjectionInput, KnnProjectionOutput> for KnnProjectionOperator
 #[cfg(test)]
 mod tests {
     use chroma_log::test::{int_as_id, upsert_generator, LoadFromGenerator, LogGenerator};
-    use chroma_segment::test::TestSegment;
+    use chroma_segment::test::TestDistributedSegment;
     use chroma_system::Operator;
 
     use crate::execution::operators::{
@@ -140,7 +140,7 @@ mod tests {
     async fn setup_knn_projection_input(
         record_distances: Vec<RecordDistance>,
     ) -> KnnProjectionInput {
-        let mut test_segment = TestSegment::default();
+        let mut test_segment = TestDistributedSegment::default();
         test_segment
             .populate_with_generator(100, upsert_generator)
             .await;

--- a/rust/worker/src/execution/operators/limit.rs
+++ b/rust/worker/src/execution/operators/limit.rs
@@ -280,7 +280,7 @@ impl Operator<LimitInput, LimitOutput> for LimitOperator {
 #[cfg(test)]
 mod tests {
     use chroma_log::test::{upsert_generator, LoadFromGenerator, LogGenerator};
-    use chroma_segment::test::TestSegment;
+    use chroma_segment::test::TestDistributedSegment;
     use chroma_system::Operator;
     use chroma_types::SignedRoaringBitmap;
     use roaring::RoaringBitmap;
@@ -298,7 +298,7 @@ mod tests {
         log_offset_ids: SignedRoaringBitmap,
         compact_offset_ids: SignedRoaringBitmap,
     ) -> LimitInput {
-        let mut test_segment = TestSegment::default();
+        let mut test_segment = TestDistributedSegment::default();
         test_segment
             .populate_with_generator(100, upsert_generator)
             .await;

--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -176,7 +176,7 @@ impl Operator<ProjectionInput, ProjectionOutput> for ProjectionOperator {
 #[cfg(test)]
 mod tests {
     use chroma_log::test::{int_as_id, upsert_generator, LoadFromGenerator, LogGenerator};
-    use chroma_segment::test::TestSegment;
+    use chroma_segment::test::TestDistributedSegment;
     use chroma_system::Operator;
 
     use crate::execution::operators::projection::ProjectionOperator;
@@ -191,7 +191,7 @@ mod tests {
     /// - Log: Upsert [81..=120]
     /// - Compacted: Upsert [1..=100]
     async fn setup_projection_input(offset_ids: Vec<u32>) -> ProjectionInput {
-        let mut test_segment = TestSegment::default();
+        let mut test_segment = TestDistributedSegment::default();
         test_segment
             .populate_with_generator(100, upsert_generator)
             .await;

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -403,7 +403,7 @@ mod tests {
     #[cfg(debug_assertions)]
     use chroma_proto::debug_client::DebugClient;
     use chroma_proto::query_executor_client::QueryExecutorClient;
-    use chroma_segment::test::TestSegment;
+    use chroma_segment::test::TestDistributedSegment;
     use chroma_sysdb::TestSysDb;
     use chroma_system::system;
     use chroma_system::DispatcherConfig;
@@ -412,7 +412,7 @@ mod tests {
     fn run_server() -> String {
         let sysdb = TestSysDb::new();
         let log = InMemoryLog::new();
-        let segments = TestSegment::default();
+        let segments = TestDistributedSegment::default();
         let port = random_port::PortPicker::new().random(true).pick().unwrap();
 
         let mut server = WorkerServer {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Proptest count endpoint
 - New functionality
   - Implement a reference segment that can be used in prop tests

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
