### PR TITLE
[BUG] Check both int and float value for numerical filter

### DIFF
--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -29,6 +29,8 @@ frontendService:
   logServiceHost: 'value: "logservice.chroma"'
   logServicePort: 'value: "50051"'
   otherEnvConfig: |
+    - name: CHROMA_ALLOW_RESET
+      value: "true"
     - name: CHROMA_OTEL_COLLECTION_ENDPOINT
       value: "http://jaeger:4317"
     - name: CHROMA_OTEL_GRANULARITY

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -1,4 +1,3 @@
-allow_reset: true
 service_name: "rust-frontend-service"
 otel_endpoint: "http://otel-collector:4317"
 sysdb:

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -91,7 +91,7 @@ impl ChromaError for CompactionManagerError {
             CompactionManagerError::MetadataApplyLogsFailed => ErrorCodes::Internal,
             CompactionManagerError::GetHnswWriterFailed => ErrorCodes::Internal,
             CompactionManagerError::HnswApplyLogsError => ErrorCodes::Internal,
-            CompactionManagerError::GetCollectionWithSegmentsError(_) => ErrorCodes::Internal,
+            CompactionManagerError::GetCollectionWithSegmentsError(e) => e.code(),
             CompactionManagerError::MetadataReaderError(e) => e.code(),
             CompactionManagerError::HnswReaderError(e) => e.code(),
             CompactionManagerError::HnswReaderConstructionError(e) => e.code(),

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -456,16 +456,15 @@ impl Bindings {
             .into());
         }
 
-        let mut frontend_clone = self.frontend.clone();
-
         let collection_id = chroma_types::CollectionUuid(
             uuid::Uuid::parse_str(&collection_id).map_err(WrappedUuidError)?,
         );
 
+        let mut frontend_clone = self.frontend.clone();
         self.runtime.block_on(async {
             frontend_clone
-                .validate_embedding(collection_id, embeddings.as_ref(), false, |e| {
-                    e.as_ref().map(|e| e.len())
+                .validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
+                    embedding.as_ref().map(|emb| emb.len())
                 })
                 .await
         })?;
@@ -512,15 +511,16 @@ impl Bindings {
             .into());
         }
 
-        let mut frontend_clone = self.frontend.clone();
-
         let collection_id = chroma_types::CollectionUuid(
             uuid::Uuid::parse_str(&collection_id).map_err(WrappedUuidError)?,
         );
 
+        let mut frontend_clone = self.frontend.clone();
         self.runtime.block_on(async {
             frontend_clone
-                .validate_embedding(collection_id, embeddings.as_ref(), false, |e| Some(e.len()))
+                .validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
+                    Some(embedding.len())
+                })
                 .await
         })?;
 
@@ -675,6 +675,15 @@ impl Bindings {
         );
 
         let include = IncludeList::try_from(include)?;
+
+        let mut frontend_clone = self.frontend.clone();
+        self.runtime.block_on(async {
+            frontend_clone
+                .validate_embedding(collection_id, Some(&query_embeddings), true, |embedding| {
+                    Some(embedding.len())
+                })
+                .await
+        })?;
 
         let request = chroma_types::QueryRequest::try_new(
             tenant,

--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -401,7 +401,10 @@ impl IntoSqliteExpr for Where {
                                 MetadataValue::Float(*i as f64),
                             ),
                         };
-                        expr.eval().or(alt.eval())
+                        match op {
+                            PrimitiveOperator::NotEqual => expr.eval().and(alt.eval()),
+                            _ => expr.eval().or(alt.eval()),
+                        }
                     }
                     MetadataComparison::Primitive(op, MetadataValue::Float(f)) => {
                         let alt = MetadataExpression {
@@ -411,7 +414,10 @@ impl IntoSqliteExpr for Where {
                                 MetadataValue::Int(*f as i64),
                             ),
                         };
-                        expr.eval().or(alt.eval())
+                        match op {
+                            PrimitiveOperator::NotEqual => expr.eval().and(alt.eval()),
+                            _ => expr.eval().or(alt.eval()),
+                        }
                     }
                     MetadataComparison::Set(op, MetadataSetValue::Int(is)) => {
                         let alt = MetadataExpression {
@@ -423,7 +429,10 @@ impl IntoSqliteExpr for Where {
                                 ),
                             ),
                         };
-                        expr.eval().or(alt.eval())
+                        match op {
+                            SetOperator::In => expr.eval().or(alt.eval()),
+                            SetOperator::NotIn => expr.eval().and(alt.eval()),
+                        }
                     }
                     MetadataComparison::Set(op, MetadataSetValue::Float(fs)) => {
                         let alt = MetadataExpression {
@@ -435,7 +444,10 @@ impl IntoSqliteExpr for Where {
                                 ),
                             ),
                         };
-                        expr.eval().or(alt.eval())
+                        match op {
+                            SetOperator::In => expr.eval().or(alt.eval()),
+                            SetOperator::NotIn => expr.eval().and(alt.eval()),
+                        }
                     }
                     _ => expr.eval(),
                 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Numerical where filter should check both int and float value
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
