### PR TITLE
[TST]: enable Rust backtraces in Python binding tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
           CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+          RUST_BACKTRACE: 1
 
   test-rust-single-node-integration:
     strategy:


### PR DESCRIPTION
## Description of changes

Hoping this helps debug test failures like this: https://github.com/chroma-core/chroma/actions/runs/14366566402/job/40280832204.

