### PR TITLE
[TST] remove conftest installs and simplify ef tests

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -38,7 +38,6 @@ from chromadb.api.async_client import (
 )
 from chromadb.utils.async_to_sync import async_class_to_sync
 import logging
-import sys
 
 logger = logging.getLogger(__name__)
 
@@ -995,74 +994,3 @@ def log_tests(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     yield
 
     logger.debug(f"Finished test: {test_name}")
-
-
-@pytest.fixture(scope="session")
-def embedding_function_dependencies() -> Generator[None, None, None]:
-    """
-    Fixture to install and uninstall dependencies required for embedding function tests.
-    This fixture has session scope to ensure dependencies are installed only once
-    for the entire test session and cleaned up afterward.
-    """
-    # List of packages to install
-    packages = [
-        "openai",
-        "cohere",
-        "sentence_transformers",
-        "google-generativeai",
-        "ollama",
-        "pillow",
-        "voyageai",
-        "open-clip-torch",
-        "text2vec",
-        "InstructorEmbedding",
-    ]
-
-    # Install packages
-    logger.info("Installing embedding function dependencies...")
-
-    executable_command = [sys.executable, "-m", "pip", "install"] + packages
-    try:
-        subprocess.check_call(executable_command)
-    except subprocess.CalledProcessError as e:
-        logger.warning(f"Failed to install embedding function dependencies: {e}")
-
-    # Yield control back to the tests
-    yield
-
-    # Uninstall packages after tests complete
-    logger.info("Uninstalling embedding function dependencies...")
-    executable_command = [sys.executable, "-m", "pip", "uninstall", "-y"] + packages
-    try:
-        subprocess.check_call(executable_command)
-    except subprocess.CalledProcessError as e:
-        logger.warning(f"Failed to uninstall embedding function dependencies: {e}")
-
-
-@pytest.fixture(scope="session")
-def openai_dependency() -> Generator[None, None, None]:
-    """
-    Fixture to install and uninstall only the OpenAI dependency.
-    This is a lighter-weight alternative to embedding_function_dependencies
-    when only OpenAI functionality is being tested.
-    """
-    # Install OpenAI package
-    logger.info("Installing OpenAI dependency...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "openai"])
-        logger.info("Installed openai")
-    except subprocess.CalledProcessError as e:
-        logger.warning(f"Failed to install openai: {e}")
-
-    # Yield control back to the tests
-    yield
-
-    # Uninstall OpenAI package after tests complete
-    logger.info("Uninstalling OpenAI dependency...")
-    try:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "uninstall", "-y", "openai"]
-        )
-        logger.info("Uninstalled openai")
-    except subprocess.CalledProcessError as e:
-        logger.warning(f"Failed to uninstall openai: {e}")

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -38,6 +38,11 @@ from chromadb.api.async_client import (
 )
 from chromadb.utils.async_to_sync import async_class_to_sync
 import logging
+import sys
+import numpy as np
+from unittest.mock import MagicMock
+from pytest import MonkeyPatch
+from chromadb.api.types import Documents, Embeddings
 
 logger = logging.getLogger(__name__)
 
