### PR TITLE
[BLD]: fix: install depot CLI before running `tilt ci`

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -7,6 +7,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Depot CLI
+      uses: depot/setup-action@v1
     - name: Install Tilt
       shell: bash
       run: |


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
