### PR TITLE
[ENH] Return the ETag for a successful PUT.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chroma-cli"
+version = "0.1.0"
+dependencies = [
+ "chroma-frontend",
+ "clap",
+ "tokio",
+ "webbrowser",
+]
+
+[[package]]
 name = "chroma-config"
 version = "0.1.0"
 dependencies = [
@@ -1839,16 +1849,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cli"
-version = "0.1.0"
-dependencies = [
- "chroma-frontend",
- "clap",
- "tokio",
- "webbrowser",
-]
 
 [[package]]
 name = "cmsketch"

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -246,7 +246,7 @@ impl Storage {
         }
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), StorageError> {
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<Option<ETag>, StorageError> {
         match self {
             Storage::ObjectStore(object_store) => object_store.put_file(key, path).await,
             Storage::S3(s3) => s3.put_file(key, path).await,
@@ -260,7 +260,7 @@ impl Storage {
         key: &str,
         bytes: Vec<u8>,
         options: PutOptions,
-    ) -> Result<(), StorageError> {
+    ) -> Result<Option<ETag>, StorageError> {
         match self {
             Storage::ObjectStore(object_store) => object_store.put_bytes(key, bytes, options).await,
             Storage::S3(s3) => s3.put_bytes(key, bytes, options).await,

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -44,7 +44,7 @@ impl LocalStorage {
         key: &str,
         bytes: &[u8],
         options: PutOptions,
-    ) -> Result<(), StorageError> {
+    ) -> Result<Option<ETag>, StorageError> {
         assert_eq!(
             options,
             PutOptions::default(),
@@ -58,14 +58,14 @@ impl LocalStorage {
         std::fs::create_dir_all(parent).unwrap();
         let res = std::fs::write(&path, bytes);
         match res {
-            Ok(_) => Ok(()),
+            Ok(_) => Ok(None),
             Err(e) => Err(StorageError::Generic {
                 source: Arc::new(e),
             }),
         }
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<(), StorageError> {
+    pub async fn put_file(&self, key: &str, path: &str) -> Result<Option<ETag>, StorageError> {
         let file = std::fs::read(path);
         match file {
             Ok(bytes_u8) => self.put_bytes(key, &bytes_u8, PutOptions::default()).await,


### PR DESCRIPTION
This enables a storage pattern wherein a file upload returns exactly the
e_tag of the file as calculated by AWS.
