### PR TITLE
[ENH] CLI profile management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,8 +1397,11 @@ dependencies = [
  "colored",
  "dialoguer",
  "indicatif",
+ "serde",
+ "serde_json",
  "sqlx",
  "tokio",
+ "toml",
  "webbrowser",
 ]
 
@@ -6371,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -7381,9 +7384,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -7402,9 +7405,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
@@ -8493,9 +8496,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
  "chroma-types",
  "clap",
  "criterion",
- "dirs",
+ "dirs 5.0.1",
  "futures",
  "indicatif",
  "rand 0.8.5",
@@ -1396,6 +1396,7 @@ dependencies = [
  "clap",
  "colored",
  "dialoguer",
+ "dirs 6.0.0",
  "indicatif",
  "serde",
  "serde_json",
@@ -2367,7 +2368,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2378,8 +2388,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5700,6 +5722,17 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "tokio",
  "toml",
  "webbrowser",

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -22,7 +22,8 @@ chroma-types = { workspace = true }
 chroma-log = { workspace = true }
 serde = { version = "1.0.215", features = ["derive"] }
 toml = "0.8.20"
-serde_json = "1.0.133"
+serde_json = { workspace = true }
+dirs = "6.0.0"
 tempfile = "3.14.0"
 
 

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -20,6 +20,9 @@ chroma-segment = { workspace = true }
 chroma-sysdb = { workspace = true }
 chroma-types = { workspace = true }
 chroma-log = { workspace = true }
+serde = { version = "1.0.215", features = ["derive"] }
+toml = "0.8.20"
+serde_json = "1.0.133"
 
 
 [[bin]]

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -23,6 +23,7 @@ chroma-log = { workspace = true }
 serde = { version = "1.0.215", features = ["derive"] }
 toml = "0.8.20"
 serde_json = "1.0.133"
+tempfile = "3.14.0"
 
 
 [[bin]]

--- a/rust/cli/src/commands/mod.rs
+++ b/rust/cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod run;
 pub mod vacuum;
+pub mod profile;

--- a/rust/cli/src/commands/mod.rs
+++ b/rust/cli/src/commands/mod.rs
@@ -1,3 +1,3 @@
+pub mod profile;
 pub mod run;
 pub mod vacuum;
-pub mod profile;

--- a/rust/cli/src/commands/profile.rs
+++ b/rust/cli/src/commands/profile.rs
@@ -1,0 +1,149 @@
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use crate::utils::{get_profiles, read_config, write_config, write_profiles};
+
+#[derive(Args, Debug)]
+pub struct DeleteArgs {
+    name: String,
+}
+
+#[derive(Args, Debug)]
+pub struct UseArgs {
+    name: String,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ProfileCommand {
+    Delete(DeleteArgs),
+    List,
+    Show,
+    Use(UseArgs),
+}
+
+#[allow(dead_code)]
+fn delete_profile(args: DeleteArgs) {
+    let mut profiles = match get_profiles() {
+        Ok(profiles) => profiles,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load profiles".red());
+            return;
+        }
+    };
+    let profile = args.name;
+
+    if !profiles.contains_key(&profile) {
+        let message = format!("Profile {} not found", profile);
+        eprintln!("\n{}\n", message.red());
+        return;
+    }
+
+    let mut config = match read_config() {
+        Ok(config) => config,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load CLI config".red());
+            return;
+        }
+    };
+
+    if config.current_profile == profile {
+        config.current_profile = "".to_string();
+        match write_config(&config) {
+            Ok(_) => {}
+            Err(_) => {
+                eprintln!("\n{}\n", "Failed to save CLI config".red());
+                return;
+            }
+        };
+    }
+
+    profiles.remove(&profile);
+    match write_profiles(&profiles) {
+        Ok(_) => {}
+        Err(_) => {
+            eprintln!("\n{}\n", "Failed to save credentials file".red());
+            return; 
+        }
+    }
+
+    println!(
+        "{} {} {}",
+        "\nProfile".green(),
+        profile.green(),
+        "successfully removed\n".green()
+    );
+}
+
+#[allow(dead_code)]
+fn list_profiles() {
+    println!("{}", "\nAvailable profiles:".blue().bold());
+    let profiles = match get_profiles() {
+        Ok(profiles) => profiles,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load profiles".red());
+            return;
+        }
+    };
+    for key in profiles.keys() {
+        println!("{} {}", ">".yellow(), key)
+    }
+    println!();
+}
+
+#[allow(dead_code)]
+fn use_profile(args: UseArgs) {
+    let profiles = match get_profiles() {
+        Ok(profiles) => profiles,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load profiles".red());
+            return;
+        }
+    };
+    
+    if !profiles.contains_key(&args.name) {
+        let message = format!("Profile {} not found", args.name);
+        eprintln!("\n{}\n", message.red());
+        return;
+    }
+
+    let mut config = match read_config() {
+        Ok(config) => config,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load CLI config".red());
+            return;
+        }
+    };
+    
+    config.current_profile = args.name;
+    match write_config(&config) {
+        Ok(_) => {}
+        Err(_) => {
+            eprintln!("\n{}\n", "Failed to save CLI config".red());
+        }
+    };
+    
+}
+
+fn show() {
+    let config = match read_config() {
+        Ok(config) => config,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load CLI config".red());
+            return;
+        }
+    };
+    
+    println!("\n{}", "Current profile: ".blue().bold());
+    if config.current_profile.is_empty() {
+       println!("\nNo profile set currently. Please use {} to add a profile\n", "chroma login".yellow()); 
+    }
+}
+
+#[allow(dead_code)]
+pub fn profile_command(command: ProfileCommand) {
+    match command {
+        ProfileCommand::Delete(args) => delete_profile(args),
+        ProfileCommand::List => list_profiles(),
+        ProfileCommand::Show => show(),
+        ProfileCommand::Use(args) => use_profile(args),
+    }
+}

--- a/rust/cli/src/commands/profile.rs
+++ b/rust/cli/src/commands/profile.rs
@@ -1,4 +1,5 @@
-use crate::utils::{get_profiles, read_config, write_config, write_profiles};
+use std::io::Write;
+use crate::utils::{get_config, get_profiles, save_config, save_profiles, CliConfig, Profiles};
 use clap::{Args, Subcommand};
 use colored::Colorize;
 use dialoguer::theme::ColorfulTheme;
@@ -22,664 +23,132 @@ pub enum ProfileCommand {
     Use(UseArgs),
 }
 
-#[allow(dead_code)]
-fn delete_profile(args: DeleteArgs) {
-    let mut profiles = match get_profiles() {
-        Ok(profiles) => profiles,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load profiles".red());
-            return;
-        }
-    };
-    let profile = args.name;
-
-    if !profiles.contains_key(&profile) {
-        let message = format!("Profile {} not found", profile);
-        eprintln!("\n{}\n", message.red());
-        return;
+fn profile_exists<W: Write>(writer: &mut W, profile_name: &str, profiles: &Profiles)-> Result<bool, std::io::Error> {
+    if !profiles.contains_key(profile_name) {
+        let message = format!("Profile {} not found", profile_name);
+        writeln!(writer, "{}", message.red())?;
+        Ok(false)
+    } else {
+        Ok(true)
     }
-
-    let mut config = match read_config() {
-        Ok(config) => config,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load CLI config".red());
-            return;
-        }
-    };
-
-    if config.current_profile == profile {
-        println!(
-            "{}",
-            "\nWarning! You are deleting the currently active profile"
-                .yellow()
-                .bold()
-        );
-        println!("All Chroma Cloud CLI operations will fail without an active profile.");
-        print!(
-            "If you wish to proceed, please use: `{}`, to set a new active profile",
-            "chroma profile use <profile name>".yellow()
-        );
-
-        println!("\nDo you want to delete profile {}? (Y/n)", profile);
-        let confirm: String = Input::with_theme(&ColorfulTheme::default())
-            .interact_text()
-            .unwrap();
-
-        if confirm.to_lowercase() != "y" && confirm.to_lowercase() != "yes" {
-            println!();
-            return;
-        }
-
-        config.current_profile = "".to_string();
-        match write_config(&config) {
-            Ok(_) => {}
-            Err(_) => {
-                eprintln!("\n{}\n", "Failed to save CLI config".red());
-                return;
-            }
-        };
-    }
-
-    profiles.remove(&profile);
-    match write_profiles(&profiles) {
-        Ok(_) => {}
-        Err(_) => {
-            eprintln!("\n{}\n", "Failed to save credentials file".red());
-            return;
-        }
-    }
-
-    println!(
-        "{} {} {}",
-        "\nProfile".green(),
-        profile.green(),
-        "successfully removed\n".green()
-    );
 }
 
