### PR TITLE
Docs: Update docker tag in documentation

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
+++ b/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
@@ -28,7 +28,7 @@ You can run a Chroma server in a Docker container, and access it using the `Http
 To start the server, run:
 
 ```terminal
-docker run -v ./chroma-data:/data -p 8000:8000 chroma-core/chroma
+docker run -v ./chroma-data:/data -p 8000:8000 chromadb/chroma
 ```
 
 This starts the server with the default configuration and stores data in `./chroma-data` (in your current working directory).


### PR DESCRIPTION


## Description of changes

*Summarize the changes made by this PR.*
The documentation for starting a container says to use `chroma-core/chroma`, which does not exist on the docker hub - it is called `chromadb/chroma` on the[ Docker Hub.](https://hub.docker.com/r/chromadb/chroma)

In order to pull and start a container the tag needs to be corrected.

## Test plan
*How are these changes tested?*
- Correct command pulls docker image on fresh OS

## Documentation Changes
- [x] *Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
