### PR TITLE
[BUG] fix wal3 test that fails consistently.

### DIFF
--- a/rust/wal3/src/cursors.rs
+++ b/rust/wal3/src/cursors.rs
@@ -242,6 +242,6 @@ mod tests {
             .unwrap();
         assert_eq!(LogPosition::from_offset(99), witness.1.position);
         assert_eq!(54321u64, witness.1.epoch_us);
-        assert_eq!("writer-test", witness.1.writer);
+        assert_eq!("test-writer", witness.1.writer);
     }
 }


### PR DESCRIPTION
Somehow it merged to main and passed, but fails consistently now.

The core of the bug is the cursor store always overwrites the writer field.
Check for that overwritten value.
