### PR TITLE
[DOC] Add client for R to the documentation

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/overview/introduction.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/overview/introduction.md
@@ -84,6 +84,7 @@ Continue with the full [getting started guide](./getting-started).
 | PHP           | [from @CodeWithKyrian](https://github.com/CodeWithKyrian/chromadb-php)                                                   |
 | PHP (Laravel) | [from @HelgeSverre](https://github.com/helgeSverre/chromadb)                                                             |
 | Clojure       | [from @levand](https://github.com/levand/clojure-chroma-client)                                                          |
+| R             | [from @cynkra](https://cynkra.github.io/rchroma/)                                                                       |
 
 
 {% br %}{% /br %}


### PR DESCRIPTION
@schochastics and I have written a ChromaDB client for R that covers all endpoints in the API.

- It can be downloaded from GitHub: https://github.com/cynkra/rchroma 
- It has a documentation website as well (linked in the PR): https://cynkra.github.io/rchroma/

We will bring it to CRAN in the next few days.

## Description of changes

- Adds a new line to the table in the documentation

## Test plan

- No tests needed

## Documentation Changes

- This is a pure documentation change

