### PR TITLE
[ENH]: add metrics for garbage collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "futures",
  "humantime",
  "itertools 0.13.0",
+ "opentelemetry",
  "proptest",
  "proptest-derive 0.3.0",
  "proptest-state-machine",

--- a/rust/garbage_collector/Cargo.toml
+++ b/rust/garbage_collector/Cargo.toml
@@ -31,6 +31,7 @@ tempfile = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 humantime = { workspace = true }
+opentelemetry = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }


### PR DESCRIPTION
## Description of changes

Adds 3 metrics to the garbage collection service as a starting point:

- total jobs, segmented by success/failure
- job duration in milliseconds (histogram)
- total # of files deleted
- total # of versions deleted

## Test plan
*How are these changes tested?*

Ran garbage collection and validated that the produced values in Granfana looked reasonable.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a