### PR TITLE
[ENH]: allow separate metric and trace endpoints in Go

### DIFF
--- a/go/cmd/logservice/main.go
+++ b/go/cmd/logservice/main.go
@@ -35,8 +35,9 @@ func main() {
 	log.Info("Starting log service")
 	config := configuration.NewLogServiceConfiguration()
 	err := otel.InitTracing(ctx, &otel.TracingConfig{
-		Service:  "log-service",
-		Endpoint: config.OPTL_TRACING_ENDPOINT,
+		Service:        "log-service",
+		TraceEndpoint:  config.OPTL_TRACING_ENDPOINT,
+		MetricEndpoint: config.OPTL_METRIC_ENDPOINT,
 	})
 	if err != nil {
 		log.Fatal("failed to initialize tracing", zap.Error(err))

--- a/go/pkg/grpcutils/service.go
+++ b/go/pkg/grpcutils/service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/chroma-core/chroma/go/shared/otel"
 	"io"
 	"net"
 	"os"
+
+	"github.com/chroma-core/chroma/go/shared/otel"
 
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -80,10 +81,12 @@ func newDefaultGrpcProvider(name string, grpcConfig *GrpcConfig, registerFunc fu
 	}
 	opts = append(opts, grpc.UnaryInterceptor(otel.ServerGrpcInterceptor))
 	OPTL_TRACING_ENDPOINT := os.Getenv("OPTL_TRACING_ENDPOINT")
+	OPTL_METRIC_ENDPOINT := os.Getenv("OPTL_METRIC_ENDPOINT")
 	if OPTL_TRACING_ENDPOINT != "" {
 		otel.InitTracing(context.Background(), &otel.TracingConfig{
-			Service:  "sysdb-service",
-			Endpoint: OPTL_TRACING_ENDPOINT,
+			Service:        "sysdb-service",
+			TraceEndpoint:  OPTL_TRACING_ENDPOINT,
+			MetricEndpoint: OPTL_METRIC_ENDPOINT,
 		})
 	}
 

--- a/go/pkg/log/configuration/config.go
+++ b/go/pkg/log/configuration/config.go
@@ -12,6 +12,7 @@ type LogServiceConfiguration struct {
 	PORT                  string
 	DATABASE_URL          string
 	OPTL_TRACING_ENDPOINT string
+	OPTL_METRIC_ENDPOINT  string
 	SYSDB_CONN            string
 	MAX_CONNS             int32
 }
@@ -42,6 +43,7 @@ func NewLogServiceConfiguration() *LogServiceConfiguration {
 		PORT:                  getEnvWithDefault("PORT", "50051"),
 		DATABASE_URL:          getEnvWithDefault("CHROMA_DATABASE_URL", "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log"),
 		OPTL_TRACING_ENDPOINT: getEnvWithDefault("OPTL_TRACING_ENDPOINT", "jaeger:4317"),
+		OPTL_METRIC_ENDPOINT:  getEnvWithDefault("OPTL_METRIC_ENDPOINT", "otel-collector:4317"),
 		SYSDB_CONN:            getEnvWithDefault("SYSDB_CONN", "sysdb"),
 		MAX_CONNS:             getEnvWithDefaultInt("MAX_CONNS", 100),
 	}

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -57,8 +57,10 @@ sysdb:
     tag: 'sysdb'
   replicaCount: 1
   env:
-  - name: OPTL_TRACING_ENDPOINT
-    value: 'value: "jaeger:4317"'
+    - name: OPTL_TRACING_ENDPOINT
+      value: 'value: "jaeger:4317"'
+    - name: OPTL_METRIC_ENDPOINT
+      value: 'value: "otel-collector:4317"'
   resources:
     limits:
       cpu: '2000m'


### PR DESCRIPTION
## Description of changes

See title. Needed because some services don't accept both OpenTelemetry traces *and* metrics.

## Test plan
*How are these changes tested?*

Tested by updating k8s config to default to traces going to Jaeger & metrics going to the OTEL collector and observed that all expected metrics appeared in Grafana.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
