### PR TITLE
[TST]: Rust cluster tests were using wrong port

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -30,6 +30,6 @@ runs:
         kubectl -n chroma port-forward svc/logservice 50052:50051 &
         kubectl -n chroma port-forward svc/query-service 50053:50051 &
         kubectl -n chroma port-forward svc/frontend-service 8000:8000 &
-        kubectl -n chroma port-forward svc/rust-frontend-service 3000:3000 &
+        kubectl -n chroma port-forward svc/rust-frontend-service 3000:8000 &
         kubectl -n chroma port-forward svc/minio 9000:9000 &
         kubectl -n chroma port-forward svc/jaeger 16686:16686 &

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -229,7 +229,7 @@ jobs:
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
           CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
-          CHROMA_SERVER_HOST: "localhost:8000"
+          CHROMA_SERVER_HOST: "localhost:3000"
       - name: Compute artifact name
         if: always()
         id: compute-artifact-name


### PR DESCRIPTION
## Description of changes

I accidentally changed the port in https://github.com/chroma-core/chroma/pull/3838. Port 3000 is the Rust frontend, port 8000 is the Python frontend.

