### PR TITLE
[ENH] SPANN: Add rust integrity tests

### DIFF
--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -3122,11 +3122,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_data_integrity_multiple_parallel_runs_with_updates_deletes() {
-        // Inserts 10k randomly generated embeddings each of 1000 dimensions in batches of 1k.
+        // Inserts 5k randomly generated embeddings each of 1000 dimensions in batches of 1k.
         // Each batch of 1k records is inserted in parallel using 10 tokio tasks.
         // After each batch of 1k, it commits and flushes to disk.
+        // Inserts another 1k adds/updates/deletes randomly chosen, commits and flushes.
         // Then reads the data back using scan api
         // and verifies that all the data is present and correct.
+        // Additionally runs GC after and verifies that the data is still correct.
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2998,6 +2998,10 @@ mod tests {
         }
     }
 
+    // NOTE(Sanket): It is non-trivial to use shuttle for this test since it requires
+    // a tokio runtime for creating the hnsw provider - the cache requires a mpsc channel,
+    // the construction of hnsw provider calls async tokio filesystem apis that also need
+    // a runtime which is not supported by shuttle.
     #[tokio::test]
     async fn test_data_integrity_multiple_parallel_runs() {
         // Inserts 10k randomly generated embeddings each of 1000 dimensions in batches of 1k.
@@ -3120,6 +3124,10 @@ mod tests {
         }
     }
 
+    // NOTE(Sanket): It is non-trivial to use shuttle for this test since it requires
+    // a tokio runtime for creating the hnsw provider - the cache requires a mpsc channel,
+    // the construction of hnsw provider calls async tokio filesystem apis that also need
+    // a runtime which is not supported by shuttle.
     #[tokio::test]
     async fn test_data_integrity_multiple_parallel_runs_with_updates_deletes() {
         // Inserts 5k randomly generated embeddings each of 1000 dimensions in batches of 1k.


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds tests that writes and then scans to verify that all the data is present
   - Different flavors of tests like inserting concurrently, writing->persisting->loading->writing_again and so on
   - Fixes code issues surfaced by them
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
