### PR TITLE
[BLD]: report test results to Datadog

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,9 @@ default-filter = "not test(/test_k8s_integration_/)"
 
 [profile.k8s_integration]
 default-filter = "test(/test_k8s_integration_/)"
+
+[profile.ci.junit]
+path = "junit.xml"
+
+[profile.ci_k8s_integration.junit]
+path = "junit.xml"

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -55,6 +55,8 @@ jobs:
         run: pip install --no-index --find-links target/wheels/ chromadb
       - name: Configure pytest to upload results to Datadog
         uses: datadog/test-visibility-github-action@v2
+        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+        if: ${{ !contains(matrix.platform, 'windows') }}
         with:
           languages: python
           api_key: ${{ secrets.DD_API_KEY }}
@@ -99,6 +101,8 @@ jobs:
           github-token: ${{ github.token }}
     - name: Configure pytest to upload results to Datadog
       uses: datadog/test-visibility-github-action@v2
+      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+      if: ${{ !contains(matrix.platform, 'windows') }}
       with:
         languages: python
         api_key: ${{ secrets.DD_API_KEY }}
@@ -134,6 +138,8 @@ jobs:
           github-token: ${{ github.token }}
       - name: Configure pytest to upload results to Datadog
         uses: datadog/test-visibility-github-action@v2
+        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+        if: ${{ !contains(matrix.platform, 'windows') }}
         with:
           languages: python
           api_key: ${{ secrets.DD_API_KEY }}
@@ -241,6 +247,8 @@ jobs:
         run: pip install --no-index --find-links target/wheels/ chromadb
       - name: Configure pytest to upload results to Datadog
         uses: datadog/test-visibility-github-action@v2
+        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+        if: ${{ !contains(matrix.platform, 'windows') }}
         with:
           languages: python
           api_key: ${{ secrets.DD_API_KEY }}
@@ -284,6 +292,8 @@ jobs:
       run: pip install --no-index --find-links target/wheels/ chromadb
     - name: Configure pytest to upload results to Datadog
       uses: datadog/test-visibility-github-action@v2
+      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+      if: ${{ !contains(matrix.platform, 'windows') }}
       with:
         languages: python
         api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Install built wheel
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
       - name: Test
         run: python -m pytest ${{ matrix.test-globs }}
         shell: bash
@@ -91,6 +97,12 @@ jobs:
       uses: ./.github/actions/rust
       with:
           github-token: ${{ github.token }}
+    - name: Configure pytest to upload results to Datadog
+      uses: datadog/test-visibility-github-action@v2
+      with:
+        languages: python
+        api_key: ${{ secrets.DD_API_KEY }}
+        site: ${{ vars.DD_SITE }}
     - name: Rust Integration Test
       run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
       shell: bash
@@ -120,6 +132,12 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
       - name: Test
         run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
         shell: bash
@@ -158,6 +176,12 @@ jobs:
       - uses: ./.github/actions/python
         with:
           python-version: ${{ matrix.python }}
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
       - uses: ./.github/actions/tilt
         with:
           depot-project-id: ${{ vars.DEPOT_PROJECT_ID }}
@@ -215,6 +239,12 @@ jobs:
       - name: Install built wheel
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
       - name: Test
         run: python -m pytest ${{ matrix.test-globs }}
         shell: bash
@@ -252,6 +282,12 @@ jobs:
     - name: Install built wheel
       shell: bash
       run: pip install --no-index --find-links target/wheels/ chromadb
+    - name: Configure pytest to upload results to Datadog
+      uses: datadog/test-visibility-github-action@v2
+      with:
+        languages: python
+        api_key: ${{ secrets.DD_API_KEY }}
+        site: ${{ vars.DD_SITE }}
     - name: Integration Test
       run: bin/python-integration-test ${{ matrix.test-globs }}
       shell: bash

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -22,7 +22,15 @@ jobs:
       - name: Build CLI
         run: cargo build --bin chroma
       - name: Test
-        run: cargo nextest run --no-capture
+        run: cargo nextest run --no-capture --profile ci
+      - name: Upload test results
+        uses: datadog/junit-upload-github-action@v1
+        with:
+            api_key: ${{ secrets.DD_API_KEY }}
+            site: ${{ vars.DD_SITE }}
+            service: chroma
+            files: target/nextest/ci/junit.xml
+            logs: true
 
   test-integration:
     strategy:
@@ -49,7 +57,12 @@ jobs:
       - name: Build CLI
         run: cargo build --bin chroma
       - name: Run tests
-        run: cargo nextest run --profile k8s_integration
+        run: cargo nextest run --profile ci_k8s_integration
+      - name: Upload test results
+        run: datadog-ci junit upload target/nextest/ci/junit.xml
+        env:
+          DD_API_KEY: ${{secrets.DD_API_KEY}}
+          DD_SITE: ${{ vars.DD_SITE }}
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -59,10 +59,13 @@ jobs:
       - name: Run tests
         run: cargo nextest run --profile ci_k8s_integration
       - name: Upload test results
-        run: datadog-ci junit upload target/nextest/ci/junit.xml
-        env:
-          DD_API_KEY: ${{secrets.DD_API_KEY}}
-          DD_SITE: ${{ vars.DD_SITE }}
+        uses: datadog/junit-upload-github-action@v1
+        with:
+            api_key: ${{ secrets.DD_API_KEY }}
+            site: ${{ vars.DD_SITE }}
+            service: chroma
+            files: target/nextest/ci/junit.xml
+            logs: true
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -163,6 +163,7 @@ jobs:
     needs: change-detection
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
     uses: ./.github/workflows/_python-tests.yml
+    secrets: inherit
     with:
       property_testing_preset: 'normal'
 
@@ -183,6 +184,7 @@ jobs:
     needs: change-detection
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
     uses: ./.github/workflows/_rust-tests.yml
+    secrets: inherit
 
   go-tests:
     name: Go tests

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -44,6 +44,7 @@ jobs:
 
   python-tests:
     uses: ./.github/workflows/_python-tests.yml
+    secrets: inherit
     with:
       python_versions: '["3.9", "3.10", "3.11", "3.12"]'
       property_testing_preset: 'normal'
@@ -55,6 +56,7 @@ jobs:
   rust-tests:
     name: Rust tests
     uses: ./.github/workflows/_rust-tests.yml
+    secrets: inherit
 
   go-tests:
     name: Go tests


### PR DESCRIPTION
## Description of changes

Allows us to track flaky tests and easily see which tests are slow. Tests on Windows are not currently reported because of a bug with Datadog's setup action (filed an issue).