### PR TITLE
[CHORE] Revert list collections to return collection object

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -31,7 +31,7 @@ from chromadb.auth import UserIdentity
 from chromadb.config import Component, Settings
 from chromadb.types import Database, Tenant, Collection as CollectionModel
 import chromadb.utils.embedding_functions as ef
-from chromadb.api.models.Collection import Collection, CollectionName
+from chromadb.api.models.Collection import Collection
 
 # Re-export the async version
 from chromadb.api.async_api import (  # noqa: F401
@@ -349,19 +349,19 @@ class ClientAPI(BaseAPI, ABC):
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> Sequence[CollectionName]:
+    ) -> Sequence[Collection]:
         """List all collections.
         Args:
             limit: The maximum number of entries to return. Defaults to None.
             offset: The number of entries to skip before returning. Defaults to None.
 
         Returns:
-            Sequence[CollectionName]: A list of collection names
+            Sequence[Collection]: A list of collections
 
         Examples:
             ```python
             client.list_collections()
-            # ["my_collection"]
+            # [collection(name="my_collection", metadata={})]
             ```
         """
         pass

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -341,19 +341,19 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> Sequence[str]:
+    ) -> Sequence[AsyncCollection]:
         """List all collections.
         Args:
             limit: The maximum number of entries to return. Defaults to None.
             offset: The number of entries to skip before returning. Defaults to None.
 
         Returns:
-            Sequence[str]: A list of collection names.
+            Sequence[AsyncCollection]: A list of collections.
 
         Examples:
             ```python
             await client.list_collections()
-            # ["my_collection"]
+            # [collection(name="my_collection", metadata={})]
             ```
         """
         pass

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -3,7 +3,6 @@ from typing import Optional, Sequence
 from uuid import UUID
 from overrides import override
 
-from chromadb.api.models.Collection import CollectionName
 from chromadb.auth import UserIdentity
 from chromadb.auth.utils import maybe_set_tenant_and_database
 from chromadb.api import AsyncAdminAPI, AsyncClientAPI, AsyncServerAPI
@@ -157,11 +156,11 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     @override
     async def list_collections(
         self, limit: Optional[int] = None, offset: Optional[int] = None
-    ) -> Sequence[CollectionName]:
+    ) -> Sequence[AsyncCollection]:
         models = await self._server.list_collections(
             limit, offset, tenant=self.tenant, database=self.database
         )
-        return [CollectionName(model.name) for model in models]
+        return [AsyncCollection(client=self._server, model=model) for model in models]
 
     @override
     async def count_collections(self) -> int:

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -28,7 +28,7 @@ from chromadb.auth import UserIdentity
 from chromadb.auth.utils import maybe_set_tenant_and_database
 from chromadb.config import Settings, System
 from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE
-from chromadb.api.models.Collection import Collection, CollectionName
+from chromadb.api.models.Collection import Collection
 from chromadb.errors import ChromaError
 from chromadb.types import Database, Tenant, Where, WhereDocument
 import chromadb.utils.embedding_functions as ef
@@ -121,9 +121,9 @@ class Client(SharedSystemClient, ClientAPI):
     @override
     def list_collections(
         self, limit: Optional[int] = None, offset: Optional[int] = None
-    ) -> Sequence[CollectionName]:
+    ) -> Sequence[Collection]:
         return [
-            CollectionName(model.name)
+            Collection(client=self._server, model=model)
             for model in self._server.list_collections(
                 limit, offset, tenant=self.tenant, database=self.database
             )

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,3 @@
-import inspect
 from typing import TYPE_CHECKING, Optional, Union
 
 from chromadb.api.models.CollectionCommon import CollectionCommon
@@ -385,42 +384,3 @@ class Collection(CollectionCommon["ServerAPI"]):
             tenant=self.tenant,
             database=self.database,
         )
