### PR TITLE
[BUG]  When moving to its own crate, I dropped the ShouldSample, assuming fastrace would do it

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -12,6 +12,55 @@ use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing_bunyan_formatter::BunyanFormattingLayer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
+struct ChromaShouldSample;
+
+const BUSY_NS: opentelemetry::Key = opentelemetry::Key::from_static_str("busy_ns");
+const IDLE_NS: opentelemetry::Key = opentelemetry::Key::from_static_str("idle_ns");
+
+fn is_slow(attributes: &[opentelemetry::KeyValue]) -> bool {
+    let mut nanos = 0i64;
+    for attr in attributes {
+        if attr.key == BUSY_NS || attr.key == IDLE_NS {
+            if let opentelemetry::Value::I64(ns) = attr.value {
+                nanos += ns;
+            }
+        }
+    }
+    nanos > 20_000_000
+}
+
+impl opentelemetry_sdk::trace::ShouldSample for ChromaShouldSample {
+    fn should_sample(
+        &self,
+        _: Option<&opentelemetry::Context>,
+        _: opentelemetry::trace::TraceId,
+        name: &str,
+        _: &opentelemetry::trace::SpanKind,
+        attributes: &[opentelemetry::KeyValue],
+        _: &[opentelemetry::trace::Link],
+    ) -> opentelemetry::trace::SamplingResult {
+        // NOTE(rescrv):  THIS IS A HACK!  If you find yourself seriously extending it, it's time
+        // to investigate honeycomb's sampling capabilities.
+
+        // If the name is not get and not insert, or the request is slow, sample it.
+        // Otherwise, drop.
+        // This filters filters foyer calls in-process so they won't be overwhelming the tracing.
+        if (name != "get" && name != "insert") || is_slow(attributes) {
+            opentelemetry::trace::SamplingResult {
+                decision: opentelemetry::trace::SamplingDecision::RecordAndSample,
+                attributes: vec![],
+                trace_state: opentelemetry::trace::TraceState::default(),
+            }
+        } else {
+            opentelemetry::trace::SamplingResult {
+                decision: opentelemetry::trace::SamplingDecision::Drop,
+                attributes: vec![],
+                trace_state: opentelemetry::trace::TraceState::default(),
+            }
+        }
+    }
+}
+
 pub fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
     println!(
         "Registering jaeger subscriber for {} at endpoint {}",
@@ -28,7 +77,9 @@ pub fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
         .with_endpoint(otel_endpoint)
         .build()
         .expect("could not build span exporter for tracing");
-    let trace_config = opentelemetry_sdk::trace::Config::default().with_resource(resource.clone());
+    let trace_config = opentelemetry_sdk::trace::Config::default()
+        .with_sampler(ChromaShouldSample)
+        .with_resource(resource.clone());
     let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
         .with_batch_exporter(tracing_span_exporter, opentelemetry_sdk::runtime::Tokio)
         .with_config(trace_config)


### PR DESCRIPTION
Turns out that's not enough and we get tons of `get` messages in the
traces from the Foyer cache.  Bring this back for now.
