### PR TITLE
[ENH] Add in parallel to local hsnw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "futures",
  "parking_lot",
  "proptest",
+ "rayon",
  "roaring",
  "sea-query",
  "sea-query-binder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ regex = "1.11.1"
 pyo3 = { version = "0.23.3", features = ["abi3-py39"] }
 tower-http = { version = "0.6.2", features = ["trace"] }
 bytemuck = "1.21.0"
+rayon = "1.10.0"
 validator = { version = "0.19", features = ["derive"] }
 rust-embed = { version = "8.5.0", features = ["include-exclude", "debug-embed"] }
 hnswlib = { version = "0.8.0", git = "https://github.com/chroma-core/hnswlib.git" }
@@ -79,7 +80,6 @@ proptest-state-machine = "0.3.0"
 proptest-derive = "0.5.1"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
-rayon = "1.10.0"
 shuttle = "0.7.1"
 tempfile = "3.14.0"
 itertools = "0.13.0"

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -73,8 +73,6 @@ class RustBindingsAPI(ServerAPI):
     def start(self) -> None:
         # Construct the SqliteConfig
         # TOOD: We should add a "config converter"
-        # TODO: How to name this file?
-        # TODO: proper path handling
         if self._system.settings.require("is_persistent"):
             persist_path = self._system.settings.require("persist_directory")
             sqlite_persist_path = persist_path + "/chroma.sqlite3"
@@ -500,7 +498,8 @@ class RustBindingsAPI(ServerAPI):
             CollectionDeleteEvent(
                 # NOTE: the delete amount is not observable from python
                 # TODO: Fix this when posthog is pushed into Rust frontend
-                collection_uuid=str(collection_id), delete_amount=0
+                collection_uuid=str(collection_id),
+                delete_amount=0,
             )
         )
 

--- a/rust/frontend/sample_configs/single_node.yaml
+++ b/rust/frontend/sample_configs/single_node.yaml
@@ -1,4 +1,1 @@
 persist_path: "./chroma"
-open_telemetry:
-  service_name: "rust-frontend-service"
-  endpoint: "http://otel-collector:4317"

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -102,8 +102,8 @@ pub struct FrontendServerConfig {
     pub persist_path: Option<String>,
 }
 
