### PR TITLE
Add lovable.dev docs to the frameworks section

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/integrations/chroma-integrations.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/chroma-integrations.md
@@ -43,3 +43,4 @@ We welcome pull requests to add new Integrations to the community.
 | [Haystack](./frameworks/haystack)       | ✓      | -            |
 | [OpenLIT](./frameworks/openlit)         | ✓      | Coming Soon! |
 | [Anthropic MCP](./frameworks/anthropic-mcp) | ✓ | Coming Soon! |
+| [Lovable.dev](./frameworks/lovable) | -      | ✓          |

--- a/docs/docs.trychroma.com/markdoc/content/integrations/frameworks/lovable.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/frameworks/lovable.md
@@ -1,3 +1,8 @@
+---
+id: lovable
+name: Lovable.dev
+---
+
 # Lovable.dev
 
 [Lovable.dev](https://www.lovable.dev) is a versatile platform designed to help developers quickly build and deploy AI-powered applications. Whether you're working on search engines, recommendation systems, or any other type of AI-driven project, Lovable.dev makes it easy to integrate advanced AI models and manage your data efficiently.

--- a/docs/docs.trychroma.com/markdoc/content/integrations/frameworks/lovable.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/frameworks/lovable.md
@@ -1,0 +1,30 @@
+# Lovable.dev
+
+[Lovable.dev](https://www.lovable.dev) is a versatile platform designed to help developers quickly build and deploy AI-powered applications. Whether you're working on search engines, recommendation systems, or any other type of AI-driven project, Lovable.dev makes it easy to integrate advanced AI models and manage your data efficiently.
+
+## Using ChromaDB for Vector Storage
+
+Lovable.dev allows you to integrate [ChromaDB](https://www.npmjs.com/package/chromadb), a powerful vector storage solution, to store and manage vector embeddings. ChromaDB is designed to handle embeddings and other high-dimensional data efficiently, making it ideal for a wide range of AI applications.
+
+To get started with ChromaDB for vector storage, input the following prompt into Lovable.dev:
+
+### Input Prompt:
+```
+Build an application utilizing ChromaDB (https://www.npmjs.com/package/chromadb) as storage
+```
+
+### What Happens When You Enter the Prompt:
+Upon submitting the above prompt, Lovable.dev will automatically generate the necessary code and architecture to create a simple **chat application** that demonstrates how to use the ChromaDB SDK. This application will showcase how to:
+
+1. **Store User Messages and Responses**: The chat app will store user inputs and relevant responses as vector embeddings in ChromaDB.
+2. **Query Vector Data**: The app will use ChromaDB to query stored embeddings for relevant information or past messages to generate a contextually relevant response.
+3. **Retrieve Information**: The chat application will retrieve relevant vector data from ChromaDB based on the user's input, demonstrating how to leverage ChromaDB's efficient retrieval capabilities.
+
+This simple chat app serves as a great starting point for developers looking to explore how ChromaDB works in practice, especially for applications that rely on vector storage and similarity search.
+
+Once you input the prompt, you'll be ready to deploy your own AI-powered application with ChromaDB.
+
+## Learn More
+
+- [Lovable.dev Documentation](https://www.lovable.dev/docs)
+- [ChromaDB NPM Package](https://www.npmjs.com/package/chromadb)


### PR DESCRIPTION
## Description of changes

Adds a Markdown doc of how to utilize the Lovable tool for creating code with Chroma Node SDK 

## Test plan
Run it locally, navigate to integrations, in the frameworks section you should see `Lovable.dev`, when pressing it opens the full doc. 

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust



<img width="1423" alt="Screenshot 2025-03-12 at 17 49 16" src="https://github.com/user-attachments/assets/54d1992f-fdbc-4a54-81d6-4f8f905df3b9" />
