### PR TITLE
[ENH]: use separate exports for JS EFs

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -41,10 +41,89 @@
         "types": "./dist/cjs/chromadb.d.cts",
         "default": "./dist/cjs/chromadb.cjs"
       }
+    },
+    "./embeddings/cohere": {
+      "import": {
+        "types": "./dist/embeddings/cohere.d.ts",
+        "default": "./dist/embeddings/cohere.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/cohere.d.cts",
+        "default": "./dist/cjs/embeddings/cohere.cjs"
+      }
+    },
+    "./embeddings/google-gemini": {
+      "import": {
+        "types": "./dist/embeddings/google-gemini.d.ts",
+        "default": "./dist/embeddings/google-gemini.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/google-gemini.d.cts",
+        "default": "./dist/cjs/embeddings/google-gemini.cjs"
+      }
+    },
+    "./embeddings/hugging-face": {
+      "import": {
+        "types": "./dist/embeddings/hugging-face.d.ts",
+        "default": "./dist/embeddings/hugging-face.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/hugging-face.d.cts",
+        "default": "./dist/cjs/embeddings/hugging-face.cjs"
+      }
+    },
+    "./embeddings/jina": {
+      "import": {
+        "types": "./dist/embeddings/jina.d.ts",
+        "default": "./dist/embeddings/jina.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/jina.d.cts",
+        "default": "./dist/cjs/embeddings/jina.cjs"
+      }
+    },
+    "./embeddings/ollama": {
+      "import": {
+        "types": "./dist/embeddings/ollama.d.ts",
+        "default": "./dist/embeddings/ollama.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/ollama.d.cts",
+        "default": "./dist/cjs/embeddings/ollama.cjs"
+      }
+    },
+    "./embeddings/openai": {
+      "import": {
+        "types": "./dist/embeddings/openai.d.ts",
+        "default": "./dist/embeddings/openai.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/openai.d.cts",
+        "default": "./dist/cjs/embeddings/openai.cjs"
+      }
+    },
+    "./embeddings/transformers": {
+      "import": {
+        "types": "./dist/embeddings/transformers.d.ts",
+        "default": "./dist/embeddings/transformers.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/transformers.d.cts",
+        "default": "./dist/cjs/embeddings/transformers.cjs"
+      }
+    },
+    "./embeddings/voyageai": {
+      "import": {
+        "types": "./dist/embeddings/voyageai.d.ts",
+        "default": "./dist/embeddings/voyageai.mjs"
+      },
+      "require": {
+        "types": "./dist/embeddings/voyageai.d.cts",
+        "default": "./dist/cjs/embeddings/voyageai.cjs"
+      }
     }
   },
   "files": [
-    "src",
     "dist"
   ],
   "scripts": {
@@ -64,7 +143,6 @@
     "node": ">=14.17.0"
   },
   "dependencies": {
-    "cliui": "^8.0.1",
     "isomorphic-fetch": "^3.0.0"
   },
   "peerDependencies": {
@@ -72,7 +150,8 @@
     "cohere-ai": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "openai": "^3.0.0 || ^4.0.0",
     "voyageai": "^0.0.3-1",
-    "ollama": "^0.5.0"
+    "ollama": "^0.5.0",
+    "chromadb-default-embed": "^2.13.0"
   },
   "peerDependenciesMeta": {
     "@google/generative-ai": {

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -10,9 +10,9 @@ importers:
       "@google/generative-ai":
         specifier: ^0.1.1
         version: 0.1.3
-      cliui:
-        specifier: ^8.0.1
-        version: 8.0.1
+      chromadb-default-embed:
+        specifier: ^2.13.0
+        version: 2.13.2
       cohere-ai:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
         version: 7.10.5(@aws-sdk/client-sso-oidc@3.596.0)
@@ -866,6 +866,13 @@ packages:
       }
     engines: { node: ">=18.0.0" }
 
+  "@huggingface/jinja@0.1.3":
+    resolution:
+      {
+        integrity: sha512-9KsiorsdIK8+7VmlamAT7Uh90zxAhC/SeKaKc80v58JhtPYuwaJpmR/ST7XAUxrHAFqHTCoTH5aJnJDwSL6xIQ==,
+      }
+    engines: { node: ">=18" }
+
   "@isaacs/cliui@8.0.2":
     resolution:
       {
@@ -1154,6 +1161,66 @@ packages:
         integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
       }
     engines: { node: ">=14" }
+
+  "@protobufjs/aspromise@1.1.2":
+    resolution:
+      {
+        integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
+      }
+
+  "@protobufjs/base64@1.1.2":
+    resolution:
+      {
+        integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
+      }
+
+  "@protobufjs/codegen@2.0.4":
+    resolution:
+      {
+        integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
+      }
+
+  "@protobufjs/eventemitter@1.1.0":
+    resolution:
+      {
+        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
+      }
+
+  "@protobufjs/fetch@1.1.0":
+    resolution:
+      {
+        integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==,
+      }
+
+  "@protobufjs/float@1.0.2":
+    resolution:
+      {
+        integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
+      }
+
+  "@protobufjs/inquire@1.1.0":
+    resolution:
+      {
+        integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
+      }
+
+  "@protobufjs/path@1.1.2":
+    resolution:
+      {
+        integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
+      }
+
+  "@protobufjs/pool@1.1.0":
+    resolution:
+      {
+        integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
+      }
+
+  "@protobufjs/utf8@1.1.0":
+    resolution:
+      {
+        integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
+      }
 
   "@rollup/rollup-android-arm-eabi@4.18.0":
     resolution:
@@ -1764,6 +1831,12 @@ packages:
     resolution:
       {
         integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
+
+  "@types/long@4.0.2":
+    resolution:
+      {
+        integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==,
       }
 
   "@types/minimist@1.2.5":
@@ -2392,6 +2465,12 @@ packages:
       }
     engines: { node: ">=10" }
 
+  chromadb-default-embed@2.13.2:
+    resolution:
+      {
+        integrity: sha512-mhqo5rLjkF2KkxAV0WS82vNIXWpVMzvz5y5ayIB2FxcebUbEBNlcRh6XSSqYChWMfJ9us1ZzLQU8RXqsy3sKaA==,
+      }
+
   ci-info@3.9.0:
     resolution:
       {
@@ -2456,12 +2535,25 @@ packages:
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
 
+  color-string@1.9.1:
+    resolution:
+      {
+        integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==,
+      }
+
   color-support@1.1.3:
     resolution:
       {
         integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==,
       }
     hasBin: true
+
+  color@4.2.3:
+    resolution:
+      {
+        integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==,
+      }
+    engines: { node: ">=12.5.0" }
 
   combined-stream@1.0.8:
     resolution:
@@ -2611,6 +2703,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  decompress-response@6.0.0:
+    resolution:
+      {
+        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
+      }
+    engines: { node: ">=10" }
+
   dedent@1.5.3:
     resolution:
       {
@@ -2621,6 +2720,13 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-extend@0.6.0:
+    resolution:
+      {
+        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
+      }
+    engines: { node: ">=4.0.0" }
 
   deepmerge@4.3.1:
     resolution:
@@ -2881,6 +2987,13 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
+  expand-template@2.0.3:
+    resolution:
+      {
+        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
+      }
+    engines: { node: ">=6" }
+
   expect@29.7.0:
     resolution:
       {
@@ -2945,6 +3058,12 @@ packages:
         integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
       }
     engines: { node: ">=8" }
+
+  flatbuffers@1.12.0:
+    resolution:
+      {
+        integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==,
+      }
 
   for-each@0.3.3:
     resolution:
@@ -3102,6 +3221,12 @@ packages:
         integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==,
       }
 
+  github-from-package@0.0.0:
+    resolution:
+      {
+        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
+      }
+
   glob-parent@5.1.2:
     resolution:
       {
@@ -3155,6 +3280,12 @@ packages:
     resolution:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
+
+  guid-typescript@1.0.9:
+    resolution:
+      {
+        integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==,
       }
 
   handlebars@4.7.8:
@@ -3325,6 +3456,12 @@ packages:
         integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
       }
 
+  ini@1.3.8:
+    resolution:
+      {
+        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
+      }
+
   internal-slot@1.0.7:
     resolution:
       {
@@ -3350,6 +3487,12 @@ packages:
     resolution:
       {
         integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+      }
+
+  is-arrayish@0.3.2:
+    resolution:
+      {
+        integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==,
       }
 
   is-bigint@1.0.4:
@@ -3974,6 +4117,12 @@ packages:
       }
     engines: { node: ">=10" }
 
+  long@4.0.0:
+    resolution:
+      {
+        integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==,
+      }
+
   lower-case@2.0.2:
     resolution:
       {
@@ -4103,6 +4252,13 @@ packages:
       }
     engines: { node: ">=6" }
 
+  mimic-response@3.1.0:
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: { node: ">=10" }
+
   min-indent@1.0.1:
     resolution:
       {
@@ -4209,6 +4365,12 @@ packages:
         integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==,
       }
 
+  napi-build-utils@2.0.0:
+    resolution:
+      {
+        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
+      }
+
   natural-compare@1.4.0:
     resolution:
       {
@@ -4233,10 +4395,23 @@ packages:
         integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==,
       }
 
+  node-abi@3.74.0:
+    resolution:
+      {
+        integrity: sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==,
+      }
+    engines: { node: ">=10" }
+
   node-addon-api@5.1.0:
     resolution:
       {
         integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==,
+      }
+
+  node-addon-api@6.1.0:
+    resolution:
+      {
+        integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==,
       }
 
   node-domexception@1.0.0:
@@ -4372,6 +4547,31 @@ packages:
         integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
       }
     engines: { node: ">=6" }
+
+  onnx-proto@4.0.4:
+    resolution:
+      {
+        integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==,
+      }
+
+  onnxruntime-common@1.14.0:
+    resolution:
+      {
+        integrity: sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==,
+      }
+
+  onnxruntime-node@1.14.0:
+    resolution:
+      {
+        integrity: sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==,
+      }
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.14.0:
+    resolution:
+      {
+        integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==,
+      }
 
   openai@4.51.0:
     resolution:
@@ -4550,6 +4750,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  platform@1.3.6:
+    resolution:
+      {
+        integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==,
+      }
+
   plur@4.0.0:
     resolution:
       {
@@ -4585,6 +4791,14 @@ packages:
         optional: true
       ts-node:
         optional: true
+
+  prebuild-install@7.1.3:
+    resolution:
+      {
+        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
 
   prettier@2.8.7:
     resolution:
@@ -4633,6 +4847,13 @@ packages:
         integrity: sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==,
       }
     engines: { node: ">=14" }
+
+  protobufjs@6.11.4:
+    resolution:
+      {
+        integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==,
+      }
+    hasBin: true
 
   pump@3.0.0:
     resolution:
@@ -4684,6 +4905,13 @@ packages:
         integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==,
       }
     engines: { node: ">=8" }
+
+  rc@1.2.8:
+    resolution:
+      {
+        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
+      }
+    hasBin: true
 
   react-is@18.3.1:
     resolution:
@@ -4931,6 +5159,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  sharp@0.32.6:
+    resolution:
+      {
+        integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==,
+      }
+    engines: { node: ">=14.15.0" }
+
   shebang-command@1.2.0:
     resolution:
       {
@@ -4984,6 +5219,24 @@ packages:
         integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
       }
     engines: { node: ">=14" }
+
+  simple-concat@1.0.1:
+    resolution:
+      {
+        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
+      }
+
+  simple-get@4.0.1:
+    resolution:
+      {
+        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
+      }
+
+  simple-swizzle@0.2.2:
+    resolution:
+      {
+        integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==,
+      }
 
   sisteransi@1.0.5:
     resolution:
@@ -5187,6 +5440,13 @@ packages:
         integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==,
       }
     engines: { node: ">=8" }
