### PR TITLE
[ENH]: Prefetch posting list in query + compactor

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -108,10 +108,13 @@ impl ArrowBlockfileProvider {
         }
         let count = futures.len();
 
+        tracing::info!("Prefetching {} blocks for blockfile ID: {:?}", count, id);
+
         while let Some(result) = futures.next().await {
             result?;
         }
 
+        tracing::info!("Prefetched {} blocks for blockfile ID: {:?}", count, id);
         Ok(count)
     }
 

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -187,6 +187,7 @@ impl ArrowBlockfileProvider {
     pub async fn clear(&self) -> Result<(), CacheError> {
         self.block_manager.block_cache.clear().await?;
         self.root_manager.cache.clear().await?;
+        self.root_manager.prefetched_roots.lock().clear();
         Ok(())
     }
 }

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -12,6 +12,11 @@ use chroma_index::metadata::types::{
     MetadataIndexError, MetadataIndexFlusher, MetadataIndexReader, MetadataIndexWriter,
 };
 use chroma_types::SegmentType;
+use chroma_types::BOOL_METADATA;
+use chroma_types::F32_METADATA;
+use chroma_types::FULL_TEXT_PLS;
+use chroma_types::STRING_METADATA;
+use chroma_types::U32_METADATA;
 use chroma_types::{MaterializedLogOperation, MetadataValue, Segment, SegmentUuid};
 use core::panic;
 use roaring::RoaringBitmap;
@@ -20,12 +25,6 @@ use std::fmt::{self, Debug, Formatter};
 use tantivy::tokenizer::NgramTokenizer;
 use thiserror::Error;
 use uuid::Uuid;
-
-const FULL_TEXT_PLS: &str = "full_text_pls";
-const STRING_METADATA: &str = "string_metadata";
-const BOOL_METADATA: &str = "bool_metadata";
-const F32_METADATA: &str = "f32_metadata";
-const U32_METADATA: &str = "u32_metadata";
 
 #[derive(Clone)]
 pub struct MetadataSegmentWriter<'me> {

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -6,7 +6,10 @@ use chroma_blockstore::{
 };
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::fulltext::types::FullTextIndexError;
-use chroma_types::{DataRecord, MaterializedLogOperation, Segment, SegmentType, SegmentUuid};
+use chroma_types::{
+    DataRecord, MaterializedLogOperation, Segment, SegmentType, SegmentUuid, MAX_OFFSET_ID,
+    OFFSET_ID_TO_DATA, OFFSET_ID_TO_USER_ID, USER_ID_TO_OFFSET_ID,
+};
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
@@ -15,11 +18,6 @@ use std::sync::atomic::{self, AtomicU32};
 use std::sync::Arc;
 use thiserror::Error;
 use uuid::Uuid;
