### PR TITLE
[ENH] Add attributes for frontend metrics

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -548,7 +548,10 @@ async fn create_database(
     State(mut server): State<FrontendServer>,
     Json(CreateDatabasePayload { name }): Json<CreateDatabasePayload>,
 ) -> Result<Json<CreateDatabaseResponse>, ServerError> {
-    server.metrics.create_database.add(1, &[]);
+    server
+        .metrics
+        .create_database
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!("Creating database [{}] for tenant [{}]", name, tenant);
     server
         .authenticate_and_authorize(
@@ -607,7 +610,10 @@ async fn list_databases(
     Query(ListDatabasesParams { limit, offset }): Query<ListDatabasesParams>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<ListDatabasesResponse>, ServerError> {
-    server.metrics.list_databases.add(1, &[]);
+    server
+        .metrics
+        .list_databases
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!("Listing database for tenant [{}]", tenant);
     server
         .authenticate_and_authorize(
@@ -647,7 +653,10 @@ async fn get_database(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<GetDatabaseResponse>, ServerError> {
-    server.metrics.get_database.add(1, &[]);
+    server
+        .metrics
+        .get_database
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!("Getting database [{}] for tenant [{}]", database, tenant);
     server
         .authenticate_and_authorize(
@@ -687,7 +696,10 @@ async fn delete_database(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<DeleteDatabaseResponse>, ServerError> {
-    server.metrics.delete_database.add(1, &[]);
+    server
+        .metrics
+        .delete_database
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!("Deleting database [{}] for tenant [{}]", database, tenant);
     server
         .authenticate_and_authorize(
@@ -735,7 +747,10 @@ async fn list_collections(
     Query(ListCollectionsParams { limit, offset }): Query<ListCollectionsParams>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<ListCollectionsResponse>, ServerError> {
-    server.metrics.list_collections.add(1, &[]);
+    server
+        .metrics
+        .list_collections
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!(
         "Listing collections in database [{}] for tenant [{}] with limit [{:?}] and offset [{:?}]",
         database,
@@ -788,7 +803,10 @@ async fn count_collections(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<CountCollectionsResponse>, ServerError> {
-    server.metrics.count_collections.add(1, &[]);
+    server
+        .metrics
+        .count_collections
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!("Counting number of collections in database [{database}] for tenant [{tenant}]",);
     server
         .authenticate_and_authorize(
@@ -840,7 +858,10 @@ async fn create_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<CreateCollectionPayload>,
 ) -> Result<Json<Collection>, ServerError> {
-    server.metrics.create_collection.add(1, &[]);
+    server
+        .metrics
+        .create_collection
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!("Creating collection in database [{database}] for tenant [{tenant}]");
     server
         .authenticate_and_authorize(
@@ -908,7 +929,10 @@ async fn get_collection(
     Path((tenant, database, collection_name)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<Collection>, ServerError> {
-    server.metrics.get_collection.add(1, &[]);
+    server
+        .metrics
+        .get_collection
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!(
         "Getting collection [{collection_name}] in database [{database}] for tenant [{tenant}]"
     );
@@ -960,7 +984,13 @@ async fn update_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<UpdateCollectionPayload>,
 ) -> Result<Json<UpdateCollectionResponse>, ServerError> {
-    server.metrics.update_collection.add(1, &[]);
+    server.metrics.update_collection.add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.clone()),
+            KeyValue::new("collection_id", collection_id.clone()),
+        ],
+    );
     tracing::info!(
         "Updating collection [{collection_id}] in database [{database}] for tenant [{tenant}]"
     );
@@ -1029,7 +1059,10 @@ async fn delete_collection(
     Path((tenant, database, collection_name)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<UpdateCollectionResponse>, ServerError> {
-    server.metrics.delete_collection.add(1, &[]);
+    server
+        .metrics
+        .delete_collection
+        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
     tracing::info!(
         "Deleting collection [{collection_name}] in database [{database}] for tenant [{tenant}]"
     );
@@ -1080,7 +1113,13 @@ async fn collection_add(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<AddCollectionRecordsPayload>,
 ) -> Result<(StatusCode, Json<AddCollectionRecordsResponse>), ServerError> {
-    server.metrics.collection_add.add(1, &[]);
+    server.metrics.collection_add.add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.clone()),
+            KeyValue::new("collection_id", collection_id.clone()),
+        ],
+    );
     server
         .authenticate_and_authorize(
             &headers,
@@ -1161,7 +1200,13 @@ async fn collection_update(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<UpdateCollectionRecordsPayload>,
 ) -> Result<Json<UpdateCollectionRecordsResponse>, ServerError> {
-    server.metrics.collection_update.add(1, &[]);
+    server.metrics.collection_update.add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.clone()),
+            KeyValue::new("collection_id", collection_id.clone()),
+        ],
+    );
     server
         .authenticate_and_authorize(
             &headers,
@@ -1246,7 +1291,13 @@ async fn collection_upsert(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<UpsertCollectionRecordsPayload>,
 ) -> Result<Json<UpsertCollectionRecordsResponse>, ServerError> {
-    server.metrics.collection_upsert.add(1, &[]);
+    server.metrics.collection_upsert.add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.clone()),
+            KeyValue::new("collection_id", collection_id.clone()),
+        ],
+    );
     server
         .authenticate_and_authorize(
             &headers,
@@ -1330,7 +1381,13 @@ async fn collection_delete(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<DeleteCollectionRecordsPayload>,
 ) -> Result<Json<DeleteCollectionRecordsResponse>, ServerError> {
-    server.metrics.collection_delete.add(1, &[]);
+    server.metrics.collection_delete.add(
+        1,
+        &[
+            KeyValue::new("tenant", tenant.clone()),
+            KeyValue::new("collection_id", collection_id.clone()),
+        ],
+    );
     server
         .authenticate_and_authorize(
             &headers,
@@ -1401,7 +1458,6 @@ async fn collection_count(
         1,
         &[
             KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("database", database.clone()),
             KeyValue::new("collection_id", collection_id.clone()),
         ],
     );


### PR DESCRIPTION
## Description of changes
Record tenant, database, and collection_id (where appropriate) attributes for the various frontend endpoints. This will allow us to perform usage queries such as gets per tenant (as well as per database / collection).

## Test plan
These changes are not tested (yet). The plan is to merge into staging, then manually create some honeycomb dashboards / graphs to verify these attributes are being passed as expected.
