### PR TITLE
[ENH]: add user-agent header to clients

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, cast, Tuple, Sequence, Dict
 import logging
 import httpx
 from overrides import override
+from chromadb import __version__
 from chromadb.auth import UserIdentity
 from chromadb.api.async_api import AsyncServerAPI
 from chromadb.api.base_http_client import BaseHTTPClient
@@ -108,6 +109,11 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         if loop_hash not in self._clients:
             headers = (self._settings.chroma_server_headers or {}).copy()
             headers["Content-Type"] = "application/json"
+            headers["User-Agent"] = (
+                "Chroma Python Client v"
+                + __version__
+                + " (https://github.com/chroma-core/chroma)"
+            )
 
             self._clients[loop_hash] = httpx.AsyncClient(
                 timeout=None,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -7,6 +7,7 @@ import httpx
 import urllib.parse
 from overrides import override
 
+from chromadb import __version__
 from chromadb.api.configuration import CollectionConfigurationInternal
 from chromadb.api.base_http_client import BaseHTTPClient
 from chromadb.types import Database, Tenant, Collection as CollectionModel
@@ -64,6 +65,11 @@ class FastAPI(BaseHTTPClient, ServerAPI):
 
         self._header = system.settings.chroma_server_headers or {}
         self._header["Content-Type"] = "application/json"
+        self._header["User-Agent"] = (
+            "Chroma Python Client v"
+            + __version__
+            + " (https://github.com/chroma-core/chroma)"
+        )
 
         if self._settings.chroma_server_ssl_verify is not None:
             self._session = httpx.Client(verify=self._settings.chroma_server_ssl_verify)

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -52,7 +52,7 @@
     "build": "pnpm -r build",
     "build:core": "NODE_OPTIONS=--enable-source-maps pnpm --filter @internal/chromadb-core build",
     "build:packages": "NODE_OPTIONS=--enable-source-maps pnpm --filter \"!@internal/chromadb-core\" build",
-    "test": "pnpm -r -v test",
+    "test": "pnpm -r test",
     "publish:packages": "pnpm publish -r --access public --no-git-checks --filter \"!@internal/chromadb-core\"",
     "release": "pnpm build && pnpm publish:packages",
     "release_alpha": "pnpm build && pnpm publish:packages --tag alpha",

--- a/clients/js/packages/chromadb-core/src/ChromaClient.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaClient.ts
@@ -1,3 +1,4 @@
+import { version } from "../package.json";
 import { AdminClient } from "./AdminClient";
 import { authOptionsToAuthProvider, ClientAuthProvider } from "./auth";
 import { chromaFetch } from "./ChromaFetch";
@@ -77,6 +78,11 @@ export class ChromaClient {
 
     this.api = new DefaultApi(apiConfig, undefined, chromaFetch);
     this.api.options = fetchOptions ?? {};
+
+    this.api.options.headers = {
+      ...this.api.options.headers,
+      "user-agent": `Chroma Javascript Client v${version} (https://github.com/chroma-core/chroma)`,
+    };
 
     if (auth !== undefined) {
       this.authProvider = authOptionsToAuthProvider(auth);


### PR DESCRIPTION
## Description of changes

Official Chroma clients now include their version in a request header, user-agent. JS currently sends `Chroma Javascript Client v2.0.1 (https://github.com/chroma-core/chroma)` and Python currently sends `Chroma Python Client v1.0.0 (https://github.com/chroma-core/chroma)`.

## Test plan
*How are these changes tested?*

Validated by logging received headers.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a