### PR TITLE
[ENH] Remove timestamp_us from wal3 LogPosition.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ dependencies = [
  "chroma-cache",
  "chroma-config",
  "chroma-error",
+ "chroma-index",
  "chroma-storage",
  "chroma-sysdb",
  "chroma-system",

--- a/rust/wal3/src/batch_manager.rs
+++ b/rust/wal3/src/batch_manager.rs
@@ -217,7 +217,7 @@ mod tests {
     use crate::{LogWriterOptions, Manifest, SnapshotOptions, ThrottleOptions};
 
     #[tokio::test]
-    async fn test_batches() {
+    async fn test_k8s_integration_batches() {
         let batch_manager = BatchManager::new(ThrottleOptions {
             throughput: 100,
             headroom: 1,

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -564,16 +564,16 @@ mod tests {
         let fragment = Fragment {
             path: "path".to_string(),
             seq_no: FragmentSeqNo(1),
-            start: LogPosition::uni(1),
-            limit: LogPosition::uni(42),
+            start: LogPosition::from_offset(1),
+            limit: LogPosition::from_offset(42),
             num_bytes: 4100,
             setsum: Setsum::default(),
         };
-        assert!(!fragment.possibly_contains_position(LogPosition::uni(0)));
-        assert!(fragment.possibly_contains_position(LogPosition::uni(1)));
-        assert!(fragment.possibly_contains_position(LogPosition::uni(41)));
-        assert!(!fragment.possibly_contains_position(LogPosition::uni(42)));
-        assert!(!fragment.possibly_contains_position(LogPosition::uni(u64::MAX)));
+        assert!(!fragment.possibly_contains_position(LogPosition::from_offset(0)));
+        assert!(fragment.possibly_contains_position(LogPosition::from_offset(1)));
+        assert!(fragment.possibly_contains_position(LogPosition::from_offset(41)));
+        assert!(!fragment.possibly_contains_position(LogPosition::from_offset(42)));
+        assert!(!fragment.possibly_contains_position(LogPosition::from_offset(u64::MAX)));
     }
 
     #[test]
@@ -581,16 +581,16 @@ mod tests {
         let fragment1 = Fragment {
             path: "path1".to_string(),
             seq_no: FragmentSeqNo(1),
-            start: LogPosition::uni(1),
-            limit: LogPosition::uni(22),
+            start: LogPosition::from_offset(1),
+            limit: LogPosition::from_offset(22),
             num_bytes: 4100,
             setsum: Setsum::default(),
         };
         let fragment2 = Fragment {
             path: "path2".to_string(),
             seq_no: FragmentSeqNo(2),
-            start: LogPosition::uni(22),
-            limit: LogPosition::uni(42),
+            start: LogPosition::from_offset(22),
+            limit: LogPosition::from_offset(42),
             num_bytes: 4100,
             setsum: Setsum::default(),
         };
@@ -602,12 +602,12 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment1, fragment2],
         };
-        assert!(!manifest.contains_position(LogPosition::uni(0)));
-        assert!(manifest.contains_position(LogPosition::uni(1)));
-        assert!(manifest.contains_position(LogPosition::uni(41)));
-        assert!(manifest.contains_position(LogPosition::uni(41)));
-        assert!(!manifest.contains_position(LogPosition::uni(42)));
-        assert!(!manifest.contains_position(LogPosition::uni(u64::MAX)));
+        assert!(!manifest.contains_position(LogPosition::from_offset(0)));
+        assert!(manifest.contains_position(LogPosition::from_offset(1)));
+        assert!(manifest.contains_position(LogPosition::from_offset(41)));
+        assert!(manifest.contains_position(LogPosition::from_offset(41)));
+        assert!(!manifest.contains_position(LogPosition::from_offset(42)));
+        assert!(!manifest.contains_position(LogPosition::from_offset(u64::MAX)));
     }
 
     #[test]
@@ -615,8 +615,8 @@ mod tests {
         let fragment1 = Fragment {
             path: "path1".to_string(),
             seq_no: FragmentSeqNo(1),
-            start: LogPosition::uni(1),
-            limit: LogPosition::uni(22),
+            start: LogPosition::from_offset(1),
+            limit: LogPosition::from_offset(22),
             num_bytes: 4100,
             setsum: Setsum::from_hexdigest(
                 "4eec78e0b5cd15df7b36fd42cdc3aecb1986ffa3655c338201db88f80d855465",
@@ -626,8 +626,8 @@ mod tests {
         let fragment2 = Fragment {
             path: "path2".to_string(),
             seq_no: FragmentSeqNo(2),
-            start: LogPosition::uni(22),
-            limit: LogPosition::uni(42),
+            start: LogPosition::from_offset(22),
+            limit: LogPosition::from_offset(42),
             num_bytes: 4100,
             setsum: Setsum::from_hexdigest(
                 "dd901afef0e5d336aaa52a2df7f785c909091fd0aa011980de443a61a889d3e1",
@@ -665,8 +665,8 @@ mod tests {
         let fragment1 = Fragment {
             path: "path1".to_string(),
             seq_no: FragmentSeqNo(1),
-            start: LogPosition::uni(1),
-            limit: LogPosition::uni(22),
+            start: LogPosition::from_offset(1),
+            limit: LogPosition::from_offset(22),
             num_bytes: 41,
             setsum: Setsum::from_hexdigest(
                 "4eec78e0b5cd15df7b36fd42cdc3aecb1986ffa3655c338201db88f80d855465",
@@ -676,8 +676,8 @@ mod tests {
         let fragment2 = Fragment {
             path: "path2".to_string(),
             seq_no: FragmentSeqNo(2),
-            start: LogPosition::uni(22),
-            limit: LogPosition::uni(42),
+            start: LogPosition::from_offset(22),
+            limit: LogPosition::from_offset(42),
             num_bytes: 42,
             setsum: Setsum::from_hexdigest(
                 "dd901afef0e5d336aaa52a2df7f785c909091fd0aa011980de443a61a889d3e1",
@@ -711,8 +711,8 @@ mod tests {
                     Fragment {
                         path: "path1".to_string(),
                         seq_no: FragmentSeqNo(1),
-                        start: LogPosition::uni(1),
-                        limit: LogPosition::uni(22),
+                        start: LogPosition::from_offset(1),
+                        limit: LogPosition::from_offset(22),
                         num_bytes: 41,
                         setsum: Setsum::from_hexdigest(
                             "4eec78e0b5cd15df7b36fd42cdc3aecb1986ffa3655c338201db88f80d855465"
@@ -722,8 +722,8 @@ mod tests {
                     Fragment {
                         path: "path2".to_string(),
                         seq_no: FragmentSeqNo(2),
-                        start: LogPosition::uni(22),
-                        limit: LogPosition::uni(42),
+                        start: LogPosition::from_offset(22),
+                        limit: LogPosition::from_offset(42),
                         num_bytes: 42,
                         setsum: Setsum::from_hexdigest(
                             "dd901afef0e5d336aaa52a2df7f785c909091fd0aa011980de443a61a889d3e1"

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use chroma_storage::{ETag, Storage};
 use setsum::Setsum;
@@ -220,16 +220,8 @@ impl ManifestManager {
 
     /// Assign a timestamp to a record.
     pub fn assign_timestamp(&self, record_count: usize) -> Option<(FragmentSeqNo, LogPosition)> {
-        let epoch_micros = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_micros() as u64;
         // SAFETY(rescrv):  Mutex poisoning.
         let mut staging = self.staging.lock().unwrap();
-        // Advance time.
-        if staging.next_log_position.timestamp_us < epoch_micros {
-            staging.next_log_position.timestamp_us = epoch_micros;
-        }
         // Steal the offset.
         let position = staging.next_log_position;
         // Advance the offset for the next assign_timestamp call.
@@ -480,8 +472,8 @@ mod tests {
                     path: "path2".to_string(),
                     seq_no: FragmentSeqNo(2),
                     num_bytes: 20,
-                    start: LogPosition::uni(22),
-                    limit: LogPosition::uni(42),
+                    start: LogPosition::from_offset(22),
+                    limit: LogPosition::from_offset(42),
                     setsum: Setsum::default(),
                 },
                 d1_tx,
@@ -501,8 +493,8 @@ mod tests {
                     path: "path1".to_string(),
                     seq_no: FragmentSeqNo(1),
                     num_bytes: 30,
-                    start: LogPosition::uni(1),
-                    limit: LogPosition::uni(22),
+                    start: LogPosition::from_offset(1),
+                    limit: LogPosition::from_offset(22),
                     setsum: Setsum::default(),
                 },
                 d2_tx,
@@ -545,16 +537,16 @@ mod tests {
                         path: "path1".to_string(),
                         seq_no: FragmentSeqNo(1),
                         num_bytes: 30,
-                        start: LogPosition::uni(1),
-                        limit: LogPosition::uni(22),
+                        start: LogPosition::from_offset(1),
+                        limit: LogPosition::from_offset(22),
                         setsum: Setsum::default(),
                     },
                     Fragment {
                         path: "path2".to_string(),
                         seq_no: FragmentSeqNo(2),
                         num_bytes: 20,
-                        start: LogPosition::uni(22),
-                        limit: LogPosition::uni(42),
+                        start: LogPosition::from_offset(22),
+                        limit: LogPosition::from_offset(42),
                         setsum: Setsum::default(),
                     }
                 ],
@@ -594,8 +586,8 @@ mod tests {
                     path: "path2".to_string(),
                     seq_no: FragmentSeqNo(2),
                     num_bytes: 20,
-                    start: LogPosition::uni(22),
-                    limit: LogPosition::uni(42),
+                    start: LogPosition::from_offset(22),
+                    limit: LogPosition::from_offset(42),
                     setsum: Setsum::default(),
                 },
                 d1_tx,
@@ -615,8 +607,8 @@ mod tests {
                     path: "path1".to_string(),
                     seq_no: FragmentSeqNo(1),
                     num_bytes: 30,
-                    start: LogPosition::uni(1),
-                    limit: LogPosition::uni(22),
+                    start: LogPosition::from_offset(1),
+                    limit: LogPosition::from_offset(22),
                     setsum: Setsum::default(),
                 },
                 d2_tx,
@@ -638,16 +630,16 @@ mod tests {
                         path: "path1".to_string(),
                         seq_no: FragmentSeqNo(1),
                         num_bytes: 30,
-                        start: LogPosition::uni(1),
-                        limit: LogPosition::uni(22),
+                        start: LogPosition::from_offset(1),
+                        limit: LogPosition::from_offset(22),
                         setsum: Setsum::default(),
                     },
                     Fragment {
                         path: "path2".to_string(),
                         seq_no: FragmentSeqNo(2),
                         num_bytes: 20,
-                        start: LogPosition::uni(22),
-                        limit: LogPosition::uni(42),
+                        start: LogPosition::from_offset(22),
+                        limit: LogPosition::from_offset(42),
                         setsum: Setsum::default(),
                     }
                 ],

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -83,34 +83,41 @@ impl LogWriter {
 
     /// Append a message to a log.
     pub async fn append(&self, message: Vec<u8>) -> Result<LogPosition, Error> {
+        self.append_many(vec![message]).await
+    }
+
+    pub async fn append_many(&self, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
         // SAFETY(rescrv):  Mutex poisoning.
         let inner = { self.inner.lock().unwrap().clone() };
-        if let Some(epoch_writer) = inner {
-            let res = epoch_writer.writer.append(message).await;
-            if matches!(res, Err(Error::LogContention)) {
-                let writer = OnceLogWriter::open(
-                    epoch_writer.writer.options.clone(),
-                    epoch_writer.writer.storage.clone(),
-                    epoch_writer.writer.prefix.clone(),
-                    self.writer.clone(),
-                )
-                .await?;
-                // SAFETY(rescrv):  Mutex poisoning.
-                let mut inner = self.inner.lock().unwrap();
-                if let Some(second) = inner.as_mut() {
-                    if second.epoch == epoch_writer.epoch {
-                        second.epoch += 1;
-                        second.writer = writer;
+        loop {
+            if let Some(ref epoch_writer) = inner {
+                let res = epoch_writer.writer.append(messages.clone()).await;
+                if matches!(res, Err(Error::LogContention)) {
+                    let writer = OnceLogWriter::open(
+                        epoch_writer.writer.options.clone(),
+                        epoch_writer.writer.storage.clone(),
+                        epoch_writer.writer.prefix.clone(),
+                        self.writer.clone(),
+                    )
+                    .await?;
+                    // SAFETY(rescrv):  Mutex poisoning.
+                    let mut inner = self.inner.lock().unwrap();
+                    if let Some(second) = inner.as_mut() {
+                        if second.epoch == epoch_writer.epoch {
+                            second.epoch += 1;
+                            second.writer = writer;
+                        }
+                    } else {
+                        // This should never happen, so just be polite with an error.
+                        return Err(Error::LogClosed);
                     }
                 } else {
-                    // This should never happen, so just be polite with an error.
-                    return Err(Error::LogClosed);
+                    return res;
                 }
+            } else {
+                // This should never happen, so just be polite with an error.
+                return Err(Error::LogClosed);
             }
-            res
-        } else {
-            // This should never happen, so just be polite with an error.
-            Err(Error::LogClosed)
         }
     }
 }
@@ -234,9 +241,9 @@ impl OnceLogWriter {
         Ok(())
     }
 
-    async fn append(self: &Arc<Self>, message: Vec<u8>) -> Result<LogPosition, Error> {
+    async fn append(self: &Arc<Self>, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.batch_manager.push_work(message, tx);
+        self.batch_manager.push_work(messages, tx);
         if let Some((fragment_seq_no, log_position, work)) =
             self.batch_manager.take_work(&self.manifest_manager)?
         {
@@ -255,15 +262,15 @@ impl OnceLogWriter {
         fragment_seq_no: FragmentSeqNo,
         log_position: LogPosition,
         work: Vec<(
-            Vec<u8>,
+            Vec<Vec<u8>>,
             tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
         )>,
     ) {
         let mut messages = Vec::with_capacity(work.len());
         let mut notifies = Vec::with_capacity(work.len());
         for work in work.into_iter() {
-            messages.push(work.0);
-            notifies.push(work.1);
+            notifies.push((work.0.len(), work.1));
+            messages.extend(work.0);
         }
         if messages.is_empty() {
             tracing::error!("somehow got empty messages");
@@ -273,16 +280,16 @@ impl OnceLogWriter {
             .append_batch_internal(fragment_seq_no, log_position, messages)
             .await
         {
-            Ok(log_position) => {
-                for (idx, notify) in notifies.into_iter().enumerate() {
-                    let log_position = log_position + idx;
+            Ok(mut log_position) => {
+                for (num_messages, notify) in notifies.into_iter() {
                     if notify.send(Ok(log_position)).is_err() {
                         // TODO(rescrv):  Counter this.
                     }
+                    log_position += num_messages;
                 }
             }
             Err(e) => {
-                for notify in notifies {
+                for (_, notify) in notifies {
                     if notify.send(Err(e.clone())).is_err() {
                         // TODO(rescrv):  Counter this.
                     }


### PR DESCRIPTION
The timestamp_us field was supposed to be helpful, but it leads to
ambiguity when providing offsets to scan.  Chiefly, what should be the
behavior when a LogPosition with a timestamp different from the one
assigned to that offset is used for scan.  This does away with the
ambiguity and reverts to just logging the timestamp of insertion, which
can drift and therefore won't be monotonic.
