### PR TITLE
doc: update docker.md to use 'chromadb' instead of 'chroma-core'

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
+++ b/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
@@ -28,7 +28,7 @@ You can run a Chroma server in a Docker container, and access it using the `Http
 To start the server, run:
 
 ```terminal
-docker run -v ./chroma-data:/data -p 8000:8000 chroma-core/chroma
+docker run -v ./chroma-data:/data -p 8000:8000 chromadb/chroma
 ```
 
 This starts the server with the default configuration and stores data in `./chroma-data` (in your current working directory).


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*

If run old docker command it will throw an error that repo not found, change repo from `chroma-core` to `chromadb` instead

## Test plan
*How are these changes tested?*

repeat a step in documentation

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
