### PR TITLE
[ENH] Log gc

### DIFF
--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -104,4 +104,20 @@ impl Log {
             }
         }
     }
+
+    // Only supported in sqlite. Distributed has a different workflow.
+    pub async fn purge_logs(
+        &mut self,
+        collection_id: CollectionUuid,
+        seq_id: u64,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        match self {
+            Log::Sqlite(log) => log
+                .purge_logs(collection_id, seq_id)
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
+            Log::Grpc(_) => unimplemented!(),
+            Log::InMemory(_) => unimplemented!(),
+        }
+    }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - On push logs, log service sends an async msg to compactor to purge logs
   - compactor queries the max seq id of the segments
   - It then sends a purge request to the log with the min of the two seq ids
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
