### PR TITLE
[ENH] chroma-load potpourri

### DIFF
--- a/rust/load/chroma_load_config.yaml
+++ b/rust/load/chroma_load_config.yaml
@@ -1,4 +1,4 @@
 load_service:
   service_name: chroma-load
   otel_endpoint: "http://otel-collector:4317"
-  port: 3000
+  port: 3001

--- a/rust/load/src/lib.rs
+++ b/rust/load/src/lib.rs
@@ -201,7 +201,7 @@ pub async fn client_for_url(url: String) -> ChromaClient {
         ChromaClient::new(ChromaClientOptions {
             url: Some(url),
             auth: ChromaAuthMethod::None,
-            database: "hf-tiny-stories".to_string(),
+            database: "default_database".to_string(),
         })
         .await
         .unwrap()
@@ -760,7 +760,7 @@ impl Workload {
                             batch_size: 100,
                             // Associativity is the ratio of documents in a cluster to documents
                             // written by the workload.  It is ignored for load.
-                            associativity: 0.0,
+                            associativity: 1.0,
                         },
                         &mut state.guac,
                     )


### PR DESCRIPTION
- Change the default listening port to 3001 to not conflict with RFE.
- Fix a bug in bit-difference where it would generate zero-sized clusters.
- Fix a bug in bit-difference where duplicate IDs would be generated.
- Change the default database to "default_database" for zero-auth connections.
- Set associativity to 1.0 for random_upsert.
