### PR TITLE
[ENH] CLI - Update command updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,9 @@ dependencies = [
  "dirs 6.0.0",
  "indicatif",
  "predicates",
+ "regex",
  "reqwest 0.12.9",
+ "semver",
  "serde",
  "serde_json",
  "sqlx",
@@ -6652,9 +6654,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "seq-macro"

--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -1,6 +1,11 @@
+import re
 import sys
 
 import chromadb_rust_bindings
+import requests
+from packaging.version import parse
+
+import chromadb
 
 
 def build_cli_args(**kwargs):
@@ -14,9 +19,38 @@ def build_cli_args(**kwargs):
     return args
 
 
-def app():
+def update():
     try:
-        args = sys.argv
+        url = f"https://api.github.com/repos/chroma-core/chroma/releases"
+        response = requests.get(url)
+        response.raise_for_status()
+        releases = response.json()
+
+        version_pattern = re.compile(r'^\d+\.\d+\.\d+$')
+        numeric_releases = [r["tag_name"] for r in releases if version_pattern.fullmatch(r["tag_name"])]
+
+        if not numeric_releases:
+            print("Couldn't fetch the latest Chroma version")
+            return
+
+        latest = max(numeric_releases, key=parse)
+        if latest == chromadb.__version__:
+            print("Your Chroma version is up-to-date")
+            return
+
+        print(
+            f"A new version of Chroma is available!\nIf you're using pip, run 'pip install --upgrade chromadb' to upgrade to version {latest}")
+
+    except Exception as e:
+        print("Couldn't fetch the latest Chroma version")
+
+
+def app():
+    args = sys.argv
+    if ["chroma", "update"] in args:
+        update()
+        return
+    try:
         chromadb_rust_bindings.cli(args)
     except KeyboardInterrupt:
         pass

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -22,8 +22,6 @@ rand = {workspace = true}
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true}
-strum = "0.27.1"
-strum_macros = "0.27.1"
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tempfile = { workspace = true }

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -29,6 +29,8 @@ toml = "0.8.20"
 webbrowser = "1.0.3"
 strum = "0.27.1"
 strum_macros = "0.27.1"
+semver = "1.0.26"
+regex = "1.11.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/rust/cli/src/commands/mod.rs
+++ b/rust/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod db;
 pub mod profile;
 pub mod run;
+pub mod update;
 pub mod vacuum;

--- a/rust/cli/src/commands/update.rs
+++ b/rust/cli/src/commands/update.rs
@@ -1,0 +1,83 @@
+use crate::utils::CliError;
+use colored::Colorize;
+use regex::Regex;
+use semver::Version;
+use std::error::Error;
+use thiserror::Error;
+
+const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/chroma-core/chroma/releases";
+const UNIX_CURL: &str = "curl -sSL https://raw.githubusercontent.com/chroma-core/chroma/main/rust/cli/install/install.sh | bash";
+const WINDOWS_CURL: &str = "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/chroma-core/chroma/main/rust/cli/install/install.ps1'))";
+
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    #[error("Failed to fetch the latest Chroma CLI version")]
+    FailedVersionFetch,
+    #[error("Failed to get the current Chroma CLI version")]
+    CurrentVersionUndetected,
+    #[error("Failed to update the Chroma CLI")]
+    UpdateFailed,
+}
+
+async fn version_check(current_version: Version) -> Result<(), Box<dyn Error>> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(GITHUB_RELEASES_URL)
+        .header("User-Agent", "reqwest")
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        return Err(UpdateError::FailedVersionFetch.into());
+    }
+
+    let releases: Vec<String> = response.json().await?;
+
+    let cli_version_pattern = Regex::new(r"^cli-(\d+\.\d+\.\d+)$")?;
+    let mut cli_versions = Vec::new();
+
+    for release in releases {
+        if let Some(caps) = cli_version_pattern.captures(&release) {
+            if let Some(ver_match) = caps.get(1) {
+                let ver_str = ver_match.as_str();
+                if let Ok(ver) = Version::parse(ver_str) {
+                    cli_versions.push(ver);
+                }
+            }
+        }
+    }
+
+    if cli_versions.is_empty() {
+        return Err(UpdateError::FailedVersionFetch.into());
+    }
+
+    let latest = cli_versions
+        .into_iter()
+        .max()
+        .unwrap_or(current_version.clone());
+
+    if latest == current_version {
+        println!("{}", "Your Chroma CLI version is up-to-date!".green());
+    } else {
+        println!(
+            "A new version of the Chroma CLI is available! To upgrade to version {} run",
+            latest
+        );
+        if cfg!(target_os = "windows") {
+            println!("{}", WINDOWS_CURL.green());
+        } else {
+            println!("{}", UNIX_CURL.green());
+        }
+    }
+
+    Ok(())
+}
+
+pub fn update() -> Result<(), CliError> {
+    let current_version = Version::parse(env!("CARGO_PKG_VERSION"))
+        .map_err(|_| UpdateError::CurrentVersionUndetected)?;
+    let runtime = tokio::runtime::Runtime::new().map_err(|_| UpdateError::UpdateFailed)?;
+    Ok(runtime
+        .block_on(version_check(current_version))
+        .map_err(|_| UpdateError::FailedVersionFetch)?)
+}

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -5,6 +5,7 @@ mod utils;
 use crate::commands::db::{db_command, DbCommand};
 use crate::commands::profile::{profile_command, ProfileCommand};
 use crate::commands::run::{run, RunArgs};
+use crate::commands::update::update;
 use crate::commands::vacuum::{vacuum, VacuumArgs};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
@@ -20,6 +21,7 @@ enum Command {
     Profile(ProfileCommand),
     Run(RunArgs),
     Support,
+    Update,
     Vacuum(VacuumArgs),
 }
 
@@ -55,6 +57,7 @@ pub fn chroma_cli(args: Vec<String>) {
             let url = "https://discord.gg/MMeYNTmh3x";
             open_browser(url)
         }
+        Command::Update => update(),
         Command::Vacuum(args) => vacuum(args),
     };
 

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -2,6 +2,7 @@ use crate::client::ClientError;
 use crate::commands::db::DbError;
 use crate::commands::profile::ProfileError;
 use crate::commands::run::RunError;
+use crate::commands::update::UpdateError;
 use crate::commands::vacuum::VacuumError;
 use arboard::Clipboard;
 use colored::Colorize;
@@ -44,6 +45,8 @@ pub enum CliError {
     Client(#[from] ClientError),
     #[error("{0}")]
     Db(#[from] DbError),
+    #[error("{0}")]
+    Update(#[from] UpdateError),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Description of changes
Update the update command to agree with new CLI project structure. Python CLI entry point handles updating independently of the Rust CLI.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
