### PR TITLE
[ENH]: allow overriding default garbage collection mode per tenant & clean up cutoff time parameters

### DIFF
--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -23,6 +23,7 @@ type Collection struct {
 
 type CollectionToGc struct {
 	ID              types.UniqueID
+	TenantID        string
 	Name            string
 	VersionFilePath string
 	LatestVersion   int64

--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -46,6 +46,7 @@ func convertCollectionToGcToModel(collectionToGc []*dbmodel.CollectionToGc) []*m
 			Name:            collectionInfo.Name,
 			VersionFilePath: collectionInfo.VersionFileName,
 			LatestVersion:   int64(collectionInfo.Version),
+			TenantID:        collectionInfo.TenantID,
 		}
 		collections = append(collections, &collection)
 	}

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -446,6 +446,7 @@ func (s *Server) ListCollectionsToGc(ctx context.Context, req *coordinatorpb.Lis
 			Id:              collectionToGc.ID.String(),
 			Name:            collectionToGc.Name,
 			VersionFilePath: collectionToGc.VersionFilePath,
+			TenantId:        collectionToGc.TenantID,
 		})
 	}
 	return res, nil

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -60,7 +60,8 @@ func (s *collectionDb) ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64
 	var collections []*dbmodel.CollectionToGc
 	// Use the read replica for this so as to not overwhelm the writer.
 	query := s.read_db.Table("collections").
