### PR TITLE
[ENH]: push down `validate_embeddings()` into Frontend

### DIFF
--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -209,7 +209,7 @@ impl Frontend {
         Ok(UpdateCollectionResponse {})
     }
 
-    pub async fn validate_embedding<Embedding, F>(
+    async fn validate_embedding<Embedding, F>(
         &mut self,
         collection_id: CollectionUuid,
         option_embeddings: Option<&Vec<Embedding>>,
@@ -530,6 +530,12 @@ impl Frontend {
             ..
         } = request;
 
+        self.validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
+            Some(embedding.len())
+        })
+        .await
+        .map_err(|err| err.boxed())?;
+
         let embeddings = embeddings.map(|embeddings| embeddings.into_iter().map(Some).collect());
 
         let records = to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)
@@ -556,6 +562,12 @@ impl Frontend {
             metadatas,
             ..
         }: UpdateCollectionRecordsRequest = request;
+
+        self.validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
+            embedding.as_ref().map(|emb| emb.len())
+        })
+        .await
+        .map_err(|err| err.boxed())?;
 
         let records = to_records(
             ids,
@@ -588,6 +600,12 @@ impl Frontend {
             metadatas,
             ..
         } = request;
+
+        self.validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
+            Some(embedding.len())
+        })
+        .await
+        .map_err(|err| err.boxed())?;
 
         let embeddings = embeddings.map(|embeddings| embeddings.into_iter().map(Some).collect());
 
