### PR TITLE
[ENH] Rust Log Service Stub

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -23,6 +23,13 @@ docker_build(
 )
 
 docker_build(
+  'local:rust-log-service',
+  '.',
+  only=["rust/", "idl/", "Cargo.toml", "Cargo.lock"],
+  dockerfile='./rust/log/Dockerfile',
+)
+
+docker_build(
   'local:sysdb',
   '.',
   only=['go/', 'idl/'],
@@ -147,9 +154,10 @@ k8s_resource('postgres', resource_deps=['k8s_setup'], labels=["infrastructure"],
 k8s_resource('sysdb-migration-sysdb-migration', resource_deps=['postgres'], labels=["infrastructure"])
 k8s_resource('logservice-migration-logservice-migration', resource_deps=['postgres'], labels=["infrastructure"])
 k8s_resource('logservice', resource_deps=['sysdb-migration-sysdb-migration'], labels=["chroma"], port_forwards='50052:50051')
+k8s_resource('rust-log-service', labels=["chroma"], port_forwards='50054:50051')
 k8s_resource('sysdb', resource_deps=['sysdb-migration-sysdb-migration'], labels=["chroma"], port_forwards='50051:50051')
 k8s_resource('frontend-service', resource_deps=['sysdb', 'logservice'],labels=["chroma"], port_forwards='8000:8000')
-k8s_resource('rust-frontend-service', resource_deps=['sysdb', 'logservice'], labels=["chroma"], port_forwards='3000:8000')
+k8s_resource('rust-frontend-service', resource_deps=['sysdb', 'logservice', 'rust-log-service'], labels=["chroma"], port_forwards='3000:8000')
 k8s_resource('query-service', resource_deps=['sysdb'], labels=["chroma"], port_forwards='50053:50051')
 k8s_resource('compaction-service', resource_deps=['sysdb'], labels=["chroma"])
 k8s_resource('jaeger', resource_deps=['k8s_setup'], labels=["observability"])

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.26
+version: 0.1.27
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -1,0 +1,91 @@
+{{if .Values.rustLogService.configuration}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rust-log-service-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+{{  .Values.rustLogService.configuration | indent 4 }}
+{{ end }}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rust-log-service
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.rustLogService.replicaCount }}
+  selector:
+    matchLabels:
+      app: rust-log-service
+  template:
+    metadata:
+      labels:
+        app: rust-log-service
+    spec:
+      containers:
+        - name: rust-log-service
+          {{ if .Values.rustLogService.command }}
+          command: {{ .Values.rustLogService.command }}
+          {{ end }}
+          image: "{{ .Values.rustLogService.image.repository }}:{{ .Values.rustLogService.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 50051
+          {{ if .Values.rustLogService.resources }}
+          resources:
+            limits:
+              cpu: {{ .Values.rustLogService.resources.limits.cpu }}
+              memory: {{ .Values.rustLogService.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.rustLogService.resources.requests.cpu }}
+              memory: {{ .Values.rustLogService.resources.requests.memory }}
+          {{ end }}
+          env:
+            - name: CONFIG_PATH
+              value: "/config/config.yaml"
+            {{ if .Values.rustLogService.otherEnvConfig }}
+              {{ .Values.rustLogService.otherEnvConfig | nindent 12 }}
+            {{ end }}
+          {{if .Values.rustLogService.configuration}}
+          volumeMounts:
+            - name: rust-log-service-config
+              mountPath: /config/
+          {{ end }}
+
+      {{if .Values.rustLogService.tolerations}}
+      tolerations:
+        {{ toYaml .Values.rustLogService.tolerations | nindent 8 }}
+      {{ end }}
+      {{if .Values.rustLogService.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.rustLogService.nodeSelector | nindent 8 }}
+      {{ end }}
+      {{if .Values.rustLogService.configuration}}
+      volumes:
+        - name: rust-frontend-service-config
+          configMap:
+            name: rust-frontend-service-config
+      {{ end }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: rust-log-service
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - name: server-port
+      port: 50051
+      targetPort: 50051
+  selector:
+    app: rust-frontend-service
+  type: ClusterIP
+
+
+---

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -79,6 +79,12 @@ logService:
   flags:
   replicaCount: 1
 
+
+rustLogService:
+  image:
+    repository: 'local'
+    tag: 'rust-log-service'
+
 queryService:
   image:
     repository: 'local'

--- a/rust/log/Cargo.toml
+++ b/rust/log/Cargo.toml
@@ -3,6 +3,10 @@ name = "chroma-log"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "log_service"
+path = "src/bin/log.rs"
+
 [dependencies]
 async-trait = { workspace = true }
 # Used by tracing

--- a/rust/log/Cargo.toml
+++ b/rust/log/Cargo.toml
@@ -36,6 +36,9 @@ chroma-sysdb = { workspace = true }
 chroma-types = { workspace = true }
 chroma-sqlite = { workspace = true }
 
+[features]
+server = []
+
 [dev-dependencies]
 tempfile = { workspace = true }
 proptest = { workspace = true }

--- a/rust/log/Dockerfile
+++ b/rust/log/Dockerfile
@@ -1,0 +1,35 @@
+FROM rust:1.81.0 AS builder
+
+ARG RELEASE_MODE=
+
+WORKDIR /chroma/
+
+ENV PROTOC_ZIP=protoc-25.1-linux-x86_64.zip
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/$PROTOC_ZIP \
+    && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
+    && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
+    && rm -f $PROTOC_ZIP
+
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY idl/ idl/
+COPY rust/ rust/
+
+FROM builder AS log_service_builder
+# sharing=locked is necessary to prevent cargo build from running concurrently on the same mounted directory
+RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
+    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+    cd rust/log && \
+    if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin log_service --release; else cargo build --bin log_service; fi && \
+    cd ../.. && \
+    if [ "$RELEASE_MODE" = "1" ]; then mv target/release/log_service ./log_service; else mv target/debug/log_service ./log_service; fi
+
+
+FROM debian:bookworm-slim AS runner
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+# TODO: config
+# COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
+
+FROM runner AS log_service
+COPY --from=log_service_builder /chroma/log_service .
+ENTRYPOINT [ "./log_service" ]

--- a/rust/log/Dockerfile
+++ b/rust/log/Dockerfile
@@ -20,7 +20,7 @@ FROM builder AS log_service_builder
 RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
     --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
     cd rust/log && \
-    if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin log_service --release; else cargo build --bin log_service; fi && \
+    if [ "$RELEASE_MODE" = "1" ]; then cargo build --features server --bin log_service --release; else cargo build --features server --bin log_service; fi && \
     cd ../.. && \
     if [ "$RELEASE_MODE" = "1" ]; then mv target/release/log_service ./log_service; else mv target/debug/log_service ./log_service; fi
 

--- a/rust/log/src/bin/log.rs
+++ b/rust/log/src/bin/log.rs
@@ -1,4 +1,5 @@
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "server")]
     chroma_log::log_entrypoint().await;
 }

