### PR TITLE
[ENH]  Add support to chroma-load for custom data sets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "chroma-types",
  "futures",
  "parking_lot",
+ "proptest",
  "roaring",
  "sea-query",
  "sea-query-binder",


### PR DESCRIPTION
I envision a new engineer coming into the company tasked with
benchmarkign some aspect of the system.  They create a workload
description for it and commit that code.  Then they come to the code
this PR touches and add an entry for their collection that references
one of the three reference collections.
