### PR TITLE
[ENH]  Every wal3 fragment can optionally mark itself dirty.

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -130,7 +130,6 @@ impl S3Storage {
                 ))
             }
             Err(e) => {
-                tracing::error!("error: {}", e);
                 match e {
                     SdkError::ServiceError(err) => {
                         let inner = err.into_err();
@@ -142,13 +141,13 @@ impl S3Storage {
                                 })
                             }
                             aws_sdk_s3::operation::get_object::GetObjectError::InvalidObjectState(msg) => {
-                                 tracing::error!("invalid object state: {}", msg);
+                                tracing::error!("invalid object state: {}", msg);
                                 Err(StorageError::Generic {
                                     source: Arc::new(inner),
                                 })
                             }
                             _ => {
-                                 tracing::error!("error: {}", inner.to_string());
+                                tracing::error!("error: {}", inner.to_string());
                                 Err(StorageError::Generic {
                                     source: Arc::new(inner),
                                 })

--- a/rust/wal3/examples/wal3-bench.rs
+++ b/rust/wal3/examples/wal3-bench.rs
@@ -59,6 +59,7 @@ async fn main() {
             storage,
             "wal3bench",
             "benchmark writer",
+            (),
         )
         .await
         .unwrap(),

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -17,7 +17,7 @@ pub use batch_manager::BatchManager;
 pub use manifest::{Manifest, Snapshot, SnapshotPointer};
 pub use manifest_manager::ManifestManager;
 pub use reader::{Limits, LogReader};
-pub use writer::{upload_parquet, LogWriter};
+pub use writer::{upload_parquet, LogWriter, MarkDirty};
 
 /////////////////////////////////////////////// Error //////////////////////////////////////////////
 
@@ -39,6 +39,8 @@ pub enum Error {
     LogFull,
     #[error("the log is closed")]
     LogClosed,
+    #[error("an empty batch was passed to append")]
+    EmptyBatch,
     #[error("an internal, otherwise unclassifiable error")]
     Internal,
     #[error("could not find FSN in path: {0}")]
@@ -67,6 +69,7 @@ impl chroma_error::ChromaError for Error {
             Self::LogContention => chroma_error::ErrorCodes::Aborted,
             Self::LogFull => chroma_error::ErrorCodes::Aborted,
             Self::LogClosed => chroma_error::ErrorCodes::FailedPrecondition,
+            Self::EmptyBatch => chroma_error::ErrorCodes::InvalidArgument,
             Self::Internal => chroma_error::ErrorCodes::Internal,
             Self::MissingFragmentSequenceNumber(_) => chroma_error::ErrorCodes::Internal,
             Self::CorruptManifest(_) => chroma_error::ErrorCodes::DataLoss,

--- a/rust/wal3/tests/test_k8s_integration_01_empty_and_open.rs
+++ b/rust/wal3/tests/test_k8s_integration_01_empty_and_open.rs
@@ -25,6 +25,7 @@ async fn test_k8s_integration_01_empty_and_open() {
         Arc::clone(&storage),
         "test_k8s_integration_01_empty_and_append",
         "test writer",
+        (),
     )
     .await
     .unwrap_err();

--- a/rust/wal3/tests/test_k8s_integration_03_initialized_append_succeeds.rs
+++ b/rust/wal3/tests/test_k8s_integration_03_initialized_append_succeeds.rs
@@ -37,6 +37,7 @@ async fn test_k8s_integration_03_initialized_append_succeeds() {
         Arc::clone(&storage),
         "test_k8s_integration_03_initialized_append_succeeds",
         "test writer",
+        (),
     )
     .await
     .unwrap();

--- a/rust/wal3/tests/test_k8s_integration_04_initialized_append_until_snapshot.rs
+++ b/rust/wal3/tests/test_k8s_integration_04_initialized_append_until_snapshot.rs
@@ -44,6 +44,7 @@ async fn test_k8s_integration_04_initialized_append_until_snapshot() {
         Arc::clone(&storage),
         "test_k8s_integration_04_initialized_append_until_snapshot",
         "test writer",
+        (),
     )
     .await
     .unwrap();

--- a/rust/wal3/tests/test_k8s_integration_05_crash_safety_initialize_fails.rs
+++ b/rust/wal3/tests/test_k8s_integration_05_crash_safety_initialize_fails.rs
@@ -68,6 +68,7 @@ async fn test_k8s_integration_05_crash_safety_initialize_fails() {
         Arc::clone(&storage),
         "test_k8s_integration_05_crash_safety_initialize_fails",
         "test writer",
+        (),
     )
     .await
     .unwrap();


### PR DESCRIPTION
Given a future, the dirty bit will be optimistically set, and definitely
flushed before writing the manifest.  This guarantees that any log
making progress is logging its progress on the side.
