### PR TITLE
[BUG]: Fix foyer lodc buffer splitter bug by bumping version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c58abe110f35cc40c1f48e681129dc8430aef4ba201ba73bf6c87ca3576d0f"
+checksum = "cb3b4e79fe76576b3970ada6437b30bee8cefe28685535290c3188d9b79b981e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2925,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-common"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6eb1586b4448758d7a52548f23a7eedcd07d74cbffaf22283d7834ef87d88ea"
+checksum = "9e71666dc1f66539cc9a21668fa59d11dbf9e1fd7cb9048d3e2293e28080f5d0"
 dependencies = [
  "ahash",
  "bytes",
@@ -2953,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e4e245cea0609b5b703b0f27985d063c0713c4e0a91c5c1dc720f36e37fa32"
+checksum = "5e9332460864db122775ef95b0603562288674daad7a8df0add81adaca7e5e09"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2979,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-storage"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1bde4890e21d1dd8583f620a5d0c15aca2e42db33c184a1f3b8e403bfa29b53"
+checksum = "cfae1b6d15d65c014e72047939fcf937f964582c6561942e736fc5dec1fc8c3c"
 dependencies = [
  "ahash",
  "allocator-api2",

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { workspace = true }
-foyer = { version = "0.15.1", features = ["tracing"] }
+foyer = { version = "0.15.3", features = ["tracing"] }
 mixtrics = { version = "0.0.4", features = ["opentelemetry_0_27"] }
 anyhow = "1.0"
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fix foyer large object disk cache bug by bumping to the latest version.
   - FYI: https://github.com/foyer-rs/foyer/pull/912

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
