### PR TITLE
[DOC] update embedding function doc referencing texts -> input

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/cohere.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/cohere.md
@@ -15,7 +15,7 @@ This embedding function relies on the `cohere` python package, which you can ins
 ```python
 import chromadb.utils.embedding_functions as embedding_functions
 cohere_ef  = embedding_functions.CohereEmbeddingFunction(api_key="YOUR_API_KEY",  model_name="large")
-cohere_ef(texts=["document1","document2"])
+cohere_ef(input=["document1","document2"])
 ```
 
 {% /Tab %}
@@ -58,7 +58,7 @@ multilingual_texts  = [ 'Hello from Cohere!', 'مرحبًا من كوهير!',
         'Ciao da Cohere!', '您好，来自 Cohere！',
         'कोहिअर से नमस्ते!'  ]
 
-cohere_ef(texts=multilingual_texts)
+cohere_ef(input=multilingual_texts)
 
 ```
 

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/voyageai.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/voyageai.md
@@ -15,7 +15,7 @@ This embedding function relies on the `voyageai` python package, which you can i
 ```python
 import chromadb.utils.embedding_functions as embedding_functions
 voyageai_ef  = embedding_functions.VoyageAIEmbeddingFunction(api_key="YOUR_API_KEY",  model_name="voyage-3-large")
-voyageai_ef(texts=["document1","document2"])
+voyageai_ef(input=["document1","document2"])
 ```
 
 {% /Tab %}
@@ -56,7 +56,7 @@ multilingual_texts  = [ 'Hello from VoyageAI!', 'مرحباً من VoyageAI!!',
         'Ciao da VoyageAI!', '您好，来自 VoyageAI！',
         'कोहिअर से VoyageAI!'  ]
 
-voyageai_ef(texts=multilingual_texts)
+voyageai_ef(input=multilingual_texts)
 
 ```
 


### PR DESCRIPTION
## Description of changes

Documentation for some embedding function integrations refer to `texts` which throws an error. should refer to them as `input`
