### PR TITLE
[ENH]: bump the max response payload size limit for query service clients

### DIFF
--- a/chromadb/execution/executor/distributed.py
+++ b/chromadb/execution/executor/distributed.py
@@ -230,7 +230,11 @@ class DistributedExecutor(Executor):
         with self._mtx:
             if grpc_url not in self._grpc_stub_pool:
                 channel = grpc.insecure_channel(
-                    grpc_url, options=[("grpc.max_concurrent_streams", 1000)]
+                    grpc_url,
+                    options=[
+                        ("grpc.max_concurrent_streams", 1000),
+                        ("grpc.max_receive_message_length", 32000000),  # 32 MB
+                    ],
                 )
                 interceptors = [OtelInterceptor()]
                 channel = grpc.intercept_channel(channel, *interceptors)

--- a/rust/frontend/src/executor/client_manager.rs
+++ b/rust/frontend/src/executor/client_manager.rs
@@ -116,7 +116,8 @@ impl ClientManager {
                 let channel = ServiceBuilder::new()
                     .layer(chroma_tracing::GrpcTraceLayer)
                     .service(channel);
-                let client = QueryExecutorClient::new(channel);
+                let client =
+                    QueryExecutorClient::new(channel).max_decoding_message_size(32 * 1024 * 1024); // 32 MB
 
                 let mut node_name_to_client_guard = self.node_name_to_client.write();
                 node_name_to_client_guard.insert(node.to_string(), client);

--- a/rust/frontend/src/executor/config.rs
+++ b/rust/frontend/src/executor/config.rs
@@ -8,6 +8,11 @@ use chroma_error::ChromaError;
 use chroma_system::System;
 use serde::{Deserialize, Serialize};
 
+// 32 MB
+fn default_max_query_service_response_size_bytes() -> usize {
+    1024 * 1024 * 32
+}
+
 /// Configuration for the distributed executor.
 /// # Fields
 /// - `connections_per_node` - The number of connections to maintain per node
@@ -26,6 +31,8 @@ pub struct DistributedExecutorConfig {
     pub retry: RetryConfig,
     pub assignment: chroma_config::assignment::config::AssignmentPolicyConfig,
     pub memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
+    #[serde(default = "default_max_query_service_response_size_bytes")]
+    pub max_query_service_response_size_bytes: usize,
 }
 
 #[derive(Deserialize, Clone, Serialize, Debug)]

--- a/rust/frontend/src/executor/distributed.rs
+++ b/rust/frontend/src/executor/distributed.rs
@@ -55,6 +55,7 @@ impl Configurable<(config::DistributedExecutorConfig, System)> for DistributedEx
             config.connections_per_node,
             config.connect_timeout_ms,
             config.request_timeout_ms,
+            config.max_query_service_response_size_bytes,
         );
         let client_manager_handle = system.start_component(client_manager);
 


### PR DESCRIPTION
## Description of changes

Will prevent frontends from erroring on large responses. I added config parameter for the Rust frontend and hardcoded the limit to 32MB for the Python frontend since we're removing it soon.

## Test plan
*How are these changes tested?*

Tested by creating 1k documents of 10kB and calling `.get(limit=1000)`. This threw an error on main and worked on this branch. I can check in this test if desired, but it's not super straightforward to do in a clean way since we don't have a good pattern for E2E Rust tests yet.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a