### PR TITLE
[ENH]: consistent config field casing, add default and debug impls

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -229,7 +229,7 @@ jobs:
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
           CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
-          CHROMA_SERVER_HOST: "localhost:3000"
+          CHROMA_SERVER_HOST: "localhost:8000"
       - name: Compute artifact name
         if: always()
         id: compute-artifact-name

--- a/Tiltfile
+++ b/Tiltfile
@@ -144,7 +144,7 @@ k8s_resource('logservice-migration-logservice-migration', resource_deps=['postgr
 k8s_resource('logservice', resource_deps=['sysdb-migration-sysdb-migration'], labels=["chroma"], port_forwards='50052:50051')
 k8s_resource('sysdb', resource_deps=['sysdb-migration-sysdb-migration'], labels=["chroma"], port_forwards='50051:50051')
 k8s_resource('frontend-service', resource_deps=['sysdb', 'logservice'],labels=["chroma"], port_forwards='8000:8000')
-k8s_resource('rust-frontend-service', resource_deps=['sysdb', 'logservice'], labels=["chroma"], port_forwards='3000:3000')
+k8s_resource('rust-frontend-service', resource_deps=['sysdb', 'logservice'], labels=["chroma"], port_forwards='3000:8000')
 k8s_resource('query-service', resource_deps=['sysdb'], labels=["chroma"], port_forwards='50053:50051')
 k8s_resource('compaction-service', resource_deps=['sysdb'], labels=["chroma"])
 

--- a/bin/rust-integration-test.sh
+++ b/bin/rust-integration-test.sh
@@ -16,7 +16,7 @@ cargo run --bin chroma -- run bin/rust_single_node_integration_test_config.yaml 
 
 echo "Waiting for Chroma server to be available..."
 for i in {1..30}; do
-    if curl -s http://localhost:3000/api/v2/heartbeat > /dev/null; then
+    if curl -s http://localhost:8000/api/v2/heartbeat > /dev/null; then
         echo "Chroma server is up!"
         break
     fi
@@ -24,7 +24,7 @@ for i in {1..30}; do
     sleep 1
 done
 
-if ! curl -s http://localhost:3000/api/v2/heartbeat > /dev/null; then
+if ! curl -s http://localhost:8000/api/v2/heartbeat > /dev/null; then
     echo "Chroma server failed to start within 60 seconds."
     exit 1
 fi
@@ -32,7 +32,7 @@ fi
 export CHROMA_INTEGRATION_TEST_ONLY=1
 export CHROMA_API_IMPL=chromadb.api.fastapi.FastAPI
 export CHROMA_SERVER_HOST=localhost
-export CHROMA_SERVER_HTTP_PORT=3000
+export CHROMA_SERVER_HTTP_PORT=8000
 
 echo testing: python -m pytest "$@"
 python -m pytest "$@"

--- a/bin/rust_single_node_integration_test_config.yaml
+++ b/bin/rust_single_node_integration_test_config.yaml
@@ -1,17 +1,6 @@
 allow_reset: true
 sqlitedb:
-  hash_type:
-    SHA256:
-  migration_mode:
-    Apply:
-segment_manager:
-  hnsw_index_pool_cache_config:
-    memory:
-      capacity: 65536
-sysdb:
-  Sqlite:
-    log_topic_namespace: "default"
-    log_tenant: "default"
+  url: "./chroma_integration_test_tmp_dir/chroma.sqlite3"
 collections_with_segments_provider:
   cache:
     nop:
@@ -22,11 +11,3 @@ collections_with_segments_provider:
 open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"
-log:
-  Sqlite:
-    tenant_id: "default"
-    topic_namespace: "default"
-executor:
-  Local:
-    local_executor_config:
-scorecard_enabled: false

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -19,10 +19,10 @@ spec:
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              port: 3000
+              port: 8000
               path: /api/v2/healthcheck
           ports:
-            - containerPort: 3000
+            - containerPort: 8000
           {{ if .Values.rustFrontendService.resources }}
           resources:
             limits:
@@ -55,8 +55,8 @@ metadata:
 spec:
   ports:
     - name: server-port
-      port: 3000
-      targetPort: 3000
+      port: 8000
+      targetPort: 8000
   selector:
     app: rust-frontend-service
   type: ClusterIP

--- a/rust/blockstore/src/config.rs
+++ b/rust/blockstore/src/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BlockfileProviderConfig {
     Arrow(Box<super::arrow::config::ArrowBlockfileProviderConfig>),
     Memory,

--- a/rust/config/src/assignment/config.rs
+++ b/rust/config/src/assignment/config.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Deserialize, Clone, Serialize)]
+#[derive(Default, Deserialize, Clone, Serialize, Debug)]
 /// The type of hasher to use.
 /// # Options
 /// - Murmur3: The murmur3 hasher.
@@ -9,7 +9,8 @@ pub enum HasherType {
     Murmur3,
 }
 
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
 /// The configuration for the assignment policy.
 /// # Options
 /// - RendezvousHashing: The rendezvous hashing assignment policy.
@@ -26,7 +27,7 @@ impl Default for AssignmentPolicyConfig {
     }
 }
 
