### PR TITLE
[ENH] return configuration in server response

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -15,9 +15,6 @@ from chromadb.api.collection_configuration import (
     UpdateCollectionConfiguration,
     create_collection_configuration_to_json,
     update_collection_configuration_to_json,
-    create_collection_configuration_from_legacy_metadata_dict,
-    populate_create_hnsw_defaults,
-    validate_create_hnsw_config,
 )
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, System, Settings
 from chromadb.telemetry.opentelemetry import (
@@ -312,27 +309,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 "get_or_create": get_or_create,
             },
         )
-
         model = CollectionModel.from_json(resp_json)
-
-        # TODO @jai: Remove this once server response contains configuration
-        if configuration is None or configuration.get("hnsw") is None:
-            if model.metadata is not None:
-                model.configuration_json = create_collection_configuration_to_json(
-                    create_collection_configuration_from_legacy_metadata_dict(
-                        model.metadata
-                    )
-                )
-        else:
-            # At this point we know configuration is not None and has hnsw
-            assert configuration is not None  # Help type checker
-            hnsw_config = configuration.get("hnsw")
-            assert hnsw_config is not None  # Help type checker
-            populate_create_hnsw_defaults(hnsw_config)
-            validate_create_hnsw_config(hnsw_config)
-            model.configuration_json = create_collection_configuration_to_json(
-                configuration
-            )
 
         return model
 

--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -52,24 +52,24 @@ def default_collection_configuration() -> CollectionConfiguration:
 
 
 def load_collection_configuration_from_json_str(
-    json_str: str,
+    config_json_str: str,
 ) -> CollectionConfiguration:
-    json_map = json.loads(json_str)
-    return load_collection_configuration_from_json(json_map)
+    config_json_map = json.loads(config_json_str)
+    return load_collection_configuration_from_json(config_json_map)
 
 
 # TODO: make warnings prettier and add link to migration docs
 def load_collection_configuration_from_json(
-    json_map: Dict[str, Any]
+    config_json_map: Dict[str, Any]
 ) -> CollectionConfiguration:
-    if json_map.get("hnsw") is None:
-        if json_map.get("embedding_function") is None:
+    if config_json_map.get("hnsw") is None:
+        if config_json_map.get("embedding_function") is None:
             return CollectionConfiguration(
                 hnsw=None,
                 embedding_function=None,
             )
         else:
-            ef_config = json_map["embedding_function"]
+            ef_config = config_json_map["embedding_function"]
             if ef_config["type"] == "legacy":
                 warnings.warn(
                     "legacy embedding function config",
@@ -92,13 +92,13 @@ def load_collection_configuration_from_json(
                     embedding_function=ef.build_from_config(ef_config["config"]),
                 )
     else:
-        if json_map.get("embedding_function") is None:
+        if config_json_map.get("embedding_function") is None:
             return CollectionConfiguration(
-                hnsw=cast(HNSWConfiguration, json_map["hnsw"]),
+                hnsw=cast(HNSWConfiguration, config_json_map["hnsw"]),
                 embedding_function=None,
             )
         else:
-            ef_config = json_map["embedding_function"]
+            ef_config = config_json_map["embedding_function"]
             if ef_config["type"] == "legacy":
                 warnings.warn(
                     "legacy embedding function config",
@@ -106,7 +106,7 @@ def load_collection_configuration_from_json(
                     stacklevel=2,
                 )
                 return CollectionConfiguration(
-                    hnsw=cast(HNSWConfiguration, json_map["hnsw"]),
+                    hnsw=cast(HNSWConfiguration, config_json_map["hnsw"]),
                     embedding_function=None,
                 )
             else:
@@ -117,7 +117,7 @@ def load_collection_configuration_from_json(
                         f"Embedding function {ef_config['name']} not found. Add @register_embedding_function decorator to the class definition."
                     )
                 return CollectionConfiguration(
-                    hnsw=cast(HNSWConfiguration, json_map["hnsw"]),
+                    hnsw=cast(HNSWConfiguration, config_json_map["hnsw"]),
                     embedding_function=ef.build_from_config(ef_config["config"]),
                 )
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -12,9 +12,6 @@ from chromadb.api.collection_configuration import (
     UpdateCollectionConfiguration,
     update_collection_configuration_to_json,
     create_collection_configuration_to_json,
-    create_collection_configuration_from_legacy_metadata_dict,
-    populate_create_hnsw_defaults,
-    validate_create_hnsw_config,
 )
 from chromadb import __version__
 from chromadb.api.base_http_client import BaseHTTPClient
@@ -267,24 +264,6 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         )
         model = CollectionModel.from_json(resp_json)
 
-        # TODO @jai: Remove this once server response contains configuration
-        if configuration is None or configuration.get("hnsw") is None:
-            if model.metadata is not None:
-                model.configuration_json = create_collection_configuration_to_json(
-                    create_collection_configuration_from_legacy_metadata_dict(
-                        model.metadata
-                    )
-                )
-        else:
-            # At this point we know configuration is not None and has hnsw
-            assert configuration is not None  # Help type checker
-            hnsw_config = configuration.get("hnsw")
-            assert hnsw_config is not None  # Help type checker
-            populate_create_hnsw_defaults(hnsw_config)
-            validate_create_hnsw_config(hnsw_config)
-            model.configuration_json = create_collection_configuration_to_json(
-                configuration
-            )
         return model
 
     @trace_method("FastAPI.get_collection", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -5,6 +5,7 @@ from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     create_collection_configuration_to_json_str,
     UpdateCollectionConfiguration,
+    update_collection_configuration_to_json_str,
 )
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, System, logger
 from chromadb.db.system import SysDB
@@ -525,6 +526,11 @@ class GrpcSysDB(SysDB):
                 dimension=write_dimension,
                 metadata=to_proto_update_metadata(write_metadata)
                 if write_metadata
+                else None,
+                configuration_json_str=update_collection_configuration_to_json_str(
+                    write_configuration
+                )
+                if write_configuration
                 else None,
             )
             if metadata is None:

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -8,6 +8,7 @@ from typing_extensions import TypedDict, TypeVar
 from uuid import UUID
 from enum import Enum
 from pydantic import BaseModel
