### PR TITLE
[BLD]: remove rustup self update in CI

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -7,16 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Update rustup
-      if: runner.os != 'Windows'
-      shell: bash
-      run: |
-        rustup self update
-    - name: Update rustup on Windows
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $env:CARGO_HOME="C:\Users\Default\.cargo"; rustup self update
     - name: Setup Rust
       shell: bash
       # (reads from rust-toolchain.toml)


### PR DESCRIPTION
## Description of changes

Depot runner images now ship with a new enough version of rustup for `rust-toolchain.toml` to work properly.