### PR TITLE
[ENH] grpc changes for update collection config

### DIFF
--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -5,6 +5,7 @@ from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     create_collection_configuration_to_json_str,
     UpdateCollectionConfiguration,
+    update_collection_configuration_to_json_str,
 )
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, System, logger
 from chromadb.db.system import SysDB
@@ -525,6 +526,11 @@ class GrpcSysDB(SysDB):
                 dimension=write_dimension,
                 metadata=to_proto_update_metadata(write_metadata)
                 if write_metadata
+                else None,
+                configuration_json_str=update_collection_configuration_to_json_str(
+                    write_configuration
+                )
+                if write_configuration
                 else None,
             )
             if metadata is None:

--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -49,14 +49,15 @@ type DeleteCollection struct {
 }
 
 type UpdateCollection struct {
-	ID            types.UniqueID
-	Name          *string
-	Dimension     *int32
-	Metadata      *CollectionMetadata[CollectionMetadataValueType]
-	ResetMetadata bool
-	TenantID      string
-	DatabaseName  string
-	Ts            types.Timestamp
+	ID                      types.UniqueID
+	Name                    *string
+	Dimension               *int32
+	Metadata                *CollectionMetadata[CollectionMetadataValueType]
+	ResetMetadata           bool
+	NewConfigurationJsonStr *string
+	TenantID                string
+	DatabaseName            string
+	Ts                      types.Timestamp
 }
 
 type FlushCollectionCompaction struct {

--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -1,0 +1,126 @@
+package model
+
+type EmbeddingFunctionConfiguration struct {
+	Type   string                             `json:"type"`
+	Config *EmbeddingFunctionNewConfiguration `json:"config,omitempty"`
+}
+
+type EmbeddingFunctionNewConfiguration struct {
+	Name   string      `json:"name"`
+	Config interface{} `json:"config"`
+}
+
+type VectorIndexConfiguration struct {
+	Type  string              `json:"type"`
+	Hnsw  *HnswConfiguration  `json:"hnsw,omitempty"`
+	Spann *SpannConfiguration `json:"spann,omitempty"`
+}
+
+type HnswConfiguration struct {
+	Space          string  `json:"space"`
+	EfConstruction int     `json:"ef_construction"`
+	EfSearch       int     `json:"ef_search"`
+	MaxNeighbors   int     `json:"max_neighbors"`
+	NumThreads     int     `json:"num_threads"`
+	ResizeFactor   float64 `json:"resize_factor"`
+	BatchSize      int     `json:"batch_size"`
+	SyncThreshold  int     `json:"sync_threshold"`
+}
+
+// DefaultHnswConfiguration returns the default HNSW configuration
+func DefaultHnswConfiguration() *HnswConfiguration {
+	return &HnswConfiguration{
+		Space:          "l2",
+		EfConstruction: 100,
+		EfSearch:       100,
+		MaxNeighbors:   16,
+		NumThreads:     16,
+		ResizeFactor:   1.2,
+		BatchSize:      100,
+		SyncThreshold:  1000,
+	}
+}
+
+type SpannConfiguration struct {
+	SearchNprobe   int    `json:"search_nprobe"`
+	WriteNprobe    int    `json:"write_nprobe"`
+	Space          string `json:"space"`
+	ConstructionEf int    `json:"construction_ef"`
+	SearchEf       int    `json:"search_ef"`
+	M              int    `json:"m"`
+}
+
+type InternalCollectionConfiguration struct {
+	VectorIndex       *VectorIndexConfiguration       `json:"vector_index"`
+	EmbeddingFunction *EmbeddingFunctionConfiguration `json:"embedding_function,omitempty"`
+}
+
+// DefaultHnswCollectionConfiguration returns a default configuration using HNSW
+func DefaultHnswCollectionConfiguration() *InternalCollectionConfiguration {
+	return &InternalCollectionConfiguration{
+		VectorIndex: &VectorIndexConfiguration{
+			Type: "hnsw",
+			Hnsw: DefaultHnswConfiguration(),
+		},
+	}
+}
+
+// FromLegacyMetadata creates a configuration from legacy metadata
+func FromLegacyMetadata(metadata map[string]interface{}) *InternalCollectionConfiguration {
+	config := DefaultHnswCollectionConfiguration()
+
+	// Try to extract HNSW parameters from legacy metadata
+	if metadata != nil {
+		if efConstruction, ok := metadata["hnsw:construction_ef"].(float64); ok {
+			config.VectorIndex.Hnsw.EfConstruction = int(efConstruction)
+		}
+		if efSearch, ok := metadata["hnsw:ef"].(float64); ok {
+			config.VectorIndex.Hnsw.EfSearch = int(efSearch)
+		}
+		if maxNeighbors, ok := metadata["hnsw:max_elements"].(float64); ok {
+			config.VectorIndex.Hnsw.MaxNeighbors = int(maxNeighbors)
+		}
+		if numThreads, ok := metadata["hnsw:num_threads"].(float64); ok {
+			config.VectorIndex.Hnsw.NumThreads = int(numThreads)
+		}
+		if resizeFactor, ok := metadata["hnsw:resize_factor"].(float64); ok {
+			config.VectorIndex.Hnsw.ResizeFactor = resizeFactor
+		}
+		if batchSize, ok := metadata["hnsw:batch_size"].(float64); ok {
+			config.VectorIndex.Hnsw.BatchSize = int(batchSize)
+		}
+		if syncThreshold, ok := metadata["hnsw:sync_threshold"].(float64); ok {
+			config.VectorIndex.Hnsw.SyncThreshold = int(syncThreshold)
+		}
+		if space, ok := metadata["hnsw:space"].(string); ok {
+			config.VectorIndex.Hnsw.Space = space
+		}
+	}
+
+	return config
+}
+
+// Update configuration types
+type UpdateHnswConfiguration struct {
+	EfSearch      *int     `json:"ef_search,omitempty"`
+	MaxNeighbors  *int     `json:"max_neighbors,omitempty"`
+	NumThreads    *int     `json:"num_threads,omitempty"`
+	ResizeFactor  *float64 `json:"resize_factor,omitempty"`
+	BatchSize     *int     `json:"batch_size,omitempty"`
+	SyncThreshold *int     `json:"sync_threshold,omitempty"`
+}
+
+type UpdateSpannConfiguration struct {
+	SpannConfig *SpannConfiguration `json:"spann_config,omitempty"`
+}
+
+type UpdateVectorIndexConfiguration struct {
+	Type  string                    `json:"type"`
+	Hnsw  *UpdateHnswConfiguration  `json:"hnsw,omitempty"`
+	Spann *UpdateSpannConfiguration `json:"spann,omitempty"`
+}
+
+type InternalUpdateCollectionConfiguration struct {
+	VectorIndex       *UpdateVectorIndexConfiguration `json:"vector_index,omitempty"`
+	EmbeddingFunction *EmbeddingFunctionConfiguration `json:"embedding_function,omitempty"`
+}

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -607,6 +608,120 @@ func (tc *Catalog) GetSoftDeletedCollections(ctx context.Context, collectionID *
 	return collectionList, nil
 }
 
+// updateCollectionConfiguration handles parsing and updating collection configuration
+func (tc *Catalog) updateCollectionConfiguration(
+	existingConfigJsonStr *string,
+	updateConfigJsonStr *string,
+	collectionMetadata []*dbmodel.CollectionMetadata,
+) (*string, error) {
+	if updateConfigJsonStr == nil {
+		return nil, nil
+	}
+
+	// Parse existing configuration
+	var existingConfig model.InternalCollectionConfiguration
+	var parseErr error
+	if existingConfigJsonStr != nil {
+		parseErr = json.Unmarshal([]byte(*existingConfigJsonStr), &existingConfig)
+		if parseErr != nil {
+			// Try to create config from legacy metadata
+			metadataMap := make(map[string]interface{})
+			for _, m := range collectionMetadata {
+				if m.StrValue != nil {
+					metadataMap[*m.Key] = *m.StrValue
+				} else if m.IntValue != nil {
+					metadataMap[*m.Key] = float64(*m.IntValue)
+				} else if m.FloatValue != nil {
+					metadataMap[*m.Key] = *m.FloatValue
+				} else if m.BoolValue != nil {
+					metadataMap[*m.Key] = *m.BoolValue
+				}
+			}
+			existingConfig = *model.FromLegacyMetadata(metadataMap)
+		} else if existingConfig.VectorIndex == nil {
+			// If the config was parsed but has no vector index, use default HNSW
+			existingConfig = *model.DefaultHnswCollectionConfiguration()
+		}
+	} else {
+		// If no existing config, try to create from legacy metadata first
+		metadataMap := make(map[string]interface{})
+		for _, m := range collectionMetadata {
+			if m.StrValue != nil {
+				metadataMap[*m.Key] = *m.StrValue
+			} else if m.IntValue != nil {
+				metadataMap[*m.Key] = float64(*m.IntValue)
+			} else if m.FloatValue != nil {
+				metadataMap[*m.Key] = *m.FloatValue
+			} else if m.BoolValue != nil {
+				metadataMap[*m.Key] = *m.BoolValue
+			}
+		}
+		if len(metadataMap) > 0 {
+			existingConfig = *model.FromLegacyMetadata(metadataMap)
+		} else {
+			// If no legacy metadata, use default HNSW
+			existingConfig = *model.DefaultHnswCollectionConfiguration()
+		}
+	}
+
+	// Parse update configuration
+	var updateConfig model.InternalUpdateCollectionConfiguration
+	if err := json.Unmarshal([]byte(*updateConfigJsonStr), &updateConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse update configuration: %w", err)
+	}
+
+	// Update existing configuration with new values
+	if updateConfig.VectorIndex != nil {
+		if updateConfig.VectorIndex.Type == "hnsw" && updateConfig.VectorIndex.Hnsw != nil {
+			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Type != "hnsw" {
+				existingConfig.VectorIndex = &model.VectorIndexConfiguration{
+					Type: "hnsw",
+					Hnsw: model.DefaultHnswConfiguration(),
+				}
+			}
+			if updateConfig.VectorIndex.Hnsw.EfSearch != nil {
+				existingConfig.VectorIndex.Hnsw.EfSearch = *updateConfig.VectorIndex.Hnsw.EfSearch
+			}
+			if updateConfig.VectorIndex.Hnsw.MaxNeighbors != nil {
+				existingConfig.VectorIndex.Hnsw.MaxNeighbors = *updateConfig.VectorIndex.Hnsw.MaxNeighbors
+			}
+			if updateConfig.VectorIndex.Hnsw.NumThreads != nil {
+				existingConfig.VectorIndex.Hnsw.NumThreads = *updateConfig.VectorIndex.Hnsw.NumThreads
+			}
+			if updateConfig.VectorIndex.Hnsw.ResizeFactor != nil {
+				existingConfig.VectorIndex.Hnsw.ResizeFactor = *updateConfig.VectorIndex.Hnsw.ResizeFactor
+			}
+			if updateConfig.VectorIndex.Hnsw.SyncThreshold != nil {
+				existingConfig.VectorIndex.Hnsw.SyncThreshold = *updateConfig.VectorIndex.Hnsw.SyncThreshold
+			}
+			if updateConfig.VectorIndex.Hnsw.BatchSize != nil {
+				existingConfig.VectorIndex.Hnsw.BatchSize = *updateConfig.VectorIndex.Hnsw.BatchSize
+			}
+		} else if updateConfig.VectorIndex.Type == "spann" && updateConfig.VectorIndex.Spann != nil {
+			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Type != "spann" {
+				existingConfig.VectorIndex = &model.VectorIndexConfiguration{
+					Type:  "spann",
+					Spann: updateConfig.VectorIndex.Spann.SpannConfig,
+				}
+			} else {
+				existingConfig.VectorIndex.Spann = updateConfig.VectorIndex.Spann.SpannConfig
+			}
+		}
+	}
+
+	if updateConfig.EmbeddingFunction != nil {
+		existingConfig.EmbeddingFunction = updateConfig.EmbeddingFunction
+	}
+
+	// Serialize updated config back to JSON
+	updatedConfigBytes, err := json.Marshal(existingConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize updated configuration: %w", err)
+	}
+	updatedConfigStr := string(updatedConfigBytes)
+	return &updatedConfigStr, nil
+}
+
 func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model.UpdateCollection, ts types.Timestamp) (*model.Collection, error) {
 	log.Info("updating collection", zap.String("collectionId", updateCollection.ID.String()))
 	var result *model.Collection
@@ -627,12 +742,24 @@ func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model
 		if len(collections) == 0 {
 			return common.ErrCollectionNotFound
 		}
+		collection := collections[0]
+
+		// Update configuration
+		newConfigJsonStr, err := tc.updateCollectionConfiguration(
+			collection.Collection.ConfigurationJsonStr,
+			updateCollection.NewConfigurationJsonStr,
+			collection.CollectionMetadata,
+		)
+		if err != nil {
+			return err
+		}
 
 		dbCollection := &dbmodel.Collection{
-			ID:        updateCollection.ID.String(),
-			Name:      updateCollection.Name,
-			Dimension: updateCollection.Dimension,
-			Ts:        ts,
+			ID:                   updateCollection.ID.String(),
+			Name:                 updateCollection.Name,
+			Dimension:            updateCollection.Dimension,
+			ConfigurationJsonStr: newConfigJsonStr,
+			Ts:                   ts,
 		}
 		err = tc.metaDomain.CollectionDb(txCtx).Update(dbCollection)
 		if err != nil {
@@ -675,7 +802,7 @@ func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model
 		if err != nil {
 			return err
 		}
-		if collectionList == nil || len(collectionList) == 0 {
+		if len(collectionList) == 0 {
 			return common.ErrCollectionNotFound
 		}
 		result = convertCollectionToModel(collectionList)[0]

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -751,4 +752,208 @@ func TestCatalog_ListCollectionsToGc_NilParameters(t *testing.T) {
 	// Verify mock expectations
 	mockMetaDomain.AssertExpectations(t)
 	mockCollectionDb.AssertExpectations(t)
+}
+
+func TestUpdateCollectionConfiguration(t *testing.T) {
+	// Create a new catalog instance
+	catalog := NewTableCatalog(nil, nil, nil, false)
+
+	tests := []struct {
+		name                string
+		existingConfigJson  *string
+		updateConfigJson    *string
+		collectionMetadata  []*dbmodel.CollectionMetadata
+		expectedError       bool
+		expectedHnswConfig  *model.HnswConfiguration
+		expectedSpannConfig *model.SpannConfiguration
+	}{
+		{
+			name: "Update HNSW configuration",
+			existingConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"space": "l2",
+						"ef_construction": 100,
+						"ef_search": 100,
+						"max_neighbors": 16,
+						"num_threads": 16,
+						"resize_factor": 1.2,
+						"batch_size": 100,
+						"sync_threshold": 1000
+					}
+				}
+			}`),
+			updateConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"ef_search": 20,
+						"num_threads": 4
+					}
+				}
+			}`),
+			expectedHnswConfig: &model.HnswConfiguration{
+				Space:          "l2",
+				EfConstruction: 100,
+				EfSearch:       20,
+				MaxNeighbors:   16,
+				NumThreads:     4,
+				ResizeFactor:   1.2,
+				BatchSize:      100,
+				SyncThreshold:  1000,
+			},
+		},
+		{
+			name:               "Update from legacy metadata",
+			existingConfigJson: nil,
+			collectionMetadata: []*dbmodel.CollectionMetadata{
+				{
+					Key:      strPtr("hnsw:ef"),
+					IntValue: int64Ptr(50),
+				},
+				{
+					Key:      strPtr("hnsw:num_threads"),
+					IntValue: int64Ptr(8),
+				},
+				{
+					Key:        strPtr("hnsw:resize_factor"),
+					FloatValue: float64Ptr(1.2),
+				},
+				{
+					Key:      strPtr("hnsw:batch_size"),
+					IntValue: int64Ptr(100),
+				},
+				{
+					Key:      strPtr("hnsw:sync_threshold"),
+					IntValue: int64Ptr(1000),
+				},
+			},
+			updateConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"ef_search": 20
+					}
+				}
+			}`),
+			expectedHnswConfig: &model.HnswConfiguration{
+				Space:          "l2",
+				EfConstruction: 100,
+				EfSearch:       20,
+				MaxNeighbors:   16,
+				NumThreads:     8,
+				ResizeFactor:   1.2,
+				BatchSize:      100,
+				SyncThreshold:  1000,
+			},
+		},
+		{
+			name: "Convert from HNSW to SPANN",
+			existingConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"space": "l2",
+						"ef_construction": 100,
+						"ef_search": 100,
+						"max_neighbors": 16,
+						"num_threads": 16,
+						"resize_factor": 1.2,
+						"batch_size": 100,
+						"sync_threshold": 1000
+					}
+				}
+			}`),
+			updateConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "spann",
+					"spann": {
+						"spann_config": {
+							"search_nprobe": 10,
+							"write_nprobe": 5,
+							"space": "l2",
+							"construction_ef": 100,
+							"search_ef": 50,
+							"m": 16
+						}
+					}
+				}
+			}`),
+			expectedSpannConfig: &model.SpannConfiguration{
+				SearchNprobe:   10,
+				WriteNprobe:    5,
+				Space:          "l2",
+				ConstructionEf: 100,
+				SearchEf:       50,
+				M:              16,
+			},
+		},
+		{
+			name: "Invalid update configuration JSON",
+			existingConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"space": "l2",
+						"ef_construction": 100,
+						"ef_search": 100,
+						"max_neighbors": 16,
+						"num_threads": 16,
+						"resize_factor": 1.2,
+						"batch_size": 100,
+						"sync_threshold": 1000
+					}
+				}
+			}`),
+			updateConfigJson: strPtr(`{invalid json`),
+			expectedError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := catalog.updateCollectionConfiguration(
+				tt.existingConfigJson,
+				tt.updateConfigJson,
+				tt.collectionMetadata,
+			)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+
+			// Parse the result to verify the configuration
+			var config model.InternalCollectionConfiguration
+			err = json.Unmarshal([]byte(*result), &config)
+			assert.NoError(t, err)
+
+			if tt.expectedHnswConfig != nil {
+				assert.Equal(t, "hnsw", config.VectorIndex.Type)
+				assert.Equal(t, tt.expectedHnswConfig, config.VectorIndex.Hnsw)
+			}
+
+			if tt.expectedSpannConfig != nil {
+				assert.Equal(t, "spann", config.VectorIndex.Type)
+				assert.Equal(t, tt.expectedSpannConfig, config.VectorIndex.Spann)
+			}
+		})
+	}
+}
+
+// Helper functions
+func strPtr(s string) *string {
+	return &s
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
 }

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -314,9 +314,10 @@ func (s *Server) UpdateCollection(ctx context.Context, req *coordinatorpb.Update
 	}
 
 	updateCollection := &model.UpdateCollection{
-		ID:        parsedCollectionID,
-		Name:      req.Name,
-		Dimension: req.Dimension,
+		ID:                      parsedCollectionID,
+		Name:                    req.Name,
+		Dimension:               req.Dimension,
+		NewConfigurationJsonStr: req.ConfigurationJsonStr,
 	}
 
 	resetMetadata := req.GetResetMetadata()

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -208,6 +208,7 @@ message UpdateCollectionRequest {
     UpdateMetadata metadata = 5;
     bool reset_metadata = 6;
   }
+  optional string configuration_json_str = 7;
 }
 
 message UpdateCollectionResponse {

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -838,8 +838,12 @@ impl GrpcSysDb {
         name: Option<String>,
         metadata: Option<CollectionMetadataUpdate>,
         dimension: Option<u32>,
-        _configuration: Option<UpdateCollectionConfiguration>,
+        configuration: Option<UpdateCollectionConfiguration>,
     ) -> Result<(), UpdateCollectionError> {
+        let mut configuration_json_str = None;
+        if let Some(configuration) = configuration {
+            configuration_json_str = Some(serde_json::to_string(&configuration).unwrap());
+        }
         let req = chroma_proto::UpdateCollectionRequest {
             id: collection_id.0.to_string(),
             name: name.clone(),
@@ -854,6 +858,7 @@ impl GrpcSysDb {
                 }
             }),
             dimension: dimension.map(|dim| dim as i32),
+            configuration_json_str,
         };
 
         self.client.update_collection(req).await.map_err(|e| {


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - add `configuration_json_str` to go grpc implementation and enable writing to grpc service from rust
   - add logic to overwrite existing configuration attributes with the updated configuration attributes

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