-#[allow(dead_code)]
-fn list_profiles() {
-    let profiles = match get_profiles() {
-        Ok(profiles) => profiles,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load profiles".red());
-            return;
+fn confirm_deletion<W: Write>(writer: &mut W, profile_name: &str) -> Result<bool, std::io::Error> {
+    let message = format!(
+        "{}\n{}\n{} {}, {}\n\nDo you want to delete profile {}? (Y/n)",
+        "Warning! You are deleting the currently active profile".yellow().bold(),
+        "All Chroma Cloud CLI operations will fail without an active profile.",
+        "If you wish to proceed, please use:",
+        "chroma profile use <profile name>".yellow(),
+        "to set a new profile",
+        profile_name
+    );
+    writeln!(writer, "{}", message)?;
+
+    let confirm: String = Input::with_theme(&ColorfulTheme::default())
+        .interact_text()
+        .unwrap();
+    
+    Ok(confirm.to_lowercase() == "y" || confirm.to_lowercase() == "yes")
+}
+
+fn delete_profile<W: Write>(writer: &mut W,args: DeleteArgs, profiles: &mut Profiles, config: &mut CliConfig) -> Result<(), std::io::Error> {
+    let profile = args.name;
+    if !profile_exists(writer, &profile, profiles)? { return Ok(()) }
+    
+    if config.current_profile == profile {
+        let confirmed = confirm_deletion(writer, &profile)?;
+        if confirmed {
+            println!();
+            config.current_profile = "".to_string();
+            if save_config(config).is_err() { return Ok(()) }
+        } else {
+            return Ok(());
         }
     };
 
-    let config = match read_config() {
-        Ok(config) => config,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load CLI config".red());
-            return;
-        }
-    };
+    profiles.remove(&profile);
+    if save_profiles(profiles).is_err() { return Ok(()) }
 
+    writeln!(writer,
+        "{} {} {}",
+        "Profile".green(),
+        profile.green(),
+        "successfully removed".green()
+    )?;
+    Ok(())
+}
+
+fn list_profiles<W: Write>(writer: &mut W, profiles: Profiles, config: CliConfig) -> Result<(), std::io::Error> {
     if profiles.is_empty() {
-        println!(
-            "\nNo profiles defined at the moment. To set a new profile use {}\n",
+        writeln!(writer,
+            "No profiles defined at the moment. To add a new profile use {}",
             "chroma login".yellow()
-        );
-        return;
+        )?;
+        return Ok(())
     }
 
-    println!("{}", "\nAvailable profiles:".blue().bold());
+    writeln!(writer, "{}", "Available profiles:".blue().bold())?;
 
     if !config.current_profile.is_empty() {
         let current_profile_label = format!("{} (current)", config.current_profile).bold();
-        println!("{} {}", ">".yellow(), current_profile_label);
+        writeln!(writer, "{} {}", ">".yellow(), current_profile_label)?;
     }
 
     for key in profiles.keys() {
         if *key != config.current_profile {
-            println!("{} {}", ">".yellow(), key)
+            writeln!(writer, "{} {}", ">".yellow(), key)?;
         }
     }
-    println!();
+    Ok(())
 }
 
-#[allow(dead_code)]
-fn use_profile(args: UseArgs) {
-    let profiles = match get_profiles() {
-        Ok(profiles) => profiles,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load profiles".red());
-            return;
-        }
-    };
-
-    if !profiles.contains_key(&args.name) {
-        let message = format!("Profile {} not found", args.name);
-        eprintln!("\n{}\n", message.red());
-        return;
-    }
-
-    let mut config = match read_config() {
-        Ok(config) => config,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load CLI config".red());
-            return;
-        }
-    };
-
+fn use_profile<W: Write>(writer: &mut W, args: UseArgs, profiles: Profiles, config: &mut CliConfig) -> Result<(), std::io::Error> {
+    let exists = profile_exists(writer, &args.name, &profiles)?;
+    if !exists { return Ok(()) }
+    
     config.current_profile = args.name;
-    match write_config(&config) {
-        Ok(_) => {}
-        Err(_) => {
-            eprintln!("\n{}\n", "Failed to save CLI config".red());
-        }
-    };
+    _ = save_config(config);
+    let message = format!("Current profile set to {}", config.current_profile);
+    writeln!(writer, "{}", message.green())?;
+    Ok(())
 }
 
