### PR TITLE
[CHORE] Remove js bindings from release

### DIFF
--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -13,10 +13,7 @@ on:
 env:
   PNPM_CACHE_FOLDER: .cache/pnpm
 jobs:
-  release-js-bindings:
-    uses: ./.github/workflows/_build_js_binding.yml
   release:
-    needs: release-js-bindings
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description of changes

JS release fails because js bindings used in release. Talked to Itai, he said its safe to remove

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
