### PR TITLE
[ENH]: add Default impl for Collection type

### DIFF
--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -20,6 +20,7 @@ pyo3 = { workspace = true, optional = true }
 validator = { workspace = true }
 regex = { workspace = true }
 utoipa = { workspace = true }
+
 # (Cross-crate testing dependencies)
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -72,6 +72,25 @@ pub struct Collection {
     pub last_compaction_time_secs: u64,
 }
 
+impl Default for Collection {
+    fn default() -> Self {
+        Self {
+            collection_id: CollectionUuid::new(),
+            name: "".to_string(),
+            configuration_json: Value::Null,
+            metadata: None,
+            dimension: None,
+            tenant: "".to_string(),
+            database: "".to_string(),
+            log_position: 0,
+            version: 0,
+            total_records_post_compaction: 0,
+            size_bytes_post_compaction: 0,
+            last_compaction_time_secs: 0,
+        }
+    }
+}
+
 #[cfg(feature = "pyo3")]
 #[pyo3::pymethods]
 impl Collection {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -422,10 +422,8 @@ mod tests {
     use chroma_system::{Dispatcher, DispatcherConfig};
     use chroma_types::SegmentUuid;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord, Segment};
-    use serde_json::Value;
     use std::collections::HashMap;
     use std::path::PathBuf;
-    use std::str::FromStr;
 
     #[tokio::test]
     async fn test_compaction_manager() {
@@ -437,8 +435,18 @@ mod tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmpdir.path().to_str().unwrap()));
 
-        let collection_uuid_1 =
-            CollectionUuid::from_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let tenant_1 = "tenant_1".to_string();
+        let collection_1 = Collection {
+            name: "collection_1".to_string(),
+            dimension: Some(1),
+            tenant: tenant_1.clone(),
+            database: "database_1".to_string(),
+            log_position: -1,
+            ..Default::default()
+        };
+
+        let collection_uuid_1 = collection_1.collection_id;
+
         in_memory_log.add_log(
             collection_uuid_1,
             InternalLogRecord {
@@ -459,8 +467,17 @@ mod tests {
             },
         );
 
-        let collection_uuid_2 =
-            CollectionUuid::from_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let tenant_2 = "tenant_2".to_string();
+        let collection_2 = Collection {
+            name: "collection_2".to_string(),
+            dimension: Some(1),
+            tenant: tenant_2.clone(),
+            database: "database_2".to_string(),
+            log_position: -1,
+            ..Default::default()
+        };
+
+        let collection_uuid_2 = collection_2.collection_id;
         in_memory_log.add_log(
             collection_uuid_2,
             InternalLogRecord {
@@ -483,37 +500,6 @@ mod tests {
 
         let mut sysdb = SysDb::Test(TestSysDb::new());
 
-        let tenant_1 = "tenant_1".to_string();
-        let collection_1 = Collection {
-            collection_id: collection_uuid_1,
-            name: "collection_1".to_string(),
-            configuration_json: Value::Null,
-            metadata: None,
-            dimension: Some(1),
-            tenant: tenant_1.clone(),
-            database: "database_1".to_string(),
-            log_position: -1,
-            version: 0,
-            total_records_post_compaction: 0,
-            size_bytes_post_compaction: 0,
-            last_compaction_time_secs: 0,
-        };
-
-        let tenant_2 = "tenant_2".to_string();
-        let collection_2 = Collection {
-            collection_id: collection_uuid_2,
-            name: "collection_2".to_string(),
-            configuration_json: Value::Null,
-            metadata: None,
-            dimension: Some(1),
-            tenant: tenant_2.clone(),
-            database: "database_2".to_string(),
-            log_position: -1,
-            version: 0,
-            total_records_post_compaction: 0,
-            size_bytes_post_compaction: 0,
-            last_compaction_time_secs: 0,
-        };
         match sysdb {
             SysDb::Test(ref mut sysdb) => {
                 sysdb.add_collection(collection_1);

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -147,7 +147,6 @@ mod tests {
     use chroma_log::in_memory_log::InMemoryLog;
     use chroma_sysdb::TestSysDb;
     use chroma_types::{Collection, Segment, SegmentScope, SegmentType, SegmentUuid};
-    use serde_json::Value;
     use std::collections::HashMap;
     use std::str::FromStr;
 
@@ -155,45 +154,36 @@ mod tests {
     async fn test_register_operator() {
         let mut sysdb = SysDb::Test(TestSysDb::new());
         let log = Log::InMemory(InMemoryLog::new());
-        let collection_version = 0;
-        let collection_uuid_1 =
-            CollectionUuid::from_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let tenant_1 = "tenant_1".to_string();
         let total_records_post_compaction: u64 = 5;
         let size_bytes_post_compaction: u64 = 25000;
         let last_compaction_time_secs: u64 = 1741037006;
+        let collection_version = 0;
+
+        let tenant_1 = "tenant_1".to_string();
         let collection_1 = Collection {
-            collection_id: collection_uuid_1,
             name: "collection_1".to_string(),
-            configuration_json: Value::Null,
-            metadata: None,
             dimension: Some(1),
             tenant: tenant_1.clone(),
             database: "database_1".to_string(),
-            log_position: 0,
-            version: collection_version,
             total_records_post_compaction,
             size_bytes_post_compaction,
             last_compaction_time_secs,
+            ..Default::default()
         };
+        let collection_uuid_1 = collection_1.collection_id;
 
-        let collection_uuid_2 =
-            CollectionUuid::from_str("00000000-0000-0000-0000-000000000002").unwrap();
         let tenant_2 = "tenant_2".to_string();
         let collection_2 = Collection {
-            collection_id: collection_uuid_2,
             name: "collection_2".to_string(),
-            configuration_json: Value::Null,
-            metadata: None,
             dimension: Some(1),
             tenant: tenant_2.clone(),
             database: "database_2".to_string(),
-            log_position: 0,
-            version: collection_version,
             total_records_post_compaction,
             size_bytes_post_compaction,
             last_compaction_time_secs,
+            ..Default::default()
         };
+        let collection_uuid_2 = collection_2.collection_id;
 
         match sysdb {
             SysDb::Test(ref mut sysdb) => {


### PR DESCRIPTION
## Description of changes
Adds a default impl for Collection. Makes it much easier to construct `Collection`s in tests, helps document exactly what fields any given test cares about, and prevents us from needing to update every manual `Collection` construction when we add a new field.
