### PR TITLE
[ENH] Add GHA for CLI release and install scripts

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,191 @@
+name: Release CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: "Release name to use (e.g. cli-1.2.3) when dispatching manually"
+        required: false
+  push:
+    tags:
+      - 'cli_release_[0-9]*.[0-9]*.[0-9]*'
+
+jobs:
+  build-linux:
+    name: Build Linux binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build Linux binary
+        run: cargo build --release --manifest-path=rust/cli/Cargo.toml
+
+      - name: Rename binary artifact for Linux
+        run: mv rust/cli/target/release/chroma chroma-linux
+
+      - name: Upload Linux binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chroma-linux
+          path: chroma-linux
+
+  build-windows:
+    name: Build Windows binary
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build Windows binary
+        run: cargo build --release --manifest-path=rust/cli/Cargo.toml
+
+      - name: Rename binary artifact for Windows
+        shell: powershell
+        run: |
+          Move-Item -Path rust\cli\target\release\chroma.exe -Destination chroma-windows.exe -Force
+          Get-ChildItem -Path .
+
+      - name: Upload Windows binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chroma-windows
+          path: chroma-windows.exe
+
+  build-macos:
+    name: Build macOS binaries (Intel & ARM64)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Add ARM64 target for macOS
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Build macOS Intel binary
+        run: cargo build --release --manifest-path=rust/cli/Cargo.toml
+
+      - name: Build macOS ARM64 binary
+        run: cargo build --release --manifest-path=rust/cli/Cargo.toml --target aarch64-apple-darwin
+
+      - name: Rename macOS binaries
+        run: |
+          mv rust/cli/target/release/chroma chroma-macos-intel
+          mv rust/cli/target/aarch64-apple-darwin/release/chroma chroma-macos-arm64
+          chmod +x chroma-macos-*
+
+      - name: Upload macOS Intel binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chroma-macos-intel
+          path: chroma-macos-intel
+
+      - name: Upload macOS ARM64 binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chroma-macos-arm64
+          path: chroma-macos-arm64
+
+  release:
+    name: Create GitHub Release and Attach Assets
+    runs-on: ubuntu-latest
+    needs: [ build-linux, build-windows, build-macos ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Ensure all binaries are executable
+        run: chmod +x artifacts/* || true
+
+      - name: Determine release info
+        id: release_info
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            # The tag is available as refs/tags/cli_release_a.b.c.
+            TAG=${GITHUB_REF#refs/tags/}
+            VERSION=${TAG#cli_release_}
+            echo "release_name=cli-${VERSION}" >> $GITHUB_OUTPUT
+            echo "tag_name=${TAG}" >> $GITHUB_OUTPUT
+          else
+            if [ -z "${{ github.event.inputs.release_name }}" ]; then
+              echo "::error::Manual dispatch requires a release_name input."
+              exit 1
+            fi
+            echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+            echo "tag_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.release_info.outputs.tag_name }}
+          release_name: ${{ steps.release_info.outputs.release_name }}
+          body: "CLI release."
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux binary to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/chroma-linux/chroma-linux
+          asset_name: chroma-linux
+          asset_content_type: application/octet-stream
+
+      - name: Upload Windows binary to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/chroma-windows/chroma-windows.exe
+          asset_name: chroma-windows.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload macOS Intel binary to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/chroma-macos-intel/chroma-macos-intel
+          asset_name: chroma-macos-intel
+          asset_content_type: application/octet-stream
+
+      - name: Upload macOS ARM64 binary to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/chroma-macos-arm64/chroma-macos-arm64
+          asset_name: chroma-macos-arm64
+          asset_content_type: application/octet-stream

--- a/rust/cli/install/install.ps1
+++ b/rust/cli/install/install.ps1
@@ -1,0 +1,39 @@
+# Chroma CLI Installer Script for Windows (PowerShell)
+# Usage:
+#   iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/chroma-core/chroma/main/rust/cli/install/install.ps1'))
+
+$ErrorActionPreference = 'Stop'
+
+$repo    = "chroma-core/chroma"
+$release = "cli-0.1.0"
+$asset = "chroma-windows.exe"
+
+$downloadUrl = "https://github.com/$repo/releases/download/$release/$asset"
+Write-Host "Downloading $asset from $downloadUrl ..."
+
+$tempFile = Join-Path $env:TEMP "chroma.exe"
+Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
+
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
+if ($isAdmin) {
+    $installDir = Join-Path $env:ProgramFiles "Chroma"
+} else {
+    $installDir = Join-Path $env:USERPROFILE "bin"
+}
+
+if (-not (Test-Path $installDir)) {
+    New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+}
+
+$installPath = Join-Path $installDir "chroma.exe"
+Move-Item -Path $tempFile -Destination $installPath -Force
+
+Write-Host "Chroma has been installed to: $installPath"
+
+$pathDirs = $env:PATH -split ';'
+if ($pathDirs -notcontains $installDir) {
+    Write-Warning "WARNING ⚠️: The directory '$installDir' is not in your PATH."
+    Write-Host "To add it for the current session, run:"
+    Write-Host "    `\$env:PATH = '$installDir;' + \$env:PATH"
+    Write-Host "To add it permanently, update your system environment variables."
+}

--- a/rust/cli/install/install.sh
+++ b/rust/cli/install/install.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -e
+
+# ----------------------------------------------
+# Chroma CLI Installer Script
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/chroma-core/chroma/main/rust/cli/install/install.sh | bash
+# ----------------------------------------------
+
+REPO="chroma-core/chroma"
+RELEASE="cli-0.1.0"
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+ASSET=""
+
+case "$OS" in
+  Linux*)
+    ASSET="chroma-linux"
+    ;;
+  Darwin*)
+    if [ "$ARCH" = "arm64" ]; then
+      ASSET="chroma-macos-arm64"
+    else
+      ASSET="chroma-macos-intel"
+    fi
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    ASSET="chroma-windows.exe"
+    ;;
+  *)
+    echo "Unsupported OS: $OS"
+    exit 1
+    ;;
+esac
+
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${RELEASE}/${ASSET}"
+echo "Downloading ${ASSET} from ${DOWNLOAD_URL}..."
+curl -L "$DOWNLOAD_URL" -o chroma
+
+chmod +x chroma
+
+if [ -w /usr/local/bin ]; then
+  sudo mv chroma /usr/local/bin/chroma
+else
+  mkdir -p "$HOME/.local/bin"
+  mv chroma "$HOME/.local/bin/chroma"
+
+  case ":$PATH:" in
+    *:"$HOME/.local/bin":*)
+      ;;
+    *)
+      echo "====================="
+      echo "Warning ⚠️: $HOME/.local/bin is not in your PATH."
+      echo "To add it, you can run:"
+      echo '  export PATH="$HOME/.local/bin:$PATH"'
+      echo "====================="
+      ;;
+  esac
+fi


### PR DESCRIPTION
## Description of changes

* Adding a GHA to make a CLI release and install scripts for it (unix and power shell).
* Chose /usr/local/bin and ~/.local/bin as these are often included in the PATH by default.
* Currently GHA is dispatch-able for testing purposes.

## Test plan
* Will test GHA for release and install scripts on Mac and Windows.

## Documentation Changes
TBA
