### PR TITLE
[ENH]: hook up database and tenant methods to Rust bindings

### DIFF
--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -31,6 +31,7 @@ if platform.system() != "Windows":
 elif platform.system() == "Windows":
     import ctypes
 
+
 # RustBindingsAPI is an implementation of ServerAPI which shims
 # the Rust bindings to the Python API, providing a full implementation
 # of the API. It could be that bindings was a direct implementation of
@@ -84,10 +85,9 @@ class RustBindingsAPI(ServerAPI):
 
         # Construct the Rust bindings
         self.bindings = rust_bindings.Bindings(
-            proxy_frontend=self.proxy_segment_api,
             sqlite_db_config=sqlite_config,
             persist_path=persist_path,
-            hnsw_cache_size=hnsw_cache_size
+            hnsw_cache_size=hnsw_cache_size,
         )
 
     # ////////////////////////////// Admin API //////////////////////////////
@@ -98,7 +98,12 @@ class RustBindingsAPI(ServerAPI):
 
     @override
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
-        return self.bindings.get_database(name, tenant)
+        database = self.bindings.get_database(name, tenant)
+        return {
+            "id": database.id,
+            "name": database.name,
+            "tenant": database.tenant,
+        }
 
     @override
     def delete_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
@@ -111,7 +116,15 @@ class RustBindingsAPI(ServerAPI):
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
     ) -> Sequence[Database]:
-        return self.bindings.list_databases(limit, offset, tenant)
+        databases = self.bindings.list_databases(limit, offset, tenant)
+        return [
+            {
+                "id": database.id,
+                "name": database.name,
+                "tenant": database.tenant,
+            }
+            for database in databases
+        ]
 
     @override
     def create_tenant(self, name: str) -> None:

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -22,7 +22,7 @@ from chromadb.types import Collection as CollectionModel
 from chromadb import __version__
 from chromadb.errors import (
     InvalidDimensionException,
-    InvalidCollectionException,
+    NotFoundError,
     VersionMismatchError,
 )
 from chromadb.api.types import (
@@ -313,7 +313,7 @@ class SegmentAPI(ServerAPI):
         if existing:
             return existing[0]
         else:
-            raise InvalidCollectionException(f"Collection {name} does not exist.")
+            raise NotFoundError(f"Collection {name} does not exist.")
 
     @trace_method("SegmentAPI.list_collection", OpenTelemetryGranularity.OPERATION)
     @override
@@ -906,9 +906,7 @@ class SegmentAPI(ServerAPI):
     def _get_collection(self, collection_id: UUID) -> t.Collection:
         collections = self._sysdb.get_collections(id=collection_id)
         if not collections or len(collections) == 0:
-            raise InvalidCollectionException(
-                f"Collection {collection_id} does not exist."
-            )
+            raise NotFoundError(f"Collection {collection_id} does not exist.")
         return collections[0]
 
     @trace_method("SegmentAPI._scan", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -17,7 +17,6 @@ from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, System
 from chromadb.db.base import Cursor, SqlDB, ParameterValue, get_sql
 from chromadb.db.system import SysDB
 from chromadb.errors import (
-    InvalidCollectionException,
     NotFoundError,
     UniqueConstraintError,
 )
@@ -559,9 +558,7 @@ class SqlSysDB(SqlDB, SysDB):
     ) -> CollectionAndSegments:
         collections = self.get_collections(id=collection_id)
         if len(collections) == 0:
-            raise InvalidCollectionException(
-                f"Collection {collection_id} does not exist."
-            )
+            raise NotFoundError(f"Collection {collection_id} does not exist.")
         return CollectionAndSegments(
             collection=collections[0],
             segments=self.get_segments(collection=collection_id),

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -27,13 +27,6 @@ class InvalidDimensionException(ChromaError):
         return "InvalidDimension"
 
 
-class InvalidCollectionException(ChromaError):
-    @classmethod
-    @overrides
-    def name(cls) -> str:
-        return "InvalidCollection"
-
-
 class IDAlreadyExistsError(ChromaError):
     @overrides
     def code(self) -> int:
@@ -183,7 +176,6 @@ class QuotaError(ChromaError):
 error_types: Dict[str, Type[ChromaError]] = {
     "InvalidDimension": InvalidDimensionException,
     "InvalidArgumentError": InvalidArgumentError,
-    "InvalidCollection": InvalidCollectionException,
     "IDAlreadyExists": IDAlreadyExistsError,
     "DuplicateID": DuplicateIDError,
     "InvalidUUID": InvalidUUIDError,

--- a/chromadb/test/api/test_delete_database.py
+++ b/chromadb/test/api/test_delete_database.py
@@ -2,8 +2,8 @@ import pytest
 from chromadb.api.client import AdminClient, Client
 from chromadb.config import System
 from chromadb.db.impl.sqlite import SqliteDB
-from chromadb.errors import InvalidCollectionException, NotFoundError
-from chromadb.test.conftest import NOT_CLUSTER_ONLY, ClientFactories
+from chromadb.errors import NotFoundError
+from chromadb.test.conftest import ClientFactories
 
 
 def test_deletes_database(client_factories: ClientFactories) -> None:
@@ -22,10 +22,10 @@ def test_deletes_database(client_factories: ClientFactories) -> None:
     with pytest.raises(NotFoundError):
         admin_client.get_database("test_delete_database")
 
-    with pytest.raises(InvalidCollectionException):
+    with pytest.raises(NotFoundError):
         client.get_collection("foo")
 
-    with pytest.raises(InvalidCollectionException):
+    with pytest.raises(NotFoundError):
         collection.upsert(["foo"], [0.0, 0.0, 0.0])
 
 
@@ -48,7 +48,7 @@ def test_does_not_affect_other_databases(client_factories: ClientFactories) -> N
 
     assert second_client.get_collection("test").id == second_collection.id
 
-    with pytest.raises(InvalidCollectionException):
+    with pytest.raises(NotFoundError):
         first_client.get_collection("test")
 
 
@@ -63,7 +63,7 @@ def test_collection_was_removed(sqlite_persistent: System) -> None:
 
     admin_client.delete_database("test_delete_database")
 
-    with pytest.raises(InvalidCollectionException):
+    with pytest.raises(NotFoundError):
         client.get_collection("foo")
 
     # Check table

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -7,7 +7,7 @@ from chromadb.errors import ChromaError
 from chromadb.api.fastapi import FastAPI
 from chromadb.api.types import QueryResult, EmbeddingFunction, Document
 from chromadb.config import Settings
-from chromadb.errors import InvalidCollectionException
+from chromadb.errors import NotFoundError
 import chromadb.server.fastapi
 import pytest
 import tempfile
@@ -230,9 +230,7 @@ def test_collection_add_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.add(**batch_records)
 
 
@@ -289,9 +287,7 @@ def test_collection_get_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.get()
 
 
@@ -361,12 +357,14 @@ def test_delete(client):
     with pytest.raises(Exception):
         collection.delete()
 
+
 def test_delete_returns_none(client):
     client.reset()
     collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
     assert collection.delete(ids=batch_records["ids"]) is None
+
 
 def test_delete_with_index(client):
     client.reset()
@@ -381,9 +379,7 @@ def test_collection_delete_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.delete(ids=["id1"])
 
 
@@ -400,9 +396,7 @@ def test_collection_count_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.count()
 
 
@@ -420,9 +414,7 @@ def test_collection_modify_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.modify(name="test2")
 
 
@@ -585,9 +577,7 @@ def test_collection_peek_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.peek()
 
 
@@ -596,9 +586,7 @@ def test_collection_query_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.query(query_texts=["test"])
 
 
@@ -607,9 +595,7 @@ def test_collection_update_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.update(ids=["id1"], documents=["test"])
 
 
@@ -1531,9 +1517,7 @@ def test_collection_upsert_with_invalid_collection_throws(client):
     collection = client.create_collection("test")
     client.delete_collection("test")
 
-    with pytest.raises(
-        InvalidCollectionException, match=r"Collection .* does not exist."
-    ):
+    with pytest.raises(NotFoundError, match=r"Collection .* does not exist."):
         collection.upsert(**initial_records)
 
 

--- a/rust/python_bindings/rust_bindings.pyi
+++ b/rust/python_bindings/rust_bindings.pyi
@@ -1,8 +1,7 @@
-from typing import Any, List, Optional, Sequence
+from typing import List, Optional, Sequence
 from uuid import UUID
 from chromadb import CollectionMetadata, Embeddings, IDs
 from chromadb.api.configuration import CollectionConfigurationInternal
-from chromadb.api.segment import SegmentAPI
 from chromadb.api.types import (
     CollectionMetadata,
     Documents,
@@ -12,9 +11,14 @@ from chromadb.api.types import (
     URIs,
     Include,
 )
-from chromadb.types import Database, Tenant, Collection as CollectionModel
+from chromadb.types import Tenant, Collection as CollectionModel
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT
 from enum import Enum
+
+class DatabaseFromBindings:
+    id: UUID
+    name: str
+    tenant: str
 
 # Result Types
 
@@ -56,21 +60,22 @@ class SqliteDBConfig:
 class Bindings:
     def __init__(
         self,
-        proxy_frontend: SegmentAPI,
         sqlite_db_config: SqliteDBConfig,
         persist_path: str,
         hnsw_cache_size: int,
     ) -> None: ...
     def heartbeat(self) -> int: ...
     def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None: ...
-    def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database: ...
+    def get_database(
+        self, name: str, tenant: str = DEFAULT_TENANT
+    ) -> DatabaseFromBindings: ...
     def delete_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None: ...
     def list_databases(
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
-    ) -> Sequence[Database]: ...
+    ) -> Sequence[DatabaseFromBindings]: ...
     def create_tenant(self, name: str) -> None: ...
     def get_tenant(self, name: str) -> Tenant: ...
     def create_collection(

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -172,6 +172,7 @@ impl GetTenantRequest {
 }
 
 #[derive(Serialize)]
+#[pyclass]
 pub struct GetTenantResponse {
     pub name: String,
 }


### PR DESCRIPTION
## Description of changes

Plumbs through database and tenant methods to Rust SQLite Python bindings. Removes the `InvalidCollectionException` Python exception and replaces with `NotFound` since we can't map to it from a Rust error code.