@@ -901,6 +919,15 @@ impl Frontend {
     }
 
     pub async fn query(&mut self, request: QueryRequest) -> Result<QueryResponse, QueryError> {
+        self.validate_embedding(
+            request.collection_id,
+            Some(&request.embeddings),
+            true,
+            |embedding| Some(embedding.len()),
+        )
+        .await
+        .map_err(|err| err.boxed())?;
+
         let retries = Arc::new(AtomicUsize::new(0));
         let query_to_retry = || {
             let mut self_clone = self.clone();

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -799,16 +799,6 @@ async fn collection_add(
         format!("collection:{}", collection_id).as_str(),
     ]);
 
-    server
-        .frontend
-        .validate_embedding(
-            collection_id,
-            payload.embeddings.as_ref(),
-            true,
-            |embedding| Some(embedding.len()),
-        )
-        .await?;
-
     let request = chroma_types::AddCollectionRecordsRequest::try_new(
         tenant_id,
         database_name,
@@ -879,16 +869,6 @@ async fn collection_update(
         format!("collection:{}", collection_id).as_str(),
     ]);
 
-    server
-        .frontend
-        .validate_embedding(
-            collection_id,
-            payload.embeddings.as_ref(),
-            true,
-            |embedding| embedding.as_ref().map(|e| e.len()),
-        )
-        .await?;
-
     let request = chroma_types::UpdateCollectionRecordsRequest::try_new(
         tenant_id,
         database_name,
@@ -957,16 +937,6 @@ async fn collection_upsert(
         format!("tenant:{}", tenant_id).as_str(),
         format!("collection:{}", collection_id).as_str(),
     ]);
-
-    server
-        .frontend
-        .validate_embedding(
-            collection_id,
-            payload.embeddings.as_ref(),
-            true,
-            |embedding| Some(embedding.len()),
-        )
-        .await?;
 
     let request = chroma_types::UpsertCollectionRecordsRequest::try_new(
         tenant_id,
@@ -1221,15 +1191,6 @@ async fn collection_query(
         format!("tenant:{}", tenant_id).as_str(),
         format!("collection:{}", collection_id).as_str(),
     ]);
-    server
-        .frontend
-        .validate_embedding(
-            collection_id,
-            Some(&payload.query_embeddings),
-            true,
-            |embedding| Some(embedding.len()),
-        )
-        .await?;
 
     let request = QueryRequest::try_new(
         tenant_id,

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -16,14 +16,8 @@ pub enum ValidationError {
     DimensionInconsistent,
     #[error("Collection expecting embedding with dimension of {0}, got {1}")]
     DimensionMismatch(u32, u32),
-    #[error("Deleting collection records without filter")]
-    EmptyDelete,
-    #[error("Empty metadata")]
-    EmptyMetadata,
     #[error("Error getting collection: {0}")]
     GetCollection(#[from] GetCollectionError),
-    #[error("Invalid name: {0}")]
-    Name(String),
     #[error("Error updatding collection: {0}")]
     UpdateCollection(#[from] UpdateCollectionError),
 }
@@ -34,10 +28,7 @@ impl ChromaError for ValidationError {
             ValidationError::CollectionId => ErrorCodes::InvalidArgument,
             ValidationError::DimensionInconsistent => ErrorCodes::InvalidArgument,
             ValidationError::DimensionMismatch(_, _) => ErrorCodes::InvalidArgument,
-            ValidationError::EmptyDelete => ErrorCodes::InvalidArgument,
-            ValidationError::EmptyMetadata => ErrorCodes::InvalidArgument,
             ValidationError::GetCollection(err) => err.code(),
-            ValidationError::Name(_) => ErrorCodes::InvalidArgument,
             ValidationError::UpdateCollection(err) => err.code(),
         }
     }

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -375,15 +375,6 @@ impl Bindings {
             uuid::Uuid::parse_str(&collection_id).map_err(WrappedUuidError)?,
         );
 
-        let mut frontend_clone = self.frontend.clone();
-        self.runtime.block_on(async {
-            frontend_clone
-                .validate_embedding(collection_id, Some(&embeddings), true, |embedding| {
-                    Some(embedding.len())
-                })
-                .await
-        })?;
-
         let req = chroma_types::AddCollectionRecordsRequest::try_new(
             tenant,
             database,
@@ -431,13 +422,6 @@ impl Bindings {
         );
 
         let mut frontend_clone = self.frontend.clone();
-        self.runtime.block_on(async {
-            frontend_clone
-                .validate_embedding(collection_id, embeddings.as_ref(), false, |embedding| {
-                    embedding.as_ref().map(|emb| emb.len())
-                })
-                .await
-        })?;
 
         let req = chroma_types::UpdateCollectionRecordsRequest::try_new(
             tenant,
@@ -486,13 +470,6 @@ impl Bindings {
         );
 
         let mut frontend_clone = self.frontend.clone();
-        self.runtime.block_on(async {
-            frontend_clone
-                .validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
-                    Some(embedding.len())
-                })
-                .await
-        })?;
 
         let req = chroma_types::UpsertCollectionRecordsRequest::try_new(
             tenant,
@@ -645,15 +622,6 @@ impl Bindings {
         );
 
         let include = IncludeList::try_from(include)?;
-
-        let mut frontend_clone = self.frontend.clone();
-        self.runtime.block_on(async {
-            frontend_clone
-                .validate_embedding(collection_id, Some(&query_embeddings), false, |embedding| {
-                    Some(embedding.len())
-                })
-                .await
-        })?;
 
         let request = chroma_types::QueryRequest::try_new(
             tenant,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -784,14 +784,14 @@ pub enum AddCollectionRecordsError {
     #[error("Failed to get collection: {0}")]
     Collection(#[from] GetCollectionError),
     #[error(transparent)]
-    Internal(#[from] Box<dyn ChromaError>),
+    Other(#[from] Box<dyn ChromaError>),
 }
 
 impl ChromaError for AddCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
             AddCollectionRecordsError::Collection(err) => err.code(),
-            AddCollectionRecordsError::Internal(err) => err.code(),
+            AddCollectionRecordsError::Other(err) => err.code(),
         }
     }
 }
@@ -844,13 +844,13 @@ pub struct UpdateCollectionRecordsResponse {}
 #[derive(Error, Debug)]
 pub enum UpdateCollectionRecordsError {
     #[error(transparent)]
-    Internal(#[from] Box<dyn ChromaError>),
+    Other(#[from] Box<dyn ChromaError>),
 }
 
 impl ChromaError for UpdateCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            UpdateCollectionRecordsError::Internal(err) => err.code(),
+            UpdateCollectionRecordsError::Other(err) => err.code(),
         }
     }
 }
@@ -903,13 +903,13 @@ pub struct UpsertCollectionRecordsResponse {}
 #[derive(Error, Debug)]
 pub enum UpsertCollectionRecordsError {
     #[error(transparent)]
-    Internal(#[from] Box<dyn ChromaError>),
+    Other(#[from] Box<dyn ChromaError>),
 }
 
 impl ChromaError for UpsertCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            UpsertCollectionRecordsError::Internal(err) => err.code(),
+            UpsertCollectionRecordsError::Other(err) => err.code(),
         }
     }
 }
@@ -1342,14 +1342,14 @@ pub enum QueryError {
     #[error("Error executing plan: {0}")]
     Executor(#[from] ExecutorError),
     #[error(transparent)]
-    Internal(#[from] Box<dyn ChromaError>),
+    Other(#[from] Box<dyn ChromaError>),
 }
 
 impl ChromaError for QueryError {
     fn code(&self) -> ErrorCodes {
         match self {
             QueryError::Executor(e) => e.code(),
-            QueryError::Internal(err) => err.code(),
+            QueryError::Other(err) => err.code(),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Centralizes logic for validating embedding dimension and updating collection dimension size. Needed when calling frontend methods directly.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust