### PR TITLE
[ENH]: update JS EFs to conform to new interface

### DIFF
--- a/clients/js/src/embeddings/CohereEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/CohereEmbeddingFunction.ts
@@ -100,7 +100,7 @@ export class CohereEmbeddingFunction implements IEmbeddingFunction {
   }) {
     this.model = model;
 
-    const apiKey = cohere_api_key ?? process.env[cohere_api_key_env_var!];
+    const apiKey = cohere_api_key ?? process.env[cohere_api_key_env_var];
     if (!apiKey) {
       throw new Error(
         `Cohere API key is required. Please provide it in the constructor or set the environment variable ${cohere_api_key_env_var}.`,

--- a/clients/js/src/embeddings/CohereEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/CohereEmbeddingFunction.ts
@@ -1,4 +1,7 @@
-import { IEmbeddingFunction } from "./IEmbeddingFunction";
+import type {
+  EmbeddingFunctionSpace,
+  IEmbeddingFunction,
+} from "./IEmbeddingFunction";
 
 interface CohereAIAPI {
   createEmbedding: (params: {
@@ -73,19 +76,39 @@ class CohereAISDK7 implements CohereAIAPI {
   }
 }
 
+interface StoredConfig {
+  model_name: string;
+  api_key_env_var: string;
+}
+
 export class CohereEmbeddingFunction implements IEmbeddingFunction {
+  name = "cohere";
+
   private cohereAiApi?: CohereAIAPI;
   private model: string;
   private apiKey: string;
+  private apiKeyEnvVar: string;
+
   constructor({
     cohere_api_key,
-    model,
+    model = "large",
+    cohere_api_key_env_var = "CHROMA_COHERE_API_KEY",
   }: {
-    cohere_api_key: string;
+    cohere_api_key?: string;
     model?: string;
+    cohere_api_key_env_var: string;
   }) {
-    this.model = model || "large";
-    this.apiKey = cohere_api_key;
+    this.model = model;
+
+    const apiKey = cohere_api_key ?? process.env[cohere_api_key_env_var!];
+    if (!apiKey) {
+      throw new Error(
+        `Cohere API key is required. Please provide it in the constructor or set the environment variable ${cohere_api_key_env_var}.`,
+      );
+    }
+
+    this.apiKey = apiKey;
+    this.apiKeyEnvVar = cohere_api_key_env_var;
   }
 
   private async initCohereClient() {
@@ -118,5 +141,67 @@ export class CohereEmbeddingFunction implements IEmbeddingFunction {
       model: this.model,
       input: texts,
     });
+  }
+
+  buildFromConfig(config: StoredConfig): CohereEmbeddingFunction {
+    return new CohereEmbeddingFunction({
+      model: config.model_name,
+      cohere_api_key_env_var: config.api_key_env_var,
+    });
+  }
+
+  getConfig(): StoredConfig {
+    return {
+      model_name: this.model,
+      api_key_env_var: this.apiKeyEnvVar,
+    };
+  }
+
+  validateConfigUpdate(oldConfig: StoredConfig, newConfig: StoredConfig): void {
+    if (oldConfig.model_name !== newConfig.model_name) {
+      throw new Error(
+        "CohereEmbeddingFunction model_name cannot be changed after initialization.",
+      );
+    }
+  }
+
+  supportedSpaces(): EmbeddingFunctionSpace[] {
+    if (this.model === "embed-english-v3.0") {
+      return ["cosine", "l2", "inner_product"];
+    }
+
+    if (this.model === "embed-english-light-v3.0") {
+      return ["cosine", "inner_product", "l2"];
+    }
+
+    if (this.model === "embed-english-v2.0") {
+      return ["cosine"];
+    }
+
+    if (this.model === "embed-english-light-v2.0") {
+      return ["cosine"];
+    }
+
+    if (this.model === "embed-multilingual-v3.0") {
+      return ["cosine", "l2", "inner_product"];
+    }
+
+    if (this.model === "embed-multilingual-light-v3.0") {
+      return ["cosine", "l2", "inner_product"];
+    }
+
+    if (this.model === "embed-multilingual-v2.0") {
+      return ["inner_product"];
+    }
+
+    return ["cosine", "l2", "inner_product"];
+  }
+
+  defaultSpace(): EmbeddingFunctionSpace {
+    if (this.model == "embed-multilingual-v2.0") {
+      return "inner_product";
+    }
+
+    return "cosine";
   }
 }

--- a/clients/js/src/embeddings/DefaultEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/DefaultEmbeddingFunction.ts
@@ -5,6 +5,8 @@ import { IEmbeddingFunction } from "./IEmbeddingFunction";
 let TransformersApi: Promise<any>;
 
 export class DefaultEmbeddingFunction implements IEmbeddingFunction {
+  name = "onnx_mini_lm_l6_v2";
+
   private pipelinePromise?: Promise<any> | null;
   private transformersApi: any;
   private model: string;

--- a/clients/js/src/embeddings/DefaultEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/DefaultEmbeddingFunction.ts
@@ -4,8 +4,14 @@ import { IEmbeddingFunction } from "./IEmbeddingFunction";
 // Dynamically import module
 let TransformersApi: Promise<any>;
 
+interface StoredConfig {
+  model_name: string;
+  revision: string;
+  quantized: boolean;
+}
+
 export class DefaultEmbeddingFunction implements IEmbeddingFunction {
-  name = "onnx_mini_lm_l6_v2";
+  name = "default";
 
   private pipelinePromise?: Promise<any> | null;
   private transformersApi: any;
@@ -66,6 +72,30 @@ export class DefaultEmbeddingFunction implements IEmbeddingFunction {
     let pipe = await this.pipelinePromise;
     let output = await pipe(texts, { pooling: "mean", normalize: true });
     return output.tolist();
+  }
+
+  getConfig(): StoredConfig {
+    return {
+      model_name: this.model,
+      revision: this.revision,
+      quantized: this.quantized,
+    };
+  }
+
+  buildFromConfig(config: StoredConfig): DefaultEmbeddingFunction {
+    return new DefaultEmbeddingFunction({
+      model: config.model_name,
+      revision: config.revision,
+      quantized: config.quantized,
+    });
+  }
+
+  validateConfigUpdate(oldConfig: StoredConfig, newConfig: StoredConfig): void {
+    if (oldConfig.model_name !== newConfig.model_name) {
+      throw new Error(
+        "DefaultEmbeddingFunction model_name cannot be changed after initialization.",
+      );
+    }
   }
 
   private async loadClient() {

--- a/clients/js/src/embeddings/HuggingFaceEmbeddingServerFunction.ts
+++ b/clients/js/src/embeddings/HuggingFaceEmbeddingServerFunction.ts
@@ -1,8 +1,12 @@
 import { IEmbeddingFunction } from "./IEmbeddingFunction";
 
-let CohereAiApi: any;
+type StoredConfig = {
+  url: string;
+};
 
 export class HuggingFaceEmbeddingServerFunction implements IEmbeddingFunction {
+  name = "huggingface_server";
+
   private url: string;
 
   constructor({ url }: { url: string }) {
@@ -26,5 +30,24 @@ export class HuggingFaceEmbeddingServerFunction implements IEmbeddingFunction {
 
     const data = await response.json();
     return data;
+  }
+
+  buildFromConfig(config: StoredConfig): HuggingFaceEmbeddingServerFunction {
+    return new HuggingFaceEmbeddingServerFunction(config);
+  }
+
+  toConfig(): StoredConfig {
+    return {
+      url: this.url,
+    };
+  }
+
+  validateConfigUpdate(
+    oldConfig: Record<string, any>,
+    newConfig: Record<string, any>,
+  ): void {
+    if (oldConfig.url !== newConfig.url) {
+      throw new Error("Changing the URL is not allowed.");
+    }
   }
 }

--- a/clients/js/src/embeddings/IEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/IEmbeddingFunction.ts
@@ -1,3 +1,20 @@
+export type EmbeddingFunctionSpace = "cosine" | "l2" | "inner_product";
+
 export interface IEmbeddingFunction {
   generate(texts: string[]): Promise<number[][]>;
+  name?: string;
+  defaultSpace?(): EmbeddingFunctionSpace;
+  supportedSpaces?(): EmbeddingFunctionSpace[];
+  buildFromConfig?(config: Record<string, any>): IEmbeddingFunction;
+  getConfig?(): Record<string, any>;
+  validateConfigUpdate?(
+    oldConfig: Record<string, any>,
+    newConfig: Record<string, any>,
+  ): void;
 }
+
+export type EmbeddingFunctionConstructor = (new (
+  ...args: any[]
+) => IEmbeddingFunction) & {
+  name?: string;
+};

--- a/clients/js/src/embeddings/OllamaEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/OllamaEmbeddingFunction.ts
@@ -1,28 +1,30 @@
-import { IEmbeddingFunction } from "./IEmbeddingFunction";
-const DEFAULT_MODEL = "chroma/all-minilm-l6-v2-f32";
-const DEFAULT_LOCAL_URL = "http://localhost:11434";
-export class OllamaEmbeddingFunction implements IEmbeddingFunction {
-  private readonly url?: string | undefined;
-  private readonly model: string;
-  private ollamaClient: any;
+import type { Ollama } from "ollama";
+import type { IEmbeddingFunction } from "./IEmbeddingFunction";
 
-  constructor(
-    {
-      url = DEFAULT_LOCAL_URL,
-      model = DEFAULT_MODEL,
-    }: { url?: string; model?: string } = {
-      url: DEFAULT_LOCAL_URL,
-      model: DEFAULT_MODEL,
-    },
-  ) {
+type StoredConfig = {
+  url: string;
+  model_name: string;
+};
+
+export class OllamaEmbeddingFunction implements IEmbeddingFunction {
+  name = "ollama";
+
+  private readonly url: string;
+  private readonly model: string;
+  private ollamaClient?: Ollama;
+
+  constructor({
+    url = "http://localhost:11434",
+    model = "chroma/all-minilm-l6-v2-f32",
+  }: { url?: string; model?: string } = {}) {
     // we used to construct the client here, but we need to async import the types
     // for the openai npm package, and the constructor can not be async
     if (url && url.endsWith("/api/embeddings")) {
       this.url = url.slice(0, -"/api/embeddings".length);
     } else {
-      this.url = url || DEFAULT_LOCAL_URL;
+      this.url = url;
     }
-    this.model = model || DEFAULT_MODEL;
+    this.model = model;
   }
 
   private async initClient() {
@@ -61,13 +63,25 @@ export class OllamaEmbeddingFunction implements IEmbeddingFunction {
 
   public async generate(texts: string[]) {
     await this.initClient();
-    return await this.ollamaClient
-      .embed({
-        model: this.model,
-        input: texts,
-      })
-      .then((response: any) => {
-        return response.embeddings;
-      });
+    return await this.ollamaClient!.embed({
+      model: this.model,
+      input: texts,
+    }).then((response: any) => {
+      return response.embeddings;
+    });
+  }
+
+  buildFromConfig(config: StoredConfig): OllamaEmbeddingFunction {
+    return new OllamaEmbeddingFunction({
+      url: config.url,
+      model: config.model_name,
+    });
+  }
+
+  getConfig(): StoredConfig {
+    return {
+      url: this.url,
+      model_name: this.model,
+    };
   }
 }

--- a/clients/js/src/embeddings/TransformersEmbeddingFunction.ts
+++ b/clients/js/src/embeddings/TransformersEmbeddingFunction.ts
@@ -3,7 +3,15 @@ import { IEmbeddingFunction } from "./IEmbeddingFunction";
 // Dynamically import module
 let TransformersApi: Promise<any>;
 
+type StoredConfig = {
+  model: string;
+  revision: string;
+  quantized: boolean;
+};
+
 export class TransformersEmbeddingFunction implements IEmbeddingFunction {
+  name = "transformers";
+
   private pipelinePromise?: Promise<any> | null;
   private transformersApi: any;
   private model: string;
@@ -95,6 +103,36 @@ export class TransformersEmbeddingFunction implements IEmbeddingFunction {
     } catch (e) {
       throw new Error(
         "Please install @xenova/transformers as a dependency with, e.g. `npm install @xenova/transformers`",
+      );
+    }
+  }
+
+  buildFromConfig(config: StoredConfig): TransformersEmbeddingFunction {
+    return new TransformersEmbeddingFunction({
+      model: config.model,
+      revision: config.revision,
+      quantized: config.quantized,
+    });
+  }
+
+  getConfig(): StoredConfig {
+    return {
+      model: this.model,
+      revision: this.revision,
+      quantized: this.quantized,
+    };
+  }
+
+  validateConfigUpdate(oldConfig: StoredConfig, newConfig: StoredConfig): void {
+    if (oldConfig.model !== newConfig.model) {
+      throw new Error("Cannot change the model of the embedding function.");
+    }
+    if (oldConfig.revision !== newConfig.revision) {
+      throw new Error("Cannot change the revision of the embedding function.");
+    }
+    if (oldConfig.quantized !== newConfig.quantized) {
+      throw new Error(
+        "Cannot change the quantization of the embedding function.",
       );
     }
   }

--- a/clients/js/src/embeddings/all.ts
+++ b/clients/js/src/embeddings/all.ts
@@ -1,0 +1,9 @@
+export { CohereEmbeddingFunction } from "./CohereEmbeddingFunction";
+export { DefaultEmbeddingFunction } from "./DefaultEmbeddingFunction";
+export { GoogleGenerativeAiEmbeddingFunction } from "./GoogleGeminiEmbeddingFunction";
+export { HuggingFaceEmbeddingServerFunction } from "./HuggingFaceEmbeddingServerFunction";
+export { JinaEmbeddingFunction } from "./JinaEmbeddingFunction";
+export { OllamaEmbeddingFunction } from "./OllamaEmbeddingFunction";
+export { OpenAIEmbeddingFunction } from "./OpenAIEmbeddingFunction";
+export { TransformersEmbeddingFunction } from "./TransformersEmbeddingFunction";
+export { VoyageAIEmbeddingFunction } from "./VoyageAIEmbeddingFunction";

--- a/clients/js/src/embeddings/registry.ts
+++ b/clients/js/src/embeddings/registry.ts
@@ -1,0 +1,22 @@
+import type { EmbeddingFunctionConstructor } from "./IEmbeddingFunction";
+import * as allEmbeddingFunctions from "./all";
+
+const knownEmbeddingFunctions = new Map<string, EmbeddingFunctionConstructor>(
+  Object.values(allEmbeddingFunctions).map((fn) => [fn.name, fn]),
+);
+
+export const registerEmbeddingFunction = (fn: EmbeddingFunctionConstructor) => {
+  if (!fn.name) {
+    throw new Error("Embedding function must have a name to be registered.");
+  }
+
+  knownEmbeddingFunctions.set(fn.name, fn);
+};
+
+export const getEmbeddingFunction = (name: string) => {
+  const fn = knownEmbeddingFunctions.get(name);
+  if (!fn) {
+    throw new Error(`Embedding function ${name} not found`);
+  }
+  return fn;
+};

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -3,14 +3,7 @@ export { AdminClient } from "./AdminClient";
 export { CloudClient } from "./CloudClient";
 export { Collection } from "./Collection";
 export { IEmbeddingFunction } from "./embeddings/IEmbeddingFunction";
-export { OpenAIEmbeddingFunction } from "./embeddings/OpenAIEmbeddingFunction";
-export { CohereEmbeddingFunction } from "./embeddings/CohereEmbeddingFunction";
-export { TransformersEmbeddingFunction } from "./embeddings/TransformersEmbeddingFunction";
-export { DefaultEmbeddingFunction } from "./embeddings/DefaultEmbeddingFunction";
-export { HuggingFaceEmbeddingServerFunction } from "./embeddings/HuggingFaceEmbeddingServerFunction";
-export { JinaEmbeddingFunction } from "./embeddings/JinaEmbeddingFunction";
-export { GoogleGenerativeAiEmbeddingFunction } from "./embeddings/GoogleGeminiEmbeddingFunction";
-export { OllamaEmbeddingFunction } from "./embeddings/OllamaEmbeddingFunction";
+export * from "./embeddings/all";
 
 export {
   IncludeEnum,

--- a/clients/js/test/add.collections.test.ts
+++ b/clients/js/test/add.collections.test.ts
@@ -1,9 +1,4 @@
-import {
-  expect,
-  test,
-  describe,
-  beforeEach,
-} from "@jest/globals";
+import { expect, test, describe, beforeEach } from "@jest/globals";
 import { DOCUMENTS, EMBEDDINGS, IDS } from "./data";
 import { METADATAS } from "./data";
 import { IncludeEnum } from "../src/types";
@@ -128,6 +123,7 @@ describe("add collections", () => {
     test("it should add Cohere embeddings", async () => {
       const embedder = new CohereEmbeddingFunction({
         cohere_api_key: process.env.COHERE_API_KEY || "",
+        cohere_api_key_env_var: "COHERE_API_KEY",
       });
       const collection = await client.createCollection({
         name: "test",
@@ -151,7 +147,8 @@ describe("add collections", () => {
     test("it should add VoyageAI embeddings", async () => {
       const embedder = new VoyageAIEmbeddingFunction({
         api_key: process.env.VOYAGE_API_KEY || "",
-        model: "voyage-3-large"
+        model: "voyage-3-large",
+        api_key_env_var: "VOYAGE_API_KEY",
       });
       const collection = await client.createCollection({
         name: "test",


### PR DESCRIPTION
## Description of changes

Updates JS EFs to conform to similar interface as Python. Remaining tasks to do in follow-up PRs:

- add config validation using JSON schemas
- add tests, ideally covering config cross-language

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a