--- a/rust/log/src/bin/log.rs
+++ b/rust/log/src/bin/log.rs
@@ -1,0 +1,4 @@
+#[tokio::main]
+async fn main() {
+    chroma_log::log_entrypoint().await;
+}

--- a/rust/log/src/lib.rs
+++ b/rust/log/src/lib.rs
@@ -13,7 +13,9 @@ use chroma_error::ChromaError;
 use config::LogConfig;
 pub use local_compaction_manager::*;
 pub use log::*;
+use server::{LogServer, LogServerConfig};
 pub use types::*;
+mod server;
 
 use async_trait::async_trait;
 
@@ -36,5 +38,26 @@ impl Configurable<LogConfig> for Log {
 
         registry.register(res.clone());
         Ok(res)
+    }
+}
+
+// Entrypoint for the wal3 based log server
+#[allow(dead_code)]
+pub async fn log_entrypoint() {
+    let config = LogServerConfig::default();
+    let registry = chroma_config::registry::Registry::new();
+    let log_server = LogServer::try_from_config(&config, &registry)
+        .await
+        .expect("Failed to create log server");
+
+    let server_join_handle = tokio::spawn(async move {
+        let _ = crate::server::LogServer::run(log_server).await;
+    });
+
+    match server_join_handle.await {
+        Ok(_) => {}
+        Err(e) => {
+            tracing::error!("Error terminating server: {:?}", e);
+        }
     }
 }

--- a/rust/log/src/lib.rs
+++ b/rust/log/src/lib.rs
@@ -13,9 +13,12 @@ use chroma_error::ChromaError;
 use config::LogConfig;
 pub use local_compaction_manager::*;
 pub use log::*;
-use server::{LogServer, LogServerConfig};
 pub use types::*;
