### PR TITLE
BUG: JS Client - Make embedding function parameter optional

### DIFF
--- a/clients/js/packages/chromadb-core/src/types.ts
+++ b/clients/js/packages/chromadb-core/src/types.ts
@@ -144,7 +144,7 @@ export type GetOrCreateCollectionParams = CreateCollectionParams;
 
 export type GetCollectionParams = {
   name: string;
-  embeddingFunction: IEmbeddingFunction;
+  embeddingFunction?: IEmbeddingFunction;
 };
 
 export type DeleteCollectionParams = {


### PR DESCRIPTION
## Description of changes

In the JS Client the `embeddingFunction` parameter for `getCollection` is optional, but in the type definition the `?` is missing making the type checker think it is a mandatory parameter.

The docustring for getCollection, indicating that `embeddingFunction` is optional is here:
https://github.com/chroma-core/chroma/blob/69dc7949147a412919f637e95f01274f988085cd/clients/js/packages/chromadb-core/src/ChromaClient.ts#L392

*Summarize the changes made by this PR.*
 - I changed `embeddingFunction: IEmbeddingFunction;` to `embeddingFunction?: IEmbeddingFunction;`

## Test plan
*How are these changes tested?*
- [X] No type errors when calling `getCollection` with just a `name` field
- [X] The correct collection is returned when `getCollection` is called without an `embeddingFunction`

## Documentation Changes
These changes make the code allign with the `getCollection` docustring, so no changes required.

