### PR TITLE
[ENH]  Have one error type for Storage.

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -219,7 +219,7 @@ pub enum GetError {
     #[error(transparent)]
     BlockLoadError(#[from] BlockLoadError),
     #[error(transparent)]
-    StorageGetError(#[from] chroma_storage::GetError),
+    StorageGetError(#[from] chroma_storage::StorageError),
 }
 
 impl ChromaError for GetError {
@@ -435,7 +435,7 @@ pub enum RootManagerError {
     #[error(transparent)]
     UUIDParseError(#[from] uuid::Error),
     #[error(transparent)]
-    StorageGetError(#[from] chroma_storage::GetError),
+    StorageGetError(#[from] chroma_storage::StorageError),
     #[error(transparent)]
     FromBytesError(#[from] FromBytesError),
 }

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_storage::{GetError, Storage};
+use chroma_storage::{Storage, StorageError};
 use chroma_system::{Operator, OperatorType};
 use thiserror::Error;
 
@@ -53,7 +53,7 @@ impl FetchVersionFileOutput {
 #[derive(Error, Debug)]
 pub enum FetchVersionFileError {
     #[error("Error fetching version file: {0}")]
-    StorageError(#[from] GetError),
+    StorageError(#[from] StorageError),
     #[error("Error parsing version file")]
     ParseError,
     #[error("Invalid storage configuration: {0}")]

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -290,7 +290,7 @@ impl HnswIndexProvider {
                         }
                         Err(e) => {
                             tracing::error!("Failed to load hnsw index file from storage: {}", e);
-                            return Err(Box::new(HnswIndexProviderFileError::StorageGetError(e)));
+                            return Err(Box::new(HnswIndexProviderFileError::StorageError(e)));
                         }
                     };
                     tracing::info!(
@@ -600,7 +600,7 @@ pub enum HnswIndexProviderFlushError {
     #[error("HNSW Save Error")]
     HnswSaveError(#[from] Box<dyn ChromaError>),
     #[error("Storage Put Error")]
-    StoragePutError(#[from] chroma_storage::PutError),
+    StoragePutError(#[from] chroma_storage::StorageError),
 }
 
 impl ChromaError for HnswIndexProviderFlushError {
@@ -615,12 +615,10 @@ impl ChromaError for HnswIndexProviderFlushError {
 
 #[derive(Error, Debug)]
 pub enum HnswIndexProviderFileError {
-    #[error("IO Error")]
+    #[error("IO Error: {0}")]
     IOError(#[from] std::io::Error),
-    #[error("Storage Get Error")]
-    StorageGetError(#[from] chroma_storage::GetError),
-    #[error("Storage Put Error")]
-    StoragePutError(#[from] chroma_storage::PutError),
+    #[error("Storage Error: {0}")]
+    StorageError(#[from] chroma_storage::StorageError),
     #[error("Must provide full path to file")]
     InvalidFilePath,
 }

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -249,12 +249,12 @@ impl TestReferenceSegment {
                 plan.filter
                     .query_ids
                     .as_ref()
-                    .is_none_or(|ids| ids.contains(k))
+                    .map_or(true, |ids| ids.contains(k))
                     && plan
                         .filter
                         .where_clause
                         .as_ref()
-                        .is_none_or(|w| w.eval(rec))
+                        .map_or(true, |w| w.eval(rec))
             })
             .map(|(_, v)| v.clone())
             .collect::<Vec<_>>();

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -249,12 +249,12 @@ impl TestReferenceSegment {
                 plan.filter
                     .query_ids
                     .as_ref()
-                    .map_or(true, |ids| ids.contains(k))
+                    .is_none_or(|ids| ids.contains(k))
                     && plan
                         .filter
                         .where_clause
                         .as_ref()
-                        .map_or(true, |w| w.eval(rec))
+                        .is_none_or(|w| w.eval(rec))
             })
             .map(|(_, v)| v.clone())
             .collect::<Vec<_>>();

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = { workspace = true }
 rand = { workspace = true}
 serde = { workspace = true }
 tempfile = { workspace = true }
-thiserror = { workspace = true }
+thiserror.workspace = true
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{RateLimitingConfig, StorageConfig},
-    s3::{S3GetError, S3PutError, S3Storage},
+    s3::S3Storage,
 };
 use crate::{ETag, PutOptions, StorageConfigError};
 use async_trait::async_trait;
@@ -8,18 +8,19 @@ use aws_sdk_s3::primitives::{ByteStream, Length};
 use bytes::Bytes;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
-use chroma_error::{ChromaError, ErrorCodes};
+use chroma_error::ChromaError;
 use futures::future::BoxFuture;
 use futures::{future::Shared, stream, FutureExt, StreamExt};
 use parking_lot::Mutex;
 use std::ops::Range;
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
-use thiserror::Error;
 use tokio::{
     io::AsyncReadExt,
     sync::{Semaphore, SemaphorePermit},
 };
 use tracing::{Instrument, Span};
+
+use crate::StorageError;
 
 /// Wrapper over s3 storage that provides proxy features such as
 /// request coalescing, rate limiting, etc.
@@ -37,12 +38,8 @@ pub struct AdmissionControlledS3Storage {
                 Shared<
                     Pin<
                         Box<
-                            dyn Future<
-                                    Output = Result<
-                                        (Arc<Vec<u8>>, Option<ETag>),
-                                        AdmissionControlledS3StorageError,
-                                    >,
-                                > + Send
+                            dyn Future<Output = Result<(Arc<Vec<u8>>, Option<ETag>), StorageError>>
+                                + Send
                                 + 'static,
                         >,
                     >,
@@ -51,20 +48,6 @@ pub struct AdmissionControlledS3Storage {
         >,
     >,
     rate_limiter: Arc<RateLimitPolicy>,
-}
-
-#[derive(Error, Debug, Clone)]
-pub enum AdmissionControlledS3StorageError {
-    #[error("Error performing a get call from s3 storage {0}")]
-    S3GetError(#[from] S3GetError),
-}
-
-impl ChromaError for AdmissionControlledS3StorageError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            AdmissionControlledS3StorageError::S3GetError(e) => e.code(),
-        }
-    }
 }
 
 impl AdmissionControlledS3Storage {
@@ -88,14 +71,8 @@ impl AdmissionControlledS3Storage {
         storage: S3Storage,
         rate_limiter: Arc<RateLimitPolicy>,
         key: String,
-    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), AdmissionControlledS3StorageError> {
-        let (content_length, ranges, e_tag) = match storage.get_key_ranges(&key).await {
-            Ok(ranges) => ranges,
-            Err(e) => {
-                tracing::error!("Error heading s3: {}", e);
-                return Err(AdmissionControlledS3StorageError::S3GetError(e));
-            }
-        };
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
+        let (content_length, ranges, e_tag) = storage.get_key_ranges(&key).await?;
 
         // .buffer_unordered() below will hang if the range is empty (https://github.com/rust-lang/futures-rs/issues/2740), so we short-circuit here
         if content_length == 0 {
@@ -133,15 +110,17 @@ impl AdmissionControlledS3Storage {
                                     Ok(_) => Ok(()),
                                     Err(e) => {
                                         tracing::error!("Error reading from s3: {}", e);
-                                        Err(AdmissionControlledS3StorageError::S3GetError(
-                                            S3GetError::ByteStreamError(e.to_string()),
-                                        ))
+                                        Err(StorageError::Generic {
+                                            source: Arc::new(e),
+                                        })
                                     }
                                 }
                             }
                             Err(e) => {
                                 tracing::error!("Error reading from s3: {}", e);
-                                Err(AdmissionControlledS3StorageError::S3GetError(e))
+                                Err(StorageError::Generic {
+                                    source: Arc::new(e),
+                                })
                             }
                         }
                         // _token gets dropped due to RAII and we've released the permit.
@@ -162,27 +141,17 @@ impl AdmissionControlledS3Storage {
         storage: S3Storage,
         rate_limiter: Arc<RateLimitPolicy>,
         key: String,
-    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), AdmissionControlledS3StorageError> {
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
         // Acquire permit.
         let _permit = rate_limiter.enter().await;
-        let bytes_res = storage
+        storage
             .get_with_e_tag(&key)
             .instrument(tracing::trace_span!(parent: Span::current(), "S3 get"))
-            .await;
-        match bytes_res {
-            Ok((bytes, e_tag)) => Ok((bytes, e_tag)),
-            Err(e) => {
-                tracing::error!("Error reading from s3: {}", e);
-                Err(AdmissionControlledS3StorageError::S3GetError(e))
-            }
-        }
+            .await
         // Permit gets dropped here due to RAII.
     }
 
-    pub async fn get_parallel(
-        &self,
-        key: String,
-    ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
+    pub async fn get_parallel(&self, key: String) -> Result<Arc<Vec<u8>>, StorageError> {
         // If there is a duplicate request and the original request finishes
         // before we look it up in the map below then we will end up with another
         // request to S3.
@@ -217,35 +186,32 @@ impl AdmissionControlledS3Storage {
         Ok(res?.0)
     }
 
-    pub async fn get(
-        &self,
-        key: String,
-    ) -> Result<Arc<Vec<u8>>, AdmissionControlledS3StorageError> {
+    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, StorageError> {
         self.get_with_e_tag(key).await.map(|(bytes, _e_tag)| bytes)
     }
 
     pub async fn get_with_e_tag(
         &self,
-        key: String,
-    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), AdmissionControlledS3StorageError> {
+        key: &str,
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
         // If there is a duplicate request and the original request finishes
         // before we look it up in the map below then we will end up with another
         // request to S3.
         let future_to_await;
         {
             let mut requests = self.outstanding_read_requests.lock();
-            let maybe_inflight = requests.get(&key).cloned();
+            let maybe_inflight = requests.get(key).cloned();
             future_to_await = match maybe_inflight {
                 Some(fut) => fut,
                 None => {
                     let get_storage_future = AdmissionControlledS3Storage::read_from_storage(
                         self.storage.clone(),
                         self.rate_limiter.clone(),
-                        key.clone(),
+                        key.to_string(),
                     )
                     .boxed()
                     .shared();
-                    requests.insert(key.clone(), get_storage_future.clone());
+                    requests.insert(key.to_string(), get_storage_future.clone());
                     get_storage_future
                 }
             };
@@ -254,7 +220,7 @@ impl AdmissionControlledS3Storage {
         let res = future_to_await.await;
         {
             let mut requests = self.outstanding_read_requests.lock();
-            requests.remove(&key);
+            requests.remove(key);
         }
         res
     }
@@ -265,9 +231,9 @@ impl AdmissionControlledS3Storage {
         total_size_bytes: usize,
         create_bytestream_fn: impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         // Acquire permit.
         let _permit = self.rate_limiter.enter().await;
         self.storage
@@ -282,9 +248,9 @@ impl AdmissionControlledS3Storage {
         total_size_bytes: usize,
         create_bytestream_fn: impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         let (part_count, size_of_last_part, upload_id) = self
             .storage
             .prepare_multipart_upload(key, total_size_bytes)
@@ -319,9 +285,9 @@ impl AdmissionControlledS3Storage {
         total_size_bytes: usize,
         create_bytestream_fn: impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         if self.storage.is_oneshot_upload(total_size_bytes) {
             return self
                 .oneshot_upload(key, total_size_bytes, create_bytestream_fn, options)
@@ -332,10 +298,12 @@ impl AdmissionControlledS3Storage {
             .await
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), S3PutError> {
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), StorageError> {
         let file_size = tokio::fs::metadata(path)
             .await
-            .map_err(|err| S3PutError::S3PutError(err.to_string()))?
+            .map_err(|err| StorageError::Generic {
+                source: Arc::new(err),
+            })?
             .len();
 
         let path = path.to_string();
@@ -353,7 +321,9 @@ impl AdmissionControlledS3Storage {
                         .length(Length::Exact(range.len() as u64))
                         .build()
                         .await
-                        .map_err(|err| S3PutError::S3PutError(err.to_string()))
+                        .map_err(|err| StorageError::Generic {
+                            source: Arc::new(err),
+                        })
                 }
                 .boxed()
             },
@@ -367,7 +337,7 @@ impl AdmissionControlledS3Storage {
         key: &str,
         bytes: Vec<u8>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         let bytes = Arc::new(Bytes::from(bytes));
 
         self.put_object(
@@ -563,11 +533,7 @@ mod tests {
             .await
             .unwrap();
 
-        let buf = admission_controlled_storage
-            .get("test".to_string())
-            .await
-            .unwrap();
-
+        let buf = admission_controlled_storage.get("test").await.unwrap();
         let buf = String::from_utf8(Arc::unwrap_or_clone(buf)).unwrap();
         assert_eq!(buf, test_data);
     }

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
 use self::config::StorageConfig;
-use self::s3::S3GetError;
-use admissioncontrolleds3::AdmissionControlledS3StorageError;
 use async_trait::async_trait;
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
@@ -19,82 +17,170 @@ use thiserror::Error;
 
 pub use s3::s3_client_for_test_with_new_bucket;
 
-#[derive(Clone)]
-pub enum Storage {
-    ObjectStore(object_store::ObjectStore),
-    S3(s3::S3Storage),
-    Local(local::LocalStorage),
-    AdmissionControlledS3(admissioncontrolleds3::AdmissionControlledS3Storage),
+/// A StorageError captures all kinds of errors that can come from storage.
+//
+// This was borrowed from Apache Arrow's ObjectStore crate.
+// Copyer:  Robert Escriva
+// Commit:  5508978a3c5c4eb65ef6410e097887a8adaba38a
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Converted from Snafu to thiserror.
+
+#[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageError {
+    /// A fallback error type when no variant matches
+    #[error("Generic error: {source}")]
+    Generic {
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// A generic message.
+    #[error("Error message: {message}")]
+    Message {
+        /// The message
+        message: String,
+    },
+
+    /// Error when the object is not found at given location
+    #[error("Object at location {path} not found: {source}")]
+    NotFound {
+        /// The path to file
+        path: String,
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error for invalid path
+    #[error("Encountered object with invalid path: {source}")]
+    InvalidPath {
+        /// The wrapped error
+        source: PathError,
+    },
+
+    /// Error when `tokio::spawn` failed
+    #[error("Error joining spawned task.")]
+    JoinError,
+
+    /// Error when the attempted operation is not supported
+    #[error("Operation not supported: {source}")]
+    NotSupported {
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error when the object already exists
+    #[error("Object at location {path} already exists: {source}")]
+    AlreadyExists {
+        /// The path to the
+        path: String,
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error when the required conditions failed for the operation
+    #[error("Request precondition failure for path {path}: {source}")]
+    Precondition {
+        /// The path to the file
+        path: String,
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error when the object at the location isn't modified
+    #[error("Object at location {path} not modified: {source}")]
+    NotModified {
+        /// The path to the file
+        path: String,
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error when an operation is not implemented
+    #[error("Operation not yet implemented.")]
+    NotImplemented,
+
+    /// Error when the used credentials don't have enough permission
+    /// to perform the requested operation
+    #[error("The operation lacked the necessary privileges to complete for path {path}: {source}")]
+    PermissionDenied {
+        /// The path to the file
+        path: String,
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error when the used credentials lack valid authentication
+    #[error("The operation lacked valid authentication credentials for path {path}: {source}")]
+    Unauthenticated {
+        /// The path to the file
+        path: String,
+        /// The wrapped error
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// Error when a configuration key is invalid for the store used
+    #[error("Configuration key: '{key}' is not valid for store '{store}'.")]
+    UnknownConfigurationKey {
+        /// The object store used
+        store: &'static str,
+        /// The configuration key used
+        key: String,
+    },
 }
 
-#[derive(Error, Debug, Clone)]
-pub enum GetError {
-    #[error("No such key: {0}")]
-    NoSuchKey(String),
-    #[error("Precondition not met")]
-    ConditionNotMet,
-    #[error("ObjectStore error: {0}")]
-    ObjectStoreError(Arc<::object_store::Error>),
-    #[error("S3 error: {0}")]
-    S3Error(#[from] S3GetError),
-    #[error("Local storage error: {0}")]
-    LocalError(String),
-}
-
-impl ChromaError for GetError {
+impl ChromaError for StorageError {
     fn code(&self) -> ErrorCodes {
         match self {
-            GetError::NoSuchKey(_) => ErrorCodes::NotFound,
-            GetError::ObjectStoreError(_) => ErrorCodes::Internal,
-            GetError::S3Error(_) => ErrorCodes::Internal,
-            GetError::LocalError(_) => ErrorCodes::Internal,
-            GetError::ConditionNotMet => ErrorCodes::FailedPrecondition,
+            StorageError::Generic { .. } => ErrorCodes::Internal,
+            StorageError::Message { .. } => ErrorCodes::Internal,
+            StorageError::NotFound { .. } => ErrorCodes::NotFound,
+            StorageError::InvalidPath { .. } => ErrorCodes::InvalidArgument,
+            StorageError::JoinError => ErrorCodes::Internal,
+            StorageError::NotSupported { .. } => ErrorCodes::Unimplemented,
+            StorageError::AlreadyExists { .. } => ErrorCodes::AlreadyExists,
+            StorageError::Precondition { .. } => ErrorCodes::FailedPrecondition,
+            StorageError::NotModified { .. } => ErrorCodes::FailedPrecondition,
+            StorageError::NotImplemented => ErrorCodes::Unimplemented,
+            StorageError::PermissionDenied { .. } => ErrorCodes::PermissionDenied,
+            StorageError::Unauthenticated { .. } => ErrorCodes::Unauthenticated,
+            StorageError::UnknownConfigurationKey { .. } => ErrorCodes::InvalidArgument,
         }
     }
 }
 
-impl From<::object_store::Error> for GetError {
-    fn from(e: ::object_store::Error) -> Self {
-        match e {
-            ::object_store::Error::NotFound { path, source: _ } => {
-                GetError::NoSuchKey(path.to_string())
-            }
-            _ => GetError::ObjectStoreError(Arc::new(e)),
-        }
-    }
+/// Error returned by [`Path::parse`]
+#[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PathError {
+    /// Error when a path contains non-unicode characters
+    #[error("Path \"{path}\" contained non-unicode characters: {source}")]
+    NonUnicode {
+        /// The source path
+        path: String,
+        /// The underlying `UTF8Error`
+        source: std::str::Utf8Error,
+    },
 }
 
-#[derive(Error, Debug)]
-pub enum PutError {
-    #[error("ObjectStore error: {0}")]
-    ObjectStoreError(Arc<::object_store::Error>),
-    #[error("S3 error: {0}")]
-    S3Error(#[from] s3::S3PutError),
-    #[error("Local storage error: {0}")]
-    LocalError(String),
-}
-
-impl ChromaError for PutError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            PutError::ObjectStoreError(_) => ErrorCodes::Internal,
-            PutError::S3Error(_) => ErrorCodes::Internal,
-            PutError::LocalError(_) => ErrorCodes::Internal,
-        }
-    }
-}
-
-impl From<std::io::Error> for PutError {
-    fn from(e: std::io::Error) -> Self {
-        Self::LocalError(e.to_string())
-    }
-}
-
-impl From<::object_store::Error> for PutError {
-    fn from(e: ::object_store::Error) -> Self {
-        Self::ObjectStoreError(Arc::new(e))
-    }
-}
+// END BORROWED CODE
 
 #[derive(Error, Debug)]
 pub enum StorageConfigError {
@@ -102,6 +188,14 @@ pub enum StorageConfigError {
     InvalidStorageConfig,
     #[error("Failed to create bucket: {0}")]
     FailedToCreateBucket(String),
+}
+
+#[derive(Clone)]
+pub enum Storage {
+    ObjectStore(object_store::ObjectStore),
+    S3(s3::S3Storage),
+    Local(local::LocalStorage),
+    AdmissionControlledS3(admissioncontrolleds3::AdmissionControlledS3Storage),
 }
 
 impl ChromaError for StorageConfigError {
@@ -113,64 +207,14 @@ impl ChromaError for StorageConfigError {
     }
 }
 
-#[derive(Error, Debug)]
-pub enum RenameError {
-    #[error("ObjectStore error: {0}")]
-    ObjectStoreError(Arc<::object_store::Error>),
-    #[error("S3 error: {0}")]
-    S3Error(#[from] s3::S3PutError),
-    #[error("Local storage error: {0}")]
-    LocalError(String),
-}
-
-impl ChromaError for RenameError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            RenameError::ObjectStoreError(_) => ErrorCodes::Internal,
-            RenameError::S3Error(_) => ErrorCodes::Internal,
-            RenameError::LocalError(_) => ErrorCodes::Internal,
-        }
-    }
-}
-
-impl From<::object_store::Error> for RenameError {
-    fn from(e: ::object_store::Error) -> Self {
-        Self::ObjectStoreError(Arc::new(e))
-    }
-}
-
 impl Storage {
-    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
+    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, StorageError> {
         match self {
-            Storage::ObjectStore(object_store) => object_store.get(key).await,
-            Storage::S3(s3) => {
-                let res = s3.get(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                        _ => Err(GetError::S3Error(e)),
-                    },
-                }
-            }
-            Storage::Local(local) => {
-                let res = local.get(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => Err(GetError::LocalError(e)),
-                }
-            }
+            Storage::ObjectStore(object_store) => Ok(object_store.get(key).await?),
+            Storage::S3(s3) => s3.get(key).await,
+            Storage::Local(local) => local.get(key).await,
             Storage::AdmissionControlledS3(admission_controlled_storage) => {
-                let res = admission_controlled_storage.get(key.to_string()).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        AdmissionControlledS3StorageError::S3GetError(e) => match e {
-                            S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                            _ => Err(GetError::S3Error(e)),
-                        },
-                    },
-                }
+                admission_controlled_storage.get(key).await
             }
         }
     }
@@ -178,85 +222,36 @@ impl Storage {
     pub async fn get_with_e_tag(
         &self,
         key: &str,
-    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), GetError> {
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
         match self {
-            Storage::ObjectStore(_) => Err(GetError::ConditionNotMet),
-            Storage::S3(s3) => {
-                let res = s3.get_with_e_tag(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                        _ => Err(GetError::S3Error(e)),
-                    },
-                }
-            }
-            Storage::Local(_) => Err(GetError::ConditionNotMet),
+            Storage::ObjectStore(object_store) => object_store.get_with_e_tag(key).await,
+            Storage::S3(s3) => s3.get_with_e_tag(key).await,
+            Storage::Local(local) => local.get_with_e_tag(key).await,
             Storage::AdmissionControlledS3(admission_controlled_storage) => {
-                let res = admission_controlled_storage
-                    .get_with_e_tag(key.to_string())
-                    .await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        AdmissionControlledS3StorageError::S3GetError(e) => match e {
-                            S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                            _ => Err(GetError::S3Error(e)),
-                        },
-                    },
-                }
+                admission_controlled_storage.get_with_e_tag(key).await
             }
         }
     }
 
-    pub async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, GetError> {
+    pub async fn get_parallel(&self, key: &str) -> Result<Arc<Vec<u8>>, StorageError> {
         match self {
             Storage::ObjectStore(object_store) => object_store.get_parallel(key).await,
-            Storage::S3(s3) => {
-                let res = s3.get_parallel(key).await;
-                match res {
-                    Ok(res) => Ok(res.0),
-                    Err(e) => match e {
-                        S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                        _ => Err(GetError::S3Error(e)),
-                    },
-                }
-            }
-            Storage::Local(local) => {
-                let res = local.get(key).await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => Err(GetError::LocalError(e)),
-                }
-            }
+            Storage::S3(s3) => s3.get_parallel(key).await.map(|res| res.0),
+            Storage::Local(local) => local.get(key).await,
             Storage::AdmissionControlledS3(admission_controlled_storage) => {
-                let res = admission_controlled_storage
+                admission_controlled_storage
                     .get_parallel(key.to_string())
-                    .await;
-                match res {
-                    Ok(res) => Ok(res),
-                    Err(e) => match e {
-                        AdmissionControlledS3StorageError::S3GetError(e) => match e {
-                            S3GetError::NoSuchKey(_) => Err(GetError::NoSuchKey(key.to_string())),
-                            _ => Err(GetError::S3Error(e)),
-                        },
-                    },
-                }
+                    .await
             }
         }
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), PutError> {
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), StorageError> {
         match self {
             Storage::ObjectStore(object_store) => object_store.put_file(key, path).await,
-            Storage::S3(s3) => s3.put_file(key, path).await.map_err(PutError::S3Error),
-            Storage::Local(local) => local
-                .put_file(key, path)
-                .await
-                .map_err(PutError::LocalError),
-            Storage::AdmissionControlledS3(as3) => {
-                as3.put_file(key, path).await.map_err(PutError::S3Error)
-            }
+            Storage::S3(s3) => s3.put_file(key, path).await,
+            Storage::Local(local) => local.put_file(key, path).await,
+            Storage::AdmissionControlledS3(as3) => as3.put_file(key, path).await,
         }
     }
 
@@ -265,65 +260,36 @@ impl Storage {
         key: &str,
         bytes: Vec<u8>,
         options: PutOptions,
-    ) -> Result<(), PutError> {
+    ) -> Result<(), StorageError> {
         match self {
             Storage::ObjectStore(object_store) => object_store.put_bytes(key, bytes, options).await,
-            Storage::S3(s3) => s3
-                .put_bytes(key, bytes, options)
-                .await
-                .map_err(PutError::S3Error),
-            Storage::Local(local) => local
-                .put_bytes(key, &bytes, options)
-                .await
-                .map_err(PutError::LocalError),
-            Storage::AdmissionControlledS3(as3) => as3
-                .put_bytes(key, bytes, options)
-                .await
-                .map_err(PutError::S3Error),
+            Storage::S3(s3) => s3.put_bytes(key, bytes, options).await,
+            Storage::Local(local) => local.put_bytes(key, &bytes, options).await,
+            Storage::AdmissionControlledS3(as3) => as3.put_bytes(key, bytes, options).await,
         }
     }
 
-    pub async fn delete(&self, key: &str) -> Result<(), PutError> {
+    pub async fn delete(&self, key: &str) -> Result<(), StorageError> {
         match self {
             Storage::ObjectStore(object_store) => object_store.delete(key).await,
-            Storage::S3(s3) => s3.delete(key).await.map_err(PutError::S3Error),
-            Storage::Local(local) => local.delete(key).await.map_err(PutError::LocalError),
-            Storage::AdmissionControlledS3(_) => {
-                unimplemented!("delete not implemented for AdmissionControlledS3")
-            }
+            Storage::S3(s3) => s3.delete(key).await,
+            Storage::Local(local) => local.delete(key).await,
+            Storage::AdmissionControlledS3(_) => Err(StorageError::NotImplemented),
         }
     }
 
-    pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), RenameError> {
+    pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
         match self {
-            Storage::ObjectStore(object_store) => object_store
-                .rename(src_key, dst_key)
-                .await
-                .map_err(|e| match e {
-                    PutError::ObjectStoreError(e) => RenameError::ObjectStoreError(e),
-                    PutError::S3Error(e) => RenameError::S3Error(e),
-                    PutError::LocalError(e) => RenameError::LocalError(e),
-                }),
-            Storage::S3(s3) => s3
-                .rename(src_key, dst_key)
-                .await
-                .map_err(RenameError::S3Error),
-            Storage::Local(local) => local
-                .rename(src_key, dst_key)
-                .await
-                .map_err(RenameError::LocalError),
-            Storage::AdmissionControlledS3(_) => {
-                unimplemented!("rename not implemented for AdmissionControlledS3")
-            }
+            Storage::ObjectStore(object_store) => object_store.rename(src_key, dst_key).await,
+            Storage::S3(s3) => s3.rename(src_key, dst_key).await,
+            Storage::Local(local) => local.rename(src_key, dst_key).await,
+            Storage::AdmissionControlledS3(_) => Err(StorageError::NotImplemented),
         }
     }
 
-    pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, GetError> {
+    pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
         match self {
-            Storage::Local(local) => local
-                .list_prefix(prefix)
-                .await
-                .map_err(GetError::LocalError),
+            Storage::Local(local) => local.list_prefix(prefix).await,
             Storage::S3(_) => {
                 unimplemented!("list_prefix not implemented for S3")
             }

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -7,7 +7,7 @@ use chroma_error::ChromaError;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::PutOptions;
+use crate::{ETag, PutOptions, StorageError};
 
 #[derive(Clone)]
 pub struct LocalStorage {
@@ -22,12 +22,21 @@ impl LocalStorage {
         }
     }
 
-    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, String> {
+    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, StorageError> {
         let file_path = format!("{}/{}", self.root, key);
         match std::fs::read(file_path) {
             Ok(bytes_u8) => Ok(Arc::new(bytes_u8)),
-            Err(e) => Err::<Arc<Vec<u8>>, String>(e.to_string()),
+            Err(e) => Err(StorageError::Generic {
+                source: Arc::new(e),
+            }),
         }
+    }
+
+    pub async fn get_with_e_tag(
+        &self,
+        _: &str,
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
+        Err(StorageError::NotImplemented)
     }
 
     pub async fn put_bytes(
@@ -35,7 +44,7 @@ impl LocalStorage {
         key: &str,
         bytes: &[u8],
         options: PutOptions,
-    ) -> Result<(), String> {
+    ) -> Result<(), StorageError> {
         assert_eq!(
             options,
             PutOptions::default(),
@@ -50,19 +59,23 @@ impl LocalStorage {
         let res = std::fs::write(&path, bytes);
         match res {
             Ok(_) => Ok(()),
-            Err(e) => Err::<(), String>(e.to_string()),
+            Err(e) => Err(StorageError::Generic {
+                source: Arc::new(e),
+            }),
         }
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), String> {
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), StorageError> {
         let file = std::fs::read(path);
         match file {
             Ok(bytes_u8) => self.put_bytes(key, &bytes_u8, PutOptions::default()).await,
-            Err(e) => Err::<(), String>(e.to_string()),
+            Err(e) => Err(StorageError::Generic {
+                source: Arc::new(e),
+            }),
         }
     }
 
-    pub async fn delete(&self, key: &str) -> Result<(), String> {
+    pub async fn delete(&self, key: &str) -> Result<(), StorageError> {
         let path = format!("{}/{}", self.root, key);
         tracing::info!(path = %path, "Deleting file");
 
@@ -73,12 +86,14 @@ impl LocalStorage {
             }
             Err(e) => {
                 tracing::error!(error = %e, path = %path, "Failed to delete file");
-                Err(e.to_string())
+                Err(StorageError::Generic {
+                    source: Arc::new(e),
+                })
             }
         }
     }
 
-    pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), String> {
+    pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
         let src_path = format!("{}/{}", self.root, src_key);
         let dst_path = format!("{}/{}", self.root, dst_key);
         tracing::info!(src = %src_path, dst = %dst_path, "Renaming file");
@@ -87,7 +102,9 @@ impl LocalStorage {
         if let Some(parent) = std::path::Path::new(&dst_path).parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 tracing::error!(error = %e, path = %parent.display(), "Failed to create parent directory");
-                return Err(e.to_string());
+                return Err(StorageError::Generic {
+                    source: Arc::new(e),
+                });
             }
         }
 
@@ -98,22 +115,31 @@ impl LocalStorage {
             }
             Err(e) => {
                 tracing::error!(error = %e, src = %src_path, dst = %dst_path, "Failed to rename file");
-                Err(e.to_string())
+                Err(StorageError::Generic {
+                    source: Arc::new(e),
+                })
             }
         }
     }
 
-    pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, String> {
+    pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
         let search_path = Path::new(&self.root).join(prefix);
-        let entries = std::fs::read_dir(search_path).map_err(|e| e.to_string())?;
+        let entries = std::fs::read_dir(search_path).map_err(|e| StorageError::Generic {
+            source: Arc::new(e),
+        })?;
         entries
             .into_iter()
             .map(|e| {
-                e.map_err(|e| e.to_string()).and_then(|e| {
+                e.map_err(|e| StorageError::Generic {
+                    source: Arc::new(e),
+                })
+                .and_then(|e| {
                     e.file_name()
                         .to_str()
                         .map(|s| s.to_string())
-                        .ok_or("Unable to convert path to string".to_string())
+                        .ok_or(StorageError::Message {
+                            message: "Unable to convert path to string".to_string(),
+                        })
                 })
             })
             .collect()

--- a/rust/storage/src/object_store.rs
+++ b/rust/storage/src/object_store.rs
@@ -38,12 +38,10 @@ impl From<object_store::Error> for StorageError {
                 path,
                 source: source.into(),
             },
-            object_store::Error::Precondition { path, source } => {
-                StorageError::Precondition {
-                    path,
-                    source: source.into(),
-                }
-            }
+            object_store::Error::Precondition { path, source } => StorageError::Precondition {
+                path,
+                source: source.into(),
+            },
             object_store::Error::NotModified { path, source } => StorageError::NotModified {
                 path,
                 source: source.into(),

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -13,7 +13,7 @@ use super::stream::ByteStreamItem;
 use super::stream::S3ByteStream;
 use super::PutOptions;
 use super::StorageConfigError;
-use crate::{ETag, GetError};
+use crate::{ETag, StorageError};
 use async_trait::async_trait;
 use aws_config::retry::RetryConfig;
 use aws_config::timeout::TimeoutConfigBuilder;
@@ -29,7 +29,6 @@ use bytes::Bytes;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
-use chroma_error::ErrorCodes;
 use futures::future::BoxFuture;
 use futures::stream;
 use futures::FutureExt;
@@ -40,7 +39,6 @@ use std::clone::Clone;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
-use thiserror::Error;
 use tokio::io::AsyncReadExt;
 use tracing::Instrument;
 use tracing::Span;
@@ -51,42 +49,6 @@ pub struct S3Storage {
     pub(super) client: aws_sdk_s3::Client,
     pub(super) upload_part_size_bytes: usize,
     pub(super) download_part_size_bytes: usize,
-}
-
-#[derive(Error, Debug)]
-pub enum S3PutError {
-    #[error("S3 PUT error: {0}")]
-    S3PutError(String),
-    #[error("S3 Dispatch failure error")]
-    S3DispatchFailure,
-    #[error("Condition did not match")]
-    ConditionNotMet,
-}
-
-impl ChromaError for S3PutError {
-    fn code(&self) -> ErrorCodes {
-        match self {
-            S3PutError::S3PutError(_) => ErrorCodes::Internal,
-            S3PutError::S3DispatchFailure => ErrorCodes::Internal,
-            S3PutError::ConditionNotMet => ErrorCodes::FailedPrecondition,
-        }
-    }
-}
-
-#[derive(Error, Debug, Clone)]
-pub enum S3GetError {
-    #[error("S3 GET error: {0}")]
-    S3GetError(String),
-    #[error("No such key: {0}")]
-    NoSuchKey(String),
-    #[error("ByteStream error: {0}")]
-    ByteStreamError(String),
-}
-
-impl ChromaError for S3GetError {
-    fn code(&self) -> ErrorCodes {
-        ErrorCodes::Internal
-    }
 }
 
 impl S3Storage {
@@ -150,7 +112,7 @@ impl S3Storage {
             Box<dyn Stream<Item = ByteStreamItem> + Unpin + Send>,
             Option<ETag>,
         ),
-        S3GetError,
+        StorageError,
     > {
         let res = self
             .client
@@ -172,22 +134,31 @@ impl S3Storage {
                 match e {
                     SdkError::ServiceError(err) => {
                         let inner = err.into_err();
-                        match inner {
+                        match &inner {
                             aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(msg) => {
                                  tracing::error!("no such key: {}", msg);
-                                Err(S3GetError::NoSuchKey(msg.to_string()))
+                                Err(StorageError::NotFound {
+                                    path: key.to_string(),
+                                    source: Arc::new(inner),
+                                })
                             }
                             aws_sdk_s3::operation::get_object::GetObjectError::InvalidObjectState(msg) => {
                                  tracing::error!("invalid object state: {}", msg);
-                                Err(S3GetError::S3GetError(msg.to_string()))
+                                Err(StorageError::Generic {
+                                    source: Arc::new(inner),
+                                })
                             }
                             _ => {
                                  tracing::error!("error: {}", inner.to_string());
-                                Err(S3GetError::S3GetError(inner.to_string()))
+                                Err(StorageError::Generic {
+                                    source: Arc::new(inner),
+                                })
                             }
                         }
                     }
-                    _ => Err(S3GetError::S3GetError(e.to_string())),
+                    _ => Err(StorageError::Generic {
+                        source: Arc::new(e),
+                    }),
                 }
             }
         }
@@ -196,7 +167,7 @@ impl S3Storage {
     pub(super) async fn get_key_ranges(
         &self,
         key: &str,
-    ) -> Result<(i64, Vec<(i64, i64)>, Option<ETag>), S3GetError> {
+    ) -> Result<(i64, Vec<(i64, i64)>, Option<ETag>), StorageError> {
         let part_size = self.download_part_size_bytes as i64;
         let head_res = self
             .client
@@ -209,11 +180,15 @@ impl S3Storage {
             Ok(res) => match res.content_length {
                 Some(len) => (len, res.e_tag),
                 None => {
-                    return Err(S3GetError::S3GetError("No content length".to_string()));
+                    return Err(StorageError::Message {
+                        message: "No content length".to_string(),
+                    })
                 }
             },
             Err(e) => {
-                return Err(S3GetError::S3GetError(e.to_string()));
+                return Err(StorageError::Generic {
+                    source: Arc::new(e),
+                })
             }
         };
         // Round up.
@@ -235,12 +210,12 @@ impl S3Storage {
         &self,
         key: String,
         range_str: String,
-    ) -> Result<GetObjectOutput, S3GetError> {
+    ) -> Result<GetObjectOutput, StorageError> {
         let res = self
             .client
             .get_object()
             .bucket(self.bucket.clone())
-            .key(key)
+            .key(&key)
             .range(range_str)
             .send()
             .await;
@@ -251,19 +226,28 @@ impl S3Storage {
                 match e {
                     SdkError::ServiceError(err) => {
                         let inner = err.into_err();
-                        match inner {
-                            aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(msg) => {
-                                Err(S3GetError::NoSuchKey(msg.to_string()))
+                        match &inner {
+                            aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_) => {
+                                Err(StorageError::NotFound {
+                                    path: key.to_string(),
+                                    source: Arc::new(inner),
+                                })
                             }
-                            aws_sdk_s3::operation::get_object::GetObjectError::InvalidObjectState(msg) => {
-                                Err(S3GetError::S3GetError(msg.to_string()))
+                            aws_sdk_s3::operation::get_object::GetObjectError::InvalidObjectState(_) => {
+                                Err(StorageError::Generic {
+                                    source: Arc::new(inner),
+                                })
                             }
                             _ => {
-                                Err(S3GetError::S3GetError(inner.to_string()))
+                                Err(StorageError::Generic {
+                                    source: Arc::new(inner),
+                                })
                             }
                         }
                     }
-                    _ => Err(S3GetError::S3GetError(e.to_string())),
+                    _ => Err(StorageError::Generic {
+                        source: Arc::new(e),
+                    }),
                 }
             }
         }
@@ -272,7 +256,7 @@ impl S3Storage {
     pub(super) async fn get_parallel(
         &self,
         key: &str,
-    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), S3GetError> {
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
         let (content_length, ranges, e_tag) = self.get_key_ranges(key).await?;
 
         // .buffer_unordered() below will hang if the range is empty (https://github.com/rust-lang/futures-rs/issues/2740), so we short-circuit here
@@ -299,7 +283,9 @@ impl S3Storage {
                                 Ok(_) => Ok(()),
                                 Err(e) => {
                                     tracing::error!("Error reading range: {:?}", e);
-                                    Err(S3GetError::ByteStreamError(e.to_string()))
+                                    Err(StorageError::Generic {
+                                        source: Arc::new(e),
+                                    })
                                 }
                             }
                         }
@@ -316,14 +302,14 @@ impl S3Storage {
         Ok((Arc::new(output_buffer), e_tag))
     }
 
-    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, S3GetError> {
+    pub async fn get(&self, key: &str) -> Result<Arc<Vec<u8>>, StorageError> {
         self.get_with_e_tag(key).await.map(|(buf, _)| buf)
     }
 
     pub async fn get_with_e_tag(
         &self,
         key: &str,
-    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), S3GetError> {
+    ) -> Result<(Arc<Vec<u8>>, Option<ETag>), StorageError> {
         let (mut stream, e_tag) = self
             .get_stream_and_e_tag(key)
             .instrument(tracing::trace_span!(parent: Span::current(), "S3 get stream"))
@@ -337,25 +323,9 @@ impl S3Storage {
                         Ok(chunk) => {
                             buf.extend(chunk);
                         }
-                        Err(err) => {
-                            tracing::error!("Error reading from S3: {}", err);
-                            match err {
-                                GetError::ObjectStoreError(e) => {
-                                    return Err(S3GetError::S3GetError(e.to_string()));
-                                }
-                                GetError::S3Error(e) => {
-                                    return Err(e);
-                                }
-                                GetError::NoSuchKey(e) => {
-                                    return Err(S3GetError::NoSuchKey(e));
-                                }
-                                GetError::LocalError(_) => unreachable!(),
-                                GetError::ConditionNotMet => {
-                                    return Err(S3GetError::S3GetError(
-                                        "Condition not met".to_string(),
-                                    ));
-                                }
-                            }
+                        Err(e) => {
+                            tracing::error!("Error reading from S3: {}", e);
+                            return Err(e);
                         }
                     }
                 }
@@ -381,7 +351,7 @@ impl S3Storage {
         key: &str,
         bytes: Vec<u8>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         let bytes = Arc::new(Bytes::from(bytes));
 
         self.put_object(
@@ -396,10 +366,12 @@ impl S3Storage {
         .await
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), S3PutError> {
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), StorageError> {
         let file_size = tokio::fs::metadata(path)
             .await
-            .map_err(|err| S3PutError::S3PutError(err.to_string()))?
+            .map_err(|err| StorageError::Generic {
+                source: Arc::new(err),
+            })?
             .len();
 
         let path = path.to_string();
@@ -417,7 +389,9 @@ impl S3Storage {
                         .length(Length::Exact(range.len() as u64))
                         .build()
                         .await
-                        .map_err(|err| S3PutError::S3PutError(err.to_string()))
+                        .map_err(|err| StorageError::Generic {
+                            source: Arc::new(err),
+                        })
                 }
                 .boxed()
             },
@@ -432,9 +406,9 @@ impl S3Storage {
         total_size_bytes: usize,
         create_bytestream_fn: impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         if self.is_oneshot_upload(total_size_bytes) {
             return self
                 .oneshot_upload(key, total_size_bytes, create_bytestream_fn, options)
@@ -451,9 +425,9 @@ impl S3Storage {
         total_size_bytes: usize,
         create_bytestream_fn: impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         let req = self
             .client
             .put_object()
@@ -473,9 +447,14 @@ impl S3Storage {
         req.send().await.map_err(|err| {
             let err = err.into_service_error();
             if err.meta().code() == Some("PreconditionFailed") {
-                S3PutError::ConditionNotMet
+                StorageError::Precondition {
+                    path: key.to_string(),
+                    source: Arc::new(err),
+                }
             } else {
-                S3PutError::S3PutError(format!("{:?}", err))
+                StorageError::Generic {
+                    source: Arc::new(err),
+                }
             }
         })?;
 
@@ -486,7 +465,7 @@ impl S3Storage {
         &self,
         key: &str,
         total_size_bytes: usize,
-    ) -> Result<(usize, usize, String), S3PutError> {
+    ) -> Result<(usize, usize, String), StorageError> {
         let mut part_count = (total_size_bytes / self.upload_part_size_bytes) + 1;
         let mut size_of_last_part = total_size_bytes % self.upload_part_size_bytes;
         if size_of_last_part == 0 {
@@ -501,14 +480,16 @@ impl S3Storage {
             .key(key)
             .send()
             .await
-            .map_err(|err| S3PutError::S3PutError(err.to_string()))?
+            .map_err(|err| StorageError::Generic {
+                source: Arc::new(err.into_service_error()),
+            })?
             .upload_id
         {
             Some(upload_id) => upload_id,
             None => {
-                return Err(S3PutError::S3PutError(
-                    "Multipart upload creation response missing upload ID".to_string(),
-                ));
+                return Err(StorageError::Message {
+                    message: "Multipart upload creation response missing upload ID".to_string(),
+                });
             }
         };
 
@@ -524,8 +505,8 @@ impl S3Storage {
         size_of_last_part: usize,
         create_bytestream_fn: &impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
-    ) -> Result<CompletedPart, S3PutError> {
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
+    ) -> Result<CompletedPart, StorageError> {
         let this_part = if part_count - 1 == part_index {
             size_of_last_part
         } else {
@@ -547,7 +528,9 @@ impl S3Storage {
             .part_number(part_number)
             .send()
             .await
-            .map_err(|err| S3PutError::S3PutError(err.to_string()))?;
+            .map_err(|err| StorageError::Generic {
+                source: Arc::new(err.into_service_error()),
+            })?;
 
         Ok(CompletedPart::builder()
             .e_tag(upload_part_res.e_tag.unwrap_or_default())
@@ -561,7 +544,7 @@ impl S3Storage {
         upload_id: &str,
         upload_parts: Vec<CompletedPart>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         let complete_req = self
             .client
             .complete_multipart_upload()
@@ -587,7 +570,9 @@ impl S3Storage {
         complete_req
             .send()
             .await
-            .map_err(|err| S3PutError::S3PutError(err.to_string()))?;
+            .map_err(|err| StorageError::Generic {
+                source: Arc::new(err.into_service_error()),
+            })?;
 
         Ok(())
     }
@@ -598,9 +583,9 @@ impl S3Storage {
         total_size_bytes: usize,
         create_bytestream_fn: impl Fn(
             Range<usize>,
-        ) -> BoxFuture<'static, Result<ByteStream, S3PutError>>,
+        ) -> BoxFuture<'static, Result<ByteStream, StorageError>>,
         options: PutOptions,
-    ) -> Result<(), S3PutError> {
+    ) -> Result<(), StorageError> {
         let (part_count, size_of_last_part, upload_id) =
             self.prepare_multipart_upload(key, total_size_bytes).await?;
 
@@ -624,7 +609,7 @@ impl S3Storage {
             .await
     }
 
-    pub async fn delete(&self, key: &str) -> Result<(), S3PutError> {
+    pub async fn delete(&self, key: &str) -> Result<(), StorageError> {
         tracing::info!(key = %key, "Deleting object from S3");
 
         match self
@@ -641,12 +626,14 @@ impl S3Storage {
             }
             Err(e) => {
                 tracing::error!(error = %e, key = %key, "Failed to delete object from S3");
-                Err(S3PutError::S3PutError(e.to_string()))
+                Err(StorageError::Generic {
+                    source: Arc::new(e.into_service_error()),
+                })
             }
         }
     }
 
-    pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), S3PutError> {
+    pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
         tracing::info!(src = %src_key, dst = %dst_key, "Renaming object in S3");
 
         // S3 doesn't have a native rename operation, so we need to copy and delete
@@ -675,7 +662,9 @@ impl S3Storage {
             }
             Err(e) => {
                 tracing::error!(error = %e, src = %src_key, dst = %dst_key, "Failed to copy object");
-                Err(S3PutError::S3PutError(e.to_string()))
+                Err(StorageError::Generic {
+                    source: Arc::new(e.into_service_error()),
+                })
             }
         }
     }
@@ -995,7 +984,13 @@ mod tests {
             .await
             .unwrap_err();
         eprintln!("{:?}", err);
-        assert!(matches!(err, S3PutError::ConditionNotMet));
+        assert!(matches!(
+            &err,
+            StorageError::Precondition { path: _, source: _ }
+        ));
+        if let StorageError::Precondition { path, source: _ } = err {
+            assert_eq!("test", path)
+        }
     }
 
     #[tokio::test]
@@ -1058,7 +1053,14 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(matches!(err, S3PutError::ConditionNotMet));
+        eprintln!("{:?}", err);
+        assert!(matches!(
+            &err,
+            StorageError::Precondition { path: _, source: _ }
+        ));
+        if let StorageError::Precondition { path, source: _ } = err {
+            assert_eq!("test", path)
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR shreds the Storage crate's error handling to mimick
object_store.  The motivation for doing this was very specific:
Multiple levels of error enums (that change based upon the backend) made
robustly handling if-match conflicts tedious and error-prone.
