### PR TITLE
[BUG] Fix import openai error caused by bundling Node-native modules in noExternal

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chromadb-root",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",

--- a/clients/js/packages/chromadb-client/package.json
+++ b/clients/js/packages/chromadb-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A JavaScript interface for chroma with embedding functions as peer dependencies",
   "license": "Apache-2.0",
   "type": "module",

--- a/clients/js/packages/chromadb-core/package.json
+++ b/clients/js/packages/chromadb-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/chromadb-core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "description": "Core functionality for ChromaDB JavaScript client",
   "license": "Apache-2.0",

--- a/clients/js/packages/chromadb/package.json
+++ b/clients/js/packages/chromadb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "2.1.0",
+  "version": "2.2.3",
   "description": "A JavaScript interface for chroma with embedding functions as bundled dependencies",
   "license": "Apache-2.0",
   "type": "module",

--- a/clients/js/packages/chromadb/package.json
+++ b/clients/js/packages/chromadb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "2.2.3",
+  "version": "2.2.0",
   "description": "A JavaScript interface for chroma with embedding functions as bundled dependencies",
   "license": "Apache-2.0",
   "type": "module",

--- a/clients/js/packages/chromadb/tsup.config.ts
+++ b/clients/js/packages/chromadb/tsup.config.ts
@@ -12,15 +12,7 @@ export default defineConfig((options: Options) => {
     // Include core package and all embedding packages in the bundle for the thick client
     noExternal: [
       '@internal/chromadb-core',
-      '@google/generative-ai',
-      '@xenova/transformers',
       'chromadb-default-embed',
-      'cohere-ai',
-      'openai',
-      'voyageai',
-      'ollama',
-      'isomorphic-fetch',
-      'cliui'
     ],
     ...options,
   };


### PR DESCRIPTION
Closes #3762 

Bundling the OpenAI library via noExternal resulted in dynamic require errors due to Node-native dependencies like 'http' and 'util'. Marked 'openai' explicitly as external to prevent these issues.

## Description of changes

* Removes embedding functions that use http from noExternal. They'll just be installed separately as a dependency from package.json instead of being bundled
* Bumps js client to v2.2.0

## Test plan

- Released a test package `@philipithomas/chromadb v2.3.3` to test changes.
