### PR TITLE
[CHORE] Add purge logs no-op impl to go log service

### DIFF
--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -105,6 +105,11 @@ func (s *logServer) UpdateCollectionLogOffset(ctx context.Context, req *logservi
 	return
 }
 
+func (s *logServer) PurgeDirtyForCollection(ctx context.Context, req *logservicepb.PurgeDirtyForCollectionRequest) (res *logservicepb.PurgeDirtyForCollectionResponse, err error) {
+	// no-op for now
+	return
+}
+
 func NewLogServer(lr *repository.LogRepository) logservicepb.LogServiceServer {
 	return &logServer{
 		lr: lr,


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds a no-op impl so that we don't get errors on this call for deployments using the legacy path. 
 - New functionality
   - None

## Test plan
*How are these changes tested?*
They are not automated test
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
