### PR TITLE
[ENH]: stop/kill worker threads when dispatcher is stopped

### DIFF
--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -5,12 +5,17 @@ use std::sync::Arc;
 use super::operator::OperatorType;
 use super::{operator::TaskMessage, worker_thread::WorkerThread};
 use crate::execution::config::DispatcherConfig;
-use crate::{Component, ComponentContext, Handler, ReceiverForMessage, System};
+use crate::{
+    Component, ComponentContext, ComponentHandle, ConsumeJoinHandleError, Handler,
+    ReceiverForMessage, System,
+};
 use async_trait::async_trait;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
+use parking_lot::Mutex;
 use std::fmt::Debug;
+use thiserror::Error;
 use tracing::{trace_span, Instrument, Span};
 
 /// The dispatcher is responsible for distributing tasks to worker threads.
@@ -61,6 +66,7 @@ pub struct Dispatcher {
     task_queue: VecDeque<(TaskMessage, Span)>,
     waiters: Vec<TaskRequestMessage>,
     active_io_tasks: Arc<AtomicU64>,
+    worker_handles: Arc<Mutex<Vec<ComponentHandle<WorkerThread>>>>,
 }
 
 impl Dispatcher {
@@ -72,6 +78,7 @@ impl Dispatcher {
             task_queue: VecDeque::new(),
             waiters: Vec::new(),
             active_io_tasks: Arc::new(AtomicU64::new(active_io_tasks as u64)),
+            worker_handles: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -84,9 +91,10 @@ impl Dispatcher {
         system: &mut System,
         self_receiver: Box<dyn ReceiverForMessage<TaskRequestMessage>>,
     ) {
+        let mut worker_handles = self.worker_handles.lock();
         for _ in 0..self.config.num_worker_threads {
             let worker = WorkerThread::new(self_receiver.clone(), self.config.worker_queue_size);
-            system.start_component(worker);
+            worker_handles.push(system.start_component(worker));
         }
     }
 
@@ -201,6 +209,20 @@ impl TaskRequestMessage {
     }
 }
 
+#[derive(Debug, Error)]
+enum DispatcherStopError {
+    #[error("Failed to stop worker thread: {0}")]
+    JoinError(ConsumeJoinHandleError),
+}
+
+impl ChromaError for DispatcherStopError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            DispatcherStopError::JoinError(_) => chroma_error::ErrorCodes::Internal,
+        }
+    }
+}
+
 // ============= Component implementation =============
 
 #[async_trait]
@@ -215,6 +237,23 @@ impl Component for Dispatcher {
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
         self.spawn_workers(&mut ctx.system.clone(), ctx.receiver());
+    }
+
+    async fn on_stop(&mut self) -> Result<(), Box<dyn ChromaError>> {
+        let mut worker_handles = {
+            let mut handles = self.worker_handles.lock();
+            handles.drain(..).collect::<Vec<_>>()
+        };
+
+        for mut handle in worker_handles.drain(..) {
+            handle.stop();
+            handle
+                .join()
+                .await
+                .map_err(|e| DispatcherStopError::JoinError(e).boxed())?;
+        }
+
+        Ok(())
     }
 }
 

--- a/rust/system/src/system.rs
+++ b/rust/system/src/system.rs
@@ -55,7 +55,7 @@ impl System {
                 let join_handle = tokio::spawn(task_future.instrument(child_span));
                 ComponentHandle::new(
                     cancel_token,
-                    Some(ConsumableJoinHandle::new(join_handle)),
+                    Some(ConsumableJoinHandle::from_tokio_task_handle(join_handle)),
                     sender,
                 )
             }
@@ -63,11 +63,14 @@ impl System {
                 tracing::debug!("Spawning on dedicated thread");
                 // Spawn on a dedicated thread
                 let rt = Builder::new_current_thread().enable_all().build().unwrap();
-                let _join_handle = std::thread::spawn(move || {
+                let join_handle = std::thread::spawn(move || {
                     rt.block_on(async move { executor.run(rx).await });
                 });
-                // TODO: Implement Join for dedicated threads
-                ComponentHandle::new(cancel_token, None, sender)
+                ComponentHandle::new(
+                    cancel_token,
+                    Some(ConsumableJoinHandle::from_thread_handle(join_handle)),
+                    sender,
+                )
             }
         }
     }

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -1,11 +1,12 @@
 use super::{scheduler::Scheduler, ChannelError, RequestError, WrappedMessage};
 use async_trait::async_trait;
 use chroma_config::registry::Injectable;
