### PR TITLE
[CLN] Cleanup Tiltfile resource definitions

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.29
+version: 0.1.30
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -1,4 +1,3 @@
-{{if .Values.rustLogService.configuration}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   config.yaml: |
+{{if .Values.rustLogService.configuration }}
 {{  .Values.rustLogService.configuration | indent 4 }}
 {{ end }}
 


### PR DESCRIPTION
## Description of changes

Make it so that `tilt up` works without any manual fixes (having to create namespace) on a fresh, new cluster.

Clean up the k8s_setup dumping ground. Refactor so that each resource is clearly grouped with its associated objects.

Create new resources for memberlists:
- query-service-memberlist
- compaction-service-memberlist
- test-memberlist

## Test plan

Run `tilt up` on a brand new cluster, make sure all resources come up properly, without any manual fixes. Ensure there are no uncategorized resources.
