### PR TITLE
[CHORE]: Remove unused optional dependency `graphlib_backport`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Chroma."
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = ["Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent"]
-dependencies = ['build >= 1.0.3', 'pydantic >= 1.9', 'chroma-hnswlib==0.7.6', 'fastapi==0.115.9', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-instrumentation-fastapi>=0.41b0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
+dependencies = ['build >= 1.0.3', 'pydantic >= 1.9', 'chroma-hnswlib==0.7.6', 'fastapi==0.115.9', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-instrumentation-fastapi>=0.41b0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
 
 [tool.black]
 line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 bcrypt>=4.0.1
 chroma-hnswlib==0.7.6
 fastapi==0.115.9
-graphlib_backport==1.0.3; python_version < '3.9'
 grpcio>=1.58.0
 httpx>=0.27.0
 importlib-resources

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,4 +12,5 @@ pytest
 pytest-asyncio
 pytest-xdist
 setuptools_scm
+types-jsonschema
 types-protobuf


### PR DESCRIPTION
## Description of changes

In `pyproject.toml`, there is a conditional import for `graphlib_backport` for python<3.9. But "requires-python" is ">=3.9". So this conditional installation can never be triggered, so I removed it. Maybe there is a reason you keep it around, but it seemed redundant to me.

Also, I added `types-jsonschema` to `requirements_dev.txt` because I was getting missing stub warnings around `jsonschema`.

## Test plan
*How are these changes tested?*

I built the project locally with the dependency changes.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
