### PR TITLE
[BUG]: fix cache insert order

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -164,7 +164,7 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
     uses: ./.github/workflows/_python-tests.yml
     with:
-      property_testing_preset: 'fast'
+      property_testing_preset: 'normal'
 
   python-vulnerability-scan:
     name: Python vulnerability scan

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -768,4 +768,31 @@ mod test {
             .expect("Value should not be None");
         assert_eq!(value, large_value);
     }
+
+    #[tokio::test]
+    async fn test_inserted_key_immediately_available() {
+        let dir = tempfile::tempdir()
+            .expect("To be able to create temp path")
+            .path()
+            .to_str()
+            .expect("To be able to parse path")
+            .to_string();
+        let cache = FoyerCacheConfig {
+            dir: Some(dir.clone()),
+            flush: true,
+            ..Default::default()
+        }
+        .build_hybrid_test::<String, String>()
+        .await
+        .unwrap();
+
+        cache.insert("key1".to_string(), "foo".to_string()).await;
+
+        let value = cache
+            .get(&"key1".to_string())
+            .await
+            .expect("Expected to be able to get value")
+            .expect("Value should not be None");
+        assert_eq!(value, "foo");
+    }
 }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -465,9 +465,10 @@ where
 
     async fn insert(&self, key: K, value: V) {
         let _stopwatch = Stopwatch::new(&self.insert_latency);
-        self.cache.insert(key.clone(), value.clone());
-        // Also insert to the disk cache.
-        self.insert_to_disk(key, value);
+        // Immediately insert to the disk cache
+        self.insert_to_disk(key.clone(), value.clone());
+        // Insert to the in-memory cache
+        self.cache.insert(key, value);
     }
 
     async fn remove(&self, key: &K) {


### PR DESCRIPTION
## Description of changes

Resolves errors like 

> Error running Filter Operator: Error reading metadata index: Full text index error: Blockfile write error: I/O error when serving from cache bincode error: Parser error: Arrow file does not contain correct footer

seen in CI (e.x. https://github.com/chroma-core/chroma/actions/runs/13921206137/job/38968795196#step:5:1968).

This does not actually resolve the root issue or track down the cause, but sidesteps it for now since most (all?) cache reads in CI tests can be served from memory.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added test currently fails on main.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a