@@ -994,3 +999,61 @@ def log_tests(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     yield
 
     logger.debug(f"Finished test: {test_name}")
+
+
+@pytest.fixture
+def mock_embeddings() -> Callable[[Documents], Embeddings]:
+    """Return mock embeddings for testing"""
+
+    def _mock_embeddings(input: Documents) -> Embeddings:
+        return [np.array([0.1, 0.2, 0.3], dtype=np.float32) for _ in input]
+
+    return _mock_embeddings
+
+
+@pytest.fixture
+def mock_common_deps(monkeypatch: MonkeyPatch) -> MonkeyPatch:
+    """Mock common dependencies"""
+    # Create mock modules
+    mock_modules = {
+        "PIL": MagicMock(),
+        "torch": MagicMock(),
+        "openai": MagicMock(),
+        "cohere": MagicMock(),
+        "sentence_transformers": MagicMock(),
+        "ollama": MagicMock(),
+        "InstructorEmbedding": MagicMock(),
+        "voyageai": MagicMock(),
+        "text2vec": MagicMock(),
+        "open_clip": MagicMock(),
+        "boto3": MagicMock(),
+    }
+
+    # Mock all modules at once using monkeypatch.setitem
+    monkeypatch.setattr(sys, "modules", dict(sys.modules, **mock_modules))
+
+    # Mock submodules and attributes
+    mock_attributes = {
+        "PIL.Image": MagicMock(),
+        "sentence_transformers.SentenceTransformer": MagicMock(),
+        "ollama.Client": MagicMock(),
+        "InstructorEmbedding.INSTRUCTOR": MagicMock(),
+        "voyageai.Client": MagicMock(),
+        "text2vec.SentenceModel": MagicMock(),
+    }
+
+    # Setup OpenCLIP mock with specific behavior
+    mock_model = MagicMock()
+    mock_model.encode_text.return_value = np.array([[0.1, 0.2, 0.3]])
+    mock_model.encode_image.return_value = np.array([[0.1, 0.2, 0.3]])
+    mock_modules["open_clip"].create_model_and_transforms.return_value = (
+        mock_model,
+        MagicMock(),
+        mock_model,
+    )
+
+    # Mock all attributes
+    for path, mock in mock_attributes.items():
+        monkeypatch.setattr(path, mock, raising=False)
+
+    return monkeypatch

--- a/chromadb/test/ef/test_openai_ef.py
+++ b/chromadb/test/ef/test_openai_ef.py
@@ -7,28 +7,25 @@ from chromadb.utils.embedding_functions.openai_embedding_function import (
 )
 
 
-@pytest.mark.usefixtures("openai_dependency")
-class TestOpenAIEmbeddingFunction:
-    def test_with_embedding_dimensions(self) -> None:
-        if os.environ.get("OPENAI_API_KEY") is None:
-            pytest.skip("OPENAI_API_KEY not set")
-        ef = OpenAIEmbeddingFunction(
-            api_key=os.environ["OPENAI_API_KEY"],
-            model_name="text-embedding-3-small",
-            dimensions=64,
-        )
-        embeddings = ef(["hello world"])
-        assert embeddings is not None
-        assert len(embeddings) == 1
-        assert len(embeddings[0]) == 64
+def test_with_embedding_dimensions() -> None:
+    if os.environ.get("OPENAI_API_KEY") is None:
+        pytest.skip("OPENAI_API_KEY not set")
+    ef = OpenAIEmbeddingFunction(
+        api_key=os.environ["OPENAI_API_KEY"],
+        model_name="text-embedding-3-small",
+        dimensions=64,
+    )
+    embeddings = ef(["hello world"])
+    assert embeddings is not None
+    assert len(embeddings) == 1
+    assert len(embeddings[0]) == 64
 
-    def test_with_embedding_dimensions_not_working_with_old_model(self) -> None:
-        if os.environ.get("OPENAI_API_KEY") is None:
-            pytest.skip("OPENAI_API_KEY not set")
-        ef = OpenAIEmbeddingFunction(
-            api_key=os.environ["OPENAI_API_KEY"], dimensions=64
-        )
-        with pytest.raises(
-            Exception, match="This model does not support specifying dimensions"
-        ):
-            ef(["hello world"])
+
+def test_with_embedding_dimensions_not_working_with_old_model() -> None:
+    if os.environ.get("OPENAI_API_KEY") is None:
+        pytest.skip("OPENAI_API_KEY not set")
+    ef = OpenAIEmbeddingFunction(api_key=os.environ["OPENAI_API_KEY"], dimensions=64)
+    with pytest.raises(
+        Exception, match="This model does not support specifying dimensions"
+    ):
+        ef(["hello world"])

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -1,377 +1,22 @@
 import pytest
-import os
-import sys
-from typing import List, Dict, Any
+from typing import List, Any, Callable
 from jsonschema import ValidationError
-import numpy as np
-from unittest.mock import MagicMock
-from pytest import MonkeyPatch
+from unittest.mock import MagicMock, create_autospec
 from chromadb.utils.embedding_functions.schemas import (
     validate_config_schema,
     load_schema,
     get_available_schemas,
 )
+from chromadb.utils.embedding_functions import known_embedding_functions
 from chromadb.api.types import Documents, Embeddings
-from chromadb.utils.embedding_functions import (
-    known_embedding_functions,
-)
-import numpy.typing as npt
+from pytest import MonkeyPatch
 
-# Set dummy environment variables for API keys
-os.environ["CHROMA_OPENAI_API_KEY"] = "dummy_openai_key"
-os.environ["CHROMA_HUGGINGFACE_API_KEY"] = "dummy_huggingface_key"
-os.environ["CHROMA_JINA_API_KEY"] = "dummy_jina_key"
-os.environ["CHROMA_COHERE_API_KEY"] = "dummy_cohere_key"
-os.environ["CHROMA_GOOGLE_PALM_API_KEY"] = "dummy_google_palm_key"
-os.environ["CHROMA_GOOGLE_GENAI_API_KEY"] = "dummy_google_genai_key"
-os.environ["CHROMA_GOOGLE_VERTEX_API_KEY"] = "dummy_google_vertex_key"
-os.environ["CHROMA_VOYAGEAI_API_KEY"] = "dummy_voyageai_key"
-os.environ["CHROMA_ROBOFLOW_API_KEY"] = "dummy_roboflow_key"
-os.environ["AWS_ACCESS_KEY_ID"] = "dummy_aws_access_key"
-os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_aws_secret_key"
-os.environ["AWS_REGION"] = "us-east-1"
-
-
-def mock_embeddings(input: Documents) -> Embeddings:
-    """Return mock embeddings for testing"""
-    return [np.array([0.1, 0.2, 0.3], dtype=np.float32) for _ in input]
-
-
-class BaseMockEmbedding:
-    def __init__(self, **kwargs: Any) -> None:
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-    def __call__(self, input: Documents) -> Embeddings:
-        return mock_embeddings(input)
-
-
-MockOpenAIEmbeddings = type("MockOpenAIEmbeddings", (BaseMockEmbedding,), {})
-MockCohereEmbeddings = type("MockCohereEmbeddings", (BaseMockEmbedding,), {})
-MockGooglePalmEmbeddings = type("MockGooglePalmEmbeddings", (BaseMockEmbedding,), {})
-MockGoogleGenerativeAIEmbeddings = type(
-    "MockGoogleGenerativeAIEmbeddings", (BaseMockEmbedding,), {}
-)
-MockJinaEmbeddings = type("MockJinaEmbeddings", (BaseMockEmbedding,), {})
-MockVoyageAIEmbeddings = type("MockVoyageAIEmbeddings", (BaseMockEmbedding,), {})
-MockHuggingFaceEmbeddings = type("MockHuggingFaceEmbeddings", (BaseMockEmbedding,), {})
-MockGoogleVertexEmbeddings = type(
-    "MockGoogleVertexEmbeddings", (BaseMockEmbedding,), {}
-)
-MockRoboflowEmbeddings = type("MockRoboflowEmbeddings", (BaseMockEmbedding,), {})
-
-
-class MockOpenCLIPModule:
-    @staticmethod
-    def create_model_and_transforms(
-        model_name: str, pretrained: str = "", device: str = "cpu", **kwargs: Any
-    ) -> tuple[Any, Any, Any]:
-        model = MagicMock()
-        model.encode_text.return_value = np.array([[0.1, 0.2, 0.3]])
-        model.encode_image.return_value = np.array([[0.1, 0.2, 0.3]])
-        return (model, MagicMock(), model)
-
-    @staticmethod
-    def get_tokenizer(model_name: str) -> Any:
-        tokenizer = MagicMock()
-        tokenizer.encode.return_value = np.array([[1, 2, 3]])
-        return tokenizer
-
-
-class MockSentenceModel:
-    def __init__(self, model_name_or_path: str) -> None:
-        self.model_name = model_name_or_path
-
-    def encode(self, texts: List[str], **kwargs: Any) -> npt.NDArray[np.float32]:
-        return np.array([[0.1, 0.2, 0.3] for _ in texts])
-
-
-class MockText2VecModule:
-    SentenceModel = MockSentenceModel
-
-
-class MockOllamaClient:
-    def __init__(self, host: str = "", **kwargs: Any) -> None:
-        self.host = host
-
-    def embed(self, model: str, input: List[str], **kwargs: Any) -> Dict[str, Any]:
-        return {"embeddings": [[0.1, 0.2, 0.3] for _ in input]}
-
-
-class MockOllamaModule:
-    Client = MockOllamaClient
-
-
-class MockHttpxClient:
-    def __init__(self, headers: Dict[str, str] = {}) -> None:
-        self.headers = headers
-
-    def post(self, url: str, json: Dict[str, Any] = {}) -> Any:
-        mock_response = MagicMock()
-        mock_response.json.return_value = [[0.1, 0.2, 0.3]]
-        return mock_response
-
-
-class MockHttpx:
-    @staticmethod
-    def Client(*args: Any, **kwargs: Any) -> MockHttpxClient:
-        return MockHttpxClient()
-
-
-class MockSentenceTransformer:
-    def __init__(self, model_name: str, device: str = "cpu", **kwargs: Any) -> None:
-        self.model_name = model_name
-        self.device = device
-
-    def __call__(self, input: Documents) -> Embeddings:
-        return mock_embeddings(input)
-
-
-class MockInstructorEmbeddingFunction:
-    def __init__(self, model_name: str, device: str = "cpu") -> None:
-        self.model_name = model_name
-        self.device = device
-
-    def __call__(self, input: Documents) -> Embeddings:
-        return mock_embeddings(input)
-
-
-class MockVoyageAIClient:
-    def __init__(self, api_key: str) -> None:
-        self.api_key = api_key
-
-    def embed(self, texts: List[str], model: str = "voyage-2") -> Dict[str, Any]:
-        return {"embeddings": [[0.1, 0.2, 0.3] for _ in texts]}
-
-
-class MockVoyageAIModule:
-    Client = MockVoyageAIClient
-
-
-# Test configurations for each embedding function
-EMBEDDING_FUNCTION_CONFIGS: Dict[str, Dict[str, Any]] = {
-    "openai": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "text-embedding-ada-002",
-            "api_key_env_var": "CHROMA_OPENAI_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_OPENAI_API_KEY",
-            "model_name": "text-embedding-ada-002",
-        },
-        "mocks": [
-            ("openai.Embedding", MockOpenAIEmbeddings),
-        ],
-    },
-    "huggingface": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
-            "api_key_env_var": "CHROMA_HUGGINGFACE_API_KEY",
-        },
-        "config": {
-            "model_name": "sentence-transformers/all-MiniLM-L6-v2",
-            "api_key_env_var": "CHROMA_HUGGINGFACE_API_KEY",
-        },
-        "mocks": [
-            ("httpx", MockHttpx),
-        ],
-    },
-    "sentence_transformer": {
-        "args": {
-            "model_name": "all-MiniLM-L6-v2",
-        },
-        "config": {
-            "model_name": "all-MiniLM-L6-v2",
-        },
-        "mocks": [
-            ("sentence_transformers.SentenceTransformer", MockSentenceTransformer),
-        ],
-    },
-    "cohere": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "embed-english-v3.0",
-            "api_key_env_var": "CHROMA_COHERE_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_COHERE_API_KEY",
-            "model_name": "embed-english-v3.0",
-        },
-        "mocks": [
-            ("cohere.Client", MockCohereEmbeddings),
-        ],
-    },
-    "google_palm": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "models/embedding-gecko-001",
-            "api_key_env_var": "CHROMA_GOOGLE_PALM_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_GOOGLE_PALM_API_KEY",
-            "model_name": "models/embedding-gecko-001",
-        },
-    },
-    "google_generative_ai": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "models/embedding-001",
-            "task_type": "RETRIEVAL_DOCUMENT",
-            "api_key_env_var": "CHROMA_GOOGLE_GENAI_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_GOOGLE_GENAI_API_KEY",
-            "model_name": "models/embedding-001",
-            "task_type": "RETRIEVAL_DOCUMENT",
-        },
-    },
-    "google_vertex": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "models/embedding-001",
-            "api_key_env_var": "CHROMA_GOOGLE_VERTEX_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_GOOGLE_VERTEX_API_KEY",
-            "model_name": "models/embedding-001",
-        },
-    },
-    "ollama": {
-        "args": {
-            "url": "http://localhost:11434",
-            "model_name": "llama2",
-            "timeout": 60,
-        },
-        "config": {
-            "url": "http://localhost:11434",
-            "model_name": "llama2",
-            "timeout": 60,
-        },
-        "mocks": [
-            ("ollama", MockOllamaModule),
-        ],
-    },
-    "instructor": {
-        "args": {
-            "model_name": "hkunlp/instructor-large",
-            "instruction": "Represent the document for retrieval",
-        },
-        "config": {
-            "model_name": "hkunlp/instructor-large",
-            "instruction": "Represent the document for retrieval",
-        },
-        "mocks": [
-            ("InstructorEmbedding.INSTRUCTOR", MockInstructorEmbeddingFunction),
-        ],
-    },
-    "jina": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "jina-embeddings-v2-base-en",
-            "api_key_env_var": "CHROMA_JINA_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_JINA_API_KEY",
-            "model_name": "jina-embeddings-v2-base-en",
-        },
-        "mocks": [
-            ("requests.Session", MockJinaEmbeddings),
-        ],
-    },
-    "voyageai": {
-        "args": {
-            "api_key": "dummy_key",
-            "model_name": "voyage-2",
-            "api_key_env_var": "CHROMA_VOYAGEAI_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_VOYAGEAI_API_KEY",
-            "model_name": "voyage-2",
-        },
-        "mocks": [
-            ("voyageai", MockVoyageAIModule),
-        ],
-    },
-    "onnx_mini_lm_l6_v2": {
-        "args": {
-            "preferred_providers": ["onnxruntime"],
-        },
-        "config": {
-            "preferred_providers": ["onnxruntime"],
-        },
-        "mocks": [
-            ("onnxruntime", MagicMock()),
-        ],
-    },
-    "open_clip": {
-        "args": {
-            "model_name": "ViT-B-32",
-            "checkpoint": "laion2b_s34b_b79k",
-            "device": "cpu",
-        },
-        "config": {
-            "model_name": "ViT-B-32",
-            "checkpoint": "laion2b_s34b_b79k",
-            "device": "cpu",
-        },
-        "mocks": [
-            ("open_clip", MockOpenCLIPModule),
-        ],
-    },
-    "roboflow": {
-        "args": {
-            "api_key": "dummy_key",
-            "api_key_env_var": "CHROMA_ROBOFLOW_API_KEY",
-        },
-        "config": {
-            "api_key_env_var": "CHROMA_ROBOFLOW_API_KEY",
-        },
-        "mocks": [
-            ("roboflow", MockRoboflowEmbeddings),
-        ],
-    },
-    "text2vec": {
-        "args": {
-            "model_name": "shibing624/text2vec-base-chinese",
-        },
-        "config": {
-            "model_name": "shibing624/text2vec-base-chinese",
-        },
-        "mocks": [
-            ("text2vec", MockText2VecModule),
-        ],
-    },
-}
-
-# Skip these embedding functions in tests as they require complex setup
+# Skip these embedding functions in tests
 SKIP_EMBEDDING_FUNCTIONS = [
-    "huggingface_server",  # Requires a running server
-    "chroma_langchain",  # Requires LangChain setup
-    "default",  # Special case that delegates to ONNXMiniLM_L6_V2
-    "amazon_bedrock",  # Requires complex mocking of boto3 session
-    "google_vertex",  # Requires complex mocking of vertexai
-    "google_generative_ai",  # Requires complex mocking of google.generativeai
-    "google_palm",  # Requires complex mocking of google.generativeai
+    "chroma_langchain",
 ]
 
 
