### PR TITLE
[TST]: parallelize Python property tests in a single job

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -56,7 +56,7 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY }}
           site: ${{ vars.DD_SITE }}
       - name: Test
-        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist loadgroup' || '' }} -v --color=yes
+        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -56,7 +56,7 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY }}
           site: ${{ vars.DD_SITE }}
       - name: Test
-        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v
+        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist loadgroup' || '' }} -v
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
-        platform: [depot-ubuntu-24.04-4, depot-windows-2022-4]
+        platform: [depot-ubuntu-24.04-8, depot-windows-2022-8]
         test-globs:
           - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
           - "chromadb/test/property"

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -56,7 +56,7 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY }}
           site: ${{ vars.DD_SITE }}
       - name: Test
-        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist loadgroup' || '' }} -v
+        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist loadgroup' || '' }} -v --color=yes
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -21,17 +21,13 @@ jobs:
       matrix:
         python: ${{fromJson(inputs.python_versions)}}
         platform: [depot-ubuntu-24.04-4, depot-windows-2022-4]
-        test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'",
-                  "chromadb/test/property/test_add.py",
-                  "chromadb/test/property/test_collections.py",
-                  "chromadb/test/property/test_collections_with_database_tenant.py",
-                  "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
-                  "chromadb/test/property/test_cross_version_persist.py",
-                  "chromadb/test/property/test_embeddings.py",
-                  "chromadb/test/property/test_filtering.py",
-                  "chromadb/test/property/test_persist.py",
-                  "chromadb/test/property/test_restart_persist.py",
-                  ]
+        test-globs:
+          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
+          - "chromadb/test/property"
+        include:
+          - test-globs: "chromadb/test/property"
+            parallelized: true
+
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +56,7 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY }}
           site: ${{ vars.DD_SITE }}
       - name: Test
-        run: python -m pytest ${{ matrix.test-globs }}
+        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -248,6 +248,7 @@ collection_st: st.SearchStrategy[strategies.Collection] = st.shared(
     embeddings_strategy=strategies.recordsets(collection_st, max_size=200),
 )
 @settings(deadline=None)
+@pytest.mark.xdist_group(name="test_cycle_versions")
 def test_cycle_versions(
     version_settings: Tuple[str, Settings],
     collection_strategy: strategies.Collection,

--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -133,7 +133,7 @@ def configurations(versions: List[str]) -> List[Tuple[str, Settings]]:
                 chroma_segment_manager_impl="chromadb.segment.impl.manager.local.LocalSegmentManager",
                 allow_reset=True,
                 is_persistent=True,
-                persist_directory=tempfile.gettempdir() + "/persistence_test_chromadb",
+                persist_directory=tempfile.mkdtemp(),
             ),
         )
         for version in versions
@@ -141,7 +141,7 @@ def configurations(versions: List[str]) -> List[Tuple[str, Settings]]:
 
 
 test_old_versions = versions()
-base_install_dir = tempfile.gettempdir() + "/persistence_test_chromadb_versions"
+base_install_dir = tempfile.mkdtemp()
 
 
 # This fixture is not shared with the rest of the tests because it is unique in how it
@@ -248,7 +248,6 @@ collection_st: st.SearchStrategy[strategies.Collection] = st.shared(
     embeddings_strategy=strategies.recordsets(collection_st, max_size=200),
 )
 @settings(deadline=None)
-@pytest.mark.xdist_group(name="test_cycle_versions")
 def test_cycle_versions(
     version_settings: Tuple[str, Settings],
     collection_strategy: strategies.Collection,

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -29,10 +29,10 @@ from hypothesis.stateful import (
     MultipleResults,
 )
 import os
-import shutil
 from chromadb.api.client import Client as ClientCreator
 from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 import numpy as np
+import tempfile
 
 CreatePersistAPI = Callable[[], ServerAPI]
 
@@ -46,6 +46,7 @@ configurations = (
             chroma_segment_manager_impl="chromadb.segment.impl.manager.local.LocalSegmentManager",
             allow_reset=True,
             is_persistent=True,
+            persist_directory=tempfile.mkdtemp(),
         )
     ]
     if "CHROMA_RUST_BINDINGS_TEST_ONLY" in os.environ
