### PR TITLE
[ENH]  Add the number of bytes written to the log to the manifest.

### DIFF
--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -345,6 +345,7 @@ pub struct Fragment {
     pub seq_no: FragmentSeqNo,
     pub start: LogPosition,
     pub limit: LogPosition,
+    pub num_bytes: u64,
     #[serde(
         deserialize_with = "deserialize_setsum",
         serialize_with = "serialize_setsum"


### PR DESCRIPTION
This gives us a count of total number of bytes ingested through the log.
