### PR TITLE
[ENH] When recovering a wal3 manifest, mark it dirty.

### DIFF
--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -264,7 +264,7 @@ impl OnceLogWriter {
             writer,
         )
         .await?;
-        manifest_manager.recover().await?;
+        manifest_manager.recover(&*mark_dirty).await?;
         let flusher = Mutex::new(None);
         let this = Arc::new(Self {
             options,


### PR DESCRIPTION
There was a write hole where recovery would fail to write the dirty bit.  Plug it.