### PR TITLE
[ENH] Add support to convert Get/QueryResult to pandas dataframe

### DIFF
--- a/chromadb/test/utils/test_result_df_transform.py
+++ b/chromadb/test/utils/test_result_df_transform.py
@@ -1,0 +1,184 @@
+import numpy as np
+from typing import List, Dict, Any, cast, Union
+from chromadb.utils.results import (
+    _transform_embeddings,
+    _add_query_fields,
+    _add_get_fields,
+    query_result_to_dfs,
+    get_result_to_df,
+)
+from chromadb.api.types import (
+    QueryResult,
+    GetResult,
+)
+from numpy.typing import NDArray
+
+
+def test_transform_embeddings() -> None:
+    # Test with None input
+    assert _transform_embeddings(None) is None
+
+    # Test with numpy arrays
+    embeddings = cast(
+        List[NDArray[Union[np.int32, np.float32]]],
+        [np.array([1.0, 2.0]), np.array([3.0, 4.0])],
+    )
+    transformed = _transform_embeddings(embeddings)
+    assert isinstance(transformed, list)
+    assert transformed == [[1.0, 2.0], [3.0, 4.0]]
+
+    # Test with list of lists
+    embeddings = cast(
+        List[NDArray[Union[np.int32, np.float32]]],
+        [np.array([1.0, 2.0]), np.array([3.0, 4.0])],
+    )
+    transformed = _transform_embeddings(embeddings)
+    assert transformed == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_add_query_fields() -> None:
+    data_dict: Dict[str, Any] = {}
+    query_result: QueryResult = {
+        "ids": [["id1"], ["id2"]],
+        "embeddings": [[np.array([1.0, 2.0])], [np.array([3.0, 4.0])]],
+        "documents": [["doc1"], ["doc2"]],
+        "metadatas": [[{"key": "value1"}], [{"key": "value2"}]],
+        "distances": [[0.1], [0.2]],
+        "uris": [["uri1", "uri2"]],
+        "data": [
+            [np.array([1, 2, 3]), np.array([4, 5, 6])]
+        ],  # Using numpy arrays as Image type
+        "included": ["embeddings", "documents", "metadatas", "distances"],
+    }
+
+    _add_query_fields(data_dict, query_result, 0)
+    assert np.array_equal(data_dict["embedding"], [np.array([1.0, 2.0])])
+    assert data_dict["document"] == ["doc1"]
+    assert data_dict["metadata"] == [{"key": "value1"}]
+    assert data_dict["distance"] == [0.1]
+
+
+def test_add_get_fields() -> None:
+    data_dict: Dict[str, Any] = {}
+    get_result: GetResult = {
+        "ids": ["id1", "id2"],
+        "embeddings": [np.array([1.0, 2.0]), np.array([3.0, 4.0])],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"key": "value1"}, {"key": "value2"}],
+        "uris": ["uri1", "uri2"],
+        "data": [
+            np.array([1, 2, 3]),
+            np.array([4, 5, 6]),
+        ],  # Using numpy arrays as Image type
+        "included": ["embeddings", "documents", "metadatas"],
+    }
+
+    _add_get_fields(data_dict, get_result)
+    assert all(
+        np.array_equal(a, b)
+        for a, b in zip(
+            data_dict["embedding"], [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+        )
+    )
+    assert data_dict["document"] == ["doc1", "doc2"]
+    assert data_dict["metadata"] == [{"key": "value1"}, {"key": "value2"}]
+
+
+def test_query_result_to_dfs() -> None:
+    query_result: QueryResult = {
+        "ids": [["id1", "id2"]],
+        "embeddings": [[np.array([1.0, 2.0]), np.array([3.0, 4.0])]],
+        "documents": [["doc1", "doc2"]],
+        "metadatas": [[{"key": "value1"}, {"key": "value2"}]],
+        "distances": [[0.1, 0.2]],
+        "uris": [["uri1", "uri2"]],
+        "data": [
+            [np.array([1, 2, 3]), np.array([4, 5, 6])]
+        ],  # Using numpy arrays as Image type
+        "included": ["embeddings", "documents", "metadatas", "distances"],
+    }
+
+    dfs = query_result_to_dfs(query_result)
+    assert len(dfs) == 1  # Only one query
+
+    # Test DataFrame
+    df = dfs[0]
+    assert df.index[0] == "id1"
+    assert df["document"].iloc[0] == "doc1"
+    assert df["metadata"].iloc[0] == {"key": "value1"}
+    assert np.array_equal(df["embedding"].iloc[0], np.array([1.0, 2.0]))
+    assert df["distance"].iloc[0] == 0.1
+
+    # Test column order
+    assert list(df.columns) == ["embedding", "document", "metadata", "distance"]
+
+
+def test_get_result_to_df() -> None:
+    get_result: GetResult = {
+        "ids": ["id1", "id2"],
+        "embeddings": [np.array([1.0, 2.0]), np.array([3.0, 4.0])],
+        "documents": ["doc1", "doc2"],
+        "metadatas": [{"key": "value1"}, {"key": "value2"}],
+        "uris": ["uri1", "uri2"],
+        "data": [
+            np.array([1, 2, 3]),
+            np.array([4, 5, 6]),
+        ],  # Using numpy arrays as Image type
+        "included": ["embeddings", "documents", "metadatas"],
+    }
+
+    df = get_result_to_df(get_result)
+    assert len(df) == 2
+    assert list(df.index) == ["id1", "id2"]
+    assert df["document"].tolist() == ["doc1", "doc2"]
+    assert df["metadata"].tolist() == [{"key": "value1"}, {"key": "value2"}]
+    assert all(
+        np.array_equal(a, b)
+        for a, b in zip(
+            df["embedding"].tolist(), [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+        )
+    )
+
+    # Test column order
+    assert list(df.columns) == ["embedding", "document", "metadata"]
+
+
+def test_query_result_to_dfs_with_missing_fields() -> None:
+    query_result: QueryResult = {
+        "ids": [["id1"]],
+        "documents": [["doc1"]],
+        "embeddings": [[]],  # type:ignore
+        "metadatas": [[]],
+        "distances": [[]],
+        "uris": [[]],
+        "data": [[]],
+        "included": ["documents"],
+    }
+
+    dfs = query_result_to_dfs(query_result)
+    assert len(dfs) == 1
+    df = dfs[0]
+    assert df.index[0] == "id1"
+    assert df["document"].iloc[0] == "doc1"
+    assert "metadata" not in df.columns
+    assert "embedding" not in df.columns
+    assert "distance" not in df.columns
+
+
+def test_get_result_to_df_with_missing_fields() -> None:
+    get_result: GetResult = {
+        "ids": ["id1", "id2"],
+        "documents": ["doc1", "doc2"],
+        "embeddings": [],
+        "metadatas": [],
+        "uris": [],
+        "data": [],
+        "included": ["documents"],
+    }
+
+    df = get_result_to_df(get_result)
+    assert len(df) == 2
+    assert list(df.index) == ["id1", "id2"]
+    assert df["document"].tolist() == ["doc1", "doc2"]
+    assert "metadata" not in df.columns
+    assert "embedding" not in df.columns

--- a/chromadb/utils/results.py
+++ b/chromadb/utils/results.py
@@ -1,0 +1,125 @@
+from typing import List, Dict, Any, Optional, Union
+import numpy as np
+import pandas as pd
+from chromadb.api.types import QueryResult, GetResult
+
+
+def _transform_embeddings(
+    embeddings: Optional[List[np.ndarray]],  # type: ignore
+) -> Optional[Union[List[List[float]], List[np.ndarray]]]:  # type: ignore
+    """
+    Transform embeddings from numpy arrays to lists of floats.
+    This is a shared helper function to avoid duplicating the transformation logic.
+    """
+    if embeddings is None:
+        return None
+    return (
+        [emb.tolist() for emb in embeddings]
+        if isinstance(embeddings[0], np.ndarray)
+        else embeddings
+    )
+
+
+def _add_query_fields(
+    data_dict: Dict[str, Any],
+    query_result: QueryResult,
+    query_idx: int,
+) -> None:
+    """
+    Helper function to add fields from a query result to a dictionary.
+    Handles the nested array structure specific to query results.
+
+    Args:
+        data_dict: Dictionary to add the fields to
+        query_result: QueryResult containing the data
+        query_idx: Index of the current query being processed
+    """
+    for field in query_result["included"]:
+        value = query_result.get(field)
+        if value is not None:
+            key = field.rstrip("s")  # DF naming convention is not plural
+            if field == "embeddings":
+                value = _transform_embeddings(value)  # type: ignore
+            if isinstance(value, list) and len(value) > 0:
+                value = value[query_idx]  # type: ignore
+            data_dict[key] = value
+
+
+def _add_get_fields(
+    data_dict: Dict[str, Any],
+    get_result: GetResult,
+) -> None:
+    """
+    Helper function to add fields from a get result to a dictionary.
+    Handles the flat array structure specific to get results.
+
+    Args:
+        data_dict: Dictionary to add the fields to
+        get_result: GetResult containing the data
+    """
+    for field in get_result["included"]:
+        value = get_result.get(field)
+        if value is not None:
+            key = field.rstrip("s")  # DF naming convention is not plural
+            if field == "embeddings":
+                value = _transform_embeddings(value)  # type: ignore
+            data_dict[key] = value
+
+
+def query_result_to_dfs(query_result: QueryResult) -> List["pd.DataFrame"]:
+    """
+    Function to convert QueryResult to list of DataFrames.
+    Handles the nested array structure specific to query results.
+    Column order is defined by the order of the fields in the QueryResult.
+
+    Args:
+        query_result: QueryResult to convert to DataFrames.
+
+    Returns:
+        List of DataFrames.
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        raise ImportError("pandas is required to convert query results to DataFrames.")
+
+    dfs = []
+    num_queries = len(query_result["ids"])
+
+    for i in range(num_queries):
+        data_for_df: Dict[str, Any] = {}
+        data_for_df["id"] = query_result["ids"][i]
+
+        _add_query_fields(data_for_df, query_result, i)
+
+        df = pd.DataFrame(data_for_df)
+        df.set_index("id", inplace=True)
+        dfs.append(df)
+    return dfs
+
+
+def get_result_to_df(get_result: GetResult) -> "pd.DataFrame":
+    """
+    Function to convert GetResult to a DataFrame.
+    Handles the flat array structure specific to get results.
+    Column order is defined by the order of the fields in the GetResult.
+
+    Args:
+        get_result: GetResult to convert to a DataFrame.
+
+    Returns:
+        DataFrame.
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        raise ImportError("pandas is required to convert get results to a DataFrame.")
+
+    data_for_df: Dict[str, Any] = {}
+    data_for_df["id"] = get_result["ids"]
+
+    _add_get_fields(data_for_df, get_result)
+
+    df = pd.DataFrame(data_for_df)
+    df.set_index("id", inplace=True)
+    return df

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ httpx
 hypothesis==6.112.2 # TODO: Resolve breaking changes and bump version
 hypothesis[numpy]==6.112.2 # TODO: Resolve breaking changes and bump version
 mypy-protobuf
+pandas
 pre-commit
 protobuf==5.28.0 # Later version not compatible with opentelemetry 1.27.0
 psutil


### PR DESCRIPTION
## Description of changes

This PR adds support to convert both get and query results to pandas dataframes. As a byproduct, users can now get results in row format.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
