### PR TITLE
[ENH] Use registry everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "async-trait",
  "chroma-error",
  "murmur3",
+ "parking_lot",
  "serde",
  "thiserror 1.0.69",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,6 +1266,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chroma-error",
+ "figment",
  "murmur3",
  "parking_lot",
  "serde",
@@ -1482,6 +1483,8 @@ dependencies = [
 name = "chroma-sqlite"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "chroma-config",
  "chroma-error",
  "chroma-types",
  "futures",
@@ -1491,6 +1494,7 @@ dependencies = [
  "rust-embed",
  "sea-query",
  "sea-query-binder",
+ "serde",
  "sha2",
  "sqlx",
  "tempfile",
@@ -5518,6 +5522,7 @@ dependencies = [
  "chroma-sysdb",
  "chroma-system",
  "chroma-types",
+ "mdac",
  "numpy",
  "pyo3",
  "serde",

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use chroma_cache::{CacheError, PersistentCache};
-use chroma_config::Configurable;
+use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -181,6 +181,7 @@ impl ArrowBlockfileProvider {
 impl Configurable<(ArrowBlockfileProviderConfig, Storage)> for ArrowBlockfileProvider {
     async fn try_from_config(
         config: &(ArrowBlockfileProviderConfig, Storage),
+        _registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (blockfile_config, storage) = config;
         let block_cache = match chroma_cache::from_config_persistent(

--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -14,6 +14,7 @@ use super::types::BlockfileWriter;
 use super::{BlockfileReader, Key, Value};
 use async_trait::async_trait;
 use chroma_cache::PersistentCache;
+use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
@@ -117,15 +118,16 @@ impl BlockfileProvider {
 impl Configurable<(BlockfileProviderConfig, Storage)> for BlockfileProvider {
     async fn try_from_config(
         config: &(BlockfileProviderConfig, Storage),
+        registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (blockfile_config, storage) = config;
         match blockfile_config {
             BlockfileProviderConfig::Arrow(blockfile_config) => {
                 Ok(BlockfileProvider::ArrowBlockfileProvider(
-                    ArrowBlockfileProvider::try_from_config(&(
-                        *blockfile_config.clone(),
-                        storage.clone(),
-                    ))
+                    ArrowBlockfileProvider::try_from_config(
+                        &(*blockfile_config.clone(), storage.clone()),
+                        registry,
+                    )
                     .await?,
                 ))
             }

--- a/rust/config/Cargo.toml
+++ b/rust/config/Cargo.toml
@@ -13,5 +13,6 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
+figment = { workspace = true }
 
 chroma-error = { workspace = true }

--- a/rust/config/Cargo.toml
+++ b/rust/config/Cargo.toml
@@ -12,5 +12,6 @@ murmur3 = "0.5.2"
 async-trait = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+parking_lot = { workspace = true }
 
 chroma-error = { workspace = true }

--- a/rust/config/src/assignment/assignment_policy.rs
+++ b/rust/config/src/assignment/assignment_policy.rs
@@ -2,7 +2,7 @@ use super::{
     config::{AssignmentPolicyConfig, HasherType},
     rendezvous_hash::{AssignmentError, Hasher, Murmur3Hasher},
 };
-use crate::Configurable;
+use crate::{registry::Registry, Configurable};
 use async_trait::async_trait;
 use chroma_error::ChromaError;
 use std::fmt::Debug;
@@ -71,6 +71,7 @@ impl Default for RendezvousHashingAssignmentPolicy {
 impl Configurable<AssignmentPolicyConfig> for RendezvousHashingAssignmentPolicy {
     async fn try_from_config(
         config: &AssignmentPolicyConfig,
+        _registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let AssignmentPolicyConfig::RendezvousHashing(assignment_policy_config) = config;
         let hasher = match assignment_policy_config.hasher {

--- a/rust/config/src/assignment/mod.rs
+++ b/rust/config/src/assignment/mod.rs
@@ -1,17 +1,27 @@
 pub mod assignment_policy;
 pub mod config;
 pub mod rendezvous_hash;
-use crate::Configurable;
+use crate::{registry::Registry, Configurable};
 
 use self::{assignment_policy::AssignmentPolicy, config::AssignmentPolicyConfig};
+use async_trait::async_trait;
 use chroma_error::ChromaError;
 
-pub async fn from_config(
-    config: &AssignmentPolicyConfig,
-) -> Result<Box<dyn AssignmentPolicy>, Box<dyn ChromaError>> {
-    match &config {
-        crate::assignment::config::AssignmentPolicyConfig::RendezvousHashing(_) => Ok(Box::new(
-            assignment_policy::RendezvousHashingAssignmentPolicy::try_from_config(config).await?,
-        )),
+#[async_trait]
+impl Configurable<AssignmentPolicyConfig> for Box<dyn AssignmentPolicy> {
+    async fn try_from_config(
+        config: &AssignmentPolicyConfig,
+        registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        match &config {
+            crate::assignment::config::AssignmentPolicyConfig::RendezvousHashing(_) => {
+                Ok(Box::new(
+                    assignment_policy::RendezvousHashingAssignmentPolicy::try_from_config(
+                        config, registry,
+                    )
+                    .await?,
+                ))
+            }
+        }
     }
 }

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod assignment;
+pub mod registry;
 
 use async_trait::async_trait;
 use chroma_error::ChromaError;
@@ -10,7 +11,7 @@ use chroma_error::ChromaError;
 /// Components that need to be configured from the config object should implement this trait.
 #[async_trait]
 pub trait Configurable<T> {
-    async fn try_from_config(worker_config: &T) -> Result<Self, Box<dyn ChromaError>>
+    async fn try_from_config(config: &T) -> Result<Self, Box<dyn ChromaError>>
     where
         Self: Sized;
 }

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -3,6 +3,8 @@ pub mod registry;
 
 use async_trait::async_trait;
 use chroma_error::ChromaError;
+use registry::Registry;
+use thiserror::Error;
 
 /// # Description
 /// A trait for configuring a struct from a config object.
@@ -11,7 +13,19 @@ use chroma_error::ChromaError;
 /// Components that need to be configured from the config object should implement this trait.
 #[async_trait]
 pub trait Configurable<T> {
-    async fn try_from_config(config: &T) -> Result<Self, Box<dyn ChromaError>>
+    async fn try_from_config(config: &T, registry: &Registry) -> Result<Self, Box<dyn ChromaError>>
     where
         Self: Sized;
+}
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("Config error: {0}")]
+    ConfigError(#[from] figment::Error),
+}
+
+impl ChromaError for ConfigError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        chroma_error::ErrorCodes::Internal
+    }
 }

--- a/rust/config/src/registry.rs
+++ b/rust/config/src/registry.rs
@@ -1,7 +1,7 @@
 use chroma_error::ChromaError;
 use parking_lot::Mutex;
 use std::{
-    any::{Any, TypeId},
+    any::{type_name, Any, TypeId},
     collections::HashMap,
     sync::Arc,
 };
@@ -23,8 +23,8 @@ pub struct Registry {
 
 #[derive(Debug, Error)]
 pub enum RegistryError {
-    #[error("Type not found in the registry")]
-    TypeNotFound,
+    #[error("Type [{0}] not found in the registry")]
+    TypeNotFound(String),
 }
 
 impl ChromaError for RegistryError {
@@ -51,7 +51,7 @@ impl Registry {
             .get(&TypeId::of::<T>())
             .and_then(|boxed| boxed.downcast_ref::<T>())
             .cloned()
-            .ok_or(RegistryError::TypeNotFound)
+            .ok_or(RegistryError::TypeNotFound(type_name::<T>().to_string()))
     }
 }
 

--- a/rust/config/src/registry.rs
+++ b/rust/config/src/registry.rs
@@ -1,0 +1,77 @@
+use parking_lot::Mutex;
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+};
+
+pub trait Injectable: Any + Send + Sync + Clone {}
+
+/// A simple registry that stores any type that implements `Injectable`.
+/// This is a simple implementation of a service locator pattern.
+/// ## Note
+/// Types stored in the registry will be cloned when retrieved.
+/// Therefore, it is recommended to store types that are cheap to clone and
+/// also that are "Shareable" - i.e cloning them results in non-divergent state
+/// upon Mutation. (Commonly implemented via Arc<Inner> pattern)
+struct Registry {
+    storage: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
+}
+
+impl Registry {
+    fn new() -> Self {
+        Self {
+            storage: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn insert<T: Injectable>(&self, value: Box<T>) {
+        let mut storage = self.storage.lock();
+        storage.insert(TypeId::of::<T>(), value);
+    }
+
+    fn get<T: Injectable>(&self) -> Option<T> {
+        let storage = self.storage.lock();
+        storage
+            .get(&TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast_ref::<T>())
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{atomic::AtomicUsize, Arc};
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct TestInjectable {
+        inner: Arc<AtomicUsize>,
+    }
+
+    impl Injectable for TestInjectable {}
+
+    #[test]
+    fn test_registry_returns_same() {
+        let registry = Registry::new();
+        let injectable = Box::new(TestInjectable::default());
+        registry.insert(injectable);
+        let retrieved_1 = registry
+            .get::<TestInjectable>()
+            .expect("To be able to get the TestInjectable");
+        assert_eq!(
+            retrieved_1.inner.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        retrieved_1
+            .inner
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let retrieved_2 = registry
+            .get::<TestInjectable>()
+            .expect("To be able to get the TestInjectable");
+        assert_eq!(
+            retrieved_2.inner.load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+}

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -1,5 +1,6 @@
 use crate::{executor::config::ExecutorConfig, CollectionsWithSegmentsProviderConfig};
 use chroma_log::config::LogConfig;
+use chroma_segment::local_segment_manager::LocalSegmentManagerConfig;
 use chroma_sqlite::config::SqliteDBConfig;
 use chroma_sysdb::SysDbConfig;
 use figment::providers::{Env, Format, Yaml};
@@ -17,6 +18,7 @@ pub struct FrontendConfig {
     #[serde(default)]
     pub allow_reset: bool,
     pub sqlitedb: Option<SqliteDBConfig>,
+    pub segment_manager: Option<LocalSegmentManagerConfig>,
     pub sysdb: SysDbConfig,
     #[serde(default = "CircuitBreakerConfig::default")]
     pub circuit_breaker: CircuitBreakerConfig,

--- a/rust/frontend/src/executor/mod.rs
+++ b/rust/frontend/src/executor/mod.rs
@@ -8,7 +8,7 @@ use local::LocalExecutor;
 
 //////////////////////// Exposed Modules ////////////////////////
 pub(super) mod client_manager;
-pub(crate) mod config;
+pub mod config;
 // TODO: This should be private once we fix dep injection
 mod distributed;
 pub mod local;

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -3,9 +3,11 @@ use crate::{
     CollectionsWithSegmentsProvider,
 };
 use backon::Retryable;
-use chroma_config::Configurable;
+use chroma_config::{registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_sysdb::sysdb;
+use chroma_log::Log;
+use chroma_sqlite::db::SqliteDb;
+use chroma_sysdb::SysDb;
 use chroma_system::System;
 use chroma_types::{
     operator::{Filter, KnnBatch, KnnProjection, Limit, Projection, Scan},
@@ -115,8 +117,8 @@ fn to_records<
 pub struct Frontend {
     allow_reset: bool,
     executor: Executor,
-    log_client: Box<chroma_log::Log>,
-    sysdb_client: Box<sysdb::SysDb>,
+    log_client: Log,
+    sysdb_client: SysDb,
     collections_with_segments_provider: CollectionsWithSegmentsProvider,
     max_batch_size: u32,
 }
@@ -124,9 +126,9 @@ pub struct Frontend {
 impl Frontend {
     pub fn new(
         allow_reset: bool,
-        sysdb_client: Box<sysdb::SysDb>,
+        sysdb_client: SysDb,
         collections_with_segments_provider: CollectionsWithSegmentsProvider,
-        log_client: Box<chroma_log::Log>,
+        log_client: Log,
         executor: Executor,
         max_batch_size: u32,
     ) -> Self {
@@ -897,25 +899,30 @@ impl Frontend {
 impl Configurable<(FrontendConfig, System)> for Frontend {
     async fn try_from_config(
         (config, system): &(FrontendConfig, System),
+        registry: &registry::Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
-        let sysdb_client = chroma_sysdb::from_config(&config.sysdb).await?;
-        let mut log_client = chroma_log::from_config(&config.log).await?;
-        let max_batch_size = log_client.get_max_batch_size().await?;
+        // Create sqlitedb if configured
+        if let Some(sqlitedb) = &config.sqlitedb {
+            SqliteDb::try_from_config(sqlitedb, registry).await?;
+        }
 
-        let collections_with_segments_provider =
-            CollectionsWithSegmentsProvider::try_from_config(&(
-                config.collections_with_segments_provider.clone(),
-                sysdb_client.clone(),
-            ))
-            .await?;
+        let sysdb = SysDb::try_from_config(&config.sysdb, registry).await?;
+        let mut log = Log::try_from_config(&config.log, registry).await?;
+        let max_batch_size = log.get_max_batch_size().await?;
+
+        let collections_with_segments_provider = CollectionsWithSegmentsProvider::try_from_config(
+            &config.collections_with_segments_provider.clone(),
+            registry,
+        )
+        .await?;
 
         let executor =
-            Executor::try_from_config(&(config.executor.clone(), system.clone())).await?;
+            Executor::try_from_config(&(config.executor.clone(), system.clone()), registry).await?;
         Ok(Frontend::new(
             config.allow_reset,
-            sysdb_client,
+            sysdb,
             collections_with_segments_provider,
-            log_client,
+            log,
             executor,
             max_batch_size,
         ))

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -8,7 +8,7 @@ mod server;
 mod tower_tracing;
 mod types;
 
-use chroma_config::Configurable;
+use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
 use chroma_system::System;
 use frontend::Frontend;
@@ -41,8 +41,9 @@ pub async fn frontend_service_entrypoint() {
     };
     chroma_tracing::init_otel_tracing(&config.service_name, &config.otel_endpoint);
     let system = System::new();
+    let registry = Registry::new();
 
-    let frontend = Frontend::try_from_config(&(config.clone(), system))
+    let frontend = Frontend::try_from_config(&(config.clone(), system), &registry)
         .await
         .expect("Error creating Frontend Config");
     fn rule_to_rule(rule: &ScorecardRule) -> Result<Rule, ScorecardRuleError> {

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -78,7 +78,7 @@ pub struct GarbageCollectorOrchestrator {
     collection_id: CollectionUuid,
     version_file_path: String,
     cutoff_time_hours: u32,
-    sysdb_client: Box<SysDb>,
+    sysdb_client: SysDb,
     dispatcher: ComponentHandle<Dispatcher>,
     // Result Channel
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
@@ -103,7 +103,7 @@ impl GarbageCollectorOrchestrator {
         collection_id: CollectionUuid,
         version_file_path: String,
         cutoff_time_hours: u32,
-        sysdb_client: Box<SysDb>,
+        sysdb_client: SysDb,
         dispatcher: ComponentHandle<Dispatcher>,
         storage: Storage,
     ) -> Self {

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -23,8 +23,10 @@ pub async fn garbage_collector_service_entrypoint() {
     // Enable OTEL tracing.
     init_otel_tracing(&config.service_name, &config.otel_endpoint);
 
+    let registry = chroma_config::registry::Registry::new();
+
     // Setup the dispatcher and the pool of workers.
-    let dispatcher = Dispatcher::try_from_config(&config.dispatcher_config)
+    let dispatcher = Dispatcher::try_from_config(&config.dispatcher_config, &registry)
         .await
         .expect("Failed to create dispatcher from config");
 
@@ -34,7 +36,7 @@ pub async fn garbage_collector_service_entrypoint() {
     // Start a background task to periodically check for garbage.
     // Garbage collector is a component that gets notified every
     // gc_interval_mins to check for garbage.
-    let mut garbage_collector_component = GarbageCollector::try_from_config(&config)
+    let mut garbage_collector_component = GarbageCollector::try_from_config(&config, &registry)
         .await
         .expect("Failed to create garbage collector component");
     garbage_collector_component.set_dispatcher(dispatcher_handle);

--- a/rust/garbage_collector/src/operators/compute_unused_between_versions.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_between_versions.rs
@@ -13,7 +13,7 @@ pub struct ComputeUnusedBetweenVersionsOperator {}
 pub struct ComputeUnusedBetweenVersionsInput {
     pub version_file: CollectionVersionFile,
     pub epoch_id: i64,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
     pub version_to_content: HashMap<i64, Vec<u8>>,
 }
@@ -22,7 +22,7 @@ pub struct ComputeUnusedBetweenVersionsInput {
 pub struct ComputeUnusedBetweenVersionsOutput {
     pub version_file: CollectionVersionFile,
     pub epoch_id: i64,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
     pub unused_s3_files: HashSet<String>,
 }

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -13,7 +13,7 @@ pub struct DeleteVersionsAtSysDbOperator {}
 pub struct DeleteVersionsAtSysDbInput {
     pub version_file: CollectionVersionFile,
     pub epoch_id: i64,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
     pub unused_s3_files: HashSet<String>,
 }
@@ -77,7 +77,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_versions_success() {
-        let sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
@@ -105,7 +105,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_versions_empty_list() {
-        let sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),

--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -21,7 +21,7 @@ pub struct FetchSparseIndexFilesOperator {
 pub struct FetchSparseIndexFilesInput {
     pub version_file: CollectionVersionFile,
     pub epoch_id: i64,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
 }
 
@@ -29,7 +29,7 @@ pub struct FetchSparseIndexFilesInput {
 pub struct FetchSparseIndexFilesOutput {
     pub version_file: CollectionVersionFile,
     pub epoch_id: i64,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
     pub version_to_content: HashMap<i64, Vec<u8>>,
 }

--- a/rust/garbage_collector/src/operators/mark_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/mark_versions_at_sysdb.rs
@@ -12,7 +12,7 @@ pub struct MarkVersionsAtSysDbOperator {}
 pub struct MarkVersionsAtSysDbInput {
     pub version_file: CollectionVersionFile,
     pub versions_to_delete: VersionListForCollection,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub epoch_id: i64,
 }
 
@@ -20,7 +20,7 @@ pub struct MarkVersionsAtSysDbInput {
 pub struct MarkVersionsAtSysDbOutput {
     pub version_file: CollectionVersionFile,
     pub epoch_id: i64,
-    pub sysdb_client: Box<SysDb>,
+    pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
 }
 
@@ -74,7 +74,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mark_versions_success() {
-        let sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
@@ -100,7 +100,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mark_versions_empty_list() {
-        let sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
@@ -126,7 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mark_versions_error() {
-        let sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -6,6 +6,7 @@ use super::{HnswIndex, HnswIndexConfig, Index, IndexConfig, IndexUuid};
 use async_trait::async_trait;
 use chroma_cache::AysncPartitionedMutex;
 use chroma_cache::{Cache, Weighted};
+use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_distance::DistanceFunction;
 use chroma_error::ChromaError;
@@ -73,6 +74,7 @@ impl Debug for HnswIndexProvider {
 impl Configurable<(HnswProviderConfig, Storage)> for HnswIndexProvider {
     async fn try_from_config(
         config: &(HnswProviderConfig, Storage),
+        _registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (hnsw_config, storage) = config;
         // TODO(rescrv):  Long-term we should migrate this to the component API.

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -42,8 +42,15 @@ impl Default for GrpcLogConfig {
 }
 
 #[derive(Deserialize, Clone, Serialize)]
+pub struct SqliteLogConfig {
+    pub tenant_id: String,
+    pub topic_namespace: String,
+}
+
+#[derive(Deserialize, Clone, Serialize)]
 pub enum LogConfig {
     Grpc(GrpcLogConfig),
+    Sqlite(SqliteLogConfig),
 }
 
 impl Default for LogConfig {

--- a/rust/log/src/lib.rs
+++ b/rust/log/src/lib.rs
@@ -8,17 +8,33 @@ pub mod sqlite_log;
 pub mod test;
 pub mod types;
 
-use chroma_config::Configurable;
+use chroma_config::{registry::Injectable, Configurable};
 use chroma_error::ChromaError;
 use config::LogConfig;
 pub use local_compaction_manager::*;
 pub use log::*;
 pub use types::*;
 
-pub async fn from_config(config: &LogConfig) -> Result<Box<log::Log>, Box<dyn ChromaError>> {
-    match &config {
-        config::LogConfig::Grpc(_) => Ok(Box::new(log::Log::Grpc(
-            grpc_log::GrpcLog::try_from_config(config).await?,
-        ))),
+use async_trait::async_trait;
+
+impl Injectable for Log {}
+
+#[async_trait]
+impl Configurable<LogConfig> for Log {
+    async fn try_from_config(
+        config: &LogConfig,
+        registry: &chroma_config::registry::Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let res = match &config {
+            LogConfig::Grpc(grpc_log_config) => {
+                Self::Grpc(grpc_log::GrpcLog::try_from_config(grpc_log_config, registry).await?)
+            }
+            LogConfig::Sqlite(sqlite_log_config) => Self::Sqlite(
+                sqlite_log::SqliteLog::try_from_config(sqlite_log_config, registry).await?,
+            ),
+        };
+
+        registry.register(res.clone());
+        Ok(res)
     }
 }

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -1,6 +1,9 @@
 use std::fmt::{Debug, Formatter};
 
+use crate::Log;
 use async_trait::async_trait;
+use chroma_config::registry::Registry;
+use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_segment::local_hnsw::LocalHnswSegmentReaderError;
 use chroma_segment::local_segment_manager::{LocalSegmentManager, LocalSegmentManagerError};
@@ -14,31 +17,37 @@ use chroma_system::{Component, ComponentContext};
 use chroma_types::{
     Chunk, CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError, LogRecord,
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::Log;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalCompactionManagerConfig {}
 
 pub struct LocalCompactionManager {
-    log: Box<Log>,
+    log: Log,
     sqlite_db: SqliteDb,
     hnsw_segment_manager: LocalSegmentManager,
-    sysdb: Box<SysDb>,
-    // TODO(Sanket): config
+    sysdb: SysDb,
 }
 
-impl LocalCompactionManager {
-    pub fn new(
-        log: Box<Log>,
-        sqlite_db: SqliteDb,
-        hnsw_segment_manager: LocalSegmentManager,
-        sysdb: Box<SysDb>,
-    ) -> Self {
-        LocalCompactionManager {
+#[async_trait]
+impl Configurable<LocalCompactionManagerConfig> for LocalCompactionManager {
+    async fn try_from_config(
+        _config: &LocalCompactionManagerConfig,
+        registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let log = registry.get::<Log>().map_err(|e| e.boxed())?;
+        let sqlite_db = registry.get::<SqliteDb>().map_err(|e| e.boxed())?;
+        let hnsw_segment_manager = registry
+            .get::<LocalSegmentManager>()
+            .map_err(|e| e.boxed())?;
+        let sysdb = registry.get::<SysDb>().map_err(|e| e.boxed())?;
+        Ok(Self {
             log,
             sqlite_db,
             hnsw_segment_manager,
             sysdb,
-        }
+        })
     }
 }
 

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -1,7 +1,9 @@
 use crate::{
-    CollectionInfo, CompactionManagerError, CompactionMessage, LocalCompactionManager,
-    PurgeLogsMessage,
+    config::SqliteLogConfig, CollectionInfo, CompactionManagerError, CompactionMessage,
+    LocalCompactionManager, PurgeLogsMessage,
 };
+use async_trait::async_trait;
+use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes, WrappedSqlxError};
 use chroma_sqlite::{db::SqliteDb, helpers::get_embeddings_queue_topic_name};
 use chroma_system::{ChannelError, ComponentHandle, RequestError};
@@ -485,9 +487,25 @@ fn operation_to_code(operation: Operation) -> u32 {
     }
 }
 
+#[async_trait]
+impl Configurable<SqliteLogConfig> for SqliteLog {
+    async fn try_from_config(
+        config: &SqliteLogConfig,
+        registry: &chroma_config::registry::Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let sqlite_db = registry.get::<SqliteDb>().map_err(|e| e.boxed())?;
+        Ok(Self::new(
+            sqlite_db,
+            config.tenant_id.clone(),
+            config.topic_namespace.clone(),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chroma_config::{registry::Registry, Configurable};
     use chroma_sqlite::config::SqliteDBConfig;
     use chroma_types::{are_metadatas_close_to_equal, CollectionUuid};
     use proptest::prelude::*;
@@ -496,11 +514,14 @@ mod tests {
 
     async fn setup_sqlite_log() -> SqliteLog {
         let path = tempdir().unwrap().into_path();
-        let db = SqliteDb::try_from_config(&SqliteDBConfig {
-            url: path.to_str().unwrap().to_string(),
-            migration_mode: chroma_sqlite::config::MigrationMode::Apply,
-            hash_type: chroma_sqlite::config::MigrationHash::SHA256,
-        })
+        let db = SqliteDb::try_from_config(
+            &SqliteDBConfig {
+                url: path.to_str().unwrap().to_string(),
+                migration_mode: chroma_sqlite::config::MigrationMode::Apply,
+                hash_type: chroma_sqlite::config::MigrationHash::SHA256,
+            },
+            &Registry::new(),
+        )
         .await
         .unwrap();
 

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -506,16 +506,16 @@ impl Configurable<SqliteLogConfig> for SqliteLog {
 mod tests {
     use super::*;
     use chroma_config::{registry::Registry, Configurable};
-    use chroma_sqlite::config::SqliteDBConfig;
+    use chroma_sqlite::{config::SqliteDBConfig, db::test_utils::new_test_db_persist_path};
     use chroma_types::{are_metadatas_close_to_equal, CollectionUuid};
     use proptest::prelude::*;
+
     use tokio::runtime::Runtime;
 
     async fn setup_sqlite_log() -> SqliteLog {
-        let path = tempdir().unwrap().into_path();
         let db = SqliteDb::try_from_config(
             &SqliteDBConfig {
-                url: path.to_str().unwrap().to_string(),
+                url: new_test_db_persist_path(),
                 migration_mode: chroma_sqlite::config::MigrationMode::Apply,
                 hash_type: chroma_sqlite::config::MigrationHash::SHA256,
             },

--- a/rust/memberlist/src/memberlist_provider.rs
+++ b/rust/memberlist/src/memberlist_provider.rs
@@ -1,5 +1,6 @@
 use super::config::MemberlistProviderConfig;
 use async_trait::async_trait;
+use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_system::{Component, ComponentContext, Handler, ReceiverForMessage, StreamHandler};
@@ -91,6 +92,7 @@ impl ChromaError for CustomResourceMemberlistProviderConfigurationError {
 impl Configurable<MemberlistProviderConfig> for CustomResourceMemberlistProvider {
     async fn try_from_config(
         config: &MemberlistProviderConfig,
+        _registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let MemberlistProviderConfig::CustomResource(my_config) = &config;
         let kube_client = match Client::try_default().await {

--- a/rust/python_bindings/Cargo.toml
+++ b/rust/python_bindings/Cargo.toml
@@ -28,3 +28,4 @@ chroma-cache = { workspace = true }
 chroma-system = { workspace = true }
 chroma-types = { workspace = true }
 chroma-error = { workspace = true, features = ["validator"] }
+mdac = { workspace = true }

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -1,18 +1,21 @@
 use crate::errors::{ChromaPyResult, WrappedPyErr, WrappedSerdeJsonError, WrappedUuidError};
-use chroma_cache::FoyerCacheConfig;
-use chroma_config::Configurable;
+use chroma_config::{registry::Registry, Configurable};
 use chroma_frontend::{
-    executor::{local::LocalExecutor, Executor},
+    executor::config::{ExecutorConfig, LocalExecutorConfig},
     frontend::Frontend,
     get_collection_with_segments_provider::{
         CacheInvalidationRetryConfig, CollectionsWithSegmentsProvider,
         CollectionsWithSegmentsProviderConfig,
     },
+    FrontendConfig,
 };
-use chroma_log::{LocalCompactionManager, Log};
+use chroma_log::{
+    config::{LogConfig, SqliteLogConfig},
+    LocalCompactionManager, Log,
+};
 use chroma_segment::local_segment_manager::{LocalSegmentManager, LocalSegmentManagerConfig};
 use chroma_sqlite::{config::SqliteDBConfig, db::SqliteDb};
-use chroma_sysdb::{sqlite::SqliteSysDb, sysdb::SysDb};
+use chroma_sysdb::{sqlite::SqliteSysDb, sysdb::SysDb, SqliteSysDbConfig, SysDbConfig};
 use chroma_system::System;
 use chroma_types::{
     Collection, CollectionMetadataUpdate, CountCollectionsRequest, CountResponse,
@@ -22,6 +25,7 @@ use chroma_types::{
     ListCollectionsRequest, ListDatabasesRequest, Metadata, QueryResponse, UpdateCollectionRequest,
     UpdateMetadata,
 };
+use mdac::CircuitBreakerConfig;
 use pyo3::{exceptions::PyValueError, pyclass, pymethods, types::PyAnyMethods, PyObject, Python};
 use std::time::SystemTime;
 
@@ -32,7 +36,6 @@ const DEFAULT_TENANT: &str = "default_tenant";
 pub(crate) struct Bindings {
     runtime: tokio::runtime::Runtime,
     frontend: Frontend,
-    _compaction_manager_handle: chroma_system::ComponentHandle<LocalCompactionManager>,
 }
 
 #[pyclass]
@@ -64,58 +67,22 @@ impl Bindings {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _guard = runtime.enter();
         let system = System::new();
+        let registry = Registry::new();
 
         //////////////////////////// Frontend Setup ////////////////////////////
 
-        // This set up code is extremely janky, I've left comments
-        // on the parts that need to be cleaned up.
-        // TODO(hammadb): Clean up this code - this is just to unblock us in short term
-        // TODO: clean up this construction
-        let sqlite_db =
-            runtime.block_on(async { SqliteDb::try_from_config(&sqlite_db_config).await })?;
+        // TOOD(hammadb): HAMMAD BEFORE MERGING REGISTRY: persist path and hsnw cache size
+        // TODO: consume the log configuration from the input python
+        let sysdb_config = SysDbConfig::Sqlite(SqliteSysDbConfig {
+            log_topic_namespace: "default".to_string(),
+            log_tenant: "default".to_string(),
+        });
 
-        let cache_config = FoyerCacheConfig {
-            capacity: hnsw_cache_size,
-            ..Default::default()
-        };
+        let log_config = LogConfig::Sqlite(SqliteLogConfig {
+            tenant_id: "default".to_string(),
+            topic_namespace: "default".to_string(),
+        });
 
-        let cache_config = chroma_cache::CacheConfig::Memory(cache_config);
-        let segment_manager_config = LocalSegmentManagerConfig {
-            hnsw_index_pool_cache_config: cache_config,
-            persist_path: persist_path.clone(),
-        };
-        // Create the hnsw segment manager.
-        let segment_manager = runtime.block_on(LocalSegmentManager::try_from_config(&(
-            segment_manager_config,
-            sqlite_db.clone(),
-        )))?;
-        let sqlite_sysdb = SqliteSysDb::new(
-            sqlite_db.clone(),
-            "default".to_string(),
-            "default".to_string(),
-        );
-        let sysdb = Box::new(SysDb::Sqlite(sqlite_sysdb));
-        // TODO: get the log configuration from the config sysdb
-        let mut log = Box::new(Log::Sqlite(chroma_log::sqlite_log::SqliteLog::new(
-            sqlite_db.clone(),
-            "default".to_string(),
-            "default".to_string(),
-        )));
-        let max_batch_size = runtime.block_on(log.get_max_batch_size())?;
-
-        // Spawn the compaction manager.
-        let handle = system.start_component(LocalCompactionManager::new(
-            log.clone(),
-            sqlite_db.clone(),
-            segment_manager.clone(),
-            sysdb.clone(),
-        ));
-        if let Log::Sqlite(sqlite_log) = log.as_ref() {
-            sqlite_log.init_compactor_handle(handle.clone())?;
-        }
-
-        // TODO: clean up the cache configuration and decide the source of truth owner
-        // make cache not a no-op
         let collection_cache_config = CollectionsWithSegmentsProviderConfig {
             // No retry to sysdb on local chroma
             cache_invalidation_retry_policy: CacheInvalidationRetryConfig::new(0, 0),
@@ -123,36 +90,112 @@ impl Bindings {
             cache: chroma_cache::CacheConfig::Nop,
         };
 
-        let collections_cache = runtime.block_on(async {
-            CollectionsWithSegmentsProvider::try_from_config(&(
-                collection_cache_config,
-                sysdb.clone(),
-            ))
-            .await
+        let executor_config = ExecutorConfig::Local(LocalExecutorConfig {});
+
+        let frontend_config = FrontendConfig {
+            allow_reset,
+            sqlitedb: Some(sqlite_db_config),
+            sysdb: sysdb_config,
+            // TODO: Move circuit breaker config to the server config, it has nothing
+            // to do with the frontend, only to do with the server
+            circuit_breaker: CircuitBreakerConfig::default(),
+            collections_with_segments_provider: collection_cache_config,
+            // TODO: The following fields should be removed from FrontendConfig and into
+            // the server config. They have nothing to do with the frontend.
+            service_name: "chroma".to_string(),
+            otel_endpoint: "http://localhost:4317".to_string(),
+            log: log_config,
+            executor: executor_config,
+            scorecard_enabled: false,
+            // TODO: scorecard should be removed from the frontend config and moved to the server config
+            scorecard: vec![],
+        };
+        let frontend = runtime.block_on(async {
+            Frontend::try_from_config(&(frontend_config, system), &registry).await
         })?;
 
-        // TODO: executor should NOT be exposed to the bindings module. try_from_config should work.
-        // The reason this works this way right now is because try_from_config cannot share the sqlite_db
-        // across the downstream components.
-        let executor = Executor::Local(LocalExecutor::new(
-            segment_manager,
-            sqlite_db,
-            handle.clone(),
-        ));
-        let frontend = Frontend::new(
-            allow_reset,
-            sysdb.clone(),
-            collections_cache,
-            log,
-            executor,
-            max_batch_size,
-        );
+        // This set up code is extremely janky, I've left comments
+        // on the parts that need to be cleaned up.
+        // TODO(hammadb): Clean up this code - this is just to unblock us in short term
+        // TODO: clean up this construction
+        // let sqlite_db =
+        //     runtime.block_on(async { SqliteDb::try_from_config(&sqlite_db_config).await })?;
 
-        Ok(Bindings {
-            runtime,
-            frontend,
-            _compaction_manager_handle: handle,
-        })
+        // let cache_config = FoyerCacheConfig {
+        //     capacity: hnsw_cache_size,
+        //     ..Default::default()
+        // };
+
+        // let cache_config = chroma_cache::CacheConfig::Memory(cache_config);
+        // let segment_manager_config = LocalSegmentManagerConfig {
+        //     hnsw_index_pool_cache_config: cache_config,
+        //     persist_path: persist_path.clone(),
+        // };
+        // // Create the hnsw segment manager.
+        // let segment_manager = runtime.block_on(LocalSegmentManager::try_from_config(&(
+        //     segment_manager_config,
+        //     sqlite_db.clone(),
+        // )))?;
+        // let sqlite_sysdb = SqliteSysDb::new(
+        //     sqlite_db.clone(),
+        //     "default".to_string(),
+        //     "default".to_string(),
+        // );
+        // let sysdb = Box::new(SysDb::Sqlite(sqlite_sysdb));
+        // // TODO: get the log configuration from the config sysdb
+        // let mut log = Box::new(Log::Sqlite(chroma_log::sqlite_log::SqliteLog::new(
+        //     sqlite_db.clone(),
+        //     "default".to_string(),
+        //     "default".to_string(),
+        // )));
+        // let max_batch_size = runtime.block_on(log.get_max_batch_size())?;
+
+        // // Spawn the compaction manager.
+        // let handle = system.start_component(LocalCompactionManager::new(
+        //     log.clone(),
+        //     sqlite_db.clone(),
+        //     segment_manager.clone(),
+        //     sysdb.clone(),
+        // ));
+        // if let Log::Sqlite(sqlite_log) = log.as_ref() {
+        //     sqlite_log.init_compactor_handle(handle.clone())?;
+        // }
+
+        // // TODO: clean up the cache configuration and decide the source of truth owner
+        // // make cache not a no-op
+        // let collection_cache_config = CollectionsWithSegmentsProviderConfig {
+        //     // No retry to sysdb on local chroma
+        //     cache_invalidation_retry_policy: CacheInvalidationRetryConfig::new(0, 0),
+        //     permitted_parallelism: 32,
+        //     cache: chroma_cache::CacheConfig::Nop,
+        // };
+
+        // let collections_cache = runtime.block_on(async {
+        //     CollectionsWithSegmentsProvider::try_from_config(&(
+        //         collection_cache_config,
+        //         sysdb.clone(),
+        //     ))
+        //     .await
+        // })?;
+
+        // // TODO: executor should NOT be exposed to the bindings module. try_from_config should work.
+        // // The reason this works this way right now is because try_from_config cannot share the sqlite_db
+        // // across the downstream components.
+        // let executor = Executor::Local(LocalExecutor::new(
+        //     segment_manager,
+        //     sqlite_db,
+        //     handle.clone(),
+        // ));
+        // let frontend = Frontend::new(
+        //     allow_reset,
+        //     sysdb.clone(),
+        //     collections_cache,
+        //     log,
+        //     executor,
+        //     max_batch_size,
+        // );
+
+        Ok(Bindings { runtime, frontend })
     }
 
     /// Returns the current eopch time in ns

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -1,21 +1,18 @@
 use crate::errors::{ChromaPyResult, WrappedPyErr, WrappedSerdeJsonError, WrappedUuidError};
+use chroma_cache::FoyerCacheConfig;
 use chroma_config::{registry::Registry, Configurable};
 use chroma_frontend::{
     executor::config::{ExecutorConfig, LocalExecutorConfig},
     frontend::Frontend,
     get_collection_with_segments_provider::{
-        CacheInvalidationRetryConfig, CollectionsWithSegmentsProvider,
-        CollectionsWithSegmentsProviderConfig,
+        CacheInvalidationRetryConfig, CollectionsWithSegmentsProviderConfig,
     },
     FrontendConfig,
 };
-use chroma_log::{
-    config::{LogConfig, SqliteLogConfig},
-    LocalCompactionManager, Log,
-};
-use chroma_segment::local_segment_manager::{LocalSegmentManager, LocalSegmentManagerConfig};
-use chroma_sqlite::{config::SqliteDBConfig, db::SqliteDb};
-use chroma_sysdb::{sqlite::SqliteSysDb, sysdb::SysDb, SqliteSysDbConfig, SysDbConfig};
+use chroma_log::config::{LogConfig, SqliteLogConfig};
+use chroma_segment::local_segment_manager::LocalSegmentManagerConfig;
+use chroma_sqlite::config::SqliteDBConfig;
+use chroma_sysdb::{SqliteSysDbConfig, SysDbConfig};
 use chroma_system::System;
 use chroma_types::{
     Collection, CollectionMetadataUpdate, CountCollectionsRequest, CountResponse,
@@ -71,6 +68,16 @@ impl Bindings {
 
         //////////////////////////// Frontend Setup ////////////////////////////
 
+        let cache_config = FoyerCacheConfig {
+            capacity: hnsw_cache_size,
+            ..Default::default()
+        };
+        let cache_config = chroma_cache::CacheConfig::Memory(cache_config);
+        let segment_manager_config = LocalSegmentManagerConfig {
+            hnsw_index_pool_cache_config: cache_config,
+            persist_path: persist_path.clone(),
+        };
+
         // TOOD(hammadb): HAMMAD BEFORE MERGING REGISTRY: persist path and hsnw cache size
         // TODO: consume the log configuration from the input python
         let sysdb_config = SysDbConfig::Sqlite(SqliteSysDbConfig {
@@ -94,6 +101,7 @@ impl Bindings {
 
         let frontend_config = FrontendConfig {
             allow_reset,
+            segment_manager: Some(segment_manager_config),
             sqlitedb: Some(sqlite_db_config),
             sysdb: sysdb_config,
             // TODO: Move circuit breaker config to the server config, it has nothing
@@ -110,90 +118,10 @@ impl Bindings {
             // TODO: scorecard should be removed from the frontend config and moved to the server config
             scorecard: vec![],
         };
+
         let frontend = runtime.block_on(async {
             Frontend::try_from_config(&(frontend_config, system), &registry).await
         })?;
-
-        // This set up code is extremely janky, I've left comments
-        // on the parts that need to be cleaned up.
-        // TODO(hammadb): Clean up this code - this is just to unblock us in short term
-        // TODO: clean up this construction
-        // let sqlite_db =
-        //     runtime.block_on(async { SqliteDb::try_from_config(&sqlite_db_config).await })?;
-
-        // let cache_config = FoyerCacheConfig {
-        //     capacity: hnsw_cache_size,
-        //     ..Default::default()
-        // };
-
-        // let cache_config = chroma_cache::CacheConfig::Memory(cache_config);
-        // let segment_manager_config = LocalSegmentManagerConfig {
-        //     hnsw_index_pool_cache_config: cache_config,
-        //     persist_path: persist_path.clone(),
-        // };
-        // // Create the hnsw segment manager.
-        // let segment_manager = runtime.block_on(LocalSegmentManager::try_from_config(&(
-        //     segment_manager_config,
-        //     sqlite_db.clone(),
-        // )))?;
-        // let sqlite_sysdb = SqliteSysDb::new(
-        //     sqlite_db.clone(),
-        //     "default".to_string(),
-        //     "default".to_string(),
-        // );
-        // let sysdb = Box::new(SysDb::Sqlite(sqlite_sysdb));
-        // // TODO: get the log configuration from the config sysdb
-        // let mut log = Box::new(Log::Sqlite(chroma_log::sqlite_log::SqliteLog::new(
-        //     sqlite_db.clone(),
-        //     "default".to_string(),
-        //     "default".to_string(),
-        // )));
-        // let max_batch_size = runtime.block_on(log.get_max_batch_size())?;
-
-        // // Spawn the compaction manager.
-        // let handle = system.start_component(LocalCompactionManager::new(
-        //     log.clone(),
-        //     sqlite_db.clone(),
-        //     segment_manager.clone(),
-        //     sysdb.clone(),
-        // ));
-        // if let Log::Sqlite(sqlite_log) = log.as_ref() {
-        //     sqlite_log.init_compactor_handle(handle.clone())?;
-        // }
-
-        // // TODO: clean up the cache configuration and decide the source of truth owner
-        // // make cache not a no-op
-        // let collection_cache_config = CollectionsWithSegmentsProviderConfig {
-        //     // No retry to sysdb on local chroma
-        //     cache_invalidation_retry_policy: CacheInvalidationRetryConfig::new(0, 0),
-        //     permitted_parallelism: 32,
-        //     cache: chroma_cache::CacheConfig::Nop,
-        // };
-
-        // let collections_cache = runtime.block_on(async {
-        //     CollectionsWithSegmentsProvider::try_from_config(&(
-        //         collection_cache_config,
-        //         sysdb.clone(),
-        //     ))
-        //     .await
-        // })?;
-
-        // // TODO: executor should NOT be exposed to the bindings module. try_from_config should work.
-        // // The reason this works this way right now is because try_from_config cannot share the sqlite_db
-        // // across the downstream components.
-        // let executor = Executor::Local(LocalExecutor::new(
-        //     segment_manager,
-        //     sqlite_db,
-        //     handle.clone(),
-        // ));
-        // let frontend = Frontend::new(
-        //     allow_reset,
-        //     sysdb.clone(),
-        //     collections_cache,
-        //     log,
-        //     executor,
-        //     max_batch_size,
-        // );
 
         Ok(Bindings { runtime, frontend })
     }

--- a/rust/sqlite/Cargo.toml
+++ b/rust/sqlite/Cargo.toml
@@ -16,5 +16,9 @@ pyo3 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+
 chroma-error = { workspace = true, features = ["sqlx"] }
 chroma-types = { workspace = true }
+chroma-config = { workspace = true }

--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -1,6 +1,15 @@
+use crate::db::{SqliteCreationError, SqliteDb};
+use async_trait::async_trait;
+use chroma_config::{
+    registry::{Injectable, Registry},
+    Configurable,
+};
+use chroma_error::ChromaError;
 use pyo3::{pyclass, pymethods};
+use serde::{Deserialize, Serialize};
+use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
 
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[pyclass]
 pub struct SqliteDBConfig {
     // The SQLite database URL
@@ -12,7 +21,7 @@ pub struct SqliteDBConfig {
 /// Migration mode for the database
 /// - Apply: Apply the migrations
 /// - Validate: Validate the applied migrations and ensure none are unappliued
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[pyclass(eq, eq_int)]
 pub enum MigrationMode {
     Apply,
@@ -22,7 +31,7 @@ pub enum MigrationMode {
 /// The hash function to use for the migration files
 /// - SHA256: Use SHA256 hash
 /// - MD5: Use MD5 hash
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
 #[pyclass(eq, eq_int)]
 pub enum MigrationHash {
     SHA256,
@@ -40,5 +49,75 @@ impl SqliteDBConfig {
             hash_type,
             migration_mode,
         }
+    }
+}
+
+//////////////////////// Configurable Implementation ////////////////////////
+
+impl Injectable for SqliteDb {}
+
+#[async_trait]
+impl Configurable<SqliteDBConfig> for SqliteDb {
+    async fn try_from_config(
+        config: &SqliteDBConfig,
+        registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        // TODO: copy all other pragmas from python and add basic tests
+        // TODO: make this file path handling more robust
+        let filename = config.url.trim_end_matches('/').to_string() + "/chroma.sqlite3";
+        let options = SqliteConnectOptions::new()
+            .filename(filename)
+            // Due to a bug in the python code, foreign_keys is turned off
+            // The python code enabled it in a transaction, however,
+            // https://www.sqlite.org/pragma.html states that foreign_keys
+            // is a no-op in a transaction. In order to be able to run our migrations
+            // we turn it off
+            .pragma("foreign_keys", "OFF")
+            .pragma("case_sensitive_like", "ON")
+            .create_if_missing(true);
+        let conn = SqlitePool::connect_with(options)
+            .await
+            .map_err(|e| Box::new(SqliteCreationError::SqlxError(e)) as Box<dyn ChromaError>)?;
+
+        let db = SqliteDb::new(conn, config.hash_type);
+
+        db.initialize_migrations_table().await?;
+        match config.migration_mode {
+            MigrationMode::Apply => {
+                db.apply_all_migration()
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
+            }
+            MigrationMode::Validate => {
+                db.validate_all_migrations()
+                    .await
+                    .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?;
+            }
+        }
+
+        registry.register(db.clone());
+        Ok(db)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::new_test_db_path;
+    use chroma_config::registry::Registry;
+
+    #[tokio::test]
+    async fn test_sqlite_db_config_registry() {
+        let config = SqliteDBConfig {
+            url: new_test_db_path(),
+            hash_type: MigrationHash::SHA256,
+            migration_mode: MigrationMode::Apply,
+        };
+
+        let registry = Registry::new();
+        let _db = SqliteDb::try_from_config(&config, &registry).await.unwrap();
+        let _retrieved_db = registry
+            .get::<SqliteDb>()
+            .expect("To be able to retrieve the db");
     }
 }

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -1,6 +1,7 @@
 use super::config::StorageConfig;
 use super::StorageConfigError;
 use async_trait::async_trait;
+use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use std::sync::Arc;
@@ -51,7 +52,10 @@ impl LocalStorage {
 
 #[async_trait]
 impl Configurable<StorageConfig> for LocalStorage {
-    async fn try_from_config(config: &StorageConfig) -> Result<Self, Box<dyn ChromaError>> {
+    async fn try_from_config(
+        config: &StorageConfig,
+        _registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
         match &config {
             StorageConfig::Local(local_config) => {
                 let storage = LocalStorage::new(&local_config.root);

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -25,6 +25,7 @@ use aws_sdk_s3::types::CompletedMultipartUpload;
 use aws_sdk_s3::types::CompletedPart;
 use aws_smithy_types::byte_stream::Length;
 use bytes::Bytes;
+use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use chroma_error::ErrorCodes;
@@ -546,7 +547,10 @@ impl S3Storage {
 
 #[async_trait]
 impl Configurable<StorageConfig> for S3Storage {
-    async fn try_from_config(config: &StorageConfig) -> Result<Self, Box<dyn ChromaError>> {
+    async fn try_from_config(
+        config: &StorageConfig,
+        _registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
         match &config {
             StorageConfig::S3(s3_config) => {
                 let client = match &s3_config.credentials {

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -1,3 +1,7 @@
+use crate::SqliteSysDbConfig;
+use async_trait::async_trait;
+use chroma_config::registry::Registry;
+use chroma_config::Configurable;
 use chroma_error::{ChromaError, WrappedSqlxError};
 use chroma_sqlite::db::SqliteDb;
 use chroma_sqlite::helpers::{delete_metadata, get_embeddings_queue_topic_name, update_metadata};
@@ -899,6 +903,24 @@ impl SqliteSysDb {
         } else {
             Some(metadata)
         }
+    }
+}
+
+//////////////////////// Configurable Implementation ////////////////////////
+
+#[async_trait]
+impl Configurable<SqliteSysDbConfig> for SqliteSysDb {
+    async fn try_from_config(
+        config: &SqliteSysDbConfig,
+        registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        // Assume the registry has a sqlite db
+        let db = registry.get::<SqliteDb>().map_err(|e| e.boxed())?;
+        Ok(Self::new(
+            db,
+            config.log_tenant.clone(),
+            config.log_topic_namespace.clone(),
+        ))
     }
 }
 

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -7,6 +7,7 @@ use super::{operator::TaskMessage, worker_thread::WorkerThread};
 use crate::execution::config::DispatcherConfig;
 use crate::{Component, ComponentContext, Handler, ReceiverForMessage, System};
 use async_trait::async_trait;
+use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use std::fmt::Debug;
@@ -174,7 +175,10 @@ impl Dispatcher {
 
 #[async_trait]
 impl Configurable<DispatcherConfig> for Dispatcher {
-    async fn try_from_config(config: &DispatcherConfig) -> Result<Self, Box<dyn ChromaError>> {
+    async fn try_from_config(
+        config: &DispatcherConfig,
+        _registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
         Ok(Dispatcher::new(config.clone()))
     }
 }

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -1,5 +1,6 @@
 use super::{scheduler::Scheduler, ChannelError, RequestError, WrappedMessage};
 use async_trait::async_trait;
+use chroma_config::registry::Injectable;
 use core::panic;
 use futures::Stream;
 use parking_lot::Mutex;
@@ -186,6 +187,9 @@ pub struct ComponentHandle<C: Component + Debug> {
     join_handle: Option<ConsumableJoinHandle>,
     sender: ComponentSender<C>,
 }
+
+// Blanket implementation for all components of the Injectable trait
+impl<C> Injectable for ComponentHandle<C> where C: Component {}
 
 // Implemented manually because of https://github.com/rust-lang/rust/issues/26925.
 impl<C: Component> Clone for ComponentHandle<C> {

--- a/rust/worker/benches/get.rs
+++ b/rust/worker/benches/get.rs
@@ -2,7 +2,7 @@
 mod load;
 
 use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};
-use chroma_config::Configurable;
+use chroma_config::{registry::Registry, Configurable};
 use chroma_segment::test::TestDistributedSegment;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -125,9 +125,11 @@ fn bench_get(criterion: &mut Criterion) {
 
     let config = RootConfig::default();
     let system = System::default();
+    let registry = Registry::new();
     let dispatcher = runtime
         .block_on(Dispatcher::try_from_config(
             &config.query_service.dispatcher,
+            &registry,
         ))
         .expect("Should be able to initialize dispatcher");
     let dispatcher_handle = runtime.block_on(async { system.start_component(dispatcher) });

--- a/rust/worker/benches/load.rs
+++ b/rust/worker/benches/load.rs
@@ -53,7 +53,7 @@ pub async fn sift1m_segments() -> TestDistributedSegment {
 
 pub fn empty_fetch_log(collection_uuid: CollectionUuid) -> FetchLogOperator {
     FetchLogOperator {
-        log_client: Log::InMemory(InMemoryLog::default()).into(),
+        log_client: Log::InMemory(InMemoryLog::default()),
         batch_size: 100,
         start_log_offset_id: 0,
         maximum_fetch_count: Some(0),

--- a/rust/worker/benches/query.rs
+++ b/rust/worker/benches/query.rs
@@ -5,7 +5,7 @@ use chroma_benchmark::{
     benchmark::{bench_run, tokio_multi_thread},
     datasets::sift::Sift1MData,
 };
-use chroma_config::Configurable;
+use chroma_config::{registry::Registry, Configurable};
 use chroma_segment::test::TestDistributedSegment;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -130,9 +130,11 @@ fn bench_query(criterion: &mut Criterion) {
 
     let config = RootConfig::default();
     let system = System::default();
+    let registry = Registry::new();
     let dispatcher = runtime
         .block_on(Dispatcher::try_from_config(
             &config.query_service.dispatcher,
+            &registry,
         ))
         .expect("Should be able to initialize dispatcher");
     let dispatcher_handle = runtime.block_on(async { system.start_component(dispatcher) });

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -16,8 +16,8 @@ use crate::compactor::types::CompactionJob;
 
 pub(crate) struct Scheduler {
     my_member_id: String,
-    log: Box<Log>,
-    sysdb: Box<SysDb>,
+    log: Log,
+    sysdb: SysDb,
     policy: Box<dyn SchedulerPolicy>,
     job_queue: Vec<CompactionJob>,
     max_concurrent_jobs: usize,
@@ -37,8 +37,8 @@ impl Scheduler {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         my_ip: String,
-        log: Box<Log>,
-        sysdb: Box<SysDb>,
+        log: Log,
+        sysdb: SysDb,
         policy: Box<dyn SchedulerPolicy>,
         max_concurrent_jobs: usize,
         min_compaction_size: usize,
@@ -290,8 +290,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_scheduler() {
-        let mut log = Box::new(Log::InMemory(InMemoryLog::new()));
-        let in_memory_log = match *log {
+        let mut log = Log::InMemory(InMemoryLog::new());
+        let in_memory_log = match log {
             Log::InMemory(ref mut in_memory_log) => in_memory_log,
             _ => panic!("Invalid log type"),
         };
@@ -340,7 +340,7 @@ mod tests {
             },
         );
 
-        let mut sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let mut sysdb = SysDb::Test(TestSysDb::new());
 
         let tenant_1 = "tenant_1".to_string();
         let collection_1 = Collection {
@@ -369,7 +369,7 @@ mod tests {
             version: 0,
             total_records_post_compaction: 0,
         };
-        match *sysdb {
+        match sysdb {
             SysDb::Test(ref mut sysdb) => {
                 sysdb.add_collection(collection_1);
                 sysdb.add_collection(collection_2);
@@ -423,7 +423,7 @@ mod tests {
         assert_eq!(jobs[0].collection_id, collection_uuid_1,);
 
         // Add last compaction time for tenant_2
-        match *sysdb {
+        match sysdb {
             SysDb::Test(ref mut sysdb) => {
                 let last_compaction_time_2 = 1;
                 sysdb.add_tenant_last_compaction_time(tenant_2, last_compaction_time_2);
@@ -494,8 +494,8 @@ mod tests {
         expected = "offset in sysdb is less than offset in log, this should not happen!"
     )]
     async fn test_scheduler_panic() {
-        let mut log = Box::new(Log::InMemory(InMemoryLog::new()));
-        let in_memory_log = match *log {
+        let mut log = Log::InMemory(InMemoryLog::new());
+        let in_memory_log = match log {
             Log::InMemory(ref mut in_memory_log) => in_memory_log,
             _ => panic!("Invalid log type"),
         };
@@ -580,7 +580,7 @@ mod tests {
         );
         let _ = log.update_collection_log_offset(collection_uuid_1, 2).await;
 
-        let mut sysdb = Box::new(SysDb::Test(TestSysDb::new()));
+        let mut sysdb = SysDb::Test(TestSysDb::new());
 
         let tenant_1 = "tenant_1".to_string();
         let collection_1 = Collection {
@@ -596,7 +596,7 @@ mod tests {
             total_records_post_compaction: 0,
         };
 
-        match *sysdb {
+        match sysdb {
             SysDb::Test(ref mut sysdb) => {
                 sysdb.add_collection(collection_1);
                 let last_compaction_time_1 = 2;

--- a/rust/worker/src/execution/operators/fetch_log.rs
+++ b/rust/worker/src/execution/operators/fetch_log.rs
@@ -29,7 +29,7 @@ use tracing::trace;
 /// It should be run at the start of an orchestrator to get the latest data of a collection
 #[derive(Clone, Debug)]
 pub struct FetchLogOperator {
-    pub log_client: Box<Log>,
+    pub log_client: Log,
     pub batch_size: u32,
     pub start_log_offset_id: u32,
     pub maximum_fetch_count: Option<u32>,
@@ -119,7 +119,7 @@ mod tests {
 
     use super::Log;
 
-    fn setup_in_memory_log() -> (CollectionUuid, Box<Log>) {
+    fn setup_in_memory_log() -> (CollectionUuid, Log) {
         let collection_id = CollectionUuid::new();
         let mut in_memory_log = InMemoryLog::new();
         upsert_generator
@@ -136,7 +136,7 @@ mod tests {
                     },
                 )
             });
-        (collection_id, Box::new(Log::InMemory(in_memory_log)))
+        (collection_id, Log::InMemory(in_memory_log))
     }
 
     #[tokio::test]

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -43,8 +43,8 @@ pub struct RegisterInput {
     collection_version: i32,
     segment_flush_info: Arc<[SegmentFlushInfo]>,
     total_records_post_compaction: u64,
-    sysdb: Box<SysDb>,
-    log: Box<Log>,
+    sysdb: SysDb,
+    log: Log,
 }
 
 impl RegisterInput {
@@ -57,8 +57,8 @@ impl RegisterInput {
         collection_version: i32,
         segment_flush_info: Arc<[SegmentFlushInfo]>,
         total_records_post_compaction: u64,
-        sysdb: Box<SysDb>,
-        log: Box<Log>,
+        sysdb: SysDb,
+        log: Log,
     ) -> Self {
         RegisterInput {
             tenant,
@@ -153,8 +153,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_operator() {
-        let mut sysdb = Box::new(SysDb::Test(TestSysDb::new()));
-        let log = Box::new(Log::InMemory(InMemoryLog::new()));
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+        let log = Log::InMemory(InMemoryLog::new());
         let collection_version = 0;
         let collection_uuid_1 =
             CollectionUuid::from_str("00000000-0000-0000-0000-000000000001").unwrap();
@@ -189,7 +189,7 @@ mod tests {
             total_records_post_compaction,
         };
 
-        match *sysdb {
+        match sysdb {
             SysDb::Test(ref mut sysdb) => {
                 sysdb.add_collection(collection_1);
                 sysdb.add_collection(collection_2);
@@ -221,7 +221,7 @@ mod tests {
             metadata: None,
             file_path: file_path_2.clone(),
         };
-        match *sysdb {
+        match sysdb {
             SysDb::Test(ref mut sysdb) => {
                 sysdb.add_segment(segment_1);
                 sysdb.add_segment(segment_2);

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -113,8 +113,8 @@ pub struct CompactOrchestrator {
     // Component Execution
     collection_id: CollectionUuid,
     // Dependencies
-    log: Box<Log>,
-    sysdb: Box<SysDb>,
+    log: Log,
+    sysdb: SysDb,
     blockfile_provider: BlockfileProvider,
     hnsw_index_provider: HnswIndexProvider,
     // State we hold across the execution
@@ -239,8 +239,8 @@ impl CompactOrchestrator {
     pub fn new(
         compaction_job: CompactionJob,
         collection_id: CollectionUuid,
-        log: Box<Log>,
-        sysdb: Box<SysDb>,
+        log: Log,
+        sysdb: SysDb,
         blockfile_provider: BlockfileProvider,
         hnsw_index_provider: HnswIndexProvider,
         dispatcher: ComponentHandle<Dispatcher>,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -2,10 +2,11 @@ use std::iter::once;
 
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
-use chroma_config::Configurable;
+use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
 use chroma_index::hnsw_provider::HnswIndexProvider;
 use chroma_log::Log;
+use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
 use chroma_tracing::util::wrap_span_with_parent_context;
@@ -41,8 +42,8 @@ pub struct WorkerServer {
     // Component dependencies
     dispatcher: Option<ComponentHandle<Dispatcher>>,
     // Service dependencies
-    log: Box<Log>,
-    _sysdb: Box<SysDb>,
+    log: Log,
+    _sysdb: SysDb,
     hnsw_index_provider: HnswIndexProvider,
     blockfile_provider: BlockfileProvider,
     port: u16,
@@ -50,39 +51,23 @@ pub struct WorkerServer {
 
 #[async_trait]
 impl Configurable<QueryServiceConfig> for WorkerServer {
-    async fn try_from_config(config: &QueryServiceConfig) -> Result<Self, Box<dyn ChromaError>> {
-        let sysdb_config = &config.sysdb;
-        let sysdb = match chroma_sysdb::from_config(sysdb_config).await {
-            Ok(sysdb) => sysdb,
-            Err(err) => {
-                tracing::error!("Failed to create sysdb component: {:?}", err);
-                return Err(err);
-            }
-        };
-        let log_config = &config.log;
-        let log = match chroma_log::from_config(log_config).await {
-            Ok(log) => log,
-            Err(err) => {
-                tracing::error!("Failed to create log component: {:?}", err);
-                return Err(err);
-            }
-        };
-        let storage = match chroma_storage::from_config(&config.storage).await {
-            Ok(storage) => storage,
-            Err(err) => {
-                tracing::error!("Failed to create storage component: {:?}", err);
-                return Err(err);
-            }
-        };
-
-        let blockfile_provider = BlockfileProvider::try_from_config(&(
-            config.blockfile_provider.clone(),
-            storage.clone(),
-        ))
+    async fn try_from_config(
+        config: &QueryServiceConfig,
+        registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let sysdb = SysDb::try_from_config(&config.sysdb, registry).await?;
+        let log = Log::try_from_config(&config.log, registry).await?;
+        let storage = Storage::try_from_config(&config.storage, registry).await?;
+        let blockfile_provider = BlockfileProvider::try_from_config(
+            &(config.blockfile_provider.clone(), storage.clone()),
+            registry,
+        )
         .await?;
-        let hnsw_index_provider =
-            HnswIndexProvider::try_from_config(&(config.hnsw_provider.clone(), storage.clone()))
-                .await?;
+        let hnsw_index_provider = HnswIndexProvider::try_from_config(
+            &(config.hnsw_provider.clone(), storage.clone()),
+            registry,
+        )
+        .await?;
         Ok(WorkerServer {
             dispatcher: None,
             system: None,
@@ -418,8 +403,8 @@ mod tests {
         let mut server = WorkerServer {
             dispatcher: None,
             system: None,
-            _sysdb: Box::new(SysDb::Test(sysdb)),
-            log: Box::new(Log::InMemory(log)),
+            _sysdb: SysDb::Test(sysdb),
+            log: Log::InMemory(log),
             hnsw_index_provider: test_hnsw_index_provider(),
             blockfile_provider: segments.blockfile_provider,
             port,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds a "registry" that is used as a service locator
   - All `from_config` etc usage is now standardized on try_from_config from `Configurable` 
   - All usage try_from_config recieves a registry
   - The registry is used to get services that are shared
 - New functionality
   - /

## Test plan
*How are these changes tested?*
This a non-functional change. existing tests are the cover
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None