### PR TITLE
[BUG] Pass down ef_search from collection config to hnsw load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,8 +3419,8 @@ dependencies = [
 
 [[package]]
 name = "hnswlib"
-version = "0.8.0"
-source = "git+https://github.com/chroma-core/hnswlib.git#57c14ff2f7159ad34014e29012f06429643aaee8"
+version = "0.8.1"
+source = "git+https://github.com/chroma-core/hnswlib.git#340a6fff21f0ba2db2bc720636eba4d7736b9534"
 dependencies = [
  "cc",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ bytemuck = "1.21.0"
 rayon = "1.10.0"
 validator = { version = "0.19", features = ["derive"] }
 rust-embed = { version = "8.5.0", features = ["include-exclude", "debug-embed"] }
-hnswlib = { version = "0.8.0", git = "https://github.com/chroma-core/hnswlib.git" }
+hnswlib = { version = "0.8.1", git = "https://github.com/chroma-core/hnswlib.git" }
 reqwest = { version = "0.12.9",  features = ["rustls-tls-native-roots", "http2"], default-features = false }
 random-port = "0.1.1"
 ndarray = { version = "0.16.1", features = ["approx"] }

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -222,12 +222,14 @@ impl PersistentIndex<HnswIndexConfig> for HnswIndex {
     fn load(
         path: &str,
         index_config: &IndexConfig,
+        ef_search: usize,
         id: IndexUuid,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let index = hnswlib::HnswIndex::load(hnswlib::HnswIndexLoadConfig {
             distance_function: map_distance_function(index_config.distance_function.clone()),
             dimensionality: index_config.dimensionality,
             persist_path: path.into(),
+            ef_search,
         })
         .map_err(|e| WrappedHnswInitError::Other(e).boxed())?;
 

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -180,6 +180,7 @@ impl HnswIndexProvider {
         cache_key: &CacheKey,
         dimensionality: i32,
         distance_function: DistanceFunction,
+        ef_search: usize,
     ) -> Result<HnswIndexRef, Box<HnswIndexProviderForkError>> {
         // We take a lock here to synchronize concurrent forks of the same index.
         // Otherwise, we could end up with a corrupted index since the filesystem
@@ -222,7 +223,7 @@ impl HnswIndexProvider {
         // another thread has loaded the index and we return it.
         match self.get(&new_id, cache_key).await {
             Some(index) => Ok(index.clone()),
-            None => match HnswIndex::load(storage_path_str, &index_config, new_id) {
+            None => match HnswIndex::load(storage_path_str, &index_config, ef_search, new_id) {
                 Ok(index) => {
                     let index = HnswIndexRef {
                         inner: Arc::new(RwLock::new(index)),
@@ -316,6 +317,7 @@ impl HnswIndexProvider {
         cache_key: &CacheKey,
         dimensionality: i32,
         distance_function: DistanceFunction,
+        ef_search: usize,
     ) -> Result<HnswIndexRef, Box<HnswIndexProviderOpenError>> {
         let index_storage_path = self.temporary_storage_path.join(id.to_string());
 
@@ -351,7 +353,7 @@ impl HnswIndexProvider {
         // another thread has loaded the index and we return it.
         match self.get(id, cache_key).await {
             Some(index) => Ok(index.clone()),
-            None => match HnswIndex::load(index_storage_path_str, &index_config, *id) {
+            None => match HnswIndex::load(index_storage_path_str, &index_config, ef_search, *id) {
                 Ok(index) => {
                     let index = HnswIndexRef {
                         inner: Arc::new(RwLock::new(index)),
@@ -682,6 +684,7 @@ mod tests {
                 &collection_id,
                 dimensionality,
                 distance_function,
+                default_hnsw_params.ef_search,
             )
             .await
             .unwrap();

--- a/rust/index/src/types.rs
+++ b/rust/index/src/types.rs
@@ -64,6 +64,7 @@ pub trait PersistentIndex<C>: Index<C> {
     fn load(
         path: &str,
         index_config: &IndexConfig,
+        ef_search: usize,
         id: IndexUuid,
     ) -> Result<Self, Box<dyn ChromaError>>
     where

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -139,6 +139,7 @@ impl DistributedHNSWSegmentWriter {
                     &segment.collection,
                     dimensionality as i32,
                     hnsw_configuration.space.clone().into(),
+                    hnsw_configuration.ef_search,
                 )
                 .await
             {
@@ -346,6 +347,7 @@ impl DistributedHNSWSegmentReader {
                                 &segment.collection,
                                 dimensionality as i32,
                                 hnsw_configuration.space.clone().into(),
+                                hnsw_configuration.ef_search,
                             )
                             .await
                         {

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -491,6 +491,7 @@ impl<'me> SpannSegmentReader<'me> {
             &segment.collection,
             params.space.clone().into(),
             dimensionality,
+            params.search_ef,
             posting_list_id.as_ref(),
             versions_map_id.as_ref(),
             blockfile_provider,

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -138,6 +138,7 @@ impl LocalHnswSegmentReader {
                         let index = HnswIndex::load(
                             index_folder_str,
                             &index_config,
+                            hnsw_configuration.ef_search,
                             chroma_index::IndexUuid(segment.id.0),
                         )
                         .map_err(|_| LocalHnswSegmentReaderError::HnswIndexLoadError)?;
@@ -538,6 +539,7 @@ impl LocalHnswSegmentWriter {
                         let index = HnswIndex::load(
                             index_folder_str,
                             &index_config,
+                            hnsw_configuration.ef_search,
                             chroma_index::IndexUuid(segment.id.0),
                         )
                         .map_err(|_| LocalHnswSegmentWriterError::HnswIndexLoadError)?;

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -79,6 +79,7 @@ fn add_to_index_and_get_reader<'a>(
         let collection_id = CollectionUuid::new();
         let dimensionality = 128;
         let params = InternalSpannConfiguration::default();
+        let ef_search = params.search_ef;
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),
@@ -137,6 +138,7 @@ fn add_to_index_and_get_reader<'a>(
                 &collection_id,
                 params.space.into(),
                 dimensionality,
+                ef_search,
                 Some(&paths.pl_id),
                 Some(&paths.versions_map_id),
                 &blockfile_provider,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - After https://github.com/chroma-core/hnswlib/pull/31, need to update all callsites of hnsw.load() to pass in ef_search obtained from collection config
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