+import warnings
 
 from chromadb.api.configuration import (
     ConfigurationInternal,
@@ -143,7 +144,18 @@ class Collection(
 
     def get_configuration(self) -> CollectionConfiguration:
         """Returns the configuration of the collection"""
-        return load_collection_configuration_from_json(self.configuration_json)
+        try:
+            return load_collection_configuration_from_json(self.configuration_json)
+        except Exception as e:
+            warnings.warn(
+                f"server does not respond with configuration_json. Please update server: {e}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return CollectionConfiguration(
+                hnsw={},
+                embedding_function=None,
+            )
 
     def set_configuration(self, configuration: CollectionConfiguration) -> None:
         """Sets the configuration of the collection"""
@@ -160,12 +172,23 @@ class Collection(
     @override
     def from_json(cls, json_map: Dict[str, Any]) -> Self:
         """Deserializes a Collection object from JSON"""
+        configuration: CollectionConfiguration = {
+            "hnsw": {},
+            "embedding_function": None,
+        }
+        try:
+            configuration_json = json_map.get("configuration_json", None)
+            configuration = load_collection_configuration_from_json(configuration_json)
+        except Exception as e:
+            warnings.warn(
+                f"server does not respond with configuration_json. Please update server: {e}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return cls(
             id=json_map["id"],
             name=json_map["name"],
-            configuration=load_collection_configuration_from_json(
-                json_map.get("configuration_json", None)
-            ),
+            configuration=configuration,
             metadata=json_map.get("metadata", None),
             dimension=json_map.get("dimension", None),
             tenant=json_map["tenant"],

--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -35,6 +35,7 @@ export namespace Api {
   }
 
   export interface Collection {
+    configuration_json: Api.InternalCollectionConfiguration;
     database: string;
     /**
      * @type {number | null}
@@ -255,6 +256,100 @@ export namespace Api {
     Uris = "uris",
   }
 
+  export interface InternalCollectionConfiguration {
+    embedding_function?: Api.EmbeddingFunctionConfiguration | null;
+    vector_index?: Api.VectorIndexConfiguration;
+  }
+
+  export interface InternalSpannConfiguration {
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    construction_ef?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     */
+    initial_lambda?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    m?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    merge_threshold?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    num_centers_to_merge_to?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    num_samples_kmeans?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    reassign_nbr_count?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    search_ef?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    search_nprobe?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     */
+    search_rng_epsilon?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     */
+    search_rng_factor?: number;
+    space?: Api.HnswSpace;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    split_threshold?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     * minimum: 0
+     */
+    write_nprobe?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     */
+    write_rng_epsilon?: number;
+    /**
+     * @type {number}
+     * @memberof InternalSpannConfiguration
+     */
+    write_rng_factor?: number;
+  }
+
   export interface QueryRequestPayload extends Api.RawWhereFields {
     ids?: string[] | null;
     include?: Api.Include[];
@@ -397,6 +492,7 @@ export namespace Api {
   export interface UpsertCollectionRecordsResponse {}
 
   export interface Vec2 {
+    configuration_json: Api.InternalCollectionConfiguration;
     database: string;
     /**
      * @type {number | null}
@@ -422,5 +518,23 @@ export namespace Api {
      * @memberof Vec2
      */
     version: number;
+  }
+
+  export type VectorIndexConfiguration =
+    | Api.VectorIndexConfiguration.ObjectValue
+    | Api.VectorIndexConfiguration.ObjectValue2;
+
+  /**
+   * @export
+   * @namespace VectorIndexConfiguration
+   */
+  export namespace VectorIndexConfiguration {
+    export interface ObjectValue {
+      hnsw: Api.HnswConfiguration;
+    }
+
+    export interface ObjectValue2 {
+      spann: Api.InternalSpannConfiguration;
+    }
   }
 }

--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -49,14 +49,15 @@ type DeleteCollection struct {
 }
 
 type UpdateCollection struct {
-	ID            types.UniqueID
-	Name          *string
-	Dimension     *int32
-	Metadata      *CollectionMetadata[CollectionMetadataValueType]
-	ResetMetadata bool
-	TenantID      string
-	DatabaseName  string
-	Ts            types.Timestamp
+	ID                      types.UniqueID
+	Name                    *string
+	Dimension               *int32
+	Metadata                *CollectionMetadata[CollectionMetadataValueType]
+	ResetMetadata           bool
+	NewConfigurationJsonStr *string
+	TenantID                string
+	DatabaseName            string
+	Ts                      types.Timestamp
 }
 
 type FlushCollectionCompaction struct {

--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -1,0 +1,126 @@
+package model
+
+type EmbeddingFunctionConfiguration struct {
+	Type   string                             `json:"type"`
+	Config *EmbeddingFunctionNewConfiguration `json:"config,omitempty"`
+}
+
+type EmbeddingFunctionNewConfiguration struct {
+	Name   string      `json:"name"`
+	Config interface{} `json:"config"`
+}
+
+type VectorIndexConfiguration struct {
+	Type  string              `json:"type"`
+	Hnsw  *HnswConfiguration  `json:"hnsw,omitempty"`
+	Spann *SpannConfiguration `json:"spann,omitempty"`
+}
+
+type HnswConfiguration struct {
+	Space          string  `json:"space"`
+	EfConstruction int     `json:"ef_construction"`
+	EfSearch       int     `json:"ef_search"`
+	MaxNeighbors   int     `json:"max_neighbors"`
+	NumThreads     int     `json:"num_threads"`
+	ResizeFactor   float64 `json:"resize_factor"`
+	BatchSize      int     `json:"batch_size"`
+	SyncThreshold  int     `json:"sync_threshold"`
+}
+
+// DefaultHnswConfiguration returns the default HNSW configuration
+func DefaultHnswConfiguration() *HnswConfiguration {
+	return &HnswConfiguration{
+		Space:          "l2",
+		EfConstruction: 100,
+		EfSearch:       100,
+		MaxNeighbors:   16,
+		NumThreads:     16,
+		ResizeFactor:   1.2,
+		BatchSize:      100,
+		SyncThreshold:  1000,
+	}
+}
+
+type SpannConfiguration struct {
+	SearchNprobe   int    `json:"search_nprobe"`
+	WriteNprobe    int    `json:"write_nprobe"`
+	Space          string `json:"space"`
+	ConstructionEf int    `json:"construction_ef"`
+	SearchEf       int    `json:"search_ef"`
+	M              int    `json:"m"`
+}
+
+type InternalCollectionConfiguration struct {
+	VectorIndex       *VectorIndexConfiguration       `json:"vector_index"`
+	EmbeddingFunction *EmbeddingFunctionConfiguration `json:"embedding_function,omitempty"`
+}
+
+// DefaultHnswCollectionConfiguration returns a default configuration using HNSW
+func DefaultHnswCollectionConfiguration() *InternalCollectionConfiguration {
+	return &InternalCollectionConfiguration{
+		VectorIndex: &VectorIndexConfiguration{
+			Type: "hnsw",
+			Hnsw: DefaultHnswConfiguration(),
+		},
+	}
+}
+
+// FromLegacyMetadata creates a configuration from legacy metadata
+func FromLegacyMetadata(metadata map[string]interface{}) *InternalCollectionConfiguration {
+	config := DefaultHnswCollectionConfiguration()
+
+	// Try to extract HNSW parameters from legacy metadata
+	if metadata != nil {
+		if efConstruction, ok := metadata["hnsw:construction_ef"].(float64); ok {
+			config.VectorIndex.Hnsw.EfConstruction = int(efConstruction)
+		}
+		if efSearch, ok := metadata["hnsw:ef"].(float64); ok {
+			config.VectorIndex.Hnsw.EfSearch = int(efSearch)
+		}
+		if maxNeighbors, ok := metadata["hnsw:max_elements"].(float64); ok {
+			config.VectorIndex.Hnsw.MaxNeighbors = int(maxNeighbors)
+		}
+		if numThreads, ok := metadata["hnsw:num_threads"].(float64); ok {
+			config.VectorIndex.Hnsw.NumThreads = int(numThreads)
+		}
+		if resizeFactor, ok := metadata["hnsw:resize_factor"].(float64); ok {
+			config.VectorIndex.Hnsw.ResizeFactor = resizeFactor
+		}
+		if batchSize, ok := metadata["hnsw:batch_size"].(float64); ok {
+			config.VectorIndex.Hnsw.BatchSize = int(batchSize)
+		}
+		if syncThreshold, ok := metadata["hnsw:sync_threshold"].(float64); ok {
+			config.VectorIndex.Hnsw.SyncThreshold = int(syncThreshold)
+		}
+		if space, ok := metadata["hnsw:space"].(string); ok {
+			config.VectorIndex.Hnsw.Space = space
+		}
+	}
+
+	return config
+}
+
+// Update configuration types
+type UpdateHnswConfiguration struct {
+	EfSearch      *int     `json:"ef_search,omitempty"`
+	MaxNeighbors  *int     `json:"max_neighbors,omitempty"`
+	NumThreads    *int     `json:"num_threads,omitempty"`
+	ResizeFactor  *float64 `json:"resize_factor,omitempty"`
+	BatchSize     *int     `json:"batch_size,omitempty"`
+	SyncThreshold *int     `json:"sync_threshold,omitempty"`
+}
+
+type UpdateSpannConfiguration struct {
+	SpannConfig *SpannConfiguration `json:"spann_config,omitempty"`
+}
+
+type UpdateVectorIndexConfiguration struct {
+	Type  string                    `json:"type"`
+	Hnsw  *UpdateHnswConfiguration  `json:"hnsw,omitempty"`
+	Spann *UpdateSpannConfiguration `json:"spann,omitempty"`
+}
+
+type InternalUpdateCollectionConfiguration struct {
+	VectorIndex       *UpdateVectorIndexConfiguration `json:"vector_index,omitempty"`
+	EmbeddingFunction *EmbeddingFunctionConfiguration `json:"embedding_function,omitempty"`
+}

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -607,6 +608,120 @@ func (tc *Catalog) GetSoftDeletedCollections(ctx context.Context, collectionID *
 	return collectionList, nil
 }
 
+// updateCollectionConfiguration handles parsing and updating collection configuration
+func (tc *Catalog) updateCollectionConfiguration(
+	existingConfigJsonStr *string,
+	updateConfigJsonStr *string,
+	collectionMetadata []*dbmodel.CollectionMetadata,
+) (*string, error) {
+	if updateConfigJsonStr == nil {
+		return nil, nil
+	}
+
+	// Parse existing configuration
+	var existingConfig model.InternalCollectionConfiguration
+	var parseErr error
+	if existingConfigJsonStr != nil {
+		parseErr = json.Unmarshal([]byte(*existingConfigJsonStr), &existingConfig)
+		if parseErr != nil {
+			// Try to create config from legacy metadata
+			metadataMap := make(map[string]interface{})
+			for _, m := range collectionMetadata {
+				if m.StrValue != nil {
+					metadataMap[*m.Key] = *m.StrValue
+				} else if m.IntValue != nil {
+					metadataMap[*m.Key] = float64(*m.IntValue)
+				} else if m.FloatValue != nil {
+					metadataMap[*m.Key] = *m.FloatValue
+				} else if m.BoolValue != nil {
+					metadataMap[*m.Key] = *m.BoolValue
+				}
+			}
+			existingConfig = *model.FromLegacyMetadata(metadataMap)
+		} else if existingConfig.VectorIndex == nil {
+			// If the config was parsed but has no vector index, use default HNSW
+			existingConfig = *model.DefaultHnswCollectionConfiguration()
+		}
+	} else {
+		// If no existing config, try to create from legacy metadata first
+		metadataMap := make(map[string]interface{})
+		for _, m := range collectionMetadata {
+			if m.StrValue != nil {
+				metadataMap[*m.Key] = *m.StrValue
+			} else if m.IntValue != nil {
+				metadataMap[*m.Key] = float64(*m.IntValue)
+			} else if m.FloatValue != nil {
+				metadataMap[*m.Key] = *m.FloatValue
+			} else if m.BoolValue != nil {
+				metadataMap[*m.Key] = *m.BoolValue
+			}
+		}
+		if len(metadataMap) > 0 {
+			existingConfig = *model.FromLegacyMetadata(metadataMap)
+		} else {
+			// If no legacy metadata, use default HNSW
+			existingConfig = *model.DefaultHnswCollectionConfiguration()
+		}
+	}
+
+	// Parse update configuration
+	var updateConfig model.InternalUpdateCollectionConfiguration
+	if err := json.Unmarshal([]byte(*updateConfigJsonStr), &updateConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse update configuration: %w", err)
+	}
+
+	// Update existing configuration with new values
+	if updateConfig.VectorIndex != nil {
+		if updateConfig.VectorIndex.Type == "hnsw" && updateConfig.VectorIndex.Hnsw != nil {
+			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Type != "hnsw" {
+				existingConfig.VectorIndex = &model.VectorIndexConfiguration{
+					Type: "hnsw",
+					Hnsw: model.DefaultHnswConfiguration(),
+				}
+			}
+			if updateConfig.VectorIndex.Hnsw.EfSearch != nil {
+				existingConfig.VectorIndex.Hnsw.EfSearch = *updateConfig.VectorIndex.Hnsw.EfSearch
+			}
+			if updateConfig.VectorIndex.Hnsw.MaxNeighbors != nil {
+				existingConfig.VectorIndex.Hnsw.MaxNeighbors = *updateConfig.VectorIndex.Hnsw.MaxNeighbors
+			}
+			if updateConfig.VectorIndex.Hnsw.NumThreads != nil {
+				existingConfig.VectorIndex.Hnsw.NumThreads = *updateConfig.VectorIndex.Hnsw.NumThreads
+			}
+			if updateConfig.VectorIndex.Hnsw.ResizeFactor != nil {
+				existingConfig.VectorIndex.Hnsw.ResizeFactor = *updateConfig.VectorIndex.Hnsw.ResizeFactor
+			}
+			if updateConfig.VectorIndex.Hnsw.SyncThreshold != nil {
+				existingConfig.VectorIndex.Hnsw.SyncThreshold = *updateConfig.VectorIndex.Hnsw.SyncThreshold
+			}
+			if updateConfig.VectorIndex.Hnsw.BatchSize != nil {
+				existingConfig.VectorIndex.Hnsw.BatchSize = *updateConfig.VectorIndex.Hnsw.BatchSize
+			}
+		} else if updateConfig.VectorIndex.Type == "spann" && updateConfig.VectorIndex.Spann != nil {
+			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Type != "spann" {
+				existingConfig.VectorIndex = &model.VectorIndexConfiguration{
+					Type:  "spann",
+					Spann: updateConfig.VectorIndex.Spann.SpannConfig,
+				}
+			} else {
+				existingConfig.VectorIndex.Spann = updateConfig.VectorIndex.Spann.SpannConfig
+			}
+		}
+	}
+
+	if updateConfig.EmbeddingFunction != nil {
+		existingConfig.EmbeddingFunction = updateConfig.EmbeddingFunction
+	}
+
+	// Serialize updated config back to JSON
+	updatedConfigBytes, err := json.Marshal(existingConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize updated configuration: %w", err)
+	}
+	updatedConfigStr := string(updatedConfigBytes)
+	return &updatedConfigStr, nil
+}
+
 func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model.UpdateCollection, ts types.Timestamp) (*model.Collection, error) {
 	log.Info("updating collection", zap.String("collectionId", updateCollection.ID.String()))
 	var result *model.Collection
@@ -627,12 +742,24 @@ func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model
 		if len(collections) == 0 {
 			return common.ErrCollectionNotFound
 		}
+		collection := collections[0]
+
+		// Update configuration
+		newConfigJsonStr, err := tc.updateCollectionConfiguration(
+			collection.Collection.ConfigurationJsonStr,
+			updateCollection.NewConfigurationJsonStr,
+			collection.CollectionMetadata,
+		)
+		if err != nil {
+			return err
+		}
 
 		dbCollection := &dbmodel.Collection{
-			ID:        updateCollection.ID.String(),
-			Name:      updateCollection.Name,
-			Dimension: updateCollection.Dimension,
-			Ts:        ts,
+			ID:                   updateCollection.ID.String(),
+			Name:                 updateCollection.Name,
+			Dimension:            updateCollection.Dimension,
+			ConfigurationJsonStr: newConfigJsonStr,
+			Ts:                   ts,
 		}
 		err = tc.metaDomain.CollectionDb(txCtx).Update(dbCollection)
 		if err != nil {
@@ -675,7 +802,7 @@ func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model
 		if err != nil {
 			return err
 		}
-		if collectionList == nil || len(collectionList) == 0 {
+		if len(collectionList) == 0 {
 			return common.ErrCollectionNotFound
 		}
 		result = convertCollectionToModel(collectionList)[0]

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -751,4 +752,208 @@ func TestCatalog_ListCollectionsToGc_NilParameters(t *testing.T) {
 	// Verify mock expectations
 	mockMetaDomain.AssertExpectations(t)
 	mockCollectionDb.AssertExpectations(t)
+}
+
+func TestUpdateCollectionConfiguration(t *testing.T) {
+	// Create a new catalog instance
+	catalog := NewTableCatalog(nil, nil, nil, false)
+
+	tests := []struct {
+		name                string
+		existingConfigJson  *string
+		updateConfigJson    *string
+		collectionMetadata  []*dbmodel.CollectionMetadata
+		expectedError       bool
+		expectedHnswConfig  *model.HnswConfiguration
+		expectedSpannConfig *model.SpannConfiguration
+	}{
+		{
+			name: "Update HNSW configuration",
+			existingConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"space": "l2",
+						"ef_construction": 100,
+						"ef_search": 100,
+						"max_neighbors": 16,
+						"num_threads": 16,
+						"resize_factor": 1.2,
+						"batch_size": 100,
+						"sync_threshold": 1000
+					}
+				}
+			}`),
+			updateConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"ef_search": 20,
+						"num_threads": 4
+					}
+				}
+			}`),
+			expectedHnswConfig: &model.HnswConfiguration{
+				Space:          "l2",
+				EfConstruction: 100,
+				EfSearch:       20,
+				MaxNeighbors:   16,
+				NumThreads:     4,
+				ResizeFactor:   1.2,
+				BatchSize:      100,
+				SyncThreshold:  1000,
+			},
+		},
+		{
+			name:               "Update from legacy metadata",
+			existingConfigJson: nil,
+			collectionMetadata: []*dbmodel.CollectionMetadata{
+				{
+					Key:      strPtr("hnsw:ef"),
+					IntValue: int64Ptr(50),
+				},
+				{
+					Key:      strPtr("hnsw:num_threads"),
+					IntValue: int64Ptr(8),
+				},
+				{
+					Key:        strPtr("hnsw:resize_factor"),
+					FloatValue: float64Ptr(1.2),
+				},
+				{
+					Key:      strPtr("hnsw:batch_size"),
+					IntValue: int64Ptr(100),
+				},
+				{
+					Key:      strPtr("hnsw:sync_threshold"),
+					IntValue: int64Ptr(1000),
+				},
+			},
+			updateConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"ef_search": 20
+					}
+				}
+			}`),
+			expectedHnswConfig: &model.HnswConfiguration{
+				Space:          "l2",
+				EfConstruction: 100,
+				EfSearch:       20,
+				MaxNeighbors:   16,
+				NumThreads:     8,
+				ResizeFactor:   1.2,
+				BatchSize:      100,
+				SyncThreshold:  1000,
+			},
+		},
+		{
+			name: "Convert from HNSW to SPANN",
+			existingConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"space": "l2",
+						"ef_construction": 100,
+						"ef_search": 100,
+						"max_neighbors": 16,
+						"num_threads": 16,
+						"resize_factor": 1.2,
+						"batch_size": 100,
+						"sync_threshold": 1000
+					}
+				}
+			}`),
+			updateConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "spann",
+					"spann": {
+						"spann_config": {
+							"search_nprobe": 10,
+							"write_nprobe": 5,
+							"space": "l2",
+							"construction_ef": 100,
+							"search_ef": 50,
+							"m": 16
+						}
+					}
+				}
+			}`),
+			expectedSpannConfig: &model.SpannConfiguration{
+				SearchNprobe:   10,
+				WriteNprobe:    5,
+				Space:          "l2",
+				ConstructionEf: 100,
+				SearchEf:       50,
+				M:              16,
+			},
+		},
+		{
+			name: "Invalid update configuration JSON",
+			existingConfigJson: strPtr(`{
+				"vector_index": {
+					"type": "hnsw",
+					"hnsw": {
+						"space": "l2",
+						"ef_construction": 100,
+						"ef_search": 100,
+						"max_neighbors": 16,
+						"num_threads": 16,
+						"resize_factor": 1.2,
+						"batch_size": 100,
+						"sync_threshold": 1000
+					}
+				}
+			}`),
+			updateConfigJson: strPtr(`{invalid json`),
+			expectedError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := catalog.updateCollectionConfiguration(
+				tt.existingConfigJson,
+				tt.updateConfigJson,
+				tt.collectionMetadata,
+			)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+
+			// Parse the result to verify the configuration
+			var config model.InternalCollectionConfiguration
+			err = json.Unmarshal([]byte(*result), &config)
+			assert.NoError(t, err)
+
+			if tt.expectedHnswConfig != nil {
+				assert.Equal(t, "hnsw", config.VectorIndex.Type)
+				assert.Equal(t, tt.expectedHnswConfig, config.VectorIndex.Hnsw)
+			}
+
+			if tt.expectedSpannConfig != nil {
+				assert.Equal(t, "spann", config.VectorIndex.Type)
+				assert.Equal(t, tt.expectedSpannConfig, config.VectorIndex.Spann)
+			}
+		})
+	}
+}
+
+// Helper functions
+func strPtr(s string) *string {
+	return &s
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
 }

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -314,9 +314,10 @@ func (s *Server) UpdateCollection(ctx context.Context, req *coordinatorpb.Update
 	}
 
 	updateCollection := &model.UpdateCollection{
-		ID:        parsedCollectionID,
-		Name:      req.Name,
-		Dimension: req.Dimension,
+		ID:                      parsedCollectionID,
+		Name:                    req.Name,
+		Dimension:               req.Dimension,
+		NewConfigurationJsonStr: req.ConfigurationJsonStr,
 	}
 
 	resetMetadata := req.GetResetMetadata()

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -208,6 +208,7 @@ message UpdateCollectionRequest {
     UpdateMetadata metadata = 5;
     bool reset_metadata = 6;
   }
+  optional string configuration_json_str = 7;
 }
 
 message UpdateCollectionResponse {

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -635,7 +635,6 @@ mod test {
                 vector_index: chroma_types::VectorIndexConfiguration::Spann(params),
                 embedding_function: None,
             },
-            legacy_configuration_json: (),
             metadata: None,
             dimension: None,
             tenant: "test".to_string(),

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -338,7 +338,6 @@ impl SqliteSysDb {
             version: 0,
             size_bytes_post_compaction: 0,
             last_compaction_time_secs: 0,
-            legacy_configuration_json: (),
         })
     }
 
@@ -725,7 +724,6 @@ impl SqliteSysDb {
                     database: first_row.get(5),
                     size_bytes_post_compaction: 0,
                     last_compaction_time_secs: 0,
-                    legacy_configuration_json: (),
                 }))
             })
             .collect::<Result<Vec<_>, GetCollectionsError>>()?;

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -838,8 +838,12 @@ impl GrpcSysDb {
         name: Option<String>,
         metadata: Option<CollectionMetadataUpdate>,
         dimension: Option<u32>,
-        _configuration: Option<UpdateCollectionConfiguration>,
+        configuration: Option<UpdateCollectionConfiguration>,
     ) -> Result<(), UpdateCollectionError> {
+        let mut configuration_json_str = None;
+        if let Some(configuration) = configuration {
+            configuration_json_str = Some(serde_json::to_string(&configuration).unwrap());
+        }
         let req = chroma_proto::UpdateCollectionRequest {
             id: collection_id.0.to_string(),
             name: name.clone(),
@@ -854,6 +858,7 @@ impl GrpcSysDb {
                 }
             }),
             dimension: dimension.map(|dim| dim as i32),
+            configuration_json_str,
         };
 
         self.client.update_collection(req).await.map_err(|e| {

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -247,7 +247,6 @@ impl SysDb {
                     collection_id,
                     name,
                     config: configuration,
-                    legacy_configuration_json: (),
                     metadata,
                     dimension,
                     tenant: tenant.clone(),

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -1,5 +1,8 @@
 use super::{Metadata, MetadataValueConversionError};
-use crate::{chroma_proto, test_segment, InternalCollectionConfiguration, Segment, SegmentScope};
+use crate::{
+    chroma_proto, test_segment, CollectionConfiguration, InternalCollectionConfiguration, Segment,
+    SegmentScope,
+};
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -49,13 +52,21 @@ impl std::fmt::Display for CollectionUuid {
     }
 }
 
-const CONFIGURATION_JSON_STR: &str = r#"{"hnsw_configuration": {"space": "l2", "ef_construction": 100, "ef_search": 100, "num_threads": 16, "M": 16, "resize_factor": 1.2, "batch_size": 100, "sync_threshold": 1000, "_type": "HNSWConfigurationInternal"}, "_type": "CollectionConfigurationInternal"}"#;
+fn serialize_internal_collection_configuration<S: serde::Serializer>(
+    config: &InternalCollectionConfiguration,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let collection_config: CollectionConfiguration = config.clone().into();
+    collection_config.serialize(serializer)
+}
 
-fn emit_legacy_config_json_str<S: serde::Serializer>(_: &(), s: S) -> Result<S::Ok, S::Error> {
-    serde_json::from_str::<serde_json::Value>(CONFIGURATION_JSON_STR)
-        .unwrap()
-        .serialize(s)
-        .map_err(serde::ser::Error::custom)
+fn deserialize_internal_collection_configuration<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<InternalCollectionConfiguration, D::Error> {
+    let collection_config = CollectionConfiguration::deserialize(deserializer)?;
+    collection_config
+        .try_into()
+        .map_err(serde::de::Error::custom)
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
@@ -64,7 +75,11 @@ pub struct Collection {
     #[serde(rename = "id")]
     pub collection_id: CollectionUuid,
     pub name: String,
-    #[serde(skip, default = "InternalCollectionConfiguration::default_hnsw")]
+    #[serde(
+        serialize_with = "serialize_internal_collection_configuration",
+        deserialize_with = "deserialize_internal_collection_configuration",
+        rename = "configuration_json"
+    )]
     pub config: InternalCollectionConfiguration,
     pub metadata: Option<Metadata>,
     pub dimension: Option<i32>,
@@ -78,12 +93,6 @@ pub struct Collection {
     pub size_bytes_post_compaction: u64,
     #[serde(skip)]
     pub last_compaction_time_secs: u64,
-    #[serde(
-        serialize_with = "emit_legacy_config_json_str",
-        skip_deserializing,
-        rename = "configuration_json"
-    )]
-    pub legacy_configuration_json: (),
 }
 
 impl Default for Collection {
@@ -92,7 +101,6 @@ impl Default for Collection {
             collection_id: CollectionUuid::new(),
             name: "".to_string(),
             config: InternalCollectionConfiguration::default_hnsw(),
-            legacy_configuration_json: (),
             metadata: None,
             dimension: None,
             tenant: "".to_string(),
@@ -217,7 +225,6 @@ impl TryFrom<chroma_proto::Collection> for Collection {
             total_records_post_compaction: proto_collection.total_records_post_compaction,
             size_bytes_post_compaction: proto_collection.size_bytes_post_compaction,
             last_compaction_time_secs: proto_collection.last_compaction_time_secs,
-            legacy_configuration_json: (),
         })
     }
 }

--- a/rust/types/src/collection_configuration.rs
+++ b/rust/types/src/collection_configuration.rs
@@ -22,7 +22,7 @@ pub struct EmbeddingFunctionNewConfiguration {
     pub config: serde_json::Value,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum VectorIndexConfiguration {
     Hnsw(HnswConfiguration),
@@ -68,7 +68,7 @@ fn default_vector_index_config() -> VectorIndexConfiguration {
     VectorIndexConfiguration::Hnsw(HnswConfiguration::default())
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct InternalCollectionConfiguration {
     #[serde(default = "default_vector_index_config")]
     pub vector_index: VectorIndexConfiguration,


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Removed `#[serde(skip_serializing)]` attribute from `config` field in `Collection` struct, allowing it to be serialized
  - Added `ToSchema` derive macro to `VectorIndexConfiguration` enum, enabling OpenAPI schema generation
  - Added `ToSchema` derive macro to `InternalCollectionConfiguration` struct for OpenAPI schema generation
  - Added `ToSchema` derive macro to `InternalSpannConfiguration` struct for OpenAPI schema generation

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

No documentation changes required as these changes are related to internal serialization and schema generation capabilities.