-const DEFAULT_CONFIG_PATH: &str = "./sample_configs/distributed.yaml";
-const DEFAULT_SINGLE_NODE_CONFIG_FILENAME: &str = "./sample_configs/single_node.yaml";
+const DEFAULT_CONFIG_PATH: &str = "sample_configs/distributed.yaml";
+const DEFAULT_SINGLE_NODE_CONFIG_FILENAME: &str = "sample_configs/single_node.yaml";
 
 #[derive(Embed)]
 #[folder = "./"]

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -59,7 +59,6 @@ impl Bindings {
         hnsw_cache_size: usize,
         persist_path: Option<String>,
     ) -> ChromaPyResult<Self> {
-        // TODO: runtime config
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _guard = runtime.enter();
         let system = System::new();
@@ -115,7 +114,6 @@ impl Bindings {
     }
 
     /// Returns the current eopch time in ns
-    /// TODO(hammadb): This should proxy to ServerAPI
     #[allow(dead_code)]
     fn heartbeat(&self) -> ChromaPyResult<u128> {
         let duration_since_epoch = std::time::SystemTime::now()
@@ -128,11 +126,6 @@ impl Bindings {
     fn get_max_batch_size(&self) -> u32 {
         self.frontend.clone().get_max_batch_size()
     }
-
-    // TODO(hammadb): Determine our pattern for optional arguments in python
-    // options include using Option or passing defaults from python
-    // or using pyargs annotations such as
-    // #[pyargs(limit = "None", offset = "None")]
 
     ////////////////////////////// Admin API //////////////////////////////
 

--- a/rust/segment/Cargo.toml
+++ b/rust/segment/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }
+rayon = { workspace = true }
 
 chroma-blockstore = { workspace = true }
 chroma-cache = { workspace = true }

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -8,10 +8,7 @@ use chroma_types::{
     operator::RecordDistance, Chunk, HnswParametersFromSegmentError, LogRecord, Operation,
     OperationRecord, Segment, SegmentUuid, SingleNodeHnswParameters,
 };
-use rayon::{
-    iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
-    ThreadPoolBuilder,
-};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sea_query::{Expr, OnConflict, Query, SqliteQueryBuilder};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -607,9 +607,10 @@ impl LocalHnswSegmentWriter {
         let index_len = guard.index.len_with_deleted();
         let index_capacity = guard.index.capacity();
         if index_len + hsnw_batch.len() >= index_capacity {
+            let needed_capacity = (index_len + hsnw_batch.len()).next_power_of_two();
             guard
                 .index
-                .resize(index_capacity * 2)
+                .resize(needed_capacity)
                 .map_err(|_| LocalHnswSegmentWriterError::HnswIndexResizeError)?;
         }
         let index_for_pool = &guard.index;

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -5,10 +5,13 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::{HnswIndex, HnswIndexConfig, Index, IndexConfig, PersistentIndex};
 use chroma_sqlite::{db::SqliteDb, table::MaxSeqId};
 use chroma_types::{
-    operator::RecordDistance, Chunk, HnswParametersFromSegmentError, LogRecord, Operation, Segment,
-    SegmentUuid, SingleNodeHnswParameters,
+    operator::RecordDistance, Chunk, HnswParametersFromSegmentError, LogRecord, Operation,
+    OperationRecord, Segment, SegmentUuid, SingleNodeHnswParameters,
 };
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::{
+    iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
+    ThreadPoolBuilder,
+};
 use sea_query::{Expr, OnConflict, Query, SqliteQueryBuilder};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
@@ -522,7 +525,8 @@ impl LocalHnswSegmentWriter {
         }
         let mut max_seq_id = u64::MIN;
         // In order to insert into hnsw index in parallel, we need to collect all the embeddings
-        let mut hsnw_batch = Vec::with_capacity(log_chunk.len());
+        let mut hnsw_batch: HashMap<u32, Vec<(u32, &OperationRecord)>> =
+            HashMap::with_capacity(log_chunk.len());
         for (log, _) in log_chunk.iter() {
             guard.num_elements_since_last_persist += 1;
             max_seq_id = max_seq_id.max(log.log_offset as u64);
@@ -540,7 +544,15 @@ impl LocalHnswSegmentWriter {
                                     .id_map
                                     .label_to_id
                                     .insert(next_label, log.record.id.clone());
-                                hsnw_batch.push((next_label as usize, &log.record));
+                                let records_for_label = match hnsw_batch.get_mut(&next_label) {
+                                    Some(records) => records,
+                                    None => {
+                                        hnsw_batch.insert(next_label, Vec::new());
+                                        // SAFETY: We just inserted the key. We have exclusive access to the map.
+                                        hnsw_batch.get_mut(&next_label).unwrap()
+                                    }
+                                };
+                                records_for_label.push((next_label, &log.record));
                                 next_label += 1;
                             }
                             None => {
@@ -552,14 +564,15 @@ impl LocalHnswSegmentWriter {
                 Operation::Update => {
                     if let Some(label) = guard.id_map.id_to_label.get(&log.record.id).cloned() {
                         if let Some(_embedding) = &log.record.embedding {
-                            let index_len = guard.index.len_with_deleted();
-                            let index_capacity = guard.index.capacity();
-                            if index_len + 1 > index_capacity {
-                                guard.index.resize(index_capacity * 2).map_err(|_| {
-                                    LocalHnswSegmentWriterError::HnswIndexResizeError
-                                })?;
-                            }
-                            hsnw_batch.push((label as usize, &log.record));
+                            let records_for_label = match hnsw_batch.get_mut(&label) {
+                                Some(records) => records,
+                                None => {
+                                    hnsw_batch.insert(label, Vec::new());
+                                    // SAFETY: We just inserted the key. We have exclusive access to the map.
+                                    hnsw_batch.get_mut(&label).unwrap()
+                                }
+                            };
+                            records_for_label.push((label, &log.record));
                         }
                     }
                 }
@@ -567,7 +580,15 @@ impl LocalHnswSegmentWriter {
                     if let Some(label) = guard.id_map.id_to_label.get(&log.record.id).cloned() {
                         guard.id_map.id_to_label.remove(&log.record.id);
                         guard.id_map.label_to_id.remove(&label);
-                        hsnw_batch.push((label as usize, &log.record));
+                        let records_for_label = match hnsw_batch.get_mut(&label) {
+                            Some(records) => records,
+                            None => {
+                                hnsw_batch.insert(label, Vec::new());
+                                // SAFETY: We just inserted the key. We have exclusive access to the map.
+                                hnsw_batch.get_mut(&label).unwrap()
+                            }
+                        };
+                        records_for_label.push((label, &log.record));
                     }
                 }
                 Operation::Upsert => {
@@ -589,7 +610,15 @@ impl LocalHnswSegmentWriter {
                                 .id_map
                                 .label_to_id
                                 .insert(label, log.record.id.clone());
-                            hsnw_batch.push((label as usize, &log.record));
+                            let records_for_label = match hnsw_batch.get_mut(&label) {
+                                Some(records) => records,
+                                None => {
+                                    hnsw_batch.insert(label, Vec::new());
+                                    // SAFETY: We just inserted the key. We have exclusive access to the map.
+                                    hnsw_batch.get_mut(&label).unwrap()
+                                }
+                            };
+                            records_for_label.push((label, &log.record));
                             if update_label {
                                 next_label += 1;
                             }
@@ -606,33 +635,43 @@ impl LocalHnswSegmentWriter {
         // Resize the index if needed
         let index_len = guard.index.len_with_deleted();
         let index_capacity = guard.index.capacity();
-        if index_len + hsnw_batch.len() >= index_capacity {
-            let needed_capacity = (index_len + hsnw_batch.len()).next_power_of_two();
+        if index_len + hnsw_batch.len() >= index_capacity {
+            let needed_capacity = (index_len + hnsw_batch.len()).next_power_of_two();
             guard
                 .index
                 .resize(needed_capacity)
                 .map_err(|_| LocalHnswSegmentWriterError::HnswIndexResizeError)?;
         }
         let index_for_pool = &guard.index;
-        (0..hsnw_batch.len()).into_par_iter().for_each(|i| {
-            let (label, log_record) = hsnw_batch[i];
-            match log_record.operation {
-                Operation::Add | Operation::Upsert | Operation::Update => {
-                    let embedding = log_record
-                        .embedding
-                        .as_ref()
-                        .expect("Add, update or upsert should have an embedding at this point");
-                    let _ = index_for_pool
-                        .add(label, embedding)
-                        .map_err(|_| LocalHnswSegmentWriterError::HnwsIndexAddError);
+
+        hnsw_batch
+            .into_par_iter()
+            .map(|(_, records)| {
+                for (label, log_record) in records {
+                    match log_record.operation {
+                        Operation::Add | Operation::Upsert | Operation::Update => {
+                            let embedding = log_record.embedding.as_ref().expect(
+                                "Add, update or upsert should have an embedding at this point",
+                            );
+                            match index_for_pool.add(label as usize, embedding) {
+                                Ok(_) => {}
+                                Err(_e) => {
+                                    return Err(LocalHnswSegmentWriterError::HnwsIndexAddError);
+                                }
+                            }
+                        }
+                        Operation::Delete => match index_for_pool.delete(label as usize) {
+                            Ok(_) => {}
+                            Err(_e) => {
+                                return Err(LocalHnswSegmentWriterError::HnswIndexDeleteError);
+                            }
+                        },
+                    }
                 }
-                Operation::Delete => {
-                    let _ = index_for_pool
-                        .delete(label)
-                        .map_err(|_| LocalHnswSegmentWriterError::HnswIndexDeleteError);
-                }
-            }
-        });
+                Ok(())
+            })
+            .find_any(|result| result.is_err())
+            .unwrap_or(Ok(()))?;
 
         guard.id_map.total_elements_added = next_label - 1;
         if guard.num_elements_since_last_persist >= guard.sync_threshold as u64 {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Uses rayon to write in batches to hnsw, mirror'ing python
   - misc cleanup
   - disable otel in config for logspam, we should eventually turn it on
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
Existing tests and manually
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None