### PR TITLE
[BUG]: return correct tenant class in Python from Rust bindings

### DIFF
--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -150,7 +150,8 @@ class RustBindingsAPI(ServerAPI):
 
     @override
     def get_tenant(self, name: str) -> Tenant:
-        return self.bindings.get_tenant(name)
+        tenant = self.bindings.get_tenant(name)
+        return Tenant(name=tenant.name)
 
     # ////////////////////////////// Base API //////////////////////////////
 

--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -39,6 +39,9 @@ class QueryResponse:
     distances: Optional[List[List[float]]]
     include: Include
 
+class GetTenantResponse:
+    name: str
+
 # SqliteDBConfig types
 class MigrationMode(Enum):
     Apply = 0
@@ -78,7 +81,7 @@ class Bindings:
         tenant: str = DEFAULT_TENANT,
     ) -> Sequence[DatabaseFromBindings]: ...
     def create_tenant(self, name: str) -> None: ...
-    def get_tenant(self, name: str) -> Tenant: ...
+    def get_tenant(self, name: str) -> GetTenantResponse: ...
     def count_collections(
         self, tenant: str = DEFAULT_TENANT, database: str = DEFAULT_DATABASE
     ) -> int: ...

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -206,6 +206,15 @@ pub struct GetTenantResponse {
     pub name: String,
 }
 
+#[cfg(feature = "pyo3")]
+#[pyo3::pymethods]
+impl GetTenantResponse {
+    #[getter]
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum GetTenantError {
     #[error(transparent)]


### PR DESCRIPTION
## Description of changes

Rust bindings were not returning the actual `Tenant` class that downstream consumers expected.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a