### PR TITLE
[BLD] Update Dockerfile cache mounts to address collisions

### DIFF
--- a/rust/cli/Dockerfile
+++ b/rust/cli/Dockerfile
@@ -15,9 +15,9 @@ COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY rust/ rust/
 
-# sharing=locked is necessary to prevent cargo build from running concurrently on the same mounted directory
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-  --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# we want to avoid caching the target directory because Buildkit has its own cache that conflicts with the cargo cache
+RUN --mount=type=cache,target=/usr/local/cargo/git/ \
+  --mount=type=cache,target=/usr/local/cargo/registry/ \
   cd rust/cli && \
   if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin chroma --release; else cargo build --bin chroma; fi && \
   cd ../.. && \

--- a/rust/garbage_collector/Dockerfile
+++ b/rust/garbage_collector/Dockerfile
@@ -16,8 +16,9 @@ COPY idl/ idl/
 COPY rust/ rust/
 
 FROM builder AS garbage_collector_builder
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# we want to avoid caching the target directory because Buildkit has its own cache that conflicts with the cargo cache
+RUN --mount=type=cache,target=/usr/local/cargo/git/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
     cd rust/garbage_collector && \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin garbage_collector_service --release; else cargo build --bin garbage_collector_service; fi && \
     cd ../.. && \

--- a/rust/load/Dockerfile
+++ b/rust/load/Dockerfile
@@ -10,9 +10,9 @@ COPY idl/ idl/
 COPY rust/ rust/
 
 FROM builder AS load_service_builder
-# sharing=locked is necessary to prevent cargo build from running concurrently on the same mounted directory
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# we want to avoid caching the target directory because Buildkit has its own cache that conflicts with the cargo cache
+RUN --mount=type=cache,target=/usr/local/cargo/git/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin chroma-load --release; else cargo build --bin chroma-load; fi && \
     if [ "$RELEASE_MODE" = "1" ]; then mv target/release/chroma-load ./chroma-load; else mv target/debug/chroma-load ./chroma-load; fi
 

--- a/rust/log-service/Dockerfile
+++ b/rust/log-service/Dockerfile
@@ -16,9 +16,9 @@ COPY idl/ idl/
 COPY rust/ rust/
 
 FROM builder AS log_service_builder
-# sharing=locked is necessary to prevent cargo build from running concurrently on the same mounted directory
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# we want to avoid caching the target directory because Buildkit has its own cache that conflicts with the cargo cache
+RUN --mount=type=cache,target=/usr/local/cargo/git/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
     cd rust/log-service && \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin log_service --release; else cargo build --bin log_service; fi && \
     cd ../.. && \

--- a/rust/worker/Dockerfile
+++ b/rust/worker/Dockerfile
@@ -16,17 +16,18 @@ COPY idl/ idl/
 COPY rust/ rust/
 
 FROM builder AS query_service_builder
-# sharing=locked is necessary to prevent cargo build from running concurrently on the same mounted directory
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# we want to avoid caching the target directory because Buildkit has its own cache that conflicts with the cargo cache
+RUN --mount=type=cache,target=/usr/local/cargo/git/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
     cd rust/worker && \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin query_service --release; else cargo build --bin query_service; fi && \
     cd ../.. && \
     if [ "$RELEASE_MODE" = "1" ]; then mv target/release/query_service ./query_service; else mv target/debug/query_service ./query_service; fi
 
 FROM builder AS compaction_service_builder
-RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
-    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+# we want to avoid caching the target directory because Buildkit has its own cache that conflicts with the cargo cache
+RUN --mount=type=cache,target=/usr/local/cargo/git/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
     cd rust/worker && \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin compaction_service --release; else cargo build --bin compaction_service; fi && \
     cd ../.. && \


### PR DESCRIPTION
## Description of changes

This updates the caching directives in our rust `Dockerfile`s to hopefully address the cache contention issues we've been seeing between rust's build cache and Buildkit's native caching machinery. This is as advised from the folks at Depot.

## Test plan
`tilt up`

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust