### PR TITLE
[BUG] Fix query/compaction sset definitions

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.31
+version: 0.1.32
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -90,10 +90,6 @@ spec:
       nodeSelector:
         {{ toYaml .Values.compactionService.nodeSelector | nindent 8 }}
       {{ end }}
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          partition: 0
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -109,10 +109,6 @@ spec:
       nodeSelector:
         {{ toYaml .Values.queryService.nodeSelector | nindent 8 }}
       {{ end }}
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          partition: 0
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
## Description of changes

This has been broken for a while. The rendered yaml does not apply, failing with error:

```
Error from server (BadRequest): error when creating "chart.yaml": StatefulSet
in version "v1" cannot be handled as a StatefulSet: strict decoding error:
unknown field "spec.template.spec.updateStrategy"
```

The `updateStrategy` fields are specified at the incorrect level, should be specified under the top level spec. Decided to just remove them, because rollingUpdate is the default anyway.

## Test plan

Render yaml from helm chart, apply directly using `kubectl`.