### PR TITLE
[ENH] Make rust cache hash deterministic by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,6 +1270,7 @@ dependencies = [
 name = "chroma-cache"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-trait",
  "chroma-config",
@@ -1281,6 +1282,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_yaml",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -17,7 +17,7 @@ opentelemetry = { version = "0.27.0", default-features = false, features = [
 
 # TODO(rescrv):  Deprecated.  Find a suitable replacement for such things.
 serde_yaml = "0.9"
-
+ahash = "0.8.11"
 async-trait = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
@@ -29,6 +29,9 @@ uuid = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
 chroma-types = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -17,6 +17,7 @@ opentelemetry = { version = "0.27.0", default-features = false, features = [
 
 # TODO(rescrv):  Deprecated.  Find a suitable replacement for such things.
 serde_yaml = "0.9"
+# NOTE(hammadb): https://github.com/chroma-core/chroma/pull/3809 Do not change this version unless you know the implications.
 ahash = "0.8.11"
 async-trait = { workspace = true }
 parking_lot = { workspace = true }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -1,4 +1,5 @@
 use super::{CacheError, Weighted};
+use ahash::RandomState;
 use chroma_error::ChromaError;
 use chroma_types::CollectionAndSegments;
 use clap::Parser;
@@ -47,6 +48,10 @@ const fn default_reclaimers() -> usize {
 
 const fn default_recover_concurrency() -> usize {
     16
+}
+
+const fn default_deterministic_hashing() -> bool {
+    true
 }
 
 const fn default_admission_rate_limit() -> usize {
@@ -130,6 +135,14 @@ pub struct FoyerCacheConfig {
     #[arg(long, default_value_t = 16)]
     #[serde(default = "default_recover_concurrency")]
     pub recover_concurrency: usize,
+
+    /// Enable deterministic hashing.
+    /// If true, the cache will use a deterministic hasher which is stable
+    /// across restarts. Note that this hasher is not necessarily stable across
+    /// architectures or versions of foyer, and the underlying AHash.
+    #[arg(long, default_value_t = true)]
+    #[serde(default = "default_deterministic_hashing")]
+    pub deterministic_hashing: bool,
 
     /// Enable rated ticket admission picker if `admission_rate_limit > 0`. (MiB/s)
     #[arg(long, default_value_t = 100)]
@@ -237,6 +250,7 @@ impl Default for FoyerCacheConfig {
             flush: default_flush(),
             reclaimers: default_reclaimers(),
             recover_concurrency: default_recover_concurrency(),
+            deterministic_hashing: default_deterministic_hashing(),
             admission_rate_limit: default_admission_rate_limit(),
             shards: default_shards(),
             eviction: default_eviction(),
@@ -328,6 +342,19 @@ where
             }
         };
 
+        let builder = match config.deterministic_hashing {
+            true => {
+                let rs = RandomState::with_seeds(
+                    18408126631592559320,
+                    14098607199905812554,
+                    3530350452151671086,
+                    4042281453092388365,
+                );
+                builder.with_hash_builder(rs)
+            }
+            false => builder,
+        };
+
         let Some(dir) = config.dir.as_ref() else {
             return Err(Box::new(CacheError::InvalidCacheConfig(
                 "missing dir".to_string(),
@@ -343,6 +370,7 @@ where
                     .with_file_size(config.file_size * MIB),
             )
             .with_flush(config.flush)
+            .with_recover_mode(foyer::RecoverMode::Strict)
             .with_large_object_disk_cache_options(
                 LargeEngineOptions::new()
                     .with_indexer_shards(config.shards)
@@ -579,5 +607,62 @@ where
 impl crate::Weighted for CollectionAndSegments {
     fn weight(&self) -> usize {
         1
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    impl crate::Weighted for String {
+        fn weight(&self) -> usize {
+            self.len()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_foyer_hybrid_cache_can_recover() {
+        let dir = tempfile::tempdir()
+            .expect("To be able to create temp path")
+            .path()
+            .to_str()
+            .expect("To be able to parse path")
+            .to_string();
+        let cache = FoyerCacheConfig {
+            dir: Some(dir.clone()),
+            ..FoyerCacheConfig::default()
+        }
+        .build_hybrid::<String, String>()
+        .await
+        .unwrap();
+
+        cache.insert("key1".to_string(), "value1".to_string()).await;
+        drop(cache);
+
+        // Test that we can recover the cache from disk.
+        let cache2 = FoyerCacheConfig {
+            dir: Some(dir.clone()),
+            ..FoyerCacheConfig::default()
+        }
+        .build_hybrid::<String, String>()
+        .await
+        .unwrap();
+
+        assert_eq!(
+            cache2.get(&"key1".to_string()).await.unwrap(),
+            Some("value1".to_string())
+        );
+
+        // Deterministic hashing off should not be able to recover the cache.
+        let cache3 = FoyerCacheConfig {
+            dir: Some(dir.clone()),
+            deterministic_hashing: false,
+            ..FoyerCacheConfig::default()
+        }
+        .build_hybrid::<String, String>()
+        .await
+        .unwrap();
+
+        assert_eq!(cache3.get(&"key1".to_string()).await.unwrap(), None);
     }
 }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -344,6 +344,7 @@ where
 
         let builder = match config.deterministic_hashing {
             true => {
+                // These are generated from a good RNG.
                 let rs = RandomState::with_seeds(
                     18408126631592559320,
                     14098607199905812554,

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -51,8 +51,20 @@ query_service:
             block_manager_config:
                 max_block_size_bytes: 16384
                 block_cache_config:
-                    lru:
+                    disk:
+                        dir: "/cache/chroma/query-service/block-cache"
+                        # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
                         capacity: 1000
+                        mem: 8000 # 8GiB
+                        disk: 12884 # 12GiB
+                        file_size: 256 #  256 MiB
+                        flushers: 4
+                        flush: false
+                        reclaimers: 2
+                        recover_concurrency: 16
+                        admission_rate_limit: 256 # 256MiB/s
+                        shards: 64
+                        eviction: lru
             sparse_index_manager_config:
                 sparse_index_cache_config:
                     lru:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Foyer internally uses AHash for hashing, which the default constructor of randomizes itself internally so each new process has essentially different hash function. https://github.com/tkaitchuck/aHash/issues/132
This provides an option to pin the keys AHash uses. 
 - New functionality
   - /

## Test plan
*How are these changes tested?*
Added a test that validates persistence by creating a new cache is able to read the old key. Without the config, this is expected to fail. 
I also debugged into foyer and confirmed we are hitting disk
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
