### PR TITLE
[ENH]: Huggingface Embedding Server authorization (#4222)

### DIFF
--- a/clients/js/packages/chromadb-core/src/embeddings/HuggingFaceEmbeddingServerFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/HuggingFaceEmbeddingServerFunction.ts
@@ -3,17 +3,20 @@ import { IEmbeddingFunction } from "./IEmbeddingFunction";
 
 type StoredConfig = {
   url: string;
+  apiKey?: string;
 };
 
 export class HuggingFaceEmbeddingServerFunction implements IEmbeddingFunction {
   name = "huggingface_server";
 
   private url: string;
+  private apiKey?: string;
 
-  constructor({ url }: { url: string }) {
+  constructor({ url, apiKey }: { url: string, apiKey?: string }) {
     // we used to construct the client here, but we need to async import the types
     // for the openai npm package, and the constructor can not be async
     this.url = url;
+    this.apiKey = apiKey;
   }
 
   public async generate(texts: string[]) {
@@ -21,6 +24,7 @@ export class HuggingFaceEmbeddingServerFunction implements IEmbeddingFunction {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        ...(this.apiKey && { "Authorization": `Bearer ${this.apiKey}` })
       },
       body: JSON.stringify({ inputs: texts }),
     });
@@ -40,6 +44,7 @@ export class HuggingFaceEmbeddingServerFunction implements IEmbeddingFunction {
   getConfig(): StoredConfig {
     return {
       url: this.url,
+      apiKey: this.apiKey
     };
   }
 

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/hugging-face-server.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/hugging-face-server.md
@@ -43,7 +43,7 @@ huggingface_ef = HuggingFaceEmbeddingServer(url="http://localhost:8001/embed")
 
 ```typescript
 import  {HuggingFaceEmbeddingServerFunction} from 'chromadb';
-const embedder = new HuggingFaceEmbeddingServerFunction({url:"http://localhost:8001/embed"})
+const embedder = new HuggingFaceEmbeddingServerFunction({ url: "http://localhost:8001/embed" })
 
 // use directly
 const embeddings = embedder.generate(["document1","document2"])
@@ -57,3 +57,30 @@ collection = await client.getCollection({name: "name", embeddingFunction: embedd
 {% /TabbedCodeBlock %}
 
 The embedding model is configured on the server side. Check the docker-compose file in `examples/server_side_embeddings/huggingface/docker-compose.yml` for an example of how to configure the server.
+
+## Authentication
+
+The embedding server can be configured to only allow usage with API keys. 
+You can use authentication in the chroma clients:
+
+{% TabbedCodeBlock %}
+
+{% Tab label="python" %}
+
+```python
+from chromadb.utils.embedding_functions import HuggingFaceEmbeddingServer
+huggingface_ef = HuggingFaceEmbeddingServer(url="http://localhost:8001/embed", api_key="your secret key")
+```
+
+{% /Tab %}
+
+{% Tab label="typescript" %}
+
+
+```typescript
+import  {HuggingFaceEmbeddingServerFunction} from 'chromadb';
+const embedder = new HuggingFaceEmbeddingServerFunction({ url: "http://localhost:8001/embed", apiKey: "your secret key" })
+```
+
+{% /Tab %}
+{% /TabbedCodeBlock %}


### PR DESCRIPTION
## Description of changes
Add Bearer authorization option to `HuggingFaceEmbeddingServerFunction`

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

Documentation has been updated.
