### PR TITLE
[ENH] Add ttl to sysdb cache on RFE

### DIFF
--- a/bin/rust_single_node_integration_test_config.yaml
+++ b/bin/rust_single_node_integration_test_config.yaml
@@ -4,6 +4,7 @@ sqlitedb:
 collections_with_segments_provider:
   cache:
     nop:
+  cache_ttl_secs: 60
   permitted_parallelism: 32
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -1,7 +1,6 @@
 use super::{CacheError, Weighted};
 use ahash::RandomState;
 use chroma_error::ChromaError;
-use chroma_types::CollectionAndSegments;
 use clap::Parser;
 use foyer::{
     CacheBuilder, DirectFsDeviceOptions, Engine, FifoConfig, FifoPicker, HybridCacheBuilder,
@@ -636,12 +635,6 @@ where
     K: Clone + Send + Sync + Eq + PartialEq + Hash + StorageKey + 'static,
     V: Clone + Send + Sync + Weighted + StorageValue + 'static,
 {
-}
-
-impl crate::Weighted for CollectionAndSegments {
-    fn weight(&self) -> usize {
-        1
-    }
 }
 
 #[cfg(test)]

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -13,6 +13,7 @@ collections_with_segments_provider:
   cache:
     lru:
       capacity: 1000
+  cache_ttl_secs: 60
   permitted_parallelism: 180
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -13,6 +13,7 @@ collections_with_segments_provider:
   cache:
     lru:
       capacity: 1000
+  cache_ttl_secs: 60
   permitted_parallelism: 180
   cache_invalidation_retry_policy:
     delay_ms: 0

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -1,11 +1,14 @@
 use backon::ConstantBuilder;
-use chroma_cache::{AysncPartitionedMutex, Cache, CacheError};
+use chroma_cache::{AysncPartitionedMutex, Cache, CacheError, Weighted};
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_types::{CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError};
 use serde::{Deserialize, Serialize};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use thiserror::Error;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -35,6 +38,7 @@ impl Default for CacheInvalidationRetryConfig {
 #[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct CollectionsWithSegmentsProviderConfig {
     pub cache: chroma_cache::CacheConfig,
+    pub cache_ttl_secs: u32,
     pub permitted_parallelism: u32,
     #[serde(default = "CacheInvalidationRetryConfig::default")]
     pub cache_invalidation_retry_policy: CacheInvalidationRetryConfig,
@@ -44,6 +48,7 @@ impl Default for CollectionsWithSegmentsProviderConfig {
     fn default() -> Self {
         Self {
             cache: chroma_cache::CacheConfig::Nop,
+            cache_ttl_secs: 60,
             permitted_parallelism: 100,
             cache_invalidation_retry_policy: CacheInvalidationRetryConfig::default(),
         }
@@ -56,9 +61,11 @@ impl Configurable<CollectionsWithSegmentsProviderConfig> for CollectionsWithSegm
         config: &CollectionsWithSegmentsProviderConfig,
         registry: &chroma_config::registry::Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
-        let collections_with_segments_cache =
-            chroma_cache::from_config::<CollectionUuid, CollectionAndSegments>(&config.cache)
-                .await?;
+        let collections_with_segments_cache = chroma_cache::from_config::<
+            CollectionUuid,
+            CollectionAndSegmentsWithTtl,
+        >(&config.cache)
+        .await?;
         let sysdb_rpc_lock =
             AysncPartitionedMutex::with_parallelism(config.permitted_parallelism as usize, ());
 
@@ -75,17 +82,32 @@ impl Configurable<CollectionsWithSegmentsProviderConfig> for CollectionsWithSegm
         Ok(Self {
             sysdb_client: sysdb,
             collections_with_segments_cache: collections_with_segments_cache.into(),
+            cache_ttl_secs: config.cache_ttl_secs,
             sysdb_rpc_lock,
             retry_backoff,
         })
     }
 }
 
+impl Weighted for CollectionAndSegmentsWithTtl {
+    fn weight(&self) -> usize {
+        1
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CollectionAndSegmentsWithTtl {
+    pub collection_and_segments: CollectionAndSegments,
+    // Duration since unix epoch upto which the cache entry is valid.
+    pub expires_at: Duration,
+}
+
 #[derive(Clone, Debug)]
 pub struct CollectionsWithSegmentsProvider {
     pub(crate) sysdb_client: SysDb,
     pub(crate) collections_with_segments_cache:
-        Arc<dyn Cache<CollectionUuid, CollectionAndSegments>>,
+        Arc<dyn Cache<CollectionUuid, CollectionAndSegmentsWithTtl>>,
+    pub(crate) cache_ttl_secs: u32,
     pub(crate) sysdb_rpc_lock: chroma_cache::AysncPartitionedMutex<CollectionUuid>,
     pub(crate) retry_backoff: ConstantBuilder,
 }
@@ -116,42 +138,56 @@ impl CollectionsWithSegmentsProvider {
         &mut self,
         collection_id: CollectionUuid,
     ) -> Result<CollectionAndSegments, CollectionsWithSegmentsProviderError> {
-        match self
+        if let Some(collection_and_segments_with_ttl) = self
             .collections_with_segments_cache
             .get(&collection_id)
             .await?
         {
-            Some(collection_and_segments) => Ok(collection_and_segments),
-            None => {
-                tracing::info!("Cache miss for collection {}", collection_id);
-                // We acquire a lock to prevent the sysdb from experiencing a thundering herd.
-                // This can happen when a large number of threads try to get the same collection
-                // at the same time.
-                let _guard = self.sysdb_rpc_lock.lock(&collection_id).await;
-                // Double checked locking pattern to avoid lock contention in the
-                // happy path when the collection is already cached.
-                match self
-                    .collections_with_segments_cache
-                    .get(&collection_id)
-                    .await?
-                {
-                    Some(collection_and_segments) => Ok(collection_and_segments),
-                    None => {
-                        tracing::info!("Cache miss again for collection {}", collection_id);
-                        let collection_and_segments_sysdb = self
-                            .sysdb_client
-                            .get_collection_with_segments(collection_id)
-                            .await?;
-                        // Insert only if the collection dimension is set.
-                        if collection_and_segments_sysdb.collection.dimension.is_some() {
-                            self.collections_with_segments_cache
-                                .insert(collection_id, collection_and_segments_sysdb.clone())
-                                .await;
-                        }
-                        Ok(collection_and_segments_sysdb)
-                    }
-                }
+            if collection_and_segments_with_ttl.expires_at
+                >= SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Do not deploy before UNIX epoch")
+            {
+                return Ok(collection_and_segments_with_ttl.collection_and_segments);
             }
         }
+        // We acquire a lock to prevent the sysdb from experiencing a thundering herd.
+        // This can happen when a large number of threads try to get the same collection
+        // at the same time.
+        let _guard = self.sysdb_rpc_lock.lock(&collection_id).await;
+        // Double checked locking pattern to avoid lock contention in the
+        // happy path when the collection is already cached.
+        if let Some(collection_and_segments_with_ttl) = self
+            .collections_with_segments_cache
+            .get(&collection_id)
+            .await?
+        {
+            if collection_and_segments_with_ttl.expires_at
+                >= SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Do not deploy before UNIX epoch")
+            {
+                return Ok(collection_and_segments_with_ttl.collection_and_segments);
+            }
+        }
+        tracing::info!("Cache miss for collection {}", collection_id);
+        let collection_and_segments_sysdb = self
+            .sysdb_client
+            .get_collection_with_segments(collection_id)
+            .await?;
+        let collection_and_segments_sysdb_with_ttl = CollectionAndSegmentsWithTtl {
+            collection_and_segments: collection_and_segments_sysdb.clone(),
+            expires_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Do not deploy before UNIX epoch")
+                + Duration::from_secs(self.cache_ttl_secs as u64), // Cache for 1 minute
+        };
+        // Insert only if the collection dimension is set.
+        if collection_and_segments_sysdb.collection.dimension.is_some() {
+            self.collections_with_segments_cache
+                .insert(collection_id, collection_and_segments_sysdb_with_ttl)
+                .await;
+        }
+        Ok(collection_and_segments_sysdb)
     }
 }

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -163,7 +163,7 @@ impl CollectionsWithSegmentsProvider {
             .await?
         {
             if collection_and_segments_with_ttl.expires_at
-                >= SystemTime::now()
+                > SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("Do not deploy before UNIX epoch")
             {

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -106,6 +106,7 @@ impl Bindings {
             cache_invalidation_retry_policy: CacheInvalidationRetryConfig::new(0, 0),
             permitted_parallelism: 32,
             cache: chroma_cache::CacheConfig::Nop,
+            cache_ttl_secs: 60,
         };
 
         let executor_config = ExecutorConfig::Local(LocalExecutorConfig {});


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds a configurable ttl to collection_and_segments cache on RFE
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
