### PR TITLE
[TST]: add invaariant assertions for ordered blockfile writing

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -16,5 +16,10 @@ runs:
       uses: arduino/setup-protoc@v2
     - name: Use sccache
       uses: mozilla-actions/sccache-action@v0.0.7
+    - name: Enable sccache
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -14,9 +14,7 @@ runs:
       shell: bash
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
-    - name: Cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: rust/worker
+    - name: Use sccache
+      uses: mozilla-actions/sccache-action@v0.0.7
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -54,3 +54,15 @@ jobs:
         uses: ./.github/actions/rust
       - name: Test compile
         run: cargo bench --no-run
+
+  can-build-release:
+    runs-on: depot-ubuntu-22.04-16
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+      - name: Build in release mode
+        run: cargo build --release

--- a/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
@@ -18,6 +18,7 @@ pub struct OrderedBlockDelta {
     pub(in crate::arrow) id: Uuid,
     copied_up_to_row_of_old_block: usize,
     old_block: Option<Block>,
+    last_added_key: Option<(String, KeyWrapper)>,
 }
 
 impl Delta for OrderedBlockDelta {
@@ -32,6 +33,7 @@ impl Delta for OrderedBlockDelta {
             id,
             copied_up_to_row_of_old_block: 0,
             old_block: None,
+            last_added_key: None,
         }
     }
 
