### PR TITLE
[ENH]: make config field renames backwards compatible

### DIFF
--- a/rust/blockstore/src/config.rs
+++ b/rust/blockstore/src/config.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
 pub enum BlockfileProviderConfig {
+    #[serde(alias = "arrow")]
     Arrow(Box<super::arrow::config::ArrowBlockfileProviderConfig>),
+    #[serde(alias = "memory")]
     Memory,
 }
 

--- a/rust/config/src/assignment/config.rs
+++ b/rust/config/src/assignment/config.rs
@@ -10,7 +10,6 @@ pub enum HasherType {
 }
 
 #[derive(Deserialize, Clone, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
 /// The configuration for the assignment policy.
 /// # Options
 /// - RendezvousHashing: The rendezvous hashing assignment policy.
@@ -18,6 +17,7 @@ pub enum HasherType {
 /// See config.rs in the root of the worker crate for an example of how to use
 /// config files to configure the worker.
 pub enum AssignmentPolicyConfig {
+    #[serde(alias = "rendezvous_hashing")]
     RendezvousHashing(RendezvousHashingAssignmentPolicyConfig),
 }
 

--- a/rust/frontend/src/executor/config.rs
+++ b/rust/frontend/src/executor/config.rs
@@ -32,9 +32,10 @@ pub struct DistributedExecutorConfig {
 pub struct LocalExecutorConfig {}
 
 #[derive(Deserialize, Clone, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
 pub enum ExecutorConfig {
+    #[serde(alias = "distributed")]
     Distributed(DistributedExecutorConfig),
+    #[serde(alias = "local")]
     Local(LocalExecutorConfig),
 }
 

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -57,9 +57,10 @@ impl Default for SqliteLogConfig {
 }
 
 #[derive(Deserialize, Clone, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
 pub enum LogConfig {
+    #[serde(alias = "grpc")]
     Grpc(GrpcLogConfig),
+    #[serde(alias = "sqlite")]
     Sqlite(SqliteLogConfig),
 }
 

--- a/rust/memberlist/src/config.rs
+++ b/rust/memberlist/src/config.rs
@@ -13,8 +13,8 @@ pub(crate) enum MemberlistProviderType {
 /// # Options
 /// - CustomResource: Use a custom resource to get the memberlist
 #[derive(Deserialize, Clone, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
 pub enum MemberlistProviderConfig {
+    #[serde(alias = "custom_resource")]
     CustomResource(CustomResourceMemberlistProviderConfig),
 }
 

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Serialize)]
-#[serde(rename_all = "snake_case")]
 /// The configuration for the chosen storage.
 /// # Options
 /// - S3: The configuration for the s3 storage.
@@ -17,6 +16,7 @@ pub enum StorageConfig {
     #[serde(alias = "local")]
     Local(LocalStorageConfig),
     #[serde(alias = "admissioncontrolleds3")]
+    #[serde(alias = "admission_controlled_s3")]
     AdmissionControlledS3(AdmissionControlledS3StorageConfig),
 }
 
@@ -165,8 +165,8 @@ impl Default for CountBasedPolicyConfig {
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
 pub enum RateLimitingConfig {
+    #[serde(alias = "count_based_policy")]
     CountBasedPolicy(CountBasedPolicyConfig),
 }
 

--- a/rust/sysdb/src/config.rs
+++ b/rust/sysdb/src/config.rs
@@ -77,9 +77,10 @@ impl Default for SqliteSysDbConfig {
 //////////////////////// SYSDB CONFIG ////////////////////////
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
-#[serde(rename_all = "snake_case")]
 pub enum SysDbConfig {
+    #[serde(alias = "grpc")]
     Grpc(GrpcSysDbConfig),
+    #[serde(alias = "sqlite")]
     Sqlite(SqliteSysDbConfig),
 }
 


### PR DESCRIPTION
## Description of changes

Config fields that were renamed in https://github.com/chroma-core/chroma/pull/3838 are now aliased instead so that either casing can be provided. After merge, I'll create a task to switch back to `rename_all = "snake_case"` in a few weeks.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust