### PR TITLE
[ENH] Re-enable wal3 with values that work well in tilt even if tests run long.

### DIFF
--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -23,8 +23,8 @@ log:
     port: 50051
     connect_timeout_ms: 5000
     request_timeout_ms: 5000
-    #alt_host: "rust-log-service.chroma"
-    #use_alt_host_for_everything: true
+    alt_host: "rust-log-service.chroma"
+    use_alt_host_for_everything: true
 
 executor:
   distributed:

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -24,7 +24,7 @@ impl ChromaGrpcClients {
         let sysdb_channel = Channel::from_static("http://localhost:50051")
             .connect()
             .await?;
-        let logservice_channel = Channel::from_static("http://localhost:50052")
+        let logservice_channel = Channel::from_static("http://localhost:50054")
             .connect()
             .await?;
         let queryservice_channel = Channel::from_static("http://localhost:50053")

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::future::Future;

--- a/rust/python_bindings/src/lib.rs
+++ b/rust/python_bindings/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 mod bindings;
 mod errors;
 

--- a/rust/sysdb/src/lib.rs
+++ b/rust/sysdb/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 pub mod config;
 pub mod sqlite;
 #[allow(clippy::module_inception)]

--- a/rust/wal3/examples/wal3-bench.rs
+++ b/rust/wal3/examples/wal3-bench.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/rust/wal3/src/batch_manager.rs
+++ b/rust/wal3/src/batch_manager.rs
@@ -187,6 +187,9 @@ impl BatchManager {
         let mut work = std::mem::take(&mut state.enqueued);
         state.enqueued = work.split_off(split_off);
         state.last_batch = Instant::now();
+        if !state.enqueued.is_empty() {
+            self.write_finished.notify_one();
+        }
         Ok(Some((fragment_seq_no, log_position, work)))
     }
 

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -103,7 +103,6 @@ impl LogWriter {
             writer.to_string(),
             Arc::clone(&mark_dirty),
         )
-        .instrument(tracing::info_span!("open_or_initialize"))
         .await
         {
             Ok(writer) => writer,
@@ -148,6 +147,7 @@ impl LogWriter {
         self.append_many(vec![message]).await
     }
 
+    #[tracing::instrument(skip(self, messages))]
     pub async fn append_many(&self, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
         // SAFETY(rescrv):  Mutex poisoning.
         let inner = { self.inner.lock().unwrap().clone() };
@@ -325,6 +325,7 @@ impl OnceLogWriter {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, messages))]
     async fn append(self: &Arc<Self>, messages: Vec<Vec<u8>>) -> Result<LogPosition, Error> {
         if messages.is_empty() {
             return Err(Error::EmptyBatch);
@@ -340,6 +341,7 @@ impl OnceLogWriter {
         rx.await.map_err(|_| Error::Internal)?
     }
 
+    #[tracing::instrument(skip(self, work))]
     #[allow(clippy::type_complexity)]
     async fn append_batch(
         self: Arc<Self>,
@@ -382,6 +384,7 @@ impl OnceLogWriter {
         }
     }
 
+    #[tracing::instrument(skip(self, messages))]
     async fn append_batch_internal(
         &self,
         fragment_seq_no: FragmentSeqNo,
@@ -471,6 +474,7 @@ pub fn construct_parquet(
     Ok((buffer, setsum))
 }
 
+#[tracing::instrument(skip(options, storage, messages))]
 pub async fn upload_parquet(
     options: &LogWriterOptions,
     storage: &Storage,

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -8,7 +8,6 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use setsum::Setsum;
-use tracing::instrument::Instrument;
 
 use crate::{
     unprefixed_fragment_path, BatchManager, CursorStore, CursorStoreOptions, Error,

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -40,8 +40,8 @@ query_service:
             port: 50051
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
-            #alt_host: "rust-log-service.chroma"
-            #use_alt_host_for_everything: true
+            alt_host: "rust-log-service.chroma"
+            use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -77,7 +77,7 @@ query_service:
             weighted_lru:
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
-    fetch_log_batch_size: 8000
+    fetch_log_batch_size: 1000
 
 compaction_service:
     service_name: "compaction-service"
@@ -116,8 +116,8 @@ compaction_service:
             port: 50051
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
-            #alt_host: "rust-log-service.chroma"
-            #use_alt_host_for_everything: true
+            alt_host: "rust-log-service.chroma"
+            use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -132,7 +132,7 @@ compaction_service:
         max_compaction_size: 10000
         max_partition_size: 5000
         disabled_collections: [] # uuids to disable compaction for
-        fetch_log_batch_size: 8000
+        fetch_log_batch_size: 1000
     blockfile_provider:
         arrow:
             block_manager_config:

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -77,7 +77,7 @@ query_service:
             weighted_lru:
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
-    fetch_log_batch_size: 1000
+    fetch_log_batch_size: 2000
 
 compaction_service:
     service_name: "compaction-service"
@@ -132,7 +132,7 @@ compaction_service:
         max_compaction_size: 10000
         max_partition_size: 5000
         disabled_collections: [] # uuids to disable compaction for
-        fetch_log_batch_size: 1000
+        fetch_log_batch_size: 2000
     blockfile_provider:
         arrow:
             block_manager_config:

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -77,7 +77,7 @@ query_service:
             weighted_lru:
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
-    fetch_log_batch_size: 2000
+    fetch_log_batch_size: 4000
 
 compaction_service:
     service_name: "compaction-service"
@@ -132,7 +132,7 @@ compaction_service:
         max_compaction_size: 10000
         max_partition_size: 5000
         disabled_collections: [] # uuids to disable compaction for
-        fetch_log_batch_size: 2000
+        fetch_log_batch_size: 4000
     blockfile_provider:
         arrow:
             block_manager_config:


### PR DESCRIPTION
This adds some tracing, re-enables the wal3-backed log.
