### PR TITLE
[ENH] Backfill segments from log

### DIFF
--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use chroma_log::{BackfillMessage, LocalCompactionManager};
 use chroma_segment::{
@@ -20,7 +23,7 @@ pub struct LocalExecutor {
     hnsw_manager: LocalSegmentManager,
     metadata_reader: SqliteMetadataReader,
     compactor_handle: ComponentHandle<LocalCompactionManager>,
-    backfill_status: HashMap<CollectionUuid, bool>,
+    backfilled_collections: Arc<parking_lot::Mutex<HashSet<CollectionUuid>>>,
 }
 
 impl LocalExecutor {
@@ -33,23 +36,32 @@ impl LocalExecutor {
             hnsw_manager,
             metadata_reader: SqliteMetadataReader::new(sqlite_db),
             compactor_handle,
-            backfill_status: HashMap::new(),
+            backfilled_collections: Arc::new(parking_lot::Mutex::new(HashSet::new())),
         }
     }
 }
 
 impl LocalExecutor {
     pub async fn count(&mut self, plan: Count) -> Result<CountResult, ExecutorError> {
+        self.try_backfill_collection(&plan.scan.collection_and_segments)
+            .await?;
         self.metadata_reader
             .count(plan)
             .await
             .map_err(|err| ExecutorError::Internal(Box::new(err)))
     }
 
-    pub async fn backfill_collection(
+    // If collection has already been backfilled, this function does nothing.
+    pub async fn try_backfill_collection(
         &mut self,
         collection_and_segment: &CollectionAndSegments,
     ) -> Result<(), ExecutorError> {
+        {
+            let backfill_guard = self.backfilled_collections.lock();
+            if backfill_guard.contains(&collection_and_segment.collection.collection_id) {
+                return Ok(());
+            }
+        }
         let backfill_msg = BackfillMessage {
             collection_and_segment: collection_and_segment.clone(),
         };
@@ -58,20 +70,15 @@ impl LocalExecutor {
             .await
             .map_err(|_| ExecutorError::BackfillError)?
             .map_err(|_| ExecutorError::BackfillError)?;
-        self.backfill_status
-            .insert(collection_and_segment.collection.collection_id, true);
+        let mut backfill_guard = self.backfilled_collections.lock();
+        backfill_guard.insert(collection_and_segment.collection.collection_id);
         Ok(())
     }
 
     pub async fn get(&mut self, plan: Get) -> Result<GetResult, ExecutorError> {
         let collection_and_segments = plan.scan.collection_and_segments.clone();
-        if self
-            .backfill_status
-            .get(&collection_and_segments.collection.collection_id)
-            .map_or(true, |&status| !status)
-        {
-            self.backfill_collection(&collection_and_segments).await?;
-        }
+        self.try_backfill_collection(&collection_and_segments)
+            .await?;
         let load_embedding = plan.proj.embedding;
         let mut result = self
             .metadata_reader
@@ -103,13 +110,8 @@ impl LocalExecutor {
 
     pub async fn knn(&mut self, plan: Knn) -> Result<KnnBatchResult, ExecutorError> {
         let collection_and_segments = plan.scan.collection_and_segments.clone();
-        if self
-            .backfill_status
-            .get(&collection_and_segments.collection.collection_id)
-            .map_or(true, |&status| !status)
-        {
-            self.backfill_collection(&collection_and_segments).await?;
-        }
+        self.try_backfill_collection(&collection_and_segments)
+            .await?;
         if let Some(dimensionality) = collection_and_segments.collection.dimension {
             let allowed_user_ids = if plan.filter.where_clause.is_none() {
                 plan.filter.query_ids.unwrap_or_default()

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -7,7 +7,7 @@ use chroma_types::{
     ScalarEncodingConversionError, UpdateMetadata, UpdateMetadataValue,
 };
 use futures::TryStreamExt;
-use sqlx::{Execute, QueryBuilder, Row};
+use sqlx::{QueryBuilder, Row};
 use std::{str::FromStr, sync::OnceLock};
 use thiserror::Error;
 

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -414,7 +414,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     async fn setup_sqlite_log() -> SqliteLog {
-        let path = tempdir().unwrap().into_path().join("test.db");
+        let path = tempdir().unwrap().into_path();
         let db = SqliteDb::try_from_config(&SqliteDBConfig {
             url: path.to_str().unwrap().to_string(),
             migration_mode: chroma_sqlite::config::MigrationMode::Apply,

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -7,7 +7,7 @@ use chroma_types::{
     ScalarEncodingConversionError, UpdateMetadata, UpdateMetadataValue,
 };
 use futures::TryStreamExt;
-use sqlx::{QueryBuilder, Row};
+use sqlx::{Execute, QueryBuilder, Row};
 use std::{str::FromStr, sync::OnceLock};
 use thiserror::Error;
 
@@ -129,8 +129,31 @@ impl SqliteLog {
 
         let end_timestamp_ns = end_timestamp_ns.unwrap_or(i64::MAX);
 
-        let mut logs = sqlx::query(
-            r#"
+        let mut logs;
+        if batch_size < 0 {
+            logs = sqlx::query(
+                r#"
+            SELECT
+              seq_id,
+              id,
+              operation,
+              vector,
+              encoding,
+              metadata
+            FROM embeddings_queue
+            WHERE topic = ?
+            AND seq_id > ?
+            AND CAST(strftime('%s', created_at) AS INTEGER) <= (? / 1000000000)
+            ORDER BY seq_id ASC
+            "#,
+            )
+            .bind(topic)
+            .bind(offset)
+            .bind(end_timestamp_ns)
+            .fetch(self.db.get_conn());
+        } else {
+            logs = sqlx::query(
+                r#"
             SELECT
               seq_id,
               id,
@@ -145,12 +168,13 @@ impl SqliteLog {
             ORDER BY seq_id ASC
             LIMIT ?
             "#,
-        )
-        .bind(topic)
-        .bind(offset)
-        .bind(end_timestamp_ns)
-        .bind(batch_size)
-        .fetch(self.db.get_conn());
+            )
+            .bind(topic)
+            .bind(offset)
+            .bind(end_timestamp_ns)
+            .bind(batch_size)
+            .fetch(self.db.get_conn());
+        }
 
         let mut records = Vec::new();
         while let Some(row) = logs.try_next().await.map_err(WrappedSqlxError)? {
@@ -235,7 +259,7 @@ impl SqliteLog {
             .await
             .map_err(WrappedSqlxError)?;
         let start_log_offset: i64 = row.get("max_seq_id");
-        let end_log_offset = start_log_offset + records.len() as i64;
+        let total_records = records.len() as i64;
 
         let topic = get_topic_name(&self.tenant_id, &self.topic_namespace, collection_id);
 
@@ -285,7 +309,7 @@ impl SqliteLog {
             let compact_message = CompactionMessage {
                 collection_id,
                 start_offset: start_log_offset,
-                end_offset: end_log_offset,
+                total_records,
             };
             handle.request(compact_message, None).await??;
         }

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -116,12 +116,9 @@ impl Bindings {
         )));
 
         // Spawn the compaction manager.
-        let metadata_writer = SqliteMetadataWriter {
-            db: sqlite_db.clone(),
-        };
         let handle = system.start_component(LocalCompactionManager::new(
             log.clone(),
-            metadata_writer,
+            sqlite_db.clone(),
             segment_manager.clone(),
             sysdb.clone(),
         ));
@@ -162,7 +159,11 @@ impl Bindings {
         // TODO: executor should NOT be exposed to the bindings module. try_from_config should work.
         // The reason this works this way right now is because try_from_config cannot share the sqlite_db
         // across the downstream components.
-        let executor = Executor::Local(LocalExecutor::new(segment_manager, sqlite_db));
+        let executor = Executor::Local(LocalExecutor::new(
+            segment_manager,
+            sqlite_db,
+            handle.clone(),
+        ));
         let frontend = Frontend::new(false, sysdb.clone(), collections_cache, log, executor);
 
         Ok(Bindings {

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -9,10 +9,7 @@ use chroma_frontend::{
     },
 };
 use chroma_log::{LocalCompactionManager, Log};
-use chroma_segment::{
-    local_segment_manager::{LocalSegmentManager, LocalSegmentManagerConfig},
-    sqlite_metadata::SqliteMetadataWriter,
-};
+use chroma_segment::local_segment_manager::{LocalSegmentManager, LocalSegmentManagerConfig};
 use chroma_sqlite::{config::SqliteDBConfig, db::SqliteDb};
 use chroma_sysdb::{sqlite::SqliteSysDb, sysdb::SysDb};
 use chroma_system::System;

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -5,7 +5,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::{HnswIndex, HnswIndexConfig, Index, IndexConfig, PersistentIndex};
 use chroma_sqlite::{db::SqliteDb, table::MaxSeqId};
 use chroma_types::{operator::RecordDistance, Chunk, LogRecord, Operation, Segment, SegmentUuid};
-use sea_query::{Expr, Func, Query, SqliteQueryBuilder};
+use sea_query::{Expr, Query, SqliteQueryBuilder};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use serde_pickle::{DeOptions, SerOptions};
@@ -148,7 +148,7 @@ impl LocalHnswSegmentReader {
     ) -> Result<u64, LocalHnswSegmentReaderError> {
         let guard = self.index.inner.read().await;
         let (sql, values) = Query::select()
-            .expr(Func::max(Expr::col(MaxSeqId::SeqId)))
+            .column(MaxSeqId::SeqId)
             .from(MaxSeqId::Table)
             .and_where(Expr::col(MaxSeqId::SegmentId).eq(segment_id.to_string()))
             .build_sqlx(SqliteQueryBuilder);
@@ -158,7 +158,7 @@ impl LocalHnswSegmentReader {
         Ok(row_opt
             .map(|row| row.try_get::<u64, _>(0))
             .transpose()?
-            .unwrap_or(0))
+            .unwrap_or_default())
     }
 
     pub async fn get_embedding_by_user_id(

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -4,11 +4,12 @@ use chroma_cache::Weighted;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::{HnswIndex, HnswIndexConfig, Index, IndexConfig, PersistentIndex};
 use chroma_sqlite::{db::SqliteDb, table::MaxSeqId};
-use chroma_types::{operator::RecordDistance, Chunk, LogRecord, Operation, Segment};
-use sea_query::{Query, SqliteQueryBuilder};
+use chroma_types::{operator::RecordDistance, Chunk, LogRecord, Operation, Segment, SegmentUuid};
+use sea_query::{Expr, Func, Query, SqliteQueryBuilder};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use serde_pickle::{DeOptions, SerOptions};
+use sqlx::Row;
 use thiserror::Error;
 
 use crate::utils::{
@@ -44,6 +45,8 @@ pub enum LocalHnswSegmentReaderError {
     GetEmbeddingError,
     #[error("Error querying knn")]
     QueryError,
+    #[error("Error reading from sqlite")]
+    SqliteError(#[from] sqlx::error::Error),
 }
 
 impl ChromaError for LocalHnswSegmentReaderError {
@@ -58,6 +61,7 @@ impl ChromaError for LocalHnswSegmentReaderError {
             LocalHnswSegmentReaderError::IdNotFound => ErrorCodes::Internal,
             LocalHnswSegmentReaderError::GetEmbeddingError => ErrorCodes::Internal,
             LocalHnswSegmentReaderError::QueryError => ErrorCodes::Internal,
+            LocalHnswSegmentReaderError::SqliteError(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -67,7 +71,6 @@ impl LocalHnswSegmentReader {
         Self { index: hnsw_index }
     }
 
-    #[allow(dead_code)]
     pub async fn from_segment(
         segment: &Segment,
         dimensionality: usize,
@@ -137,6 +140,25 @@ impl LocalHnswSegmentReader {
             .get(offset_id as usize)
             .map_err(|_| LocalHnswSegmentReaderError::GetEmbeddingError)?
             .ok_or(LocalHnswSegmentReaderError::GetEmbeddingError)
+    }
+
+    pub async fn current_max_seq_id(
+        &self,
+        segment_id: &SegmentUuid,
+    ) -> Result<u64, LocalHnswSegmentReaderError> {
+        let guard = self.index.inner.read().await;
+        let (sql, values) = Query::select()
+            .expr(Func::max(Expr::col(MaxSeqId::SeqId)))
+            .from(MaxSeqId::Table)
+            .and_where(Expr::col(MaxSeqId::SegmentId).eq(segment_id.to_string()))
+            .build_sqlx(SqliteQueryBuilder);
+        let row_opt = sqlx::query_with(&sql, values)
+            .fetch_optional(guard.sqlite.get_conn())
+            .await?;
+        Ok(row_opt
+            .map(|row| row.try_get::<u64, _>(0))
+            .transpose()?
+            .unwrap_or(0))
     }
 
     pub async fn get_embedding_by_user_id(
@@ -530,7 +552,6 @@ impl LocalHnswSegmentWriter {
     }
 }
 
-#[allow(dead_code)]
 async fn persist(
     guard: tokio::sync::RwLockWriteGuard<'_, Inner>,
 ) -> Result<tokio::sync::RwLockWriteGuard<'_, Inner>, LocalHnswSegmentWriterError> {

--- a/rust/segment/src/local_segment_manager.rs
+++ b/rust/segment/src/local_segment_manager.rs
@@ -103,7 +103,6 @@ impl LocalSegmentManager {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn get_hnsw_writer(
         &self,
         segment: &Segment,

--- a/rust/segment/src/local_segment_manager.rs
+++ b/rust/segment/src/local_segment_manager.rs
@@ -123,6 +123,7 @@ impl LocalSegmentManager {
                 .await?;
                 // Open the FDs.
                 writer.index.start().await;
+                // Backfill.
                 self.hnsw_index_pool
                     .insert(index_uuid, writer.index.clone())
                     .await;

--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -499,7 +499,7 @@ impl SqliteMetadataReader {
         segment_id: &SegmentUuid,
     ) -> Result<u64, SqliteMetadataError> {
         let (sql, values) = Query::select()
-            .expr(Func::max(Expr::col(MaxSeqId::SeqId)))
+            .column(MaxSeqId::SeqId)
             .from(MaxSeqId::Table)
             .and_where(Expr::col(MaxSeqId::SegmentId).eq(segment_id.to_string()))
             .build_sqlx(SqliteQueryBuilder);
@@ -509,7 +509,7 @@ impl SqliteMetadataReader {
         Ok(row_opt
             .map(|row| row.try_get::<u64, _>(0))
             .transpose()?
-            .unwrap_or(0))
+            .unwrap_or_default())
     }
 
     pub async fn count(

--- a/rust/sqlite/src/db.rs
+++ b/rust/sqlite/src/db.rs
@@ -263,7 +263,7 @@ pub mod test_utils {
     }
 
     pub fn new_test_db_path() -> String {
-        let path = tempdir().unwrap().into_path().join("test.db");
+        let path = tempdir().unwrap().into_path();
         path.to_str().unwrap().to_string()
     }
 

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1301,6 +1301,8 @@ pub enum ExecutorError {
     Internal(Box<dyn ChromaError>),
     #[error("No client found for node: {0}")]
     NoClientFound(String),
+    #[error("Error sending backfill request to compactor")]
+    BackfillError,
 }
 
 impl ChromaError for ExecutorError {
@@ -1313,6 +1315,7 @@ impl ChromaError for ExecutorError {
             ExecutorError::InconsistentData => ErrorCodes::Internal,
             ExecutorError::Internal(e) => e.code(),
             ExecutorError::NoClientFound(_) => ErrorCodes::Internal,
+            ExecutorError::BackfillError => ErrorCodes::Internal,
         }
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds the backfill logic in get() and query() path
   - executor keeps an in-memory hash map of backfill status for optimization
   - if need to backfill it sends a request to compaction manager to backfill
   - compaction manager backfills by fetching logs and max seq ids for both the segments
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
