### PR TITLE
[ENH] Implement SourceRecordSegment operator

### DIFF
--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -827,6 +827,15 @@ impl RecordSegmentReader<'_> {
             .map(|vec| vec.into_iter().map(|(_, data)| data).collect())
     }
 
+    pub async fn get_data_stream<'me>(
+        &'me self,
+        offset_range: impl RangeBounds<u32> + Clone + Send + 'me,
+    ) -> impl Stream<Item = Result<DataRecord<'me>, Box<dyn ChromaError>>> + 'me {
+        self.id_to_data
+            .get_range_stream(""..="", offset_range)
+            .map(|res| res.map(|(_, rec)| rec))
+    }
+
     /// Get a stream of offset ids from the smallest to the largest in the given range
     pub fn get_offset_stream<'me>(
         &'me self,

--- a/rust/worker/src/execution/operators/mod.rs
+++ b/rust/worker/src/execution/operators/mod.rs
@@ -22,3 +22,4 @@ pub mod partition_log;
 pub mod prefetch_record;
 pub mod prefetch_segment;
 pub mod projection;
+pub mod source_record_segment;

--- a/rust/worker/src/execution/operators/source_record_segment.rs
+++ b/rust/worker/src/execution/operators/source_record_segment.rs
@@ -1,0 +1,118 @@
+use async_trait::async_trait;
+use chroma_blockstore::provider::BlockfileProvider;
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_segment::{
+    blockfile_record::{RecordSegmentReader, RecordSegmentReaderCreationError},
+    types::{materialize_logs, LogMaterializerError, MaterializeLogsResult},
+};
+use chroma_system::Operator;
+use chroma_types::{Chunk, LogRecord, OperationRecord, Segment};
+use futures::{StreamExt, TryStreamExt};
+use thiserror::Error;
+
+/// The `SourceRecordSegmentOperator` generates materialized logs from the data in the record segment
+///
+/// # Parameters
+/// None
+///
+/// # Inputs
+/// - `blockfile_provider`: The blockfile_provider
+/// - `record_segment`: The record segment information
+///
+/// # Outputs
+/// - `materialized_logs`: The materialized log generated from record segement data
+/// - `collection_logical_size`: The logical size of the collection
+#[derive(Clone, Debug)]
+pub struct SourceRecordSegmentOperator {}
+
+#[derive(Clone, Debug)]
+pub struct SourceRecordSegmentInput {
+    pub blockfile_provider: BlockfileProvider,
+    pub record_segment: Segment,
+}
+
+#[derive(Clone, Debug)]
+pub struct SourceRecordSegmentOutput {
+    pub materialized_logs: MaterializeLogsResult,
+    pub collection_record_count: u64,
+    pub collection_logical_size_bytes: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum SourceRecordSegmentError {
+    #[error("Error materializing log: {0}")]
+    LogMaterialization(#[from] LogMaterializerError),
+    #[error("Error creating record segment reader: {0}")]
+    RecordReader(#[from] RecordSegmentReaderCreationError),
+    #[error("Error reading record segment: {0}")]
+    RecordSegment(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for SourceRecordSegmentError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            SourceRecordSegmentError::LogMaterialization(e) => e.code(),
+            SourceRecordSegmentError::RecordReader(e) => e.code(),
+            SourceRecordSegmentError::RecordSegment(e) => e.code(),
+        }
+    }
+}
+
+#[async_trait]
+impl Operator<SourceRecordSegmentInput, SourceRecordSegmentOutput> for SourceRecordSegmentOperator {
+    type Error = SourceRecordSegmentError;
+    async fn run(
+        &self,
+        input: &SourceRecordSegmentInput,
+    ) -> Result<SourceRecordSegmentOutput, SourceRecordSegmentError> {
+        tracing::trace!("[{}]: {:?}", self.get_name(), input);
+        let raw_logs = match RecordSegmentReader::from_segment(
+            &input.record_segment,
+            &input.blockfile_provider,
+        )
+        .await
+        {
+            Ok(reader) => {
+                reader
+                    .get_data_stream(..)
+                    .await
+                    .enumerate()
+                    .map(|(offset, res)| {
+                        res.map(|rec| LogRecord {
+                            // Log offset starts with 1
+                            log_offset: offset as i64 + 1,
+                            record: OperationRecord {
+                                id: rec.id.to_string(),
+                                embedding: Some(rec.embedding.to_vec()),
+                                encoding: Some(chroma_types::ScalarEncoding::FLOAT32),
+                                metadata: rec.metadata.map(|meta| {
+                                    meta.into_iter().map(|(k, v)| (k, v.into())).collect()
+                                }),
+                                document: rec.document.map(ToString::to_string),
+                                operation: chroma_types::Operation::Add,
+                            },
+                        })
+                    })
+                    .try_collect::<Vec<_>>()
+                    .await?
+            }
+            Err(e) => return Err((*e).into()),
+        };
+        let collection_record_count = u64::try_from(raw_logs.len()).unwrap_or_default();
+        let materialized_logs = materialize_logs(&None, Chunk::new(raw_logs.into()), None).await?;
+        let mut collection_logical_size_bytes = 0;
+        for record in &materialized_logs {
+            // This should always be positive because the operation is always add
+            collection_logical_size_bytes += record
+                .hydrate(None)
+                .await?
+                .compute_logical_size_delta_bytes();
+        }
+        Ok(SourceRecordSegmentOutput {
+            materialized_logs,
+            collection_record_count,
+            collection_logical_size_bytes: u64::try_from(collection_logical_size_bytes)
+                .unwrap_or_default(),
+        })
+    }
+}

--- a/rust/worker/src/execution/operators/source_record_segment.rs
+++ b/rust/worker/src/execution/operators/source_record_segment.rs
@@ -1,49 +1,33 @@
 use async_trait::async_trait;
-use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_segment::{
-    blockfile_record::{RecordSegmentReader, RecordSegmentReaderCreationError},
-    types::{materialize_logs, LogMaterializerError, MaterializeLogsResult},
-};
+use chroma_segment::blockfile_record::RecordSegmentReader;
 use chroma_system::Operator;
-use chroma_types::{Chunk, LogRecord, OperationRecord, Segment};
+use chroma_types::{Chunk, LogRecord, OperationRecord};
 use futures::{StreamExt, TryStreamExt};
 use thiserror::Error;
 
-/// The `SourceRecordSegmentOperator` generates materialized logs from the data in the record segment
+/// The `SourceRecordSegmentOperator` generates logs from the data in the record segment
 ///
 /// # Parameters
 /// None
 ///
 /// # Inputs
-/// - `blockfile_provider`: The blockfile_provider
-/// - `record_segment`: The record segment information
+/// - `record_reader`: The record segment reader, if the collection is initialized
 ///
 /// # Outputs
-/// - `materialized_logs`: The materialized log generated from record segement data
-/// - `collection_logical_size`: The logical size of the collection
+/// - Chunk of addition logs
 #[derive(Clone, Debug)]
 pub struct SourceRecordSegmentOperator {}
 
 #[derive(Clone, Debug)]
 pub struct SourceRecordSegmentInput {
-    pub blockfile_provider: BlockfileProvider,
-    pub record_segment: Segment,
+    pub record_segment_reader: Option<RecordSegmentReader<'static>>,
 }
 
-#[derive(Clone, Debug)]
-pub struct SourceRecordSegmentOutput {
-    pub materialized_logs: MaterializeLogsResult,
-    pub collection_record_count: u64,
-    pub collection_logical_size_bytes: u64,
-}
+pub type SourceRecordSegmentOutput = Chunk<LogRecord>;
 
 #[derive(Debug, Error)]
 pub enum SourceRecordSegmentError {
-    #[error("Error materializing log: {0}")]
-    LogMaterialization(#[from] LogMaterializerError),
-    #[error("Error creating record segment reader: {0}")]
-    RecordReader(#[from] RecordSegmentReaderCreationError),
     #[error("Error reading record segment: {0}")]
     RecordSegment(#[from] Box<dyn ChromaError>),
 }
@@ -51,8 +35,6 @@ pub enum SourceRecordSegmentError {
 impl ChromaError for SourceRecordSegmentError {
     fn code(&self) -> ErrorCodes {
         match self {
-            SourceRecordSegmentError::LogMaterialization(e) => e.code(),
-            SourceRecordSegmentError::RecordReader(e) => e.code(),
             SourceRecordSegmentError::RecordSegment(e) => e.code(),
         }
     }
@@ -66,13 +48,8 @@ impl Operator<SourceRecordSegmentInput, SourceRecordSegmentOutput> for SourceRec
         input: &SourceRecordSegmentInput,
     ) -> Result<SourceRecordSegmentOutput, SourceRecordSegmentError> {
         tracing::trace!("[{}]: {:?}", self.get_name(), input);
-        let raw_logs = match RecordSegmentReader::from_segment(
-            &input.record_segment,
-            &input.blockfile_provider,
-        )
-        .await
-        {
-            Ok(reader) => {
+        let logs = match input.record_segment_reader.as_ref() {
+            Some(reader) => {
                 reader
                     .get_data_stream(..)
                     .await
@@ -96,23 +73,8 @@ impl Operator<SourceRecordSegmentInput, SourceRecordSegmentOutput> for SourceRec
                     .try_collect::<Vec<_>>()
                     .await?
             }
-            Err(e) => return Err((*e).into()),
+            None => Default::default(),
         };
-        let collection_record_count = u64::try_from(raw_logs.len()).unwrap_or_default();
-        let materialized_logs = materialize_logs(&None, Chunk::new(raw_logs.into()), None).await?;
-        let mut collection_logical_size_bytes = 0;
-        for record in &materialized_logs {
-            // This should always be positive because the operation is always add
-            collection_logical_size_bytes += record
-                .hydrate(None)
-                .await?
-                .compute_logical_size_delta_bytes();
-        }
-        Ok(SourceRecordSegmentOutput {
-            materialized_logs,
-            collection_record_count,
-            collection_logical_size_bytes: u64::try_from(collection_logical_size_bytes)
-                .unwrap_or_default(),
-        })
+        Ok(Chunk::new(logs.into()))
     }
 }

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,9 +1,9 @@
-mod compact;
 mod count;
 pub mod spann_knn;
 pub(crate) use compact::*;
 pub(crate) use count::*;
 
+mod compact;
 pub mod get;
 pub mod knn;
 pub mod knn_filter;


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Update the compact orchestrator to use record segment instead of log service during rebuild
 - New functionality
   - Implement a `SourceRecordSegmentOperator` that generate materialized logs based on data from record segment
   

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
