### PR TITLE
[ENH] Introduce request priority in storage layer

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/unordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/unordered_block_delta.rs
@@ -138,11 +138,13 @@ mod test {
     use crate::arrow::{
         block::{delta::UnorderedBlockDelta, Block},
         config::TEST_MAX_BLOCK_SIZE_BYTES,
-        provider::BlockManager,
+        provider::{BlockGetRequest, BlockManager},
     };
     #[cfg(test)]
     use chroma_cache::new_cache_for_test;
-    use chroma_storage::{local::LocalStorage, Storage};
+    use chroma_storage::{
+        admissioncontrolleds3::StorageRequestPriority, local::LocalStorage, Storage,
+    };
     use chroma_types::{DataRecord, MetadataValue};
     use rand::{random, Rng};
     use roaring::RoaringBitmap;
@@ -194,7 +196,11 @@ mod test {
             values_before_flush.push(read.to_vec());
         }
         block_manager.flush(&block).await.unwrap();
-        let block = block_manager.get(&block.clone().id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: block.id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let key = format!("key{}", i);
@@ -234,7 +240,11 @@ mod test {
         }
         block_manager.flush(&block).await.unwrap();
 
-        let block = block_manager.get(&delta_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: delta_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
 
         assert_eq!(size, block.get_size());
         #[allow(clippy::needless_range_loop)]
@@ -261,7 +271,11 @@ mod test {
         let new_id = forked_block.id;
         let block = block_manager.commit::<&str, String>(forked_block).await;
         block_manager.flush(&block).await.unwrap();
-        let forked_block = block_manager.get(&new_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: new_id,
+            priority: StorageRequestPriority::High,
+        };
+        let forked_block = block_manager.get(block_get_request).await.unwrap().unwrap();
         for i in 0..n {
             let key = format!("key{}", i);
             let read = forked_block.get::<&str, &str>("prefix", &key);
@@ -296,7 +310,11 @@ mod test {
             values_before_flush.push(read);
         }
         block_manager.flush(&block).await.unwrap();
-        let block = block_manager.get(&delta_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: delta_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
         assert_eq!(size, block.get_size());
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
@@ -329,7 +347,11 @@ mod test {
         let delta_id = delta.id;
         let block = block_manager.commit::<&str, RoaringBitmap>(delta).await;
         block_manager.flush(&block).await.unwrap();
-        let block = block_manager.get(&delta_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: delta_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
 
         assert_eq!(size, block.get_size());
 
@@ -394,7 +416,11 @@ mod test {
         let delta_id = delta.id;
         let block = block_manager.commit::<&str, &DataRecord>(delta).await;
         block_manager.flush(&block).await.unwrap();
-        let block = block_manager.get(&delta_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: delta_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
         for i in 0..3 {
             let read = block.get::<&str, DataRecord>("", ids[i]).unwrap();
             assert_eq!(read.id, ids[i]);
@@ -429,7 +455,11 @@ mod test {
         let delta_id = delta.id;
         let block = block_manager.commit::<u32, String>(delta).await;
         block_manager.flush(&block).await.unwrap();
-        let block = block_manager.get(&delta_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: delta_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
         assert_eq!(size, block.get_size());
 
         // test save/load
@@ -465,7 +495,11 @@ mod test {
         }
         block_manager.flush(&block).await.unwrap();
 
-        let block = block_manager.get(&delta_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: delta_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
 
         assert_eq!(size, block.get_size());
         #[allow(clippy::needless_range_loop)]
@@ -492,7 +526,11 @@ mod test {
         let new_id = forked_block.id;
         let block = block_manager.commit::<u32, u32>(forked_block).await;
         block_manager.flush(&block).await.unwrap();
-        let forked_block = block_manager.get(&new_id).await.unwrap().unwrap();
+        let block_get_request = BlockGetRequest {
+            id: new_id,
+            priority: StorageRequestPriority::High,
+        };
+        let forked_block = block_manager.get(block_get_request).await.unwrap().unwrap();
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let key = i as u32;

--- a/rust/blockstore/src/arrow/block/delta/unordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/unordered_block_delta.rs
@@ -138,7 +138,7 @@ mod test {
     use crate::arrow::{
         block::{delta::UnorderedBlockDelta, Block},
         config::TEST_MAX_BLOCK_SIZE_BYTES,
-        provider::{BlockGetRequest, BlockManager},
+        provider::BlockManager,
     };
     #[cfg(test)]
     use chroma_cache::new_cache_for_test;
@@ -196,11 +196,11 @@ mod test {
             values_before_flush.push(read.to_vec());
         }
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: block.id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&block.id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let key = format!("key{}", i);
@@ -240,11 +240,11 @@ mod test {
         }
         block_manager.flush(&block).await.unwrap();
 
-        let block_get_request = BlockGetRequest {
-            id: delta_id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&delta_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(size, block.get_size());
         #[allow(clippy::needless_range_loop)]
@@ -271,11 +271,11 @@ mod test {
         let new_id = forked_block.id;
         let block = block_manager.commit::<&str, String>(forked_block).await;
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: new_id,
-            priority: StorageRequestPriority::High,
-        };
-        let forked_block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let forked_block = block_manager
+            .get(&new_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
         for i in 0..n {
             let key = format!("key{}", i);
             let read = forked_block.get::<&str, &str>("prefix", &key);
@@ -310,11 +310,11 @@ mod test {
             values_before_flush.push(read);
         }
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: delta_id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&delta_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(size, block.get_size());
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
@@ -347,11 +347,11 @@ mod test {
         let delta_id = delta.id;
         let block = block_manager.commit::<&str, RoaringBitmap>(delta).await;
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: delta_id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&delta_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(size, block.get_size());
 
@@ -416,11 +416,11 @@ mod test {
         let delta_id = delta.id;
         let block = block_manager.commit::<&str, &DataRecord>(delta).await;
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: delta_id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&delta_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
         for i in 0..3 {
             let read = block.get::<&str, DataRecord>("", ids[i]).unwrap();
             assert_eq!(read.id, ids[i]);
@@ -455,11 +455,11 @@ mod test {
         let delta_id = delta.id;
         let block = block_manager.commit::<u32, String>(delta).await;
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: delta_id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&delta_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(size, block.get_size());
 
         // test save/load
@@ -495,11 +495,11 @@ mod test {
         }
         block_manager.flush(&block).await.unwrap();
 
-        let block_get_request = BlockGetRequest {
-            id: delta_id,
-            priority: StorageRequestPriority::High,
-        };
-        let block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let block = block_manager
+            .get(&delta_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
 
         assert_eq!(size, block.get_size());
         #[allow(clippy::needless_range_loop)]
@@ -526,11 +526,11 @@ mod test {
         let new_id = forked_block.id;
         let block = block_manager.commit::<u32, u32>(forked_block).await;
         block_manager.flush(&block).await.unwrap();
-        let block_get_request = BlockGetRequest {
-            id: new_id,
-            priority: StorageRequestPriority::High,
-        };
-        let forked_block = block_manager.get(block_get_request).await.unwrap().unwrap();
+        let forked_block = block_manager
+            .get(&new_id, StorageRequestPriority::P0)
+            .await
+            .unwrap()
+            .unwrap();
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
             let key = i as u32;

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -1,5 +1,5 @@
 use super::migrations::{apply_migrations_to_blockfile, MigrationError};
-use super::provider::{GetError, RootManager};
+use super::provider::{BlockGetRequest, GetError, RootManager};
 use super::root::{RootReader, RootWriter, Version};
 use super::{block::delta::UnorderedBlockDelta, provider::BlockManager};
 use super::{
@@ -13,6 +13,7 @@ use crate::key::CompositeKey;
 use crate::key::KeyWrapper;
 use chroma_error::ChromaError;
 use chroma_error::ErrorCodes;
+use chroma_storage::admissioncontrolleds3::StorageRequestPriority;
 use futures::future::join_all;
 use futures::{Stream, StreamExt, TryStreamExt};
 use parking_lot::Mutex;
@@ -181,7 +182,11 @@ impl ArrowUnorderedBlockfileWriter {
 
         let delta = match delta {
             None => {
-                let block = match self.block_manager.get(&target_block_id).await {
+                let block_get_request = BlockGetRequest {
+                    id: target_block_id,
+                    priority: StorageRequestPriority::High,
+                };
+                let block = match self.block_manager.get(block_get_request).await {
                     Ok(Some(block)) => block,
                     Ok(None) => {
                         return Err(Box::new(ArrowBlockfileError::BlockNotFound));
@@ -260,7 +265,11 @@ impl ArrowUnorderedBlockfileWriter {
 
         let delta = match delta {
             None => {
-                let block = match self.block_manager.get(&target_block_id).await {
+                let block_get_request = BlockGetRequest {
+                    id: target_block_id,
+                    priority: StorageRequestPriority::High,
+                };
+                let block = match self.block_manager.get(block_get_request).await {
                     Ok(Some(block)) => block,
                     Ok(None) => {
                         return Err(Box::new(ArrowBlockfileError::BlockNotFound));
@@ -314,7 +323,11 @@ impl ArrowUnorderedBlockfileWriter {
 
         let delta = match delta {
             None => {
-                let block = match self.block_manager.get(&target_block_id).await {
+                let block_get_request = BlockGetRequest {
+                    id: target_block_id,
+                    priority: StorageRequestPriority::High,
+                };
+                let block = match self.block_manager.get(block_get_request).await {
                     Ok(Some(block)) => block,
                     Ok(None) => {
                         return Err(Box::new(ArrowBlockfileError::BlockNotFound));
@@ -378,12 +391,15 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         }
     }
 
-    pub(super) async fn get_block(&self, block_id: Uuid) -> Result<Option<&Block>, GetError> {
+    pub(super) async fn get_block(
+        &self,
+        request: BlockGetRequest,
+    ) -> Result<Option<&Block>, GetError> {
         // NOTE(rescrv):  This will complain with clippy, but we don't want to hold a reference to
         // the loaded_blocks map across a call to the block manager.
         #[allow(clippy::map_entry)]
-        if !self.loaded_blocks.lock().contains_key(&block_id) {
-            let block = match self.block_manager.get(&block_id).await {
+        if !self.loaded_blocks.lock().contains_key(&request.id) {
+            let block = match self.block_manager.get(request.clone()).await {
                 Ok(Some(block)) => block,
                 Ok(None) => {
                     return Ok(None);
@@ -392,10 +408,12 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     return Err(e);
                 }
             };
-            self.loaded_blocks.lock().insert(block_id, Box::new(block));
+            self.loaded_blocks
+                .lock()
+                .insert(request.id, Box::new(block));
         }
 
-        if let Some(block) = self.loaded_blocks.lock().get(&block_id) {
+        if let Some(block) = self.loaded_blocks.lock().get(&request.id) {
             // https://github.com/mitsuhiko/memo-map/blob/a5db43853b2561145d7778dc2a5bd4b861fbfd75/src/lib.rs#L163
             // This is safe because we only ever insert Box<Block> into the HashMap
             // We never remove the Box<Block> from the HashMap, so the reference is always valid
@@ -429,7 +447,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
             if !self.block_manager.cached(block_id).await
                 && !self.loaded_blocks.lock().contains_key(block_id)
             {
-                futures.push(self.get_block(*block_id));
+                let block_get_request = BlockGetRequest {
+                    id: *block_id,
+                    priority: StorageRequestPriority::Medium,
+                };
+                futures.push(self.get_block(block_get_request));
             }
         }
         join_all(futures).await;
@@ -455,7 +477,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     ) -> Result<Option<V>, Box<dyn ChromaError>> {
         let search_key = CompositeKey::new(prefix.to_string(), key.clone());
         let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
-        let block = self.get_block(target_block_id).await;
+        let block_get_request = BlockGetRequest {
+            id: target_block_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = self.get_block(block_get_request).await;
         match block {
             Ok(Some(block)) => Ok(block.get(prefix, key.clone())),
             Ok(None) => {
@@ -486,7 +512,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                 .map(Ok),
         )
         .try_filter_map(move |block_id| async move {
-            match self.get_block(block_id).await {
+            let block_get_request = BlockGetRequest {
+                id: block_id,
+                priority: StorageRequestPriority::High,
+            };
+            match self.get_block(block_get_request).await {
                 Ok(Some(block)) => Ok(Some(block)),
                 Ok(None) => Err(Box::new(ArrowBlockfileError::BlockNotFound)),
                 Err(e) => Err(Box::new(ArrowBlockfileError::BlockFetchError(e))),
@@ -520,7 +550,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
 
         let mut result: Vec<(K, V)> = vec![];
         for block_id in block_ids {
-            let block_opt = match self.get_block(block_id).await {
+            let block_get_request = BlockGetRequest {
+                id: block_id,
+                priority: StorageRequestPriority::High,
+            };
+            let block_opt = match self.get_block(block_get_request).await {
                 Ok(Some(block)) => Some(block),
                 Ok(None) => {
                     return Err(Box::new(ArrowBlockfileError::BlockNotFound));
@@ -549,7 +583,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
     ) -> Result<bool, Box<dyn ChromaError>> {
         let search_key = CompositeKey::new(prefix.to_string(), key.clone());
         let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
-        let block = match self.get_block(target_block_id).await {
+        let block_get_request = BlockGetRequest {
+            id: target_block_id,
+            priority: StorageRequestPriority::High,
+        };
+        let block = match self.get_block(block_get_request).await {
             Ok(Some(block)) => block,
             Ok(None) => {
                 return Ok(false);
@@ -587,7 +625,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
             self.load_blocks(&block_ids).await;
             let mut result: usize = 0;
             for block_id in block_ids {
-                let block = match self.get_block(block_id).await {
+                let block_get_request = BlockGetRequest {
+                    id: block_id,
+                    priority: StorageRequestPriority::High,
+                };
+                let block = match self.get_block(block_get_request).await {
                     Ok(Some(block)) => block,
                     Ok(None) => {
                         return Err(Box::new(ArrowBlockfileError::BlockNotFound));
@@ -636,8 +678,12 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
             } else {
                 self.load_blocks(&block_ids).await;
                 for block_id in block_ids.iter().take(block_ids.len() - 1) {
+                    let block_get_request = BlockGetRequest {
+                        id: *block_id,
+                        priority: StorageRequestPriority::High,
+                    };
                     let block =
-                        self.get_block(*block_id)
+                        self.get_block(block_get_request)
                             .await
                             .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?
                             .ok_or(Box::new(ArrowBlockfileError::BlockNotFound)
@@ -645,8 +691,12 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     rank += block.len();
                 }
             }
+            let block_get_request = BlockGetRequest {
+                id: *last_id,
+                priority: StorageRequestPriority::High,
+            };
             let last_block = self
-                .get_block(*last_id)
+                .get_block(block_get_request)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>)?
                 .ok_or(Box::new(ArrowBlockfileError::BlockNotFound) as Box<dyn ChromaError>)?;
@@ -664,7 +714,11 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         }
 
         for (_, block_id) in self.root.sparse_index.data.forward.iter() {
-            match self.get_block(block_id.id).await {
+            let block_get_request = BlockGetRequest {
+                id: block_id.id,
+                priority: StorageRequestPriority::High,
+            };
+            match self.get_block(block_get_request).await {
                 Ok(Some(block)) => {
                     if block.get_size() > self.block_manager.max_block_size_bytes() {
                         return false;

--- a/rust/blockstore/src/arrow/migrations.rs
+++ b/rust/blockstore/src/arrow/migrations.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::{
-    provider::{BlockGetRequest, BlockManager},
+    provider::BlockManager,
     root::{RootWriter, Version},
     sparse_index::SetCountError,
 };
@@ -51,11 +51,9 @@ async fn migrate_v1_to_v1_1(
                 .collect::<Vec<Uuid>>();
         }
         for block_id in block_ids.iter() {
-            let block_get_request = BlockGetRequest {
-                id: *block_id,
-                priority: StorageRequestPriority::High,
-            };
-            let block = block_manager.get(block_get_request).await;
+            let block = block_manager
+                .get(block_id, StorageRequestPriority::P0)
+                .await;
             match block {
                 Ok(Some(block)) => {
                     match root.sparse_index.set_count(*block_id, block.len() as u32) {

--- a/rust/blockstore/src/arrow/migrations.rs
+++ b/rust/blockstore/src/arrow/migrations.rs
@@ -1,11 +1,12 @@
 use std::collections::HashSet;
 
 use super::{
-    provider::BlockManager,
+    provider::{BlockGetRequest, BlockManager},
     root::{RootWriter, Version},
     sparse_index::SetCountError,
 };
 use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::admissioncontrolleds3::StorageRequestPriority;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -50,7 +51,11 @@ async fn migrate_v1_to_v1_1(
                 .collect::<Vec<Uuid>>();
         }
         for block_id in block_ids.iter() {
-            let block = block_manager.get(block_id).await;
+            let block_get_request = BlockGetRequest {
+                id: *block_id,
+                priority: StorageRequestPriority::High,
+            };
+            let block = block_manager.get(block_get_request).await;
             match block {
                 Ok(Some(block)) => {
                     match root.sparse_index.set_count(*block_id, block.len() as u32) {

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -3,8 +3,7 @@ use crate::types::{DELETE_LIST_FILE_PREFIX, RENAMED_FILE_PREFIX};
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::HNSW_INDEX_S3_PREFIX;
-use chroma_storage::admissioncontrolleds3::{StorageRequest, StorageRequestPriority};
-use chroma_storage::Storage;
+use chroma_storage::{PutOptions, Storage};
 use chroma_system::{Operator, OperatorType};
 use futures::stream::StreamExt;
 use std::collections::HashSet;
@@ -112,16 +111,8 @@ impl DeleteUnusedFilesOperator {
             "Writing deletion list to S3"
         );
 
-        let storage_request = StorageRequest {
-            key: path.clone(),
-            priority: StorageRequestPriority::High,
-        };
         self.storage
-            .put_bytes(
-                storage_request,
-                final_content.into_bytes(),
-                Default::default(),
-            )
+            .put_bytes(&path, final_content.into_bytes(), PutOptions::default())
             .await
             .map_err(|e| DeleteUnusedFilesError::WriteListError {
                 path: path.clone(),
@@ -301,12 +292,8 @@ mod tests {
     use tempfile::TempDir;
 
     async fn create_test_file(storage: &Storage, path: &str, content: &[u8]) {
-        let storage_request = StorageRequest {
-            key: path.to_string(),
-            priority: StorageRequestPriority::High,
-        };
         storage
-            .put_bytes(storage_request, content.to_vec(), PutOptions::default())
+            .put_bytes(path, content.to_vec(), PutOptions::default())
             .await
             .unwrap();
     }

--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_storage::{admissioncontrolleds3::{StorageRequest, StorageRequestPriority}, Storage};
+use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
@@ -125,11 +125,14 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                             // Attempt to fetch each file
                             for file_path in &file_paths.paths {
                                 let prefixed_path = format!("sparse_index/{}", file_path);
-                                let storage_request = StorageRequest {
-                                    key: prefixed_path.clone(),
-                                    priority: StorageRequestPriority::High,
-                                };
-                                match self.storage.get(storage_request).await {
+                                match self
+                                    .storage
+                                    .get(
+                                        &prefixed_path,
+                                        GetOptions::new(StorageRequestPriority::P0),
+                                    )
+                                    .await
+                                {
                                     Ok(content) => {
                                         total_files_fetched += 1;
                                         total_bytes_fetched += content.len();

--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_storage::Storage;
+use chroma_storage::{admissioncontrolleds3::{StorageRequest, StorageRequestPriority}, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
@@ -125,7 +125,11 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                             // Attempt to fetch each file
                             for file_path in &file_paths.paths {
                                 let prefixed_path = format!("sparse_index/{}", file_path);
-                                match self.storage.get(&prefixed_path).await {
+                                let storage_request = StorageRequest {
+                                    key: prefixed_path.clone(),
+                                    priority: StorageRequestPriority::High,
+                                };
+                                match self.storage.get(storage_request).await {
                                     Ok(content) => {
                                         total_files_fetched += 1;
                                         total_bytes_fetched += content.len();

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_storage::admissioncontrolleds3::{StorageRequest, StorageRequestPriority};
-use chroma_storage::{Storage, StorageError};
+use chroma_storage::admissioncontrolleds3::StorageRequestPriority;
+use chroma_storage::{GetOptions, Storage, StorageError};
 use chroma_system::{Operator, OperatorType};
 use thiserror::Error;
 
@@ -88,18 +88,21 @@ impl Operator<FetchVersionFileInput, FetchVersionFileOutput> for FetchVersionFil
             "Starting to fetch version file"
         );
 
-        let storage_request = StorageRequest {
-            key: input.version_file_path.clone(),
-            priority: StorageRequestPriority::High,
-        };
-        let content = input.storage.get(storage_request).await.map_err(|e| {
-            tracing::error!(
-                error = ?e,
-                path = %input.version_file_path,
-                "Failed to fetch version file"
-            );
-            FetchVersionFileError::StorageError(e)
-        })?;
+        let content = input
+            .storage
+            .get(
+                &input.version_file_path,
+                GetOptions::new(StorageRequestPriority::P0),
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    path = %input.version_file_path,
+                    "Failed to fetch version file"
+                );
+                FetchVersionFileError::StorageError(e)
+            })?;
 
         tracing::info!(
             path = %input.version_file_path,
@@ -151,13 +154,9 @@ mod tests {
         let test_content = vec![1, 2, 3, 4, 5];
         let test_file_path = "test_version_file.txt";
 
-        let storage_request = StorageRequest {
-            key: test_file_path.to_string(),
-            priority: StorageRequestPriority::High,
-        };
         // Add more detailed error handling for the put operation
         match storage
-            .put_bytes(storage_request, test_content.clone(), PutOptions::default())
+            .put_bytes(test_file_path, test_content.clone(), PutOptions::default())
             .await
         {
             Ok(_) => tracing::info!("Successfully wrote test file"),

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -442,7 +442,7 @@ impl CountBasedPolicy {
         let mut remaining_tokens = Vec::with_capacity(bandwidth_allocation.len());
         for allocation in bandwidth_allocation {
             remaining_tokens.push(Semaphore::new(
-                (max_allowed_outstanding as f32 * allocation) as usize,
+                (max_allowed_outstanding as f32 * allocation).ceil() as usize,
             ));
         }
         Self { remaining_tokens }

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -464,7 +464,9 @@ impl CountBasedPolicy {
                 },
             }
         }
-        let token_res = self.remaining_tokens[priority as usize].acquire().await;
+        let token_res = self.remaining_tokens[StorageRequestPriority::as_usize(priority)]
+            .acquire()
+            .await;
         match token_res {
             Ok(token) => token,
             Err(e) => panic!("AcquireToken Failed {}", e),

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -56,6 +56,16 @@ pub enum StorageRequestPriority {
     Medium = 1,
 }
 
+impl StorageRequestPriority {
+    pub fn max() -> Self {
+        StorageRequestPriority::Medium
+    }
+
+    pub fn as_usize(self) -> usize {
+        self as usize
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StorageRequest {
     pub key: String,
@@ -441,7 +451,9 @@ impl CountBasedPolicy {
     }
     async fn acquire(&self, priority: StorageRequestPriority) -> SemaphorePermit<'_> {
         // TODO(Sanket): Check for index out of bound.
-        for lower_pri in priority as usize..=StorageRequestPriority::Medium as usize {
+        for lower_pri in StorageRequestPriority::as_usize(priority)
+            ..=StorageRequestPriority::as_usize(StorageRequestPriority::max())
+        {
             match self.remaining_tokens[lower_pri].try_acquire() {
                 Ok(token) => {
                     return token;

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -148,11 +148,17 @@ impl Default for AdmissionControlledS3StorageConfig {
 pub struct CountBasedPolicyConfig {
     #[serde(default = "CountBasedPolicyConfig::default_max_concurrent_requests")]
     pub max_concurrent_requests: usize,
+    #[serde(default = "CountBasedPolicyConfig::default_bandwidth_allocation")]
+    pub bandwidth_allocation: Vec<f32>,
 }
 
 impl CountBasedPolicyConfig {
     fn default_max_concurrent_requests() -> usize {
         15
+    }
+
+    fn default_bandwidth_allocation() -> Vec<f32> {
+        vec![1.0]
     }
 }
 
@@ -160,6 +166,7 @@ impl Default for CountBasedPolicyConfig {
     fn default() -> Self {
         CountBasedPolicyConfig {
             max_concurrent_requests: Self::default_max_concurrent_requests(),
+            bandwidth_allocation: Self::default_bandwidth_allocation(),
         }
     }
 }

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -154,11 +154,11 @@ pub struct CountBasedPolicyConfig {
 
 impl CountBasedPolicyConfig {
     fn default_max_concurrent_requests() -> usize {
-        15
+        30
     }
 
     fn default_bandwidth_allocation() -> Vec<f32> {
-        vec![1.0]
+        vec![0.7, 0.3]
     }
 }
 

--- a/rust/storage/src/local.rs
+++ b/rust/storage/src/local.rs
@@ -65,10 +65,15 @@ impl LocalStorage {
         }
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<Option<ETag>, StorageError> {
+    pub async fn put_file(
+        &self,
+        key: &str,
+        path: &str,
+        options: PutOptions,
+    ) -> Result<Option<ETag>, StorageError> {
         let file = std::fs::read(path);
         match file {
-            Ok(bytes_u8) => self.put_bytes(key, &bytes_u8, PutOptions::default()).await,
+            Ok(bytes_u8) => self.put_bytes(key, &bytes_u8, options).await,
             Err(e) => Err(StorageError::Generic {
                 source: Arc::new(e),
             }),

--- a/rust/storage/src/object_store.rs
+++ b/rust/storage/src/object_store.rs
@@ -187,7 +187,12 @@ impl ObjectStore {
         Ok(Arc::new(output_buffer))
     }
 
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<Option<ETag>, StorageError> {
+    pub async fn put_file(
+        &self,
+        key: &str,
+        path: &str,
+        _: crate::PutOptions,
+    ) -> Result<Option<ETag>, StorageError> {
         let multipart = self.object_store.put_multipart(&Path::from(key)).await?;
         let multipart = Arc::new(Mutex::new(multipart));
         let file_size = tokio::fs::metadata(path)
@@ -329,6 +334,8 @@ impl ObjectStore {
 
 #[cfg(test)]
 mod tests {
+    use crate::PutOptions;
+
     use super::*;
 
     #[test]
@@ -383,7 +390,10 @@ mod tests {
         let bytes = b"test data".to_vec();
         let path = "test_file";
         tokio::fs::write(path, &bytes).await.unwrap();
-        object_store.put_file(key, path).await.unwrap();
+        object_store
+            .put_file(key, path, PutOptions::default())
+            .await
+            .unwrap();
         let result = object_store.get(key).await.unwrap();
         assert_eq!(result, bytes.into());
         std::fs::remove_file(path).unwrap();

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -372,7 +372,12 @@ impl S3Storage {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn put_file(&self, key: &str, path: &str) -> Result<Option<ETag>, StorageError> {
+    pub async fn put_file(
+        &self,
+        key: &str,
+        path: &str,
+        options: PutOptions,
+    ) -> Result<Option<ETag>, StorageError> {
         let file_size = tokio::fs::metadata(path)
             .await
             .map_err(|err| StorageError::Generic {
@@ -401,7 +406,7 @@ impl S3Storage {
                 }
                 .boxed()
             },
-            PutOptions::default(),
+            options,
         )
         .await
     }
@@ -781,6 +786,8 @@ pub async fn s3_client_for_test_with_new_bucket() -> crate::Storage {
 mod tests {
     use std::future::ready;
 
+    use crate::admissioncontrolleds3::StorageRequestPriority;
+
     use super::*;
     use rand::{distributions::Alphanumeric, Rng, SeedableRng};
     use std::io::Write;
@@ -869,7 +876,11 @@ mod tests {
         }
 
         storage
-            .put_file("test", temp_file.path().to_str().unwrap())
+            .put_file(
+                "test",
+                temp_file.path().to_str().unwrap(),
+                PutOptions::default(),
+            )
             .await
             .unwrap();
 
@@ -975,6 +986,7 @@ mod tests {
                 PutOptions {
                     if_not_exists: true,
                     if_match: None,
+                    priority: StorageRequestPriority::P0,
                 },
             )
             .await
@@ -988,6 +1000,7 @@ mod tests {
                 PutOptions {
                     if_not_exists: true,
                     if_match: None,
+                    priority: StorageRequestPriority::P0,
                 },
             )
             .await
@@ -1013,6 +1026,7 @@ mod tests {
                 PutOptions {
                     if_not_exists: true,
                     if_match: None,
+                    priority: StorageRequestPriority::P0,
                 },
             )
             .await
@@ -1028,6 +1042,7 @@ mod tests {
                 PutOptions {
                     if_not_exists: false,
                     if_match: e_tag,
+                    priority: StorageRequestPriority::P0,
                 },
             )
             .await
@@ -1045,6 +1060,7 @@ mod tests {
                 PutOptions {
                     if_not_exists: true,
                     if_match: None,
+                    priority: StorageRequestPriority::P0,
                 },
             )
             .await
@@ -1058,6 +1074,7 @@ mod tests {
                 PutOptions {
                     if_not_exists: false,
                     if_match: Some(ETag("e_tag".to_string())),
+                    priority: StorageRequestPriority::P0,
                 },
             )
             .await
@@ -1083,5 +1100,6 @@ mod tests {
 
         assert!(!default.if_not_exists);
         assert_eq!(default.if_match, None);
+        assert_eq!(default.priority, StorageRequestPriority::P0);
     }
 }

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -1,3 +1,4 @@
+use chroma_storage::admissioncontrolleds3::{StorageRequest, StorageRequestPriority};
 use chroma_types::{
     Collection, CollectionAndSegments, CollectionUuid, Database, FlushCompactionResponse,
     GetCollectionSizeError, GetCollectionWithSegmentsError, GetSegmentsError, ListDatabasesError,
@@ -333,8 +334,12 @@ impl TestSysDb {
         // Write the serialized bytes to storage
         if let Some(storage) = storage {
             let result = tokio::task::block_in_place(|| {
+                let storage_request = StorageRequest {
+                    key: version_file_name.clone(),
+                    priority: StorageRequestPriority::High,
+                };
                 tokio::runtime::Handle::current().block_on(storage.put_bytes(
-                    &version_file_name,
+                    storage_request,
                     version_file_bytes,
                     PutOptions::default(),
                 ))

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -1,4 +1,3 @@
-use chroma_storage::admissioncontrolleds3::{StorageRequest, StorageRequestPriority};
 use chroma_types::{
     Collection, CollectionAndSegments, CollectionUuid, Database, FlushCompactionResponse,
     GetCollectionSizeError, GetCollectionWithSegmentsError, GetSegmentsError, ListDatabasesError,
@@ -334,12 +333,8 @@ impl TestSysDb {
         // Write the serialized bytes to storage
         if let Some(storage) = storage {
             let result = tokio::task::block_in_place(|| {
-                let storage_request = StorageRequest {
-                    key: version_file_name.clone(),
-                    priority: StorageRequestPriority::High,
-                };
                 tokio::runtime::Handle::current().block_on(storage.put_bytes(
-                    storage_request,
+                    &version_file_name,
                     version_file_bytes,
                     PutOptions::default(),
                 ))

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use setsum::Setsum;
 
-use chroma_storage::{Storage, StorageError};
+use chroma_storage::{admissioncontrolleds3::{StorageRequest, StorageRequestPriority}, Storage, StorageError};
 
 use crate::{
     parse_fragment_path, Error, Fragment, LogPosition, LogReaderOptions, Manifest, ScrubError,
@@ -145,9 +145,13 @@ impl LogReader {
     #[tracing::instrument(skip(self))]
     pub async fn fetch(&self, fragment: &Fragment) -> Result<Arc<Vec<u8>>, Error> {
         let path = format!("{}/{}", self.prefix, fragment.path);
+        let storage_request = StorageRequest {
+            key: path.clone(),
+            priority: StorageRequestPriority::High,
+        };
         Ok(self
             .storage
-            .get_with_e_tag(&path)
+            .get_with_e_tag(storage_request)
             .await
             .map_err(Arc::new)?
             .0)
@@ -295,10 +299,12 @@ pub async fn read_parquet(
     prefix: &str,
     path: &str,
 ) -> Result<(Setsum, Vec<(LogPosition, Vec<u8>)>, u64), Error> {
-    let parquet = storage
-        .get(&format!("{prefix}/{path}"))
-        .await
-        .map_err(Arc::new)?;
+    let path = format!("{prefix}/{path}");
+    let storage_request = StorageRequest {
+        key: path.clone(),
+        priority: StorageRequestPriority::High,
+    };
+    let parquet = storage.get(storage_request).await.map_err(Arc::new)?;
     let num_bytes = parquet.len() as u64;
     let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::from_owner(parquet.to_vec()))
         .map_err(Arc::new)?;

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use arrow::array::{ArrayRef, BinaryArray, RecordBatch, UInt64Array};
-use chroma_storage::admissioncontrolleds3::{StorageRequest, StorageRequestPriority};
+use chroma_storage::admissioncontrolleds3::StorageRequestPriority;
 use chroma_storage::{PutOptions, Storage, StorageError};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
@@ -491,12 +491,12 @@ pub async fn upload_parquet(
     loop {
         tracing::info!("upload_parquet: {:?}", path);
         let (buffer, setsum) = construct_parquet(log_position, &messages)?;
-        let storage_request = StorageRequest {
-            key: path.clone(),
-            priority: StorageRequestPriority::High,
-        };
         match storage
-            .put_bytes(storage_request, buffer.clone(), PutOptions::if_not_exists())
+            .put_bytes(
+                &path,
+                buffer.clone(),
+                PutOptions::if_not_exists(StorageRequestPriority::P0),
+            )
             .await
         {
             Ok(_) => {

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime};
 
 use arrow::array::{ArrayRef, BinaryArray, RecordBatch, UInt64Array};
+use chroma_storage::admissioncontrolleds3::{StorageRequest, StorageRequestPriority};
 use chroma_storage::{PutOptions, Storage, StorageError};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
@@ -490,8 +491,12 @@ pub async fn upload_parquet(
     loop {
         tracing::info!("upload_parquet: {:?}", path);
         let (buffer, setsum) = construct_parquet(log_position, &messages)?;
+        let storage_request = StorageRequest {
+            key: path.clone(),
+            priority: StorageRequestPriority::High,
+        };
         match storage
-            .put_bytes(&path, buffer.clone(), PutOptions::if_not_exists())
+            .put_bytes(storage_request, buffer.clone(), PutOptions::if_not_exists())
             .await
         {
             Ok(_) => {

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -36,8 +36,8 @@ query_service:
                 download_part_size_bytes: 8388608 # 8MiB
             rate_limiting_policy:
                 count_based_policy:
-                    max_concurrent_requests: 15
-                    bandwidth_allocation: [0.9, 0.1]
+                    max_concurrent_requests: 30
+                    bandwidth_allocation: [0.7, 0.3]
     log:
         grpc:
             host: "logservice.chroma"
@@ -111,7 +111,7 @@ compaction_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 30
-                    bandwidth_allocation: [0.9, 0.1]
+                    bandwidth_allocation: [0.7, 0.3]
     log:
         grpc:
             host: "logservice.chroma"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -37,6 +37,7 @@ query_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 15
+                    bandwidth_allocation: [0.9, 0.1]
     log:
         grpc:
             host: "logservice.chroma"
@@ -110,6 +111,7 @@ compaction_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 30
+                    bandwidth_allocation: [0.9, 0.1]
     log:
         grpc:
             host: "logservice.chroma"
@@ -173,3 +175,4 @@ log_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 500
+                    bandwidth_allocation: [1.0]

--- a/rust/worker/tests/config_from_default_path.rs
+++ b/rust/worker/tests/config_from_default_path.rs
@@ -230,8 +230,9 @@ fn test_config_from_default_path() {
                 match config.rate_limiting_policy {
                     chroma_storage::config::RateLimitingConfig::CountBasedPolicy(config) => {
                         assert_eq!(config.max_concurrent_requests, 15);
-                        assert_eq!(config.bandwidth_allocation.len(), 1);
-                        assert_eq!(config.bandwidth_allocation[0], 1.0);
+                        assert_eq!(config.bandwidth_allocation.len(), 2);
+                        assert_eq!(config.bandwidth_allocation[0], 0.7);
+                        assert_eq!(config.bandwidth_allocation[1], 0.3);
                     }
                 }
             }

--- a/rust/worker/tests/config_missing_default_field.rs
+++ b/rust/worker/tests/config_missing_default_field.rs
@@ -184,8 +184,9 @@ fn test_missing_default_field() {
                 match config.rate_limiting_policy {
                     chroma_storage::config::RateLimitingConfig::CountBasedPolicy(config) => {
                         assert_eq!(config.max_concurrent_requests, 15);
-                        assert_eq!(config.bandwidth_allocation.len(), 1);
-                        assert_eq!(config.bandwidth_allocation[0], 1.0);
+                        assert_eq!(config.bandwidth_allocation.len(), 2);
+                        assert_eq!(config.bandwidth_allocation[0], 0.7);
+                        assert_eq!(config.bandwidth_allocation[1], 0.3);
                     }
                 }
             }

--- a/rust/worker/tests/config_missing_default_field.rs
+++ b/rust/worker/tests/config_missing_default_field.rs
@@ -178,6 +178,19 @@ fn test_missing_default_field() {
             HnswGarbageCollectionPolicyConfig::FullRebuild => {}
             _ => panic!("Expected FullRebuild policy"),
         }
+        match config.query_service.storage {
+            chroma_storage::config::StorageConfig::AdmissionControlledS3(config) => {
+                assert_eq!(config.s3_config.bucket, "chroma");
+                match config.rate_limiting_policy {
+                    chroma_storage::config::RateLimitingConfig::CountBasedPolicy(config) => {
+                        assert_eq!(config.max_concurrent_requests, 15);
+                        assert_eq!(config.bandwidth_allocation.len(), 1);
+                        assert_eq!(config.bandwidth_allocation[0], 1.0);
+                    }
+                }
+            }
+            _ => panic!("Expected AdmissionControlledS3 storage config"),
+        }
         Ok(())
     });
 }

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -34,7 +34,7 @@ query_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 30
-                    bandwidth_allocation: [0.9, 0.1]
+                    bandwidth_allocation: [0.7, 0.3]
     log:
         grpc:
             host: "logservice.chroma"
@@ -111,7 +111,7 @@ compaction_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 30
-                    bandwidth_allocation: [0.9, 0.1]
+                    bandwidth_allocation: [0.7, 0.3]
     log:
         grpc:
             host: "logservice.chroma"
@@ -178,3 +178,4 @@ log_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 500
+                    bandwidth_allocation: [1.0]

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -33,7 +33,8 @@ query_service:
                 download_part_size_bytes: 8388608 # 8MiB
             rate_limiting_policy:
                 count_based_policy:
-                    max_concurrent_requests: 15
+                    max_concurrent_requests: 30
+                    bandwidth_allocation: [0.9, 0.1]
     log:
         grpc:
             host: "logservice.chroma"
@@ -110,6 +111,7 @@ compaction_service:
             rate_limiting_policy:
                 count_based_policy:
                     max_concurrent_requests: 30
+                    bandwidth_allocation: [0.9, 0.1]
     log:
         grpc:
             host: "logservice.chroma"


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - Introduces a notion of tagging s3 requests with their priority
   - NAC divides the total network bandwidth amongst these priority variants
   - This allocation of bandwidth distribution is configurable
   - Changes the blockfile layer to suitably tag priority of s3 requests. Currently, prefetching is low priority and everything else is high priority
   - When executing a request, NAC successively checks for bandwidth availability from lower priority channels and if any of them have availability then it dispatches the request otherwise it blocks on the semaphore of its own priority channel

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None