### PR TITLE
[CHORE] rename inner_product to IP & remove error raise on legacy embedding functions 

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -56,7 +56,7 @@ Embeddings = List[Embedding]
 class Space(Enum):
     COSINE = "cosine"
     L2 = "l2"
-    INNER_PRODUCT = "inner_product"
+    IP = "IP"
 
 
 def normalize_embeddings(
@@ -529,9 +529,7 @@ class EmbeddingFunction(Protocol[D]):
             DeprecationWarning,
             stacklevel=2,
         )
-        raise NotImplementedError(
-            "name() is not implemented for this embedding function."
-        )
+        return NotImplemented
 
     def default_space(self) -> Space:
         """
@@ -543,7 +541,7 @@ class EmbeddingFunction(Protocol[D]):
         """
         Return the supported spaces for the embedding function.
         """
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[D]":
@@ -562,9 +560,7 @@ class EmbeddingFunction(Protocol[D]):
             DeprecationWarning,
             stacklevel=2,
         )
-        raise NotImplementedError(
-            "build_from_config() is not implemented for this embedding function."
-        )
+        return NotImplemented
 
     def get_config(self) -> Dict[str, Any]:
         """
@@ -582,9 +578,7 @@ class EmbeddingFunction(Protocol[D]):
             DeprecationWarning,
             stacklevel=2,
         )
-        raise NotImplementedError(
-            "get_config() is not implemented for this embedding function."
-        )
+        return NotImplemented
 
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]

--- a/chromadb/utils/embedding_functions/cohere_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cohere_embedding_function.py
@@ -57,26 +57,26 @@ class CohereEmbeddingFunction(EmbeddingFunction[Documents]):
 
     def default_space(self) -> Space:
         if self.model_name == "embed-multilingual-v2.0":
-            return Space.INNER_PRODUCT
+            return Space.IP
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
         if self.model_name == "embed-english-v3.0":
-            return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+            return [Space.COSINE, Space.L2, Space.IP]
         elif self.model_name == "embed-english-light-v3.0":
-            return [Space.COSINE, Space.INNER_PRODUCT, Space.L2]
+            return [Space.COSINE, Space.IP, Space.L2]
         elif self.model_name == "embed-english-v2.0":
             return [Space.COSINE]
         elif self.model_name == "embed-english-light-v2.0":
             return [Space.COSINE]
         elif self.model_name == "embed-multilingual-v3.0":
-            return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+            return [Space.COSINE, Space.L2, Space.IP]
         elif self.model_name == "embed-multilingual-light-v3.0":
-            return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+            return [Space.COSINE, Space.L2, Space.IP]
         elif self.model_name == "embed-multilingual-v2.0":
-            return [Space.INNER_PRODUCT]
+            return [Space.IP]
         else:
-            return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+            return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -73,7 +73,7 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
@@ -190,7 +190,7 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
@@ -314,7 +314,7 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -76,7 +76,7 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
@@ -169,7 +169,7 @@ class HuggingFaceEmbeddingServer(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/instructor_embedding_function.py
+++ b/chromadb/utils/embedding_functions/instructor_embedding_function.py
@@ -74,7 +74,7 @@ class InstructorEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -91,7 +91,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/ollama_embedding_function.py
+++ b/chromadb/utils/embedding_functions/ollama_embedding_function.py
@@ -79,7 +79,7 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -315,7 +315,7 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     def max_tokens(self) -> int:
         # Default token limit for ONNX Mini LM L6 V2 model

--- a/chromadb/utils/embedding_functions/open_clip_embedding_function.py
+++ b/chromadb/utils/embedding_functions/open_clip_embedding_function.py
@@ -137,7 +137,7 @@ class OpenCLIPEmbeddingFunction(EmbeddingFunction[Embeddable]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -130,7 +130,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/roboflow_embedding_function.py
+++ b/chromadb/utils/embedding_functions/roboflow_embedding_function.py
@@ -113,7 +113,7 @@ class RoboflowEmbeddingFunction(EmbeddingFunction[Embeddable]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -72,7 +72,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/text2vec_embedding_function.py
+++ b/chromadb/utils/embedding_functions/text2vec_embedding_function.py
@@ -54,7 +54,7 @@ class Text2VecEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -65,7 +65,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
         return Space.COSINE
 
     def supported_spaces(self) -> List[Space]:
-        return [Space.COSINE, Space.L2, Space.INNER_PRODUCT]
+        return [Space.COSINE, Space.L2, Space.IP]
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":

--- a/clients/js/packages/chromadb-core/src/embeddings/CohereEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/CohereEmbeddingFunction.ts
@@ -171,11 +171,11 @@ export class CohereEmbeddingFunction implements IEmbeddingFunction {
 
   supportedSpaces(): EmbeddingFunctionSpace[] {
     if (this.model === "embed-english-v3.0") {
-      return ["cosine", "l2", "inner_product"];
+      return ["cosine", "l2", "ip"];
     }
 
     if (this.model === "embed-english-light-v3.0") {
-      return ["cosine", "inner_product", "l2"];
+      return ["cosine", "ip", "l2"];
     }
 
     if (this.model === "embed-english-v2.0") {
@@ -187,23 +187,23 @@ export class CohereEmbeddingFunction implements IEmbeddingFunction {
     }
 
     if (this.model === "embed-multilingual-v3.0") {
-      return ["cosine", "l2", "inner_product"];
+      return ["cosine", "l2", "ip"];
     }
 
     if (this.model === "embed-multilingual-light-v3.0") {
-      return ["cosine", "l2", "inner_product"];
+      return ["cosine", "l2", "ip"];
     }
 
     if (this.model === "embed-multilingual-v2.0") {
-      return ["inner_product"];
+      return ["ip"];
     }
 
-    return ["cosine", "l2", "inner_product"];
+    return ["cosine", "l2", "ip"];
   }
 
   defaultSpace(): EmbeddingFunctionSpace {
     if (this.model == "embed-multilingual-v2.0") {
-      return "inner_product";
+      return "ip";
     }
 
     return "cosine";

--- a/clients/js/packages/chromadb-core/src/embeddings/IEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/IEmbeddingFunction.ts
@@ -1,4 +1,4 @@
-export type EmbeddingFunctionSpace = "cosine" | "l2" | "inner_product";
+export type EmbeddingFunctionSpace = "cosine" | "l2" | "ip";
 
 export interface IEmbeddingFunction {
   generate(texts: string[]): Promise<number[][]>;


### PR DESCRIPTION
## Description of changes
rename inner_product to IP and remove error raise on legacy embedding functions, instead returning NotImplemented to stop erroring out.