-def test_all_schemas_are_valid_json() -> None:
-    """Test that all schemas are valid JSON"""
-    schema_names = get_available_schemas()
-    for schema_name in schema_names:
-        # This will raise an exception if the schema is not valid JSON
-        schema: Dict[str, Any] = load_schema(schema_name)
-        assert isinstance(schema, dict)
-        assert "$schema" in schema
-        assert "title" in schema
-        assert "description" in schema
-        assert "version" in schema
-        assert "properties" in schema
-
-
-# Get embedding function names for parametrization
 def get_embedding_function_names() -> List[str]:
     """Get all embedding function names to test"""
     return [
@@ -381,197 +26,106 @@ def get_embedding_function_names() -> List[str]:
     ]
 
 
-@pytest.mark.parametrize("ef_name", get_embedding_function_names())
-def test_embedding_function_config_roundtrip(
-    ef_name: str, monkeypatch: MonkeyPatch
-) -> None:
-    """
-    Test that embedding functions can be:
-    1. Created with arguments
-    2. Get their config
-    3. Be recreated from that config
-    4. Validate their config
-    """
-    if ef_name not in EMBEDDING_FUNCTION_CONFIGS:
-        pytest.skip(f"No test configuration for {ef_name}")
+class TestEmbeddingFunctionSchemas:
+    """Test class for embedding function schemas"""
 
