### PR TITLE
[ENH] Retry query paths on transport errors

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -788,9 +788,16 @@ impl ServiceBasedFrontend {
         };
         let res = delete_to_retry
             .retry(self.collections_with_segments_provider.get_retry_backoff())
-            .when(|e| e.code() == ErrorCodes::NotFound)
+            // NOTE: Transport level errors will manifest as unknown errors, and they should also be retried
+            .when(|e| matches!(e.code(), ErrorCodes::NotFound | ErrorCodes::Unknown))
             .notify(|_, _| {
-                retries.fetch_add(1, Ordering::Relaxed);
+                let retried = retries.fetch_add(1, Ordering::Relaxed);
+                if retried > 0 {
+                    tracing::info!(
+                        "Retrying delete() request for collection {}",
+                        request.collection_id
+                    );
+                }
             })
             .await;
         self.metrics

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -871,13 +871,16 @@ impl ServiceBasedFrontend {
         };
         let res = count_to_retry
             .retry(self.collections_with_segments_provider.get_retry_backoff())
-            .when(|e| e.code() == ErrorCodes::NotFound)
+            // NOTE: Transport level errors will manifest as unknown errors, and they should also be retried
+            .when(|e| matches!(e.code(), ErrorCodes::NotFound | ErrorCodes::Unknown))
             .notify(|_, _| {
-                tracing::info!(
-                    "Retrying count() request for collection {}",
-                    request.collection_id
-                );
-                retries.fetch_add(1, Ordering::Relaxed);
+                let retried = retries.fetch_add(1, Ordering::Relaxed);
+                if retried > 0 {
+                    tracing::info!(
+                        "Retrying count() request for collection {}",
+                        request.collection_id
+                    );
+                }
             })
             .await;
         self.metrics
@@ -986,13 +989,16 @@ impl ServiceBasedFrontend {
         };
         let res = get_to_retry
             .retry(self.collections_with_segments_provider.get_retry_backoff())
-            .when(|e| e.code() == ErrorCodes::NotFound)
+            // NOTE: Transport level errors will manifest as unknown errors, and they should also be retried
+            .when(|e| matches!(e.code(), ErrorCodes::NotFound | ErrorCodes::Unknown))
             .notify(|_, _| {
-                tracing::info!(
-                    "Retrying get() request for collection {}",
-                    request.collection_id
-                );
-                retries.fetch_add(1, Ordering::Relaxed);
+                let retried = retries.fetch_add(1, Ordering::Relaxed);
+                if retried > 0 {
+                    tracing::info!(
+                        "Retrying get() request for collection {}",
+                        request.collection_id
+                    );
+                }
             })
             .await;
         self.metrics
@@ -1114,13 +1120,16 @@ impl ServiceBasedFrontend {
         };
         let res = query_to_retry
             .retry(self.collections_with_segments_provider.get_retry_backoff())
-            .when(|e| e.code() == ErrorCodes::NotFound)
+            // NOTE: Transport level errors will manifest as unknown errors, and they should also be retried
+            .when(|e| matches!(e.code(), ErrorCodes::NotFound | ErrorCodes::Unknown))
             .notify(|_, _| {
-                tracing::info!(
-                    "Retrying query() request for collection {}",
-                    request.collection_id
-                );
-                retries.fetch_add(1, Ordering::Relaxed);
+                let retried = retries.fetch_add(1, Ordering::Relaxed);
+                if retried > 0 {
+                    tracing::info!(
+                        "Retrying query() request for collection {}",
+                        request.collection_id
+                    );
+                }
             })
             .await;
         self.metrics


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - We would like to retry failed reads from transport errors. These error will manifest as `Unknown` error codes in frontend.
   - Only trace on retried requests.
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
