### PR TITLE
[CHORE] Add test to validate embedding function error handling

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -94,7 +94,6 @@ def validation_context(name: str) -> Callable[[Callable[..., T]], Callable[..., 
             try:
                 return func(self, *args, **kwargs)
             except Exception as e:
-                # modify the error message
                 msg = f"{str(e)} in {name}."
                 # add the rest of the args to the error message if they exist
                 e.args = (msg,) + e.args[1:] if e.args else ()

--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -1,5 +1,16 @@
 from chromadb.utils import embedding_functions
-from chromadb.utils.embedding_functions import EmbeddingFunction
+from chromadb.utils.embedding_functions import (
+    EmbeddingFunction,
+    register_embedding_function,
+)
+from typing import Dict, Any
+import pytest
+from chromadb.api.types import (
+    Embeddings,
+    Space,
+    Embeddable,
+)
+from chromadb.api.models.CollectionCommon import validation_context
 
 
 def test_get_builtins_holds() -> None:
@@ -54,3 +65,39 @@ def test_ef_imports() -> None:
         assert hasattr(embedding_functions, ef)
         assert isinstance(getattr(embedding_functions, ef), type)
         assert issubclass(getattr(embedding_functions, ef), EmbeddingFunction)
+
+
+@register_embedding_function
+class CustomEmbeddingFunction(EmbeddingFunction[Embeddable]):
+    def __init__(self, dim: int = 3):
+        self._dim = dim
+
+    @validation_context("custom_ef_call")
+    def __call__(self, input: Embeddable) -> Embeddings:
+        raise Exception("This is a test exception")
+
+    @staticmethod
+    def name() -> str:
+        return "custom_ef"
+
+    def get_config(self) -> Dict[str, Any]:
+        return {"dim": self._dim}
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "CustomEmbeddingFunction":
+        return CustomEmbeddingFunction(dim=config["dim"])
+
+    def default_space(self) -> Space:
+        return "cosine"
+
+
+def test_validation_context_with_custom_ef() -> None:
+    custom_ef = CustomEmbeddingFunction()
+
+    with pytest.raises(Exception) as excinfo:
+        custom_ef(["test data"])
+
+    original_msg = "This is a test exception"
+    expected_msg = f"{original_msg} in custom_ef_call."
+    assert str(excinfo.value) == expected_msg
+    assert excinfo.value.args == (expected_msg,)

--- a/chromadb/test/ef/test_openai_ef.py
+++ b/chromadb/test/ef/test_openai_ef.py
@@ -29,3 +29,10 @@ def test_with_embedding_dimensions_not_working_with_old_model() -> None:
         Exception, match="This model does not support specifying dimensions"
     ):
         ef(["hello world"])
+
+
+def test_with_incorrect_api_key() -> None:
+    pytest.importorskip("openai", reason="openai not installed")
+    ef = OpenAIEmbeddingFunction(api_key="incorrect_api_key", dimensions=64)
+    with pytest.raises(Exception, match="Incorrect API key provided"):
+        ef(["hello world"])


### PR DESCRIPTION
## Description of changes

This PR adds tests for validation_context to ensure the errors raised match the ones given by the caller, in this case an embedding function. tests for https://github.com/chroma-core/chroma/pull/4235
## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
