### PR TITLE
Fix Docker image name in server startup command

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
+++ b/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
@@ -28,7 +28,7 @@ You can run a Chroma server in a Docker container, and access it using the `Http
 To start the server, run:
 
 ```terminal
-docker run -v ./chroma-data:/data -p 8000:8000 chroma-core/chroma
+docker run -v ./chroma-data:/data -p 8000:8000 chromadb/chroma
 ```
 
 This starts the server with the default configuration and stores data in `./chroma-data` (in your current working directory).


### PR DESCRIPTION
Update the Docker run command to use the correct image repository (`chromadb/chroma`).   The previous image (`chroma-core/chroma`) may be outdated or incorrect.   This ensures users pull the proper image for the server.