### PR TITLE
[BUG] Turn off wal3 dual-log write as it flaked in CI.

### DIFF
--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -23,8 +23,8 @@ log:
     port: 50051
     connect_timeout_ms: 5000
     request_timeout_ms: 5000
-    alt_host: "rust-log-service.chroma"
-    use_alt_host_for_everything: true
+    #alt_host: "rust-log-service.chroma"
+    #use_alt_host_for_everything: true
 
 executor:
   distributed:

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -40,8 +40,8 @@ query_service:
             port: 50051
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
-            alt_host: "rust-log-service.chroma"
-            use_alt_host_for_everything: true
+            #alt_host: "rust-log-service.chroma"
+            #use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -116,8 +116,8 @@ compaction_service:
             port: 50051
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
-            alt_host: "rust-log-service.chroma"
-            use_alt_host_for_everything: true
+            #alt_host: "rust-log-service.chroma"
+            #use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100


### PR DESCRIPTION
This leaves the code merged, but effectively reverts #4084 because it flaked in CI on hosted.