-
-const USER_ID_TO_OFFSET_ID: &str = "user_id_to_offset_id";
-const OFFSET_ID_TO_USER_ID: &str = "offset_id_to_user_id";
-const OFFSET_ID_TO_DATA: &str = "offset_id_to_data";
-const MAX_OFFSET_ID: &str = "max_offset_id";
 
 #[derive(Clone)]
 pub struct RecordSegmentWriter {

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 const HNSW_PATH: &str = "hnsw_path";
 const VERSION_MAP_PATH: &str = "version_map_path";
-const POSTING_LIST_PATH: &str = "posting_list_path";
+pub const POSTING_LIST_PATH: &str = "posting_list_path";
 const MAX_HEAD_ID_BF_PATH: &str = "max_head_id_path";
 
 #[derive(Clone)]

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -18,17 +18,16 @@ use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::SpannIndexWri
 use chroma_types::Collection;
 use chroma_types::InternalSpannConfiguration;
 use chroma_types::SegmentUuid;
+use chroma_types::HNSW_PATH;
+use chroma_types::MAX_HEAD_ID_BF_PATH;
+use chroma_types::POSTING_LIST_PATH;
+use chroma_types::VERSION_MAP_PATH;
 use chroma_types::{MaterializedLogOperation, Segment, SegmentScope, SegmentType};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use thiserror::Error;
 use uuid::Uuid;
-
-const HNSW_PATH: &str = "hnsw_path";
-const VERSION_MAP_PATH: &str = "version_map_path";
-pub const POSTING_LIST_PATH: &str = "posting_list_path";
-const MAX_HEAD_ID_BF_PATH: &str = "max_head_id_path";
 
 #[derive(Clone)]
 pub struct SpannSegmentWriter {

--- a/rust/worker/src/execution/operators/prefetch_segment.rs
+++ b/rust/worker/src/execution/operators/prefetch_segment.rs
@@ -1,6 +1,5 @@
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::ChromaError;
-use chroma_segment::distributed_spann::POSTING_LIST_PATH;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::{Segment, SegmentType};
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -68,10 +67,7 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
         &self,
         input: &PrefetchSegmentInput,
     ) -> Result<PrefetchSegmentOutput, PrefetchSegmentError> {
-        if input.segment.r#type != SegmentType::BlockfileMetadata
-            && input.segment.r#type != SegmentType::BlockfileRecord
-            && input.segment.r#type != SegmentType::Spann
-        {
+        if !input.segment.prefetch_supported() {
             return Err(PrefetchSegmentError::UnsupportedSegmentType(
                 input.segment.r#type,
             ));
@@ -83,32 +79,21 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
             input.segment.id,
         );
 
-        let total_blocks_fetched = if SegmentType::Spann == input.segment.r#type {
-            let mut total_blocks_fetched = 0;
-            if let Some(path) = input.segment.file_path.get(POSTING_LIST_PATH) {
-                let blockfile_id = Uuid::parse_str(&path[0])?;
-                total_blocks_fetched += input.blockfile_provider.prefetch(&blockfile_id).await?;
-            }
-            total_blocks_fetched
-        } else {
-            let mut futures = input
-                .segment
-                .file_path
-                .values()
-                .flatten()
-                .map(|blockfile_id| async move {
-                    let blockfile_id = Uuid::parse_str(blockfile_id)?;
-                    let count = input.blockfile_provider.prefetch(&blockfile_id).await?;
-                    Ok::<_, PrefetchSegmentError>(count)
-                })
-                .collect::<FuturesUnordered<_>>();
+        let mut futures = input
+            .segment
+            .filepaths_to_prefetch()
+            .into_iter()
+            .map(|blockfile_id| async move {
+                let blockfile_id = Uuid::parse_str(&blockfile_id)?;
+                let count = input.blockfile_provider.prefetch(&blockfile_id).await?;
+                Ok::<_, PrefetchSegmentError>(count)
+            })
+            .collect::<FuturesUnordered<_>>();
 
-            let mut total_blocks_fetched = 0;
-            while let Some(result) = futures.next().await {
-                total_blocks_fetched += result?;
-            }
-            total_blocks_fetched
-        };
+        let mut total_blocks_fetched = 0;
+        while let Some(result) = futures.next().await {
+            total_blocks_fetched += result?;
+        }
 
         Ok(PrefetchSegmentOutput {
             num_blocks_fetched: total_blocks_fetched,

--- a/rust/worker/src/execution/operators/prefetch_segment.rs
+++ b/rust/worker/src/execution/operators/prefetch_segment.rs
@@ -73,12 +73,6 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
             ));
         }
 
-        tracing::info!(
-            "Prefetching segment: {:?} ({:?})",
-            input.segment.r#type,
-            input.segment.id,
-        );
-
         let mut futures = input
             .segment
             .filepaths_to_prefetch()


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - Prefetches Posting lists in the beginning of query and compaction. Also, tracks which sparse index ids were already prefetched so as to not do it again. This state is not persistent across restarts and has a ttl.

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
