### PR TITLE
[FIX] remove chromadb-js-bindings from chromadb package to fix build

### DIFF
--- a/clients/js/packages/chromadb/package.json
+++ b/clients/js/packages/chromadb/package.json
@@ -41,13 +41,6 @@
     "semver": "^7.7.1",
     "voyageai": "^0.0.3-1"
   },
-  "optionalDependencies": {
-    "chromadb-js-bindings-darwin-arm64": "^0.0.1",
-    "chromadb-js-bindings-darwin-x64": "^0.0.1",
-    "chromadb-js-bindings-linux-arm64-gnu": "^0.0.1",
-    "chromadb-js-bindings-linux-x64-gnu": "^0.0.1",
-    "chromadb-js-bindings-win32-x64-msvc": "^0.0.1"
-  },
   "devDependencies": {
     "@internal/chromadb-core": "workspace:*",
     "@types/semver": "^7.7.0",

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -126,10 +126,6 @@ importers:
       voyageai:
         specifier: ^0.0.3-1
         version: 0.0.3-1
-    optionalDependencies:
-      chromadb-js-bindings-darwin-arm64:
-        specifier: ^0.0.1
-        version: 0.0.1
     devDependencies:
       '@internal/chromadb-core':
         specifier: workspace:*
@@ -1690,12 +1686,6 @@ packages:
 
   chromadb-default-embed@2.14.0:
     resolution: {integrity: sha512-odCiCzZ5jqNI0sS6RcRxObx8gM7aCPULQkdWw/OgqIGdIUOKUj9b8jDElLbZ6feMKNB0MSQhtXi0P8QEeVO75w==}
-
-  chromadb-js-bindings-darwin-arm64@0.0.1:
-    resolution: {integrity: sha512-YEFF2KObB73iaXyRLcC0eSbaHQ8/6vs2Pg2ue+V9jMQL1pcZYlcYLI/2AtELGjOxJTd086iJoMPJpQqy8LNyxQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -6012,9 +6002,6 @@ snapshots:
       sharp: 0.32.6
     optionalDependencies:
       onnxruntime-node: 1.14.0
-
-  chromadb-js-bindings-darwin-arm64@0.0.1:
-    optional: true
 
   ci-info@3.9.0: {}
 


### PR DESCRIPTION
Follow-up to https://github.com/chroma-core/chroma/pull/4285

Removes packages that were built by that PR and are now failing. 