### PR TITLE
[ENH]: add seq ID migration to Python

### DIFF
--- a/chromadb/db/base.py
+++ b/chromadb/db/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Optional, Sequence, Tuple, Type
 from types import TracebackType
 from typing_extensions import Protocol, Self, Literal
 from abc import ABC, abstractmethod
@@ -9,7 +9,6 @@ import pypika.queries
 from chromadb.config import System, Component
 from uuid import UUID
 from itertools import islice, count
-from chromadb.types import SeqId
 
 
 class Cursor(Protocol):
@@ -105,29 +104,6 @@ class SqlDB(Component):
     def param(self, idx: int) -> pypika.Parameter:
         """Return a PyPika Parameter object for the given index"""
         return pypika.Parameter(self.parameter_format().format(idx))
-
-    @staticmethod
-    def decode_seq_id(seq_id_bytes: Union[bytes, int]) -> SeqId:
-        """Decode a byte array into a SeqID"""
-        if isinstance(seq_id_bytes, int):
-            return seq_id_bytes
-
-        if len(seq_id_bytes) == 8:
-            return int.from_bytes(seq_id_bytes, "big")
-        elif len(seq_id_bytes) == 24:
-            return int.from_bytes(seq_id_bytes, "big")
-        else:
-            raise ValueError(f"Unknown SeqID type with length {len(seq_id_bytes)}")
-
-    @staticmethod
-    def encode_seq_id(seq_id: SeqId) -> bytes:
-        """Encode a SeqID into a byte array"""
-        if seq_id.bit_length() <= 64:
-            return int.to_bytes(seq_id, 8, "big")
-        elif seq_id.bit_length() <= 192:
-            return int.to_bytes(seq_id, 24, "big")
-        else:
-            raise ValueError(f"Unsupported SeqID: {seq_id}")
 
 
 _context = local()

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -158,7 +158,7 @@ class SqlEmbeddingsQueue(SqlDB, Producer, Consumer):
             cur.execute(sql, params)
             results = cur.fetchall()
             if results:
-                min_seq_id = min(self.decode_seq_id(row[0]) for row in results)
+                min_seq_id = min(row[0] for row in results)
             else:
                 return
 

--- a/chromadb/migrations/metadb/00005-max-seq-id-int.sqlite.sql
+++ b/chromadb/migrations/metadb/00005-max-seq-id-int.sqlite.sql
@@ -1,0 +1,27 @@
+ALTER TABLE max_seq_id ADD COLUMN int_seq_id INTEGER;
+
+-- Convert 8 byte wide big-endian integer as blob to native 64 bit integer.
+-- Adapted from https://stackoverflow.com/a/70296198.
+UPDATE max_seq_id SET int_seq_id = (
+  SELECT (
+       (instr('123456789ABCDEF', substr(hex(seq_id), -1 , 1)) <<  0)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -2 , 1)) <<  4)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -3 , 1)) <<  8)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -4 , 1)) << 12)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -5 , 1)) << 16)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -6 , 1)) << 20)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -7 , 1)) << 24)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -8 , 1)) << 28)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -9 , 1)) << 32)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -10, 1)) << 36)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -11, 1)) << 40)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -12, 1)) << 44)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -13, 1)) << 48)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -14, 1)) << 52)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -15, 1)) << 56)
+     | (instr('123456789ABCDEF', substr(hex(seq_id), -16, 1)) << 60)
+    )
+);
+
+ALTER TABLE max_seq_id DROP COLUMN seq_id;
+ALTER TABLE max_seq_id RENAME COLUMN int_seq_id TO seq_id;

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -89,7 +89,7 @@ class SqliteMetadataSegment(MetadataReader):
             if result is None:
                 return self._consumer.min_seqid()
             else:
-                return self._db.decode_seq_id(result[0])
+                return cast(int, result[0])
 
     @trace_method("SqliteMetadataSegment.count", OpenTelemetryGranularity.ALL)
     @override
@@ -283,7 +283,7 @@ class SqliteMetadataSegment(MetadataReader):
         ).insert(
             ParameterValue(self._db.uuid_to_db(self._id)),
             ParameterValue(record["record"]["id"]),
-            ParameterValue(self._db.encode_seq_id(record["log_offset"])),
+            ParameterValue(record["log_offset"]),
         )
         sql, params = get_sql(q)
         sql = sql + "RETURNING id"
@@ -474,7 +474,7 @@ class SqliteMetadataSegment(MetadataReader):
         q = (
             self._db.querybuilder()
             .update(t)
-            .set(t.seq_id, ParameterValue(self._db.encode_seq_id(record["log_offset"])))
+            .set(t.seq_id, ParameterValue(record["log_offset"]))
             .where(t.segment_id == ParameterValue(self._db.uuid_to_db(self._id)))
             .where(t.embedding_id == ParameterValue(record["record"]["id"]))
         )
@@ -511,7 +511,7 @@ class SqliteMetadataSegment(MetadataReader):
                 .columns("segment_id", "seq_id")
                 .insert(
                     ParameterValue(self._db.uuid_to_db(self._id)),
-                    ParameterValue(self._db.encode_seq_id(record["log_offset"])),
+                    ParameterValue(record["log_offset"]),
                 )
             )
             sql, params = get_sql(q)

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -150,7 +150,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
             result = cur.fetchone()
 
             if result:
-                self._max_seq_id = self._db.decode_seq_id(result[0])
+                self._max_seq_id = result[0]
             elif self._index_exists():
                 # Migrate the max_seq_id from the legacy field in the pickled file to the SQLite database
                 q = (
@@ -159,9 +159,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                     .columns("segment_id", "seq_id")
                     .insert(
                         ParameterValue(self._db.uuid_to_db(self._id)),
-                        ParameterValue(
-                            self._db.encode_seq_id(self._persist_data.max_seq_id)
-                        ),
+                        ParameterValue(self._persist_data.max_seq_id),
                     )
                 )
                 sql, params = get_sql(q)
@@ -264,7 +262,7 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                 .columns("segment_id", "seq_id")
                 .insert(
                     ParameterValue(self._db.uuid_to_db(self._id)),
-                    ParameterValue(self._db.encode_seq_id(self._max_seq_id)),
+                    ParameterValue(self._max_seq_id),
                 )
             )
             sql, params = get_sql(q)


### PR DESCRIPTION
## Description of changes

This migration was added to the Rust local implementation, but not the Python local implementation.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust