### PR TITLE
[ENH]  Make PutOptions part of the storage API.

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use chroma_cache::{CacheError, PersistentCache};
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_storage::Storage;
+use chroma_storage::{PutOptions, Storage};
 use futures::{stream::FuturesUnordered, StreamExt};
 use std::sync::Arc;
 use thiserror::Error;
@@ -383,7 +383,10 @@ impl BlockManager {
         };
         let key = format!("block/{}", block.id);
         let block_bytes_len = bytes.len();
-        let res = self.storage.put_bytes(&key, bytes).await;
+        let res = self
+            .storage
+            .put_bytes(&key, bytes, PutOptions::default())
+            .await;
         match res {
             Ok(_) => {
                 tracing::info!(
@@ -517,7 +520,10 @@ impl RootManager {
             }
         };
         let key = format!("sparse_index/{}", root.id);
-        let res = self.storage.put_bytes(&key, bytes).await;
+        let res = self
+            .storage
+            .put_bytes(&key, bytes, PutOptions::default())
+            .await;
         match res {
             Ok(_) => {
                 tracing::info!("Root written to storage");

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -208,11 +208,15 @@ impl DeleteUnusedFilesOperator {
 mod tests {
     use super::*;
     use chroma_storage::local::LocalStorage;
+    use chroma_storage::PutOptions;
     use std::path::Path;
     use tempfile::TempDir;
 
     async fn create_test_file(storage: &Storage, path: &str, content: &[u8]) {
-        storage.put_bytes(path, content.to_vec()).await.unwrap();
+        storage
+            .put_bytes(path, content.to_vec(), PutOptions::default())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -119,6 +119,7 @@ mod tests {
     use chroma_storage::config::{
         ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
     };
+    use chroma_storage::PutOptions;
     use tracing_subscriber;
 
     async fn setup_test_storage() -> Storage {
@@ -156,7 +157,7 @@ mod tests {
 
         // Add more detailed error handling for the put operation
         match storage
-            .put_bytes(test_file_path, test_content.clone())
+            .put_bytes(test_file_path, test_content.clone(), PutOptions::default())
             .await
         {
             Ok(_) => tracing::info!("Successfully wrote test file"),

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -13,19 +13,19 @@ aws-smithy-types = "1.2"
 aws-config = { version = "1.5", features = ["behavior-version-latest"] }
 object_store = { version = "0.11", features = ["aws"] }
 
-serde = { workspace = true }
-futures = { workspace = true }
-thiserror = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
+parking_lot = { workspace = true }
+rand = { workspace = true}
+serde = { workspace = true }
 tempfile = { workspace = true }
-tracing = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-parking_lot = { workspace = true }
+tracing = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
 
 [dev-dependencies]
-"rand" = { workspace = true}
 rand_xorshift = { workspace = true }

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -362,7 +362,12 @@ impl AdmissionControlledS3Storage {
         .await
     }
 
-    pub async fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> Result<(), S3PutError> {
+    pub async fn put_bytes(
+        &self,
+        key: &str,
+        bytes: Vec<u8>,
+        options: PutOptions,
+    ) -> Result<(), S3PutError> {
         let bytes = Arc::new(Bytes::from(bytes));
 
         self.put_object(
@@ -372,7 +377,7 @@ impl AdmissionControlledS3Storage {
                 let bytes = bytes.clone();
                 async move { Ok(ByteStream::from(bytes.slice(range))) }.boxed()
             },
-            PutOptions::default(),
+            options,
         )
         .await
     }
@@ -513,6 +518,7 @@ mod tests {
             .put_bytes(
                 test_data_key.as_str(),
                 test_data_value_string.as_bytes().to_vec(),
+                crate::PutOptions::default(),
             )
             .await
             .unwrap();
@@ -549,7 +555,11 @@ mod tests {
 
         let test_data = "test data";
         admission_controlled_storage
-            .put_bytes("test", test_data.as_bytes().to_vec())
+            .put_bytes(
+                "test",
+                test_data.as_bytes().to_vec(),
+                crate::PutOptions::default(),
+            )
             .await
             .unwrap();
 

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -7,6 +7,8 @@ use chroma_error::ChromaError;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::PutOptions;
+
 #[derive(Clone)]
 pub struct LocalStorage {
     root: String,
@@ -28,7 +30,17 @@ impl LocalStorage {
         }
     }
 
-    pub async fn put_bytes(&self, key: &str, bytes: &[u8]) -> Result<(), String> {
+    pub async fn put_bytes(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        options: PutOptions,
+    ) -> Result<(), String> {
+        assert_eq!(
+            options,
+            PutOptions::default(),
+            "local does not support put options"
+        );
         let path = format!("{}/{}", self.root, key);
         tracing::debug!("Writing to path: {}", path);
         // Create the path if it doesn't exist, we unwrap since this should only be used in tests
@@ -45,7 +57,7 @@ impl LocalStorage {
     pub async fn put_file(&self, key: &str, path: &str) -> Result<(), String> {
         let file = std::fs::read(path);
         match file {
-            Ok(bytes_u8) => self.put_bytes(key, &bytes_u8).await,
+            Ok(bytes_u8) => self.put_bytes(key, &bytes_u8, PutOptions::default()).await,
             Err(e) => Err::<(), String>(e.to_string()),
         }
     }


### PR DESCRIPTION
This makes the put_bytes call take a PutOptions so that atomic
operations like put-if-not-exist and put-if-match can be supported.
