### PR TITLE
[DOC] add logical operation section in fts docs

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
@@ -41,3 +41,26 @@ await collection.query({
 {% /Tab %}
 
 {% /TabbedCodeBlock %}
+
+#### Using logical operators
+
+You can also use the logical operators `$and` and `$or` to combine multiple filters
+
+```python
+{
+    "$and": [
+        {"$contains": "search_string_1"},
+        {"$contains": "search_string_2"},
+    ]
+}
+```
+
+An `$or` operator will return results that match any of the filters in the list
+```python
+{
+    "$or": [
+        {"$contains": "search_string_1"},
+        {"$contains": "search_string_2"},
+    ]
+}
+```

--- a/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
@@ -50,7 +50,7 @@ You can also use the logical operators `$and` and `$or` to combine multiple filt
 {
     "$and": [
         {"$contains": "search_string_1"},
-        {"$contains": "search_string_2"},
+        {"$not_contains": "search_string_2"},
     ]
 }
 ```
@@ -60,7 +60,7 @@ An `$or` operator will return results that match any of the filters in the list
 {
     "$or": [
         {"$contains": "search_string_1"},
-        {"$contains": "search_string_2"},
+        {"$not_contains": "search_string_2"},
     ]
 }
 ```


### PR DESCRIPTION
## Description of changes

This PR adds a section describing full text search's support for logical operators, like $and and $or

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
