### PR TITLE
[BUG]  chroma-load has an oob access

### DIFF
--- a/rust/load/src/lib.rs
+++ b/rust/load/src/lib.rs
@@ -428,7 +428,7 @@ impl WhereMixin {
                     Skew::Uniform => WORDS[uniform(0, WORDS.len() as u64)(guac) as usize],
                     Skew::Zipf { theta } => {
                         let z = ZIPF_CACHE.from_theta(WORDS.len() as u64, *theta);
-                        WORDS[z.next(guac) as usize]
+                        WORDS[z.next(guac) as usize % WORDS.len()]
                     }
                 };
                 serde_json::json!({"$contains": word.to_string()})


### PR DESCRIPTION
In the full text search code, we use guacamole and rely upon the zipf
distribution to be within range.  This must be broken in guacamole and I
want to hack around it rather than debug statistics.
