### PR TITLE
[ENH] Add Baseten integration

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -14,6 +14,7 @@ def test_get_builtins_holds() -> None:
     """
     expected_builtins = {
         "AmazonBedrockEmbeddingFunction",
+        "BasetenEmbeddingFunction",
         "CohereEmbeddingFunction",
         "VoyageAIEmbeddingFunction",
         "GoogleGenerativeAiEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -52,6 +52,9 @@ from chromadb.utils.embedding_functions.amazon_bedrock_embedding_function import
 from chromadb.utils.embedding_functions.chroma_langchain_embedding_function import (
     ChromaLangchainEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.baseten_embedding_function import (
+    BasetenEmbeddingFunction,
+)
 
 try:
     from chromadb.is_thin_client import is_thin_client
@@ -78,6 +81,7 @@ _all_classes: Set[str] = {
     "Text2VecEmbeddingFunction",
     "AmazonBedrockEmbeddingFunction",
     "ChromaLangchainEmbeddingFunction",
+    "BasetenEmbeddingFunction",
     "DefaultEmbeddingFunction",
 }
 
@@ -135,6 +139,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "text2vec": Text2VecEmbeddingFunction,
     "amazon_bedrock": AmazonBedrockEmbeddingFunction,
     "chroma_langchain": ChromaLangchainEmbeddingFunction,
+    "baseten": BasetenEmbeddingFunction,
     "default": DefaultEmbeddingFunction,
 }
 
@@ -201,6 +206,7 @@ __all__ = [
     "DefaultEmbeddingFunction",
     "CohereEmbeddingFunction",
     "OpenAIEmbeddingFunction",
+    "BasetenEmbeddingFunction",
     "HuggingFaceEmbeddingFunction",
     "HuggingFaceEmbeddingServer",
     "SentenceTransformerEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/baseten_embedding_function.py
+++ b/chromadb/utils/embedding_functions/baseten_embedding_function.py
@@ -1,0 +1,83 @@
+import os
+from chromadb.utils.embedding_functions.openai_embedding_function import OpenAIEmbeddingFunction
+from chromadb.api.types import Documents, EmbeddingFunction
+from typing import Dict, Any, Optional
+
+class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
+
+    def __init__(
+            self,
+            api_key: Optional[str],
+            api_base: str,
+            api_key_env_var: str = "CHROMA_BASETEN_API_KEY",
+            ):
+        """
+        Initialize the BasetenEmbeddingFunction.
+        Args:
+            api_key (str, optional): The API key for your Baseten account
+            api_base (str, required): The Baseten URL of the deployment
+            api_key_env_var (str, optional): The environment variable to use for the API key. Defaults to "CHROMA_BASETEN_API_KEY".
+        """
+        try:
+            import openai
+        except ImportError:
+            raise ValueError(
+                "The openai python package is not installed. Please install it with `pip install openai`"
+            )
+
+        self.api_key_env_var = api_key_env_var
+        # Prioritize api_key argument, then environment variable
+        resolved_api_key = api_key or os.getenv(api_key_env_var)
+        if not resolved_api_key:
+            raise ValueError(f"API key not provided and {api_key_env_var} environment variable is not set.")
+        self.api_key = resolved_api_key
+        if not api_base:
+            raise ValueError("The api_base argument must be provided.")
+        self.api_base = api_base
+        self.model_name = "baseten-embedding-model"
+        self.dimensions = None
+
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url=self.api_base
+        )
+        
+    @staticmethod
+    def name() -> str:
+        return "baseten"
+    
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "api_base": self.api_base,
+            "api_key_env_var": self.api_key_env_var
+        }
+        
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "BasetenEmbeddingFunction":
+        """
+        Build the BasetenEmbeddingFunction from a configuration dictionary.
+
+        Args:
+            config (Dict[str, Any]): A dictionary containing the configuration parameters.
+                                     Expected keys: 'api_key', 'api_base', 'api_key_env_var'.
+
+        Returns:
+            BasetenEmbeddingFunction: An instance of BasetenEmbeddingFunction.
+        """
+        api_key_env_var = config.get("api_key_env_var")
+        api_base = config.get("api_base")
+        if api_key_env_var is None or api_base is None:
+            raise ValueError("Missing 'api_key_env_var' or 'api_base' in configuration for BasetenEmbeddingFunction.")
+
+        # Note: We rely on the __init__ method to handle potential missing api_key
+        # by checking the environment variable if the config value is None.
+        # However, api_base must be present either in config or have a default.
+        if api_base is None:
+             raise ValueError("Missing 'api_base' in configuration for BasetenEmbeddingFunction.")
+
+        return BasetenEmbeddingFunction(
+            api_key=None, # Pass None if not in config, __init__ will check env var
+            api_base=api_base,
+            api_key_env_var=api_key_env_var,
+        )

--- a/docs/docs.trychroma.com/markdoc/content/integrations/chroma-integrations.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/chroma-integrations.md
@@ -14,6 +14,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [OpenAI](./embedding-models/openai)                                     | ✓      | ✓          |
 | [Google Gemini](./embedding-models/google-gemini)                       | ✓      | ✓          |
 | [Cohere](./embedding-models/cohere)                                     | ✓      | ✓          |
+| [Baseten](./embedding-models/baseten)                                   | ✓      | -          |
 | [Hugging Face](./embedding-models/hugging-face)                         | ✓      | -          |
 | [Instructor](./embedding-models/instructor)                             | ✓      | -          |
 | [Hugging Face Embedding Server](./embedding-models/hugging-face-server) | ✓      | ✓          |

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/baseten.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/baseten.md
@@ -1,0 +1,38 @@
+---
+name: Baseten
+id: baseten
+---
+
+# Baseten
+
+Baseten is a model inference provider for dedicated deployments of any open-source, fine-tuned, or custom model, including embedding models. Baseten specializes in low-latency, high-throughput deployments using Baseten Embedding Inference (BEI), the fastest runtime on the market for embedding models.
+
+Chroma provides a convenient integration with any OpenAI-compatible embedding model deployed on Baseten. Every embedding model deployed with BEI is compatible with the OpenAI SDK.
+
+{% Banner type="tip" %}
+Get started easily with an embedding model from Baseten's model library, like [Mixedbread Embed Large](https://www.baseten.co/library/mixedbread-embed-large-v1/).
+{% /Banner %}
+
+{% Tabs %}
+
+{% Tab label="python" %}
+
+This embedding function relies on the `openai` python package, which you can install with `pip install openai`.
+
+You must set the `api_key` and `api_base`, replacing the `api_base` with the URL from the model deployed in your Baseten account.
+
+```python
+import os
+import chromadb.utils.embedding_functions as embedding_functions
+
+baseten_ef = embedding_functions.BasetenEmbeddingFunction(
+                api_key=os.environ["BASETEN_API_KEY"],
+                api_base="https://model-xxxxxxxx.api.baseten.co/environments/production/sync/v1",
+            )
+
+baseten_ef(input=["This is my first text to embed", "This is my second document"])
+```
+
+{% /Tab %}
+
+{% /Tabs %}


### PR DESCRIPTION
## Description of changes

This PR adds a Baseten integration for using Chroma with models deployed on Baseten

## Test plan

Tested locally with deployed model, output is identical to OpenAI integration.

## Documentation Changes

Integration is documented in appropriate file.