+
+  strip-json-comments@2.0.1:
+    resolution:
+      {
+        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
   strip-json-comments@3.1.1:
     resolution:
@@ -5450,6 +5710,12 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tunnel-agent@0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
 
   tweetnacl@0.14.5:
     resolution:
@@ -6594,6 +6860,8 @@ snapshots:
 
   "@google/generative-ai@0.1.3": {}
 
+  "@huggingface/jinja@0.1.3": {}
+
   "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
@@ -6914,6 +7182,29 @@ snapshots:
 
   "@pkgjs/parseargs@0.11.0":
     optional: true
+
+  "@protobufjs/aspromise@1.1.2": {}
+
+  "@protobufjs/base64@1.1.2": {}
+
+  "@protobufjs/codegen@2.0.4": {}
+
+  "@protobufjs/eventemitter@1.1.0": {}
+
+  "@protobufjs/fetch@1.1.0":
+    dependencies:
+      "@protobufjs/aspromise": 1.1.2
+      "@protobufjs/inquire": 1.1.0
+
+  "@protobufjs/float@1.0.2": {}
+
+  "@protobufjs/inquire@1.1.0": {}
+
+  "@protobufjs/path@1.1.2": {}
+
+  "@protobufjs/pool@1.1.0": {}
+
+  "@protobufjs/utf8@1.1.0": {}
 
   "@rollup/rollup-android-arm-eabi@4.18.0":
     optional: true
@@ -7356,6 +7647,8 @@ snapshots:
 
   "@types/json-schema@7.0.15": {}
 
+  "@types/long@4.0.2": {}
+
   "@types/minimist@1.2.5": {}
 
   "@types/node-fetch@2.6.11":
@@ -7775,6 +8068,14 @@ snapshots:
 
   chownr@2.0.0: {}
 
+  chromadb-default-embed@2.13.2:
+    dependencies:
+      "@huggingface/jinja": 0.1.3
+      onnxruntime-web: 1.14.0
+      sharp: 0.32.6
+    optionalDependencies:
+      onnxruntime-node: 1.14.0
+
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.3.1: {}
@@ -7821,7 +8122,17 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+
   color-support@1.1.3: {}
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
 
   combined-stream@1.0.8:
     dependencies:
@@ -7923,7 +8234,13 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@1.5.3: {}
+
+  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -8135,6 +8452,8 @@ snapshots:
 
   exit@0.1.2: {}
 
+  expand-template@2.0.3: {}
+
   expect@29.7.0:
     dependencies:
       "@jest/expect-utils": 29.7.0
@@ -8177,6 +8496,8 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  flatbuffers@1.12.0: {}
 
   for-each@0.3.3:
     dependencies:
@@ -8264,6 +8585,8 @@ snapshots:
 
   getopts@2.3.0: {}
 
+  github-from-package@0.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -8306,6 +8629,8 @@ snapshots:
       get-intrinsic: 1.2.4
 
   graceful-fs@4.2.11: {}
+
+  guid-typescript@1.0.9: {}
 
   handlebars@4.7.8:
     dependencies:
@@ -8388,6 +8713,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ini@1.3.8: {}
+
   internal-slot@1.0.7:
     dependencies:
       es-errors: 1.3.0
@@ -8402,6 +8729,8 @@ snapshots:
       get-intrinsic: 1.2.4
 
   is-arrayish@0.2.1: {}
+
+  is-arrayish@0.3.2: {}
 
   is-bigint@1.0.4:
     dependencies:
@@ -8921,6 +9250,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  long@4.0.0: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.6.3
@@ -8989,6 +9320,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@3.1.2:
@@ -9041,6 +9374,8 @@ snapshots:
   nan@2.20.0:
     optional: true
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
@@ -9052,7 +9387,13 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.6.3
 
+  node-abi@3.74.0:
+    dependencies:
+      semver: 7.6.2
+
   node-addon-api@5.1.0: {}
+
+  node-addon-api@6.1.0: {}
 
   node-domexception@1.0.0: {}
 
@@ -9133,6 +9474,26 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onnx-proto@4.0.4:
+    dependencies:
+      protobufjs: 6.11.4
+
+  onnxruntime-common@1.14.0: {}
+
+  onnxruntime-node@1.14.0:
+    dependencies:
+      onnxruntime-common: 1.14.0
+    optional: true
+
+  onnxruntime-web@1.14.0:
+    dependencies:
+      flatbuffers: 1.12.0
+      guid-typescript: 1.0.9
+      long: 4.0.0
+      onnx-proto: 4.0.4
+      onnxruntime-common: 1.14.0
+      platform: 1.3.6
 
   openai@4.51.0:
     dependencies:
@@ -9239,6 +9600,8 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  platform@1.3.6: {}
+
   plur@4.0.0:
     dependencies:
       irregular-plurals: 3.5.0
@@ -9253,6 +9616,21 @@ snapshots:
       yaml: 2.4.5
     optionalDependencies:
       ts-node: 10.9.2(@types/node@20.14.2)(typescript@5.4.5)
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.0.3
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.74.0
+      pump: 3.0.0
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.0.1
+      tunnel-agent: 0.6.0
 
   prettier@2.8.7: {}
 
@@ -9281,6 +9659,22 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
 
+  protobufjs@6.11.4:
+    dependencies:
+      "@protobufjs/aspromise": 1.1.2
+      "@protobufjs/base64": 1.1.2
+      "@protobufjs/codegen": 2.0.4
+      "@protobufjs/eventemitter": 1.1.0
+      "@protobufjs/fetch": 1.1.0
+      "@protobufjs/float": 1.0.2
+      "@protobufjs/inquire": 1.1.0
+      "@protobufjs/path": 1.1.2
+      "@protobufjs/pool": 1.1.0
+      "@protobufjs/utf8": 1.1.0
+      "@types/long": 4.0.2
+      "@types/node": 20.14.2
+      long: 4.0.0
+
   pump@3.0.0:
     dependencies:
       end-of-stream: 1.4.4
@@ -9301,6 +9695,13 @@ snapshots:
   queue-tick@1.0.1: {}
 
   quick-lru@4.0.1: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-is@18.3.1: {}
 
@@ -9474,6 +9875,17 @@ snapshots:
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
 
+  sharp@0.32.6:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.3
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.3
+      semver: 7.6.2
+      simple-get: 4.0.1
+      tar-fs: 3.0.6
+      tunnel-agent: 0.6.0
+
   shebang-command@1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -9498,6 +9910,18 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  simple-swizzle@0.2.2:
+    dependencies:
+      is-arrayish: 0.3.2
 
   sisteransi@1.0.5: {}
 
@@ -9630,6 +10054,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -9835,6 +10261,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   tweetnacl@0.14.5: {}
 

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -2,17 +2,10 @@ export { ChromaClient } from "./ChromaClient";
 export { AdminClient } from "./AdminClient";
 export { CloudClient } from "./CloudClient";
 export { Collection } from "./Collection";
-export { IEmbeddingFunction } from "./embeddings/IEmbeddingFunction";
-export { OpenAIEmbeddingFunction } from "./embeddings/OpenAIEmbeddingFunction";
-export { CohereEmbeddingFunction } from "./embeddings/CohereEmbeddingFunction";
-export { TransformersEmbeddingFunction } from "./embeddings/TransformersEmbeddingFunction";
-export { DefaultEmbeddingFunction } from "./embeddings/DefaultEmbeddingFunction";
-export { HuggingFaceEmbeddingServerFunction } from "./embeddings/HuggingFaceEmbeddingServerFunction";
-export { JinaEmbeddingFunction } from "./embeddings/JinaEmbeddingFunction";
-export { GoogleGenerativeAiEmbeddingFunction } from "./embeddings/GoogleGeminiEmbeddingFunction";
-export { OllamaEmbeddingFunction } from "./embeddings/OllamaEmbeddingFunction";
+export type { IEmbeddingFunction } from "./embeddings/IEmbeddingFunction";
+export * from "./embeddings/DefaultEmbeddingFunction";
 
-export {
+export type {
   IncludeEnum,
   GetParams,
   CollectionMetadata,

--- a/clients/js/tsup.config.ts
+++ b/clients/js/tsup.config.ts
@@ -5,6 +5,16 @@ export default defineConfig((options: Options) => {
   const commonOptions: Partial<Options> = {
     entry: {
       chromadb: "src/index.ts",
+      "embeddings/cohere": "src/embeddings/CohereEmbeddingFunction.ts",
+      "embeddings/google": "src/embeddings/GoogleGeminiEmbeddingFunction.ts",
+      "embeddings/huggingface":
+        "src/embeddings/HuggingFaceEmbeddingServerFunction.ts",
+      "embeddings/jina": "src/embeddings/JinaEmbeddingFunction.ts",
+      "embeddings/ollama": "src/embeddings/OllamaEmbeddingFunction.ts",
+      "embeddings/openai": "src/embeddings/OpenAIEmbeddingFunction.ts",
+      "embeddings/transformers":
+        "src/embeddings/TransformersEmbeddingFunction.ts",
+      "embeddings/voyageai": "src/embeddings/VoyageAIEmbeddingFunction.ts",
     },
     sourcemap: true,
     dts: true,


### PR DESCRIPTION
## Description of changes

Each embedding function is now exposed behind a separate module export. For consumers using bundlers like Webpack/turbopack/*, this means that the bundler no longer attempts to bundle & chunk every EF dependency. The dependencies for the default EF are always installed.

This is a breaking change.

## Test plan
*How are these changes tested?*

An error is thrown if the user doesn't have the dependency for their EF installed:

**ESM, Next.js with turbopack**
<img width="652" alt="Screenshot 2025-03-03 at 14 01 54" src="https://github.com/user-attachments/assets/3e20ca28-9552-419e-a765-c145a7b457ce" />

Once the dependency is installed, the client & EF work as expected.

**CJS, no bundler**

Example script:

```javascript
const {ChromaClient} = require("chromadb")
const {OpenAIEmbeddingFunction} = require("chromadb/embeddings/openai")

const ef = new OpenAIEmbeddingFunction({})
ef.generate(["foo"]).then(result => console.log(result))
```

An error is thrown if the user doesn't have the dependency for the OpenAI EF installed:

<img width="1086" alt="Screenshot 2025-03-03 at 14 02 47" src="https://github.com/user-attachments/assets/b82932d2-f975-4516-ab24-b061fee93c2c" />

-------------------

There was no meaningful change to the package size (`-27kB`).

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

need to update before merge