### PR TITLE
[ENH] Prefetch all posting lists at start of compaction

### DIFF
--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 const HNSW_PATH: &str = "hnsw_path";
 const VERSION_MAP_PATH: &str = "version_map_path";
-const POSTING_LIST_PATH: &str = "posting_list_path";
+pub const POSTING_LIST_PATH: &str = "posting_list_path";
 const MAX_HEAD_ID_BF_PATH: &str = "max_head_id_path";
 
 #[derive(Clone)]

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -296,6 +296,7 @@ impl CompactOrchestrator {
         for segment in segments {
             if segment.r#type == SegmentType::BlockfileMetadata
                 || segment.r#type == SegmentType::BlockfileRecord
+                || segment.r#type == SegmentType::Spann
             {
                 let prefetch_task = wrap(
                     Box::new(PrefetchSegmentOperator::new()),


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Speeds up compaction since all the posting lists are fetched in parallel and at the start of compaction
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
