### PR TITLE
[CHORE] Bump bytes to 1.10 to isolate problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,9 +1212,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytes-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "ru
 arrow = "52.2.0"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["macros"] }
-bytes = "1.7"
+bytes = "1.10"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
PR#3949 is failing on tests that are theoretically unchanged.  The only
change that affects rust run by those tests is the bytes crate.  Bumping
it in isolation to see if it fails.