-    # Get the embedding function class
-    ef_class = known_embedding_functions[ef_name]
+    @pytest.mark.parametrize("ef_name", get_embedding_function_names())
+    def test_embedding_function_config_roundtrip(
+        self,
+        ef_name: str,
+        mock_embeddings: Callable[[Documents], Embeddings],
+        mock_common_deps: MonkeyPatch,
+    ) -> None:
+        """Test embedding function configuration roundtrip"""
+        ef_class = known_embedding_functions[ef_name]
 
-    # Apply mocks if needed
-    test_config: Dict[str, Any] = EMBEDDING_FUNCTION_CONFIGS[ef_name]
-    if "mocks" in test_config:
-        for module_path, mock_obj in test_config["mocks"]:
-            if "." in module_path:
-                module_name, attr_name = module_path.rsplit(".", 1)
-                # Create parent module if it doesn't exist
-                if module_name not in sys.modules:
-                    sys.modules[module_name] = MagicMock()
-                monkeypatch.setattr(f"{module_name}.{attr_name}", mock_obj)
-            else:
-                sys.modules[module_path] = mock_obj
+        # Create an autospec of the embedding function class
+        mock_ef = create_autospec(ef_class, instance=True)
 
-    # Pre-mock common dependencies
-    sys.modules["PIL"] = MagicMock()
-    sys.modules["PIL.Image"] = MagicMock()
-    sys.modules["torch"] = MagicMock()
-    sys.modules["openai"] = MagicMock()
-    sys.modules["cohere"] = MagicMock()
+        # Mock the __call__ method
+        mock_call = MagicMock(return_value=mock_embeddings(["test"]))
+        mock_ef.__call__ = mock_call
 
