### PR TITLE
[PERF]: improve insert throughput by ~20% via BufWriter

### DIFF
--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{collections::HashMap, io::Write, path::Path, sync::Arc};
 
 use chroma_cache::Weighted;
 use chroma_error::{ChromaError, ErrorCodes};
@@ -708,6 +708,7 @@ async fn persist(
         // Using serde_pickle results in lots of small writes
         let mut buffered_file = std::io::BufWriter::new(&mut file);
         serde_pickle::to_writer(&mut buffered_file, &guard.id_map, SerOptions::new())?;
+        buffered_file.flush()?;
     }
     Ok(guard)
 }

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -703,11 +703,11 @@ async fn persist(
             .map_err(|_| LocalHnswSegmentWriterError::HnswIndexPersistError)?;
         // Persist id map.
         let metadata_file_path = Path::new(path).join(METADATA_FILE);
-        let mut file = tokio::fs::File::create(metadata_file_path)
-            .await?
-            .into_std()
-            .await;
-        serde_pickle::to_writer(&mut file, &guard.id_map, SerOptions::new())?;
+
+        let mut file = std::fs::File::create(metadata_file_path)?;
+        // Using serde_pickle results in lots of small writes
+        let mut buffered_file = std::io::BufWriter::new(&mut file);
+        serde_pickle::to_writer(&mut buffered_file, &guard.id_map, SerOptions::new())?;
     }
     Ok(guard)
 }


### PR DESCRIPTION
## Description of changes

`serde_pickle` makes many, many small write calls with our usage. Putting a buffered writer in front of syscalls improves throughput by ~20%.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a