### PR TITLE
[ENH] Replace global event sender channel with `ReceiverForMessage<MeterEvent>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,6 +1674,7 @@ dependencies = [
 name = "chroma-tracing"
 version = "0.1.0"
 dependencies = [
+ "chroma-system",
  "chrono",
  "fastrace",
  "fastrace-opentelemetry",

--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -596,7 +596,9 @@ impl Frontend {
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes).submit();
+        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes)
+            .submit()
+            .await;
 
         Ok(AddCollectionRecordsResponse {})
     }
@@ -636,7 +638,9 @@ impl Frontend {
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes).submit();
+        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes)
+            .submit()
+            .await;
 
         Ok(UpdateCollectionRecordsResponse {})
     }
@@ -678,7 +682,9 @@ impl Frontend {
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes).submit();
+        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes)
+            .submit()
+            .await;
 
         Ok(UpsertCollectionRecordsResponse {})
     }
@@ -760,7 +766,9 @@ impl Frontend {
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes).submit();
+        MeterEvent::collection_write(tenant_id, database_name, collection_id.0, log_bytes)
+            .submit()
+            .await;
 
         Ok(DeleteCollectionRecordsResponse {})
     }
@@ -845,7 +853,7 @@ impl Frontend {
                 },
             })
             .await?;
-        meter_event.submit();
+        meter_event.submit().await;
         Ok(res)
     }
 
@@ -950,7 +958,7 @@ impl Frontend {
                 },
             })
             .await?;
-        meter_event.submit();
+        meter_event.submit().await;
         Ok((get_result, include).into())
     }
 
@@ -1058,7 +1066,7 @@ impl Frontend {
                 },
             })
             .await?;
-        meter_event.submit();
+        meter_event.submit().await;
         Ok((query_result, include).into())
     }
 

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -70,7 +70,7 @@ pub async fn frontend_service_entrypoint_with_config(
         ];
         init_tracing(tracing_layers);
         init_panic_tracing_hook();
-        MeterEvent::init_receiver(meter_receiver);
+        MeterEvent::init_receiver(Box::new(meter_receiver));
     } else {
         eprintln!("OpenTelemetry is not enabled because it is missing from the config.");
     }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -14,11 +14,10 @@ mod types;
 
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
-use chroma_system::System;
+use chroma_system::{ReceiverForMessage, System};
 use chroma_tracing::{
     init_global_filter_layer, init_otel_layer, init_panic_tracing_hook, init_stdout_layer,
-    init_tracing,
-    meter_event::{MeterEvent, MeterEventHandler},
+    init_tracing, meter_event::MeterEvent,
 };
 use config::FrontendServerConfig;
 use frontend::Frontend;
@@ -48,19 +47,19 @@ impl ChromaError for ScorecardRuleError {
 pub async fn frontend_service_entrypoint(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
-    meter_ingestor: impl MeterEventHandler + Send + Sync + 'static,
+    meter_receiver: impl ReceiverForMessage<MeterEvent> + 'static,
 ) {
     let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
         Ok(config_path) => FrontendServerConfig::load_from_path(&config_path),
         Err(_) => FrontendServerConfig::load(),
     };
-    frontend_service_entrypoint_with_config(auth, quota_enforcer, meter_ingestor, config).await;
+    frontend_service_entrypoint_with_config(auth, quota_enforcer, meter_receiver, config).await;
 }
 
 pub async fn frontend_service_entrypoint_with_config(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
-    meter_ingestor: impl MeterEventHandler + Send + Sync + 'static,
+    meter_receiver: impl ReceiverForMessage<MeterEvent> + 'static,
     config: FrontendServerConfig,
 ) {
     if let Some(config) = &config.open_telemetry {
@@ -71,7 +70,7 @@ pub async fn frontend_service_entrypoint_with_config(
         ];
         init_tracing(tracing_layers);
         init_panic_tracing_hook();
-        MeterEvent::init_handler(meter_ingestor);
+        MeterEvent::init_receiver(meter_receiver);
     } else {
         eprintln!("OpenTelemetry is not enabled because it is missing from the config.");
     }
@@ -123,5 +122,4 @@ pub async fn frontend_service_entrypoint_with_config(
     FrontendServer::new(config, frontend, rules, auth, quota_enforcer)
         .run()
         .await;
-    MeterEvent::stop_handler();
 }

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -272,9 +272,10 @@ impl Storage {
 
     pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, GetError> {
         match self {
-            Storage::Local(_) => {
-                unimplemented!("list_prefix not implemented for LocalStorage")
-            }
+            Storage::Local(local) => local
+                .list_prefix(prefix)
+                .await
+                .map_err(GetError::LocalError),
             Storage::S3(_) => {
                 unimplemented!("list_prefix not implemented for S3")
             }

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
+use std::path::Path;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -88,6 +89,22 @@ impl LocalStorage {
                 Err(e.to_string())
             }
         }
+    }
+
+    pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, String> {
+        let search_path = Path::new(&self.root).join(prefix);
+        let entries = std::fs::read_dir(search_path).map_err(|e| e.to_string())?;
+        entries
+            .into_iter()
+            .map(|e| {
+                e.map_err(|e| e.to_string()).and_then(|e| {
+                    e.file_name()
+                        .to_str()
+                        .map(|s| s.to_string())
+                        .ok_or("Unable to convert path to string".to_string())
+                })
+            })
+            .collect()
     }
 }
 

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -19,8 +19,10 @@ tower = { workspace = true, optional = true }
 tracing-bunyan-formatter = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracing.workspace = true
+tracing = { workspace = true }
 uuid = { workspace = true }
+
+chroma-system = { workspace = true}
 
 [features]
 grpc = ["dep:tower", "dep:http"]

--- a/rust/tracing/src/meter_event.rs
+++ b/rust/tracing/src/meter_event.rs
@@ -90,8 +90,8 @@ impl MeterEvent {
         }
     }
 
-    pub fn init_receiver(receiver: impl ReceiverForMessage<MeterEvent> + 'static) {
-        if METER_EVENT_RECEIVER.set(Box::new(receiver)).is_err() {
+    pub fn init_receiver(receiver: Box<dyn ReceiverForMessage<MeterEvent>>) {
+        if METER_EVENT_RECEIVER.set(receiver).is_err() {
             tracing::error!("Meter event handler is already initialized")
         }
     }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Changed the meter event field names so that the represented value can be easily aggregated
   - Replaced global event sender channel with custom receiver that implements `ReceiverForMessage<MeterEvent>`. This allows us to spawn a component in the system and set a global receiver for the meter event message, and additional logic to listen on the receiver is hidden from the meter module.
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
