### PR TITLE
[BUG]: Correctly set trace id for debugging using honeycomb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http 0.6.2",
  "tracing",
+ "tracing-opentelemetry",
  "utoipa",
  "utoipa-axum",
  "utoipa-swagger-ui",

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -25,6 +25,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 futures = { workspace = true }
 backon = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 tower = { version = "0.4.13", features = ["discover"] }
 mdac = { workspace = true }
 opentelemetry.workspace = true


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - We were setting the wrong traceid that gets printed by client on encountering error.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
