### PR TITLE
[ENH] In JS frontends, fall back to hosted chroma package instead of third-party package

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",

--- a/clients/js/src/embeddings/DefaultEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/DefaultEmbeddingFunction.ts
@@ -93,9 +93,8 @@ export class DefaultEmbeddingFunction implements IEmbeddingFunction {
       let importResult;
       if (isBrowser()) {
         importResult = await import(
-          // todo: we can't import chromadb-default-embed here yet because the `build` script was not run before publishing our fork to NPM, so the entrypoint in our forked package points to a non-existent file.
           // @ts-expect-error
-          "https://unpkg.com/@xenova/transformers@2.13.2"
+          "https://unpkg.com/chromadb-default-embed@2.14.0"
         );
       } else {
         // @ts-expect-error


### PR DESCRIPTION
`v2.14.0` of `chromadb-default-embed` now includes a `dist/` folder. 