### PR TITLE
[BUG]: async get_or_create_collection breaking in 1.0.0 

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -13,8 +13,8 @@ from chromadb.api.base_http_client import BaseHTTPClient
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,
-    create_collection_configuration_to_json_str,
-    update_collection_configuration_to_json_str,
+    create_collection_configuration_to_json,
+    update_collection_configuration_to_json,
 )
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, System, Settings
 from chromadb.telemetry.opentelemetry import (
@@ -297,9 +297,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             json={
                 "name": name,
                 "metadata": metadata,
-                "configuration": create_collection_configuration_to_json_str(
-                    configuration
-                )
+                "configuration": create_collection_configuration_to_json(configuration)
                 if configuration
                 else None,
                 "get_or_create": get_or_create,
@@ -365,7 +363,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             json={
                 "new_metadata": new_metadata,
                 "new_name": new_name,
-                "new_configuration": update_collection_configuration_to_json_str(
+                "new_configuration": update_collection_configuration_to_json(
                     new_configuration
                 )
                 if new_configuration


### PR DESCRIPTION
Closes #4156

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - The async client was serializing the config using the old _str method which results in an error in the server (it is strange that async tests are passing as this is pretty much 100% reproducible issue unless those have been disabled)

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
