### PR TITLE
[BLD]: add `rust-toolchain.toml`, call rustup directly in CI

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -7,12 +7,39 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Update rustup
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        rustup self update
+    - name: Update rustup on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $env:CARGO_HOME="C:\Users\Default\.cargo"; rustup self update
     - name: Setup Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: "1.81.0" # this should be kept in sync with the version in rust/worker/Dockerfile
-        cache: false # we use sccache instead
-        components: "clippy,rustfmt"
+      shell: bash
+      # (reads from rust-toolchain.toml)
+      run: |
+        rustup --version
+        rustup toolchain install
+    # Needed for sccache to work on Windows
+    - name: Set default toolchain to rust-toolchain.toml on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # Read the file content as a single string
+        $toolchainToml = Get-Content .\rust-toolchain.toml -Raw
+
+        # Use regex to match the line 'channel = "<something>"'
+        if ($toolchainToml -match 'channel\s*=\s*"([^"]+)"') {
+          $channel = $matches[1]
+          Write-Host "Setting Rust default channel to: $channel"
+          rustup default $channel
+        } else {
+          Write-Error "Could not parse 'channel' from rust-toolchain.toml"
+          exit 1
+        }
     - name: Install Protoc
       uses: arduino/setup-protoc@v2
       with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+[toolchain]
+# Keep this version in sync with:
+# - rust/cli/Dockerfile
+# - rust/load/Dockerfile
+# - rust/log/Dockerfile
+# - rust/worker/Dockerfile
+channel = "1.81.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Description of changes

The prior Rust setup action frequently flaked on Windows for unknown reasons.

This also improves DX by adding a `rust-toolchain.toml`, which ensures everyone's dev environments remain in sync (`cargo` commands will error if current version does not match).