### PR TITLE
[ENH]: put metadata update logic in shared helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,11 +1476,14 @@ dependencies = [
 name = "chroma-sqlite"
 version = "0.1.0"
 dependencies = [
+ "chroma-error",
+ "chroma-types",
  "md5",
  "pyo3",
  "regex",
  "rust-embed",
  "sea-query",
+ "sea-query-binder",
  "sha2",
  "sqlx",
  "tempfile",

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -127,7 +127,7 @@ impl Handler<CompactionMessage> for LocalCompactionManager {
             .apply_logs(
                 data_chunk.clone(),
                 collection_segments.vector_segment.id,
-                &mut tx,
+                &mut *tx,
             )
             .await
             .map_err(|_| CompactionManagerError::MetadataApplyLogsFailed)?;

--- a/rust/sqlite/Cargo.toml
+++ b/rust/sqlite/Cargo.toml
@@ -6,11 +6,14 @@ edition = "2021"
 [dependencies]
 md5 = { workspace = true }
 regex = { workspace = true }
-rust-embed = {version = "8.5.0", features = ["include-exclude"]}
+rust-embed = { version = "8.5.0", features = ["include-exclude"] }
 sea-query = { workspace = true, features = ["derive"] }
-sha2 = { workspace = true}
+sea-query-binder = { workspace = true, features = ["sqlx-sqlite"] }
+sha2 = { workspace = true }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
 pyo3 = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true}
+tokio = { workspace = true }
+chroma-error = { workspace = true, features = ["sqlx"] }
+chroma-types = { workspace = true }

--- a/rust/sqlite/src/helpers.rs
+++ b/rust/sqlite/src/helpers.rs
@@ -1,0 +1,166 @@
+use crate::table::MetadataTable;
+use chroma_error::{ChromaError, WrappedSqlxError};
+use chroma_types::{Metadata, MetadataValue, UpdateMetadata};
+use sea_query::{Expr, Iden, InsertStatement, OnConflict, SimpleExpr, SqliteQueryBuilder};
+use sea_query::{Nullable, Query};
+use sea_query_binder::SqlxBinder;
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MetadataError {
+    #[error("Error constructing query: {0}")]
+    QueryError(#[from] sea_query::error::Error),
+    #[error("Error executing query: {0}")]
+    SqlxError(#[from] WrappedSqlxError),
+}
+
+impl ChromaError for MetadataError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            MetadataError::QueryError(_) => chroma_error::ErrorCodes::Internal,
+            MetadataError::SqlxError(e) => e.code(),
+        }
+    }
+}
+
+fn construct_upsert_metadata_stmt<
+    Table: MetadataTable + Iden + 'static,
+    Id: Into<SimpleExpr> + Clone,
+>(
+    id: Id,
+    metadata: Metadata,
+) -> Result<InsertStatement, sea_query::error::Error> {
+    let mut stmt = Query::insert();
+    stmt.into_table(Table::table_name())
+        .columns([
+            Table::id_column(),
+            Table::key_column(),
+            Table::str_value_column(),
+            Table::int_value_column(),
+            Table::float_value_column(),
+            Table::bool_value_column(),
+        ])
+        .on_conflict(
+            OnConflict::columns([Table::id_column(), Table::key_column()])
+                .update_columns([
+                    Table::str_value_column(),
+                    Table::int_value_column(),
+                    Table::float_value_column(),
+                    Table::bool_value_column(),
+                ])
+                .to_owned(),
+        );
+    for (key, val) in metadata {
+        stmt.values(match val {
+            MetadataValue::Bool(b) => [
+                id.clone().into(),
+                key.into(),
+                String::null().into(),
+                i32::null().into(),
+                f32::null().into(),
+                b.into(),
+            ],
+            MetadataValue::Int(i) => [
+                id.clone().into(),
+                key.into(),
+                String::null().into(),
+                i.into(),
+                f32::null().into(),
+                bool::null().into(),
+            ],
+            MetadataValue::Float(f) => [
+                id.clone().into(),
+                key.into(),
+                String::null().into(),
+                i32::null().into(),
+                f.into(),
+                bool::null().into(),
+            ],
+            MetadataValue::Str(s) => [
+                id.clone().into(),
+                key.into(),
+                s.into(),
+                i32::null().into(),
+                f32::null().into(),
+                bool::null().into(),
+            ],
+        })?;
+    }
+    Ok(stmt)
+}
+
+pub async fn update_metadata<
+    Table: MetadataTable + Iden + 'static,
+    Id: Into<SimpleExpr> + Clone,
+    C,
+>(
+    conn: &mut C,
+    id: Id,
+    metadata: UpdateMetadata,
+) -> Result<(), MetadataError>
+where
+    for<'connection> &'connection mut C: sqlx::Executor<'connection, Database = sqlx::Sqlite>,
+{
+    let mut deleted_keys = Vec::new();
+    let mut metadata_not_null = HashMap::new();
+    for (key, value) in metadata {
+        match (&value).try_into() {
+            Ok(val) => {
+                metadata_not_null.insert(key, val);
+            }
+            Err(_) => deleted_keys.push(key),
+        }
+    }
+    if !deleted_keys.is_empty() {
+        let (sql, values) = Query::delete()
+            .from_table(Table::table_name())
+            .and_where(
+                Expr::col(Table::id_column())
+                    .eq(id.clone())
+                    .and(Expr::col(Table::key_column()).is_in(deleted_keys)),
+            )
+            .to_owned()
+            .build_sqlx(SqliteQueryBuilder);
+
+        sqlx::query_with(&sql, values)
+            .execute(&mut *conn)
+            .await
+            .map_err(WrappedSqlxError)?;
+    }
+    if !metadata_not_null.is_empty() {
+        let (sql, values) = construct_upsert_metadata_stmt::<Table, Id>(id, metadata_not_null)?
+            .build_sqlx(SqliteQueryBuilder);
+
+        sqlx::query_with(&sql, values)
+            .execute(conn)
+            .await
+            .map_err(WrappedSqlxError)?;
+    }
+    Ok(())
+}
+
+pub async fn delete_metadata<
+    Table: MetadataTable + Iden + 'static,
+    Id: Into<SimpleExpr> + Clone,
+    C,
+>(
+    conn: &mut C,
+    id: Id,
+) -> Result<(), MetadataError>
+where
+    for<'connection> &'connection mut C: sqlx::Executor<'connection, Database = sqlx::Sqlite>,
+{
+    let (sql, values) = Query::delete()
+        .from_table(Table::table_name())
+        .and_where(Expr::col(Table::id_column()).eq(id))
+        .to_owned()
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values)
+        .execute(conn)
+        .await
+        .map_err(WrappedSqlxError)?;
+
+    Ok(())
+}

