### PR TITLE
[CLN]  wal3 doc<->code sync

### DIFF
--- a/rust/wal3/README.md
+++ b/rust/wal3/README.md
@@ -96,6 +96,7 @@ The Manifest is a JSON file that contains the following fields:
     - start:  The lowest log position in the fragment.  Note that this embeds time and space.
     - limit:  The lowest log position after the fragment.  Note that this embeds time and space.
     - setsum:  The setsum of the log fragment.
+- writer:  A plain-text string for debugging which process wrote the manifest.
 
 Invariants of the manifest:
 
@@ -115,21 +116,22 @@ institute rate limiting per prefix.  For example, given the following log files 
 we will group fragments in groups of 5000 and the manifest will be in a separate prefix.
 
 The following shows numbers every 5000.  I'd zero-pad to 16 hex digits for the sequence number and
-bucket fragments in groups of 4096 so the bits align and look pretty in the seqno prefix.
+bucket fragments in groups of 4096 so the bits align and look pretty in the bucket prefix.
 
 ```text
-wal3/SeqNo=    0/0000000000000000.parquet
-wal3/SeqNo=    0/0000000000000001.parquet
-wal3/SeqNo=    0/0000000000000002.parquet
+wal3/log/Bucket=    0/FragmentSeqNo=00000.parquet
+wal3/log/Bucket=    0/FragmentSeqNo=00001.parquet
+wal3/log/Bucket=    0/FragmentSeqNo=00002.parquet
 ...
-wal3/SeqNo=    0/0000000000004999.parquet
-wal3/SeqNo= 5000/0000000000005000.parquet
+wal3/log/Bucket=    0/FragmentSeqNo=04999.parquet
+wal3/log/Bucket= 5000/FragmentSeqNo=05000.parquet
 ...
-wal3/SeqNo=10000/0000000000010000.parquet
+wal3/log/Bucket=10000/FragmentSeqNo=10000.parquet
 ...
-wal3/SeqNo=15000/0000000000015000.parquet
+wal3/log/Bucket=15000/FragmentSeqNo=15000.parquet
 ...
-wal3/Manifest/MANIFEST.json
+wal3/manifest/MANIFEST.json
+wal3/snapshot/SNAPSHOT.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 ## Writer Arch Diagram

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -340,7 +340,7 @@ impl FragmentSeqNo {
 
     // Round down to the nearest multiple of 5k.
     pub fn bucket(&self) -> u64 {
-        (self.0 / 5_000) * 5_000
+        (self.0 / 4_096) * 4_096
     }
 }
 
@@ -429,7 +429,7 @@ where
 
 pub fn unprefixed_fragment_path(fragment_seq_no: FragmentSeqNo) -> String {
     format!(
-        "log/Bucket={}/FragmentSeqNo={}.parquet",
+        "log/Bucket={:016x}/FragmentSeqNo={:016x}.parquet",
         fragment_seq_no.bucket(),
         fragment_seq_no.0,
     )
@@ -440,5 +440,5 @@ pub fn parse_fragment_path(path: &str) -> Option<FragmentSeqNo> {
     let (_, basename) = path.rsplit_once('/')?;
     let fsn_equals_number = basename.strip_suffix(".parquet")?;
     let number = fsn_equals_number.strip_prefix("FragmentSeqNo=")?;
-    number.parse::<u64>().ok().map(FragmentSeqNo)
+    u64::from_str_radix(number, 16).ok().map(FragmentSeqNo)
 }

--- a/rust/wal3/tests/test_k8s_integration_03_initialized_append_succeeds.rs
+++ b/rust/wal3/tests/test_k8s_integration_03_initialized_append_succeeds.rs
@@ -43,7 +43,7 @@ async fn test_k8s_integration_03_initialized_append_succeeds() {
     .unwrap();
     let position = log.append(vec![42, 43, 44, 45]).await.unwrap();
     let fragment1 = FragmentCondition {
-        path: "log/Bucket=0/FragmentSeqNo=1.parquet".to_string(),
+        path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000001.parquet".to_string(),
         seq_no: FragmentSeqNo(1),
         start: 1,
         limit: 2,

--- a/rust/wal3/tests/test_k8s_integration_04_initialized_append_until_snapshot.rs
+++ b/rust/wal3/tests/test_k8s_integration_04_initialized_append_until_snapshot.rs
@@ -50,7 +50,7 @@ async fn test_k8s_integration_04_initialized_append_until_snapshot() {
     .unwrap();
     let position = log.append(vec![42, 43, 44, 45]).await.unwrap();
     let fragment1 = FragmentCondition {
-        path: "log/Bucket=0/FragmentSeqNo=1.parquet".to_string(),
+        path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000001.parquet".to_string(),
         seq_no: FragmentSeqNo(1),
         start: 1,
         limit: 2,
@@ -74,7 +74,7 @@ async fn test_k8s_integration_04_initialized_append_until_snapshot() {
     .await;
     let position = log.append(vec![81, 82, 83, 84]).await.unwrap();
     let fragment2 = FragmentCondition {
-        path: "log/Bucket=0/FragmentSeqNo=2.parquet".to_string(),
+        path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000002.parquet".to_string(),
         seq_no: FragmentSeqNo(2),
         start: 2,
         limit: 3,
@@ -105,7 +105,7 @@ async fn test_k8s_integration_04_initialized_append_until_snapshot() {
     tokio::time::sleep(Duration::from_secs(1)).await;
     let position = log.append(vec![90, 91, 92, 93]).await.unwrap();
     let fragment3 = FragmentCondition {
-        path: "log/Bucket=0/FragmentSeqNo=3.parquet".to_string(),
+        path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000003.parquet".to_string(),
         seq_no: FragmentSeqNo(3),
         start: 3,
         limit: 4,

--- a/rust/wal3/tests/test_k8s_integration_05_crash_safety_initialize_fails.rs
+++ b/rust/wal3/tests/test_k8s_integration_05_crash_safety_initialize_fails.rs
@@ -34,7 +34,7 @@ async fn test_k8s_integration_05_crash_safety_initialize_fails() {
     .unwrap();
     assert_eq!(path, "log/Bucket=0/FragmentSeqNo=1.parquet");
     let fragment1 = FragmentCondition {
-        path: "log/Bucket=0/FragmentSeqNo=1.parquet".to_string(),
+        path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000001.parquet".to_string(),
         seq_no: FragmentSeqNo(1),
         start: 1,
         limit: 2,
@@ -49,7 +49,7 @@ async fn test_k8s_integration_05_crash_safety_initialize_fails() {
             fragments: vec![],
         }),
         Condition::Fragment(FragmentCondition {
-            path: "log/Bucket=0/FragmentSeqNo=1.parquet".to_string(),
+            path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000001.parquet".to_string(),
             seq_no: FragmentSeqNo(1),
             start: 1,
             limit: 2,
@@ -76,7 +76,7 @@ async fn test_k8s_integration_05_crash_safety_initialize_fails() {
     assert!(matches!(log_contention, wal3::Error::LogContention));
     let position = log.append(vec![81, 82, 83, 84]).await.unwrap();
     let fragment2 = FragmentCondition {
-        path: "log/Bucket=0/FragmentSeqNo=2.parquet".to_string(),
+        path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000002.parquet".to_string(),
         seq_no: FragmentSeqNo(2),
         start: 2,
         limit: 3,

--- a/rust/wal3/tests/test_k8s_integration_05_crash_safety_initialize_fails.rs
+++ b/rust/wal3/tests/test_k8s_integration_05_crash_safety_initialize_fails.rs
@@ -32,7 +32,10 @@ async fn test_k8s_integration_05_crash_safety_initialize_fails() {
     )
     .await
     .unwrap();
-    assert_eq!(path, "log/Bucket=0/FragmentSeqNo=1.parquet");
+    assert_eq!(
+        path,
+        "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000001.parquet"
+    );
     let fragment1 = FragmentCondition {
         path: "log/Bucket=0000000000000000/FragmentSeqNo=0000000000000001.parquet".to_string(),
         seq_no: FragmentSeqNo(1),


### PR DESCRIPTION
The readme says bucket by 4096 using hex; I was doing dec 5000.
This PR changes the bucketing to be groups of 4096 and uses a padded hex for the digits.
