### PR TITLE
[ENH] Prevent tracing:error calls for soft deleted collection in compaction.

### DIFF
--- a/go/pkg/grpcutils/response.go
+++ b/go/pkg/grpcutils/response.go
@@ -31,6 +31,10 @@ func BuildInternalGrpcError(msg string) error {
 	return status.Error(codes.Internal, msg)
 }
 
+func BuildFailedPreconditionGrpcError(msg string) error {
+	return status.Error(codes.FailedPrecondition, msg)
+}
+
 func BuildAlreadyExistsGrpcError(msg string) error {
 	return status.Error(codes.AlreadyExists, msg)
 }

--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -114,6 +114,10 @@ func (s *Coordinator) CreateCollection(ctx context.Context, createCollection *mo
 	return collection, created, nil
 }
 
+func (s *Coordinator) GetCollection(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string) (*model.Collection, error) {
+	return s.catalog.GetCollection(ctx, collectionID, collectionName, tenantID, databaseName)
+}
+
 func (s *Coordinator) GetCollections(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*model.Collection, error) {
 	return s.catalog.GetCollections(ctx, collectionID, collectionName, tenantID, databaseName, limit, offset)
 }
@@ -249,4 +253,9 @@ func (s *Coordinator) MarkVersionForDeletion(ctx context.Context, req *coordinat
 
 func (s *Coordinator) DeleteCollectionVersion(ctx context.Context, req *coordinatorpb.DeleteCollectionVersionRequest) (*coordinatorpb.DeleteCollectionVersionResponse, error) {
 	return s.catalog.DeleteCollectionVersion(ctx, req)
+}
+
+// SetDeleteMode sets the delete mode for testing
+func (c *Coordinator) SetDeleteMode(mode DeleteMode) {
+	c.deleteMode = mode
 }

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/grpcutils"
 	"github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
 	"github.com/chroma-core/chroma/go/pkg/types"
@@ -334,6 +335,39 @@ func (suite *CollectionServiceTestSuite) TestCreateCollection() {
 	suite.Equal(status.Error(codes.Code(code.Code_NOT_FOUND), common.ErrDatabaseNotFound.Error()), err)
 }
 
+func (suite *CollectionServiceTestSuite) TestServer_GetCollection() {
+	// Create a test collection
+	collectionName := "test_get_collection"
+	collectionID, err := dao.CreateTestCollection(suite.db, collectionName, 128, suite.databaseId)
+	suite.NoError(err)
+
+	// Enable soft delete mode
+	suite.s.coordinator.SetDeleteMode(coordinator.SoftDelete)
+
+	// Soft delete the collection
+	err = suite.s.coordinator.DeleteCollection(context.Background(), &model.DeleteCollection{
+		ID:           types.MustParse(collectionID),
+		DatabaseName: suite.databaseName,
+		TenantID:     suite.tenantName,
+	})
+	suite.NoError(err)
+
+	// Try to get the soft-deleted collection
+	collectionIDStr := collectionID
+	getReq := &coordinatorpb.GetCollectionRequest{
+		Id:       collectionIDStr,
+		Database: &suite.databaseName,
+		Tenant:   &suite.tenantName,
+	}
+	_, err = suite.s.GetCollection(context.Background(), getReq)
+	suite.Error(err)
+	suite.Equal(status.Error(codes.FailedPrecondition, common.ErrCollectionSoftDeleted.Error()), err)
+
+	// Clean up
+	err = dao.CleanUpTestCollection(suite.db, collectionID)
+	suite.NoError(err)
+}
+
 func (suite *CollectionServiceTestSuite) TestServer_FlushCollectionCompaction() {
 	log.Info("TestServer_FlushCollectionCompaction")
 	// create test collection
@@ -484,6 +518,29 @@ func (suite *CollectionServiceTestSuite) TestServer_FlushCollectionCompaction() 
 	}
 	// nothing else should change in DB
 	validateDatabase(suite, collectionID, collection, filePaths)
+
+	// Send FlushCollectionCompaction for a collection that is soft deleted.
+	// It should fail with a failed precondition error.
+	// Create collection and soft-delete it.
+	suite.s.coordinator.SetDeleteMode(coordinator.SoftDelete)
+	collectionID, err = dao.CreateTestCollection(suite.db, "test_flush_collection_compaction_soft_delete", 128, suite.databaseId)
+	suite.NoError(err)
+	suite.s.coordinator.DeleteCollection(context.Background(), &model.DeleteCollection{
+		ID:           types.MustParse(collectionID),
+		DatabaseName: suite.databaseName,
+		TenantID:     suite.tenantName,
+	})
+	// Send FlushCollectionCompaction for the soft-deleted collection.
+	// It should fail with a failed precondition error.
+	req = &coordinatorpb.FlushCollectionCompactionRequest{
+		TenantId:          suite.tenantName,
+		CollectionId:      collectionID,
+		LogPosition:       100,
+		CollectionVersion: 1,
+	}
+	_, err = suite.s.FlushCollectionCompaction(context.Background(), req)
+	suite.Error(err)
+	suite.Equal(status.Error(codes.Code(code.Code_FAILED_PRECONDITION), common.ErrCollectionSoftDeleted.Error()), err)
 
 	// clean up
 	err = dao.CleanUpTestCollection(suite.db, collectionID)

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -48,6 +48,10 @@ func (s *collectionDb) GetCollectionEntry(collectionID *string, databaseName *st
 	return collections[0], nil
 }
 
+func (s *collectionDb) GetCollectionEntries(id *string, name *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*dbmodel.CollectionAndMetadata, error) {
+	return s.getCollections(id, name, tenantID, databaseName, limit, offset, true)
+}
+
 func (s *collectionDb) GetCollections(id *string, name *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*dbmodel.CollectionAndMetadata, error) {
 	return s.getCollections(id, name, tenantID, databaseName, limit, offset, false)
 }

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -50,6 +50,7 @@ type CollectionAndMetadata struct {
 //go:generate mockery --name=ICollectionDb
 type ICollectionDb interface {
 	GetCollections(collectionID *string, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*CollectionAndMetadata, error)
+	GetCollectionEntries(id *string, name *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*CollectionAndMetadata, error)
 	CountCollections(tenantID string, databaseName *string) (uint64, error)
 	DeleteCollectionByID(collectionID string) (int, error)
 	GetSoftDeletedCollections(collectionID *string, tenantID string, databaseName string, limit int32) ([]*CollectionAndMetadata, error)

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -88,6 +88,36 @@ func (_m *ICollectionDb) DeleteCollectionByID(collectionID string) (int, error) 
 	return r0, r1
 }
 
+// GetCollectionEntries provides a mock function with given fields: id, name, tenantID, databaseName, limit, offset
+func (_m *ICollectionDb) GetCollectionEntries(id *string, name *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*dbmodel.CollectionAndMetadata, error) {
+	ret := _m.Called(id, name, tenantID, databaseName, limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCollectionEntries")
+	}
+
+	var r0 []*dbmodel.CollectionAndMetadata
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*string, *string, string, string, *int32, *int32) ([]*dbmodel.CollectionAndMetadata, error)); ok {
+		return rf(id, name, tenantID, databaseName, limit, offset)
+	}
+	if rf, ok := ret.Get(0).(func(*string, *string, string, string, *int32, *int32) []*dbmodel.CollectionAndMetadata); ok {
+		r0 = rf(id, name, tenantID, databaseName, limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*dbmodel.CollectionAndMetadata)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*string, *string, string, string, *int32, *int32) error); ok {
+		r1 = rf(id, name, tenantID, databaseName, limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetCollectionEntry provides a mock function with given fields: collectionID, databaseName
 func (_m *ICollectionDb) GetCollectionEntry(collectionID *string, databaseName *string) (*dbmodel.Collection, error) {
 	ret := _m.Called(collectionID, databaseName)

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -49,7 +49,9 @@ message Collection {
   string configuration_json_str = 3;
   optional UpdateMetadata metadata = 4;
   optional int32 dimension = 5;
+  // This is the tenant id of the collection.
   string tenant = 6;
+  // This is the database name of the collection.
   string database = 7;
   int64 log_position = 8;
   int32 version = 9;

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -145,6 +145,19 @@ message DeleteCollectionResponse {
   reserved "status";
 }
 
+// Request to get a single collection.
+message GetCollectionRequest {
+  string id = 1;
+  optional string name = 2;
+  optional string tenant = 3;
+  optional string database = 4;
+}
+
+// Response to GetCollectionRequest.
+message GetCollectionResponse {
+  Collection collection = 1;
+}
+
 message GetCollectionsRequest {
   optional string id = 1;
   optional string name = 2;
@@ -450,6 +463,7 @@ service SysDB {
   rpc UpdateSegment(UpdateSegmentRequest) returns (UpdateSegmentResponse) {}
   rpc CreateCollection(CreateCollectionRequest) returns (CreateCollectionResponse) {}
   rpc DeleteCollection(DeleteCollectionRequest) returns (DeleteCollectionResponse) {}
+  rpc GetCollection(GetCollectionRequest) returns (GetCollectionResponse) {}
   rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse) {}
   rpc CountCollections(CountCollectionsRequest) returns (CountCollectionsResponse) {}
   rpc GetCollectionWithSegments(GetCollectionWithSegmentsRequest) returns (GetCollectionWithSegmentsResponse) {}


### PR DESCRIPTION
## Description of changes

Prevent tracing:error calls for soft deleted collection in compaction.
This PR is a duplicate of https://github.com/chroma-core/chroma/pull/3965
This PR contains only the golang or sysdb side changes.


*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Add new GRPC needed by compactor, and return desired error code from FlushCompaction and CreateCollection.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
