### PR TITLE
[ENH]: rename GC `ListOnly` mode -> `DryRun`, do not delete versions in `DryRun` mode

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -243,8 +243,8 @@ func (s *Coordinator) ListCollectionsToGc(ctx context.Context, cutoffTimeSecs *u
 	return s.catalog.ListCollectionsToGc(ctx, cutoffTimeSecs, limit)
 }
 
-func (s *Coordinator) ListCollectionVersions(ctx context.Context, collectionID types.UniqueID, tenantID string, maxCount *int64, versionsBefore *int64, versionsAtOrAfter *int64) ([]*coordinatorpb.CollectionVersionInfo, error) {
-	return s.catalog.ListCollectionVersions(ctx, collectionID, tenantID, maxCount, versionsBefore, versionsAtOrAfter)
+func (s *Coordinator) ListCollectionVersions(ctx context.Context, collectionID types.UniqueID, tenantID string, maxCount *int64, versionsBefore *int64, versionsAtOrAfter *int64, includeMarkedForDeletion bool) ([]*coordinatorpb.CollectionVersionInfo, error) {
+	return s.catalog.ListCollectionVersions(ctx, collectionID, tenantID, maxCount, versionsBefore, versionsAtOrAfter, includeMarkedForDeletion)
 }
 
 func (s *Coordinator) MarkVersionForDeletion(ctx context.Context, req *coordinatorpb.MarkVersionForDeletionRequest) (*coordinatorpb.MarkVersionForDeletionResponse, error) {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -985,6 +985,7 @@ func (tc *Catalog) ListCollectionVersions(ctx context.Context,
 	maxCount *int64,
 	versionsBefore *int64,
 	versionsAtOrAfter *int64,
+	includeMarkedForDeletion bool,
 ) ([]*coordinatorpb.CollectionVersionInfo, error) {
 	// Get collection entry to get version file name
 	collectionEntry, err := tc.metaDomain.CollectionDb(ctx).GetCollectionEntry(types.FromUniqueID(collectionID), nil)
@@ -1019,7 +1020,7 @@ func (tc *Catalog) ListCollectionVersions(ctx context.Context,
 
 	for _, version := range versions {
 		// Skip versions marked for deletion
-		if version.MarkedForDeletion {
+		if version.MarkedForDeletion && !includeMarkedForDeletion {
 			continue
 		}
 

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -365,7 +365,12 @@ func (s *Server) ListCollectionVersions(ctx context.Context, req *coordinatorpb.
 		return nil, grpcutils.BuildInternalGrpcError(err.Error())
 	}
 
-	versions, err := s.coordinator.ListCollectionVersions(ctx, collectionID, req.TenantId, req.MaxCount, req.VersionsBefore, req.VersionsAtOrAfter)
+	markedForDeletion := false
+	if req.IncludeMarkedForDeletion != nil {
+		markedForDeletion = *req.IncludeMarkedForDeletion
+	}
+
+	versions, err := s.coordinator.ListCollectionVersions(ctx, collectionID, req.TenantId, req.MaxCount, req.VersionsBefore, req.VersionsAtOrAfter, markedForDeletion)
 	if err != nil {
 		return nil, grpcutils.BuildInternalGrpcError(err.Error())
 	}

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -370,6 +370,7 @@ message ListCollectionVersionsRequest {
   // Only return versions at or after this timestamp.
   // Together with versions_before, this forms an inclusive range.
   optional int64 versions_at_or_after = 5;
+  optional bool include_marked_for_deletion = 6;
 }
 
 // Response to ListCollectionVersionsRequest.

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -217,7 +217,7 @@ impl Configurable<GarbageCollectorConfig> for GarbageCollector {
             disabled_collections,
             sysdb_client,
             storage,
-            CleanupMode::ListOnly,
+            CleanupMode::DryRun,
         ))
     }
 }

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -23,7 +23,7 @@ impl ChromaGrpcClients {
         let sysdb_channel = Channel::from_static("http://localhost:50051")
             .connect()
             .await?;
-        let logservice_channel = Channel::from_static("http://localhost:50054")
+        let logservice_channel = Channel::from_static("http://localhost:50052")
             .connect()
             .await?;
         let queryservice_channel = Channel::from_static("http://localhost:50053")
@@ -355,6 +355,7 @@ impl ChromaGrpcClients {
         max_count: Option<i64>,
         versions_before: Option<i64>,
         versions_at_or_after: Option<i64>,
+        include_marked_for_deletion: Option<bool>,
     ) -> Result<ListCollectionVersionsResponse, Box<dyn std::error::Error>> {
         let request = ListCollectionVersionsRequest {
             collection_id,
@@ -362,6 +363,7 @@ impl ChromaGrpcClients {
             max_count,
             versions_before,
             versions_at_or_after,
+            include_marked_for_deletion,
         };
 
         let response = self.sysdb.list_collection_versions(request).await?;

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -229,7 +229,7 @@ impl Operator<DeleteUnusedFilesInput, DeleteUnusedFilesOutput> for DeleteUnusedF
         // did not finish successfully (i.e. crashed before committing the work to SysDb).
         let mut file_operation_errors = Vec::new();
         match self.cleanup_mode {
-            CleanupMode::ListOnly => {
+            CleanupMode::DryRun => {
                 // Do nothing here. List is written to S3 for all modes later in this function.
             }
             CleanupMode::Rename => {
@@ -337,7 +337,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_only_mode() {
+    async fn test_dry_run_mode() {
         let tmp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let (test_files, hnsw_files) = setup_test_files(&storage).await;
@@ -347,7 +347,7 @@ mod tests {
 
         let operator = DeleteUnusedFilesOperator::new(
             storage.clone(),
-            CleanupMode::ListOnly,
+            CleanupMode::DryRun,
             "test_collection".to_string(),
         );
         let input = DeleteUnusedFilesInput {
@@ -554,10 +554,10 @@ mod tests {
         assert!(content.contains("Failed files:"));
         assert!(content.contains("nonexistent.txt"));
 
-        // Test ListOnly mode with nonexistent files (should succeed)
+        // Test DryRun mode with nonexistent files (should succeed)
         let list_operator = DeleteUnusedFilesOperator::new(
             storage,
-            CleanupMode::ListOnly,
+            CleanupMode::DryRun,
             "test_collection".to_string(),
         );
         let result = list_operator

--- a/rust/garbage_collector/src/types.rs
+++ b/rust/garbage_collector/src/types.rs
@@ -6,7 +6,7 @@ pub(crate) const DELETE_LIST_FILE_PREFIX: &str = "gc/delete-list/";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CleanupMode {
     /// Only list files that would be affected without making changes
-    ListOnly,
+    DryRun,
     /// Move files to a deletion directory instead of removing them
     Rename,
     /// Permanently delete files

--- a/rust/garbage_collector/tests/prop_test_local_files.rs
+++ b/rust/garbage_collector/tests/prop_test_local_files.rs
@@ -761,7 +761,7 @@ impl GcTest {
             sysdb,
             dispatcher_handle.clone(),
             storage,
-            CleanupMode::ListOnly,
+            CleanupMode::Delete,
         );
 
         self.last_cleanup_files = Vec::new();


### PR DESCRIPTION
## Description of changes

- Renames garbage collection `ListOnly` mode to `DryRun` for better clarity.
- Does not delete versions in `DryRun` mode, only marks them for deletion.

These changes make it possible to transition from running `DryRun` mode to running `Rename` or `Delete` modes with no additional tooling.

## Test plan
*How are these changes tested?*

Added a new E2E test for dry run mode.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a