### PR TITLE
[ENH] Allow passing system and registry into FE entrypoint

### DIFF
--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -48,7 +48,7 @@ fn run(args: RunArgs) {
 
     let runtime = tokio::runtime::Runtime::new().expect("Failed to start Chroma");
     runtime.block_on(async {
-        frontend_service_entrypoint_with_config(Arc::new(()), Arc::new(()), config).await;
+        frontend_service_entrypoint_with_config(Arc::new(()), Arc::new(()), &config).await;
     });
 }
 

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -48,7 +48,7 @@ fn run(args: RunArgs) {
 
     let runtime = tokio::runtime::Runtime::new().expect("Failed to start Chroma");
     runtime.block_on(async {
-        frontend_service_entrypoint_with_config(Arc::new(()), Arc::new(()), (), config).await;
+        frontend_service_entrypoint_with_config(Arc::new(()), Arc::new(()), config).await;
     });
 }
 

--- a/rust/frontend/src/bin/frontend_service.rs
+++ b/rust/frontend/src/bin/frontend_service.rs
@@ -1,8 +1,7 @@
-use std::sync::Arc;
-
 use chroma_frontend::frontend_service_entrypoint;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    frontend_service_entrypoint(Arc::new(()) as _, Arc::new(()) as _, ()).await;
+    frontend_service_entrypoint(Arc::new(()) as _, Arc::new(()) as _).await;
 }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -28,7 +28,7 @@ use server::FrontendServer;
 
 pub use config::{FrontendConfig, ScorecardRule};
 
-const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
+pub const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
 
 #[derive(thiserror::Error, Debug)]
 pub enum ScorecardRuleError {

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -52,7 +52,7 @@ pub async fn frontend_service_entrypoint(
         Ok(config_path) => FrontendServerConfig::load_from_path(&config_path),
         Err(_) => FrontendServerConfig::load(),
     };
-    frontend_service_entrypoint_with_config(auth, quota_enforcer, config).await;
+    frontend_service_entrypoint_with_config(auth, quota_enforcer, &config).await;
 }
 
 pub async fn frontend_service_entrypoint_with_config_system_registry(
@@ -116,7 +116,7 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
         .map(rule_to_rule)
         .collect::<Result<Vec<_>, ScorecardRuleError>>()
         .expect("error creating scorecard");
-    FrontendServer::new(config, frontend, rules, auth, quota_enforcer)
+    FrontendServer::new(config.clone(), frontend, rules, auth, quota_enforcer)
         .run()
         .await;
 }
@@ -124,7 +124,7 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
 pub async fn frontend_service_entrypoint_with_config(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
-    config: FrontendServerConfig,
+    config: &FrontendServerConfig,
 ) {
     let system = System::new();
     let registry = Registry::new();

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -60,7 +60,7 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
     quota_enforcer: Arc<dyn QuotaEnforcer>,
     system: System,
     registry: Registry,
-    config: FrontendServerConfig,
+    config: &FrontendServerConfig,
 ) {
     if let Some(config) = &config.open_telemetry {
         let tracing_layers = vec![

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -14,10 +14,10 @@ mod types;
 
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
-use chroma_system::{ReceiverForMessage, System};
+use chroma_system::System;
 use chroma_tracing::{
     init_global_filter_layer, init_otel_layer, init_panic_tracing_hook, init_stdout_layer,
-    init_tracing, meter_event::MeterEvent,
+    init_tracing,
 };
 use config::FrontendServerConfig;
 use frontend::Frontend;
@@ -47,19 +47,17 @@ impl ChromaError for ScorecardRuleError {
 pub async fn frontend_service_entrypoint(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
-    meter_receiver: impl ReceiverForMessage<MeterEvent> + 'static,
 ) {
     let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
         Ok(config_path) => FrontendServerConfig::load_from_path(&config_path),
         Err(_) => FrontendServerConfig::load(),
     };
-    frontend_service_entrypoint_with_config(auth, quota_enforcer, meter_receiver, config).await;
+    frontend_service_entrypoint_with_config(auth, quota_enforcer, config).await;
 }
 
 pub async fn frontend_service_entrypoint_with_config_system_registry(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
-    meter_receiver: impl ReceiverForMessage<MeterEvent> + 'static,
     system: System,
     registry: Registry,
     config: FrontendServerConfig,
@@ -126,7 +124,6 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
 pub async fn frontend_service_entrypoint_with_config(
     auth: Arc<dyn auth::AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
-    meter_receiver: impl ReceiverForMessage<MeterEvent> + 'static,
     config: FrontendServerConfig,
 ) {
     let system = System::new();
@@ -134,7 +131,6 @@ pub async fn frontend_service_entrypoint_with_config(
     frontend_service_entrypoint_with_config_system_registry(
         auth,
         quota_enforcer,
-        meter_receiver,
         system,
         registry,
         config,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - This allows passing the system and registry into the FE endpoint
 - New functionality
   - None

## Test plan
*How are these changes tested?*
It is untested explicitly in this change, a proxying non functional change.
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None