### PR TITLE
[ENH]  Plumb MAX_CONNS in from the environment for go pgxpool.

### DIFF
--- a/go/pkg/log/configuration/config.go
+++ b/go/pkg/log/configuration/config.go
@@ -1,12 +1,19 @@
 package configuration
 
-import "os"
+import (
+	"os"
+	"strconv"
+
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+)
 
 type LogServiceConfiguration struct {
 	PORT                  string
 	DATABASE_URL          string
 	OPTL_TRACING_ENDPOINT string
 	SYSDB_CONN            string
+	MAX_CONNS             int32
 }
 
 func getEnvWithDefault(key, defaultValue string) string {
@@ -17,11 +24,25 @@ func getEnvWithDefault(key, defaultValue string) string {
 	return value
 }
 
+func getEnvWithDefaultInt(key string, defaultValue int32) int32 {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	i, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		log.Error("cannot parse from env", zap.String("key", key), zap.Error(err))
+		return defaultValue
+	}
+	return int32(i)
+}
+
 func NewLogServiceConfiguration() *LogServiceConfiguration {
 	return &LogServiceConfiguration{
 		PORT:                  getEnvWithDefault("PORT", "50051"),
 		DATABASE_URL:          getEnvWithDefault("CHROMA_DATABASE_URL", "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log"),
 		OPTL_TRACING_ENDPOINT: getEnvWithDefault("OPTL_TRACING_ENDPOINT", "jaeger:4317"),
 		SYSDB_CONN:            getEnvWithDefault("SYSDB_CONN", "sysdb"),
+		MAX_CONNS:             getEnvWithDefaultInt("MAX_CONNS", 100),
 	}
 }

--- a/go/shared/libs/db_utils.go
+++ b/go/shared/libs/db_utils.go
@@ -8,6 +8,12 @@ import (
 )
 
 func NewPgConnection(ctx context.Context, config *configuration.LogServiceConfiguration) (conn *pgxpool.Pool, err error) {
-	conn, err = pgxpool.New(ctx, config.DATABASE_URL)
+	var conf *pgxpool.Config
+	conf, err = pgxpool.ParseConfig(config.DATABASE_URL)
+	if err != nil {
+	    return
+	}
+	conf.MaxConns = config.MAX_CONNS
+	conn, err = pgxpool.NewWithConfig(ctx, conf)
 	return
 }


### PR DESCRIPTION
This enables us to configure the connection pool size for every go
service.  It reads the MAX_CONNS environment variable and applies that
if and only if it parses as an integer.  I opted to fall back to a
reasonable default rather than error.
