### PR TITLE
[ENH] Spann works e2e on local tilt

### DIFF
--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -43,3 +43,4 @@ scorecard:
       - "op:*"
       - "collection_id:*"
     score: 100
+enable_span_indexing: true

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -103,6 +103,10 @@ fn default_max_payload_size_bytes() -> usize {
     40 * 1024 * 1024 // 40 MB
 }
 
+fn default_enable_span_indexing() -> bool {
+    false
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct FrontendServerConfig {
     #[serde(flatten)]
@@ -124,6 +128,8 @@ pub struct FrontendServerConfig {
     pub persist_path: Option<String>,
     #[serde(default)]
     pub cors_allow_origins: Option<Vec<String>>,
+    #[serde(default = "default_enable_span_indexing")]
+    pub enable_span_indexing: bool,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "sample_configs/distributed.yaml";

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -22,6 +22,8 @@ pub enum ValidationError {
     GetCollection(#[from] GetCollectionError),
     #[error("Error updating collection: {0}")]
     UpdateCollection(#[from] UpdateCollectionError),
+    #[error("SPANN is still in development. Not allowed to created spann indexes")]
+    SpannNotImplemented,
 }
 
 impl ChromaError for ValidationError {
@@ -32,6 +34,7 @@ impl ChromaError for ValidationError {
             ValidationError::DimensionMismatch(_, _) => ErrorCodes::InvalidArgument,
             ValidationError::GetCollection(err) => err.code(),
             ValidationError::UpdateCollection(err) => err.code(),
+            ValidationError::SpannNotImplemented => ErrorCodes::Unimplemented,
         }
     }
 }

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -31,7 +31,6 @@ pub struct VersionsMapInner {
 
 #[derive(Clone)]
 // Note: Fields of this struct are public for testing.
-#[derive(Clone)]
 pub struct SpannIndexWriter {
     // HNSW index and its provider for centroid search.
     pub hnsw_index: HnswIndexRef,
@@ -1003,7 +1002,8 @@ impl SpannIndexWriter {
         }
         // Normalize the embedding in case of cosine.
         let mut normalized_embedding = embedding.to_vec();
-        if self.distance_function == DistanceFunction::Cosine {
+        let distance_function: DistanceFunction = self.params.space.clone().into();
+        if distance_function == DistanceFunction::Cosine {
             normalized_embedding = normalize(embedding);
         }
         // Add to the posting list.
@@ -1705,6 +1705,7 @@ mod tests {
         provider::BlockfileProvider,
     };
     use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
+    use chroma_distance::DistanceFunction;
     use chroma_storage::{local::LocalStorage, Storage};
     use chroma_types::{CollectionUuid, DistributedSpannParameters, SpannPostingList};
     use rand::Rng;
@@ -2780,11 +2781,9 @@ mod tests {
         let blockfile_provider =
             new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
         let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
-        let m = 16;
-        let ef_construction = 200;
-        let ef_search = 200;
         let collection_id = CollectionUuid::new();
-        let distance_function = chroma_distance::DistanceFunction::Euclidean;
+        let params = DistributedSpannParameters::default();
+        let distance_function = params.space.clone().into();
         let dimensionality = 1000;
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
@@ -2792,13 +2791,10 @@ mod tests {
             None,
             None,
             None,
-            Some(m),
-            Some(ef_construction),
-            Some(ef_search),
             &collection_id,
-            distance_function.clone(),
             dimensionality,
             &blockfile_provider,
+            params,
         )
         .await
         .expect("Error creating spann index writer");
@@ -2870,11 +2866,9 @@ mod tests {
         let blockfile_provider =
             new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
         let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
-        let m = 16;
-        let ef_construction = 200;
-        let ef_search = 200;
         let collection_id = CollectionUuid::new();
-        let distance_function = chroma_distance::DistanceFunction::Euclidean;
+        let params = DistributedSpannParameters::default();
+        let distance_function = params.space.clone().into();
         let dimensionality = 1000;
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
@@ -2882,13 +2876,10 @@ mod tests {
             None,
             None,
             None,
-            Some(m),
-            Some(ef_construction),
-            Some(ef_search),
             &collection_id,
-            distance_function.clone(),
             dimensionality,
             &blockfile_provider,
+            params,
         )
         .await
         .expect("Error creating spann index writer");
@@ -2974,11 +2965,9 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;
-        let m = 16;
-        let ef_construction = 200;
-        let ef_search = 200;
         let collection_id = CollectionUuid::new();
-        let distance_function = chroma_distance::DistanceFunction::Euclidean;
+        let params = DistributedSpannParameters::default();
+        let distance_function = params.space.clone().into();
         let dimensionality = 1000;
         let mut hnsw_path = None;
         let mut versions_map_path = None;
@@ -2996,13 +2985,10 @@ mod tests {
                 versions_map_path.as_ref(),
                 pl_path.as_ref(),
                 max_bf_id_path.as_ref(),
-                Some(m),
-                Some(ef_construction),
-                Some(ef_search),
                 &collection_id,
-                distance_function.clone(),
                 dimensionality,
                 &blockfile_provider,
+                params.clone(),
             )
             .await
             .expect("Error creating spann index writer");
@@ -3079,11 +3065,9 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;
-        let m = 16;
-        let ef_construction = 200;
-        let ef_search = 200;
+        let params = DistributedSpannParameters::default();
+        let distance_function = params.space.clone().into();
         let collection_id = CollectionUuid::new();
-        let distance_function = chroma_distance::DistanceFunction::Euclidean;
         let dimensionality = 1000;
         let mut hnsw_path = None;
         let mut versions_map_path = None;
@@ -3113,13 +3097,10 @@ mod tests {
                 versions_map_path.as_ref(),
                 pl_path.as_ref(),
                 max_bf_id_path.as_ref(),
-                Some(m),
-                Some(ef_construction),
-                Some(ef_search),
                 &collection_id,
-                distance_function.clone(),
                 dimensionality,
                 &blockfile_provider,
+                params.clone(),
             )
             .await
             .expect("Error creating spann index writer");
@@ -3209,11 +3190,9 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;
-        let m = 16;
-        let ef_construction = 200;
-        let ef_search = 200;
+        let params = DistributedSpannParameters::default();
+        let distance_function: DistanceFunction = params.space.clone().into();
         let collection_id = CollectionUuid::new();
-        let distance_function = chroma_distance::DistanceFunction::Euclidean;
         let dimensionality = 1000;
         let mut hnsw_path = None;
         let mut versions_map_path = None;
@@ -3243,13 +3222,10 @@ mod tests {
                 versions_map_path.as_ref(),
                 pl_path.as_ref(),
                 max_bf_id_path.as_ref(),
-                Some(m),
-                Some(ef_construction),
-                Some(ef_search),
                 &collection_id,
-                distance_function.clone(),
                 dimensionality,
                 &blockfile_provider,
+                params.clone(),
             )
             .await
             .expect("Error creating spann index writer");
@@ -3359,13 +3335,10 @@ mod tests {
             versions_map_path.as_ref(),
             pl_path.as_ref(),
             max_bf_id_path.as_ref(),
-            Some(m),
-            Some(ef_construction),
-            Some(ef_search),
             &collection_id,
-            distance_function.clone(),
             dimensionality,
             &blockfile_provider,
+            params.clone(),
         )
         .await
         .expect("Error creating spann index writer");
@@ -3477,13 +3450,10 @@ mod tests {
             versions_map_path.as_ref(),
             pl_path.as_ref(),
             max_bf_id_path.as_ref(),
-            Some(m),
-            Some(ef_construction),
-            Some(ef_search),
             &collection_id,
-            distance_function.clone(),
             dimensionality,
             &blockfile_provider,
+            params,
         )
         .await
         .expect("Error creating spann index writer");

--- a/rust/index/src/spann/utils.rs
+++ b/rust/index/src/spann/utils.rs
@@ -120,6 +120,8 @@ pub enum KMeansError {
     MaxClusterNotFound,
     #[error("Could not assign a point to a center")]
     PointAssignmentFailed,
+    #[error("Returned 0 points in a cluster")]
+    ZeroPointsInCluster,
 }
 
 impl ChromaError for KMeansError {
@@ -127,6 +129,7 @@ impl ChromaError for KMeansError {
         match self {
             Self::MaxClusterNotFound => ErrorCodes::Internal,
             Self::PointAssignmentFailed => ErrorCodes::Internal,
+            Self::ZeroPointsInCluster => ErrorCodes::Internal,
         }
     }
 }

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -231,7 +231,10 @@ impl SpannSegmentWriter {
         record_segment_reader: &Option<RecordSegmentReader<'_>>,
         materialized_chunk: &MaterializeLogsResult,
     ) -> Result<(), ApplyMaterializedLogError> {
-        println!("(Sanket-temp) Applying materialized log chunk to spann segment writer");
+        tracing::info!(
+            "Applying {} materialized logs to spann segment writer",
+            materialized_chunk.len()
+        );
         for record in materialized_chunk {
             match record.get_operation() {
                 MaterializedLogOperation::AddNew => {
@@ -263,11 +266,15 @@ impl SpannSegmentWriter {
                 ),
             }
         }
-        println!("(Sanket-temp) Finished applying materialized log chunk to spann segment writer");
+        tracing::info!(
+            "Applied {} materialized logs to spann segment writer",
+            materialized_chunk.len()
+        );
         Ok(())
     }
 
     pub async fn commit(self) -> Result<SpannSegmentFlusher, Box<dyn ChromaError>> {
+        tracing::info!("Committing spann segment writer {}", self.id);
         let index_flusher = self
             .index
             .commit()
@@ -296,6 +303,7 @@ impl Debug for SpannSegmentFlusher {
 
 impl SpannSegmentFlusher {
     pub async fn flush(self) -> Result<HashMap<String, Vec<String>>, Box<dyn ChromaError>> {
+        tracing::info!("Flushing spann segment flusher {}", self.id);
         let index_flusher_res = self
             .index_flusher
             .flush()
@@ -317,6 +325,10 @@ impl SpannSegmentFlusher {
                 index_id_map.insert(
                     MAX_HEAD_ID_BF_PATH.to_string(),
                     vec![index_ids.max_head_id_id.to_string()],
+                );
+                tracing::info!(
+                    "Flushed file paths for spann segment flusher {:?}",
+                    index_id_map
                 );
                 Ok(index_id_map)
             }

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -231,6 +231,7 @@ impl SpannSegmentWriter {
         record_segment_reader: &Option<RecordSegmentReader<'_>>,
         materialized_chunk: &MaterializeLogsResult,
     ) -> Result<(), ApplyMaterializedLogError> {
+        println!("(Sanket-temp) Applying materialized log chunk to spann segment writer");
         for record in materialized_chunk {
             match record.get_operation() {
                 MaterializedLogOperation::AddNew => {
@@ -262,6 +263,7 @@ impl SpannSegmentWriter {
                 ),
             }
         }
+        println!("(Sanket-temp) Finished applying materialized log chunk to spann segment writer");
         Ok(())
     }
 
@@ -653,7 +655,7 @@ mod test {
             2
         );
         {
-            let read_guard = spann_writer.index.versions_map.read();
+            let read_guard = spann_writer.index.versions_map.read().await;
             assert_eq!(read_guard.versions_map.len(), 2);
             assert_eq!(
                 *read_guard

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use thiserror::Error;
 use tracing::{Instrument, Span};
 
+use crate::distributed_spann::{SpannSegmentFlusher, SpannSegmentWriter};
+
 use super::blockfile_metadata::{MetadataSegmentFlusher, MetadataSegmentWriter};
 use super::blockfile_record::{
     ApplyMaterializedLogError, RecordSegmentFlusher, RecordSegmentReader,
@@ -861,10 +863,67 @@ pub async fn materialize_logs(
 }
 
 #[derive(Clone, Debug)]
+pub enum VectorSegmentWriter {
+    Hnsw(Box<DistributedHNSWSegmentWriter>),
+    Spann(SpannSegmentWriter),
+}
+
+impl VectorSegmentWriter {
+    pub fn get_id(&self) -> SegmentUuid {
+        match self {
+            VectorSegmentWriter::Hnsw(writer) => writer.id,
+            VectorSegmentWriter::Spann(writer) => writer.id,
+        }
+    }
+
+    pub fn get_name(&self) -> &'static str {
+        match self {
+            VectorSegmentWriter::Hnsw(_) => "DistributedHNSWSegmentWriter",
+            VectorSegmentWriter::Spann(_) => "SpannSegmentWriter",
+        }
+    }
+
+    pub async fn apply_materialized_log_chunk(
+        &self,
+        record_segment_reader: &Option<RecordSegmentReader<'_>>,
+        materialized: &MaterializeLogsResult,
+    ) -> Result<(), ApplyMaterializedLogError> {
+        match self {
+            VectorSegmentWriter::Hnsw(writer) => {
+                writer
+                    .apply_materialized_log_chunk(record_segment_reader, materialized)
+                    .await
+            }
+            VectorSegmentWriter::Spann(writer) => {
+                writer
+                    .apply_materialized_log_chunk(record_segment_reader, materialized)
+                    .await
+            }
+        }
+    }
+
+    pub async fn finish(&mut self) -> Result<(), Box<dyn ChromaError>> {
+        Ok(())
+    }
+
+    pub async fn commit(self) -> Result<ChromaSegmentFlusher, Box<dyn ChromaError>> {
+        match self {
+            VectorSegmentWriter::Hnsw(writer) => writer.commit().await.map(|w| {
+                ChromaSegmentFlusher::VectorSegment(VectorSegmentFlusher::Hnsw(Box::new(w)))
+            }),
+            VectorSegmentWriter::Spann(writer) => writer
+                .commit()
+                .await
+                .map(|w| ChromaSegmentFlusher::VectorSegment(VectorSegmentFlusher::Spann(w))),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum ChromaSegmentWriter<'bf> {
     RecordSegment(RecordSegmentWriter),
     MetadataSegment(MetadataSegmentWriter<'bf>),
-    DistributedHNSWSegment(Box<DistributedHNSWSegmentWriter>),
+    VectorSegment(VectorSegmentWriter),
 }
 
 impl ChromaSegmentWriter<'_> {
@@ -872,7 +931,7 @@ impl ChromaSegmentWriter<'_> {
         match self {
             ChromaSegmentWriter::RecordSegment(writer) => writer.id,
             ChromaSegmentWriter::MetadataSegment(writer) => writer.id,
-            ChromaSegmentWriter::DistributedHNSWSegment(writer) => writer.id,
+            ChromaSegmentWriter::VectorSegment(writer) => writer.get_id(),
         }
     }
 
@@ -880,7 +939,7 @@ impl ChromaSegmentWriter<'_> {
         match self {
             ChromaSegmentWriter::RecordSegment(_) => "RecordSegmentWriter",
             ChromaSegmentWriter::MetadataSegment(_) => "MetadataSegmentWriter",
-            ChromaSegmentWriter::DistributedHNSWSegment(_) => "DistributedHNSWSegmentWriter",
+            ChromaSegmentWriter::VectorSegment(writer) => writer.get_name(),
         }
     }
 
@@ -900,7 +959,7 @@ impl ChromaSegmentWriter<'_> {
                     .apply_materialized_log_chunk(record_segment_reader, materialized)
                     .await
             }
-            ChromaSegmentWriter::DistributedHNSWSegment(writer) => {
+            ChromaSegmentWriter::VectorSegment(writer) => {
                 writer
                     .apply_materialized_log_chunk(record_segment_reader, materialized)
                     .await
@@ -912,7 +971,7 @@ impl ChromaSegmentWriter<'_> {
         match self {
             ChromaSegmentWriter::RecordSegment(_) => Ok(()),
             ChromaSegmentWriter::MetadataSegment(writer) => writer.finish().await,
-            ChromaSegmentWriter::DistributedHNSWSegment(_) => Ok(()),
+            ChromaSegmentWriter::VectorSegment(writer) => writer.finish().await,
         }
     }
 
@@ -926,19 +985,22 @@ impl ChromaSegmentWriter<'_> {
                 .commit()
                 .await
                 .map(ChromaSegmentFlusher::MetadataSegment),
-            ChromaSegmentWriter::DistributedHNSWSegment(writer) => writer
-                .commit()
-                .await
-                .map(|w| ChromaSegmentFlusher::DistributedHNSWSegment(Box::new(w))),
+            ChromaSegmentWriter::VectorSegment(writer) => writer.commit().await,
         }
     }
+}
+
+#[derive(Debug)]
+pub enum VectorSegmentFlusher {
+    Hnsw(Box<DistributedHNSWSegmentWriter>),
+    Spann(SpannSegmentFlusher),
 }
 
 #[derive(Debug)]
 pub enum ChromaSegmentFlusher {
     RecordSegment(RecordSegmentFlusher),
     MetadataSegment(MetadataSegmentFlusher),
-    DistributedHNSWSegment(Box<DistributedHNSWSegmentWriter>),
+    VectorSegment(VectorSegmentFlusher),
 }
 
 impl ChromaSegmentFlusher {
@@ -946,7 +1008,10 @@ impl ChromaSegmentFlusher {
         match self {
             ChromaSegmentFlusher::RecordSegment(flusher) => flusher.id,
             ChromaSegmentFlusher::MetadataSegment(flusher) => flusher.id,
-            ChromaSegmentFlusher::DistributedHNSWSegment(flusher) => flusher.id,
+            ChromaSegmentFlusher::VectorSegment(flusher) => match flusher {
+                VectorSegmentFlusher::Hnsw(writer) => writer.id,
+                VectorSegmentFlusher::Spann(writer) => writer.id,
+            },
         }
     }
 
@@ -954,7 +1019,10 @@ impl ChromaSegmentFlusher {
         match self {
             ChromaSegmentFlusher::RecordSegment(_) => "RecordSegmentFlusher",
             ChromaSegmentFlusher::MetadataSegment(_) => "MetadataSegmentFlusher",
-            ChromaSegmentFlusher::DistributedHNSWSegment(_) => "DistributedHNSWSegmentFlusher",
+            ChromaSegmentFlusher::VectorSegment(flusher) => match flusher {
+                VectorSegmentFlusher::Hnsw(_) => "DistributedHNSWSegmentFlusher",
+                VectorSegmentFlusher::Spann(_) => "SpannSegmentFlusher",
+            },
         }
     }
 
@@ -962,7 +1030,10 @@ impl ChromaSegmentFlusher {
         match self {
             ChromaSegmentFlusher::RecordSegment(flusher) => flusher.flush().await,
             ChromaSegmentFlusher::MetadataSegment(flusher) => flusher.flush().await,
-            ChromaSegmentFlusher::DistributedHNSWSegment(flusher) => flusher.flush().await,
+            ChromaSegmentFlusher::VectorSegment(flusher) => match flusher {
+                VectorSegmentFlusher::Hnsw(flusher) => flusher.flush().await,
+                VectorSegmentFlusher::Spann(flusher) => flusher.flush().await,
+            },
         }
     }
 }

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -9,6 +9,7 @@ use crate::validators::{
 use crate::Collection;
 use crate::CollectionConversionError;
 use crate::CollectionUuid;
+use crate::DistributedSpannParametersFromSegmentError;
 use crate::HnswParametersFromSegmentError;
 use crate::Metadata;
 use crate::SegmentConversionError;
@@ -564,6 +565,8 @@ pub type CreateCollectionResponse = Collection;
 pub enum CreateCollectionError {
     #[error("Invalid HNSW parameters: {0}")]
     InvalidHnswParameters(#[from] HnswParametersFromSegmentError),
+    #[error("Invalid Spann parameters: {0}")]
+    InvalidSpannParameters(#[from] DistributedSpannParametersFromSegmentError),
     #[error("Collection [{0}] already exists")]
     AlreadyExists(String),
     #[error("Database [{0}] does not exist")]
@@ -580,6 +583,7 @@ impl ChromaError for CreateCollectionError {
     fn code(&self) -> ErrorCodes {
         match self {
             CreateCollectionError::InvalidHnswParameters(_) => ErrorCodes::InvalidArgument,
+            CreateCollectionError::InvalidSpannParameters(_) => ErrorCodes::InvalidArgument,
             CreateCollectionError::AlreadyExists(_) => ErrorCodes::AlreadyExists,
             CreateCollectionError::DatabaseNotFound(_) => ErrorCodes::InvalidArgument,
             CreateCollectionError::Get(err) => err.code(),

--- a/rust/types/src/hnsw_parameters.rs
+++ b/rust/types/src/hnsw_parameters.rs
@@ -403,7 +403,7 @@ pub struct DistributedIndexTypeParam {
     pub index_type: DistributedIndexType,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub enum DistributedIndexType {
     #[serde(rename = "hnsw")]

--- a/rust/types/src/hnsw_parameters.rs
+++ b/rust/types/src/hnsw_parameters.rs
@@ -22,7 +22,7 @@ impl ChromaError for HnswParametersFromSegmentError {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
 pub enum HnswSpace {
     #[default]
     #[serde(rename = "l2")]
@@ -204,5 +204,220 @@ impl TryFrom<SingleNodeHnswParameters> for Metadata {
         let json_str = serde_json::to_string(&params)?;
         let parsed = serde_json::from_str::<Metadata>(&json_str)?;
         Ok(parsed)
+    }
+}
+
+fn default_search_nprobe() -> u32 {
+    128
+}
+
+fn default_search_rng_factor() -> f32 {
+    1.0
+}
+
+fn default_search_rng_epsilon() -> f32 {
+    10.0
+}
+
+fn default_write_nprobe() -> u32 {
+    128
+}
+
+fn default_write_rng_factor() -> f32 {
+    1.0
+}
+
+fn default_write_rng_epsilon() -> f32 {
+    10.0
+}
+
+fn default_split_threshold() -> u32 {
+    100
+}
+
+fn default_num_samples_kmeans() -> usize {
+    1000
+}
+
+fn default_initial_lambda() -> f32 {
+    100.0
+}
+
+fn default_reassign_nbr_count() -> u32 {
+    8
+}
+
+fn default_merge_threshold() -> u32 {
+    50
+}
+
+fn default_num_centers_to_merge_to() -> u32 {
+    8
+}
+
+fn default_construction_ef_spann() -> usize {
+    200
+}
+
+fn default_search_ef_spann() -> usize {
+    200
+}
+
+fn default_m_spann() -> usize {
+    16
+}
+
+#[derive(Debug, Error)]
+pub enum DistributedSpannParametersFromSegmentError {
+    #[error("Invalid metadata: {0}")]
+    InvalidMetadata(#[from] serde_json::Error),
+    #[error("Invalid parameters: {0}")]
+    InvalidParameters(#[from] validator::ValidationErrors),
+}
+
+impl ChromaError for DistributedSpannParametersFromSegmentError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            DistributedSpannParametersFromSegmentError::InvalidMetadata(_) => {
+                ErrorCodes::InvalidArgument
+            }
+            DistributedSpannParametersFromSegmentError::InvalidParameters(_) => {
+                ErrorCodes::InvalidArgument
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
+pub struct DistributedSpannParameters {
+    #[serde(rename = "spann:search_nprobe", default = "default_search_nprobe")]
+    #[validate(range(min = 8))]
+    pub search_nprobe: u32,
+    #[serde(
+        rename = "spann:search_rng_factor",
+        default = "default_search_rng_factor"
+    )]
+    pub search_rng_factor: f32,
+    #[serde(
+        rename = "spann:search_rng_epsilon",
+        default = "default_search_rng_epsilon"
+    )]
+    pub search_rng_epsilon: f32,
+    #[serde(
+        rename = "spann:search_split_threshold",
+        default = "default_write_nprobe"
+    )]
+    #[validate(range(min = 8))]
+    pub write_nprobe: u32,
+    #[serde(
+        rename = "spann:write_rng_factor",
+        default = "default_write_rng_factor"
+    )]
+    pub write_rng_factor: f32,
+    #[serde(
+        rename = "spann:write_rng_epsilon",
+        default = "default_write_rng_epsilon"
+    )]
+    pub write_rng_epsilon: f32,
+    #[serde(
+        rename = "spann:write_split_threshold",
+        default = "default_split_threshold"
+    )]
+    #[validate(range(min = 50))]
+    pub split_threshold: u32,
+    #[serde(
+        rename = "spann:num_samples_kmeans",
+        default = "default_num_samples_kmeans"
+    )]
+    #[validate(range(min = 500))]
+    pub num_samples_kmeans: usize,
+    #[serde(rename = "spann:initial_lambda", default = "default_initial_lambda")]
+    pub initial_lambda: f32,
+    #[serde(
+        rename = "spann:reassign_nbr_count",
+        default = "default_reassign_nbr_count"
+    )]
+    pub reassign_nbr_count: u32,
+    #[serde(rename = "spann:merge_threshold", default = "default_merge_threshold")]
+    pub merge_threshold: u32,
+    #[serde(
+        rename = "spann:num_centers_to_merge_to",
+        default = "default_num_centers_to_merge_to"
+    )]
+    pub num_centers_to_merge_to: u32,
+    #[serde(rename = "spann:space", default)]
+    pub space: HnswSpace,
+    #[serde(
+        rename = "spann:construction_ef",
+        default = "default_construction_ef_spann"
+    )]
+    pub construction_ef: usize,
+    #[serde(rename = "spann:search_ef", default = "default_search_ef_spann")]
+    pub search_ef: usize,
+    #[serde(rename = "spann:M", default = "default_m_spann")]
+    pub m: usize,
+}
+
+impl Default for DistributedSpannParameters {
+    fn default() -> Self {
+        serde_json::from_str("{}").unwrap()
+    }
+}
+
+impl TryFrom<&Option<Metadata>> for DistributedSpannParameters {
+    type Error = DistributedSpannParametersFromSegmentError;
+
+    fn try_from(value: &Option<Metadata>) -> Result<Self, Self::Error> {
+        let metadata_str = serde_json::to_string(value.as_ref().unwrap_or(&Metadata::default()))?;
+        let r = serde_json::from_str::<DistributedSpannParameters>(&metadata_str)?;
+        r.validate()?;
+        Ok(r)
+    }
+}
+
+impl TryFrom<&Segment> for DistributedSpannParameters {
+    type Error = DistributedSpannParametersFromSegmentError;
+
+    fn try_from(value: &Segment) -> Result<Self, Self::Error> {
+        DistributedSpannParameters::try_from(&value.metadata)
+    }
+}
+
+impl TryFrom<DistributedSpannParameters> for Metadata {
+    type Error = DistributedSpannParametersFromSegmentError;
+
+    fn try_from(value: DistributedSpannParameters) -> Result<Self, Self::Error> {
+        let metadata_str = serde_json::to_string(&value)?;
+        let r = serde_json::from_str::<Metadata>(&metadata_str)?;
+        Ok(r)
+    }
+}
+
+fn default_index_type() -> DistributedIndexType {
+    DistributedIndexType::Hnsw
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DistributedIndexTypeParam {
+    #[serde(alias = "index_type", default = "default_index_type")]
+    pub index_type: DistributedIndexType,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum DistributedIndexType {
+    #[serde(rename = "hnsw")]
+    Hnsw,
+    #[serde(rename = "spann")]
+    Spann,
+}
+
+impl TryFrom<&Option<Metadata>> for DistributedIndexTypeParam {
+    type Error = DistributedSpannParametersFromSegmentError;
+
+    fn try_from(value: &Option<Metadata>) -> Result<Self, Self::Error> {
+        let metadata_str = serde_json::to_string(value.as_ref().unwrap_or(&Metadata::default()))?;
+        let r = serde_json::from_str::<DistributedIndexTypeParam>(&metadata_str)?;
+        Ok(r)
     }
 }

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -15,7 +15,7 @@ use chroma_index::{
 };
 use chroma_storage::{local::LocalStorage, Storage};
 use chroma_system::Operator;
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionUuid, DistributedSpannParameters};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use futures::StreamExt;
 use rand::seq::SliceRandom;
@@ -74,25 +74,19 @@ fn add_to_index_and_get_reader<'a>(
             16,
             rx,
         );
-        let m = 32;
-        let ef_construction = 100;
-        let ef_search = 100;
         let collection_id = CollectionUuid::new();
-        let distance_function = chroma_distance::DistanceFunction::Euclidean;
         let dimensionality = 128;
+        let params = DistributedSpannParameters::default();
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
             None,
             None,
             None,
-            Some(m),
-            Some(ef_construction),
-            Some(ef_search),
             &collection_id,
-            distance_function.clone(),
             dimensionality,
             &blockfile_provider,
+            params.clone(),
         )
         .await
         .expect("Error creating spann index writer");
@@ -129,7 +123,7 @@ fn add_to_index_and_get_reader<'a>(
                 Some(&paths.hnsw_id),
                 &hnsw_provider,
                 &collection_id,
-                distance_function,
+                params.space.into(),
                 dimensionality,
                 Some(&paths.pl_id),
                 Some(&paths.versions_map_id),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -40,9 +40,11 @@ use chroma_segment::blockfile_record::RecordSegmentReader;
 use chroma_segment::blockfile_record::RecordSegmentReaderCreationError;
 use chroma_segment::blockfile_record::RecordSegmentWriter;
 use chroma_segment::distributed_hnsw::DistributedHNSWSegmentWriter;
+use chroma_segment::distributed_spann::SpannSegmentWriter;
 use chroma_segment::types::ChromaSegmentFlusher;
 use chroma_segment::types::ChromaSegmentWriter;
 use chroma_segment::types::MaterializeLogsResult;
+use chroma_segment::types::VectorSegmentWriter;
 use chroma_sysdb::SysDb;
 use chroma_system::wrap;
 use chroma_system::ChannelError;
@@ -59,6 +61,7 @@ use chroma_system::TaskResult;
 use chroma_types::Chunk;
 use chroma_types::GetCollectionsError;
 use chroma_types::GetSegmentsError;
+use chroma_types::SegmentScope;
 use chroma_types::SegmentUuid;
 use chroma_types::{CollectionUuid, LogRecord, Segment, SegmentFlushInfo, SegmentType};
 use core::panic;
@@ -102,7 +105,7 @@ enum ExecutionState {
 pub(crate) struct CompactWriters {
     pub(crate) metadata: MetadataSegmentWriter<'static>,
     pub(crate) record: RecordSegmentWriter,
-    pub(crate) vector: Box<DistributedHNSWSegmentWriter>,
+    pub(crate) vector: VectorSegmentWriter,
 }
 
 #[derive(Debug)]
@@ -149,8 +152,10 @@ pub enum GetSegmentWritersError {
     RecordSegmentWriterError,
     #[error("Error creating Metadata Segment Writer")]
     MetadataSegmentWriterError,
-    #[error("Error creating HNSW Segment Writer")]
-    HnswSegmentWriterError,
+    #[error("Error creating Vector Segment Writer")]
+    VectorSegmentWriterError,
+    #[error("Error creating Vector Segment Writer. Unknown Vector Segment Type")]
+    UnknownVectorSegmentType,
     #[error("Collection not found")]
     CollectionNotFound,
     #[error("Error getting collection")]
@@ -440,13 +445,13 @@ impl CompactOrchestrator {
 
         {
             self.num_uncompleted_tasks_by_segment
-                .entry(writers.vector.id)
+                .entry(writers.vector.get_id())
                 .and_modify(|v| {
                     *v += 1;
                 })
                 .or_insert(1);
 
-            let writer = ChromaSegmentWriter::DistributedHNSWSegment(writers.vector);
+            let writer = ChromaSegmentWriter::VectorSegment(writers.vector);
             let span = self.get_segment_writer_span(&writer);
             let operator = ApplyLogToSegmentWriterOperator::new();
             let input =
@@ -543,6 +548,24 @@ impl CompactOrchestrator {
         }
     }
 
+    async fn get_segment_from_scope(
+        &mut self,
+        segment_scope: SegmentScope,
+    ) -> Result<Segment, GetSegmentWritersError> {
+        let segments = self.get_all_segments().await?;
+        let segment = segments
+            .iter()
+            .find(|segment| segment.scope == segment_scope)
+            .cloned();
+
+        tracing::debug!("Found {:?} segment: {:?}", segment_scope, segment);
+
+        match segment {
+            Some(segment) => Ok(segment),
+            None => Err(GetSegmentWritersError::NoSegmentsFound),
+        }
+    }
+
     async fn get_segment_writers(&mut self) -> Result<CompactWriters, GetSegmentWritersError> {
         // Care should be taken to use the same writers across the compaction process
         // Since the segment writers are stateful, we should not create new writers for each partition
@@ -554,7 +577,7 @@ impl CompactOrchestrator {
 
         let record_segment = self.get_segment(SegmentType::BlockfileRecord).await?;
         let mt_segment = self.get_segment(SegmentType::BlockfileMetadata).await?;
-        let hnsw_segment = self.get_segment(SegmentType::HnswDistributed).await?;
+        let vector_segment = self.get_segment_from_scope(SegmentScope::VECTOR).await?;
 
         let borrowed_writers = self
             .writers
@@ -587,7 +610,6 @@ impl CompactOrchestrator {
 
                 tracing::debug!("Metadata Segment Writer created");
 
-                // Create a hnsw segment writer
                 let collection_res = sysdb
                     .get_collections(Some(self.collection_id), None, None, None, None, 0)
                     .await;
@@ -603,31 +625,62 @@ impl CompactOrchestrator {
                         return Err(GetSegmentWritersError::GetCollectionError(e));
                     }
                 };
-                let collection = &collection_res[0];
 
-                if let Some(dimension) = collection.dimension {
+                let dim = match collection_res[0].dimension {
+                    Some(dim) => dim,
+                    None => {
+                        tracing::error!(
+                            "Error creating vector segment writer. Collection dim missing"
+                        );
+                        return Err(GetSegmentWritersError::CollectionMissingDimension);
+                    }
+                };
+
+                if vector_segment.r#type == SegmentType::HnswDistributed {
+                    // Create a hnsw segment writer
                     let hnsw_segment_writer = match DistributedHNSWSegmentWriter::from_segment(
-                        &hnsw_segment,
-                        dimension as usize,
-                        hnsw_provider,
+                        &vector_segment,
+                        dim as usize,
+                        self.hnsw_index_provider.clone(),
                     )
                     .await
                     {
                         Ok(writer) => writer,
                         Err(e) => {
                             tracing::error!("Error creating HNSW segment writer: {:?}", e);
-                            return Err(GetSegmentWritersError::HnswSegmentWriterError);
+                            return Err(GetSegmentWritersError::VectorSegmentWriterError);
+                        }
+                    };
+                    Ok(CompactWriters {
+                        metadata: mt_segment_writer,
+                        record: record_segment_writer,
+                        vector: VectorSegmentWriter::Hnsw(hnsw_segment_writer),
+                    })
+                } else if vector_segment.r#type == SegmentType::Spann {
+                    let spann_writer = match SpannSegmentWriter::from_segment(
+                        &vector_segment,
+                        &blockfile_provider,
+                        &hnsw_provider,
+                        dim as usize,
+                    )
+                    .await
+                    {
+                        Ok(writer) => writer,
+                        Err(e) => {
+                            tracing::error!("Error creating Spann segment writer: {:?}", e);
+                            return Err(GetSegmentWritersError::VectorSegmentWriterError);
                         }
                     };
 
-                    return Ok(CompactWriters {
+                    Ok(CompactWriters {
                         metadata: mt_segment_writer,
                         record: record_segment_writer,
-                        vector: hnsw_segment_writer,
-                    });
+                        vector: VectorSegmentWriter::Spann(spann_writer),
+                    })
+                } else {
+                    tracing::error!("Error creating vector segment writer. Unknown segment type");
+                    Err(GetSegmentWritersError::UnknownVectorSegmentType)
                 }
-
-                Err(GetSegmentWritersError::CollectionMissingDimension)
             })
             .await?;
 
@@ -648,8 +701,8 @@ impl CompactOrchestrator {
             return Ok(ChromaSegmentWriter::RecordSegment(writers.record));
         }
 
-        if writers.vector.id == segment_id {
-            return Ok(ChromaSegmentWriter::DistributedHNSWSegment(writers.vector));
+        if writers.vector.get_id() == segment_id {
+            return Ok(ChromaSegmentWriter::VectorSegment(writers.vector));
         }
 
         Err(GetSegmentWritersError::NoSegmentsFound)

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,6 +1,6 @@
 mod compact;
 mod count;
-mod spann_knn;
+pub mod spann_knn;
 pub(crate) use compact::*;
 pub(crate) use count::*;
 

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -33,11 +33,6 @@ use crate::execution::operators::{
 
 use super::knn_filter::{KnnError, KnnFilterOutput, KnnOutput, KnnResult};
 
-// TODO(Sanket): Make these configurable.
-const RNG_FACTOR: f32 = 1.0;
-const QUERY_EPSILON: f32 = 10.0;
-const NUM_PROBE: usize = 64;
-
 #[derive(Debug)]
 pub struct SpannKnnOrchestrator {
     // Orchestrator parameters
@@ -172,10 +167,6 @@ impl Orchestrator for SpannKnnOrchestrator {
             SpannCentersSearchInput {
                 reader_context,
                 normalized_query: self.normalized_query_emb.clone(),
-                k: NUM_PROBE,
-                rng_epsilon: QUERY_EPSILON,
-                rng_factor: RNG_FACTOR,
-                distance_function: self.knn_filter_output.distance_function.clone(),
             },
             ctx.receiver(),
         );


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Plumbs config in the collection and segment metadata that identifies spann segment
   - Uses this information to appropriately construct readers/writers wherever needed
   - Note that it only does so for the rust frontend
   - Fixes other issues in the write and read path
   - Note: this feature is only available on Rust Frontend currently
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
