### PR TITLE
[TST]: use Depot runners in Python/Rust tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [ubuntu-latest, windows-latest]
+        platform: [depot-ubuntu-24.04, windows-latest]
         test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*' --ignore='chromadb/test/auth/test_simple_rbac_authz.py'",
                    "chromadb/test/auth/test_simple_rbac_authz.py",
                    "chromadb/test/property/test_add.py",
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [ubuntu-latest, windows-latest]
+        platform: [depot-ubuntu-24.04, windows-latest]
         test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*' --ignore='chromadb/test/auth/test_simple_rbac_authz.py'",
                    "chromadb/test/auth/test_simple_rbac_authz.py",
                    "chromadb/test/property/test_add.py",
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [ubuntu-latest, windows-latest]
+        platform: [depot-ubuntu-24.04, windows-latest]
         test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*' --ignore='chromadb/test/auth/test_simple_rbac_authz.py'",
                    "chromadb/test/property/test_add.py",
                    "chromadb/test/test_cli.py",
@@ -115,7 +115,7 @@ jobs:
                    "chromadb/test/property/test_sysdb.py",
                    "chromadb/test/stress"]
         include:
-          - platform: ubuntu-latest
+          - platform: depot-ubuntu-24.04
             env-file: compose-env.linux
           - platform: windows-latest
             env-file: compose-env.windows
@@ -137,7 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [ubuntu-latest, windows-latest]
+        platform: [depot-ubuntu-24.04, windows-latest]
         test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*' --ignore='chromadb/test/auth/test_simple_rbac_authz.py'",
                    "chromadb/test/property/test_add.py",
                    "chromadb/test/property/test_collections.py",
@@ -149,7 +149,7 @@ jobs:
                    "chromadb/test/property/test_sysdb.py",
                    "chromadb/test/stress"]
         include:
-          - platform: ubuntu-latest
+          - platform: depot-ubuntu-24.04
             env-file: compose-env.linux
     runs-on: ${{ matrix.platform }}
     steps:
@@ -172,7 +172,7 @@ jobs:
     strategy:
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [ubuntu-latest, windows-latest]
+        platform: [depot-ubuntu-24.04, windows-latest]
         test-globs: ["chromadb/test/property/test_add.py",
                    "chromadb/test/property/test_collections.py",
                    "chromadb/test/property/test_collections_with_database_tenant.py",
@@ -296,7 +296,7 @@ jobs:
     strategy:
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [ubuntu-latest] # todo: should run on Windows, currently failing because Dockerfile doesn't build
+        platform: [depot-ubuntu-24.04] # todo: should run on Windows, currently failing because Dockerfile doesn't build
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description of changes

This should speed up workflows while also being cheaper. 

Primary motivation: `test_add.py` against the Rust bindings tends to error with "disk is full" on longer runs (e.x. https://github.com/chroma-core/chroma/actions/runs/13791893549/job/38580005218). The disk size for GitHub's runner is 14GB, while Depot's is 100GB.