@@ -63,6 +65,15 @@ impl OrderedBlockDelta {
         V: ArrowWriteableValue,
     {
         let wrapped_key: KeyWrapper = key.into();
+        let this_key = (prefix.to_string(), wrapped_key.clone());
+        if let Some(ref last_key) = self.last_added_key {
+            if *last_key > this_key {
+                panic!("Found unordered keys while adding to block delta. Last key: {:?}, current key: {:?}", last_key, this_key);
+            }
+        } else {
+            self.last_added_key = Some(this_key);
+        }
+
         self.copy_up_to::<K::ReadableKey<'_>, V::ReadableValue<'_>>(prefix, &wrapped_key);
 
         // TODO: errors?
@@ -80,6 +91,8 @@ impl OrderedBlockDelta {
     pub fn copy_to_end<K: ArrowWriteableKey, V: ArrowWriteableValue>(&mut self) {
         // Copy remaining rows
         if let Some(old_block) = self.old_block.as_ref() {
+            let mut last_key = None;
+
             for i in self.copied_up_to_row_of_old_block..old_block.data.num_rows() {
                 let old_prefix = old_block
                     .data
@@ -89,6 +102,15 @@ impl OrderedBlockDelta {
                     .unwrap()
                     .value(i);
                 let old_key = K::ReadableKey::get(old_block.data.column(1), i);
+
+                if let Some(ref last_key) = last_key {
+                    if *last_key > (old_prefix, old_key.clone()) {
+                        panic!("Found unordered keys while copying to end of block. Last key: {:?}, current key: {:?}", last_key, (old_prefix, old_key));
+                    }
+                } else {
+                    last_key = Some((old_prefix, old_key.clone()));
+                }
+
                 let old_value = V::ReadableValue::get(old_block.data.column(2), i);
                 K::ReadableKey::add_to_delta(old_prefix, old_key, old_value, &mut self.builder);
             }
@@ -113,9 +135,17 @@ impl OrderedBlockDelta {
                 .unwrap();
             let key_arr = old_block.data.column(1);
 
+            let mut last_key = None;
             for i in self.copied_up_to_row_of_old_block..old_block.data.num_rows() {
                 let old_prefix = prefix_arr.value(i);
                 let old_key = K::get(key_arr, i);
+                if let Some(ref last_key) = last_key {
+                    if *last_key > (old_prefix, old_key.clone()) {
+                        panic!("Found unordered keys while copying up to excluded key. Excluded key: {:?}, last key: {:?}, current key: {:?}", (excluded_prefix, excluded_key), last_key, (old_prefix, old_key));
+                    }
+                } else {
+                    last_key = Some((old_prefix, old_key.clone()));
+                }
 
                 match old_prefix.cmp(excluded_prefix) {
                     std::cmp::Ordering::Less => {}
@@ -175,6 +205,7 @@ impl OrderedBlockDelta {
             id: Uuid::new_v4(),
             copied_up_to_row_of_old_block: 0,
             old_block: None,
+            last_added_key: None,
         };
         if new_block.get_size::<K, V>() > max_block_size_bytes {
             blocks_to_split.push(new_block);
@@ -191,6 +222,7 @@ impl OrderedBlockDelta {
                 id: Uuid::new_v4(),
                 copied_up_to_row_of_old_block: 0,
                 old_block: None,
+                last_added_key: None,
             };
 
             output.push((
@@ -224,6 +256,7 @@ impl OrderedBlockDelta {
             id: Uuid::new_v4(),
             copied_up_to_row_of_old_block: self.copied_up_to_row_of_old_block,
             old_block,
+            last_added_key: None,
         };
 
         self.copied_up_to_row_of_old_block = 0;

--- a/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
@@ -145,16 +145,21 @@ impl OrderedBlockDelta {
                 .unwrap();
             let key_arr = old_block.data.column(1);
 
+            #[cfg(debug_assertions)]
             let mut last_key = None;
             for i in self.copied_up_to_row_of_old_block..old_block.data.num_rows() {
                 let old_prefix = prefix_arr.value(i);
                 let old_key = K::get(key_arr, i);
-                if let Some(ref last_key) = last_key {
-                    if *last_key > (old_prefix, old_key.clone()) {
-                        panic!("Found unordered keys while copying up to excluded key. Excluded key: {:?}, last key: {:?}, current key: {:?}", (excluded_prefix, excluded_key), last_key, (old_prefix, old_key));
+
+                #[cfg(debug_assertions)]
+                {
+                    if let Some(ref last_key) = last_key {
+                        if *last_key > (old_prefix, old_key.clone()) {
+                            panic!("Found unordered keys while copying up to excluded key. Excluded key: {:?}, last key: {:?}, current key: {:?}", (excluded_prefix, excluded_key), last_key, (old_prefix, old_key));
+                        }
+                    } else {
+                        last_key = Some((old_prefix, old_key.clone()));
                     }
-                } else {
-                    last_key = Some((old_prefix, old_key.clone()));
                 }
 
                 match old_prefix.cmp(excluded_prefix) {

--- a/rust/blockstore/src/arrow/ordered_blockfile_writer.rs
+++ b/rust/blockstore/src/arrow/ordered_blockfile_writer.rs
@@ -395,12 +395,12 @@ mod tests {
         let id = writer.id();
 
         let prefix_1 = "key";
-        let key1 = "zzzz";
+        let key1 = "aaaa";
         let value1 = vec![1, 2, 3];
         writer.set(prefix_1, key1, value1.clone()).await.unwrap();
 
         let prefix_2 = "key";
-        let key2 = "aaaa";
+        let key2 = "zzzz";
         let value2 = vec![4, 5, 6];
         writer.set(prefix_2, key2, value2).await.unwrap();
 

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -167,6 +167,21 @@ impl FullTextIndexWriter {
 
         let token_instances = std::mem::take(&mut *self.token_instances.lock());
 
+        // Assert that the token instances are sorted
+        let cloned_token_instances = token_instances.clone().into_iter().kmerge();
+        let mut last_token_instance = None;
+        for encoded_instance in cloned_token_instances {
+            if let Some(last) = last_token_instance {
+                if last > encoded_instance {
+                    panic!(
+                        "Token instances are not sorted. Received {:?} after {:?}.",
+                        encoded_instance, last
+                    );
+                }
+            }
+            last_token_instance = Some(encoded_instance);
+        }
+
         for encoded_instance in token_instances.into_iter().kmerge() {
             match encoded_instance.get_position() {
                 Some(offset) => {

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -167,21 +167,6 @@ impl FullTextIndexWriter {
 
         let token_instances = std::mem::take(&mut *self.token_instances.lock());
 
-        // Assert that the token instances are sorted
-        let cloned_token_instances = token_instances.clone().into_iter().kmerge();
-        let mut last_token_instance = None;
-        for encoded_instance in cloned_token_instances {
-            if let Some(last) = last_token_instance {
-                if last > encoded_instance {
-                    panic!(
-                        "Token instances are not sorted. Received {:?} after {:?}.",
-                        encoded_instance, last
-                    );
-                }
-            }
-            last_token_instance = Some(encoded_instance);
-        }
-
         for encoded_instance in token_instances.into_iter().kmerge() {
             match encoded_instance.get_position() {
                 Some(offset) => {


### PR DESCRIPTION
## Description of changes

Adds invariant assertions for the ordered blockfile writer that are checked in debug mode.

## Test plan
*How are these changes tested?*

Since `#[cfg(debug_assertions)]` can break release builds when improperly used, I added a CI check for `cargo build --release`.