-#[derive(Default, Deserialize, Clone, Serialize)]
+#[derive(Default, Deserialize, Clone, Serialize, Debug)]
 /// The configuration for the rendezvous hashing assignment policy.
 /// # Fields
 /// - hasher: The type of hasher to use.

--- a/rust/frontend/frontend_config.yaml
+++ b/rust/frontend/frontend_config.yaml
@@ -2,7 +2,7 @@ open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"
 sysdb:
-  Grpc:
+  grpc:
     host: "sysdb.chroma"
     port: 50051
     connect_timeout_ms: 60000
@@ -16,22 +16,22 @@ collections_with_segments_provider:
     delay_ms: 0
     max_retries: 3
 log:
-  Grpc:
+  grpc:
     host: "logservice.chroma"
     port: 50051
     connect_timeout_ms: 5000
     request_timeout_ms: 5000
 executor:
-  Distributed:
+  distributed:
     connections_per_node: 5
     replication_factor: 2
     connect_timeout_ms: 5000
     request_timeout_ms: 5000
     assignment:
-      RendezvousHashing:
+      rendezvous_hashing:
         hasher: Murmur3
     memberlist_provider:
-      CustomResource:
+      custom_resource:
         kube_namespace: "chroma"
         memberlist_name: "query-service-memberlist"
         queue_size: 100

--- a/rust/frontend/single_node_frontend_config.yaml
+++ b/rust/frontend/single_node_frontend_config.yaml
@@ -1,33 +1,4 @@
-allow_reset: false
 persist_path: "./chroma"
-sqlitedb:
-  hash_type:
-    SHA256:
-  migration_mode:
-    Apply:
-segment_manager:
-  hnsw_index_pool_cache_config:
-    memory:
-      capacity: 65536
-sysdb:
-  Sqlite:
-    log_topic_namespace: "default"
-    log_tenant: "default"
-collections_with_segments_provider:
-  cache:
-    nop:
-  permitted_parallelism: 32
-  cache_invalidation_retry_policy:
-    delay_ms: 0
-    max_retries: 0
 open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"
-log:
-  Sqlite:
-    tenant_id: "default"
-    topic_namespace: "default"
-executor:
-  Local:
-    LocalExecutorConfig:
-scorecard_enabled: false