--- a/rust/sqlite/src/lib.rs
+++ b/rust/sqlite/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod db;
+pub mod helpers;
 mod migrations;
 pub mod table;

--- a/rust/sqlite/src/table.rs
+++ b/rust/sqlite/src/table.rs
@@ -1,5 +1,15 @@
 use sea_query::Iden;
 
+pub trait MetadataTable {
+    fn table_name() -> Self;
+    fn id_column() -> Self;
+    fn key_column() -> Self;
+    fn str_value_column() -> Self;
+    fn int_value_column() -> Self;
+    fn float_value_column() -> Self;
+    fn bool_value_column() -> Self;
+}
+
 /// The table definitions here should match the table schema in sqlite
 #[derive(Iden)]
 pub enum Embeddings {
@@ -9,17 +19,6 @@ pub enum Embeddings {
     EmbeddingId,
     SeqId,
     CreatedAt,
-}
-
-#[derive(Iden)]
-pub enum EmbeddingMetadata {
-    Table,
-    Id,
-    Key,
-    StringValue,
-    IntValue,
-    FloatValue,
-    BoolValue,
 }
 
 #[derive(Iden)]
@@ -34,4 +33,104 @@ pub enum MaxSeqId {
     Table,
     SegmentId,
     SeqId,
+}
+
+#[derive(Iden)]
+pub enum Collections {
+    Table,
+    Id,
+    Name,
+    Dimension,
+    DatabaseId,
+    ConfigJsonStr,
+}
+
+#[derive(Iden)]
+pub enum Databases {
+    Table,
+    Id,
+    Name,
+    TenantId,
+}
+
+#[derive(Iden)]
+pub enum CollectionMetadata {
+    Table,
+    CollectionId,
+    Key,
+    StrValue,
+    IntValue,
+    FloatValue,
+    BoolValue,
+}
+
+impl MetadataTable for CollectionMetadata {
+    fn table_name() -> Self {
+        CollectionMetadata::Table
+    }
+
+    fn id_column() -> Self {
+        CollectionMetadata::CollectionId
+    }
+
+    fn key_column() -> Self {
+        CollectionMetadata::Key
+    }
+
+    fn str_value_column() -> Self {
+        CollectionMetadata::StrValue
+    }
+
+    fn int_value_column() -> Self {
+        CollectionMetadata::IntValue
+    }
+
+    fn float_value_column() -> Self {
+        CollectionMetadata::FloatValue
+    }
+
+    fn bool_value_column() -> Self {
+        CollectionMetadata::BoolValue
+    }
+}
+
+#[derive(Iden)]
+pub enum EmbeddingMetadata {
+    Table,
+    Id,
+    Key,
+    StringValue,
+    IntValue,
+    FloatValue,
+    BoolValue,
+}
+
+impl MetadataTable for EmbeddingMetadata {
+    fn table_name() -> Self {
+        EmbeddingMetadata::Table
+    }
+
+    fn id_column() -> Self {
+        EmbeddingMetadata::Id
+    }
+
+    fn key_column() -> Self {
+        EmbeddingMetadata::Key
+    }
+
+    fn str_value_column() -> Self {
+        EmbeddingMetadata::StringValue
+    }
+
+    fn int_value_column() -> Self {
+        EmbeddingMetadata::IntValue
+    }
+
+    fn float_value_column() -> Self {
+        EmbeddingMetadata::FloatValue
+    }
+
+    fn bool_value_column() -> Self {
+        EmbeddingMetadata::BoolValue
+    }
 }


### PR DESCRIPTION
## Description of changes

Extracts metadata update logic into shared helpers in `chroma-sqlite` crate so that the logic can be shared with the sysdb.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
