### PR TITLE
[DOC] fixed image name typo

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
+++ b/docs/docs.trychroma.com/markdoc/content/production/containers/docker.md
@@ -71,7 +71,7 @@ To use a custom config file, mount it into the container at `/config.yaml` like 
 
 ```terminal
 echo "allow_reset: true" > config.yaml # the server will now allow clients to reset its state
-docker run -v ./chroma-data:/data -v ./config.yaml:/config.yaml -p 8000:8000 chroma-core/chroma
+docker run -v ./chroma-data:/data -v ./config.yaml:/config.yaml -p 8000:8000 chromadb/chroma
 ```
 
 ## Observability with Docker
@@ -131,7 +131,7 @@ services:
     networks:
       - internal
   server:
-    image: chroma-core/chroma
+    image: chromadb/chroma
     volumes:
       - chroma_data:/data
     ports:


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - changed `chroma-core` to `chromadb` image name
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