--- a/rust/frontend/src/executor/config.rs
+++ b/rust/frontend/src/executor/config.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// - `request_timeout_ms` - The timeout for the request
 /// - `assignment` - The assignment policy to use for routing requests
 /// - `memberlist_provider` - The memberlist provider to use for getting the list of nodes
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct DistributedExecutorConfig {
     pub connections_per_node: usize,
     pub replication_factor: usize,
@@ -28,10 +28,11 @@ pub struct DistributedExecutorConfig {
     pub memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
 }
 
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct LocalExecutorConfig {}
 
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum ExecutorConfig {
     Distributed(DistributedExecutorConfig),
     Local(LocalExecutorConfig),
@@ -69,7 +70,7 @@ impl Configurable<(ExecutorConfig, System)> for Executor {
 /// - `min_delay_ms` - The minimum delay in milliseconds
 /// - `max_delay_ms` - The maximum delay in milliseconds
 /// - `max_attempts` - The maximum number of attempts
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct RetryConfig {
     pub factor: f32,
     pub min_delay_ms: u64,

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Duration};
 use thiserror::Error;
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct CacheInvalidationRetryConfig {
     pub delay_ms: u32,
     pub max_retries: u32,
@@ -32,12 +32,22 @@ impl Default for CacheInvalidationRetryConfig {
     }
 }
 
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct CollectionsWithSegmentsProviderConfig {
     pub cache: chroma_cache::CacheConfig,
     pub permitted_parallelism: u32,
     #[serde(default = "CacheInvalidationRetryConfig::default")]
     pub cache_invalidation_retry_policy: CacheInvalidationRetryConfig,
+}
+
+impl Default for CollectionsWithSegmentsProviderConfig {
+    fn default() -> Self {
+        Self {
+            cache: chroma_cache::CacheConfig::Nop,
+            permitted_parallelism: 100,
+            cache_invalidation_retry_policy: CacheInvalidationRetryConfig::default(),
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -75,7 +75,6 @@ pub async fn frontend_service_entrypoint_with_config(
     } else {
         eprintln!("OpenTelemetry is not enabled because it is missing from the config.");
     }
-
     let system = System::new();
     let registry = Registry::new();
 

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct GrpcLogConfig {
     #[serde(default = "GrpcLogConfig::default_host")]
     pub host: String,
@@ -41,13 +41,23 @@ impl Default for GrpcLogConfig {
     }
 }
 
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct SqliteLogConfig {
     pub tenant_id: String,
     pub topic_namespace: String,
 }
 
-#[derive(Deserialize, Clone, Serialize)]
+impl Default for SqliteLogConfig {
+    fn default() -> Self {
+        SqliteLogConfig {
+            tenant_id: "default".to_string(),
+            topic_namespace: "default".to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize, Clone, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum LogConfig {
     Grpc(GrpcLogConfig),
     Sqlite(SqliteLogConfig),

--- a/rust/memberlist/src/config.rs
+++ b/rust/memberlist/src/config.rs
@@ -12,7 +12,8 @@ pub(crate) enum MemberlistProviderType {
 /// The configuration for the memberlist provider.
 /// # Options
 /// - CustomResource: Use a custom resource to get the memberlist
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum MemberlistProviderConfig {
     CustomResource(CustomResourceMemberlistProviderConfig),
 }
@@ -28,7 +29,7 @@ impl Default for MemberlistProviderConfig {
 /// - kube_namespace: The namespace to use for the custom resource.
 /// - memberlist_name: The name of the custom resource to use for the memberlist.
 /// - queue_size: The size of the queue to use for the channel.
-#[derive(Deserialize, Clone, Serialize)]
+#[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct CustomResourceMemberlistProviderConfig {
     #[serde(default = "CustomResourceMemberlistProviderConfig::default_kube_namespace")]
     pub kube_namespace: String,

--- a/rust/segment/src/local_segment_manager.rs
+++ b/rust/segment/src/local_segment_manager.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use chroma_cache::{Cache, CacheConfig, CacheError};
+use chroma_cache::{Cache, CacheConfig, CacheError, FoyerCacheConfig};
 use chroma_config::{
     registry::{Injectable, Registry},
     Configurable,
@@ -10,6 +8,7 @@ use chroma_index::IndexUuid;
 use chroma_sqlite::db::SqliteDb;
 use chroma_types::Segment;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use thiserror::Error;
 
 use crate::local_hnsw::{
@@ -17,10 +16,18 @@ use crate::local_hnsw::{
     LocalHnswSegmentWriterError,
 };
 
+fn default_hnsw_index_pool_cache_config() -> CacheConfig {
+    CacheConfig::Memory(FoyerCacheConfig {
+        capacity: 65536,
+        ..Default::default()
+    })
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LocalSegmentManagerConfig {
     // TODO(Sanket): Estimate the max number of FDs that can be kept open and
     // use that as a capacity in the cache.
+    #[serde(default = "default_hnsw_index_pool_cache_config")]
     pub hnsw_index_pool_cache_config: CacheConfig,
     pub persist_path: Option<String>,
 }

--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -13,20 +13,40 @@ use tokio::fs::create_dir_all;
 #[cfg(feature = "pyo3")]
 use pyo3::{pyclass, pymethods};
 
-#[derive(Serialize, Deserialize, Clone)]
+fn default_hash_type() -> MigrationHash {
+    MigrationHash::MD5
+}
+
+fn default_migration_mode() -> MigrationMode {
+    MigrationMode::Apply
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct SqliteDBConfig {
+    #[serde(default = "default_hash_type")]
     pub hash_type: MigrationHash,
+    #[serde(default = "default_migration_mode")]
     pub migration_mode: MigrationMode,
     // The SQLite database URL
     // If unspecified, then the database is in memory only
     pub url: Option<String>,
 }
 
+impl Default for SqliteDBConfig {
+    fn default() -> Self {
+        SqliteDBConfig {
+            hash_type: default_hash_type(),
+            migration_mode: default_migration_mode(),
+            url: None,
+        }
+    }
+}
+
 /// Migration mode for the database
 /// - Apply: Apply the migrations
 /// - Validate: Validate the applied migrations and ensure none are unappliued
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "pyo3", pyclass(eq, eq_int))]
 pub enum MigrationMode {
     Apply,

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 /// The configuration for the chosen storage.
 /// # Options
 /// - S3: The configuration for the s3 storage.
@@ -164,6 +165,7 @@ impl Default for CountBasedPolicyConfig {
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RateLimitingConfig {
     CountBasedPolicy(CountBasedPolicyConfig),
 }

--- a/rust/sysdb/src/config.rs
+++ b/rust/sysdb/src/config.rs
@@ -65,9 +65,19 @@ pub struct SqliteSysDbConfig {
     pub log_tenant: String,
 }
 
+impl Default for SqliteSysDbConfig {
+    fn default() -> Self {
+        SqliteSysDbConfig {
+            log_topic_namespace: "default".to_string(),
+            log_tenant: "default".to_string(),
+        }
+    }
+}
+
 //////////////////////// SYSDB CONFIG ////////////////////////
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SysDbConfig {
     Grpc(GrpcSysDbConfig),
     Sqlite(SqliteSysDbConfig),

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -9,21 +9,21 @@ query_service:
     my_member_id: "query-service-0"
     my_port: 50051
     assignment_policy:
-        RendezvousHashing:
+        rendezvous_hashing:
             hasher: Murmur3
     memberlist_provider:
-        CustomResource:
+        custom_resource:
             kube_namespace: "chroma"
             memberlist_name: "query-service-memberlist"
             queue_size: 100
     sysdb:
-        Grpc:
+        grpc:
             host: "sysdb.chroma"
             port: 50051
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
     storage:
-        AdmissionControlledS3:
+        admission_controlled_s3:
             s3_config:
                 bucket: "chroma-storage"
                 credentials: "Minio"
@@ -32,10 +32,10 @@ query_service:
                 upload_part_size_bytes: 536870912 # 512MiB
                 download_part_size_bytes: 8388608 # 8MiB
             rate_limiting_policy:
-                CountBasedPolicy:
+                count_based_policy:
                     max_concurrent_requests: 15
     log:
-        Grpc:
+        grpc:
             host: "logservice.chroma"
             port: 50051
             connect_timeout_ms: 5000
@@ -47,7 +47,7 @@ query_service:
         task_queue_limit: 1000
         active_io_tasks: 100
     blockfile_provider:
-        Arrow:
+        arrow:
             block_manager_config:
                 max_block_size_bytes: 16384
                 block_cache_config:
@@ -82,21 +82,21 @@ compaction_service:
     my_member_id: "compaction-service-0"
     my_port: 50051
     assignment_policy:
-        RendezvousHashing:
+        rendezvous_hashing:
             hasher: Murmur3
     memberlist_provider:
-        CustomResource:
+        custom_resource:
             kube_namespace: "chroma"
             memberlist_name: "compaction-service-memberlist"
             queue_size: 100
     sysdb:
-        Grpc:
+        grpc:
             host: "sysdb.chroma"
             port: 50051
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
     storage:
-        AdmissionControlledS3:
+        admission_controlled_s3:
             s3_config:
                 bucket: "chroma-storage"
                 credentials: "Minio"
@@ -105,10 +105,10 @@ compaction_service:
                 upload_part_size_bytes: 536870912 # 512MiB
                 download_part_size_bytes: 8388608 # 8MiB
             rate_limiting_policy:
-                CountBasedPolicy:
+                count_based_policy:
                     max_concurrent_requests: 30
     log:
-        Grpc:
+        grpc:
             host: "logservice.chroma"
             port: 50051
             connect_timeout_ms: 5000
@@ -128,7 +128,7 @@ compaction_service:
         max_partition_size: 5000
         disabled_collections: [] # uuids to disable compaction for
     blockfile_provider:
-        Arrow:
+        arrow:
             block_manager_config:
                 max_block_size_bytes: 16384
                 block_cache_config:

--- a/rust/worker/tests/config_from_default_path.rs
+++ b/rust/worker/tests/config_from_default_path.rs
@@ -16,21 +16,21 @@ fn test_config_from_default_path() {
                 my_member_id: "query-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "query-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -39,10 +39,10 @@ fn test_config_from_default_path() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -54,7 +54,7 @@ fn test_config_from_default_path() {
                     task_queue_limit: 100
                     active_io_tasks: 1000
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:
@@ -77,21 +77,21 @@ fn test_config_from_default_path() {
                 my_member_id: "compaction-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "compaction-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -100,10 +100,10 @@ fn test_config_from_default_path() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -123,7 +123,7 @@ fn test_config_from_default_path() {
                     max_partition_size: 5000
                     disabled_collections: ["74b3240e-a2b0-43d7-8adb-f55a394964a1", "496db4aa-fbe1-498a-b60b-81ec0fe59792"]
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -15,21 +15,21 @@ fn test_config_from_specific_path() {
                 my_member_id: "query-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "query-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -38,10 +38,10 @@ fn test_config_from_specific_path() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -53,7 +53,7 @@ fn test_config_from_specific_path() {
                     task_queue_limit: 100
                     active_io_tasks: 1000
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:
@@ -76,21 +76,21 @@ fn test_config_from_specific_path() {
                 my_member_id: "compaction-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "compaction-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -99,10 +99,10 @@ fn test_config_from_specific_path() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -122,7 +122,7 @@ fn test_config_from_specific_path() {
                     max_partition_size: 5000
                     disabled_collections: []
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:

--- a/rust/worker/tests/config_missing_default_field.rs
+++ b/rust/worker/tests/config_missing_default_field.rs
@@ -13,21 +13,21 @@ fn test_missing_default_field() {
                 my_member_id: "query-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "query-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -36,10 +36,10 @@ fn test_missing_default_field() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -51,7 +51,7 @@ fn test_missing_default_field() {
                     task_queue_limit: 100
                     active_io_tasks: 1000
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:
@@ -74,21 +74,21 @@ fn test_missing_default_field() {
                 my_member_id: "compaction-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "compaction-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -97,10 +97,10 @@ fn test_missing_default_field() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -120,7 +120,7 @@ fn test_missing_default_field() {
                     max_partition_size: 5000
                     disabled_collections: []
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:

--- a/rust/worker/tests/config_with_env_override.rs
+++ b/rust/worker/tests/config_with_env_override.rs
@@ -43,21 +43,21 @@ fn test_config_with_env_override() {
                 service_name: "query-service"
                 otel_endpoint: "http://jaeger:4317"
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "query-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -66,10 +66,10 @@ fn test_config_with_env_override() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -81,7 +81,7 @@ fn test_config_with_env_override() {
                     task_queue_limit: 100
                     active_io_tasks: 1000
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:
@@ -101,21 +101,21 @@ fn test_config_with_env_override() {
                 service_name: "compaction-service"
                 otel_endpoint: "http://jaeger:4317"
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "compaction-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -135,7 +135,7 @@ fn test_config_with_env_override() {
                     max_partition_size: 5000
                     disabled_collections: ["c92e4d75-eb25-4295-82d8-7c53dbd33258"]
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:

--- a/rust/worker/tests/config_without_cache_directive.rs
+++ b/rust/worker/tests/config_without_cache_directive.rs
@@ -15,21 +15,21 @@ fn test_config_without_cache_directive() {
                 my_member_id: "query-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "query-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -38,10 +38,10 @@ fn test_config_without_cache_directive() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -53,7 +53,7 @@ fn test_config_without_cache_directive() {
                     task_queue_limit: 100
                     active_io_tasks: 1000
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:
@@ -72,21 +72,21 @@ fn test_config_without_cache_directive() {
                 my_member_id: "compaction-service-0"
                 my_port: 50051
                 assignment_policy:
-                    RendezvousHashing:
+                    rendezvous_hashing:
                         hasher: Murmur3
                 memberlist_provider:
-                    CustomResource:
+                    custom_resource:
                         kube_namespace: "chroma"
                         memberlist_name: "compaction-service-memberlist"
                         queue_size: 100
                 sysdb:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
                         request_timeout_ms: 1000
                 storage:
-                    AdmissionControlledS3:
+                    admission_controlled_s3:
                         s3_config:
                             bucket: "chroma"
                             credentials: Minio
@@ -95,10 +95,10 @@ fn test_config_without_cache_directive() {
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
-                            CountBasedPolicy:
+                            count_based_policy:
                                 max_concurrent_requests: 15
                 log:
-                    Grpc:
+                    grpc:
                         host: "localhost"
                         port: 50051
                         connect_timeout_ms: 5000
@@ -118,7 +118,7 @@ fn test_config_without_cache_directive() {
                     max_partition_size: 5000
                     disabled_collections: []
                 blockfile_provider:
-                    Arrow:
+                    arrow:
                         block_manager_config:
                             max_block_size_bytes: 16384
                             block_cache_config:


### PR DESCRIPTION
## Description of changes

- Adds default impls for most config fields necessary for single node.
- Changes config enums to use snake case for consistent field casing.
- Adds debug impls on config structs.

These changes are mainly in service of making it easier for users to understand and write config.

**Breaking change**: some config fields are now snake case.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a