### PR TITLE
[ENH] Unify persist path config

### DIFF
--- a/rust/frontend/single_node_frontend_config.yaml
+++ b/rust/frontend/single_node_frontend_config.yaml
@@ -1,15 +1,14 @@
 allow_reset: false
+persist_path: "./chroma"
 sqlitedb:
   hash_type:
     SHA256:
   migration_mode:
     Apply:
-  url: "./chroma/chroma.sqlite3"
 segment_manager:
   hnsw_index_pool_cache_config:
     memory:
       capacity: 65536
-  persist_path: "./chroma/"
 sysdb:
   Sqlite:
     log_topic_namespace: "default"

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -61,6 +61,8 @@ pub struct FrontendServerConfig {
     #[serde(default)]
     pub scorecard: Vec<ScorecardRule>,
     pub open_telemetry: Option<OpenTelemetryConfig>,
+    #[serde(default)]
+    pub persist_path: Option<String>,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "./frontend_config.yaml";


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - N/A
 - New functionality
   - Add the `persist_path` optional field in rust frontend server config. If provided it will fill the sqlite path and hnsw root folder for single node, unless explicitly overridden in corresponding configs.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
