### PR TITLE
[ENH]: better axum errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
 name = "chroma-error"
 version = "0.1.0"
 dependencies = [
+ "http 1.1.0",
  "sqlx",
  "thiserror 1.0.69",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ sha2 = "0.10.8"
 md5 = "0.7.0"
 regex = "1.11.1"
 pyo3 = { version = "0.23.3", features = ["abi3-py39"] }
+http = "1.1.0"
 tower-http = { version = "0.6.2", features = ["trace", "cors"] }
 bytemuck = "1.21.0"
 rayon = "1.10.0"

--- a/rust/error/Cargo.toml
+++ b/rust/error/Cargo.toml
@@ -11,8 +11,10 @@ tonic = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 validator = { workspace = true, optional = true }
 thiserror = { workspace = true }
+http = { workspace = true, optional = true }
 
 [features]
 tonic = ["dep:tonic"]
 sqlx = ["dep:sqlx"]
 validator = ["dep:validator"]
+http = ["dep:http"]

--- a/rust/error/src/lib.rs
+++ b/rust/error/src/lib.rs
@@ -58,6 +58,18 @@ pub enum ErrorCodes {
     VersionMismatch = 17,
 }
 
+impl ErrorCodes {
+    pub fn name(&self) -> &'static str {
+        match self {
+            ErrorCodes::InvalidArgument => "InvalidArgumentError",
+            ErrorCodes::NotFound => "NotFoundError",
+            ErrorCodes::Internal => "InternalError",
+            ErrorCodes::VersionMismatch => "VersionMismatchError",
+            _ => "ChromaError",
+        }
+    }
+}
+
 pub trait ChromaError: Error + Send {
     fn code(&self) -> ErrorCodes;
     fn boxed(self) -> Box<dyn ChromaError>

--- a/rust/error/src/lib.rs
+++ b/rust/error/src/lib.rs
@@ -97,9 +97,9 @@ impl From<ErrorCodes> for http::StatusCode {
 }
 
 #[cfg(feature = "http")]
-impl Into<ErrorCodes> for http::StatusCode {
-    fn into(self) -> ErrorCodes {
-        match self {
+impl From<http::StatusCode> for ErrorCodes {
+    fn from(value: http::StatusCode) -> Self {
+        match value {
             http::StatusCode::OK => ErrorCodes::Success,
             http::StatusCode::BAD_REQUEST => ErrorCodes::InvalidArgument,
             http::StatusCode::UNAUTHORIZED => ErrorCodes::Unauthenticated,

--- a/rust/error/src/lib.rs
+++ b/rust/error/src/lib.rs
@@ -70,6 +70,53 @@ impl ErrorCodes {
     }
 }
 
+#[cfg(feature = "http")]
+impl From<ErrorCodes> for http::StatusCode {
+    fn from(error_code: ErrorCodes) -> Self {
+        match error_code {
+            ErrorCodes::Success => http::StatusCode::OK,
+            ErrorCodes::Cancelled => http::StatusCode::BAD_REQUEST,
+            ErrorCodes::Unknown => http::StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorCodes::InvalidArgument => http::StatusCode::BAD_REQUEST,
+            ErrorCodes::DeadlineExceeded => http::StatusCode::GATEWAY_TIMEOUT,
+            ErrorCodes::NotFound => http::StatusCode::NOT_FOUND,
+            ErrorCodes::AlreadyExists => http::StatusCode::CONFLICT,
+            ErrorCodes::PermissionDenied => http::StatusCode::FORBIDDEN,
+            ErrorCodes::ResourceExhausted => http::StatusCode::TOO_MANY_REQUESTS,
+            ErrorCodes::FailedPrecondition => http::StatusCode::PRECONDITION_FAILED,
+            ErrorCodes::Aborted => http::StatusCode::BAD_REQUEST,
+            ErrorCodes::OutOfRange => http::StatusCode::BAD_REQUEST,
+            ErrorCodes::Unimplemented => http::StatusCode::NOT_IMPLEMENTED,
+            ErrorCodes::Internal => http::StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorCodes::Unavailable => http::StatusCode::SERVICE_UNAVAILABLE,
+            ErrorCodes::DataLoss => http::StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorCodes::Unauthenticated => http::StatusCode::UNAUTHORIZED,
+            ErrorCodes::VersionMismatch => http::StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+#[cfg(feature = "http")]
+impl Into<ErrorCodes> for http::StatusCode {
+    fn into(self) -> ErrorCodes {
+        match self {
+            http::StatusCode::OK => ErrorCodes::Success,
+            http::StatusCode::BAD_REQUEST => ErrorCodes::InvalidArgument,
+            http::StatusCode::UNAUTHORIZED => ErrorCodes::Unauthenticated,
+            http::StatusCode::FORBIDDEN => ErrorCodes::PermissionDenied,
+            http::StatusCode::NOT_FOUND => ErrorCodes::NotFound,
+            http::StatusCode::CONFLICT => ErrorCodes::AlreadyExists,
+            http::StatusCode::TOO_MANY_REQUESTS => ErrorCodes::ResourceExhausted,
+            http::StatusCode::INTERNAL_SERVER_ERROR => ErrorCodes::Internal,
+            http::StatusCode::SERVICE_UNAVAILABLE => ErrorCodes::Unavailable,
+            http::StatusCode::NOT_IMPLEMENTED => ErrorCodes::Unimplemented,
+            http::StatusCode::GATEWAY_TIMEOUT => ErrorCodes::DeadlineExceeded,
+            http::StatusCode::PRECONDITION_FAILED => ErrorCodes::FailedPrecondition,
+            _ => ErrorCodes::Unknown,
+        }
+    }
+}
+
 pub trait ChromaError: Error + Send {
     fn code(&self) -> ErrorCodes;
     fn boxed(self) -> Box<dyn ChromaError>

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -34,7 +34,7 @@ rust-embed = { workspace = true }
 chroma-cache = { workspace = true }
 chroma-config = { workspace = true }
 chroma-distance = { workspace = true }
-chroma-error = { workspace = true, features = ["validator"] }
+chroma-error = { workspace = true, features = ["validator", "http"] }
 chroma-log = { workspace = true }
 chroma-memberlist = { workspace = true }
 chroma-segment = { workspace = true }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -9,6 +9,7 @@ pub mod frontend;
 pub mod get_collection_with_segments_provider;
 pub mod quota;
 mod server;
+mod server_middleware;
 mod tower_tracing;
 mod types;
 

--- a/rust/frontend/src/server_middleware.rs
+++ b/rust/frontend/src/server_middleware.rs
@@ -1,0 +1,63 @@
+use axum::http::{header, StatusCode};
+use axum::response::IntoResponse;
+use axum::{extract::Request, middleware::Next, response::Response, Json};
+
+use crate::types::errors::status_code_to_chroma_error;
+
+/// If the request does not have a `Content-Type` header, set it to `application/json`.
+pub(crate) async fn default_json_content_type_middleware(mut req: Request, next: Next) -> Response {
+    if req
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .is_none()
+    {
+        req.headers_mut().insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("application/json"),
+        );
+    }
+    next.run(req).await
+}
+
+/// Axum occasionally returns generic errors as plain text. Chroma clients expect that JSON errors will always be returned, so this middleware converts plain text errors to JSON.
+///
+/// Inspired by https://github.com/rust-lang/crates.io/blob/edcf93b071d3564e497c7a984fd411a760db28b5/src/middleware/cargo_compat.rs
+pub(crate) async fn always_json_errors_middleware(req: Request, next: Next) -> Response {
+    let res = next.run(req).await;
+
+    let status = res.status();
+    if !status.is_client_error() && !status.is_server_error() {
+        return res;
+    }
+
+    let content_type = res.headers().get("content-type");
+    if !matches!(content_type, Some(content_type) if content_type == "text/plain; charset=utf-8") {
+        return res;
+    }
+
+    let (mut parts, body) = res.into_parts();
+
+    // The `Json` struct is somehow not able to override these headers of the
+    // `Parts` struct, so we remove them here to avoid the conflict.
+    parts.headers.remove(header::CONTENT_TYPE);
+    parts.headers.remove(header::CONTENT_LENGTH);
+
+    let bytes = match axum::body::to_bytes(body, 1_000_000).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::error!("Failed to read response body: {}", err);
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    let text = match std::str::from_utf8(&bytes) {
+        Ok(text) => text,
+        Err(_) => {
+            tracing::error!("Failed to parse response body as UTF-8");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let error_code = status_code_to_chroma_error(status);
+    let json = serde_json::json!({ "error": error_code.name(), "message": text });
+    (parts, Json(json)).into_response()
+}

--- a/rust/frontend/src/server_middleware.rs
+++ b/rust/frontend/src/server_middleware.rs
@@ -30,7 +30,7 @@ pub(crate) async fn always_json_errors_middleware(req: Request, next: Next) -> R
     }
 
     let content_type = res.headers().get("content-type");
-    if let Some("text/plain; charset=utf-8") = content_type.and_then(|v| v.to_str().ok()) {
+    if !matches!(content_type, Some(content_type) if content_type == "text/plain; charset=utf-8") {
         return res;
     }
 

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -39,47 +39,6 @@ impl ChromaError for ValidationError {
     }
 }
 
-pub(crate) fn chroma_error_code_to_status_code(error_code: ErrorCodes) -> StatusCode {
-    match error_code {
-        ErrorCodes::Success => StatusCode::OK,
-        ErrorCodes::Cancelled => StatusCode::BAD_REQUEST,
-        ErrorCodes::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorCodes::InvalidArgument => StatusCode::BAD_REQUEST,
-        ErrorCodes::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
-        ErrorCodes::NotFound => StatusCode::NOT_FOUND,
-        ErrorCodes::AlreadyExists => StatusCode::CONFLICT,
-        ErrorCodes::PermissionDenied => StatusCode::FORBIDDEN,
-        ErrorCodes::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
-        ErrorCodes::FailedPrecondition => StatusCode::PRECONDITION_FAILED,
-        ErrorCodes::Aborted => StatusCode::BAD_REQUEST,
-        ErrorCodes::OutOfRange => StatusCode::BAD_REQUEST,
-        ErrorCodes::Unimplemented => StatusCode::NOT_IMPLEMENTED,
-        ErrorCodes::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorCodes::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-        ErrorCodes::DataLoss => StatusCode::INTERNAL_SERVER_ERROR,
-        ErrorCodes::Unauthenticated => StatusCode::UNAUTHORIZED,
-        ErrorCodes::VersionMismatch => StatusCode::INTERNAL_SERVER_ERROR,
-    }
-}
-
-pub(crate) fn status_code_to_chroma_error(status_code: StatusCode) -> ErrorCodes {
-    match status_code {
-        StatusCode::OK => ErrorCodes::Success,
-        StatusCode::BAD_REQUEST => ErrorCodes::InvalidArgument,
-        StatusCode::UNAUTHORIZED => ErrorCodes::Unauthenticated,
-        StatusCode::FORBIDDEN => ErrorCodes::PermissionDenied,
-        StatusCode::NOT_FOUND => ErrorCodes::NotFound,
-        StatusCode::CONFLICT => ErrorCodes::AlreadyExists,
-        StatusCode::TOO_MANY_REQUESTS => ErrorCodes::ResourceExhausted,
-        StatusCode::INTERNAL_SERVER_ERROR => ErrorCodes::Internal,
-        StatusCode::SERVICE_UNAVAILABLE => ErrorCodes::Unavailable,
-        StatusCode::NOT_IMPLEMENTED => ErrorCodes::Unimplemented,
-        StatusCode::GATEWAY_TIMEOUT => ErrorCodes::DeadlineExceeded,
-        StatusCode::PRECONDITION_FAILED => ErrorCodes::FailedPrecondition,
-        _ => ErrorCodes::Unknown,
-    }
-}
-
 /// Wrapper around `dyn ChromaError` that implements `IntoResponse`. This means that route handlers can return `Result<_, ServerError>` and use the `?` operator to return arbitrary errors.
 pub struct ServerError(Box<dyn ChromaError>);
 
@@ -110,7 +69,7 @@ impl ErrorResponse {
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         tracing::error!("Error: {:?}", self.0);
-        let status_code = chroma_error_code_to_status_code(self.0.code());
+        let status_code: StatusCode = self.0.code().into();
 
         let error = ErrorResponse {
             error: self.0.code().name().to_string(),


### PR DESCRIPTION
## Description of changes

By default, axum returns some built-in errors (like invalid JSON) as a plaintext response. This adds middleware so that these errors are converted to JSON and don't break clients.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added a test that fails on main.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a