-    # Mock the __call__ method to avoid actual API calls
-    monkeypatch.setattr(ef_class, "__call__", mock_embeddings)
+        # Mock the class constructor to return our mock instance
+        mock_common_deps.setattr(
+            ef_class, "__new__", lambda cls, *args, **kwargs: mock_ef
+        )
 
-    # 1. Create embedding function with arguments
-    ef_instance = ef_class(**test_config["args"])
+        # Create instance with minimal args (constructor will be mocked)
+        ef_instance = ef_class()
 
-    # 2. Get config from the instance
-    config: Dict[str, Any] = ef_instance.get_config()
+        # Get the config (this will use the real method)
+        config = ef_instance.get_config()
 
-    # Check that config contains expected values
-    for key, value in test_config["config"].items():
-        assert key in config, f"Key {key} not found in config for {ef_name}"
+        # Test recreation from config
+        new_instance = ef_class.build_from_config(config)
+        new_config = new_instance.get_config()
+
+        # Configs should match
         assert (
-            config[key] == value
-        ), f"Config value mismatch for {ef_name}.{key}: expected {value}, got {config[key]}"
+            config == new_config
+        ), f"Configs don't match after recreation for {ef_name}"
 
-    # 3. Create a new instance from the config
-    new_ef_instance = ef_class.build_from_config(config)
+    def test_schema_required_fields(self) -> None:
+        """Test that schemas enforce required fields"""
+        for schema_name in get_available_schemas():
+            schema = load_schema(schema_name)
+            if "required" not in schema:
+                continue
 
