### PR TITLE
[BUG]  Fix race condition.

### DIFF
--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -880,7 +880,7 @@ impl Handler<TaskResult<ApplyLogToSegmentWriterOutput, ApplyLogToSegmentWriterOp
             }
         };
 
-        if num_tasks_left == 0 {
+        if num_tasks_left == 0 && self.num_uncompleted_materialization_tasks == 0 {
             let segment_writer = self.get_segment_writer_by_id(message.segment_id).await;
             let segment_writer = match self.ok_or_terminate(segment_writer, ctx) {
                 Some(writer) => writer,


### PR DESCRIPTION

The partitioned compaction code had a race wherein one partition could race through all work before
other partitions registered their work.  This fixes the race condition.
