### PR TITLE
[TST]: enable Rust backtraces in Tilt services

### DIFF
--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -4,16 +4,27 @@ sysdb:
     soft-delete-max-age: 1s
     soft-delete-cleanup-interval: 2s
 
-
 rustFrontendService:
-# We have to specify the command, because the Dockerfile uses the CLI since its shared with
-# single node, so in values.dev we pass the CONFIG_PATH into the chroma run command
+  # We have to specify the command, because the Dockerfile uses the CLI since its shared with
+  # single node, so in values.dev we pass the CONFIG_PATH into the chroma run command
   command: '["chroma", "run", "$(CONFIG_PATH)"]'
   otherEnvConfig: |
     - name: CHROMA_ALLOW_RESET
       value: "true"
+    - name: RUST_BACKTRACE
+      value: 'value: "1"'
 
 frontendService:
   otherEnvConfig: |
     - name: CHROMA_ALLOW_RESET
       value: "true"
+
+queryService:
+  env:
+    - name: RUST_BACKTRACE
+      value: 'value: "1"'
+
+compactionService:
+  env:
+    - name: RUST_BACKTRACE
+      value: 'value: "1"'


### PR DESCRIPTION
## Description of changes

Allows us to see the full backtrace of panics.

## Test plan
*How are these changes tested?*

Manually added a panic to the compactor and observed that a full stack trace was printed.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a