### PR TITLE
[ENH]: fix sysdb S3 config for parity between local dev & deployed env, add necessary params

### DIFF
--- a/.github/workflows/_go-tests.yml
+++ b/.github/workflows/_go-tests.yml
@@ -4,37 +4,6 @@ on:
   workflow_call:
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        platform: [depot-ubuntu-22.04]
-    runs-on: ${{ matrix.platform }}
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: chroma
-          POSTGRES_PASSWORD: chroma
-          POSTGRES_DB: chroma
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup
-        uses: ./.github/actions/go
-      - name: Build and test
-        run: make test
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-        working-directory: go
-
   cluster-test:
     runs-on: "depot-ubuntu-22.04-16"
     # OIDC token auth for Depot & AWS
@@ -49,7 +18,7 @@ jobs:
       - uses: ./.github/actions/tilt
         with:
           depot-project-id: ${{ vars.DEPOT_PROJECT_ID }}
-      - run: bin/cluster-test.sh bash -c 'cd go && go test -timeout 30s -run ^TestNodeWatcher$ github.com/chroma-core/chroma/go/pkg/memberlist_manager'
+      - run: bin/cluster-test.sh bash -c 'cd go && make test'
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs

--- a/go/cmd/coordinator/cmd.go
+++ b/go/cmd/coordinator/cmd.go
@@ -65,8 +65,14 @@ func init() {
 	Cmd.Flags().StringVar(&conf.CompactionServiceMemberlistName, "compaction-memberlist-name", "compaction-service-memberlist", "Compaction memberlist name")
 	Cmd.Flags().StringVar(&conf.CompactionServicePodLabel, "compaction-pod-label", "compaction-service", "Compaction pod label")
 
-	// Block store provider
-	Cmd.Flags().StringVar(&conf.BlockStoreProvider, "block-store-provider", "minio", "Block store provider")
+	// S3 config
+	Cmd.Flags().StringVar(&conf.MetaStoreConfig.BucketName, "bucket-name", "chroma-storage", "Bucket name")
+	Cmd.Flags().StringVar(&conf.MetaStoreConfig.Region, "s3-region", "us-east-1", "Region")
+	Cmd.Flags().StringVar(&conf.MetaStoreConfig.Endpoint, "s3-endpoint", "", "S3 endpoint")
+	Cmd.Flags().StringVar(&conf.MetaStoreConfig.AccessKeyID, "s3-access-key-id", "", "S3 access key ID")
+	Cmd.Flags().StringVar(&conf.MetaStoreConfig.SecretAccessKey, "s3-secret-access-key", "", "S3 secret access key")
+	Cmd.Flags().BoolVar(&conf.MetaStoreConfig.ForcePathStyle, "s3-force-path-style", false, "S3 force path style")
+
 	// Version file
 	Cmd.Flags().BoolVar(&conf.VersionFileEnabled, "version-file-enabled", false, "Enable version file")
 }

--- a/go/pkg/sysdb/grpc/cleaup_test.go
+++ b/go/pkg/sysdb/grpc/cleaup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
+	s3metastore "github.com/chroma-core/chroma/go/pkg/sysdb/metastore/s3"
 	"github.com/chroma-core/chroma/go/pkg/types"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/suite"
@@ -38,7 +39,15 @@ func (suite *CleanupTestSuite) SetupSuite() {
 		SoftDeleteMaxAge:           0,
 		SoftDeleteCleanupBatchSize: 10,
 		Testing:                    true,
-		BlockStoreProvider:         "none",
+		MetaStoreConfig: s3metastore.S3MetaStoreConfig{
+			BucketName:              "test-bucket",
+			Region:                  "us-east-1",
+			Endpoint:                "http://localhost:9000",
+			AccessKeyID:             "minio",
+			SecretAccessKey:         "minio123",
+			ForcePathStyle:          true,
+			CreateBucketIfNotExists: true,
+		},
 	}, grpcutils.Default)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
+	s3metastore "github.com/chroma-core/chroma/go/pkg/sysdb/metastore/s3"
 	"github.com/chroma-core/chroma/go/pkg/types"
 	"github.com/google/uuid"
 	"github.com/pingcap/log"
@@ -43,7 +44,15 @@ func (suite *CollectionServiceTestSuite) SetupSuite() {
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
 		Testing:               true,
-		BlockStoreProvider:    "none",
+		MetaStoreConfig: s3metastore.S3MetaStoreConfig{
+			BucketName:              "test-bucket",
+			Region:                  "us-east-1",
+			Endpoint:                "http://localhost:9000",
+			AccessKeyID:             "minio",
+			SecretAccessKey:         "minio123",
+			ForcePathStyle:          true,
+			CreateBucketIfNotExists: true,
+		},
 	}, grpcutils.Default)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)

--- a/go/pkg/sysdb/grpc/tenant_database_service_test.go
+++ b/go/pkg/sysdb/grpc/tenant_database_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
+	s3metastore "github.com/chroma-core/chroma/go/pkg/sysdb/metastore/s3"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/genproto/googleapis/rpc/code"
@@ -34,7 +35,15 @@ func (suite *TenantDatabaseServiceTestSuite) SetupSuite() {
 	s, err := NewWithGrpcProvider(Config{
 		SystemCatalogProvider: "database",
 		Testing:               true,
-		BlockStoreProvider:    "none",
+		MetaStoreConfig: s3metastore.S3MetaStoreConfig{
+			BucketName:              "test-bucket",
+			Region:                  "us-east-1",
+			Endpoint:                "http://localhost:9000",
+			AccessKeyID:             "minio",
+			SecretAccessKey:         "minio123",
+			ForcePathStyle:          true,
+			CreateBucketIfNotExists: true,
+		},
 	}, grpcutils.Default)
 	if err != nil {
 		suite.T().Fatalf("error creating server: %v", err)

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -3,7 +3,10 @@ sysdb:
     version-file-enabled: true
     soft-delete-max-age: 1s
     soft-delete-cleanup-interval: 2s
-
+    s3-endpoint: "http://minio:9000"
+    s3-access-key-id: "minio"
+    s3-secret-access-key: "minio123"
+    s3-force-path-style: true
 rustFrontendService:
   # We have to specify the command, because the Dockerfile uses the CLI since its shared with
   # single node, so in values.dev we pass the CONFIG_PATH into the chroma run command
@@ -15,7 +18,6 @@ rustFrontendService:
       value: 'value: "1"'
     - name: CONFIG_PATH
       value: "tilt_config.yaml"
-
 
 frontendService:
   otherEnvConfig: |


### PR DESCRIPTION
## Description of changes

Updates sysdb S3 config flags to improve parity between local dev and deployed envs. Also adds parameters necessary for configuration in deployed env (bucket name) and verifies that bucket is accessible before continuing startup.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a