### PR TITLE
[BUG] Fix JS-client dev release

### DIFF
--- a/.github/workflows/release-dev-javascript-client.yml
+++ b/.github/workflows/release-dev-javascript-client.yml
@@ -50,7 +50,7 @@ jobs:
           cache-dependency-path: 'clients/js/pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
         working-directory: ./clients/js/
 
       - name: Build packages


### PR DESCRIPTION
## Description of changes
* Match dev release for JS-client to standard release workflow.

The JS-client now has optional dependencies for the different JS-bindings libraries, so we need to ignore strictness in the checked in lock file, since pnpm install will pick the binary that matches the runner's OS as opposed to the one chosen when developing locally.