### PR TITLE
[ENH] Spann: config for GC policy + introduce spann provider + implement GC policy

### DIFF
--- a/rust/index/src/config.rs
+++ b/rust/index/src/config.rs
@@ -26,3 +26,28 @@ impl HnswProviderConfig {
         180
     }
 }
+
+fn default_garbage_collection() -> bool {
+    false
+}
+
+fn default_garbage_collection_policy() -> GarbageCollectionPolicy {
+    GarbageCollectionPolicy::Random10
+}
+
+#[derive(Deserialize, Debug, Clone, Serialize, Default)]
+pub enum GarbageCollectionPolicy {
+    #[serde(rename = "full")]
+    Full,
+    #[serde(rename = "random10")]
+    #[default]
+    Random10,
+}
+
+#[derive(Deserialize, Debug, Clone, Serialize, Default)]
+pub struct SpannProviderConfig {
+    #[serde(default = "default_garbage_collection")]
+    pub garbage_collection: bool,
+    #[serde(default = "default_garbage_collection_policy")]
+    pub garbage_collection_policy: GarbageCollectionPolicy,
+}

--- a/rust/index/src/config.rs
+++ b/rust/index/src/config.rs
@@ -27,27 +27,44 @@ impl HnswProviderConfig {
     }
 }
 
-fn default_garbage_collection() -> bool {
-    false
+fn default_garbage_collection() -> PlGarbageCollectionConfig {
+    PlGarbageCollectionConfig {
+        enabled: false,
+        policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig::default()),
+    }
 }
 
