### PR TITLE
[BUG]: remove leading slash from version file name

### DIFF
--- a/go/pkg/sysdb/metastore/s3/impl.go
+++ b/go/pkg/sysdb/metastore/s3/impl.go
@@ -22,7 +22,7 @@ import (
 // Example:
 // s3://<bucket-name>/<sysdbPathPrefix>/<tenant_id>/databases/<database_id>/collections/<collection_id>/versionfiles/file_name
 const (
-	versionFilesPathFormat = "%s/%s/databases/%s/collections/%s/versionfiles/%s"
+	versionFilesPathFormat = "%s/databases/%s/collections/%s/versionfiles/%s"
 )
 
 type S3MetaStoreConfig struct {
@@ -201,7 +201,7 @@ func (store *S3MetaStore) PutVersionFile(tenantID, databaseID, collectionID stri
 // GetVersionFilePath constructs the S3 path for a version file
 func (store *S3MetaStore) GetVersionFilePath(tenantID, databaseID, collectionID, versionFileName string) string {
 	return fmt.Sprintf(versionFilesPathFormat,
-		store.BasePathSysDB, tenantID, databaseID, collectionID, versionFileName)
+		tenantID, databaseID, collectionID, versionFileName)
 }
 
 // DeleteOldVersionFiles removes version files older than the specified version


### PR DESCRIPTION
## Description of changes

Minio and S3 treat leading in keys differently. Minio strips the leading slash, S3 does not. This means that attempting to look up the key `/foo` for `s3://sample-bucket/foo` fails, but succeeds when testing locally with Minio.

This materializes as the garbage collector being unable to fetch version files in staging.

I will update the `collections.version_file_name` column in staging after merge to manually remove the leading slash.

## Test plan
*How are these changes tested?*

I connected to the Postgres sysdb in my local environment and verified that version file names are now saved without a slash prefix.