@@ -58,6 +59,7 @@ configurations = (
             chroma_segment_manager_impl="chromadb.segment.impl.manager.local.LocalSegmentManager",
             allow_reset=True,
             is_persistent=True,
+            persist_directory=tempfile.mkdtemp(),
         ),
     ]
 )
@@ -65,15 +67,7 @@ configurations = (
 
 @pytest.fixture(scope="module", params=configurations)
 def settings(request: pytest.FixtureRequest) -> Generator[Settings, None, None]:
-    configuration = request.param
-    save_path = configuration.persist_directory
-    # Create if it doesn't exist
-    if not os.path.exists(save_path):
-        os.makedirs(save_path, exist_ok=True)
-    yield configuration
-    # Remove if it exists
-    if os.path.exists(save_path):
-        shutil.rmtree(save_path, ignore_errors=True)
+    yield request.param
 
 
 collection_st = st.shared(

--- a/chromadb/test/utils/cross_version.py
+++ b/chromadb/test/utils/cross_version.py
@@ -50,20 +50,7 @@ def install_version(version: str, dep_overrides: Dict[str, str]) -> None:
 def install(pkg: str, path: str, dep_overrides: Dict[str, str]) -> int:
     # -q -q to suppress pip output to ERROR level
     # https://pip.pypa.io/en/stable/cli/pip/#quiet
-    print("Purging pip cache")
-    # subprocess.call(
-    #     [
-    #         sys.executable,
-    #         "-m",
-    #         "pip",
-    #         "cache",
-    #         "purge",
-    #     ]
-    # )
-
     command = [sys.executable, "-m", "pip", "-q", "-q", "install", pkg]
-    # print("installing version", pkg, path, dep_overrides)
-    # command = ["uv", "pip", "-q", "install", pkg]
 
     for dep, operator_version in dep_overrides.items():
         command.append(f"{dep}{operator_version}")

--- a/chromadb/test/utils/cross_version.py
+++ b/chromadb/test/utils/cross_version.py
@@ -51,17 +51,19 @@ def install(pkg: str, path: str, dep_overrides: Dict[str, str]) -> int:
     # -q -q to suppress pip output to ERROR level
     # https://pip.pypa.io/en/stable/cli/pip/#quiet
     print("Purging pip cache")
-    subprocess.call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "cache",
-            "purge",
-        ]
-    )
+    # subprocess.call(
+    #     [
+    #         sys.executable,
+    #         "-m",
+    #         "pip",
+    #         "cache",
+    #         "purge",
+    #     ]
+    # )
 
     command = [sys.executable, "-m", "pip", "-q", "-q", "install", pkg]
+    # print("installing version", pkg, path, dep_overrides)
+    # command = ["uv", "pip", "-q", "install", pkg]
 
     for dep, operator_version in dep_overrides.items():
         command.append(f"{dep}{operator_version}")

--- a/chromadb/test/utils/cross_version.py
+++ b/chromadb/test/utils/cross_version.py
@@ -51,7 +51,7 @@ def install(pkg: str, path: str, dep_overrides: Dict[str, str]) -> int:
     # -q -q to suppress pip output to ERROR level
     # https://pip.pypa.io/en/stable/cli/pip/#quiet
     print("Purging pip cache")
-    subprocess.check_call(
+    subprocess.call(
         [
             sys.executable,
             "-m",


### PR DESCRIPTION
## Description of changes

Parallelizes Python property tests to run in a single job. Saves about 3m of wall time and is 2.6x cheaper in compute costs.

As an example, before this change a [sample run](https://github.com/chroma-core/chroma/actions/runs/14342162428/job/40203844517?pr=4211) took ~16m in wall time and consumed 8,266s of compute (after the multiplier for the instance size).

After this change, the property tests take [~13m in wall time](https://github.com/chroma-core/chroma/actions/runs/14345988691/job/40215763200?pr=4225) and consume 3,144s of compute (even though I doubled the instance size).

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a