### PR TITLE
[BUG] Fixes for dockerfile, tilt, config management

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -135,6 +135,7 @@ k8s_resource(
     'test-memberlist-reader-binding:ClusterRoleBinding',
     'lease-watcher:role',
     'logservice-serviceaccount-rolebinding:rolebinding',
+    'rust-frontend-service-config:ConfigMap',
   ],
   new_name='k8s_setup',
   labels=["infrastructure"],

--- a/Tiltfile
+++ b/Tiltfile
@@ -70,43 +70,37 @@ docker_build(
   target='compaction_service'
 )
 
-# k8s_yaml(
-#   helm(
-#     'k8s/distributed-chroma',
-#     namespace='chroma',
-#     values=[
-#       'k8s/distributed-chroma/values.yaml',
-#       # Values for local development, and for CI/CD testing.
-#       'k8s/distributed-chroma/values.dev.yaml'
-#     ]
-#     set
-#   )
-# )
 
-# We manually call helm template
+# First install the CRD
+k8s_yaml(
+  ['k8s/distributed-chroma/crds/memberlist_crd.yaml'],
+)
+
+
+# We manually call helm template so we can call set-file
 k8s_yaml(
   local(
     'helm template --set-file rustFrontendService.configuration=rust/frontend/sample_configs/distributed.yaml --values k8s/distributed-chroma/values.yaml,k8s/distributed-chroma/values.dev.yaml k8s/distributed-chroma'
-  )
+  ),
 )
-# TODO: add watch_file() for all files above
+watch_file('rust/frontend/sample_configs/distributed.yaml')
+watch_file('k8s/distributed-chroma/values.yaml')
+watch_file('k8s/distributed-chroma/values.dev.yaml')
+watch_file('k8s/distributed-chroma/*.yaml')
 
 
+# Extra stuff to make debugging and testing easier
 k8s_yaml([
+  'k8s/test/otel-collector.yaml',
+  'k8s/test/grafana-service.yaml',
+  'k8s/test/grafana.yaml',
+  'k8s/test/jaeger-service.yaml',
+  'k8s/test/jaeger.yaml',
+  'k8s/test/minio.yaml',
+  'k8s/test/prometheus.yaml',
+  'k8s/test/test-memberlist-cr.yaml',
   'k8s/test/postgres.yaml',
 ])
-
-# # Extra stuff to make debugging and testing easier
-# k8s_yaml([
-#   'k8s/test/otel-collector.yaml',
-#   'k8s/test/grafana-service.yaml',
-#   'k8s/test/grafana.yaml',
-#   'k8s/test/jaeger-service.yaml',
-#   'k8s/test/jaeger.yaml',
-#   'k8s/test/minio.yaml',
-#   'k8s/test/prometheus.yaml',
-#   'k8s/test/test-memberlist-cr.yaml',
-# ])
 
 # Lots of things assume the cluster is in a basic state. Get it into a basic
 # state before deploying anything else.
