### PR TITLE
[TST]: enable "normal" property testing preset in PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -164,7 +164,7 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
     uses: ./.github/workflows/_python-tests.yml
     with:
-      property_testing_preset: 'fast'
+      property_testing_preset: 'normal'
 
   python-vulnerability-scan:
     name: Python vulnerability scan


### PR DESCRIPTION
## Description of changes

The normal preset no longer take significantly longer than our fast preset and tests twice the number of examples.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a