### PR TITLE
Implemented delete_all and async delete_all function [Issue: #3207]

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -373,35 +373,36 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
 
     async def delete_all(
                 self,
-                confirm: bool = False
+                confirm: str = None
         ) -> None:
-            """Delete all the embeddings in this collection.
-            Args:
-                confirm: If False, function raises an Error, this is done to make sure the user wants to confirm deletion.
-            Returns:
-                None
-            Raises:
-                ValueError: If you don't provide confirmation
-            """
+        """Delete all the embeddings in this collection. To confirm you need to set confirm to "I am sure I want to delete all the data in {self.name}!"
+        Args:
+            confirm: If not equal to the confirmation string ""I am sure I want to delete all the data in {self.name}!",
+                    function raises an Error, this is done to make sure the user wants to confirm deletion.
+        Returns:
+            None
+        Raises:
+            ValueError: If you don't provide confirmation
+        """
 
-            if not confirm:
-                raise ValueError(
-                    "You need to confirm deletion of all Embeddings, set confirm to True!"
-                )
+        if confirm != f"I am sure I want to delete all the data in {self.name}!":
+            raise ValueError(
+                "You need to confirm deletion of all embeddings, please enter the correct string!"
+            )
 
-            else:
-                embeddings = await self.get()
-                delete_request = self._validate_and_prepare_delete_request(
-                    ids=embeddings["ids"],
-                    where=None,
-                    where_document=None
-                )
+        else:
+            embeddings = await self.get()
+            delete_request = self._validate_and_prepare_delete_request(
+                ids=embeddings["ids"],
+                where=None,
+                where_document=None
+            )
 
-                await self._client._delete(
-                    collection_id=self.id,
-                    ids=delete_request["ids"],
-                    where=delete_request["where"],
-                    where_document=delete_request["where_document"],
-                    tenant=self.tenant,
-                    database=self.database,
-                )
+            await self._client._delete(
+                collection_id=self.id,
+                ids=delete_request["ids"],
+                where=delete_request["where"],
+                where_document=delete_request["where_document"],
+                tenant=self.tenant,
+                database=self.database,
+            )

--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -370,3 +370,38 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             tenant=self.tenant,
             database=self.database,
         )
+
+    async def delete_all(
+                self,
+                confirm: bool = False
+        ) -> None:
+            """Delete all the embeddings in this collection.
+            Args:
+                confirm: If False, function raises an Error, this is done to make sure the user wants to confirm deletion.
+            Returns:
+                None
+            Raises:
+                ValueError: If you don't provide confirmation
+            """
+
+            if not confirm:
+                raise ValueError(
+                    "You need to confirm deletion of all Embeddings, set confirm to True!"
+                )
+
+            else:
+                embeddings = await self.get()
+                delete_request = self._validate_and_prepare_delete_request(
+                    ids=embeddings["ids"],
+                    where=None,
+                    where_document=None
+                )
+
+                await self._client._delete(
+                    collection_id=self.id,
+                    ids=delete_request["ids"],
+                    where=delete_request["where"],
+                    where_document=delete_request["where_document"],
+                    tenant=self.tenant,
+                    database=self.database,
+                )

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,6 +1,8 @@
 import inspect
 from typing import TYPE_CHECKING, Optional, Union
 
+from certifi import where
+
 from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.api.types import (
     URI,
@@ -381,6 +383,40 @@ class Collection(CollectionCommon["ServerAPI"]):
             tenant=self.tenant,
             database=self.database,
         )
+
+    def  delete_all(
+            self,
+            confirm: bool = False
+    ) -> None:
+        """Delete all the embeddings in this collection.
+        Args:
+            confirm: If False, function raises an Error, this is done to make sure the user wants to confirm deletion.
+        Returns:
+            None
+        Raises:
+            ValueError: If you don't provide confirmation
+        """
+
+        if not confirm:
+            raise ValueError(
+                "You need to confirm deletion of all Embeddings, set confirm to True!"
+            )
+
+        else:
+            delete_request = self._validate_and_prepare_delete_request(
+                ids=self.get()["ids"],
+                where=None,
+                where_document=None
+            )
+
+            self._client._delete(
+                collection_id=self.id,
+                ids=delete_request["ids"],
+                where=delete_request["where"],
+                where_document=delete_request["where_document"],
+                tenant=self.tenant,
+                database=self.database,
+            )
 
 
 class CollectionName(str):

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -386,20 +386,21 @@ class Collection(CollectionCommon["ServerAPI"]):
 
     def  delete_all(
             self,
-            confirm: bool = False
+            confirm: str = None
     ) -> None:
-        """Delete all the embeddings in this collection.
+        """Delete all the embeddings in this collection. To confirm you need to set confirm to "I am sure I want to delete all the data in {self.name}!"
         Args:
-            confirm: If False, function raises an Error, this is done to make sure the user wants to confirm deletion.
+            confirm: If not equal to the confirmation string ""I am sure I want to delete all the data in {self.name}!",
+                    function raises an Error, this is done to make sure the user wants to confirm deletion.
         Returns:
             None
         Raises:
             ValueError: If you don't provide confirmation
         """
 
-        if not confirm:
+        if confirm != f"I am sure I want to delete all the data in {self.name}!":
             raise ValueError(
-                "You need to confirm deletion of all Embeddings, set confirm to True!"
+                "You need to confirm deletion of all embeddings, please enter the correct string!"
             )
 
         else:

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -378,7 +378,8 @@ def test_delete_all(client):
     collection = client.create_collection("testspace")
     collection.add(**batch_records)
     assert collection.count() == 2
-    assert collection.delete_all(confirm=True) is None
+    assert collection.delete_all(confirm="I am sure I want to delete all the data in testspace!") is None
+    assert collection.count() == 0
 
 def test_collection_delete_with_invalid_collection_throws(client):
     client.reset()

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -373,6 +373,12 @@ def test_delete_with_index(client):
     assert collection.count() == 2
     collection.query(query_embeddings=[[1.1, 2.3, 3.2]], n_results=1)
 
+def test_delete_all(client):
+    client.reset()
+    collection = client.create_collection("testspace")
+    collection.add(**batch_records)
+    assert collection.count() == 2
+    assert collection.delete_all(confirm=True) is None
 
 def test_collection_delete_with_invalid_collection_throws(client):
     client.reset()


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - delete_all function
   - Implemented a delete_all function that deletes all the embeddings in the collection. This was done to improve the readability of the API and give users an easy, readable and safe way to delete all embeddings
   - The function requires a confirm argument, to make sure the user wants to delete all embeddings. If this argument is not set, the function raises a ValueError with an error message

## Test plan
- [x] Tests have been added and pass locally

## Documentation Changes
Docstrings added for delete_all and async delete_all functions