-fn default_garbage_collection_policy() -> GarbageCollectionPolicy {
-    GarbageCollectionPolicy::Random10
+#[derive(Deserialize, Debug, Clone, Serialize)]
+pub enum PlGarbageCollectionPolicyConfig {
+    #[serde(rename = "random_sample")]
+    RandomSample(RandomSamplePolicyConfig),
 }
 
-#[derive(Deserialize, Debug, Clone, Serialize, Default)]
-pub enum GarbageCollectionPolicy {
-    #[serde(rename = "full")]
-    Full,
-    #[serde(rename = "random10")]
-    #[default]
-    Random10,
+impl Default for PlGarbageCollectionPolicyConfig {
+    fn default() -> Self {
+        PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig::default())
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize, Default)]
 pub struct SpannProviderConfig {
     #[serde(default = "default_garbage_collection")]
-    pub garbage_collection: bool,
-    #[serde(default = "default_garbage_collection_policy")]
-    pub garbage_collection_policy: GarbageCollectionPolicy,
+    pub pl_garbage_collection: PlGarbageCollectionConfig,
+}
+
+#[derive(Deserialize, Debug, Clone, Serialize, Default)]
+pub struct PlGarbageCollectionConfig {
+    pub enabled: bool,
+    pub policy: PlGarbageCollectionPolicyConfig,
+}
+
+#[derive(Deserialize, Debug, Clone, Serialize)]
+pub struct RandomSamplePolicyConfig {
+    pub sample_size: f32,
+}
+
+impl Default for RandomSamplePolicyConfig {
+    fn default() -> Self {
+        RandomSamplePolicyConfig { sample_size: 0.1 }
+    }
 }

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -1838,7 +1838,9 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::{
-        config::PlGarbageCollectionConfig,
+        config::{
+            PlGarbageCollectionConfig, PlGarbageCollectionPolicyConfig, RandomSamplePolicyConfig,
+        },
         hnsw_provider::HnswIndexProvider,
         spann::types::{
             PlGarbageCollectionContext, SpannIndexReader, SpannIndexWriter, SpannIndexWriterError,
@@ -2069,12 +2071,16 @@ mod tests {
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
         let params = DistributedSpannParameters::default();
-        let gc_context = PlGarbageCollectionContext::try_from_config(
-            &PlGarbageCollectionConfig::default(),
-            &Registry::default(),
-        )
-        .await
-        .expect("Error converting config to gc context");
+        let pl_gc_policy = PlGarbageCollectionConfig {
+            enabled: true,
+            policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig {
+                sample_size: 1.0,
+            }),
+        };
+        let gc_context =
+            PlGarbageCollectionContext::try_from_config(&pl_gc_policy, &Registry::default())
+                .await
+                .expect("Error converting config to gc context");
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -2256,12 +2262,16 @@ mod tests {
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
         let params = DistributedSpannParameters::default();
-        let gc_context = PlGarbageCollectionContext::try_from_config(
-            &PlGarbageCollectionConfig::default(),
-            &Registry::default(),
-        )
-        .await
-        .expect("Error converting config to gc context");
+        let pl_gc_policy = PlGarbageCollectionConfig {
+            enabled: true,
+            policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig {
+                sample_size: 1.0,
+            }),
+        };
+        let gc_context =
+            PlGarbageCollectionContext::try_from_config(&pl_gc_policy, &Registry::default())
+                .await
+                .expect("Error converting config to gc context");
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -2690,12 +2700,16 @@ mod tests {
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
         let params = DistributedSpannParameters::default();
-        let gc_context = PlGarbageCollectionContext::try_from_config(
-            &PlGarbageCollectionConfig::default(),
-            &Registry::default(),
-        )
-        .await
-        .expect("Error converting config to gc context");
+        let pl_gc_policy = PlGarbageCollectionConfig {
+            enabled: true,
+            policy: PlGarbageCollectionPolicyConfig::RandomSample(RandomSamplePolicyConfig {
+                sample_size: 1.0,
+            }),
+        };
+        let gc_context =
+            PlGarbageCollectionContext::try_from_config(&pl_gc_policy, &Registry::default())
+                .await
+                .expect("Error converting config to gc context");
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,

--- a/rust/segment/src/lib.rs
+++ b/rust/segment/src/lib.rs
@@ -5,6 +5,7 @@ pub mod distributed_hnsw;
 pub mod distributed_spann;
 pub mod local_hnsw;
 pub mod local_segment_manager;
+pub mod spann_provider;
 pub mod sqlite_metadata;
 pub mod test;
 pub mod types;

--- a/rust/segment/src/spann_provider.rs
+++ b/rust/segment/src/spann_provider.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use chroma_blockstore::provider::BlockfileProvider;
+use chroma_config::{registry::Registry, Configurable};
+use chroma_error::ChromaError;
+use chroma_index::{
+    config::{GarbageCollectionPolicy, SpannProviderConfig},
+    hnsw_provider::HnswIndexProvider,
+};
+use chroma_types::Segment;
+
+use crate::distributed_spann::{SpannSegmentReader, SpannSegmentReaderError};
+
+pub struct GarbageCollection {
+    pub garbage_collection: bool,
+    pub garbage_collection_policy: GarbageCollectionPolicy,
+}
+
+pub struct SpannProvider {
+    pub hnsw_provider: HnswIndexProvider,
+    pub blockfile_provider: BlockfileProvider,
+    pub garbage_collection_config: GarbageCollection,
+}
+
+#[async_trait]
+impl Configurable<(HnswIndexProvider, BlockfileProvider, SpannProviderConfig)> for SpannProvider {
+    async fn try_from_config(
+        config: &(HnswIndexProvider, BlockfileProvider, SpannProviderConfig),
+        _registry: &Registry,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let garbage_collection_config = GarbageCollection {
+            garbage_collection: config.2.garbage_collection,
+            garbage_collection_policy: config.2.garbage_collection_policy.clone(),
+        };
+        Ok(SpannProvider {
+            hnsw_provider: config.0.clone(),
+            blockfile_provider: config.1.clone(),
+            garbage_collection_config,
+        })
+    }
+}
+
+impl SpannProvider {
+    pub async fn read(
+        &self,
+        segment: &Segment,
+        dimensionality: usize,
+    ) -> Result<SpannSegmentReader<'_>, SpannSegmentReaderError> {
+        SpannSegmentReader::from_segment(
+            segment,
+            &self.blockfile_provider,
+            &self.hnsw_provider,
+            dimensionality,
+        )
+        .await
+    }
+}

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -903,7 +903,10 @@ impl VectorSegmentWriter {
     }
 
     pub async fn finish(&mut self) -> Result<(), Box<dyn ChromaError>> {
-        Ok(())
+        match self {
+            VectorSegmentWriter::Hnsw(_) => Ok(()),
+            VectorSegmentWriter::Spann(writer) => writer.garbage_collect().await,
+        }
     }
 
     pub async fn commit(self) -> Result<ChromaSegmentFlusher, Box<dyn ChromaError>> {

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -145,5 +145,8 @@ compaction_service:
                 capacity: 8192 # 8192 MiB = 8GB
         permitted_parallelism: 180
     spann_provider:
-        garbage_collection: true
-        garbage_collection_policy: "random_10"
+        pl_garbage_collection:
+            enabled: true
+            policy:
+                random_sample:
+                    sample_size: 0.1

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -144,3 +144,6 @@ compaction_service:
             weighted_lru:
                 capacity: 8192 # 8192 MiB = 8GB
         permitted_parallelism: 180
+    spann_provider:
+        garbage_collection: true
+        garbage_collection_policy: "random_10"

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -15,6 +15,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::hnsw_provider::HnswIndexProvider;
 use chroma_log::Log;
 use chroma_memberlist::memberlist_provider::Memberlist;
+use chroma_segment::spann_provider::SpannProvider;
 use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_system::Dispatcher;
@@ -46,6 +47,7 @@ pub(crate) struct CompactionManager {
     storage: Storage,
     blockfile_provider: BlockfileProvider,
     hnsw_index_provider: HnswIndexProvider,
+    spann_provider: SpannProvider,
     // Dispatcher
     dispatcher: Option<ComponentHandle<Dispatcher>>,
     // Config
@@ -81,6 +83,7 @@ impl CompactionManager {
         storage: Storage,
         blockfile_provider: BlockfileProvider,
         hnsw_index_provider: HnswIndexProvider,
+        spann_provider: SpannProvider,
         compaction_manager_queue_size: usize,
         compaction_interval: Duration,
         min_compaction_size: usize,
@@ -95,6 +98,7 @@ impl CompactionManager {
             storage,
             blockfile_provider,
             hnsw_index_provider,
+            spann_provider,
             dispatcher: None,
             compaction_manager_queue_size,
             compaction_interval,
@@ -127,6 +131,7 @@ impl CompactionManager {
                     self.sysdb.clone(),
                     self.blockfile_provider.clone(),
                     self.hnsw_index_provider.clone(),
+                    self.spann_provider.clone(),
                     dispatcher,
                     None,
                     self.max_compaction_size,
@@ -261,6 +266,16 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
         )
         .await?;
 
+        let spann_provider = SpannProvider::try_from_config(
+            &(
+                hnsw_index_provider.clone(),
+                blockfile_provider.clone(),
+                config.spann_provider.clone(),
+            ),
+            registry,
+        )
+        .await?;
+
         Ok(CompactionManager::new(
             scheduler,
             log,
@@ -268,6 +283,7 @@ impl Configurable<CompactionServiceConfig> for CompactionManager {
             storage.clone(),
             blockfile_provider,
             hnsw_index_provider,
+            spann_provider,
             compaction_manager_queue_size,
             Duration::from_secs(compaction_interval_sec),
             min_compaction_size,
@@ -397,6 +413,8 @@ mod tests {
     use chroma_blockstore::arrow::config::TEST_MAX_BLOCK_SIZE_BYTES;
     use chroma_cache::{new_cache_for_test, new_non_persistent_cache_for_test};
     use chroma_config::assignment::assignment_policy::RendezvousHashingAssignmentPolicy;
+    use chroma_index::config::PlGarbageCollectionConfig;
+    use chroma_index::spann::types::PlGarbageCollectionContext;
     use chroma_log::in_memory_log::{InMemoryLog, InternalLogRecord};
     use chroma_memberlist::memberlist_provider::Member;
     use chroma_storage::local::LocalStorage;
@@ -607,24 +625,38 @@ mod tests {
         let sparse_index_cache = new_cache_for_test();
         let hnsw_cache = new_non_persistent_cache_for_test();
         let (_, rx) = tokio::sync::mpsc::unbounded_channel();
+        let gc_context = PlGarbageCollectionContext::try_from_config(
+            &PlGarbageCollectionConfig::default(),
+            &Registry::default(),
+        )
+        .await
+        .expect("Error converting config to gc context");
+        let blockfile_provider = BlockfileProvider::new_arrow(
+            storage.clone(),
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            block_cache,
+            sparse_index_cache,
+        );
+        let hnsw_provider = HnswIndexProvider::new(
+            storage.clone(),
+            PathBuf::from(tmpdir.path().to_str().unwrap()),
+            hnsw_cache,
+            16,
+            rx,
+        );
+        let spann_provider = SpannProvider {
+            hnsw_provider: hnsw_provider.clone(),
+            blockfile_provider: blockfile_provider.clone(),
+            garbage_collection_context: Some(gc_context),
+        };
         let mut manager = CompactionManager::new(
             scheduler,
             log,
             sysdb,
             storage.clone(),
-            BlockfileProvider::new_arrow(
-                storage.clone(),
-                TEST_MAX_BLOCK_SIZE_BYTES,
-                block_cache,
-                sparse_index_cache,
-            ),
-            HnswIndexProvider::new(
-                storage,
-                PathBuf::from(tmpdir.path().to_str().unwrap()),
-                hnsw_cache,
-                16,
-                rx,
-            ),
+            blockfile_provider,
+            hnsw_provider,
+            spann_provider,
             compaction_manager_queue_size,
             compaction_interval,
             min_compaction_size,

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -186,6 +186,8 @@ pub struct CompactionServiceConfig {
     pub blockfile_provider: chroma_blockstore::config::BlockfileProviderConfig,
     #[serde(default)]
     pub hnsw_provider: chroma_index::config::HnswProviderConfig,
+    #[serde(default)]
+    pub spann_provider: chroma_index::config::SpannProviderConfig,
 }
 
 impl CompactionServiceConfig {

--- a/rust/worker/src/execution/operators/spann_centers_search.rs
+++ b/rust/worker/src/execution/operators/spann_centers_search.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_segment::distributed_spann::{SpannSegmentReader, SpannSegmentReaderContext};
+use chroma_segment::distributed_spann::SpannSegmentReaderContext;
 use chroma_system::Operator;
 use thiserror::Error;
 
@@ -45,14 +45,15 @@ impl Operator<SpannCentersSearchInput, SpannCentersSearchOutput> for SpannCenter
         &self,
         input: &SpannCentersSearchInput,
     ) -> Result<SpannCentersSearchOutput, SpannCentersSearchError> {
-        let spann_reader = SpannSegmentReader::from_segment(
-            &input.reader_context.segment,
-            &input.reader_context.blockfile_provider,
-            &input.reader_context.hnsw_provider,
-            input.reader_context.dimension,
-        )
-        .await
-        .map_err(|_| SpannCentersSearchError::SpannSegmentReaderCreationError)?;
+        let spann_reader = input
+            .reader_context
+            .spann_provider
+            .read(
+                &input.reader_context.segment,
+                input.reader_context.dimension,
+            )
+            .await
+            .map_err(|_| SpannCentersSearchError::SpannSegmentReaderCreationError)?;
         // RNG Query.
         let res = spann_reader
             .rng_query(&input.normalized_query)

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::spann::types::SpannPosting;
-use chroma_segment::distributed_spann::{SpannSegmentReader, SpannSegmentReaderContext};
+use chroma_segment::distributed_spann::SpannSegmentReaderContext;
 use chroma_system::{Operator, OperatorType};
 use thiserror::Error;
 
@@ -53,14 +53,15 @@ impl Operator<SpannFetchPlInput, SpannFetchPlOutput> for SpannFetchPlOperator {
         &self,
         input: &SpannFetchPlInput,
     ) -> Result<SpannFetchPlOutput, SpannFetchPlError> {
-        let spann_reader = SpannSegmentReader::from_segment(
-            &input.reader_context.segment,
-            &input.reader_context.blockfile_provider,
-            &input.reader_context.hnsw_provider,
-            input.reader_context.dimension,
-        )
-        .await
-        .map_err(|_| SpannFetchPlError::SpannSegmentReaderCreationError)?;
+        let spann_reader = input
+            .reader_context
+            .spann_provider
+            .read(
+                &input.reader_context.segment,
+                input.reader_context.dimension,
+            )
+            .await
+            .map_err(|_| SpannFetchPlError::SpannSegmentReaderCreationError)?;
         let posting_list = spann_reader
             .fetch_posting_list(input.head_id)
             .await

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -40,7 +40,7 @@ use chroma_segment::blockfile_record::RecordSegmentReader;
 use chroma_segment::blockfile_record::RecordSegmentReaderCreationError;
 use chroma_segment::blockfile_record::RecordSegmentWriter;
 use chroma_segment::distributed_hnsw::DistributedHNSWSegmentWriter;
-use chroma_segment::distributed_spann::SpannSegmentWriter;
+use chroma_segment::spann_provider::SpannProvider;
 use chroma_segment::types::ChromaSegmentFlusher;
 use chroma_segment::types::ChromaSegmentWriter;
 use chroma_segment::types::MaterializeLogsResult;
@@ -120,6 +120,7 @@ pub struct CompactOrchestrator {
     sysdb: SysDb,
     blockfile_provider: BlockfileProvider,
     hnsw_index_provider: HnswIndexProvider,
+    spann_provider: SpannProvider,
     // State we hold across the execution
     pulled_log_offset: Option<i64>,
     // Dispatcher
@@ -248,6 +249,7 @@ impl CompactOrchestrator {
         sysdb: SysDb,
         blockfile_provider: BlockfileProvider,
         hnsw_index_provider: HnswIndexProvider,
+        spann_provider: SpannProvider,
         dispatcher: ComponentHandle<Dispatcher>,
         result_channel: Option<Sender<Result<CompactionResponse, CompactionError>>>,
         max_compaction_size: usize,
@@ -262,6 +264,7 @@ impl CompactOrchestrator {
             sysdb,
             blockfile_provider,
             hnsw_index_provider,
+            spann_provider,
             pulled_log_offset: None,
             dispatcher,
             num_uncompleted_materialization_tasks: 0,
@@ -571,7 +574,6 @@ impl CompactOrchestrator {
         // Nor should we create new writers across different tasks
 
         let blockfile_provider = self.blockfile_provider.clone();
-        let hnsw_provider = self.hnsw_index_provider.clone();
         let mut sysdb = self.sysdb.clone();
 
         let record_segment = self.get_segment(SegmentType::BlockfileRecord).await?;
@@ -656,13 +658,10 @@ impl CompactOrchestrator {
                         vector: VectorSegmentWriter::Hnsw(hnsw_segment_writer),
                     })
                 } else if vector_segment.r#type == SegmentType::Spann {
-                    let spann_writer = match SpannSegmentWriter::from_segment(
-                        &vector_segment,
-                        &blockfile_provider,
-                        &hnsw_provider,
-                        dim as usize,
-                    )
-                    .await
+                    let spann_writer = match self
+                        .spann_provider
+                        .write(&vector_segment, dim as usize)
+                        .await
                     {
                         Ok(writer) => writer,
                         Err(e) => {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -6,6 +6,7 @@ use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
 use chroma_index::hnsw_provider::HnswIndexProvider;
 use chroma_log::Log;
+use chroma_segment::spann_provider::SpannProvider;
 use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
@@ -284,13 +285,17 @@ impl WorkerServer {
         let pulled_log_bytes = matching_records.fetch_log_bytes;
 
         if vector_segment_type == SegmentType::Spann {
-            tracing::info!("Running KNN on SPANN segment");
+            tracing::debug!("Running KNN on SPANN segment");
+            let spann_provider = SpannProvider {
+                hnsw_provider: self.hnsw_index_provider.clone(),
+                blockfile_provider: self.blockfile_provider.clone(),
+                garbage_collection_context: None,
+            };
             let knn_orchestrator_futures = from_proto_knn(knn)?
                 .into_iter()
                 .map(|knn| {
                     SpannKnnOrchestrator::new(
-                        self.blockfile_provider.clone(),
-                        self.hnsw_index_provider.clone(),
+                        spann_provider.clone(),
                         dispatcher.clone(),
                         1000,
                         matching_records.clone(),

--- a/rust/worker/tests/config_from_default_path.rs
+++ b/rust/worker/tests/config_from_default_path.rs
@@ -1,3 +1,4 @@
+use chroma_index::config::PlGarbageCollectionPolicyConfig;
 use figment::Jail;
 use serial_test::serial;
 use uuid::Uuid;
@@ -139,6 +140,12 @@ fn test_config_from_default_path() {
                         disk:
                             capacity: 8589934592 # 8GB
                             eviction: lru
+                spann_provider:
+                    pl_garbage_collection:
+                        enabled: true
+                        policy:
+                            random_sample:
+                                sample_size: 0.1
             "#,
         );
         let config = RootConfig::load();
@@ -166,6 +173,23 @@ fn test_config_from_default_path() {
             Uuid::parse_str(&config.compaction_service.compactor.disabled_collections[1]).unwrap(),
             Uuid::parse_str("496db4aa-fbe1-498a-b60b-81ec0fe59792").unwrap()
         );
+        assert!(
+            config
+                .compaction_service
+                .spann_provider
+                .pl_garbage_collection
+                .enabled
+        );
+        match config
+            .compaction_service
+            .spann_provider
+            .pl_garbage_collection
+            .policy
+        {
+            PlGarbageCollectionPolicyConfig::RandomSample(config) => {
+                assert_eq!(config.sample_size, 0.1);
+            }
+        }
         Ok(())
     });
 }

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -1,3 +1,4 @@
+use chroma_index::config::PlGarbageCollectionPolicyConfig;
 use figment::Jail;
 use serial_test::serial;
 use worker::config::RootConfig;
@@ -138,6 +139,12 @@ fn test_config_from_specific_path() {
                         disk:
                             capacity: 1073741824
                             eviction: lru
+                spann_provider:
+                    pl_garbage_collection:
+                        enabled: true
+                        policy:
+                            random_sample:
+                                sample_size: 0.1
             "#,
         );
         let config = RootConfig::load_from_path("random_path.yaml");
@@ -149,6 +156,23 @@ fn test_config_from_specific_path() {
             "compaction-service-0"
         );
         assert_eq!(config.compaction_service.my_port, 50051);
+        assert!(
+            config
+                .compaction_service
+                .spann_provider
+                .pl_garbage_collection
+                .enabled
+        );
+        match config
+            .compaction_service
+            .spann_provider
+            .pl_garbage_collection
+            .policy
+        {
+            PlGarbageCollectionPolicyConfig::RandomSample(config) => {
+                assert_eq!(config.sample_size, 0.1);
+            }
+        }
         Ok(())
     });
 }

--- a/rust/worker/tests/config_missing_default_field.rs
+++ b/rust/worker/tests/config_missing_default_field.rs
@@ -1,3 +1,4 @@
+use chroma_index::config::PlGarbageCollectionPolicyConfig;
 use figment::Jail;
 use worker::config::RootConfig;
 
@@ -144,6 +145,23 @@ fn test_missing_default_field() {
             config.compaction_service.my_member_id,
             "compaction-service-0"
         );
+        assert!(
+            !config
+                .compaction_service
+                .spann_provider
+                .pl_garbage_collection
+                .enabled
+        );
+        match config
+            .compaction_service
+            .spann_provider
+            .pl_garbage_collection
+            .policy
+        {
+            PlGarbageCollectionPolicyConfig::RandomSample(config) => {
+                assert_eq!(config.sample_size, 0.1);
+            }
+        }
         Ok(())
     });
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Introduces spann provider similar to blockfile_provider and hnsw_provider
   - Introduces config for Garbage collection for spann
   - Plumbs config all the way to the writer. For readers it is none
   - Implement random sample x% of data and GC policy
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