+
+#[cfg(feature = "server")]
 mod server;
+#[cfg(feature = "server")]
+use server::{LogServer, LogServerConfig};
 
 use async_trait::async_trait;
 
@@ -42,7 +45,7 @@ impl Configurable<LogConfig> for Log {
 }
 
 // Entrypoint for the wal3 based log server
-#[allow(dead_code)]
+#[cfg(feature = "server")]
 pub async fn log_entrypoint() {
     let config = LogServerConfig::default();
     let registry = chroma_config::registry::Registry::new();

--- a/rust/log/src/server.rs
+++ b/rust/log/src/server.rs
@@ -1,0 +1,121 @@
+use async_trait::async_trait;
+use chroma_config::Configurable;
+use chroma_error::ChromaError;
+use chroma_types::chroma_proto::{
+    log_service_server::LogService, GetAllCollectionInfoToCompactRequest,
+    GetAllCollectionInfoToCompactResponse, PullLogsRequest, PullLogsResponse, PushLogsRequest,
+    PushLogsResponse, UpdateCollectionLogOffsetRequest, UpdateCollectionLogOffsetResponse,
+};
+use serde::{Deserialize, Serialize};
+use tokio::signal::unix::{signal, SignalKind};
+use tonic::{transport::Server, Request, Response, Status};
+
+//////////////////////// Log Server ////////////////////////
+#[derive(Clone)]
+pub struct LogServer {
+    config: LogServerConfig,
+}
+
+#[async_trait]
+impl LogService for LogServer {
+    async fn push_logs(
+        &self,
+        _request: Request<PushLogsRequest>,
+    ) -> Result<Response<PushLogsResponse>, Status> {
+        todo!("Implement wal3 backed push_logs here")
+    }
+
+    async fn pull_logs(
+        &self,
+        _request: Request<PullLogsRequest>,
+    ) -> Result<Response<PullLogsResponse>, Status> {
+        todo!("Implement wal3 backed pull_logs here")
+    }
+
+    async fn get_all_collection_info_to_compact(
+        &self,
+        _request: Request<GetAllCollectionInfoToCompactRequest>,
+    ) -> Result<Response<GetAllCollectionInfoToCompactResponse>, Status> {
+        todo!("Implement wal3 backed get_all_collection_info_to_compact here")
+    }
+
+    async fn update_collection_log_offset(
+        &self,
+        _request: Request<UpdateCollectionLogOffsetRequest>,
+    ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
+        todo!("Implement wal3 backed update_collection_log_offset here")
+    }
+}
+
+impl LogServer {
+    pub(crate) async fn run(log_server: LogServer) -> Result<(), Box<dyn std::error::Error>> {
+        let addr = format!("[::]:{}", log_server.config.port).parse().unwrap();
+        println!("Log listening on {}", addr);
+        let server = Server::builder().add_service(
+            chroma_types::chroma_proto::log_service_server::LogServiceServer::new(
+                log_server.clone(),
+            ),
+        );
+
+        let server = server.serve_with_shutdown(addr, async {
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(sigterm) => sigterm,
+                Err(e) => {
+                    tracing::error!("Failed to create signal handler: {:?}", e);
+                    return;
+                }
+            };
+            sigterm.recv().await;
+            tracing::info!("Received SIGTERM, shutting down");
+        });
+
+        server.await?;
+
+        Ok(())
+    }
+}
+
+/////////////////////////// Config ///////////////////////////
+
+fn default_otel_service_name() -> String {
+    "rust-log-service".to_string()
+}
+
+fn default_port() -> u16 {
+    50051
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct OpenTelemetryConfig {
+    pub endpoint: String,
+    #[serde(default = "default_otel_service_name")]
+    pub service_name: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct LogServerConfig {
+    #[serde(default = "default_port")]
+    pub port: u16,
+    pub opentelemetry: Option<OpenTelemetryConfig>,
+}
+
+impl Default for LogServerConfig {
+    fn default() -> Self {
+        Self {
+            port: default_port(),
+            opentelemetry: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Configurable<LogServerConfig> for LogServer {
+    async fn try_from_config(
+        config: &LogServerConfig,
+        _registry: &chroma_config::registry::Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        Ok(Self {
+            config: config.clone(),
+        })
+    }
+}


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - /
 - New functionality
   - Adds a basic grpc stub for the log service
   - Added a feature for the server because the signals are unix only and not needed by rust-bindings

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None