-
-
-class CollectionName(str):
-    """
-    A string wrapper to supply users with indicative message about list_collections only
-    returning collection names, in lieu of Collection object.
-
-    When a user will try to access an attribute on a CollectionName string, the __getattribute__ method
-    of str is invoked first. If a valid str method or property is found, it will be used. Otherwise, the fallback
-    __getattr__ defined here is invoked next. It will error if the requested attribute is a Collection
-    method or property.
-
-    For example:
-    collection_name = client.list_collections()[0] # collection_name = "test"
-
-    collection_name.startsWith("t") # Evaluates to True.
-    # __getattribute__ is invoked first, selecting startsWith from str.
-
-    collection_name.add(ids=[...], documents=[...]) # Raises the error defined below
-    # __getattribute__ is invoked first, not finding a match in str.
-    # __getattr__ from this class is invoked and raises an error
-
-    """
-
-    def __getattr__(self, item):  # type: ignore
-        collection_attributes_and_methods = [
-            member
-            for member, _ in inspect.getmembers(Collection)
-            if not member.startswith("_")
-        ]
-
-        if item in collection_attributes_and_methods:
-            raise NotImplementedError(
-                f"In Chroma v0.6.0, list_collections only returns collection names. "
-                f"Use Client.get_collection({str(self)}) to access {item}. "
-                f"See https://docs.trychroma.com/deployment/migration for more information."
-            )
-
-        raise AttributeError(f"'CollectionName' object has no attribute '{item}'")

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -184,7 +184,9 @@ class RustBindingsAPI(ServerAPI):
             CollectionModel(
                 id=collection.id,
                 name=collection.name,
-                configuration=collection.configuration,
+                configuration=load_collection_configuration_from_json(
+                    collection.configuration
+                ),
                 metadata=collection.metadata,
                 dimension=collection.dimension,
                 tenant=collection.tenant,

--- a/chromadb/test/client/test_database_tenant.py
+++ b/chromadb/test/client/test_database_tenant.py
@@ -25,38 +25,33 @@ def test_database_tenant_collections(client_factories: ClientFactories) -> None:
     # List collections in the default database
     collections = client.list_collections()
     assert len(collections) == 1
-    assert collections[0] == "collection"
-    collection = client.get_collection(collections[0])
+    assert collections[0].name == "collection"
+    collection = client.get_collection(collections[0].name)
     assert collection.metadata == {"database": DEFAULT_DATABASE}
 
     # List collections in the new database
     client.set_tenant(tenant=DEFAULT_TENANT, database="test_db")
     collections = client.list_collections()
     assert len(collections) == 1
-    collection = client.get_collection(collections[0])
-    assert collection.metadata == {"database": "test_db"}
+    assert collections[0].metadata == {"database": "test_db"}
 
     # Update the metadata in both databases to different values
     client.set_tenant(tenant=DEFAULT_TENANT, database=DEFAULT_DATABASE)
-    collection = client.get_collection(client.list_collections()[0])
-    collection.modify(metadata={"database": "default2"})
+    client.list_collections()[0].modify(metadata={"database": "default2"})
 
     client.set_tenant(tenant=DEFAULT_TENANT, database="test_db")
-    collection = client.get_collection(client.list_collections()[0])
-    collection.modify(metadata={"database": "test_db2"})
+    client.list_collections()[0].modify(metadata={"database": "test_db2"})
 
     # Validate that the metadata was updated
     client.set_tenant(tenant=DEFAULT_TENANT, database=DEFAULT_DATABASE)
     collections = client.list_collections()
     assert len(collections) == 1
-    collection = client.get_collection(collections[0])
-    assert collection.metadata == {"database": "default2"}
+    assert collections[0].metadata == {"database": "default2"}
 
     client.set_tenant(tenant=DEFAULT_TENANT, database="test_db")
     collections = client.list_collections()
     assert len(collections) == 1
-    collection = client.get_collection(collections[0])
-    assert collection.metadata == {"database": "test_db2"}
+    assert collections[0].metadata == {"database": "test_db2"}
 
     # Delete the collections and make sure databases are isolated
     client.set_tenant(tenant=DEFAULT_TENANT, database=DEFAULT_DATABASE)

--- a/chromadb/test/client/test_multiple_clients_concurrency.py
+++ b/chromadb/test/client/test_multiple_clients_concurrency.py
@@ -44,7 +44,6 @@ def test_multiple_clients_concurrently(client_factories: ClientFactories) -> Non
         client.set_database(database)
         seen_collections = client.list_collections()
         assert len(seen_collections) == COLLECTION_COUNT
-        for collection_name in seen_collections:
-            collection = client.get_collection(collection_name)
+        for collection in seen_collections:
             assert collection.name in collections
             assert collection.metadata == {"database": database}

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -91,8 +91,8 @@ class CollectionStateMachine(RuleBasedStateMachine):
     def list_collections(self) -> None:
         colls = self.client.list_collections()
         assert len(colls) == len(self.model)
-        for collection_name in colls:
-            assert collection_name in self.model
+        for c in colls:
+            assert c.name in self.model
 
     # @rule for list_collections with limit and offset
     @rule(

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -503,8 +503,7 @@ def test_metadata_cru(client):
 
     # Test list collections
     collections = client.list_collections()
-    for collection_name in collections:
-        collection = client.get_collection(collection_name)
+    for collection in collections:
         if collection.name == "testspace":
             assert collection.metadata is not None
             assert collection.metadata["a"] == 2

--- a/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
@@ -259,10 +259,10 @@ class ClientAPI(BaseAPI, ABC)
 
 ```python
 def list_collections(limit: Optional[int] = None,
-                     offset: Optional[int] = None) -> Sequence[CollectionName]
+                     offset: Optional[int] = None) -> Sequence[Collection]
 ```
 
-List all collections names.
+List all collections.
 
 **Arguments**:
 


### PR DESCRIPTION
## Description of changes
due to no ef persistence, https://github.com/chroma-core/chroma/pull/3216/ returned collection names for list_collections. since we now have ef stored in the configuration, users can now list_collections and directly use them, and list collections can return collection objects.

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
