### PR TITLE
[ENH]: add database ID to collection version file prefix

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -744,11 +744,11 @@ func (tc *Catalog) createSegmentImpl(txCtx context.Context, createSegment *model
 	return result, nil
 }
 
-func (tc *Catalog) createFirstVersionFile(ctx context.Context, createCollection *model.CreateCollection, createSegments []*model.CreateSegment, ts types.Timestamp) (string, error) {
+func (tc *Catalog) createFirstVersionFile(ctx context.Context, databaseID string, createCollection *model.CreateCollection, createSegments []*model.CreateSegment, ts types.Timestamp) (string, error) {
 	collectionVersionFilePb := &coordinatorpb.CollectionVersionFile{
 		CollectionInfoImmutable: &coordinatorpb.CollectionInfoImmutable{
 			TenantId:               createCollection.TenantID,
-			DatabaseId:             createCollection.DatabaseName,
+			DatabaseId:             databaseID,
 			CollectionId:           createCollection.ID.String(),
 			CollectionName:         createCollection.Name,
 			CollectionCreationSecs: int64(ts),
@@ -764,7 +764,7 @@ func (tc *Catalog) createFirstVersionFile(ctx context.Context, createCollection 
 	}
 	// Construct the version file name.
 	versionFileName := "0"
-	fullFilePath, err := tc.s3Store.PutVersionFile(createCollection.TenantID, createCollection.ID.String(), versionFileName, collectionVersionFilePb)
+	fullFilePath, err := tc.s3Store.PutVersionFile(createCollection.TenantID, databaseID, createCollection.ID.String(), versionFileName, collectionVersionFilePb)
 	if err != nil {
 		return "", err
 	}
@@ -783,7 +783,17 @@ func (tc *Catalog) CreateCollectionAndSegments(ctx context.Context, createCollec
 	versionFileName := ""
 	var err error
 	if tc.versionFileEnabled {
-		versionFileName, err = tc.createFirstVersionFile(ctx, createCollection, createSegments, ts)
+		databases, err := tc.metaDomain.DatabaseDb(ctx).GetDatabases(createCollection.TenantID, createCollection.DatabaseName)
+		if err != nil {
+			log.Error("error getting database", zap.Error(err))
+			return nil, false, err
+		}
+		if len(databases) == 0 {
+			log.Error("database not found", zap.Error(err))
+			return nil, false, common.ErrDatabaseNotFound
+		}
+
+		versionFileName, err = tc.createFirstVersionFile(ctx, databases[0].ID, createCollection, createSegments, ts)
 		if err != nil {
 			return nil, false, err
 		}
@@ -1066,7 +1076,7 @@ func (tc *Catalog) updateVersionFileInS3(ctx context.Context, existingVersionFil
 	// Format of version file name: <version>_<uuid>_flush
 	// The version should be left padded with 0s upto 6 digits.
 	newVersionFileName := fmt.Sprintf("%06d_%s_flush", flushCollectionCompaction.CurrentCollectionVersion+1, uuid.New().String())
-	fullFilePath, err := tc.s3Store.PutVersionFile(flushCollectionCompaction.TenantID, flushCollectionCompaction.ID.String(), newVersionFileName, existingVersionFilePb)
+	fullFilePath, err := tc.s3Store.PutVersionFile(flushCollectionCompaction.TenantID, existingVersionFilePb.CollectionInfoImmutable.DatabaseId, flushCollectionCompaction.ID.String(), newVersionFileName, existingVersionFilePb)
 	if err != nil {
 		return "", err
 	}
@@ -1430,7 +1440,7 @@ func (tc *Catalog) markVersionForDeletionInSingleCollection(
 			collectionEntry.Version,
 			uuid.New().String(),
 		)
-		newVerFileFullPath, err := tc.s3Store.PutVersionFile(tenantID, collectionID, newVersionFileName, versionFilePb)
+		newVerFileFullPath, err := tc.s3Store.PutVersionFile(tenantID, collectionEntry.DatabaseID, collectionID, newVersionFileName, versionFilePb)
 		if err != nil {
 			return err
 		}
@@ -1440,7 +1450,7 @@ func (tc *Catalog) markVersionForDeletionInSingleCollection(
 		rowsAffected, err := tc.metaDomain.CollectionDb(ctx).UpdateVersionRelatedFields(collectionID, existingVersionFileName, newVerFileFullPath, nil, nil)
 		if err != nil {
 			// Delete the newly created version file from S3 since it is not needed.
-			tc.s3Store.DeleteVersionFile(tenantID, collectionID, newVersionFileName)
+			tc.s3Store.DeleteVersionFile(tenantID, collectionEntry.DatabaseID, collectionID, newVersionFileName)
 			return err
 		}
 		if rowsAffected == 0 {
@@ -1568,7 +1578,7 @@ func (tc *Catalog) DeleteVersionEntriesForCollection(ctx context.Context, tenant
 			collectionEntry.Version,
 			uuid.New().String(),
 		)
-		newVerFileFullPath, err := tc.s3Store.PutVersionFile(tenantID, collectionID, newVersionFileName, versionFilePb)
+		newVerFileFullPath, err := tc.s3Store.PutVersionFile(tenantID, collectionEntry.DatabaseID, collectionID, newVersionFileName, versionFilePb)
 		if err != nil {
 			return err
 		}
@@ -1577,7 +1587,7 @@ func (tc *Catalog) DeleteVersionEntriesForCollection(ctx context.Context, tenant
 		rowsAffected, err := tc.metaDomain.CollectionDb(ctx).UpdateVersionRelatedFields(collectionID, existingVersionFileName, newVerFileFullPath, &oldestVersionTs, &numActiveVersions)
 		if err != nil {
 			// Delete the newly created version file from S3 since it is not needed
-			tc.s3Store.DeleteVersionFile(tenantID, collectionID, newVersionFileName)
+			tc.s3Store.DeleteVersionFile(tenantID, collectionEntry.DatabaseID, collectionID, newVersionFileName)
 			return err
 		}
 		if rowsAffected == 0 {

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -181,7 +181,7 @@ func (m *mockS3MetaStore) GetVersionFile(tenantID, collectionID string, version 
 	}, nil
 }
 
-func (m *mockS3MetaStore) PutVersionFile(tenantID, collectionID, fileName string, file *coordinatorpb.CollectionVersionFile) (string, error) {
+func (m *mockS3MetaStore) PutVersionFile(tenantID, databaseID, collectionID, fileName string, file *coordinatorpb.CollectionVersionFile) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -193,7 +193,7 @@ func (m *mockS3MetaStore) HasObjectWithPrefix(ctx context.Context, prefix string
 	return false, nil
 }
 
-func (m *mockS3MetaStore) DeleteVersionFile(tenantID, collectionID, fileName string) error {
+func (m *mockS3MetaStore) DeleteVersionFile(tenantID, databaseID, collectionID, fileName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -232,7 +232,7 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollection(t *testing.T) {
 			},
 		},
 	}
-	fileName, err := mockS3Store.PutVersionFile(tenantID, collectionID.String(), "version_1.pb", initialVersionFile)
+	fileName, err := mockS3Store.PutVersionFile(tenantID, "test_database", collectionID.String(), "version_1.pb", initialVersionFile)
 	assert.NoError(t, err)
 	assert.Equal(t, "version_1.pb", fileName)
 
@@ -313,6 +313,7 @@ func TestCatalog_DeleteCollectionVersion(t *testing.T) {
 
 	// Test data
 	tenantID := "test_tenant"
+	databaseID := "test_database"
 	collectionID := "00000000-0000-0000-0000-000000000001"
 	versions_to_delete := []int64{3}
 	currentVersion := int32(3)
@@ -333,7 +334,7 @@ func TestCatalog_DeleteCollectionVersion(t *testing.T) {
 			},
 		},
 	}
-	mockS3Store.PutVersionFile(tenantID, collectionID, existingVersionFileName, initialVersionFile)
+	mockS3Store.PutVersionFile(tenantID, databaseID, collectionID, existingVersionFileName, initialVersionFile)
 
 	// Setup mock collection entry
 	mockCollectionEntry := &dbmodel.Collection{
@@ -449,6 +450,7 @@ func TestCatalog_MarkVersionForDeletion(t *testing.T) {
 
 	// Test data
 	tenantID := "test_tenant"
+	databaseID := "test_database"
 	collectionID := "00000000-0000-0000-0000-000000000001"
 	versions := []int64{1, 2}
 	currentVersion := int32(3)
@@ -468,7 +470,7 @@ func TestCatalog_MarkVersionForDeletion(t *testing.T) {
 			},
 		},
 	}
-	mockS3Store.PutVersionFile(tenantID, collectionID, existingVersionFileName, initialVersionFile)
+	mockS3Store.PutVersionFile(tenantID, databaseID, collectionID, existingVersionFileName, initialVersionFile)
 
 	// Setup mock collection entry
 	mockCollectionEntry := &dbmodel.Collection{
@@ -606,7 +608,7 @@ func TestCatalog_MarkVersionForDeletion_VersionNotFound(t *testing.T) {
 			},
 		},
 	}
-	mockS3Store.PutVersionFile(tenantID, collectionID, existingVersionFileName, initialVersionFile)
+	mockS3Store.PutVersionFile(tenantID, "test_database", collectionID, existingVersionFileName, initialVersionFile)
 
 	// Setup mock collection entry
 	mockCollectionEntry := &dbmodel.Collection{

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -30,7 +30,7 @@ func (s *collectionDb) DeleteAll() error {
 func (s *collectionDb) GetCollectionEntry(collectionID *string, databaseName *string) (*dbmodel.Collection, error) {
 	var collections []*dbmodel.Collection
 	query := s.db.Table("collections").
-		Select("collections.id, collections.name, collections.database_id, collections.is_deleted, databases.name, databases.tenant_id, collections.version, collections.version_file_name").
+		Select("collections.id, collections.name, collections.database_id, collections.is_deleted, databases.tenant_id, collections.version, collections.version_file_name").
 		Joins("INNER JOIN databases ON collections.database_id = databases.id").
 		Where("collections.id = ?", collectionID)
 


### PR DESCRIPTION
## Description of changes

Adds the database ID to the prefix for collection files in S3 as it's a logical grouping layer.

## Test plan
*How are these changes tested?*

Validated that path in Minio now includes the database ID:

<img width="1241" alt="Screenshot 2025-04-04 at 13 19 18" src="https://github.com/user-attachments/assets/2d7d5fad-47f6-4972-b12a-e391acb53ec9" />

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a