### PR TITLE
[BUG]: use absolute cutoff time when listing collections to garbage collect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,8 +1404,8 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-state-machine",
- "prost 0.13.3",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "rand 0.8.5",
  "roaring",
  "serde",
@@ -1654,7 +1654,7 @@ dependencies = [
  "futures",
  "opentelemetry",
  "proptest",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1694,7 +1694,7 @@ dependencies = [
  "opentelemetry",
  "parquet",
  "proptest",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1832,7 +1832,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
- "prost 0.13.3",
+ "prost 0.13.5",
  "sea-query",
  "sea-query-binder",
  "serde",
@@ -1898,8 +1898,8 @@ dependencies = [
  "chroma-error",
  "proptest",
  "proptest-derive 0.5.1",
- "prost 0.13.3",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "pyo3",
  "regex",
  "roaring",
@@ -3303,7 +3303,7 @@ dependencies = [
  "proptest",
  "proptest-derive 0.3.0",
  "proptest-state-machine",
- "prost 0.13.3",
+ "prost 0.13.5",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5372,7 +5372,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.3",
+ "prost 0.13.5",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -5387,7 +5387,7 @@ checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.3",
+ "prost 0.13.5",
  "tonic",
 ]
 
@@ -5958,12 +5958,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.3",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -5981,7 +5981,7 @@ dependencies = [
  "petgraph",
  "prettyplease",
  "prost 0.12.3",
- "prost-types",
+ "prost-types 0.12.3",
  "regex",
  "syn 2.0.89",
  "tempfile",
@@ -6003,12 +6003,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2 1.0.92",
  "quote 1.0.37",
  "syn 2.0.89",
@@ -6021,6 +6021,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost 0.12.3",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -8152,7 +8161,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.3",
+ "prost 0.13.5",
  "socket2",
  "tokio",
  "tokio-stream",
@@ -8182,7 +8191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
- "prost 0.13.3",
+ "prost 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -9314,8 +9323,8 @@ dependencies = [
  "parking_lot",
  "proptest",
  "proptest-state-machine",
- "prost 0.13.3",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "rand 0.8.5",
  "rand_xorshift",
  "random-port",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 parking_lot = { version = "0.12.3", features = ["serde"] }
 parquet = "52"
 prost = "0.13"
-prost-types = "0.12"
+prost-types = "0.13.5"
 roaring = "0.10.6"
 sea-query = "0.32"
 sea-query-binder = "0.7"

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -434,8 +434,13 @@ func (s *Server) FlushCollectionCompaction(ctx context.Context, req *coordinator
 }
 
 func (s *Server) ListCollectionsToGc(ctx context.Context, req *coordinatorpb.ListCollectionsToGcRequest) (*coordinatorpb.ListCollectionsToGcResponse, error) {
-	// Dumb implementation that just returns ALL the collections for now.
-	collectionsToGc, err := s.coordinator.ListCollectionsToGc(ctx, req.CutoffTimeSecs, req.Limit)
+	absoluteCutoffTimeSecs := (*uint64)(nil)
+	if req.CutoffTime != nil {
+		cutoffTime := uint64(req.CutoffTime.Seconds)
+		absoluteCutoffTimeSecs = &cutoffTime
+	}
+
+	collectionsToGc, err := s.coordinator.ListCollectionsToGc(ctx, absoluteCutoffTimeSecs, req.Limit)
 	if err != nil {
 		log.Error("ListCollectionsToGc failed", zap.Error(err))
 		return nil, grpcutils.BuildInternalGrpcError(err.Error())

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -5,6 +5,7 @@ option go_package = "github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb";
 
 import "chromadb/proto/chroma.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 message CreateDatabaseRequest {
   string id = 1;
@@ -408,7 +409,7 @@ message ListCollectionsToGcRequest {
   // before this cutoff time.
   // SysDb can apply additional logic to return the collections that should
   // be prioritized for GC.
-  optional uint64 cutoff_time_secs = 1;
+  optional google.protobuf.Timestamp cutoff_time = 1;
 
   // Limit the number of collections that can be returned.
   // GC will get n number of collections to GC. After GC is done, it will

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -192,18 +192,6 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
         _message: GarbageCollectMessage,
         ctx: &ComponentContext<Self>,
     ) -> Self::Result {
-        // Get all collections to gc and create gc orchestrator for each.
-        tracing::info!("Getting collections to gc");
-        let collections_to_gc = self
-            .sysdb_client
-            .get_collections_to_gc(
-                Some(self.relative_cutoff_time.as_secs()),
-                Some(self.max_collections_to_gc.into()),
-            )
-            .await
-            .expect("Failed to get collections to gc");
-        tracing::info!("Got {} collections to gc", collections_to_gc.len());
-
         let absolute_cutoff_time =
             DateTime::<Utc>::from(SystemTime::now() - self.relative_cutoff_time);
         tracing::info!(
@@ -211,6 +199,18 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
             absolute_cutoff_time,
             self.relative_cutoff_time
         );
+
+        // Get all collections to gc and create gc orchestrator for each.
+        tracing::info!("Getting collections to gc");
+        let collections_to_gc = self
+            .sysdb_client
+            .get_collections_to_gc(
+                Some(absolute_cutoff_time.into()),
+                Some(self.max_collections_to_gc.into()),
+            )
+            .await
+            .expect("Failed to get collections to gc");
+        tracing::info!("Got {} collections to gc", collections_to_gc.len());
 
         let mut jobs = FuturesUnordered::new();
         for collection in collections_to_gc {


### PR DESCRIPTION
## Description of changes

We currently send a relative cutoff time in seconds to the Sysdb when it expects an absolute cutoff time. This updates the garbage collection service to send an absolute cutoff time instead.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a