### PR TITLE
[ENH]: allow specifying environment variables for garbage collector k8s template

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.34
+version: 0.1.35
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/garbage-collector.yaml
+++ b/k8s/distributed-chroma/templates/garbage-collector.yaml
@@ -58,6 +58,10 @@ spec:
           - name: CONFIG_PATH
             value: /config/config.yaml
           {{ end }}
+          {{ range .Values.garbageCollector.env }}
+          - name: {{ .name }}
+{{ .value | nindent 12 }}
+          {{ end }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description of changes

Allows specifying environment variables on the garbage collector service similar to other services.

## Test plan
*How are these changes tested?*

Tested by adding a test `env:` block to `values.yaml` and observing that the new values were correctly built with `helm template .`.