### PR TITLE
[ENH]: log OpenTelemetry export errors

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
 pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
     EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| {
-        "error,".to_string()
+        "error,opentelemetry_sdk=info,".to_string()
             + &vec![
                 "chroma",
                 "chroma-blockstore",
@@ -139,6 +139,10 @@ pub fn init_stdout_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                     .module_path()
                     .unwrap_or("")
                     .starts_with("garbage_collector")
+                || metadata
+                    .module_path()
+                    .unwrap_or("")
+                    .starts_with("opentelemetry_sdk")
         }))
         .with_filter(tracing_subscriber::filter::LevelFilter::INFO)
         .boxed()


### PR DESCRIPTION
## Description of changes

Metrics are not being exported in staging. This should help debug.

## Test plan
*How are these changes tested?*

Changed `otel_endpoint` to a non-existent endpoint and observed that errors were logged to stdout.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

n/a
