### PR TITLE
[TST] Proptest for get and count

### DIFF
--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -12,7 +12,8 @@ use chroma_types::{
     test_segment, BooleanOperator, Chunk, Collection, CollectionAndSegments, CompositeExpression,
     DocumentExpression, DocumentOperator, LogRecord, Metadata, MetadataComparison,
     MetadataExpression, MetadataSetValue, MetadataValue, Operation, OperationRecord,
-    PrimitiveOperator, Segment, SegmentScope, SegmentUuid, SetOperator, UpdateMetadata, Where,
+    PrimitiveOperator, Segment, SegmentScope, SegmentUuid, SetOperator, UpdateMetadata,
+    UpdateMetadataValue, Where, CHROMA_DOCUMENT_KEY,
 };
 use thiserror::Error;
 
@@ -183,12 +184,20 @@ impl TestReferenceSegment {
                     id,
                     embedding,
                     encoding: _,
-                    metadata,
+                    mut metadata,
                     document,
                     operation,
                 },
         } in logs
         {
+            if let Some(doc) = document.as_ref() {
+                let mut doc_embedded_meta = metadata.unwrap_or_default();
+                doc_embedded_meta.insert(
+                    CHROMA_DOCUMENT_KEY.to_string(),
+                    UpdateMetadataValue::Str(doc.clone()),
+                );
+                metadata = Some(doc_embedded_meta);
+            }
             let mut record = ProjectionRecord {
                 id: id.clone(),
                 document,

--- a/rust/types/src/execution/operator.rs
+++ b/rust/types/src/execution/operator.rs
@@ -333,13 +333,15 @@ impl From<Projection> for chroma_proto::ProjectionOperator {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ProjectionRecord {
     pub id: String,
     pub document: Option<String>,
     pub embedding: Option<Vec<f32>>,
     pub metadata: Option<Metadata>,
 }
+
+impl Eq for ProjectionRecord {}
 
 impl TryFrom<chroma_proto::ProjectionRecord> for ProjectionRecord {
     type Error = QueryConversionError;
@@ -380,7 +382,7 @@ impl TryFrom<ProjectionRecord> for chroma_proto::ProjectionRecord {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ProjectionOutput {
     pub records: Vec<ProjectionRecord>,
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Implement the logic to generate a vector of records for a collection
   - Fixed a bug in sqlite metadata impl that leads to wrong result order
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
