### PR TITLE
[ENH]: Improving local executor backfill error propagation

### DIFF
--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -72,16 +72,16 @@ impl LocalExecutor {
         self.compactor_handle
             .request(backfill_msg, None)
             .await
-            .map_err(|_| ExecutorError::BackfillError)?
-            .map_err(|_| ExecutorError::BackfillError)?;
+            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?
+            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?;
         let purge_log_msg = PurgeLogsMessage {
             collection_id: collection_and_segment.collection.collection_id,
         };
         self.compactor_handle
             .request(purge_log_msg, None)
             .await
-            .map_err(|_| ExecutorError::BackfillError)?
-            .map_err(|_| ExecutorError::BackfillError)?;
+            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?
+            .map_err(|err| ExecutorError::BackfillError(Box::new(err)))?;
         let mut backfill_guard = self.backfilled_collections.lock();
         backfill_guard.insert(collection_and_segment.collection.collection_id);
         Ok(())

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -88,9 +88,9 @@ pub enum CompactionManagerError {
     GetCollectionWithSegmentsError(#[from] GetCollectionWithSegmentsError),
     #[error("Error reading from metadata segment reader")]
     MetadataReaderError(#[from] SqliteMetadataError),
-    #[error("Error reading from hnsw segment reader")]
+    #[error("Error reading from hnsw segment reader: {0}")]
     HnswReaderError(#[from] LocalHnswSegmentReaderError),
-    #[error("Error constructing hnsw segment reader")]
+    #[error("Error constructing hnsw segment reader: {0}")]
     HnswReaderConstructionError(#[from] LocalSegmentManagerError),
     #[error("Error purging logs")]
     PurgeLogsFailure,

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -32,9 +32,9 @@ pub struct LocalHnswSegmentReader {
 
 #[derive(Error, Debug)]
 pub enum LocalHnswSegmentReaderError {
-    #[error("Error opening pickle file")]
+    #[error("Error opening pickle file: {0}")]
     PickleFileOpenError(#[from] std::io::Error),
-    #[error("Error deserializing pickle file")]
+    #[error("Error deserializing pickle file: {0}")]
     PickleFileDeserializeError(#[from] serde_pickle::Error),
     #[error("Error loading hnsw index")]
     HnswIndexLoadError,
@@ -52,7 +52,7 @@ pub enum LocalHnswSegmentReaderError {
     GetEmbeddingError,
     #[error("Error querying knn")]
     QueryError,
-    #[error("Error reading from sqlite")]
+    #[error("Error reading from sqlite: {0}")]
     SqliteError(#[from] sqlx::error::Error),
 }
 

--- a/rust/segment/src/local_segment_manager.rs
+++ b/rust/segment/src/local_segment_manager.rs
@@ -74,11 +74,11 @@ impl Configurable<LocalSegmentManagerConfig> for LocalSegmentManager {
 
 #[derive(Error, Debug)]
 pub enum LocalSegmentManagerError {
-    #[error("Error creating hnsw segment reader")]
+    #[error("Error creating hnsw segment reader: {0}")]
     LocalHnswSegmentReaderError(#[from] LocalHnswSegmentReaderError),
-    #[error("Error reading hnsw pool cache")]
+    #[error("Error reading hnsw pool cache: {0}")]
     PoolCacheError(#[from] CacheError),
-    #[error("Error creating hnsw segment writer")]
+    #[error("Error creating hnsw segment writer: {0}")]
     LocalHnswSegmentWriterError(#[from] LocalHnswSegmentWriterError),
 }
 

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1585,8 +1585,8 @@ pub enum ExecutorError {
     Internal(Box<dyn ChromaError>),
     #[error("No client found for node: {0}")]
     NoClientFound(String),
-    #[error("Error sending backfill request to compactor")]
-    BackfillError,
+    #[error("Error sending backfill request to compactor: {0}")]
+    BackfillError(Box<dyn ChromaError>),
 }
 
 impl ChromaError for ExecutorError {
@@ -1601,7 +1601,7 @@ impl ChromaError for ExecutorError {
             ExecutorError::CollectionMissingHnswConfiguration => ErrorCodes::Internal,
             ExecutorError::Internal(e) => e.code(),
             ExecutorError::NoClientFound(_) => ErrorCodes::Internal,
-            ExecutorError::BackfillError => ErrorCodes::Internal,
+            ExecutorError::BackfillError(e) => e.code(),
         }
     }
 }


### PR DESCRIPTION

Helps with tracing errors similar to #4212

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Made backfil errors related to init in HNSW index bubble up and be visible in the rust bindings

Before:

```
InternalError: Error executing plan: Error sending backfill request to compactor
```

After:

```
InternalError: Error executing plan: Error sending backfill request to compactor: Error constructing hnsw segment reader: Error creating hnsw segment reader: Error deserializing pickle file: eval error at offset 1: unsupported opcode '\0'
```

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