-    # 4. Validate the config
-    new_ef_instance.validate_config(config)
+            # Create minimal valid config
+            config = {}
+            for field in schema["required"]:
+                field_schema = schema["properties"][field]
+                field_type = (
+                    field_schema["type"][0]
+                    if isinstance(field_schema["type"], list)
+                    else field_schema["type"]
+                )
+                config[field] = self._get_dummy_value(field_type)
 
-    # 5. Get config from the new instance and verify it matches
-    new_config: Dict[str, Any] = new_ef_instance.get_config()
-    for key, value in config.items():
-        assert key in new_config, f"Key {key} not found in new config for {ef_name}"
-        assert (
-            new_config[key] == value
-        ), f"New config value mismatch for {ef_name}.{key}: expected {value}, got {new_config[key]}"
-
-
-@pytest.mark.parametrize("ef_name", get_embedding_function_names())
-def test_embedding_function_invalid_config(
-    ef_name: str, monkeypatch: MonkeyPatch
-) -> None:
-    """Test that embedding functions reject invalid configurations"""
-    if ef_name not in EMBEDDING_FUNCTION_CONFIGS:
-        pytest.skip(f"No test configuration for {ef_name}")
-
-    # Get the embedding function class
-    ef_class = known_embedding_functions[ef_name]
-
-    # Apply mocks if needed
-    test_config: Dict[str, Any] = EMBEDDING_FUNCTION_CONFIGS[ef_name]
-    if "mocks" in test_config:
-        for module_path, mock_obj in test_config["mocks"]:
-            if "." in module_path:
-                module_name, attr_name = module_path.rsplit(".", 1)
-                # Create parent module if it doesn't exist
-                if module_name not in sys.modules:
-                    sys.modules[module_name] = MagicMock()
-                monkeypatch.setattr(f"{module_name}.{attr_name}", mock_obj)
-            else:
-                sys.modules[module_path] = mock_obj
-
-    # Pre-mock dependencies
-    sys.modules["PIL"] = MagicMock()
-    sys.modules["PIL.Image"] = MagicMock()
-    sys.modules["torch"] = MagicMock()
-    sys.modules["openai"] = MagicMock()
-    sys.modules["cohere"] = MagicMock()
-
-    # Mock the __call__ method to avoid actual API calls
-    monkeypatch.setattr(ef_class, "__call__", mock_embeddings)
-
-    # Create embedding function with arguments
-    ef_instance = ef_class(**test_config["args"])
-
-    # Test with invalid property
-    invalid_config: Dict[str, Any] = test_config["config"].copy()
-    invalid_config["invalid_property"] = "invalid_value"
-
-    # Some embedding functions might allow additional properties, so we can't always expect this to fail
-    try:
-        ef_instance.validate_config(invalid_config)
-    except (ValidationError, ValueError, AssertionError):
-        # If it raises an exception, that's expected for many embedding functions
-        pass
-
-
-def test_schema_required_fields() -> None:
-    """Test that schemas enforce required fields"""
-    schema_names = get_available_schemas()
-    for schema_name in schema_names:
-        schema = load_schema(schema_name)
-        if "required" in schema:
-            required_fields = schema["required"]
-            for field in required_fields:
-                # Create a config with all required fields
-                config: Dict[str, Any] = {}
-                for req_field in required_fields:
-                    # Add a dummy value of the correct type
-                    field_schema = schema["properties"][req_field]
-                    if isinstance(field_schema["type"], list):
-                        field_type = field_schema["type"][0]
-                    else:
-                        field_type = field_schema["type"]
-
-                    if field_type == "string":
-                        config[req_field] = "dummy"
-                    elif field_type == "integer":
-                        config[req_field] = 0
-                    elif field_type == "number":
-                        config[req_field] = 0.0
-                    elif field_type == "boolean":
-                        config[req_field] = False
-                    elif field_type == "object":
-                        config[req_field] = {}
-                    elif field_type == "array":
-                        config[req_field] = []
-
-                # Remove the current field to test that it's required
+            # Test each required field
+            for field in schema["required"]:
                 test_config = config.copy()
                 del test_config[field]