-fn show() {
-    let config = match read_config() {
-        Ok(config) => config,
-        Err(_) => {
-            eprintln!("\n{}\n", "Could not load CLI config".red());
-            return;
-        }
-    };
-
+fn show<W: Write>(writer: &mut W,config: CliConfig) -> Result<(), std::io::Error> {
     if config.current_profile.is_empty() {
-        println!(
-            "\nNo profile set currently. Please use {} to add a profile\n",
-            "chroma login".yellow()
-        );
-        return;
+        writeln!(
+            writer,
+            "No profile set currently. Please use {} to add a profile, or {} to set an existing profile",
+            "chroma login".yellow(),
+            "chroma use <profile name>".yellow()
+        )?;
     }
 
-    println!("\n{}", "Current profile: ".blue().bold());
-    println!("{}\n", config.current_profile);
+    writeln!(writer, "{}", "Current profile: ".blue().bold())?;
+    writeln!(writer, "{}", config.current_profile)?;
+    Ok(())
 }
 
-#[allow(dead_code)]
-pub fn profile_command(command: ProfileCommand) {
+pub fn profile_command<W: Write>(writer: &mut W, command: ProfileCommand) -> Result<(), std::io::Error> {
+    let mut profiles = match get_profiles() {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+
+    let mut config = match get_config() {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+    
     match command {
-        ProfileCommand::Delete(args) => delete_profile(args),
-        ProfileCommand::List => list_profiles(),
-        ProfileCommand::Show => show(),
-        ProfileCommand::Use(args) => use_profile(args),
+        ProfileCommand::Delete(args) => delete_profile(writer, args, &mut profiles, &mut config),
+        ProfileCommand::List => list_profiles(writer, profiles, config),
+        ProfileCommand::Show => show(writer, config),
+        ProfileCommand::Use(args) => use_profile(writer, args, profiles, &mut config),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::profile::{
-        delete_profile, list_profiles, profile_command, show, use_profile, DeleteArgs,
-        ProfileCommand, UseArgs,
-    };
-    use crate::utils::{CliConfig, Profile, Profiles};
-    use colored::control;
-    use std::fs;
-    use tempfile::TempDir;
-
-    // Helper function to create a temporary .chroma directory with initial files
-    fn setup_test_environment(profiles: Option<Profiles>, config: Option<CliConfig>) -> TempDir {
-        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
-        let chroma_dir = temp_dir.path().join(".chroma");
-        fs::create_dir_all(&chroma_dir).expect("Failed to create .chroma directory");
-
-        let credentials_path = chroma_dir.join("credentials");
-        if let Some(profiles_data) = profiles {
-            let toml_str = toml::to_string(&profiles_data).expect("Failed to serialize profiles");
-            fs::write(&credentials_path, toml_str).expect("Failed to write credentials file");
-        } else {
-            fs::write(&credentials_path, "").expect("Failed to write empty credentials file");
-        }
-
-        let config_path = chroma_dir.join("config.json");
-        if let Some(config_data) = config {
-            let json_str =
-                serde_json::to_string_pretty(&config_data).expect("Failed to serialize config");
-            fs::write(&config_path, json_str).expect("Failed to write config file");
-        } else {
-            let default_config = CliConfig {
-                current_profile: String::new(),
-            };
-            let json_str = serde_json::to_string_pretty(&default_config)
-                .expect("Failed to serialize default config");
-            fs::write(&config_path, json_str).expect("Failed to write default config file");
-        }
-
-        // Set the HOME environment variable to the temporary directory
-        std::env::set_var("HOME", temp_dir.path());
-
-        temp_dir
-    }
-
-    #[test]
-    fn test_delete_profile_success() {
-        let profiles = Some(Profiles::from([
-            (
-                "default".to_string(),
-                Profile {
-                    name: "default".to_string(),
-                    api_key: "test_key".to_string(),
-                    team_id: "test_team".to_string(),
-                },
-            ),
-            (
-                "test".to_string(),
-                Profile {
-                    name: "test".to_string(),
-                    api_key: "another_key".to_string(),
-                    team_id: "another_team".to_string(),
-                },
-            ),
-        ]));
-        let config = Some(CliConfig {
-            current_profile: "default".to_string(),
-        });
-        let temp_dir = setup_test_environment(profiles, config);
-
-        let args = DeleteArgs {
-            name: "test".to_string(),
-        };
-        delete_profile(args);
-
-        let credentials_path = temp_dir.path().join(".chroma").join("credentials");
-        let contents = fs::read_to_string(credentials_path).expect("Failed to read credentials");
-        let updated_profiles: Profiles =
-            toml::from_str(&contents).expect("Failed to parse profiles");
-
-        assert!(updated_profiles.contains_key("default"));
-        assert!(!updated_profiles.contains_key("test"));
-    }
-
-    #[test]
-    fn test_delete_profile_not_found() {
-        let profiles = Some(Profiles::from([(
-            "default".to_string(),
-            Profile {
-                name: "default".to_string(),
-                api_key: "test_key".to_string(),
-                team_id: "test_team".to_string(),
-            },
-        )]));
-        let config = Some(CliConfig {
-            current_profile: "default".to_string(),
-        });
-        setup_test_environment(profiles, config);
-
-        let args = DeleteArgs {
-            name: "nonexistent".to_string(),
-        };
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stderr_guard = TestStderr::new(&mut output);
-            delete_profile(args);
-        }
-        control::unset_override();
-
-        let stderr_output = String::from_utf8(output).unwrap();
-        assert!(stderr_output.contains("Profile nonexistent not found"));
-    }
-
-    #[test]
-    fn test_delete_profile_current_profile() {
-        let profiles = Some(Profiles::from([
-            (
-                "default".to_string(),
-                Profile {
-                    name: "default".to_string(),
-                    api_key: "test_key".to_string(),
-                    team_id: "test_team".to_string(),
-                },
-            ),
-            (
-                "test".to_string(),
-                Profile {
-                    name: "test".to_string(),
-                    api_key: "another_key".to_string(),
-                    team_id: "another_team".to_string(),
-                },
-            ),
-        ]));
-        let config = Some(CliConfig {
-            current_profile: "default".to_string(),
-        });
-        let temp_dir = setup_test_environment(profiles, config);
-
-        let args = DeleteArgs {
-            name: "default".to_string(),
-        };
-        delete_profile(args);
-
-        let config_path = temp_dir.path().join(".chroma").join("config.json");
-        let contents = fs::read_to_string(config_path).expect("Failed to read config");
-        let updated_config: CliConfig =
-            serde_json::from_str(&contents).expect("Failed to parse config");
-
-        assert_eq!(updated_config.current_profile, "");
-    }
-
-    #[test]
-    fn test_list_profiles_success() {
-        let profiles = Some(Profiles::from([
-            (
-                "default".to_string(),
-                Profile {
-                    name: "default".to_string(),
-                    api_key: "test_key".to_string(),
-                    team_id: "test_team".to_string(),
-                },
-            ),
-            (
-                "test".to_string(),
-                Profile {
-                    name: "test".to_string(),
-                    api_key: "another_key".to_string(),
-                    team_id: "another_team".to_string(),
-                },
-            ),
-        ]));
-        setup_test_environment(profiles, None);
-
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stdout_guard = TestStdout::new(&mut output);
-            list_profiles();
-        }
-        control::unset_override();
-
-        let stdout_output = String::from_utf8(output).unwrap();
-        assert!(stdout_output.contains("Available profiles:"));
-        assert!(stdout_output.contains("> default"));
-        assert!(stdout_output.contains("> test"));
-    }
-
-    #[test]
-    fn test_list_profiles_empty() {
-        setup_test_environment(None, None);
-
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stdout_guard = TestStdout::new(&mut output);
-            list_profiles();
-        }
-        control::unset_override();
-
-        let stdout_output = String::from_utf8(output).unwrap();
-        assert!(stdout_output.contains("Available profiles:"));
-        assert!(!stdout_output.contains(">"));
-    }
-
-    #[test]
-    fn test_use_profile_success() {
-        let profiles = Some(Profiles::from([
-            (
-                "default".to_string(),
-                Profile {
-                    name: "default".to_string(),
-                    api_key: "test_key".to_string(),
-                    team_id: "test_team".to_string(),
-                },
-            ),
-            (
-                "test".to_string(),
-                Profile {
-                    name: "test".to_string(),
-                    api_key: "another_key".to_string(),
-                    team_id: "another_team".to_string(),
-                },
-            ),
-        ]));
-        let config = Some(CliConfig {
-            current_profile: "".to_string(),
-        });
-        let temp_dir = setup_test_environment(profiles, config);
-
-        let args = UseArgs {
-            name: "test".to_string(),
-        };
-        use_profile(args);
-
-        let config_path = temp_dir.path().join(".chroma").join("config.json");
-        let contents = fs::read_to_string(config_path).expect("Failed to read config");
-        let updated_config: CliConfig =
-            serde_json::from_str(&contents).expect("Failed to parse config");
-
-        assert_eq!(updated_config.current_profile, "test");
-    }
-
-    #[test]
-    fn test_use_profile_not_found() {
-        let profiles = Some(Profiles::from([(
-            "default".to_string(),
-            Profile {
-                name: "default".to_string(),
-                api_key: "test_key".to_string(),
-                team_id: "test_team".to_string(),
-            },
-        )]));
-        let config = Some(CliConfig {
-            current_profile: "".to_string(),
-        });
-        setup_test_environment(profiles, config);
-
-        let args = UseArgs {
-            name: "nonexistent".to_string(),
-        };
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stderr_guard = TestStderr::new(&mut output);
-            use_profile(args);
-        }
-        control::unset_override();
-
-        let stderr_output = String::from_utf8(output).unwrap();
-        assert!(stderr_output.contains("Profile nonexistent not found"));
-    }
-
-    #[test]
-    fn test_show_no_profile_set() {
-        let config = Some(CliConfig {
-            current_profile: "".to_string(),
-        });
-        setup_test_environment(None, config);
-
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stdout_guard = TestStdout::new(&mut output);
-            show();
-        }
-        control::unset_override();
-
-        let stdout_output = String::from_utf8(output).unwrap();
-        assert!(stdout_output.contains("Current profile:"));
-        assert!(stdout_output.contains("No profile set currently"));
-    }
-
-    #[test]
-    fn test_show_profile_set() {
-        let config = Some(CliConfig {
-            current_profile: "test".to_string(),
-        });
-        setup_test_environment(None, config);
-
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stdout_guard = TestStdout::new(&mut output);
-            show();
-        }
-        control::unset_override();
-
-        let stdout_output = String::from_utf8(output).unwrap();
-        assert!(stdout_output.contains("Current profile:"));
-        assert!(stdout_output.contains("test"));
-    }
-
-    #[test]
-    fn test_profile_command_delete() {
-        let profiles = Some(Profiles::from([(
-            "default".to_string(),
-            Profile {
-                name: "default".to_string(),
-                api_key: "test_key".to_string(),
-                team_id: "test_team".to_string(),
-            },
-        )]));
-        let temp_dir = setup_test_environment(profiles, None);
-
-        let command = ProfileCommand::Delete(DeleteArgs {
-            name: "default".to_string(),
-        });
-        profile_command(command);
-
-        let credentials_path = temp_dir.path().join(".chroma").join("credentials");
-        let contents = fs::read_to_string(credentials_path).expect("Failed to read credentials");
-        let updated_profiles: Profiles =
-            toml::from_str(&contents).expect("Failed to parse profiles");
-        assert!(!updated_profiles.contains_key("default"));
-    }
-
-    #[test]
-    fn test_profile_command_list() {
-        let profiles = Some(Profiles::from([(
-            "test".to_string(),
-            Profile {
-                name: "test".to_string(),
-                api_key: "another_key".to_string(),
-                team_id: "another_team".to_string(),
-            },
-        )]));
-        setup_test_environment(profiles, None);
-
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stdout_guard = TestStdout::new(&mut output);
-            profile_command(ProfileCommand::List);
-        }
-        control::unset_override();
-
-        let stdout_output = String::from_utf8(output).unwrap();
-        assert!(stdout_output.contains("Available profiles:"));
-        assert!(stdout_output.contains("> test"));
-    }
-
-    #[test]
-    fn test_profile_command_show() {
-        let config = Some(CliConfig {
-            current_profile: "test".to_string(),
-        });
-        setup_test_environment(None, config);
-
-        let mut output = Vec::new();
-        control::set_override(true); // Enable colored output for testing
-        {
-            let _stdout_guard = TestStdout::new(&mut output);
-            profile_command(ProfileCommand::Show);
-        }
-        control::unset_override();
-
-        let stdout_output = String::from_utf8(output).unwrap();
-        assert!(stdout_output.contains("Current profile:"));
-        assert!(stdout_output.contains("test"));
-    }
-
-    #[test]
-    fn test_profile_command_use() {
-        let profiles = Some(Profiles::from([(
-            "test".to_string(),
-            Profile {
-                name: "test".to_string(),
-                api_key: "another_key".to_string(),
-                team_id: "another_team".to_string(),
-            },
-        )]));
-        let config = Some(CliConfig {
-            current_profile: "".to_string(),
-        });
-        let temp_dir = setup_test_environment(profiles, config);
-
-        let command = ProfileCommand::Use(UseArgs {
-            name: "test".to_string(),
-        });
-        profile_command(command);
-
-        let config_path = temp_dir.path().join(".chroma").join("config.json");
-        let contents = fs::read_to_string(config_path).expect("Failed to read config");
-        let updated_config: CliConfig =
-            serde_json::from_str(&contents).expect("Failed to parse config");
-        assert_eq!(updated_config.current_profile, "test");
-    }
-
-    // Helper struct to capture stdout
-    struct TestStdout {
-        output: *mut Vec<u8>,
-    }
-
-    impl TestStdout {
-        fn new(output: &mut Vec<u8>) -> Self {
-            TestStdout {
-                output: output as *mut Vec<u8>,
-            }
-        }
-    }
-
-    impl Drop for TestStdout {
-        fn drop(&mut self) {
-            unsafe {
-                let output = &mut *self.output;
-                let _ = std::io::Write::flush(output);
-                let _ = std::io::Write::write_all(output, b"\n"); // Ensure a newline at the end
-            }
-        }
-    }
-
-    impl std::io::Write for TestStdout {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            unsafe {
-                (*self.output).extend_from_slice(buf);
-                Ok(buf.len())
-            }
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    // Helper struct to capture stderr
-    struct TestStderr {
-        output: *mut Vec<u8>,
-    }
-
-    impl TestStderr {
-        fn new(output: &mut Vec<u8>) -> Self {
-            TestStderr {
-                output: output as *mut Vec<u8>,
-            }
-        }
-    }
-
-    impl Drop for TestStderr {
-        fn drop(&mut self) {
-            unsafe {
-                let output = &mut *self.output;
-                let _ = std::io::Write::flush(output);
-                let _ = std::io::Write::write_all(output, b"\n"); // Ensure a newline at the end
-            }
-        }
-    }
-
-    impl std::io::Write for TestStderr {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            unsafe {
-                (*self.output).extend_from_slice(buf);
-                Ok(buf.len())
-            }
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
+   
 }

--- a/rust/cli/src/commands/profile.rs
+++ b/rust/cli/src/commands/profile.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 use colored::Colorize;
+use dialoguer::Input;
+use dialoguer::theme::ColorfulTheme;
 use crate::utils::{get_profiles, read_config, write_config, write_profiles};
 
 #[derive(Args, Debug)]
@@ -46,6 +48,20 @@ fn delete_profile(args: DeleteArgs) {
     };
 
     if config.current_profile == profile {
+        println!("{}", "\nWarning! You are deleting the currently active profile".yellow().bold());
+        println!("All Chroma Cloud CLI operations will fail without an active profile.");
+        print!("If you wish to proceed, please use: `{}`, to set a new active profile", "chroma profile use <profile name>".yellow());
+        
+        println!("\nDo you want to delete profile {}? (Y/n)", profile);
+        let confirm: String = Input::with_theme(&ColorfulTheme::default())
+            .interact_text()
+            .unwrap();
+        
+        if confirm.to_lowercase() != "y" && confirm.to_lowercase() != "yes" {
+            println!();
+            return;
+        }
+
         config.current_profile = "".to_string();
         match write_config(&config) {
             Ok(_) => {}
@@ -75,7 +91,6 @@ fn delete_profile(args: DeleteArgs) {
 
 #[allow(dead_code)]
 fn list_profiles() {
-    println!("{}", "\nAvailable profiles:".blue().bold());
     let profiles = match get_profiles() {
         Ok(profiles) => profiles,
         Err(_) => {
@@ -83,8 +98,31 @@ fn list_profiles() {
             return;
         }
     };
+
+    let config = match read_config() {
+        Ok(config) => config,
+        Err(_) => {
+            eprintln!("\n{}\n", "Could not load CLI config".red());
+            return;
+        }
+    };
+
+    if profiles.is_empty() {
+        println!("\nNo profiles defined at the moment. To set a new profile use {}\n", "chroma login".yellow());
+        return;
+    }
+
+    println!("{}", "\nAvailable profiles:".blue().bold());
+
+    if !config.current_profile.is_empty() {
+        let current_profile_label = format!("{} (current)", config.current_profile).bold();
+        println!("{} {}", ">".yellow(), current_profile_label);
+    }
+
     for key in profiles.keys() {
-        println!("{} {}", ">".yellow(), key)
+        if *key != config.current_profile {
+            println!("{} {}", ">".yellow(), key)
+        }
     }
     println!();
 }
@@ -132,11 +170,12 @@ fn show() {
         }
     };
     
-    println!("\n{}", "Current profile: ".blue().bold());
     if config.current_profile.is_empty() {
        println!("\nNo profile set currently. Please use {} to add a profile\n", "chroma login".yellow());
         return;
     }
+
+    println!("\n{}", "Current profile: ".blue().bold());
     println!("{}\n", config.current_profile);
 
 }
@@ -148,5 +187,369 @@ pub fn profile_command(command: ProfileCommand) {
         ProfileCommand::List => list_profiles(),
         ProfileCommand::Show => show(),
         ProfileCommand::Use(args) => use_profile(args),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use colored::control;
+    use tempfile::TempDir;
+    use crate::commands::profile::{delete_profile, list_profiles, profile_command, show, use_profile, DeleteArgs, ProfileCommand, UseArgs};
+    use crate::utils::{CliConfig, Profile, Profiles};
+
+    // Helper function to create a temporary .chroma directory with initial files
+    fn setup_test_environment(profiles: Option<Profiles>, config: Option<CliConfig>) -> TempDir {
+        let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+        let chroma_dir = temp_dir.path().join(".chroma");
+        fs::create_dir_all(&chroma_dir).expect("Failed to create .chroma directory");
+
+        let credentials_path = chroma_dir.join("credentials");
+        if let Some(profiles_data) = profiles {
+            let toml_str = toml::to_string(&profiles_data).expect("Failed to serialize profiles");
+            fs::write(&credentials_path, toml_str).expect("Failed to write credentials file");
+        } else {
+            fs::write(&credentials_path, "").expect("Failed to write empty credentials file");
+        }
+
+        let config_path = chroma_dir.join("config.json");
+        if let Some(config_data) = config {
+            let json_str =
+                serde_json::to_string_pretty(&config_data).expect("Failed to serialize config");
+            fs::write(&config_path, json_str).expect("Failed to write config file");
+        } else {
+            let default_config = CliConfig {
+                current_profile: String::new(),
+            };
+            let json_str =
+                serde_json::to_string_pretty(&default_config).expect("Failed to serialize default config");
+            fs::write(&config_path, json_str).expect("Failed to write default config file");
+        }
+
+        // Set the HOME environment variable to the temporary directory
+        std::env::set_var("HOME", temp_dir.path());
+
+        temp_dir
+    }
+
+    #[test]
+    fn test_delete_profile_success() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+        ]));
+        let config = Some(CliConfig { current_profile: "default".to_string() });
+        let temp_dir = setup_test_environment(profiles, config);
+
+        let args = DeleteArgs { name: "test".to_string() };
+        delete_profile(args);
+
+        let credentials_path = temp_dir.path().join(".chroma").join("credentials");
+        let contents = fs::read_to_string(credentials_path).expect("Failed to read credentials");
+        let updated_profiles: Profiles = toml::from_str(&contents).expect("Failed to parse profiles");
+
+        assert!(updated_profiles.contains_key("default"));
+        assert!(!updated_profiles.contains_key("test"));
+    }
+
+    #[test]
+    fn test_delete_profile_not_found() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+        ]));
+        let config = Some(CliConfig { current_profile: "default".to_string() });
+        let temp_dir = setup_test_environment(profiles, config);
+
+        let args = DeleteArgs { name: "nonexistent".to_string() };
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stderr_guard = TestStderr::new(&mut output);
+            delete_profile(args);
+        }
+        control::unset_override();
+
+        let stderr_output = String::from_utf8(output).unwrap();
+        assert!(stderr_output.contains("Profile nonexistent not found"));
+    }
+
+    #[test]
+    fn test_delete_profile_current_profile() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+        ]));
+        let config = Some(CliConfig { current_profile: "default".to_string() });
+        let temp_dir = setup_test_environment(profiles, config);
+
+        let args = DeleteArgs { name: "default".to_string() };
+        delete_profile(args);
+
+        let config_path = temp_dir.path().join(".chroma").join("config.json");
+        let contents = fs::read_to_string(config_path).expect("Failed to read config");
+        let updated_config: CliConfig =
+            serde_json::from_str(&contents).expect("Failed to parse config");
+
+        assert_eq!(updated_config.current_profile, "");
+    }
+
+    #[test]
+    fn test_list_profiles_success() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+        ]));
+        let temp_dir = setup_test_environment(profiles, None);
+
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stdout_guard = TestStdout::new(&mut output);
+            list_profiles();
+        }
+        control::unset_override();
+
+        let stdout_output = String::from_utf8(output).unwrap();
+        assert!(stdout_output.contains("Available profiles:"));
+        assert!(stdout_output.contains("> default"));
+        assert!(stdout_output.contains("> test"));
+    }
+
+    #[test]
+    fn test_list_profiles_empty() {
+        let temp_dir = setup_test_environment(None, None);
+
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stdout_guard = TestStdout::new(&mut output);
+            list_profiles();
+        }
+        control::unset_override();
+
+        let stdout_output = String::from_utf8(output).unwrap();
+        assert!(stdout_output.contains("Available profiles:"));
+        assert!(!stdout_output.contains(">"));
+    }
+
+    #[test]
+    fn test_use_profile_success() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+        ]));
+        let config = Some(CliConfig { current_profile: "".to_string() });
+        let temp_dir = setup_test_environment(profiles, config);
+
+        let args = UseArgs { name: "test".to_string() };
+        use_profile(args);
+
+        let config_path = temp_dir.path().join(".chroma").join("config.json");
+        let contents = fs::read_to_string(config_path).expect("Failed to read config");
+        let updated_config: CliConfig =
+            serde_json::from_str(&contents).expect("Failed to parse config");
+
+        assert_eq!(updated_config.current_profile, "test");
+    }
+
+    #[test]
+    fn test_use_profile_not_found() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+        ]));
+        let config = Some(CliConfig { current_profile: "".to_string() });
+        let temp_dir = setup_test_environment(profiles, config);
+
+        let args = UseArgs { name: "nonexistent".to_string() };
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stderr_guard = TestStderr::new(&mut output);
+            use_profile(args);
+        }
+        control::unset_override();
+
+        let stderr_output = String::from_utf8(output).unwrap();
+        assert!(stderr_output.contains("Profile nonexistent not found"));
+    }
+
+    #[test]
+    fn test_show_no_profile_set() {
+        let config = Some(CliConfig { current_profile: "".to_string() });
+        let temp_dir = setup_test_environment(None, config);
+
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stdout_guard = TestStdout::new(&mut output);
+            show();
+        }
+        control::unset_override();
+
+        let stdout_output = String::from_utf8(output).unwrap();
+        assert!(stdout_output.contains("Current profile:"));
+        assert!(stdout_output.contains("No profile set currently"));
+    }
+
+    #[test]
+    fn test_show_profile_set() {
+        let config = Some(CliConfig { current_profile: "test".to_string() });
+        let temp_dir = setup_test_environment(None, config);
+
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stdout_guard = TestStdout::new(&mut output);
+            show();
+        }
+        control::unset_override();
+
+        let stdout_output = String::from_utf8(output).unwrap();
+        assert!(stdout_output.contains("Current profile:"));
+        assert!(stdout_output.contains("test"));
+    }
+
+    #[test]
+    fn test_profile_command_delete() {
+        let profiles = Some(Profiles::from([
+            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
+        ]));
+        let temp_dir = setup_test_environment(profiles, None);
+
+        let command = ProfileCommand::Delete(DeleteArgs { name: "default".to_string() });
+        profile_command(command);
+
+        let credentials_path = temp_dir.path().join(".chroma").join("credentials");
+        let contents = fs::read_to_string(credentials_path).expect("Failed to read credentials");
+        let updated_profiles: Profiles = toml::from_str(&contents).expect("Failed to parse profiles");
+        assert!(!updated_profiles.contains_key("default"));
+    }
+
+    #[test]
+    fn test_profile_command_list() {
+        let profiles = Some(Profiles::from([
+            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+        ]));
+        let temp_dir = setup_test_environment(profiles, None);
+
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stdout_guard = TestStdout::new(&mut output);
+            profile_command(ProfileCommand::List);
+        }
+        control::unset_override();
+
+        let stdout_output = String::from_utf8(output).unwrap();
+        assert!(stdout_output.contains("Available profiles:"));
+        assert!(stdout_output.contains("> test"));
+    }
+
+    #[test]
+    fn test_profile_command_show() {
+        let config = Some(CliConfig { current_profile: "test".to_string() });
+        let temp_dir = setup_test_environment(None, config);
+
+        let mut output = Vec::new();
+        control::set_override(true); // Enable colored output for testing
+        {
+            let _stdout_guard = TestStdout::new(&mut output);
+            profile_command(ProfileCommand::Show);
+        }
+        control::unset_override();
+
+        let stdout_output = String::from_utf8(output).unwrap();
+        assert!(stdout_output.contains("Current profile:"));
+        assert!(stdout_output.contains("test"));
+    }
+
+    #[test]
+    fn test_profile_command_use() {
+        let profiles = Some(Profiles::from([
+            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+        ]));
+        let config = Some(CliConfig { current_profile: "".to_string() });
+        let temp_dir = setup_test_environment(profiles, config);
+
+        let command = ProfileCommand::Use(UseArgs { name: "test".to_string() });
+        profile_command(command);
+
+        let config_path = temp_dir.path().join(".chroma").join("config.json");
+        let contents = fs::read_to_string(config_path).expect("Failed to read config");
+        let updated_config: CliConfig =
+            serde_json::from_str(&contents).expect("Failed to parse config");
+        assert_eq!(updated_config.current_profile, "test");
+    }
+
+    // Helper struct to capture stdout
+    struct TestStdout {
+        output: *mut Vec<u8>,
+    }
+
+    impl TestStdout {
+        fn new(output: &mut Vec<u8>) -> Self {
+            TestStdout {
+                output: output as *mut Vec<u8>,
+            }
+        }
+    }
+
+    impl Drop for TestStdout {
+        fn drop(&mut self) {
+            unsafe {
+                let output = &mut *self.output;
+                let _ = std::io::Write::flush(output);
+                let _ = std::io::Write::write_all(output, b"\n"); // Ensure a newline at the end
+            }
+        }
+    }
+
+    impl std::io::Write for TestStdout {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            unsafe {
+                (*self.output).extend_from_slice(buf);
+                Ok(buf.len())
+            }
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // Helper struct to capture stderr
+    struct TestStderr {
+        output: *mut Vec<u8>,
+    }
+
+    impl TestStderr {
+        fn new(output: &mut Vec<u8>) -> Self {
+            TestStderr {
+                output: output as *mut Vec<u8>,
+            }
+        }
+    }
+
+    impl Drop for TestStderr {
+        fn drop(&mut self) {
+            unsafe {
+                let output = &mut *self.output;
+                let _ = std::io::Write::flush(output);
+                let _ = std::io::Write::write_all(output, b"\n"); // Ensure a newline at the end
+            }
+        }
+    }
+
+    impl std::io::Write for TestStderr {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            unsafe {
+                (*self.output).extend_from_slice(buf);
+                Ok(buf.len())
+            }
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
     }
 }

