### PR TITLE
[BUG] Remove auto fail from CLI install script

### DIFF
--- a/rust/cli/install/install.ps1
+++ b/rust/cli/install/install.ps1
@@ -12,14 +12,6 @@ if ($isAdmin) {
 }
 $expectedInstallPath = Join-Path $expectedInstallDir "chroma.exe"
 
-$existing = Get-Command chroma.exe -ErrorAction SilentlyContinue
-if ($existing) {
-    if ($existing.Path -ne $expectedInstallPath) {
-        Write-Error "Error: Chroma CLI is already installed at '$($existing.Path)'.`nPlease remove the existing installation or adjust your PATH before proceeding."
-        exit 1
-    }
-}
-
 $repo    = "chroma-core/chroma"
 $release = "cli-0.1.0"
 $asset   = "chroma-windows.exe"

--- a/rust/cli/install/install.sh
+++ b/rust/cli/install/install.sh
@@ -6,16 +6,6 @@ set -e
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/chroma-core/chroma/main/rust/cli/install/install.sh | bash
 # ----------------------------------------------
-
-EXISTING_BIN=$(command -v chroma || true)
-if [ -n "$EXISTING_BIN" ]; then
-  if [ "$EXISTING_BIN" != "/usr/local/bin/chroma" ] && [ "$EXISTING_BIN" != "$HOME/.local/bin/chroma" ]; then
-    echo "Error: Chroma CLI is already installed at ${EXISTING_BIN}."
-    echo "Please remove the existing installation and try again."
-    exit 1
-  fi
-fi
-
 REPO="chroma-core/chroma"
 RELEASE="cli-0.1.0"
 


### PR DESCRIPTION
## Description of changes

The CLI install script would fail if "which chroma" returns something, not allowing for proxy CLI in our python package.
