### PR TITLE
[TST] move cross compat test to legacy ef

### DIFF
--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -169,17 +169,6 @@ class not_implemented_ef(EmbeddingFunction[Documents]):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
 
-    @staticmethod
-    def name() -> str:
-        return "not_implemented_ef"
-
-    @staticmethod
-    def build_from_config(config: dict[str, Any]) -> "EmbeddingFunction[Documents]":
-        return not_implemented_ef()
-
-    def get_config(self) -> dict[str, Any]:
-        return {}
-
 
 def persist_generated_data_with_old_version(
     version: str,


### PR DESCRIPTION
## Description of changes

The cross version test uses a 1.0.0 custom embedding function to test cross version compatibility. This PR reverts that to a legacy embedding function to ensure we can test cross compatibility from old versions to 1.0.0

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
