### PR TITLE
[ENH] Add quota overrage details in the error string

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -278,7 +278,7 @@ pub struct QuotaExceededError {
 
 #[derive(Error, Debug)]
 pub enum QuotaEnforcerError {
-    #[error("Quota exceeded")]
+    #[error("Quota exceeded {0:?}")]
     QuotaExceeded(QuotaExceededError),
     #[error("Missing API key in the request header")]
     ApiKeyMissing,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Appends the quota overrage error struct in the error string
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
