### PR TITLE
[BUG] Gracefully handle merge operator task error

### DIFF
--- a/bin/rust_single_node_integration_test_config.yaml
+++ b/bin/rust_single_node_integration_test_config.yaml
@@ -4,7 +4,6 @@ sqlitedb:
     SHA256:
   migration_mode:
     Apply:
-  url: "./chroma_integration_test_tmp_dir/chroma.sqlite3"
 segment_manager:
   hnsw_index_pool_cache_config:
     memory:

--- a/rust/frontend/single_node_frontend_config.yaml
+++ b/rust/frontend/single_node_frontend_config.yaml
@@ -9,6 +9,7 @@ segment_manager:
   hnsw_index_pool_cache_config:
     memory:
       capacity: 65536
+  persist_path: "./chroma/"
 sysdb:
   Sqlite:
     log_topic_namespace: "default"

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -99,6 +99,7 @@ pub async fn frontend_service_entrypoint_with_config(
         .map(rule_to_rule)
         .collect::<Result<Vec<_>, ScorecardRuleError>>()
         .expect("error creating scorecard");
-    let server = FrontendServer::new(config, frontend, rules, auth, quota_enforcer);
-    FrontendServer::run(server).await;
+    FrontendServer::new(config, frontend, rules, auth, quota_enforcer)
+        .run()
+        .await;
 }

--- a/rust/worker/src/execution/operators/knn_merge.rs
+++ b/rust/worker/src/execution/operators/knn_merge.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use chroma_system::Operator;
+use thiserror::Error;
 
 use super::knn::RecordDistance;
 
@@ -35,7 +36,9 @@ pub struct KnnMergeOutput {
     pub record_distances: Vec<RecordDistance>,
 }
 