--- a/rust/cli/src/commands/profile.rs
+++ b/rust/cli/src/commands/profile.rs
@@ -134,8 +134,11 @@ fn show() {
     
     println!("\n{}", "Current profile: ".blue().bold());
     if config.current_profile.is_empty() {
-       println!("\nNo profile set currently. Please use {} to add a profile\n", "chroma login".yellow()); 
+       println!("\nNo profile set currently. Please use {} to add a profile\n", "chroma login".yellow());
+        return;
     }
+    println!("{}\n", config.current_profile);
+
 }
 
 #[allow(dead_code)]

--- a/rust/cli/src/commands/profile.rs
+++ b/rust/cli/src/commands/profile.rs
@@ -1,8 +1,8 @@
+use crate::utils::{get_profiles, read_config, write_config, write_profiles};
 use clap::{Args, Subcommand};
 use colored::Colorize;
-use dialoguer::Input;
 use dialoguer::theme::ColorfulTheme;
-use crate::utils::{get_profiles, read_config, write_config, write_profiles};
+use dialoguer::Input;
 
 #[derive(Args, Debug)]
 pub struct DeleteArgs {
@@ -48,15 +48,23 @@ fn delete_profile(args: DeleteArgs) {
     };
 
     if config.current_profile == profile {
-        println!("{}", "\nWarning! You are deleting the currently active profile".yellow().bold());
+        println!(
+            "{}",
+            "\nWarning! You are deleting the currently active profile"
+                .yellow()
+                .bold()
+        );
         println!("All Chroma Cloud CLI operations will fail without an active profile.");
-        print!("If you wish to proceed, please use: `{}`, to set a new active profile", "chroma profile use <profile name>".yellow());
-        
+        print!(
+            "If you wish to proceed, please use: `{}`, to set a new active profile",
+            "chroma profile use <profile name>".yellow()
+        );
+
         println!("\nDo you want to delete profile {}? (Y/n)", profile);
         let confirm: String = Input::with_theme(&ColorfulTheme::default())
             .interact_text()
             .unwrap();
-        
+
         if confirm.to_lowercase() != "y" && confirm.to_lowercase() != "yes" {
             println!();
             return;
@@ -77,7 +85,7 @@ fn delete_profile(args: DeleteArgs) {
         Ok(_) => {}
         Err(_) => {
             eprintln!("\n{}\n", "Failed to save credentials file".red());
-            return; 
+            return;
         }
     }
 
@@ -108,7 +116,10 @@ fn list_profiles() {
     };
 
     if profiles.is_empty() {
-        println!("\nNo profiles defined at the moment. To set a new profile use {}\n", "chroma login".yellow());
+        println!(
+            "\nNo profiles defined at the moment. To set a new profile use {}\n",
+            "chroma login".yellow()
+        );
         return;
     }
 
@@ -136,7 +147,7 @@ fn use_profile(args: UseArgs) {
             return;
         }
     };
-    
+
     if !profiles.contains_key(&args.name) {
         let message = format!("Profile {} not found", args.name);
         eprintln!("\n{}\n", message.red());
@@ -150,7 +161,7 @@ fn use_profile(args: UseArgs) {
             return;
         }
     };
-    
+
     config.current_profile = args.name;
     match write_config(&config) {
         Ok(_) => {}
@@ -158,7 +169,6 @@ fn use_profile(args: UseArgs) {
             eprintln!("\n{}\n", "Failed to save CLI config".red());
         }
     };
-    
 }
 
 fn show() {
@@ -169,15 +179,17 @@ fn show() {
             return;
         }
     };
-    
+
     if config.current_profile.is_empty() {
-       println!("\nNo profile set currently. Please use {} to add a profile\n", "chroma login".yellow());
+        println!(
+            "\nNo profile set currently. Please use {} to add a profile\n",
+            "chroma login".yellow()
+        );
         return;
     }
 
     println!("\n{}", "Current profile: ".blue().bold());
     println!("{}\n", config.current_profile);
-
 }
 
 #[allow(dead_code)]
