### PR TITLE
[ENH]: rename DistributedSpannParameters -> SpannConfiguration

### DIFF
--- a/rust/frontend/src/frontend.rs
+++ b/rust/frontend/src/frontend.rs
@@ -21,19 +21,18 @@ use chroma_types::{
     CreateTenantError, CreateTenantRequest, CreateTenantResponse, DeleteCollectionError,
     DeleteCollectionRecordsError, DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse,
     DeleteCollectionRequest, DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse,
-    DistributedHnswParameters, DistributedIndexType, DistributedIndexTypeParam,
-    DistributedSpannParameters, GetCollectionError, GetCollectionRequest, GetCollectionResponse,
-    GetCollectionsError, GetDatabaseError, GetDatabaseRequest, GetDatabaseResponse, GetRequest,
-    GetResponse, GetTenantError, GetTenantRequest, GetTenantResponse, HealthCheckResponse,
-    HeartbeatError, HeartbeatResponse, Include, ListCollectionsRequest, ListCollectionsResponse,
-    ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, Metadata, Operation,
-    OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
-    ScalarEncoding, Segment, SegmentScope, SegmentType, SegmentUuid, SingleNodeHnswParameters,
-    UpdateCollectionError, UpdateCollectionRecordsError, UpdateCollectionRecordsRequest,
-    UpdateCollectionRecordsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
-    UpdateMetadata, UpdateMetadataValue, UpsertCollectionRecordsError,
-    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, Where, CHROMA_DOCUMENT_KEY,
-    CHROMA_URI_KEY,
+    DistributedHnswParameters, DistributedIndexType, DistributedIndexTypeParam, GetCollectionError,
+    GetCollectionRequest, GetCollectionResponse, GetCollectionsError, GetDatabaseError,
+    GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse, GetTenantError,
+    GetTenantRequest, GetTenantResponse, HealthCheckResponse, HeartbeatError, HeartbeatResponse,
+    Include, ListCollectionsRequest, ListCollectionsResponse, ListDatabasesError,
+    ListDatabasesRequest, ListDatabasesResponse, Metadata, Operation, OperationRecord, QueryError,
+    QueryRequest, QueryResponse, ResetError, ResetResponse, ScalarEncoding, Segment, SegmentScope,
+    SegmentType, SegmentUuid, SingleNodeHnswParameters, SpannConfiguration, UpdateCollectionError,
+    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateCollectionRequest, UpdateCollectionResponse, UpdateMetadata, UpdateMetadataValue,
+    UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
+    Where, CHROMA_DOCUMENT_KEY, CHROMA_URI_KEY,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
@@ -439,7 +438,7 @@ impl Frontend {
                     }
                     DistributedIndexType::Spann => {
                         let validated_metadata =
-                            Metadata::try_from(DistributedSpannParameters::try_from(&metadata)?)?;
+                            Metadata::try_from(SpannConfiguration::try_from(&metadata)?)?;
                         Segment {
                             id: SegmentUuid::new(),
                             r#type: SegmentType::Spann,

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -11,7 +11,7 @@ use chroma_config::{registry::Registry, Configurable};
 use chroma_distance::{normalize, DistanceFunction};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::SpannPostingList;
-use chroma_types::{CollectionUuid, DistributedSpannParameters};
+use chroma_types::{CollectionUuid, SpannConfiguration};
 use rand::seq::SliceRandom;
 use thiserror::Error;
 use uuid::Uuid;
@@ -171,7 +171,7 @@ pub struct SpannIndexWriter {
     // TODO(Sanket): Finer grained locking for this map in future if perf is not satisfactory.
     pub versions_map: Arc<tokio::sync::RwLock<VersionsMapInner>>,
     pub dimensionality: usize,
-    pub params: DistributedSpannParameters,
+    pub params: SpannConfiguration,
     pub gc_context: GarbageCollectionContext,
     pub collection_id: CollectionUuid,
 }
@@ -275,7 +275,7 @@ impl SpannIndexWriter {
         next_head_id: u32,
         versions_map: VersionsMapInner,
         dimensionality: usize,
-        params: DistributedSpannParameters,
+        params: SpannConfiguration,
         gc_context: GarbageCollectionContext,
         collection_id: CollectionUuid,
     ) -> Self {
@@ -396,7 +396,7 @@ impl SpannIndexWriter {
         collection_id: &CollectionUuid,
         dimensionality: usize,
         blockfile_provider: &BlockfileProvider,
-        params: DistributedSpannParameters,
+        params: SpannConfiguration,
         gc_context: GarbageCollectionContext,
     ) -> Result<Self, SpannIndexWriterError> {
         let distance_function = DistanceFunction::from(params.space.clone());
@@ -1978,7 +1978,7 @@ mod tests {
     use chroma_config::{registry::Registry, Configurable};
     use chroma_distance::DistanceFunction;
     use chroma_storage::{local::LocalStorage, Storage};
-    use chroma_types::{CollectionUuid, DistributedSpannParameters, SpannPostingList};
+    use chroma_types::{CollectionUuid, SpannConfiguration, SpannPostingList};
     use rand::Rng;
     use tempfile::TempDir;
 
@@ -2019,7 +2019,7 @@ mod tests {
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),
@@ -2219,7 +2219,7 @@ mod tests {
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let pl_gc_policy = PlGarbageCollectionConfig {
             enabled: true,
             policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig {
@@ -2461,7 +2461,7 @@ mod tests {
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let pl_gc_policy = PlGarbageCollectionConfig {
             enabled: true,
             policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig {
@@ -2678,7 +2678,7 @@ mod tests {
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),
@@ -2924,7 +2924,7 @@ mod tests {
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let pl_gc_policy = PlGarbageCollectionConfig {
             enabled: true,
             policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig {
@@ -3213,7 +3213,7 @@ mod tests {
             new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
         let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
         let collection_id = CollectionUuid::new();
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let distance_function = params.space.clone().into();
         let dimensionality = 1000;
         let gc_context = GarbageCollectionContext::try_from_config(
@@ -3308,7 +3308,7 @@ mod tests {
             new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
         let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
         let collection_id = CollectionUuid::new();
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let distance_function = params.space.clone().into();
         let dimensionality = 1000;
         let gc_context = GarbageCollectionContext::try_from_config(
@@ -3417,7 +3417,7 @@ mod tests {
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;
         let collection_id = CollectionUuid::new();
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),
@@ -3526,7 +3526,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),
@@ -3661,7 +3661,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let max_block_size_bytes = 8 * 1024 * 1024;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         // Create a garbage collection context.
         let pl_gc_config = PlGarbageCollectionConfig {
             enabled: true,

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -15,9 +15,9 @@ use chroma_index::spann::utils::rng_query;
 use chroma_index::spann::utils::RngQueryError;
 use chroma_index::IndexUuid;
 use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::SpannIndexWriter};
-use chroma_types::DistributedSpannParameters;
 use chroma_types::DistributedSpannParametersFromSegmentError;
 use chroma_types::SegmentUuid;
+use chroma_types::SpannConfiguration;
 use chroma_types::{MaterializedLogOperation, Segment, SegmentScope, SegmentType};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -106,7 +106,7 @@ impl SpannSegmentWriter {
         if segment.r#type != SegmentType::Spann || segment.scope != SegmentScope::VECTOR {
             return Err(SpannSegmentWriterError::InvalidArgument);
         }
-        let params = DistributedSpannParameters::try_from(segment)?;
+        let params = SpannConfiguration::try_from(segment)?;
 
         let hnsw_id = match segment.file_path.get(HNSW_PATH) {
             Some(hnsw_path) => match hnsw_path.first() {
@@ -409,7 +409,7 @@ pub struct SpannSegmentReader<'me> {
     pub index_reader: SpannIndexReader<'me>,
     #[allow(dead_code)]
     id: SegmentUuid,
-    pub params: DistributedSpannParameters,
+    pub params: SpannConfiguration,
 }
 
 impl<'me> SpannSegmentReader<'me> {
@@ -422,7 +422,7 @@ impl<'me> SpannSegmentReader<'me> {
         if segment.r#type != SegmentType::Spann || segment.scope != SegmentScope::VECTOR {
             return Err(SpannSegmentReaderError::InvalidArgument);
         }
-        let params = DistributedSpannParameters::try_from(segment)?;
+        let params = SpannConfiguration::try_from(segment)?;
         let hnsw_id = match segment.file_path.get(HNSW_PATH) {
             Some(hnsw_path) => match hnsw_path.first() {
                 Some(index_id) => {
@@ -554,8 +554,8 @@ mod test {
     };
     use chroma_storage::{local::LocalStorage, Storage};
     use chroma_types::{
-        Chunk, CollectionUuid, DistributedSpannParameters, LogRecord, Operation, OperationRecord,
-        SegmentUuid, SpannPostingList,
+        Chunk, CollectionUuid, LogRecord, Operation, OperationRecord, SegmentUuid,
+        SpannConfiguration, SpannPostingList,
     };
 
     use crate::{
@@ -588,7 +588,7 @@ mod test {
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let mut spann_segment = chroma_types::Segment {
             id: segment_id,
             collection: collection_id,
@@ -702,10 +702,7 @@ mod test {
         .await
         .expect("Error creating spann segment writer");
         assert_eq!(spann_writer.index.dimensionality, 3);
-        assert_eq!(
-            spann_writer.index.params,
-            DistributedSpannParameters::default()
-        );
+        assert_eq!(spann_writer.index.params, SpannConfiguration::default());
         // Next head id should be 2 since one centroid is already taken up.
         assert_eq!(
             spann_writer
@@ -794,7 +791,7 @@ mod test {
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let mut spann_segment = chroma_types::Segment {
             id: segment_id,
             collection: collection_id,
@@ -953,7 +950,7 @@ mod test {
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let mut spann_segment = chroma_types::Segment {
             id: segment_id,
             collection: collection_id,
@@ -1083,10 +1080,7 @@ mod test {
         .await
         .expect("Error creating spann segment writer");
         assert_eq!(spann_writer.index.dimensionality, 3);
-        assert_eq!(
-            spann_writer.index.params,
-            DistributedSpannParameters::default()
-        );
+        assert_eq!(spann_writer.index.params, SpannConfiguration::default());
         // Next head id should be 2 since one centroid is already taken up.
         assert_eq!(
             spann_writer

--- a/rust/types/src/hnsw_parameters.rs
+++ b/rust/types/src/hnsw_parameters.rs
@@ -289,7 +289,7 @@ impl ChromaError for DistributedSpannParametersFromSegmentError {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
-pub struct DistributedSpannParameters {
+pub struct SpannConfiguration {
     #[serde(rename = "spann:search_nprobe", default = "default_search_nprobe")]
     #[validate(range(min = 32))]
     pub search_nprobe: u32,
@@ -358,35 +358,35 @@ pub struct DistributedSpannParameters {
     pub m: usize,
 }
 
-impl Default for DistributedSpannParameters {
+impl Default for SpannConfiguration {
     fn default() -> Self {
         serde_json::from_str("{}").unwrap()
     }
 }
 
-impl TryFrom<&Option<Metadata>> for DistributedSpannParameters {
+impl TryFrom<&Option<Metadata>> for SpannConfiguration {
     type Error = DistributedSpannParametersFromSegmentError;
 
     fn try_from(value: &Option<Metadata>) -> Result<Self, Self::Error> {
         let metadata_str = serde_json::to_string(value.as_ref().unwrap_or(&Metadata::default()))?;
-        let r = serde_json::from_str::<DistributedSpannParameters>(&metadata_str)?;
+        let r = serde_json::from_str::<SpannConfiguration>(&metadata_str)?;
         r.validate()?;
         Ok(r)
     }
 }
 
-impl TryFrom<&Segment> for DistributedSpannParameters {
+impl TryFrom<&Segment> for SpannConfiguration {
     type Error = DistributedSpannParametersFromSegmentError;
 
     fn try_from(value: &Segment) -> Result<Self, Self::Error> {
-        DistributedSpannParameters::try_from(&value.metadata)
+        SpannConfiguration::try_from(&value.metadata)
     }
 }
 
-impl TryFrom<DistributedSpannParameters> for Metadata {
+impl TryFrom<SpannConfiguration> for Metadata {
     type Error = DistributedSpannParametersFromSegmentError;
 
-    fn try_from(value: DistributedSpannParameters) -> Result<Self, Self::Error> {
+    fn try_from(value: SpannConfiguration) -> Result<Self, Self::Error> {
         let metadata_str = serde_json::to_string(&value)?;
         let r = serde_json::from_str::<Metadata>(&metadata_str)?;
         Ok(r)

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -17,7 +17,7 @@ use chroma_index::{
 };
 use chroma_storage::{local::LocalStorage, Storage};
 use chroma_system::Operator;
-use chroma_types::{CollectionUuid, DistributedSpannParameters};
+use chroma_types::{CollectionUuid, SpannConfiguration};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use futures::StreamExt;
 use rand::seq::SliceRandom;
@@ -78,7 +78,7 @@ fn add_to_index_and_get_reader<'a>(
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 128;
-        let params = DistributedSpannParameters::default();
+        let params = SpannConfiguration::default();
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),

--- a/rust/worker/src/execution/orchestration/knn_filter.rs
+++ b/rust/worker/src/execution/orchestration/knn_filter.rs
@@ -11,8 +11,7 @@ use chroma_system::{
     PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    CollectionAndSegments, DistributedHnswParameters, DistributedSpannParameters, Segment,
-    SegmentType,
+    CollectionAndSegments, DistributedHnswParameters, Segment, SegmentType, SpannConfiguration,
 };
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
@@ -313,7 +312,7 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for KnnFilterOrchestrator {
             }
         } else {
             let params = match self.ok_or_terminate(
-                DistributedSpannParameters::try_from(&self.collection_and_segments.vector_segment)
+                SpannConfiguration::try_from(&self.collection_and_segments.vector_segment)
                     .map_err(|_| KnnError::InvalidDistanceFunction),
                 ctx,
             ) {


### PR DESCRIPTION
## Description of changes

Rename for consistency with https://github.com/chroma-core/chroma/pull/3961. Taken out of https://github.com/chroma-core/chroma/pull/3961 to slightly decrease diff.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a