### PR TITLE
[BLD]: remove Depot from builds for Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -10,7 +10,7 @@ docker_build(
 if config.tilt_subcommand == "ci":
   custom_build(
     'logservice',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target logservice -f ./go/Dockerfile . --load',
+    'docker build -t $EXPECTED_REF --target logservice -f ./go/Dockerfile .',
     ['./go/', './idl/']
   )
 else:
@@ -25,7 +25,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'logservice-migration',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target logservice-migration -f ./go/Dockerfile.migration . --load',
+    'docker build -t $EXPECTED_REF --target logservice-migration -f ./go/Dockerfile.migration .',
     ['./go/']
   )
 else:
@@ -40,7 +40,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'rust-log-service',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF  -f ./rust/log-service/Dockerfile . --load',
+    'docker build -t $EXPECTED_REF  -f ./rust/log-service/Dockerfile .',
     ['./rust/', './idl/', './Cargo.toml', './Cargo.lock']
   )
 else:
@@ -54,7 +54,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'sysdb',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target sysdb -f ./go/Dockerfile . --load',
+    'docker build -t $EXPECTED_REF --target sysdb -f ./go/Dockerfile .',
     ['./go/', './idl/']
   )
 else:
@@ -69,7 +69,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'sysdb-migration',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target sysdb-migration -f ./go/Dockerfile.migration . --load',
+    'docker build -t $EXPECTED_REF --target sysdb-migration -f ./go/Dockerfile.migration .',
     ['./go/']
   )
 else:
@@ -85,7 +85,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'frontend-service',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF -f ./Dockerfile . --load',
+    'docker build -t $EXPECTED_REF -f ./Dockerfile . ',
     ['chromadb/', 'idl/', 'requirements.txt', 'bin/']
   )
 else:
@@ -100,7 +100,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'rust-frontend-service',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF -f ./rust/cli/Dockerfile . --load',
+    'docker build -t $EXPECTED_REF -f ./rust/cli/Dockerfile . ',
     ['./rust/', './idl/', './Cargo.toml', './Cargo.lock']
   )
 else:
@@ -114,7 +114,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'query-service',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target query_service -f ./rust/worker/Dockerfile . --load ',
+    'docker build -t $EXPECTED_REF --target query_service -f ./rust/worker/Dockerfile .',
     ['./rust/', './idl/', './Cargo.toml', './Cargo.lock']
   )
 else:
@@ -129,7 +129,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'compaction-service',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target compaction_service -f ./rust/worker/Dockerfile . --load ',
+    'docker build -t $EXPECTED_REF --target compaction_service -f ./rust/worker/Dockerfile .',
     ['./rust/', './idl/', './Cargo.toml', './Cargo.lock']
   )
 else:
@@ -144,7 +144,7 @@ else:
 if config.tilt_subcommand == "ci":
   custom_build(
     'garbage-collector',
-    'depot build --project $DEPOT_PROJECT_ID -t $EXPECTED_REF --target garbage_collector -f ./rust/garbage_collector/Dockerfile . --load ',
+    'docker build -t $EXPECTED_REF --target garbage_collector -f ./rust/garbage_collector/Dockerfile .',
     ['./rust/', './idl/', './Cargo.toml', './Cargo.lock']
   )
 else:


### PR DESCRIPTION
## Description of changes

We've been seeing a lot of build pollution/flaky builds with Depot. This (temporarily) removes Depot and builds on runners without using a cache until we resolve the issue.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a