### PR TITLE
[DBG] These debug statements and asserts trigger for a bug.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,9 +126,10 @@ serial_test = "3.2.0"
 [profile.release]
 debug = 2
 lto = "thin"
+panic = "abort"
 
 [profile.test.package.proptest]
-opt-level = 3
+opt-level = 2
 
 [profile.test.package.rand_chacha]
-opt-level = 3
+opt-level = 2

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -98,12 +98,22 @@ impl FullTextIndexWriter {
                     old_document,
                     new_document,
                 } => {
+                    if String::from_utf8_lossy(old_document.as_bytes()) != old_document {
+                        panic!("invariants violated on old_document");
+                    }
+                    if String::from_utf8_lossy(new_document.as_bytes()) != new_document {
+                        panic!("invariants violated on old_document");
+                    }
                     // Remove old version
                     let mut trigrams_to_delete = HashSet::new(); // (need to filter out duplicates, each trigram may appear multiple times in a document)
                     self.tokenizer
                         .clone()
                         .token_stream(old_document)
                         .process(&mut |token| {
+                            if String::from_utf8_lossy(token.text.as_bytes()) != token.text.as_str()
+                            {
+                                panic!("invariants violated on old_document");
+                            }
                             trigrams_to_delete.insert(TokenInstance::encode(
                                 token.text.as_str(),
                                 offset_id,

--- a/rust/index/src/fulltext/util.rs
+++ b/rust/index/src/fulltext/util.rs
@@ -68,6 +68,7 @@ fn unpack_trigram(u: u64) -> String {
 
         // Set the correct length after writing
         let total_bytes = bytes_written_c0 + bytes_written_c1 + bytes_written_c2;
+        assert!(total_bytes <= 12);
         v.set_len(len0 + total_bytes);
     }
 

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::future::Future;

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -141,9 +141,7 @@ where
             return;
         }
         self.task_state = TaskState::Running;
-        let result = AssertUnwindSafe(self.operator.run(&self.input))
-            .catch_unwind()
-            .await;
+        let result = Ok(self.operator.run(&self.input).await);
 
         match result {
             Ok(result) => {

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -175,5 +175,5 @@ pub fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
         init_stdout_layer(),
     ];
     init_tracing(layers);
-    init_panic_tracing_hook();
+    //init_panic_tracing_hook();
 }


### PR DESCRIPTION
The code path in blockfile_metadata leading up to handle_batch fails.
Specifically the assert on line 486 that checks that old document is
valid UTF8 fails one iteration of the loop to the next.