-
-                # Validation should fail
                 with pytest.raises(ValidationError):
                     validate_config_schema(test_config, schema_name)
 
+    @staticmethod
+    def _get_dummy_value(field_type: str) -> Any:
+        """Get a dummy value for a given field type"""
+        type_map = {
+            "string": "dummy",
+            "integer": 0,
+            "number": 0.0,
+            "boolean": False,
+            "object": {},
+            "array": [],
+        }
+        return type_map.get(field_type, "dummy")
 
-def test_schema_additional_properties() -> None:
-    """Test that schemas reject additional properties"""
-    schema_names = get_available_schemas()
-    for schema_name in schema_names:
-        schema = load_schema(schema_name)
-        # Create a minimal valid config
-        config: Dict[str, Any] = {}
-        if "required" in schema:
-            for field in schema["required"]:
-                # Add a dummy value of the correct type
-                field_schema = schema["properties"][field]
-                if isinstance(field_schema["type"], list):
-                    field_type = field_schema["type"][0]
-                else:
-                    field_type = field_schema["type"]
+    def test_schema_additional_properties(self) -> None:
+        """Test that schemas reject additional properties"""
+        for schema_name in get_available_schemas():
+            schema = load_schema(schema_name)
+            config = {}
 
-                if field_type == "string":
-                    config[field] = "dummy"
-                elif field_type == "integer":
-                    config[field] = 0
-                elif field_type == "number":
-                    config[field] = 0.0
-                elif field_type == "boolean":
-                    config[field] = False
-                elif field_type == "object":
-                    config[field] = {}
-                elif field_type == "array":
-                    config[field] = []
+            # Add required fields
+            if "required" in schema:
+                for field in schema["required"]:
+                    field_schema = schema["properties"][field]
+                    field_type = (
+                        field_schema["type"][0]
+                        if isinstance(field_schema["type"], list)
+                        else field_schema["type"]
+                    )
+                    config[field] = self._get_dummy_value(field_type)
 
-        # Add an additional property
-        test_config = config.copy()
-        test_config["additional_property"] = "value"
+            # Add additional property
+            test_config = config.copy()
+            test_config["additional_property"] = "value"
 
-        # Validation should fail if additionalProperties is false
-        if schema.get("additionalProperties", True) is False:
-            with pytest.raises(ValidationError):
-                validate_config_schema(test_config, schema_name)
+            # Test validation
+            if schema.get("additionalProperties", True) is False:
+                with pytest.raises(ValidationError):
+                    validate_config_schema(test_config, schema_name)

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -32,25 +32,20 @@ os.environ["AWS_SECRET_ACCESS_KEY"] = "dummy_aws_secret_key"
 os.environ["AWS_REGION"] = "us-east-1"
 
 
-# Mock for embedding functions to avoid actual API calls
-class MockEmbeddings:
-    @staticmethod
-    def mock_embeddings(input: Documents) -> Embeddings:
-        """Return mock embeddings for testing"""
-        return [np.array([0.1, 0.2, 0.3], dtype=np.float32) for _ in input]
+def mock_embeddings(input: Documents) -> Embeddings:
+    """Return mock embeddings for testing"""
+    return [np.array([0.1, 0.2, 0.3], dtype=np.float32) for _ in input]
 
 
-# Base mock for API-based embedding functions
 class BaseMockEmbedding:
     def __init__(self, **kwargs: Any) -> None:
         for key, value in kwargs.items():
             setattr(self, key, value)
 
     def __call__(self, input: Documents) -> Embeddings:
-        return MockEmbeddings.mock_embeddings(input)
+        return mock_embeddings(input)
 
 
-# Use base mock for simple API-based functions
 MockOpenAIEmbeddings = type("MockOpenAIEmbeddings", (BaseMockEmbedding,), {})
 MockCohereEmbeddings = type("MockCohereEmbeddings", (BaseMockEmbedding,), {})
 MockGooglePalmEmbeddings = type("MockGooglePalmEmbeddings", (BaseMockEmbedding,), {})
@@ -66,7 +61,6 @@ MockGoogleVertexEmbeddings = type(
 MockRoboflowEmbeddings = type("MockRoboflowEmbeddings", (BaseMockEmbedding,), {})
 
 
-# Mock for OpenCLIP - needs specific initialization structure
 class MockOpenCLIPModule:
     @staticmethod
     def create_model_and_transforms(
@@ -84,7 +78,6 @@ class MockOpenCLIPModule:
         return tokenizer
 
 
-# Mock for Text2Vec - needs specific model structure
 class MockSentenceModel:
     def __init__(self, model_name_or_path: str) -> None:
         self.model_name = model_name_or_path
@@ -97,9 +90,8 @@ class MockText2VecModule:
     SentenceModel = MockSentenceModel
 
 
-# Mock for Ollama - needs specific client structure
 class MockOllamaClient:
-    def __init__(self, host: str = "http://localhost:11434", **kwargs: Any) -> None:
+    def __init__(self, host: str = "", **kwargs: Any) -> None:
         self.host = host
 
     def embed(self, model: str, input: List[str], **kwargs: Any) -> Dict[str, Any]:
@@ -110,7 +102,6 @@ class MockOllamaModule:
     Client = MockOllamaClient
 
 
-# Mock for httpx used by HuggingFace and Jina
 class MockHttpxClient:
     def __init__(self, headers: Dict[str, str] = {}) -> None:
         self.headers = headers
@@ -127,27 +118,24 @@ class MockHttpx:
         return MockHttpxClient()
 
 
-# Mock for SentenceTransformer
 class MockSentenceTransformer:
     def __init__(self, model_name: str, device: str = "cpu", **kwargs: Any) -> None:
         self.model_name = model_name
         self.device = device
 
     def __call__(self, input: Documents) -> Embeddings:
-        return MockEmbeddings.mock_embeddings(input)
+        return mock_embeddings(input)
 
 
-# Mock for Instructor
 class MockInstructorEmbeddingFunction:
     def __init__(self, model_name: str, device: str = "cpu") -> None:
         self.model_name = model_name
         self.device = device
 
     def __call__(self, input: Documents) -> Embeddings:
-        return MockEmbeddings.mock_embeddings(input)
+        return mock_embeddings(input)
 
 
-# Mock for VoyageAI module
 class MockVoyageAIClient:
     def __init__(self, api_key: str) -> None:
         self.api_key = api_key
@@ -431,7 +419,7 @@ def test_embedding_function_config_roundtrip(
     sys.modules["cohere"] = MagicMock()
 
     # Mock the __call__ method to avoid actual API calls
-    monkeypatch.setattr(ef_class, "__call__", MockEmbeddings.mock_embeddings)
+    monkeypatch.setattr(ef_class, "__call__", mock_embeddings)
 
     # 1. Create embedding function with arguments
     ef_instance = ef_class(**test_config["args"])
@@ -485,7 +473,7 @@ def test_embedding_function_invalid_config(
             else:
                 sys.modules[module_path] = mock_obj
 
-    # Pre-mock common dependencies
+    # Pre-mock dependencies
     sys.modules["PIL"] = MagicMock()
     sys.modules["PIL.Image"] = MagicMock()
     sys.modules["torch"] = MagicMock()
@@ -493,7 +481,7 @@ def test_embedding_function_invalid_config(
     sys.modules["cohere"] = MagicMock()
 
     # Mock the __call__ method to avoid actual API calls
-    monkeypatch.setattr(ef_class, "__call__", MockEmbeddings.mock_embeddings)
+    monkeypatch.setattr(ef_class, "__call__", mock_embeddings)
 
     # Create embedding function with arguments
     ef_instance = ef_class(**test_config["args"])


### PR DESCRIPTION
## Description of changes

there have been consistent issues with embedding function tests. the root cause was the test fixture used, which attempted to install and uninstall dependencies required for the tests, and at any point if some installation did not succeed, it only pushed a log out, before continuing the tests. therefore tests were guaranteed to fail on any issue with the installation. this is also slow to have to install & uninstall packages every time the test runs. 

This pr removes the test fixtures and simplifies the mocks used for the embedding functions
