### PR TITLE
[ENH] Implement graceful shutdown for component and axum server

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.20
+version: 0.1.21
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -47,10 +47,8 @@ spec:
               memory: {{ .Values.rustFrontendService.resources.requests.memory }}
           {{ end }}
           env:
-            {{if .Values.rustFrontendService.configuration}}
             - name: CONFIG_PATH
               value: "/config/config.yaml"
-            {{ end }}
             {{ if .Values.frontendService.otherEnvConfig }}
               {{ .Values.frontendService.otherEnvConfig | nindent 12 }}
             {{ end }}

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -1,3 +1,16 @@
+{{if .Values.rustFrontendService.configuration}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rust-frontend-service-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+{{  .Values.rustFrontendService.configuration | indent 4 }}
+{{ end }}
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,14 +47,21 @@ spec:
               memory: {{ .Values.rustFrontendService.resources.requests.memory }}
           {{ end }}
           env:
+            {{if .Values.rustFrontendService.configuration}}
             - name: CONFIG_PATH
-              value: "/sample_configs/distributed.yaml"
+              value: "/config/config.yaml"
+            {{ end }}
             {{ if .Values.frontendService.otherEnvConfig }}
               {{ .Values.frontendService.otherEnvConfig | nindent 12 }}
             {{ end }}
             {{ if .Values.rustFrontendService.otherEnvConfig }}
               {{ .Values.rustFrontendService.otherEnvConfig | nindent 12 }}
             {{ end }}
+          {{if .Values.rustFrontendService.configuration}}
+          volumeMounts:
+            - name: rust-frontend-service-config
+              mountPath: /config/
+          {{ end }}
 
       {{if .Values.rustFrontendService.tolerations}}
       tolerations:
@@ -50,6 +70,12 @@ spec:
       {{if .Values.rustFrontendService.nodeSelector}}
       nodeSelector:
         {{ toYaml .Values.rustFrontendService.nodeSelector | nindent 8 }}
+      {{ end }}
+      {{if .Values.rustFrontendService.configuration}}
+      volumes:
+        - name: rust-frontend-service-config
+          configMap:
+            name: rust-frontend-service-config
       {{ end }}
 
 ---

--- a/rust/cli/Dockerfile
+++ b/rust/cli/Dockerfile
@@ -28,11 +28,11 @@ FROM debian:stable-slim AS runner
 
 RUN apt-get update && apt-get install -y dumb-init && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /chroma/rust/frontend/sample_configs /sample_configs
+COPY --from=builder /chroma/rust/frontend/sample_configs/distributed.yaml /config/config.yaml
 COPY --from=builder /chroma/rust/frontend/sample_configs/docker_single_node.yaml /config.yaml
 COPY --from=builder /chroma/chroma /usr/local/bin/chroma
 
 EXPOSE 8000
 
 ENTRYPOINT [ "dumb-init", "--", "chroma" ]
-CMD [ "run", "/config.yaml" ]
+CMD [ "run", "/config/config.yaml" ]

--- a/rust/frontend/src/executor/mod.rs
+++ b/rust/frontend/src/executor/mod.rs
@@ -42,7 +42,7 @@ impl Executor {
     pub async fn is_ready(&self) -> bool {
         match self {
             Executor::Distributed(distributed_executor) => distributed_executor.is_ready().await,
-            Executor::Local(_local_executor) => todo!(),
+            Executor::Local(_) => true,
         }
     }
     pub async fn reset(&mut self) -> Result<(), ExecutorError> {

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -96,7 +96,7 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
         );
     }
 
-    let frontend = Frontend::try_from_config(&(fe_cfg, system), &registry)
+    let frontend = Frontend::try_from_config(&(fe_cfg, system.clone()), &registry)
         .await
         .expect("Error creating Frontend Config");
     fn rule_to_rule(rule: &ScorecardRule) -> Result<Rule, ScorecardRuleError> {
@@ -116,9 +116,16 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
         .map(rule_to_rule)
         .collect::<Result<Vec<_>, ScorecardRuleError>>()
         .expect("error creating scorecard");
-    FrontendServer::new(config.clone(), frontend, rules, auth, quota_enforcer)
-        .run()
-        .await;
+    FrontendServer::new(
+        config.clone(),
+        frontend,
+        rules,
+        auth,
+        quota_enforcer,
+        system,
+    )
+    .run()
+    .await;
 }
 
 pub async fn frontend_service_entrypoint_with_config(

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -6,6 +6,7 @@ use axum::{
     routing::{get, post},
     Json, Router, ServiceExt,
 };
+use chroma_system::System;
 use chroma_types::RawWhereFields;
 use chroma_types::{
     AddCollectionRecordsResponse, ChecklistResponse, Collection, CollectionMetadataUpdate,
@@ -28,6 +29,10 @@ use std::str::FromStr;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
+};
+use tokio::{
+    select,
+    signal::unix::{signal, SignalKind},
 };
 use tower_http::cors::CorsLayer;
 use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
@@ -58,6 +63,25 @@ impl Drop for ScorecardGuard {
             self.scorecard.untrack(ticket);
         }
     }
+}
+
+async fn graceful_shutdown(system: System) {
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(sigterm) => sigterm,
+        Err(e) => {
+            tracing::error!("Failed to create SIGTERM signal handler for axum server: {e}");
+            return;
+        }
+    };
+
+    select! {
+        // Kubernetes will send SIGTERM to stop the pod gracefully
+        // TODO: add more signal handling
+        _ = sigterm.recv() => {
+            system.stop().await;
+            system.join().await;
+        },
+    };
 }
 
 pub struct Metrics {
@@ -127,6 +151,7 @@ pub(crate) struct FrontendServer {
     metrics: Arc<Metrics>,
     auth: Arc<dyn AuthenticateAndAuthorize>,
     quota_enforcer: Arc<dyn QuotaEnforcer>,
+    system: System,
 }
 
 impl FrontendServer {
@@ -136,6 +161,7 @@ impl FrontendServer {
         rules: Vec<Rule>,
         auth: Arc<dyn AuthenticateAndAuthorize>,
         quota_enforcer: Arc<dyn QuotaEnforcer>,
+        system: System,
     ) -> FrontendServer {
         // NOTE(rescrv):  Assume statically no more than 128 threads because we won't deploy on
         // hardware with that many threads anytime soon for frontends, if ever.
@@ -151,10 +177,13 @@ impl FrontendServer {
             metrics,
             auth,
             quota_enforcer,
+            system,
         }
     }
 
     pub async fn run(self) {
+        let system = self.system.clone();
+
         let FrontendServerConfig {
             port,
             listen_address,
@@ -263,10 +292,14 @@ impl FrontendServer {
         if circuit_breaker.enabled() {
             let service = AdmissionControlledService::new(circuit_breaker, app);
             axum::serve(listener, service.into_make_service())
+                .with_graceful_shutdown(graceful_shutdown(system))
                 .await
                 .unwrap();
         } else {
-            axum::serve(listener, app).await.unwrap();
+            axum::serve(listener, app)
+                .with_graceful_shutdown(graceful_shutdown(system))
+                .await
+                .unwrap();
         };
     }
 
@@ -1665,7 +1698,14 @@ mod tests {
         let frontend = Frontend::try_from_config(&(config.clone().frontend, system), &registry)
             .await
             .unwrap();
-        let app = FrontendServer::new(config, frontend, vec![], Arc::new(()), Arc::new(()));
+        let app = FrontendServer::new(
+            config,
+            frontend,
+            vec![],
+            Arc::new(()),
+            Arc::new(()),
+            System::new(),
+        );
         tokio::task::spawn(async move {
             app.run().await;
         });

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -4,7 +4,7 @@ use chroma_config::registry::Injectable;
 use core::panic;
 use futures::Stream;
 use parking_lot::Mutex;
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 use tokio::task::JoinError;
 
 use super::{system::System, ReceiverForMessage};
@@ -45,6 +45,10 @@ pub trait Component: Send + Sized + Debug + 'static {
         ComponentRuntime::Inherit
     }
     async fn start(&mut self, _ctx: &ComponentContext<Self>) -> () {}
+    async fn graceful_shutdown(&mut self) {}
+    fn graceful_shutdown_timeout(&self) -> Duration {
+        Duration::from_secs(6)
+    }
     fn on_handler_panic(&mut self, panic: Box<dyn core::any::Any + Send>) {
         // Default behavior is to log and then resume the panic
         tracing::error!("Handler panicked: {:?}", panic);


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Update rust frontend k8s template
 - New functionality
   - Adds a `graceful_shutdown` method for `Component` trait
   - Handles `SIGTERM` in frontend axum server

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
