### PR TITLE
[CLN] Deprecate v1 api

### DIFF
--- a/rust/frontend/src/bin/frontend_service.rs
+++ b/rust/frontend/src/bin/frontend_service.rs
@@ -2,6 +2,5 @@ use chroma_frontend::frontend_service_entrypoint;
 
 #[tokio::main]
 async fn main() {
-    // TODO(hammadb): Implement the frontend service entrypoint
     frontend_service_entrypoint().await;
 }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -41,10 +41,10 @@ pub async fn frontend_service_entrypoint() {
     };
     chroma_tracing::init_otel_tracing(&config.service_name, &config.otel_endpoint);
     let system = System::new();
-    // TODO: Initialize tracing.
+
     let frontend = Frontend::try_from_config(&(config.clone(), system))
         .await
-        .expect("Error creating SegmentApi from config");
+        .expect("Error creating Frontend Config");
     fn rule_to_rule(rule: &ScorecardRule) -> Result<Rule, ScorecardRuleError> {
         let patterns = rule
             .patterns

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -53,9 +53,15 @@ impl<E: ChromaError + 'static> From<E> for ServerError {
 }
 
 #[derive(Serialize)]
-struct ErrorResponse {
+pub struct ErrorResponse {
     error: String,
     message: String,
+}
+
+impl ErrorResponse {
+    pub fn new(error: String, message: String) -> Self {
+        Self { error, message }
+    }
 }
 
 impl IntoResponse for ServerError {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Return 410 GONE on v1 apis
 - New functionality
   - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None