### PR TITLE
[ENH]: add readiness probes to all services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7458,6 +7458,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-health"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
+dependencies = [
+ "async-stream",
+ "prost 0.13.3",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8561,6 +8574,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "tonic-health",
  "tracing",
  "tracing-bunyan-formatter",
  "tracing-opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic",
+ "tonic-health",
  "tower 0.5.2",
  "tracing",
  "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1.0.69"
 tokio = { version = "1.41", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-util = "0.7.12"
 tonic = "0.12"
+tonic-health = "0.12.3"
 tower = "0.5"
 backon = "1.3.0"
 tracing = { version = "0.1" }

--- a/go/cmd/logservice/main.go
+++ b/go/cmd/logservice/main.go
@@ -21,6 +21,8 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func main() {
@@ -54,6 +56,9 @@ func main() {
 		log.Fatal("failed to listen", zap.Error(err))
 	}
 	s := grpc.NewServer(grpc.UnaryInterceptor(sharedOtel.ServerGrpcInterceptor))
+	healthcheck := health.NewServer()
+	healthgrpc.RegisterHealthServer(s, healthcheck)
+
 	logservicepb.RegisterLogServiceServer(s, server)
 	log.Info("log service started", zap.String("address", listener.Addr().String()))
 	go leader.AcquireLeaderLock(ctx, func(ctx context.Context) {

--- a/go/pkg/sysdb/grpc/server.go
+++ b/go/pkg/sysdb/grpc/server.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Config struct {
@@ -159,10 +161,13 @@ func NewWithGrpcProvider(config Config, provider grpcutils.GrpcProvider) (*Serve
 		log.Info("Starting GRPC server")
 		s.grpcServer, err = provider.StartGrpcServer("coordinator", config.GrpcConfig, func(registrar grpc.ServiceRegistrar) {
 			coordinatorpb.RegisterSysDBServer(registrar, s)
+			healthgrpc.RegisterHealthServer(registrar, s.healthServer)
 		})
 		if err != nil {
 			return nil, err
 		}
+
+		s.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	}
 	return s, nil
 }

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.28
+version: 0.1.29
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -45,6 +45,9 @@ spec:
         - name: compaction-service
           image: "{{ .Values.compactionService.image.repository }}:{{ .Values.compactionService.image.tag }}"
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            grpc:
+              port: 50051
           volumeMounts:
             {{if .Values.compactionService.configuration}}
             - name: compaction-service-config

--- a/k8s/distributed-chroma/templates/logservice.yaml
+++ b/k8s/distributed-chroma/templates/logservice.yaml
@@ -35,6 +35,9 @@ spec:
           ports:
             - containerPort: 50051
               name: grpc
+          readinessProbe:
+            grpc:
+              port: 50051
           {{ if .Values.logService.resources }}
           resources:
             limits:

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -64,6 +64,9 @@ spec:
         - name: query-service
           image: "{{ .Values.queryService.image.repository }}:{{ .Values.queryService.image.tag }}"
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            grpc:
+              port: 50051
           volumeMounts:
             {{if .Values.queryService.configuration}}
             - name: query-service-config

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -35,6 +35,9 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 50051
+          readinessProbe:
+            grpc:
+              port: 50051
           {{ if .Values.rustLogService.resources }}
           resources:
             limits:

--- a/k8s/distributed-chroma/templates/sysdb-service.yaml
+++ b/k8s/distributed-chroma/templates/sysdb-service.yaml
@@ -28,6 +28,9 @@ spec:
             {{ end }}
           image: "{{ .Values.sysdb.image.repository }}:{{ .Values.sysdb.image.tag }}"
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            grpc:
+              port: 50051
           name: sysdb
           ports:
             - containerPort: 50051

--- a/rust/log/Cargo.toml
+++ b/rust/log/Cargo.toml
@@ -15,6 +15,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tonic = { workspace = true }
+tonic-health = { workspace = true }
 tracing = { workspace = true }
 # Used by tracing
 tracing-opentelemetry = { workspace = true }

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -43,6 +43,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
+tonic-health = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 num_cpus = { workspace = true }

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -273,6 +273,10 @@ impl Scheduler {
     pub(crate) fn set_memberlist(&mut self, memberlist: Memberlist) {
         self.memberlist = Some(memberlist);
     }
+
+    pub(crate) fn has_memberlist(&self) -> bool {
+        self.memberlist.is_some()
+    }
 }
 
 #[cfg(test)]

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -12,7 +12,6 @@ use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
 use chroma_tracing::util::wrap_span_with_parent_context;
 use chroma_types::{
     chroma_proto::{
-        self,
         query_executor_server::{QueryExecutor, QueryExecutorServer},
         CountPlan, CountResult, GetPlan, GetResult, KnnBatchResult, KnnPlan,
     },
@@ -96,8 +95,9 @@ impl WorkerServer {
             .add_service(QueryExecutorServer::new(worker.clone()));
 
         #[cfg(debug_assertions)]
-        let server =
-            server.add_service(chroma_proto::debug_server::DebugServer::new(worker.clone()));
+        let server = server.add_service(
+            chroma_types::chroma_proto::debug_server::DebugServer::new(worker.clone()),
+        );
 
         let server = server.serve_with_shutdown(addr, async {
             let mut sigterm = match signal(SignalKind::terminate()) {
@@ -400,17 +400,17 @@ impl QueryExecutor for WorkerServer {
 
 #[cfg(debug_assertions)]
 #[async_trait]
-impl chroma_proto::debug_server::Debug for WorkerServer {
+impl chroma_types::chroma_proto::debug_server::Debug for WorkerServer {
     async fn get_info(
         &self,
         request: Request<()>,
-    ) -> Result<Response<chroma_proto::GetInfoResponse>, Status> {
+    ) -> Result<Response<chroma_types::chroma_proto::GetInfoResponse>, Status> {
         // Note: We cannot write a middleware that instruments every service rpc
         // with a span because of https://github.com/hyperium/tonic/pull/1202.
         let request_span = trace_span!("Get info");
 
         wrap_span_with_parent_context(request_span, request.metadata()).in_scope(|| {
-            let response = chroma_proto::GetInfoResponse {
+            let response = chroma_types::chroma_proto::GetInfoResponse {
                 version: option_env!("CARGO_PKG_VERSION")
                     .unwrap_or("unknown")
                     .to_string(),
@@ -437,13 +437,14 @@ mod tests {
     use super::*;
     use chroma_index::test_hnsw_index_provider;
     use chroma_log::in_memory_log::InMemoryLog;
-    #[cfg(debug_assertions)]
-    use chroma_proto::debug_client::DebugClient;
-    use chroma_proto::query_executor_client::QueryExecutorClient;
     use chroma_segment::test::TestDistributedSegment;
     use chroma_sysdb::TestSysDb;
     use chroma_system::system;
     use chroma_system::DispatcherConfig;
+    use chroma_types::chroma_proto;
+    #[cfg(debug_assertions)]
+    use chroma_types::chroma_proto::debug_client::DebugClient;
+    use chroma_types::chroma_proto::query_executor_client::QueryExecutorClient;
     use uuid::Uuid;
 
     fn run_server() -> String {


### PR DESCRIPTION
## Description of changes

Adds a readiness probe to all services.

## Test plan
*How are these changes tested?*

Confirmed that the probe result showed up in `kubectl` and that all services in Tilt were green.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a