@@ -157,12 +151,10 @@ k8s_resource('frontend-service', resource_deps=['sysdb', 'logservice'],labels=["
 k8s_resource('rust-frontend-service', resource_deps=['sysdb', 'logservice'], labels=["chroma"], port_forwards='3000:8000')
 k8s_resource('query-service', resource_deps=['sysdb'], labels=["chroma"], port_forwards='50053:50051')
 k8s_resource('compaction-service', resource_deps=['sysdb'], labels=["chroma"])
-
-# I have no idea why these need their own lines but the others don't.
-# k8s_resource('jaeger', resource_deps=['k8s_setup'], labels=["observability"])
-# k8s_resource('grafana', resource_deps=['k8s_setup'], labels=["observability"])
-# k8s_resource('prometheus', resource_deps=['k8s_setup'], labels=["observability"])
-# k8s_resource('otel-collector', resource_deps=['k8s_setup'], labels=["observability"])
+k8s_resource('jaeger', resource_deps=['k8s_setup'], labels=["observability"])
+k8s_resource('grafana', resource_deps=['k8s_setup'], labels=["observability"])
+k8s_resource('prometheus', resource_deps=['k8s_setup'], labels=["observability"])
+k8s_resource('otel-collector', resource_deps=['k8s_setup'], labels=["observability"])
 
 # Local S3
-# k8s_resource('minio-deployment', resource_deps=['k8s_setup'], labels=["debug"], port_forwards=['9000:9000', '9005:9005'])
+k8s_resource('minio-deployment', resource_deps=['k8s_setup'], labels=["debug"], port_forwards=['9000:9000', '9005:9005'])

--- a/Tiltfile
+++ b/Tiltfile
@@ -70,34 +70,43 @@ docker_build(
   target='compaction_service'
 )
 
+# k8s_yaml(
+#   helm(
+#     'k8s/distributed-chroma',
+#     namespace='chroma',
+#     values=[
+#       'k8s/distributed-chroma/values.yaml',
+#       # Values for local development, and for CI/CD testing.
+#       'k8s/distributed-chroma/values.dev.yaml'
+#     ]
+#     set
+#   )
+# )
+
+# We manually call helm template
 k8s_yaml(
-  helm(
-    'k8s/distributed-chroma',
-    namespace='chroma',
-    values=[
-      'k8s/distributed-chroma/values.yaml',
-      # Values for local development, and for CI/CD testing.
-      'k8s/distributed-chroma/values.dev.yaml'
-    ]
+  local(
+    'helm template --set-file rustFrontendService.configuration=rust/frontend/sample_configs/distributed.yaml --values k8s/distributed-chroma/values.yaml,k8s/distributed-chroma/values.dev.yaml k8s/distributed-chroma'
   )
 )
+# TODO: add watch_file() for all files above
+
 
 k8s_yaml([
   'k8s/test/postgres.yaml',
 ])
 
-# Extra stuff to make debugging and testing easier
-k8s_yaml([
-  'k8s/test/namespace.yaml',
-  'k8s/test/otel-collector.yaml',
-  'k8s/test/grafana-service.yaml',
-  'k8s/test/grafana.yaml',
-  'k8s/test/jaeger-service.yaml',
-  'k8s/test/jaeger.yaml',
-  'k8s/test/minio.yaml',
-  'k8s/test/prometheus.yaml',
-  'k8s/test/test-memberlist-cr.yaml',
-])
+# # Extra stuff to make debugging and testing easier
+# k8s_yaml([
+#   'k8s/test/otel-collector.yaml',
+#   'k8s/test/grafana-service.yaml',
+#   'k8s/test/grafana.yaml',
+#   'k8s/test/jaeger-service.yaml',
+#   'k8s/test/jaeger.yaml',
+#   'k8s/test/minio.yaml',
+#   'k8s/test/prometheus.yaml',
+#   'k8s/test/test-memberlist-cr.yaml',
+# ])
 
 # Lots of things assume the cluster is in a basic state. Get it into a basic
 # state before deploying anything else.
@@ -150,10 +159,10 @@ k8s_resource('query-service', resource_deps=['sysdb'], labels=["chroma"], port_f
 k8s_resource('compaction-service', resource_deps=['sysdb'], labels=["chroma"])
 
 # I have no idea why these need their own lines but the others don't.
-k8s_resource('jaeger', resource_deps=['k8s_setup'], labels=["observability"])
-k8s_resource('grafana', resource_deps=['k8s_setup'], labels=["observability"])
-k8s_resource('prometheus', resource_deps=['k8s_setup'], labels=["observability"])
-k8s_resource('otel-collector', resource_deps=['k8s_setup'], labels=["observability"])
+# k8s_resource('jaeger', resource_deps=['k8s_setup'], labels=["observability"])
+# k8s_resource('grafana', resource_deps=['k8s_setup'], labels=["observability"])
+# k8s_resource('prometheus', resource_deps=['k8s_setup'], labels=["observability"])
+# k8s_resource('otel-collector', resource_deps=['k8s_setup'], labels=["observability"])
 
 # Local S3
-k8s_resource('minio-deployment', resource_deps=['k8s_setup'], labels=["debug"], port_forwards=['9000:9000', '9005:9005'])
+# k8s_resource('minio-deployment', resource_deps=['k8s_setup'], labels=["debug"], port_forwards=['9000:9000', '9005:9005'])

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.22
+version: 0.1.23
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/namespace.yaml
+++ b/k8s/distributed-chroma/templates/namespace.yaml
@@ -4,5 +4,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+  labels:
+    name: {{ .Values.namespace }}
 
 ---

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -28,7 +28,6 @@ spec:
     spec:
       containers:
         - name: rust-frontend-service
-          command: ["chroma", "run", "$(CONFIG_PATH)"]
           image: "{{ .Values.rustFrontendService.image.repository }}:{{ .Values.rustFrontendService.image.tag }}"
           imagePullPolicy: IfNotPresent
           readinessProbe:

--- a/k8s/distributed-chroma/templates/rust-frontend-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-frontend-service.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       containers:
         - name: rust-frontend-service
+          {{ if .Values.rustFrontendService.command }}
+          command: {{ .Values.rustFrontendService.command }}
+          {{ end }}
           image: "{{ .Values.rustFrontendService.image.repository }}:{{ .Values.rustFrontendService.image.tag }}"
           imagePullPolicy: IfNotPresent
           readinessProbe:

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -9,3 +9,11 @@ rustFrontendService:
 # We have to specify the command, because the Dockerfile uses the CLI since its shared with
 # single node, so in values.dev we pass the CONFIG_PATH into the chroma run command
   command: ["chroma", "run", "$CONFIG_PATH"]
+  otherEnvConfig: |
+    - name: CHROMA_ALLOW_RESET
+      value: "true"
+
+frontendService:
+  otherEnvConfig: |
+    - name: CHROMA_ALLOW_RESET
+      value: "true"

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -3,4 +3,3 @@ sysdb:
     version-file-enabled: true
     soft-delete-max-age: 1s
     soft-delete-cleanup-interval: 2s
-

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -3,3 +3,9 @@ sysdb:
     version-file-enabled: true
     soft-delete-max-age: 1s
     soft-delete-cleanup-interval: 2s
+
+
+rustFrontendService:
+# We have to specify the command, because the Dockerfile uses the CLI since its shared with
+# single node, so in values.dev we pass the CONFIG_PATH into the chroma run command
+  command: ["chroma", "run", "$CONFIG_PATH"]

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -8,7 +8,7 @@ sysdb:
 rustFrontendService:
 # We have to specify the command, because the Dockerfile uses the CLI since its shared with
 # single node, so in values.dev we pass the CONFIG_PATH into the chroma run command
-  command: ["chroma", "run", "$CONFIG_PATH"]
+  command: '["chroma", "run", "$(CONFIG_PATH)"]'
   otherEnvConfig: |
     - name: CHROMA_ALLOW_RESET
       value: "true"

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -29,8 +29,6 @@ frontendService:
   logServiceHost: 'value: "logservice.chroma"'
   logServicePort: 'value: "50051"'
   otherEnvConfig: |
-    - name: CHROMA_ALLOW_RESET
-      value: "true"
     - name: CHROMA_OTEL_COLLECTION_ENDPOINT
       value: "http://jaeger:4317"
     - name: CHROMA_OTEL_GRANULARITY

--- a/k8s/test/namespace.yaml
+++ b/k8s/test/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: chroma
-  labels:
-    name: chroma

--- a/rust/cli/Dockerfile
+++ b/rust/cli/Dockerfile
@@ -28,11 +28,10 @@ FROM debian:stable-slim AS runner
 
 RUN apt-get update && apt-get install -y dumb-init && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /chroma/rust/frontend/sample_configs/distributed.yaml /config/config.yaml
 COPY --from=builder /chroma/rust/frontend/sample_configs/docker_single_node.yaml /config.yaml
 COPY --from=builder /chroma/chroma /usr/local/bin/chroma
 
 EXPOSE 8000
 
 ENTRYPOINT [ "dumb-init", "--", "chroma" ]
-CMD [ "run", "/config/config.yaml" ]
+CMD [ "run", "/config.yaml" ]

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -1,3 +1,5 @@
+# This file is an example of configuring the frontend for
+# distributed chroma. It is used in our Tiltfile as well.
 open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - The Dockerfile in rust/cli was incorrectly overwritten to use distributed config. This dockerfile should be for single node config only
   - I moved our helm to a local command so that we can call `set-file` this also mirrors what we do in hosted chroma
   - Removed the test namespace, as its duplicated with the one in the main chart
   - Turned off reset by default, and used values.dev to override it
   - Consolidate postgres into the same section of other test components in tiltfile for cleanliness
   - Use configmap for rust-frontend-service config, mirror'ing what we do in other envs
 - New functionality
   - None

## Test plan
*How are these changes tested?*
Manually tested tilt
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