@@ -192,11 +204,14 @@ pub fn profile_command(command: ProfileCommand) {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    use colored::control;
-    use tempfile::TempDir;
-    use crate::commands::profile::{delete_profile, list_profiles, profile_command, show, use_profile, DeleteArgs, ProfileCommand, UseArgs};
+    use crate::commands::profile::{
+        delete_profile, list_profiles, profile_command, show, use_profile, DeleteArgs,
+        ProfileCommand, UseArgs,
+    };
     use crate::utils::{CliConfig, Profile, Profiles};
+    use colored::control;
+    use std::fs;
+    use tempfile::TempDir;
 
     // Helper function to create a temporary .chroma directory with initial files
     fn setup_test_environment(profiles: Option<Profiles>, config: Option<CliConfig>) -> TempDir {
@@ -221,8 +236,8 @@ mod tests {
             let default_config = CliConfig {
                 current_profile: String::new(),
             };
-            let json_str =
-                serde_json::to_string_pretty(&default_config).expect("Failed to serialize default config");
+            let json_str = serde_json::to_string_pretty(&default_config)
+                .expect("Failed to serialize default config");
             fs::write(&config_path, json_str).expect("Failed to write default config file");
         }
 
@@ -235,18 +250,37 @@ mod tests {
     #[test]
     fn test_delete_profile_success() {
         let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+            (
+                "default".to_string(),
+                Profile {
+                    name: "default".to_string(),
+                    api_key: "test_key".to_string(),
+                    team_id: "test_team".to_string(),
+                },
+            ),
+            (
+                "test".to_string(),
+                Profile {
+                    name: "test".to_string(),
+                    api_key: "another_key".to_string(),
+                    team_id: "another_team".to_string(),
+                },
+            ),
         ]));
-        let config = Some(CliConfig { current_profile: "default".to_string() });
+        let config = Some(CliConfig {
+            current_profile: "default".to_string(),
+        });
         let temp_dir = setup_test_environment(profiles, config);
 
-        let args = DeleteArgs { name: "test".to_string() };
+        let args = DeleteArgs {
+            name: "test".to_string(),
+        };
         delete_profile(args);
 
         let credentials_path = temp_dir.path().join(".chroma").join("credentials");
         let contents = fs::read_to_string(credentials_path).expect("Failed to read credentials");
-        let updated_profiles: Profiles = toml::from_str(&contents).expect("Failed to parse profiles");
+        let updated_profiles: Profiles =
+            toml::from_str(&contents).expect("Failed to parse profiles");
 
         assert!(updated_profiles.contains_key("default"));
         assert!(!updated_profiles.contains_key("test"));
@@ -254,13 +288,22 @@ mod tests {
 
     #[test]
     fn test_delete_profile_not_found() {
-        let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-        ]));
-        let config = Some(CliConfig { current_profile: "default".to_string() });
-        let temp_dir = setup_test_environment(profiles, config);
+        let profiles = Some(Profiles::from([(
+            "default".to_string(),
+            Profile {
+                name: "default".to_string(),
+                api_key: "test_key".to_string(),
+                team_id: "test_team".to_string(),
+            },
+        )]));
+        let config = Some(CliConfig {
+            current_profile: "default".to_string(),
+        });
+        setup_test_environment(profiles, config);
 