+use chroma_error::ChromaError;
 use core::panic;
 use futures::Stream;
 use parking_lot::Mutex;
 use std::{fmt::Debug, sync::Arc, time::Duration};
-use tokio::task::JoinError;
+use thiserror::Error;
 
 use super::{system::System, ReceiverForMessage};
 
@@ -45,7 +46,9 @@ pub trait Component: Send + Sized + Debug + 'static {
         ComponentRuntime::Inherit
     }
     async fn on_start(&mut self, _ctx: &ComponentContext<Self>) -> () {}
-    async fn on_stop(&mut self) {}
+    async fn on_stop(&mut self) -> Result<(), Box<dyn ChromaError>> {
+        Ok(())
+    }
     fn on_stop_timeout(&self) -> Duration {
         Duration::from_secs(6)
     }
@@ -92,26 +95,58 @@ where
 
 /// A thin wrapper over a join handle that will panic if it is consumed more than once.
 #[derive(Debug, Clone)]
-pub(super) struct ConsumableJoinHandle {
-    handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+pub(super) enum ConsumableJoinHandle {
+    TokioTask(Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>),
+    Thread(Arc<Mutex<Option<std::thread::JoinHandle<()>>>>),
+}
+
+#[derive(Debug, Error)]
+pub enum ConsumeJoinHandleError {
+    #[error("Tokio task failed: {0}")]
+    TokioTaskFailed(#[from] tokio::task::JoinError),
+    #[error("Thread panicked")]
+    ThreadPanicked(Box<dyn std::any::Any + Send + 'static>),
 }
 
 impl ConsumableJoinHandle {
-    pub(super) fn new(handle: tokio::task::JoinHandle<()>) -> Self {
-        ConsumableJoinHandle {
-            handle: Arc::new(Mutex::new(Some(handle))),
-        }
+    pub(super) fn from_tokio_task_handle(handle: tokio::task::JoinHandle<()>) -> Self {
+        ConsumableJoinHandle::TokioTask(Arc::new(Mutex::new(Some(handle))))
     }
 
-    async fn consume(&mut self) -> Result<(), JoinError> {
-        let handle = { self.handle.lock().take() };
-        match handle {
-            Some(handle) => {
-                handle.await?;
-                Ok(())
+    pub(super) fn from_thread_handle(handle: std::thread::JoinHandle<()>) -> Self {
+        ConsumableJoinHandle::Thread(Arc::new(Mutex::new(Some(handle))))
+    }
+
+    async fn consume(&mut self) -> Result<(), ConsumeJoinHandleError> {
+        match self {
+            ConsumableJoinHandle::TokioTask(handle) => {
+                let handle = { handle.lock().take() };
+                match handle {
+                    Some(handle) => {
+                        handle.await?;
+                        Ok(())
+                    }
+                    None => {
+                        panic!("Join handle already consumed");
+                    }
+                }
             }
-            None => {
-                panic!("Join handle already consumed");
+            ConsumableJoinHandle::Thread(handle) => {
+                let handle = { handle.lock().take() };
+                match handle {
+                    Some(handle) => {
+                        tokio::task::spawn_blocking(move || {
+                            handle
+                                .join()
+                                .map_err(ConsumeJoinHandleError::ThreadPanicked)?;
+                            Ok(())
+                        })
+                        .await?
+                    }
+                    None => {
+                        panic!("Join handle already consumed");
+                    }
+                }
             }
         }
     }
@@ -231,7 +266,7 @@ impl<C: Component> ComponentHandle<C> {
     }
 
     /// Consumes the underlying join handle. Panics if it is consumed twice.
-    pub async fn join(&mut self) -> Result<(), JoinError> {
+    pub async fn join(&mut self) -> Result<(), ConsumeJoinHandleError> {
         if let Some(join_handle) = &mut self.join_handle {
             join_handle.consume().await
         } else {
@@ -386,7 +421,7 @@ mod tests {
     #[should_panic(expected = "Join handle already consumed")]
     async fn join_handle_panics_if_consumed_twice() {
         let handle = tokio::spawn(async {});
-        let mut handle = ConsumableJoinHandle::new(handle);
+        let mut handle = ConsumableJoinHandle::from_tokio_task_handle(handle);
         // Should be able to clone the handle
         let mut cloned = handle.clone();
 


### PR DESCRIPTION
## Description of changes

The test `run_gc_test_ext` currently fails on `main` for me when running locally with the error "too many open files". This is because the worker threads that our system creates are never cleaned up.

This PR updates `ConsumableJoinHandle` to wrap thread handles, and updates the dispatcher to stop worker threads when the dispatcher component is stopped.

The test now passes for me locally.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a