-pub type KnnMergeError = ();
+#[derive(Error, Debug)]
+#[error("Knn merge error (unreachable)")]
+pub struct KnnMergeError;
 
 #[async_trait]
 impl Operator<KnnMergeInput, KnnMergeOutput> for KnnMergeOperator {

--- a/rust/worker/src/execution/operators/spann_knn_merge.rs
+++ b/rust/worker/src/execution/operators/spann_knn_merge.rs
@@ -3,6 +3,7 @@ use std::{cmp::Ordering, collections::BinaryHeap};
 use async_trait::async_trait;
 
 use chroma_system::Operator;
+use thiserror::Error;
 
 use super::knn::RecordDistance;
 
@@ -22,7 +23,9 @@ pub struct SpannKnnMergeOutput {
     pub merged_records: Vec<RecordDistance>,
 }
 
-pub type SpannKnnMergeError = ();
+#[derive(Error, Debug)]
+#[error("Spann knn merge error (unreachable)")]
+pub struct SpannKnnMergeError;
 
 #[derive(Debug)]
 struct RecordHeapEntry {

--- a/rust/worker/src/execution/orchestration/knn.rs
+++ b/rust/worker/src/execution/orchestration/knn.rs
@@ -282,9 +282,10 @@ impl Handler<TaskResult<KnnMergeOutput, KnnMergeError>> for KnnOrchestrator {
         message: TaskResult<KnnMergeOutput, KnnMergeError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = message
-            .into_inner()
-            .expect("KnnMergeOperator should not fail");
+        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+            Some(output) => output,
+            None => return,
+        };
 
         // Prefetch records before projection
         let prefetch_task = wrap(

--- a/rust/worker/src/execution/orchestration/knn_filter.rs
+++ b/rust/worker/src/execution/orchestration/knn_filter.rs
@@ -19,10 +19,12 @@ use crate::execution::operators::{
     filter::{FilterError, FilterInput, FilterOperator, FilterOutput},
     knn_hnsw::KnnHnswError,
     knn_log::KnnLogError,
+    knn_merge::KnnMergeError,
     knn_projection::{KnnProjectionError, KnnProjectionOutput},
     spann_bf_pl::SpannBfPlError,
     spann_centers_search::SpannCentersSearchError,
     spann_fetch_pl::SpannFetchPlError,
+    spann_knn_merge::SpannKnnMergeError,
 };
 
 #[derive(Error, Debug)]
@@ -39,12 +41,8 @@ pub enum KnnError {
     KnnLog(#[from] KnnLogError),
     #[error("Error running Knn Hnsw Operator: {0}")]
     KnnHnsw(#[from] KnnHnswError),
-    #[error("Error running Spann Head search Operator: {0}")]
-    SpannHeadSearch(#[from] SpannCentersSearchError),
-    #[error("Error running Spann fetch posting list Operator: {0}")]
-    SpannFetchPl(#[from] SpannFetchPlError),
-    #[error("Error running Spann brute force posting list Operator: {0}")]
-    SpannBfPl(#[from] SpannBfPlError),
+    #[error("Error running Knn Merge Operator")]
+    KnnMerge(#[from] KnnMergeError),
     #[error("Error running Knn Projection Operator: {0}")]
     KnnProjection(#[from] KnnProjectionError),
     #[error("Error inspecting collection dimension")]
@@ -53,6 +51,14 @@ pub enum KnnError {
     Panic(#[from] PanicError),
     #[error("Error receiving final result: {0}")]
     Result(#[from] RecvError),
+    #[error("Error running Spann Bruteforce Postinglist Operator: {0}")]
+    SpannBfPl(#[from] SpannBfPlError),
+    #[error("Error running Spann Fetch Postinglist Operator: {0}")]
+    SpannFetchPl(#[from] SpannFetchPlError),
+    #[error("Error running Spann Head Search Operator: {0}")]
+    SpannHeadSearch(#[from] SpannCentersSearchError),
+    #[error("Error running Spann Knn Merge Operator")]
+    SpannKnnMerge(#[from] SpannKnnMergeError),
     #[error("Invalid distance function")]
     InvalidDistanceFunction,
     #[error("Operation aborted because resources exhausted")]
@@ -68,13 +74,15 @@ impl ChromaError for KnnError {
             KnnError::HnswReader(e) => e.code(),
             KnnError::KnnLog(e) => e.code(),
             KnnError::KnnHnsw(e) => e.code(),
-            KnnError::SpannHeadSearch(e) => e.code(),
-            KnnError::SpannFetchPl(e) => e.code(),
-            KnnError::SpannBfPl(e) => e.code(),
+            KnnError::KnnMerge(_) => ErrorCodes::Internal,
             KnnError::KnnProjection(e) => e.code(),
             KnnError::NoCollectionDimension => ErrorCodes::InvalidArgument,
             KnnError::Panic(_) => ErrorCodes::Aborted,
             KnnError::Result(_) => ErrorCodes::Internal,
+            KnnError::SpannBfPl(e) => e.code(),
+            KnnError::SpannFetchPl(e) => e.code(),
+            KnnError::SpannHeadSearch(e) => e.code(),
+            KnnError::SpannKnnMerge(_) => ErrorCodes::Internal,
             KnnError::InvalidDistanceFunction => ErrorCodes::InvalidArgument,
             KnnError::Aborted => ErrorCodes::ResourceExhausted,
         }

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -322,9 +322,10 @@ impl Handler<TaskResult<SpannKnnMergeOutput, SpannKnnMergeError>> for SpannKnnOr
         message: TaskResult<SpannKnnMergeOutput, SpannKnnMergeError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = message
-            .into_inner()
-            .expect("KnnMergeOperator should not fail");
+        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+            Some(output) => output,
+            None => return,
+        };
 
         // Prefetch records before projection
         let prefetch_task = wrap(


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - We expected the knn merge operators to be infallible, but the task (as a wrapper of the operator) could still fail. This PR gracefully handle the task error.
   - Misc cleanups
     - Refactor the signature of frontend `run` method
     - Update single node configs to persist hnsw by default and use in-memory mode in test
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
