### PR TITLE
[ENH] Intercept GRPC status code

### DIFF
--- a/chromadb/telemetry/opentelemetry/grpc.py
+++ b/chromadb/telemetry/opentelemetry/grpc.py
@@ -67,6 +67,7 @@ class OtelInterceptor(
                 if hasattr(result, "details") and result.details():
                     span.set_attribute("rpc.detail", result.details())
                 span.set_attribute("rpc.status_code", result.code().name.lower())
+                span.set_attribute("rpc.status_code_value", result.code().value[0])
                 # Set span status based on gRPC call result
                 if result.code() != grpc.StatusCode.OK:
                     span.set_status(StatusCode.ERROR, description=str(result.code()))

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -442,7 +442,7 @@ impl Configurable<GrpcSysDbConfig> for GrpcSysDb {
     ) -> Result<Self, Box<dyn ChromaError>> {
         let host = &my_config.host;
         let port = &my_config.port;
-        println!("Connecting to sysdb at {}:{}", host, port);
+        tracing::info!("Connecting to sysdb at {}:{}", host, port);
         let connection_string = format!("http://{}:{}", host, port);
         let endpoint = match Endpoint::from_shared(connection_string) {
             Ok(endpoint) => endpoint,
@@ -459,6 +459,7 @@ impl Configurable<GrpcSysDbConfig> for GrpcSysDb {
             .layer(chroma_tracing::GrpcTraceLayer)
             .service(channel);
         let client = SysDbClient::new(channel);
+        let client_ser = ServiceBuilder::new().service(client.clone());
         Ok(GrpcSysDb { client })
     }
 }

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -459,7 +459,6 @@ impl Configurable<GrpcSysDbConfig> for GrpcSysDb {
             .layer(chroma_tracing::GrpcTraceLayer)
             .service(channel);
         let client = SysDbClient::new(channel);
-        let client_ser = ServiceBuilder::new().service(client.clone());
         Ok(GrpcSysDb { client })
     }
 }


### PR DESCRIPTION
## Description of changes
*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Modify the python grpc otel layer to match the rust side
 - New functionality
   - Intercept the grpc response status code in the grpc tower layer

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