-		Select("id, name, version, version_file_name, oldest_version_ts, num_versions").
+		Select("collections.id, collections.name, collections.version, collections.version_file_name, collections.oldest_version_ts, collections.num_versions, databases.tenant_id").
+		Joins("INNER JOIN databases ON collections.database_id = databases.id").
 		Where("version > 0")
 
 	// Apply cutoff time filter only if provided

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -29,6 +29,7 @@ type Collection struct {
 
 type CollectionToGc struct {
 	ID              string    `gorm:"id;primaryKey"`
+	TenantID        string    `gorm:"tenant_id;not null;index:idx_tenant_id"`
 	Name            string    `gorm:"name;not null;index:idx_name,unique;"`
 	Version         int32     `gorm:"version;default:0"`
 	VersionFileName string    `gorm:"version_file_name"`

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -427,6 +427,7 @@ message CollectionToGcInfo {
   string name = 2;
   string version_file_path = 3;
   int64 latest_version = 4;
+  string tenant_id = 5;
 }
 
 message ListCollectionsToGcResponse {

--- a/rust/garbage_collector/garbage_collector_config.yaml
+++ b/rust/garbage_collector/garbage_collector_config.yaml
@@ -1,6 +1,6 @@
 service_name: "garbage-collector"
 otel_endpoint: "http://otel-collector:4317"
-cutoff_time_hours: 12 # GC all versions created at time < now() - cutoff_time_hours
+relative_cutoff_time_seconds: 43200 # GC all versions created at time < now() - relative_cutoff_time_seconds (12 hours)
 max_collections_to_gc: 1000 # Maximum number of collections to GC in one run
 gc_interval_mins: 120 # Run GC every x mins
 disallow_collections: [] # collection ids to disable GC on

--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -1,22 +1,40 @@
+use std::{collections::HashMap, time::Duration};
+
 use chroma_storage::config::StorageConfig;
 use chroma_system::DispatcherConfig;
 use figment::providers::{Env, Format, Yaml};
 
+use crate::types::CleanupMode;
+
 const DEFAULT_CONFIG_PATH: &str = "./garbage_collector_config.yaml";
 
-#[allow(dead_code)]
+fn deserialize_duration_from_seconds<'de, D>(d: D) -> Result<Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let secs: u64 = serde::Deserialize::deserialize(d)?;
+    Ok(Duration::from_secs(secs))
+}
+
 #[derive(Debug, serde::Deserialize)]
-// TODO(Sanket):  Remove this dead code annotation.
 pub(super) struct GarbageCollectorConfig {
     pub(super) service_name: String,
     pub(super) otel_endpoint: String,
-    pub(super) cutoff_time_hours: u32,
+    #[serde(
+        rename = "relative_cutoff_time_seconds",
+        deserialize_with = "deserialize_duration_from_seconds"
+    )]
+    pub(super) relative_cutoff_time: Duration,
     pub(super) max_collections_to_gc: u32,
     pub(super) gc_interval_mins: u32,
     pub(super) disallow_collections: Vec<String>,
     pub(super) sysdb_config: chroma_sysdb::GrpcSysDbConfig,
     pub(super) dispatcher_config: DispatcherConfig,
     pub(super) storage_config: StorageConfig,
+    #[serde(default)]
+    pub(super) default_mode: CleanupMode,
+    #[serde(default)]
+    pub(super) tenant_mode_overrides: Option<HashMap<String, CleanupMode>>,
 }
 
 impl GarbageCollectorConfig {
@@ -52,7 +70,10 @@ mod tests {
         let config = GarbageCollectorConfig::load();
         assert_eq!(config.service_name, "garbage-collector");
         assert_eq!(config.otel_endpoint, "http://otel-collector:4317");
-        assert_eq!(config.cutoff_time_hours, 12);
+        assert_eq!(
+            config.relative_cutoff_time,
+            Duration::from_secs(12 * 60 * 60)
+        ); // 12 hours
         assert_eq!(config.max_collections_to_gc, 1000);
         assert_eq!(config.gc_interval_mins, 120);
         let empty_vec: Vec<String> = vec![];

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashSet, fmt::Debug, fmt::Formatter, str::FromStr, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::{Debug, Formatter},
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
 
 use crate::types::CleanupMode;
 use async_trait::async_trait;
@@ -10,6 +15,7 @@ use chroma_system::{
     Component, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
 };
 use chroma_types::CollectionUuid;
+use chrono::{DateTime, Utc};
 use futures::{stream::FuturesUnordered, StreamExt};
 use tracing::{span, Instrument, Span};
 use uuid::Uuid;
@@ -21,15 +27,15 @@ use crate::{
 #[allow(dead_code)]
 pub(crate) struct GarbageCollector {
     gc_interval_mins: u64,
-    cutoff_time_secs: u64,
-    cutoff_time_hours: u32,
+    absolute_cutoff_time: DateTime<Utc>,
     max_collections_to_gc: u32,
     disabled_collections: HashSet<CollectionUuid>,
     sysdb_client: SysDb,
     storage: Storage,
     dispatcher: Option<ComponentHandle<Dispatcher>>,
     system: Option<chroma_system::System>,
-    cleanup_mode: CleanupMode,
+    default_cleanup_mode: CleanupMode,
+    tenant_mode_overrides: Option<HashMap<String, CleanupMode>>,
 }
 
 impl Debug for GarbageCollector {
@@ -42,25 +48,25 @@ impl Debug for GarbageCollector {
 impl GarbageCollector {
     pub fn new(
         gc_interval_mins: u64,
-        cutoff_time_secs: u64,
-        cutoff_time_hours: u32,
+        absolute_cutoff_time: DateTime<Utc>,
         max_collections_to_gc: u32,
         disabled_collections: HashSet<CollectionUuid>,
         sysdb_client: SysDb,
         storage: Storage,
-        cleanup_mode: CleanupMode,
+        default_cleanup_mode: CleanupMode,
+        tenant_mode_overrides: Option<HashMap<String, CleanupMode>>,
     ) -> Self {
         Self {
             gc_interval_mins,
-            cutoff_time_secs,
-            cutoff_time_hours,
+            absolute_cutoff_time,
             max_collections_to_gc,
             disabled_collections,
             sysdb_client,
             storage,
             dispatcher: None,
             system: None,
-            cleanup_mode,
+            default_cleanup_mode,
+            tenant_mode_overrides,
         }
     }
 
@@ -103,7 +109,7 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
     async fn handle(
         &mut self,
         _message: GarbageCollectMessage,
-        _ctx: &ComponentContext<Self>,
+        ctx: &ComponentContext<Self>,
     ) -> Self::Result {
         // Get all collections to gc and create gc orchestrator for each.
         tracing::info!("Getting collections to gc");
@@ -122,6 +128,23 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
                 );
                 continue;
             }
+
+            tracing::info!(
+                "Processing collection: {} (tenant: {}, version_file_path: {})",
+                collection.id,
+                collection.tenant,
+                collection.version_file_path
+            );
+
+            let cleanup_mode = if let Some(tenant_mode_overrides) = &self.tenant_mode_overrides {
+                tenant_mode_overrides
+                    .get(&collection.tenant)
+                    .cloned()
+                    .unwrap_or(self.default_cleanup_mode)
+            } else {
+                self.default_cleanup_mode
+            };
+
             tracing::info!("Creating gc orchestrator for collection: {}", collection.id);
             let dispatcher = match self.dispatcher {
                 Some(ref dispatcher) => dispatcher.clone(),
@@ -130,20 +153,18 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
                     panic!("No dispatcher found");
                 }
             };
-            let instrumented_span =
-                span!(parent: None, tracing::Level::INFO, "GC job", collection_id = ?collection.id);
+            let instrumented_span = span!(parent: None, tracing::Level::INFO, "Garbage collection job", collection_id = ?collection.id, tenant_id = %collection.tenant, cleanup_mode = ?cleanup_mode);
             instrumented_span.follows_from(Span::current());
             match self.system {
                 Some(ref system) => {
                     let orchestrator = GarbageCollectorOrchestrator::new(
                         collection.id,
                         collection.version_file_path,
-                        self.cutoff_time_secs,
-                        self.cutoff_time_hours,
+                        self.absolute_cutoff_time,
                         self.sysdb_client.clone(),
                         dispatcher,
                         self.storage.clone(),
-                        self.cleanup_mode,
+                        cleanup_mode,
                     );
 
                     jobs.push(
@@ -176,7 +197,15 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
             "Completed {} jobs, failed {} jobs",
             num_completed_jobs,
             num_failed_jobs
-        )
+        );
+
+        // Schedule next run
+        ctx.scheduler.schedule(
+            GarbageCollectMessage {},
+            Duration::from_secs(self.gc_interval_mins * 60),
+            ctx,
+            || Some(span!(parent: None, tracing::Level::INFO, "Scheduled garbage collection")),
+        );
     }
 }
 
@@ -203,21 +232,318 @@ impl Configurable<GarbageCollectorConfig> for GarbageCollector {
             disabled_collections.insert(collection_id);
         }
 
-        let cutoff_time_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            - (config.cutoff_time_hours as u64 * 3600);
+        let absolute_cutoff_time = SystemTime::now() - config.relative_cutoff_time;
 
         Ok(GarbageCollector::new(
             config.gc_interval_mins as u64,
-            cutoff_time_secs,
-            config.cutoff_time_hours,
+            absolute_cutoff_time.into(),
             config.max_collections_to_gc,
             disabled_collections,
             sysdb_client,
             storage,
-            CleanupMode::DryRun,
+            config.default_mode,
+            config.tenant_mode_overrides.clone(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helper::ChromaGrpcClients;
+    use chroma_storage::config::{
+        ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
+    };
+    use chroma_sysdb::GrpcSysDbConfig;
+    use chroma_system::{DispatcherConfig, System};
+
+    async fn wait_for_new_version(
+        clients: &mut ChromaGrpcClients,
+        collection_id: String,
+        tenant_id: String,
+        current_version_count: usize,
+        max_attempts: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for attempt in 1..=max_attempts {
+            tracing::info!(
+                attempt,
+                max_attempts,
+                "Waiting for new version to be created..."
+            );
+
+            tokio::time::sleep(Duration::from_secs(2)).await;
+
+            let versions = clients
+                .list_collection_versions(
+                    collection_id.clone(),
+                    tenant_id.clone(),
+                    Some(100),
+                    None,
+                    None,
+                    None,
+                )
+                .await?;
+
+            if versions.versions.len() > current_version_count {
+                tracing::info!(
+                    previous_count = current_version_count,
+                    new_count = versions.versions.len(),
+                    "New version detected"
+                );
+                return Ok(());
+            }
+        }
+
+        Err("Timeout waiting for new version to be created".into())
+    }
+
+    const TEST_COLLECTIONS_SIZE: usize = 33;
+
+    async fn create_test_collection(
+        tenant_id: String,
+        clients: &mut ChromaGrpcClients,
+    ) -> (CollectionUuid, String) {
+        let test_uuid = uuid::Uuid::new_v4();
+        let database_name = format!("test_db_{}", test_uuid);
+        let collection_name = format!("test_collection_{}", test_uuid);
+
+        let collection_id = clients
+            .create_database_and_collection(&tenant_id, &database_name, &collection_name)
+            .await
+            .unwrap();
+
+        tracing::info!(collection_id = %collection_id, "Created collection");
+
+        let mut embeddings = vec![];
+        let mut ids = vec![];
+
+        for i in 0..TEST_COLLECTIONS_SIZE {
+            let mut embedding = vec![0.0; 3];
+            embedding[i % 3] = 1.0;
+            embeddings.push(embedding);
+            ids.push(format!("id{}", i));
+        }
+
+        // Get initial version count
+        let initial_versions = clients
+            .list_collection_versions(
+                collection_id.clone(),
+                tenant_id.clone(),
+                Some(100),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let initial_version_count = initial_versions.versions.len();
+
+        tracing::info!(
+            initial_count = initial_version_count,
+            "Initial version count"
+        );
+
+        // Add first batch of 11 records
+        tracing::info!("Adding first batch of embeddings");
+        clients
+            .add_embeddings(
+                &collection_id,
+                embeddings[..11].to_vec(),
+                ids[..11].to_vec(),
+            )
+            .await
+            .unwrap();
+
+        // Wait for new version after first batch
+        wait_for_new_version(
+            clients,
+            collection_id.clone(),
+            tenant_id.clone(),
+            initial_version_count,
+            10,
+        )
+        .await
+        .unwrap();
+
+        // Add second batch of 11 records
+        tracing::info!("Adding second batch of embeddings");
+        clients
+            .add_embeddings(
+                &collection_id,
+                embeddings[11..22].to_vec(),
+                ids[11..22].to_vec(),
+            )
+            .await
+            .unwrap();
+        // Wait for new version after first batch
+        wait_for_new_version(
+            clients,
+            collection_id.clone(),
+            tenant_id.clone(),
+            initial_version_count + 1,
+            10,
+        )
+        .await
+        .unwrap();
+
+        // After adding second batch and waiting for version, add a third batch
+        tracing::info!("Adding third batch of embeddings (modified records)");
+        clients
+            .add_embeddings(
+                &collection_id,
+                embeddings[22..].to_vec(),
+                ids[22..].to_vec(),
+            )
+            .await
+            .unwrap();
+
+        wait_for_new_version(
+            clients,
+            collection_id.clone(),
+            tenant_id.clone(),
+            initial_version_count + 2,
+            10,
+        )
+        .await
+        .unwrap();
+
+        let collection_id = CollectionUuid::from_str(&collection_id).unwrap();
+
+        (collection_id, tenant_id)
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_tenant_mode_override() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        // Setup
+        let tenant_id_for_delete_mode = format!("tenant-delete-mode-{}", Uuid::new_v4());
+        let tenant_id_for_dry_run_mode = format!("tenant-dry-run-mode-{}", Uuid::new_v4());
+
+        let mut tenant_mode_overrides = HashMap::new();
+        tenant_mode_overrides.insert(tenant_id_for_delete_mode.clone(), CleanupMode::Delete);
+
+        let config = GarbageCollectorConfig {
+            service_name: "gc".to_string(),
+            otel_endpoint: "none".to_string(),
+            relative_cutoff_time: Duration::from_secs(1),
+            max_collections_to_gc: 100,
+            gc_interval_mins: 10,
+            disallow_collections: vec![],
+            sysdb_config: GrpcSysDbConfig {
+                host: "localhost".to_string(),
+                port: 50051,
+                connect_timeout_ms: 5000,
+                request_timeout_ms: 10000,
+                num_channels: 1,
+            },
+            dispatcher_config: DispatcherConfig::default(),
+            storage_config: StorageConfig::ObjectStore(ObjectStoreConfig {
+                bucket: ObjectStoreBucketConfig {
+                    name: "chroma-storage".to_string(),
+                    r#type: ObjectStoreType::Minio,
+                },
+                upload_part_size_bytes: 1024 * 1024,   // 1MB
+                download_part_size_bytes: 1024 * 1024, // 1MB
+                max_concurrent_requests: 10,
+            }),
+            default_mode: CleanupMode::DryRun,
+            tenant_mode_overrides: Some(tenant_mode_overrides),
+        };
+        let registry = Registry::new();
+
+        // Create collections
+        let mut clients = ChromaGrpcClients::new().await.unwrap();
+        let collection_in_dry_run_mode_handle = tokio::spawn({
+            let mut clients = clients.clone();
+            let tenant_id = tenant_id_for_dry_run_mode.clone();
+            async move { create_test_collection(tenant_id, &mut clients).await }
+        });
+        let collection_in_delete_mode_handle = tokio::spawn({
+            let mut clients = clients.clone();
+            let tenant_id = tenant_id_for_delete_mode.clone();
+            async move { create_test_collection(tenant_id, &mut clients).await }
+        });
+        let (collection_in_dry_run_mode, _) = collection_in_dry_run_mode_handle.await.unwrap();
+        let (collection_in_delete_mode, _) = collection_in_delete_mode_handle.await.unwrap();
+
+        // Wait 1 second for cutoff time
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Run garbage collection
+        let mut garbage_collector_component = GarbageCollector::try_from_config(&config, &registry)
+            .await
+            .unwrap();
+
+        let dispatcher = Dispatcher::try_from_config(&config.dispatcher_config, &registry)
+            .await
+            .unwrap();
+
+        let system = System::new();
+        let dispatcher_handle = system.start_component(dispatcher);
+
+        garbage_collector_component.set_dispatcher(dispatcher_handle);
+        garbage_collector_component.set_system(system.clone());
+        let garbage_collector_handle = system.start_component(garbage_collector_component);
+
+        garbage_collector_handle
+            .request(GarbageCollectMessage {}, Some(Span::current()))
+            .await
+            .unwrap();
+
+        // Get versions for dry run mode
+        let dry_run_mode_versions = clients
+            .list_collection_versions(
+                collection_in_dry_run_mode.0.to_string(),
+                tenant_id_for_dry_run_mode,
+                None,
+                None,
+                None,
+                Some(true),
+            )
+            .await
+            .unwrap();
+
+        // Dry run should have 4 versions, one marked for deletion
+        assert_eq!(
+            dry_run_mode_versions.versions.len(),
+            4,
+            "Expected 4 versions in dry run mode, found {}",
+            dry_run_mode_versions.versions.len()
+        );
+        assert!(
+            dry_run_mode_versions
+                .versions
+                .iter()
+                .any(|v| v.marked_for_deletion),
+            "Expected at least one version to be marked for deletion in dry run mode"
+        );
+
+        let delete_mode_versions = clients
+            .list_collection_versions(
+                collection_in_delete_mode.0.to_string(),
+                tenant_id_for_delete_mode,
+                None,
+                None,
+                None,
+                Some(true),
+            )
+            .await
+            .unwrap();
+
+        // There should be 3 versions left in delete mode, since the version 1 should have been deleted.
+        assert_eq!(
+            delete_mode_versions.versions.len(),
+            3,
+            "Expected 3 versions in delete mode, found {}",
+            delete_mode_versions.versions.len()
+        );
+        assert!(
+            delete_mode_versions
+                .versions
+                .iter()
+                .all(|v| !v.marked_for_deletion),
+            "Expected no versions to be marked for deletion in delete mode"
+        );
     }
 }

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use tonic::transport::Channel;
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct ChromaGrpcClients {
     pub sysdb: SysDbClient<Channel>,
     pub log_service: LogServiceClient<Channel>,

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete.rs
@@ -12,8 +12,6 @@ pub struct ComputeVersionsToDeleteOperator {}
 pub struct ComputeVersionsToDeleteInput {
     pub version_file: CollectionVersionFile,
     pub cutoff_time: DateTime<Utc>,
-    // Absolute cutoff time in seconds.
-    pub cutoff_time_secs: u64,
     pub min_versions_to_keep: u32,
 }
 
@@ -93,7 +91,7 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
                 "Oldest version to keep: {}, min versions to keep: {}, cutoff time: {}, total versions: {}",
                 oldest_version_to_keep,
                 input.min_versions_to_keep,
-                input.cutoff_time_secs,
+                input.cutoff_time,
                 version_history.versions.len()
             );
 
@@ -114,7 +112,7 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
                     continue;
                 }
 
-                if version.created_at_secs >= input.cutoff_time_secs as i64 {
+                if version.created_at_secs >= input.cutoff_time.timestamp() {
                     tracing::debug!(
                         "Keeping version {} (created at {}) because it's newer than cutoff time",
                         version.version,
@@ -208,7 +206,6 @@ mod tests {
         let input = ComputeVersionsToDeleteInput {
             version_file,
             cutoff_time: now - Duration::hours(20),
-            cutoff_time_secs: (now - Duration::hours(20)).timestamp() as u64,
             min_versions_to_keep: 2,
         };
 

--- a/rust/garbage_collector/src/types.rs
+++ b/rust/garbage_collector/src/types.rs
@@ -3,9 +3,11 @@ pub(crate) const RENAMED_FILE_PREFIX: &str = "gc/renamed/";
 // GC will use it to list files that would be deleted.
 pub(crate) const DELETE_LIST_FILE_PREFIX: &str = "gc/delete-list/";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
 pub enum CleanupMode {
     /// Only list files that would be affected without making changes
+    #[default]
     DryRun,
     /// Move files to a deletion directory instead of removing them
     Rename,

--- a/rust/garbage_collector/tests/prop_test_local_files.rs
+++ b/rust/garbage_collector/tests/prop_test_local_files.rs
@@ -48,6 +48,7 @@ use chroma_types::SegmentFlushInfo;
 use chroma_types::SegmentScope;
 use chroma_types::SegmentType;
 use chroma_types::{CollectionUuid, SegmentUuid};
+use chrono::DateTime;
 use futures::executor::block_on;
 use garbage_collector_library::garbage_collector_orchestrator::GarbageCollectorOrchestrator;
 use garbage_collector_library::types::CleanupMode;
@@ -756,8 +757,7 @@ impl GcTest {
         let orchestrator = GarbageCollectorOrchestrator::new(
             collection.collection_id,
             version_file_name,
-            cutoff_time,
-            0,
+            DateTime::from_timestamp(cutoff_time as i64, 0).unwrap(),
             sysdb,
             dispatcher_handle.clone(),
             storage,

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -523,6 +523,7 @@ impl Configurable<GrpcSysDbConfig> for GrpcSysDb {
 #[allow(dead_code)]
 pub struct CollectionToGcInfo {
     pub id: CollectionUuid,
+    pub tenant: String,
     pub name: String,
     pub version_file_path: String,
     pub latest_version: i64,
@@ -556,6 +557,7 @@ impl TryFrom<chroma_proto::CollectionToGcInfo> for CollectionToGcInfo {
         let collection_id = CollectionUuid(collection_uuid);
         Ok(CollectionToGcInfo {
             id: collection_id,
+            tenant: value.tenant_id,
             name: value.name,
             version_file_path: value.version_file_path,
             latest_version: value.latest_version,


### PR DESCRIPTION
## Description of changes

The main change here is allowing setting different garbage collection modes per tenant. This will allow us to enable delete mode for one tenant while testing and keep everyone else in dry run mode.

I added a new test, but for it to work I ended up needing to make some changes around how cutoff time is handled (was planning to make these changes, just in a later PR).

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added a new E2E test to validate tenant overrides.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
