### PR TITLE
[CHORE] Remove frontend env config from rust frontend env config

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -1,5 +1,3 @@
-{{ $frontEndConfig := mergeOverwrite $$source1 $source2 }}
-
 {{if .Values.rustFrontendService.configuration}}
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -1,3 +1,5 @@
+{{ $frontEndConfig := mergeOverwrite $$source1 $source2 }}
+
 {{if .Values.rustFrontendService.configuration}}
 apiVersion: v1
 kind: ConfigMap
@@ -49,9 +51,6 @@ spec:
           env:
             - name: CONFIG_PATH
               value: "/config/config.yaml"
-            {{ if .Values.frontendService.otherEnvConfig }}
-              {{ .Values.frontendService.otherEnvConfig | nindent 12 }}
-            {{ end }}
             {{ if .Values.rustFrontendService.otherEnvConfig }}
               {{ .Values.rustFrontendService.otherEnvConfig | nindent 12 }}
             {{ end }}


### PR DESCRIPTION
## Description of changes
In the helm chart for the rust frontend's environment config, it was inheriting the environment config from the python config which is not what we want. We should explicitly set these values separately for each service.