### PR TITLE
[ENH] Spann: remove duplicates + not prune in query

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     env:
       CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +20,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
       - name: Test
-        run: cargo nextest run
+        run: cargo nextest run --no-capture
   test-integration:
     strategy:
       matrix:
@@ -56,6 +57,7 @@ jobs:
         platform: [depot-ubuntu-22.04-16]
     runs-on: ${{ matrix.platform }}
     env:
+      RUST_BACKTRACE: 1
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -26,7 +26,7 @@ pub use unbounded::UnboundedCacheConfig;
 pub enum CacheError {
     #[error("Invalid cache config")]
     InvalidCacheConfig(String),
-    #[error("I/O error when serving from cache")]
+    #[error("I/O error when serving from cache {0}")]
     DiskError(#[from] anyhow::Error),
 }
 

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -990,8 +990,6 @@ impl SpannIndexWriter {
                     .map_err(|_| SpannIndexWriterError::PostingListSetError)?;
             }
             // Next add to hnsw.
-            // This shouldn't exceed the capacity since this will happen only for the first few points
-            // so no need to check and increase the capacity.
             {
                 let mut write_guard = self.hnsw_index.inner.write();
                 let hnsw_len = write_guard.len_with_deleted();
@@ -1011,8 +1009,7 @@ impl SpannIndexWriter {
         }
         // Otherwise add to the posting list of these arrays.
         for (head_id, head_embedding) in ids.iter().zip(head_embeddings) {
-            self.append(*head_id as u32, id, version, embeddings, head_embedding)
-                .await?;
+            Box::pin(self.append(*head_id as u32, id, version, embeddings, head_embedding)).await?;
         }
 
         Ok(())

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -1660,6 +1660,7 @@ impl<'me> SpannIndexReader<'me> {
             .ok_or(SpannIndexReaderError::PostingListReadError)?;
 
         let mut posting_lists = Vec::with_capacity(res.doc_offset_ids.len());
+        let mut unique_ids = HashSet::new();
         for (index, doc_offset_id) in res.doc_offset_ids.iter().enumerate() {
             if self
                 .is_outdated(*doc_offset_id, res.doc_versions[index])
@@ -1667,6 +1668,10 @@ impl<'me> SpannIndexReader<'me> {
             {
                 continue;
             }
+            if unique_ids.contains(doc_offset_id) {
+                continue;
+            }
+            unique_ids.insert(*doc_offset_id);
             posting_lists.push(SpannPosting {
                 doc_offset_id: *doc_offset_id,
                 doc_embedding: res.doc_embeddings

--- a/rust/index/src/spann/utils.rs
+++ b/rust/index/src/spann/utils.rs
@@ -541,7 +541,7 @@ pub async fn rng_query(
             .query(normalized_query, k, &allowed_ids, &disallowed_ids)
             .map_err(|_| RngQueryError::HnswSearchError)?;
         for (id, distance) in ids.iter().zip(distances.iter()) {
-            if *distance <= (1_f32 + rng_epsilon) * distances[0] {
+            if !apply_rng_rule || *distance <= (1_f32 + rng_epsilon) * distances[0] {
                 nearby_ids.push(*id);
                 nearby_distances.push(*distance);
             }

--- a/rust/types/src/hnsw_parameters.rs
+++ b/rust/types/src/hnsw_parameters.rs
@@ -291,7 +291,7 @@ impl ChromaError for DistributedSpannParametersFromSegmentError {
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
 pub struct DistributedSpannParameters {
     #[serde(rename = "spann:search_nprobe", default = "default_search_nprobe")]
-    #[validate(range(min = 8))]
+    #[validate(range(min = 32))]
     pub search_nprobe: u32,
     #[serde(
         rename = "spann:search_rng_factor",

--- a/rust/worker/src/execution/operators/spann_centers_search.rs
+++ b/rust/worker/src/execution/operators/spann_centers_search.rs
@@ -12,7 +12,6 @@ pub(crate) struct SpannCentersSearchInput {
     pub(crate) normalized_query: Vec<f32>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct SpannCentersSearchOutput {
     pub(crate) center_ids: Vec<usize>,
@@ -37,13 +36,6 @@ impl ChromaError for SpannCentersSearchError {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SpannCentersSearchOperator {}
-
-impl SpannCentersSearchOperator {
-    #[allow(dead_code)]
-    pub fn new() -> Box<Self> {
-        Box::new(SpannCentersSearchOperator {})
-    }
-}
 
 #[async_trait]
 impl Operator<SpannCentersSearchInput, SpannCentersSearchOutput> for SpannCentersSearchOperator {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Removes duplicates during merge
   - Removes pruning when searching centers in hnsw
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
Added operator test for merge
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