-        let args = DeleteArgs { name: "nonexistent".to_string() };
+        let args = DeleteArgs {
+            name: "nonexistent".to_string(),
+        };
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
         {
@@ -276,13 +319,31 @@ mod tests {
     #[test]
     fn test_delete_profile_current_profile() {
         let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+            (
+                "default".to_string(),
+                Profile {
+                    name: "default".to_string(),
+                    api_key: "test_key".to_string(),
+                    team_id: "test_team".to_string(),
+                },
+            ),
+            (
+                "test".to_string(),
+                Profile {
+                    name: "test".to_string(),
+                    api_key: "another_key".to_string(),
+                    team_id: "another_team".to_string(),
+                },
+            ),
         ]));
-        let config = Some(CliConfig { current_profile: "default".to_string() });
+        let config = Some(CliConfig {
+            current_profile: "default".to_string(),
+        });
         let temp_dir = setup_test_environment(profiles, config);
 
-        let args = DeleteArgs { name: "default".to_string() };
+        let args = DeleteArgs {
+            name: "default".to_string(),
+        };
         delete_profile(args);
 
         let config_path = temp_dir.path().join(".chroma").join("config.json");
@@ -296,10 +357,24 @@ mod tests {
     #[test]
     fn test_list_profiles_success() {
         let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+            (
+                "default".to_string(),
+                Profile {
+                    name: "default".to_string(),
+                    api_key: "test_key".to_string(),
+                    team_id: "test_team".to_string(),
+                },
+            ),
+            (
+                "test".to_string(),
+                Profile {
+                    name: "test".to_string(),
+                    api_key: "another_key".to_string(),
+                    team_id: "another_team".to_string(),
+                },
+            ),
         ]));
-        let temp_dir = setup_test_environment(profiles, None);
+        setup_test_environment(profiles, None);
 
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
@@ -317,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_list_profiles_empty() {
-        let temp_dir = setup_test_environment(None, None);
+        setup_test_environment(None, None);
 
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
@@ -335,13 +410,31 @@ mod tests {
     #[test]
     fn test_use_profile_success() {
         let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
+            (
+                "default".to_string(),
+                Profile {
+                    name: "default".to_string(),
+                    api_key: "test_key".to_string(),
+                    team_id: "test_team".to_string(),
+                },
+            ),
+            (
+                "test".to_string(),
+                Profile {
+                    name: "test".to_string(),
+                    api_key: "another_key".to_string(),
+                    team_id: "another_team".to_string(),
+                },
+            ),
         ]));
-        let config = Some(CliConfig { current_profile: "".to_string() });
+        let config = Some(CliConfig {
+            current_profile: "".to_string(),
+        });
         let temp_dir = setup_test_environment(profiles, config);
 
-        let args = UseArgs { name: "test".to_string() };
+        let args = UseArgs {
+            name: "test".to_string(),
+        };
         use_profile(args);
 
         let config_path = temp_dir.path().join(".chroma").join("config.json");
@@ -354,13 +447,22 @@ mod tests {
 
     #[test]
     fn test_use_profile_not_found() {
-        let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-        ]));
-        let config = Some(CliConfig { current_profile: "".to_string() });
-        let temp_dir = setup_test_environment(profiles, config);
+        let profiles = Some(Profiles::from([(
+            "default".to_string(),
+            Profile {
+                name: "default".to_string(),
+                api_key: "test_key".to_string(),
+                team_id: "test_team".to_string(),
+            },
+        )]));
+        let config = Some(CliConfig {
+            current_profile: "".to_string(),
+        });
+        setup_test_environment(profiles, config);
 
