### PR TITLE
[ENH] Make soft delete set SizeBytesPostCompaction to 0

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -1242,6 +1242,8 @@ func (suite *APIsTestSuite) TestSoftAndHardDeleteCollection() {
 	_, _, err = suite.coordinator.CreateCollection(ctx, testCollection)
 	suite.NoError(err)
 
+	// TODO: Flush a compaction so the SizeBytesPostCompaction is updated
+
 	// Soft delete the collection
 	err = suite.coordinator.DeleteCollection(ctx, &model.DeleteCollection{
 		ID:           testCollection.ID,
@@ -1299,6 +1301,9 @@ func (suite *APIsTestSuite) TestSoftAndHardDeleteCollection() {
 	suite.Equal(id, softDeletedResults[0].ID.String())
 	renamedCollectionNamePrefix := fmt.Sprintf("deleted_%s_", testCollection.Name)
 	suite.Contains(softDeletedResults[0].Name, renamedCollectionNamePrefix)
+
+	// Verify the soft deleted collection has a size of 0
+	suite.Equal(uint64(0), softDeletedResults[0].SizeBytesPostCompaction)
 }
 
 func (suite *APIsTestSuite) TestCollectionVersioningWithMinio() {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -540,13 +540,16 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 		// Generate new name with timestamp and random number
 		oldName := *collections[0].Collection.Name
 		newName := fmt.Sprintf("_deleted_%s_%s", oldName, *types.FromUniqueID(deleteCollection.ID))
+		compactionTime := time.Now()
 
 		dbCollection := &dbmodel.Collection{
-			ID:        deleteCollection.ID.String(),
-			Name:      &newName,
-			IsDeleted: true,
-			Ts:        deleteCollection.Ts,
-			UpdatedAt: time.Now(),
+			ID:                      deleteCollection.ID.String(),
+			Name:                    &newName,
+			IsDeleted:               true,
+			Ts:                      deleteCollection.Ts,
+			UpdatedAt:               compactionTime,
+			SizeBytesPostCompaction: 0,
+			LastCompactionTimeSecs:  uint64(compactionTime.Unix()),
 		}
 		err = tc.metaDomain.CollectionDb(txCtx).Update(dbCollection)
 		if err != nil {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - Updates soft delete to set a collection's size in the SysDB to 0. Also sets the last compaction time to be the soft delete time.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
