### PR TITLE
[ENH] Improve CLI login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ version = "0.1.0"
 dependencies = [
  "arboard",
  "assert_cmd",
+ "axum 0.8.1",
  "chroma-config",
  "chroma-frontend",
  "chroma-log",
@@ -1464,6 +1465,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml",
+ "tower-http 0.6.2",
+ "urlencoding",
  "webbrowser",
 ]
 

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+axum = { workspace = true }
 arboard = "3.4.1"
 clap = { version = "4.5.28", features = ["derive"] }
 chroma-frontend = { workspace = true }
@@ -32,6 +33,8 @@ strum = "0.27.1"
 strum_macros = "0.27.1"
 semver = "1.0.26"
 regex = "1.11.1"
+urlencoding = "2.1.3"
+tower-http = {workspace = true}
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/rust/cli/src/commands/login.rs
+++ b/rust/cli/src/commands/login.rs
@@ -16,7 +16,6 @@ use rand::Rng;
 use reqwest::Method;
 use serde::Deserialize;
 use std::error::Error;
-use std::io::Write;
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 use thiserror::Error;


### PR DESCRIPTION
## Description of changes

Stand up a proper web server in the login command that allows the dashboard to send session ID and update login status to the user more gracefully.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
