### PR TITLE
[ENH]: allow overriding metrics endpoint with standard `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` if set

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -91,7 +91,9 @@ pub fn init_otel_layer(
     // Prepare meter.
     let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_tonic()
-        .with_endpoint(otel_endpoint)
+        .with_endpoint(
+            std::env::var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT").unwrap_or(otel_endpoint.clone()),
+        )
         .build()
         .expect("could not build metric exporter");
 


### PR DESCRIPTION
## Description of changes

`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is a standard environment variable used by [OTLP SDKs](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter). This updates our metric exporter set up so that this value is properly consumed if set.

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a