### PR TITLE
[ENH]: add config for Rust HTTP server

### DIFF
--- a/bin/rust_single_node_integration_test_config.yaml
+++ b/bin/rust_single_node_integration_test_config.yaml
@@ -20,13 +20,14 @@ collections_with_segments_provider:
   cache_invalidation_retry_policy:
     delay_ms: 0
     max_retries: 0
-service_name: "rust-frontend-service"
-otel_endpoint: "http://otel-collector:4317"
+open_telemetry:
+  service_name: "rust-frontend-service"
+  endpoint: "http://otel-collector:4317"
 log:
   Sqlite:
     tenant_id: "default"
     topic_namespace: "default"
 executor:
   Local:
-    LocalExecutorConfig:
+    local_executor_config:
 scorecard_enabled: false

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -1,4 +1,4 @@
-use chroma_frontend::{config::FrontendConfig, frontend_service_entrypoint_with_config};
+use chroma_frontend::{config::FrontendServerConfig, frontend_service_entrypoint_with_config};
 use clap::{Parser, Subcommand};
 use std::sync::Arc;
 
@@ -42,8 +42,8 @@ fn run(args: RunArgs) {
     println!("{}", LOGO);
 
     let config = match &args.config {
-        Some(path) => FrontendConfig::load_from_path(path),
-        None => FrontendConfig::single_node_default(),
+        Some(path) => FrontendServerConfig::load_from_path(path),
+        None => FrontendServerConfig::single_node_default(),
     };
 
     let runtime = tokio::runtime::Runtime::new().expect("Failed to start Chroma");

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -12,8 +12,8 @@ use thiserror::Error;
 /// This trait is used to configure structs from the config object.
 /// Components that need to be configured from the config object should implement this trait.
 #[async_trait]
-pub trait Configurable<T> {
-    async fn try_from_config(config: &T, registry: &Registry) -> Result<Self, Box<dyn ChromaError>>
+pub trait Configurable<T, E = Box<dyn ChromaError>> {
+    async fn try_from_config(config: &T, registry: &Registry) -> Result<Self, E>
     where
         Self: Sized;
 }

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -1,5 +1,6 @@
-service_name: "rust-frontend-service"
-otel_endpoint: "http://otel-collector:4317"
+open_telemetry:
+  service_name: "rust-frontend-service"
+  endpoint: "http://otel-collector:4317"
 sysdb:
   Grpc:
     host: "sysdb.chroma"
@@ -9,7 +10,7 @@ sysdb:
 collections_with_segments_provider:
   cache:
     lru:
-      capacity: 1000 
+      capacity: 1000
   permitted_parallelism: 180
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/frontend/single_node_frontend_config.yaml
+++ b/rust/frontend/single_node_frontend_config.yaml
@@ -20,8 +20,9 @@ collections_with_segments_provider:
   cache_invalidation_retry_policy:
     delay_ms: 0
     max_retries: 0
-service_name: "rust-frontend-service"
-otel_endpoint: "http://otel-collector:4317"
+open_telemetry:
+  service_name: "rust-frontend-service"
+  endpoint: "http://otel-collector:4317"
 log:
   Sqlite:
     tenant_id: "default"

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -21,16 +21,46 @@ pub struct FrontendConfig {
     pub sqlitedb: Option<SqliteDBConfig>,
     pub segment_manager: Option<LocalSegmentManagerConfig>,
     pub sysdb: SysDbConfig,
-    #[serde(default = "CircuitBreakerConfig::default")]
-    pub circuit_breaker: CircuitBreakerConfig,
     pub collections_with_segments_provider: CollectionsWithSegmentsProviderConfig,
-    pub service_name: String,
-    pub otel_endpoint: String,
     pub log: LogConfig,
     pub executor: ExecutorConfig,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct OpenTelemetryConfig {
+    pub endpoint: String,
+    pub service_name: String,
+}
+
+fn default_port() -> u16 {
+    3000
+}
+
+fn default_listen_address() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_max_payload_size_bytes() -> usize {
+    40 * 1024 * 1024 // 40 MB
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct FrontendServerConfig {
+    #[serde(flatten)]
+    pub frontend: FrontendConfig,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    #[serde(default = "default_listen_address")]
+    pub listen_address: String,
+    #[serde(default = "default_max_payload_size_bytes")]
+    pub max_payload_size_bytes: usize,
+    #[serde(default = "CircuitBreakerConfig::default")]
+    pub circuit_breaker: CircuitBreakerConfig,
+    #[serde(default)]
     pub scorecard_enabled: bool,
     #[serde(default)]
     pub scorecard: Vec<ScorecardRule>,
+    pub open_telemetry: Option<OpenTelemetryConfig>,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "./frontend_config.yaml";
@@ -41,7 +71,7 @@ const DEFAULT_SINGLE_NODE_CONFIG_FILENAME: &str = "single_node_frontend_config.y
 #[include = "*.yaml"]
 struct DefaultConfigurationsFolder;
 
-impl FrontendConfig {
+impl FrontendServerConfig {
     pub fn load() -> Self {
         Self::load_from_path(DEFAULT_CONFIG_PATH)
     }
@@ -79,13 +109,13 @@ impl FrontendConfig {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::FrontendConfig;
+    use crate::config::FrontendServerConfig;
     use chroma_cache::CacheConfig;
 
     #[test]
     fn test_load_config() {
-        let config = FrontendConfig::load();
-        let sysdb_config = config.sysdb;
+        let config = FrontendServerConfig::load();
+        let sysdb_config = config.frontend.sysdb;
         let sysdb_config = match sysdb_config {
             chroma_sysdb::SysDbConfig::Grpc(grpc_sys_db_config) => grpc_sys_db_config,
             chroma_sysdb::SysDbConfig::Sqlite(_) => {
@@ -99,11 +129,12 @@ mod tests {
         assert_eq!(sysdb_config.num_channels, 5);
         assert_eq!(
             config
+                .frontend
                 .collections_with_segments_provider
                 .permitted_parallelism,
             180
         );
-        match config.collections_with_segments_provider.cache {
+        match config.frontend.collections_with_segments_provider.cache {
             CacheConfig::Memory(c) => {
                 assert_eq!(c.capacity, 1000);
             }

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -1145,7 +1145,9 @@ impl Configurable<(FrontendConfig, System)> for Frontend {
     ) -> Result<Self, Box<dyn ChromaError>> {
         // Create sqlitedb if configured
         if let Some(sqlite_conf) = &config.sqlitedb {
-            SqliteDb::try_from_config(sqlite_conf, registry).await?;
+            SqliteDb::try_from_config(sqlite_conf, registry)
+                .await
+                .map_err(|e| e.boxed())?;
         };
 
         // Create segment manager if configured

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -20,6 +20,7 @@ use chroma_tracing::{
     init_tracing,
     meter_event::{init_meter_event_handler, MeterEventHandler},
 };
+use config::FrontendServerConfig;
 use frontend::Frontend;
 use get_collection_with_segments_provider::*;
 use mdac::{Pattern, Rule};
@@ -50,8 +51,8 @@ pub async fn frontend_service_entrypoint(
     meter_ingestor: impl MeterEventHandler + Send + Sync + 'static,
 ) {
     let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
-        Ok(config_path) => FrontendConfig::load_from_path(&config_path),
-        Err(_) => FrontendConfig::load(),
+        Ok(config_path) => FrontendServerConfig::load_from_path(&config_path),
+        Err(_) => FrontendServerConfig::load(),
     };
     frontend_service_entrypoint_with_config(auth, quota_enforcer, meter_ingestor, config).await;
 }
@@ -60,21 +61,25 @@ pub async fn frontend_service_entrypoint_with_config(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
     meter_ingestor: impl MeterEventHandler + Send + Sync + 'static,
-    config: FrontendConfig,
+    config: FrontendServerConfig,
 ) {
-    let tracing_layers = vec![
-        init_global_filter_layer(),
-        init_otel_layer(&config.service_name, &config.otel_endpoint),
-        init_stdout_layer(&config.service_name),
-    ];
-    init_tracing(tracing_layers);
-    init_panic_tracing_hook();
-    init_meter_event_handler(meter_ingestor);
+    if let Some(config) = &config.open_telemetry {
+        let tracing_layers = vec![
+            init_global_filter_layer(),
+            init_otel_layer(&config.service_name, &config.endpoint),
+            init_stdout_layer(&config.service_name),
+        ];
+        init_tracing(tracing_layers);
+        init_panic_tracing_hook();
+        init_meter_event_handler(meter_ingestor);
+    } else {
+        eprintln!("OpenTelemetry is not enabled because it is missing from the config.");
+    }
 
     let system = System::new();
     let registry = Registry::new();
 
-    let frontend = Frontend::try_from_config(&(config.clone(), system), &registry)
+    let frontend = Frontend::try_from_config(&(config.frontend.clone(), system), &registry)
         .await
         .expect("Error creating Frontend Config");
     fn rule_to_rule(rule: &ScorecardRule) -> Result<Rule, ScorecardRuleError> {

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -22,7 +22,6 @@ use chroma_types::{
     ListCollectionsRequest, ListDatabasesRequest, Metadata, QueryResponse, UpdateCollectionRequest,
     UpdateMetadata,
 };
-use mdac::CircuitBreakerConfig;
 use pyo3::{exceptions::PyValueError, pyclass, pymethods, types::PyAnyMethods, PyObject, Python};
 use std::time::SystemTime;
 
@@ -103,19 +102,9 @@ impl Bindings {
             segment_manager: Some(segment_manager_config),
             sqlitedb: Some(sqlite_db_config),
             sysdb: sysdb_config,
-            // TODO: Move circuit breaker config to the server config, it has nothing
-            // to do with the frontend, only to do with the server
-            circuit_breaker: CircuitBreakerConfig::default(),
             collections_with_segments_provider: collection_cache_config,
-            // TODO: The following fields should be removed from FrontendConfig and into
-            // the server config. They have nothing to do with the frontend.
-            service_name: "chroma".to_string(),
-            otel_endpoint: "http://localhost:4317".to_string(),
             log: log_config,
             executor: executor_config,
-            scorecard_enabled: false,
-            // TODO: scorecard should be removed from the frontend config and moved to the server config
-            scorecard: vec![],
         };
 
         let frontend = runtime.block_on(async {


### PR DESCRIPTION
## Description of changes

Adds a new Rust server config and moves relevant fields from the main frontend config into it.

There is one breaking change: OTEL parameters have been moved under a top-level `open_telemetry` field. Config files/env var overrides will have to be updated.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a