-        let args = UseArgs { name: "nonexistent".to_string() };
+        let args = UseArgs {
+            name: "nonexistent".to_string(),
+        };
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
         {
@@ -375,8 +477,10 @@ mod tests {
 
     #[test]
     fn test_show_no_profile_set() {
-        let config = Some(CliConfig { current_profile: "".to_string() });
-        let temp_dir = setup_test_environment(None, config);
+        let config = Some(CliConfig {
+            current_profile: "".to_string(),
+        });
+        setup_test_environment(None, config);
 
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
@@ -393,8 +497,10 @@ mod tests {
 
     #[test]
     fn test_show_profile_set() {
-        let config = Some(CliConfig { current_profile: "test".to_string() });
-        let temp_dir = setup_test_environment(None, config);
+        let config = Some(CliConfig {
+            current_profile: "test".to_string(),
+        });
+        setup_test_environment(None, config);
 
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
@@ -411,26 +517,39 @@ mod tests {
 
     #[test]
     fn test_profile_command_delete() {
-        let profiles = Some(Profiles::from([
-            ("default".to_string(), Profile { name: "default".to_string(), api_key: "test_key".to_string(), team_id: "test_team".to_string() }),
-        ]));
+        let profiles = Some(Profiles::from([(
+            "default".to_string(),
+            Profile {
+                name: "default".to_string(),
+                api_key: "test_key".to_string(),
+                team_id: "test_team".to_string(),
+            },
+        )]));
         let temp_dir = setup_test_environment(profiles, None);
 
-        let command = ProfileCommand::Delete(DeleteArgs { name: "default".to_string() });
+        let command = ProfileCommand::Delete(DeleteArgs {
+            name: "default".to_string(),
+        });
         profile_command(command);
 
         let credentials_path = temp_dir.path().join(".chroma").join("credentials");
         let contents = fs::read_to_string(credentials_path).expect("Failed to read credentials");
-        let updated_profiles: Profiles = toml::from_str(&contents).expect("Failed to parse profiles");
+        let updated_profiles: Profiles =
+            toml::from_str(&contents).expect("Failed to parse profiles");
         assert!(!updated_profiles.contains_key("default"));
     }
 
     #[test]
     fn test_profile_command_list() {
-        let profiles = Some(Profiles::from([
-            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
-        ]));
-        let temp_dir = setup_test_environment(profiles, None);
+        let profiles = Some(Profiles::from([(
+            "test".to_string(),
+            Profile {
+                name: "test".to_string(),
+                api_key: "another_key".to_string(),
+                team_id: "another_team".to_string(),
+            },
+        )]));
+        setup_test_environment(profiles, None);
 
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
@@ -447,8 +566,10 @@ mod tests {
 
     #[test]
     fn test_profile_command_show() {
-        let config = Some(CliConfig { current_profile: "test".to_string() });
-        let temp_dir = setup_test_environment(None, config);
+        let config = Some(CliConfig {
+            current_profile: "test".to_string(),
+        });
+        setup_test_environment(None, config);
 
         let mut output = Vec::new();
         control::set_override(true); // Enable colored output for testing
@@ -465,13 +586,22 @@ mod tests {
 
     #[test]
     fn test_profile_command_use() {
-        let profiles = Some(Profiles::from([
-            ("test".to_string(), Profile { name: "test".to_string(), api_key: "another_key".to_string(), team_id: "another_team".to_string() }),
-        ]));
-        let config = Some(CliConfig { current_profile: "".to_string() });
+        let profiles = Some(Profiles::from([(
+            "test".to_string(),
+            Profile {
+                name: "test".to_string(),
+                api_key: "another_key".to_string(),
+                team_id: "another_team".to_string(),
+            },
+        )]));
+        let config = Some(CliConfig {
+            current_profile: "".to_string(),
+        });
         let temp_dir = setup_test_environment(profiles, config);
 
-        let command = ProfileCommand::Use(UseArgs { name: "test".to_string() });
+        let command = ProfileCommand::Use(UseArgs {
+            name: "test".to_string(),
+        });
         profile_command(command);
 
         let config_path = temp_dir.path().join(".chroma").join("config.json");

--- a/rust/cli/src/commands/vacuum.rs
+++ b/rust/cli/src/commands/vacuum.rs
@@ -196,7 +196,7 @@ pub fn vacuum(args: VacuumArgs) {
     // Vacuum the database. This may result in a small increase in performance.
     // If you recently upgraded Chroma from a version below 0.5.6 to 0.5.6 or above, you should run this command once to greatly reduce the size of your database and enable continuous database pruning. In most other cases, vacuuming will save very little disk space.
     // The execution time of this command scales with the size of your database. It blocks both reads and writes to the database while it is running.
-    println!("{}", "\nChroma Vacuum\n".underline().bold());
+    println!("{}", "Chroma Vacuum\n".underline().bold());
 
     let mut config = FrontendServerConfig::single_node_default();
     let persistent_path = args.path.unwrap_or(config.persist_path);
@@ -286,5 +286,4 @@ pub fn vacuum(args: VacuumArgs) {
             .to_string()
             .green()
     );
-    println!();
 }

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -1,11 +1,11 @@
 mod commands;
 mod utils;
 
-use std::io;
 use crate::commands::profile::{profile_command, ProfileCommand};
 use crate::commands::run::{run, RunArgs};
 use crate::commands::vacuum::{vacuum, VacuumArgs};
 use clap::{Parser, Subcommand};
+use std::io;
 
 #[derive(Subcommand, Debug)]
 enum Command {

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -1,10 +1,10 @@
 mod commands;
 mod utils;
 
+use crate::commands::profile::{profile_command, ProfileCommand};
 use crate::commands::run::{run, RunArgs};
 use crate::commands::vacuum::{vacuum, VacuumArgs};
 use clap::{Parser, Subcommand};
-use crate::commands::profile::{profile_command, ProfileCommand};
 
 #[derive(Subcommand, Debug)]
 enum Command {

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod utils;
 
+use std::io;
 use crate::commands::profile::{profile_command, ProfileCommand};
 use crate::commands::run::{run, RunArgs};
 use crate::commands::vacuum::{vacuum, VacuumArgs};
@@ -27,16 +28,20 @@ struct Cli {
 
 pub fn chroma_cli(args: Vec<String>) {
     let cli = Cli::parse_from(args);
+    println!();
+
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
 
     match cli.command {
         Command::Docs => {
             let url = "https://docs.trychroma.com";
             if webbrowser::open(url).is_err() {
-                eprintln!("Error: Failed to open the browser. Visit {}.", url);
+                eprintln!("Error: Failed to open the browser. Visit {}\n.", url);
             }
         }
         Command::Profile(profile_subcommand) => {
-            profile_command(profile_subcommand);
+            profile_command(&mut out, profile_subcommand).expect("Failed to write output");
         }
         Command::Run(args) => {
             run(args);
@@ -44,11 +49,12 @@ pub fn chroma_cli(args: Vec<String>) {
         Command::Support => {
             let url = "https://discord.gg/MMeYNTmh3x";
             if webbrowser::open(url).is_err() {
-                eprintln!("Error: Failed to open the browser. Visit {}.", url);
+                eprintln!("Error: Failed to open the browser. Visit {}\n.", url);
             }
         }
         Command::Vacuum(args) => {
             vacuum(args);
         }
     }
+    println!();
 }

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -4,10 +4,13 @@ mod utils;
 use crate::commands::run::{run, RunArgs};
 use crate::commands::vacuum::{vacuum, VacuumArgs};
 use clap::{Parser, Subcommand};
+use crate::commands::profile::{profile_command, ProfileCommand};
 
 #[derive(Subcommand, Debug)]
 enum Command {
     Docs,
+    #[command(subcommand)]
+    Profile(ProfileCommand),
     Run(RunArgs),
     Support,
     Vacuum(VacuumArgs),
@@ -31,6 +34,9 @@ pub fn chroma_cli(args: Vec<String>) {
             if webbrowser::open(url).is_err() {
                 eprintln!("Error: Failed to open the browser. Visit {}.", url);
             }
+        }
+        Command::Profile(profile_subcommand) => {
+            profile_command(profile_subcommand);
         }
         Command::Run(args) => {
             run(args);

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -1,9 +1,9 @@
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
-use colored::Colorize;
 
 pub const LOGO: &str = "
                 \x1b[38;5;069m(((((((((    \x1b[38;5;203m(((((\x1b[38;5;220m####
@@ -31,7 +31,9 @@ pub struct ChromaCliError {
 
 impl ChromaCliError {
     fn new(msg: &str) -> ChromaCliError {
-        ChromaCliError { message: msg.to_string() }
+        ChromaCliError {
+            message: msg.to_string(),
+        }
     }
 }
 

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+
 pub const LOGO: &str = "
                 \x1b[38;5;069m(((((((((    \x1b[38;5;203m(((((\x1b[38;5;220m####
              \x1b[38;5;069m(((((((((((((\x1b[38;5;203m(((((((((\x1b[38;5;220m#########
@@ -11,3 +17,101 @@ pub const LOGO: &str = "
              \x1b[38;5;069m((((((((\x1b[38;5;203m((((((((\x1b[38;5;220m##############
                 \x1b[38;5;069m(((((\x1b[38;5;203m((((    \x1b[38;5;220m#########\x1b[0m
 ";
+
+#[derive(Debug, Deserialize)]
+pub struct CliEnvConfig {
+    pub dashboard_url: &'static str,
+    pub dashboard_api_url: &'static str,
+    pub frontend_url: &'static str,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Profile {
+    pub name: String,
+    pub api_key: String,
+    pub team_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CliConfig {
+    pub current_profile: String,
+}
+
+pub type Profiles = HashMap<String, Profile>;
+
+pub fn load_cli_env_config(dev: bool) -> CliEnvConfig{
+    match dev {
+        true => CliEnvConfig {
+            dashboard_url: "http://localhost:3001",
+            dashboard_api_url: "http://localhost:8002",
+            frontend_url: "http://localhost:8000",
+        },
+        false => CliEnvConfig {
+            dashboard_url: "https://trychroma.com",
+            dashboard_api_url: "https://backend.trychroma.com",
+            frontend_url: "https://frontend.trychroma.com",
+        }
+    }
+}
+
+fn get_credentials_file_path() -> Result<PathBuf, Box<dyn Error>> {
+    let home_dir = std::env::var("HOME")?;
+    let chroma_dir = PathBuf::from(home_dir).join(".chroma");
+    if !chroma_dir.exists() {
+        fs::create_dir_all(&chroma_dir)?;
+    }
+
+    let credentials_path = chroma_dir.join("credentials");
+    if !credentials_path.exists() {
+        fs::write(&credentials_path, "")?;
+    }
+
+    Ok(credentials_path)
+}
+
+pub fn get_profiles() -> Result<Profiles, Box<dyn Error>> {
+    let credentials_path = get_credentials_file_path()?;
+    let contents = fs::read_to_string(credentials_path)?;
+    let profiles: Profiles = toml::from_str(&contents)?;
+    Ok(profiles)
+}
+
+pub fn write_profiles(profiles: &Profiles) -> Result<(), Box<dyn Error>> {
+    let credentials_path = get_credentials_file_path()?;
+    let toml_str = toml::to_string(profiles)?;
+    fs::write(credentials_path, toml_str)?;
+    Ok(())
+}
+
+fn get_config_file_path() -> Result<PathBuf, Box<dyn Error>> {
+    let home_dir = std::env::var("HOME")?;
+    let chroma_dir = PathBuf::from(home_dir).join(".chroma");
+    if !chroma_dir.exists() {
+        fs::create_dir_all(&chroma_dir)?;
+    }
+
+    let config_path = chroma_dir.join("config.json");
+    if !config_path.exists() {
+        let default_config = CliConfig {
+            current_profile: String::new(),
+        };
+        let json_str = serde_json::to_string_pretty(&default_config)?;
+        fs::write(&config_path, json_str)?;
+    }
+
+    Ok(config_path)
+}
+
+pub fn read_config() -> Result<CliConfig, Box<dyn Error>> {
+    let config_path = get_config_file_path()?;
+    let contents = fs::read_to_string(&config_path)?;
+    let config: CliConfig = serde_json::from_str(&contents)?;
+    Ok(config)
+}
+
+pub fn write_config(config: &CliConfig) -> Result<(), Box<dyn Error>> {
+    let config_path = get_config_file_path()?;
+    let json_str = serde_json::to_string_pretty(config)?;
+    fs::write(config_path, json_str)?;
+    Ok(())
+}

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -1,8 +1,8 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
-use serde::{Deserialize, Serialize};
 
 pub const LOGO: &str = "
                 \x1b[38;5;069m(((((((((    \x1b[38;5;203m(((((\x1b[38;5;220m####

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -18,13 +18,6 @@ pub const LOGO: &str = "
                 \x1b[38;5;069m(((((\x1b[38;5;203m((((    \x1b[38;5;220m#########\x1b[0m
 ";
 
-#[derive(Debug, Deserialize)]
-pub struct CliEnvConfig {
-    pub dashboard_url: &'static str,
-    pub dashboard_api_url: &'static str,
-    pub frontend_url: &'static str,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Profile {
     pub name: String,
@@ -38,21 +31,6 @@ pub struct CliConfig {
 }
 
 pub type Profiles = HashMap<String, Profile>;
-
-pub fn load_cli_env_config(dev: bool) -> CliEnvConfig{
-    match dev {
-        true => CliEnvConfig {
-            dashboard_url: "http://localhost:3001",
-            dashboard_api_url: "http://localhost:8002",
-            frontend_url: "http://localhost:8000",
-        },
-        false => CliEnvConfig {
-            dashboard_url: "https://trychroma.com",
-            dashboard_api_url: "https://backend.trychroma.com",
-            frontend_url: "https://frontend.trychroma.com",
-        }
-    }
-}
 
 fn get_credentials_file_path() -> Result<PathBuf, Box<dyn Error>> {
     let home_dir = std::env::var("HOME")?;

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
+use colored::Colorize;
 
 pub const LOGO: &str = "
                 \x1b[38;5;069m(((((((((    \x1b[38;5;203m(((((\x1b[38;5;220m####
@@ -18,9 +19,24 @@ pub const LOGO: &str = "
                 \x1b[38;5;069m(((((\x1b[38;5;203m((((    \x1b[38;5;220m#########\x1b[0m
 ";
 
+const CHROMA_DIR: &str = ".chroma";
+const CREDENTIALS_FILE: &str = "credentials";
+const CONFIG_FILE: &str = "config.json";
+
+#[derive(Debug)]
+pub struct ChromaCliError {
+    #[allow(dead_code)]
+    pub message: String,
+}
+
+impl ChromaCliError {
+    fn new(msg: &str) -> ChromaCliError {
+        ChromaCliError { message: msg.to_string() }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Profile {
-    pub name: String,
     pub api_key: String,
     pub team_id: String,
 }
@@ -32,22 +48,25 @@ pub struct CliConfig {
 
 pub type Profiles = HashMap<String, Profile>;
 
-fn get_credentials_file_path() -> Result<PathBuf, Box<dyn Error>> {
-    let home_dir = std::env::var("HOME")?;
-    let chroma_dir = PathBuf::from(home_dir).join(".chroma");
+fn get_chroma_dir() -> Result<PathBuf, Box<dyn Error>> {
+    let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let chroma_dir = home_dir.join(CHROMA_DIR);
     if !chroma_dir.exists() {
         fs::create_dir_all(&chroma_dir)?;
-    }
+    };
+    Ok(chroma_dir)
+}
 
-    let credentials_path = chroma_dir.join("credentials");
+fn get_credentials_file_path() -> Result<PathBuf, Box<dyn Error>> {
+    let chroma_dir = get_chroma_dir()?;
+    let credentials_path = chroma_dir.join(CREDENTIALS_FILE);
     if !credentials_path.exists() {
         fs::write(&credentials_path, "")?;
     }
-
     Ok(credentials_path)
 }
 
-pub fn get_profiles() -> Result<Profiles, Box<dyn Error>> {
+pub fn read_profiles() -> Result<Profiles, Box<dyn Error>> {
     let credentials_path = get_credentials_file_path()?;
     let contents = fs::read_to_string(credentials_path)?;
     let profiles: Profiles = toml::from_str(&contents)?;
@@ -62,13 +81,8 @@ pub fn write_profiles(profiles: &Profiles) -> Result<(), Box<dyn Error>> {
 }
 
 fn get_config_file_path() -> Result<PathBuf, Box<dyn Error>> {
-    let home_dir = std::env::var("HOME")?;
-    let chroma_dir = PathBuf::from(home_dir).join(".chroma");
-    if !chroma_dir.exists() {
-        fs::create_dir_all(&chroma_dir)?;
-    }
-
-    let config_path = chroma_dir.join("config.json");
+    let chroma_dir = get_chroma_dir()?;
+    let config_path = chroma_dir.join(CONFIG_FILE);
     if !config_path.exists() {
         let default_config = CliConfig {
             current_profile: String::new(),
@@ -92,4 +106,46 @@ pub fn write_config(config: &CliConfig) -> Result<(), Box<dyn Error>> {
     let json_str = serde_json::to_string_pretty(config)?;
     fs::write(config_path, json_str)?;
     Ok(())
+}
+
+pub fn get_config() -> Option<CliConfig> {
+    match read_config() {
+        Ok(config) => Some(config),
+        Err(_) => {
+            eprintln!("{}", "Could not load CLI config".red());
+            None
+        }
+    }
+}
+
+pub fn get_profiles() -> Option<Profiles> {
+    match read_profiles() {
+        Ok(profiles) => Some(profiles),
+        Err(_) => {
+            eprintln!("{}", "Could not load profiles".red());
+            None
+        }
+    }
+}
+
+pub fn save_config(config: &CliConfig) -> Result<(), ChromaCliError> {
+    match write_config(config) {
+        Ok(_) => Ok(()),
+        Err(_e) => {
+            let message = "Could not save CLI config".red();
+            eprintln!("{}", message);
+            Err(ChromaCliError::new(&message))
+        }
+    }
+}
+
+pub fn save_profiles(profiles: &Profiles) -> Result<(), ChromaCliError> {
+    match write_profiles(profiles) {
+        Ok(_) => Ok(()),
+        Err(_e) => {
+            let message = "Could not save credentials".red();
+            eprintln!("{}", message);
+            Err(ChromaCliError::new(&message))
+        }
+    }
 }


### PR DESCRIPTION
## Description of changes
Added `chroma profile` to manage profiles users login with.
* Credentials are saved in `~/.chroma/credentials`
* Current profile set in `~/.chroma/config.json`

## Test plan
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
