### PR TITLE
[ENH]  Improve backoff and throttling of wal3.

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -524,7 +524,13 @@ impl ServiceBasedFrontend {
         self.log_client
             .push_logs(collection_id, records)
             .await
-            .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
+            .map_err(|err| {
+                if err.code() == ErrorCodes::Unavailable {
+                    AddCollectionRecordsError::Backoff
+                } else {
+                    AddCollectionRecordsError::Other(Box::new(err) as _)
+                }
+            })?;
 
         // TODO: Submit event after the response is sent
         MeterEvent::CollectionWrite {
@@ -573,7 +579,13 @@ impl ServiceBasedFrontend {
         self.log_client
             .push_logs(collection_id, records)
             .await
-            .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
+            .map_err(|err| {
+                if err.code() == ErrorCodes::Unavailable {
+                    UpdateCollectionRecordsError::Backoff
+                } else {
+                    UpdateCollectionRecordsError::Other(Box::new(err) as _)
+                }
+            })?;
 
         // TODO: Submit event after the response is sent
         MeterEvent::CollectionWrite {
@@ -624,7 +636,13 @@ impl ServiceBasedFrontend {
         self.log_client
             .push_logs(collection_id, records)
             .await
-            .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
+            .map_err(|err| {
+                if err.code() == ErrorCodes::Unavailable {
+                    UpsertCollectionRecordsError::Backoff
+                } else {
+                    UpsertCollectionRecordsError::Other(Box::new(err) as _)
+                }
+            })?;
 
         // TODO: Submit event after the response is sent
         MeterEvent::CollectionWrite {
@@ -738,7 +756,13 @@ impl ServiceBasedFrontend {
         self.log_client
             .push_logs(collection_id, records)
             .await
-            .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
+            .map_err(|err| {
+                if err.code() == ErrorCodes::Unavailable {
+                    DeleteCollectionRecordsError::Backoff
+                } else {
+                    DeleteCollectionRecordsError::Internal(Box::new(err) as _)
+                }
+            })?;
 
         if let Some(event) = read_event {
             event.submit().await;

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -596,7 +596,7 @@ pub struct LogServer {
 
 #[async_trait::async_trait]
 impl LogService for LogServer {
-    #[tracing::instrument(skip(self, request), err(Display))]
+    #[tracing::instrument(skip(self, request))]
     async fn push_logs(
         &self,
         request: Request<PushLogsRequest>,
@@ -638,9 +638,16 @@ impl LogService for LogServer {
             messages.push(buf);
         }
         let record_count = messages.len() as i32;
-        log.append_many(messages)
-            .await
-            .map_err(|err| Status::unknown(err.to_string()))?;
+        log.append_many(messages).await.map_err(|err| {
+            if let wal3::Error::Backoff = err {
+                Status::new(
+                    chroma_error::ErrorCodes::Unavailable.into(),
+                    err.to_string(),
+                )
+            } else {
+                Status::new(err.code().into(), err.to_string())
+            }
+        })?;
         Ok(Response::new(PushLogsResponse { record_count }))
     }
 

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -204,10 +204,11 @@ impl GrpcLog {
     }
 
     // ScoutLogs returns the offset of the next record to be inserted into the log.
+    #[tracing::instrument(skip(self), ret)]
     pub(super) async fn scout_logs(
         &mut self,
         collection_id: CollectionUuid,
-        _: u64,
+        start_from: u64,
     ) -> Result<u64, Box<dyn ChromaError>> {
         let request = self
             .client_for(collection_id)
@@ -226,6 +227,7 @@ impl GrpcLog {
         Ok(scout.first_uninserted_record_offset as u64)
     }
 
+    #[tracing::instrument(skip(self))]
     pub(super) async fn read(
         &mut self,
         collection_id: CollectionUuid,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -847,6 +847,8 @@ pub struct AddCollectionRecordsResponse {}
 pub enum AddCollectionRecordsError {
     #[error("Failed to get collection: {0}")]
     Collection(#[from] GetCollectionError),
+    #[error("Backoff and retry")]
+    Backoff,
     #[error(transparent)]
     Other(#[from] Box<dyn ChromaError>),
 }
@@ -855,6 +857,7 @@ impl ChromaError for AddCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
             AddCollectionRecordsError::Collection(err) => err.code(),
+            AddCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
             AddCollectionRecordsError::Other(err) => err.code(),
         }
     }
@@ -907,6 +910,8 @@ pub struct UpdateCollectionRecordsResponse {}
 
 #[derive(Error, Debug)]
 pub enum UpdateCollectionRecordsError {
+    #[error("Backoff and retry")]
+    Backoff,
     #[error(transparent)]
     Other(#[from] Box<dyn ChromaError>),
 }
@@ -914,6 +919,7 @@ pub enum UpdateCollectionRecordsError {
 impl ChromaError for UpdateCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
+            UpdateCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
             UpdateCollectionRecordsError::Other(err) => err.code(),
         }
     }
@@ -966,6 +972,8 @@ pub struct UpsertCollectionRecordsResponse {}
 
 #[derive(Error, Debug)]
 pub enum UpsertCollectionRecordsError {
+    #[error("Backoff and retry")]
+    Backoff,
     #[error(transparent)]
     Other(#[from] Box<dyn ChromaError>),
 }
@@ -973,6 +981,7 @@ pub enum UpsertCollectionRecordsError {
 impl ChromaError for UpsertCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
+            UpsertCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
             UpsertCollectionRecordsError::Other(err) => err.code(),
         }
     }
@@ -1025,6 +1034,8 @@ pub struct DeleteCollectionRecordsResponse {}
 pub enum DeleteCollectionRecordsError {
     #[error("Failed to resolve records for deletion: {0}")]
     Get(#[from] ExecutorError),
+    #[error("Backoff and retry")]
+    Backoff,
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
 }
@@ -1033,6 +1044,7 @@ impl ChromaError for DeleteCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
             DeleteCollectionRecordsError::Get(err) => err.code(),
+            DeleteCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
             DeleteCollectionRecordsError::Internal(err) => err.code(),
         }
     }

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -43,6 +43,8 @@ pub enum Error {
     LogClosed,
     #[error("an empty batch was passed to append")]
     EmptyBatch,
+    #[error("perform exponential backoff and retry")]
+    Backoff,
     #[error("an internal, otherwise unclassifiable error")]
     Internal,
     #[error("could not find FSN in path: {0}")]
@@ -74,6 +76,7 @@ impl chroma_error::ChromaError for Error {
             Self::LogFull => chroma_error::ErrorCodes::Aborted,
             Self::LogClosed => chroma_error::ErrorCodes::FailedPrecondition,
             Self::EmptyBatch => chroma_error::ErrorCodes::InvalidArgument,
+            Self::Backoff => chroma_error::ErrorCodes::Unavailable,
             Self::Internal => chroma_error::ErrorCodes::Internal,
             Self::MissingFragmentSequenceNumber(_) => chroma_error::ErrorCodes::Internal,
             Self::CorruptManifest(_) => chroma_error::ErrorCodes::DataLoss,

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -492,8 +492,8 @@ pub async fn upload_parquet(
     let exp_backoff: ExponentialBackoff = options.throttle_fragment.into();
     let start = Instant::now();
     loop {
-        tracing::info!("upload_parquet: {:?}", path);
         let (buffer, setsum) = construct_parquet(log_position, &messages)?;
+        tracing::info!("upload_parquet: {:?} with {} bytes", path, buffer.len());
         match storage
             .put_bytes(
                 &path,

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -420,7 +420,6 @@ impl OnceLogWriter {
         };
         self.manifest_manager.publish_fragment(fragment).await?;
         // Record the records/batches written.
-        self.batch_manager.update_average_batch_size(messages_len);
         self.batch_manager.finish_write();
         Ok(log_position)
     }

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -179,3 +179,9 @@ log_service:
                 count_based_policy:
                     max_concurrent_requests: 500
                     bandwidth_allocation: [1.0]
+    writer:
+        throttle_fragment:
+            batch_interval_us: 100000
+            batch_size_bytes: 8388608 # 8MiB
+            throughput: 3300
+            headroom: 200


### PR DESCRIPTION
This does multiple things:

- Adds a Backoff code to pushlogs and plumbs it upwards.
- Coalesces the two timeouts that were used in batch_manager and uses
  them everywhere.
- Stops batching by record count.  Byte count only.
- Adds a backoff condition to the batch manager.  If the batch size and
  then some is in the log, it'll set backoff mode to shed further
  writes.
- Configures the writer in tilt config.
- Plumbs an error for exp backoff.
  