### PR TITLE
[ENH] Delete version files in GC.

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -507,7 +507,9 @@ impl Handler<TaskResult<DeleteUnusedFilesOutput, DeleteUnusedFilesError>>
             .expect("Epoch ID should be set");
 
         let delete_versions_task = wrap(
-            Box::new(DeleteVersionsAtSysDbOperator {}),
+            Box::new(DeleteVersionsAtSysDbOperator {
+                storage: self.storage.clone(),
+            }),
             DeleteVersionsAtSysDbInput {
                 version_file,
                 epoch_id,

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -1,13 +1,24 @@
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
+use futures::stream::StreamExt;
 use std::collections::HashSet;
 use thiserror::Error;
 
-#[derive(Clone, Debug)]
-pub struct DeleteVersionsAtSysDbOperator {}
+#[derive(Clone)]
+pub struct DeleteVersionsAtSysDbOperator {
+    pub storage: Storage,
+}
+
+impl std::fmt::Debug for DeleteVersionsAtSysDbOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeleteVersionsAtSysDbOperator")
+            .finish_non_exhaustive()
+    }
+}
 
 #[derive(Debug)]
 pub struct DeleteVersionsAtSysDbInput {
@@ -29,11 +40,76 @@ pub struct DeleteVersionsAtSysDbOutput {
 pub enum DeleteVersionsAtSysDbError {
     #[error("Error deleting versions in sysdb: {0}")]
     SysDBError(String),
+    #[error("Error deleting version file {path}: {message}")]
+    DeleteFileError { path: String, message: String },
 }
 
 impl ChromaError for DeleteVersionsAtSysDbError {
     fn code(&self) -> ErrorCodes {
         ErrorCodes::Internal
+    }
+}
+
+impl DeleteVersionsAtSysDbOperator {
+    async fn delete_version_files(
+        &self,
+        version_file: &CollectionVersionFile,
+        versions_to_delete: &[i64],
+    ) {
+        let version_files_to_delete: Vec<String> = version_file
+            .version_history
+            .as_ref()
+            .unwrap()
+            .versions
+            .iter()
+            .filter(|v| versions_to_delete.contains(&v.version))
+            .filter_map(|v| {
+                if !v.version_file_name.is_empty() {
+                    Some(v.version_file_name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if version_files_to_delete.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            files = ?version_files_to_delete,
+            "Deleting version files"
+        );
+
+        let mut futures = Vec::new();
+        for file_path in &version_files_to_delete {
+            let storage = self.storage.clone();
+            let path = file_path.clone();
+            futures.push(async move {
+                storage
+                    .delete(&path)
+                    .await
+                    .map_err(|e| (path, e.to_string()))
+            });
+        }
+
+        let num_futures = futures.len();
+        let results = futures::stream::iter(futures)
+            .buffer_unordered(num_futures)
+            .collect::<Vec<_>>()
+            .await;
+
+        // Process any errors that occurred during file deletion
+        for result in results {
+            if let Err((path, error)) = result {
+                tracing::warn!(
+                    error = %error,
+                    path = %path,
+                    "Failed to delete version file {}, continuing since it could have been deleted already",
+                    path
+                );
+            }
+        }
     }
 }
 
@@ -69,6 +145,10 @@ impl Operator<DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOutput>
         let mut sysdb = input.sysdb_client.clone();
 
         if !input.versions_to_delete.versions.is_empty() {
+            // First, delete the version files from the storage.
+            self.delete_version_files(&input.version_file, &input.versions_to_delete.versions)
+                .await;
+
             tracing::info!(
                 versions = ?input.versions_to_delete.versions,
                 "Deleting versions from SysDB"
@@ -110,10 +190,14 @@ impl Operator<DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOutput>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chroma_storage::local::LocalStorage;
     use chroma_sysdb::TestSysDb;
+    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_delete_versions_success() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
@@ -131,7 +215,9 @@ mod tests {
             unused_s3_files: HashSet::new(),
         };
 
-        let operator = DeleteVersionsAtSysDbOperator {};
+        let operator = DeleteVersionsAtSysDbOperator {
+            storage: storage.clone(),
+        };
         let result = operator.run(&input).await;
 
         assert!(result.is_ok());
@@ -142,6 +228,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_versions_empty_list() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let sysdb = SysDb::Test(TestSysDb::new());
         let version_file = CollectionVersionFile::default();
         let versions_to_delete = VersionListForCollection {
@@ -159,7 +247,9 @@ mod tests {
             unused_s3_files: HashSet::new(),
         };
 
-        let operator = DeleteVersionsAtSysDbOperator {};
+        let operator = DeleteVersionsAtSysDbOperator {
+            storage: storage.clone(),
+        };
         let result = operator.run(&input).await;
 
         assert!(result.is_ok());


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   -  Delete version files as part of GC. SysDb creates new version file at every compaction since version files are immutable. Clean up these extra version files.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
