### PR TITLE
[DOC]: Fix docstring defaults for query filters

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -232,10 +232,10 @@ class BaseAPI(ABC):
 
         Args:
             ids: The IDs of the entries to get. Defaults to None.
-            where: Conditional filtering on metadata. Defaults to {}.
+            where: Conditional filtering on metadata. Defaults to None.
             limit: The maximum number of entries to return. Defaults to None.
             offset: The number of entries to skip before returning. Defaults to None.
-            where_document: Conditional filtering on documents. Defaults to {}.
+            where_document: Conditional filtering on documents. Defaults to None.
             include: The fields to include in the response.
                           Defaults to ["metadatas", "documents"].
         Returns:
@@ -257,8 +257,8 @@ class BaseAPI(ABC):
         Args:
             collection_id: The UUID of the collection to delete the entries from.
             ids: The IDs of the entries to delete. Defaults to None.
-            where: Conditional filtering on metadata. Defaults to {}.
-            where_document: Conditional filtering on documents. Defaults to {}.
+            where: Conditional filtering on metadata. Defaults to None.
+            where_document: Conditional filtering on documents. Defaults to None.
 
         Returns:
             IDs: The list of IDs of the entries that were deleted.
@@ -281,8 +281,8 @@ class BaseAPI(ABC):
             collection_id: The UUID of the collection to query.
             query_embeddings: The embeddings to use as the query.
             n_results: The number of results to return. Defaults to 10.
-            where: Conditional filtering on metadata. Defaults to {}.
-            where_document: Conditional filtering on documents. Defaults to {}.
+            where: Conditional filtering on metadata. Defaults to None.
+            where_document: Conditional filtering on documents. Defaults to None.
             include: The fields to include in the response.
                           Defaults to ["metadatas", "documents", "distances"].
 

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -226,10 +226,10 @@ class AsyncBaseAPI(ABC):
 
         Args:
             ids: The IDs of the entries to get. Defaults to None.
-            where: Conditional filtering on metadata. Defaults to {}.
+            where: Conditional filtering on metadata. Defaults to None.
             limit: The maximum number of entries to return. Defaults to None.
             offset: The number of entries to skip before returning. Defaults to None.
-            where_document: Conditional filtering on documents. Defaults to {}.
+            where_document: Conditional filtering on documents. Defaults to None.
             include: The fields to include in the response.
                           Defaults to ["embeddings", "metadatas", "documents"].
         Returns:
@@ -251,8 +251,8 @@ class AsyncBaseAPI(ABC):
         Args:
             collection_id: The UUID of the collection to delete the entries from.
             ids: The IDs of the entries to delete. Defaults to None.
-            where: Conditional filtering on metadata. Defaults to {}.
-            where_document: Conditional filtering on documents. Defaults to {}.
+            where: Conditional filtering on metadata. Defaults to None.
+            where_document: Conditional filtering on documents. Defaults to None.
 
         Returns:
             IDs: The list of IDs of the entries that were deleted.
@@ -275,8 +275,8 @@ class AsyncBaseAPI(ABC):
             collection_id: The UUID of the collection to query.
             query_embeddings: The embeddings to use as the query.
             n_results: The number of results to return. Defaults to 10.
-            where: Conditional filtering on metadata. Defaults to {}.
-            where_document: Conditional filtering on documents. Defaults to {}.
+            where: Conditional filtering on metadata. Defaults to None.
+            where_document: Conditional filtering on documents. Defaults to None.
             include: The fields to include in the response.
                           Defaults to ["embeddings", "metadatas", "documents", "distances"].
 


### PR DESCRIPTION
## Description of changes

The docstrings for `where` and `where_document` indicated that they default to `{}`. This is inconsistent with the actual type definition, and additionally confusing because sending `None` is OK, but sending `{}` is not.

So, this is a small find-and-replace for these instances.

## NOTE

This also comes up with respect to the `headers` in the [Docs site](https://github.com/chroma-core/chroma/blob/069ca5fb5223a1e466244f3c6e858c8e183ce233/docs/docs.trychroma.com/markdoc/content/reference/python/client.md?plain=1#L66) regarding the HTTP Client. In this case, the docs are clearly inconsistent with the code right above it, but I wasn't sure if I should change it, because `None` gets converted to `{}` in sending the request. I'm still inclined to correct it to match the actual code.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
