### PR TITLE
[CHORE] Demote "Block: <UUID> written to storage (<>B)" to debug

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -412,7 +412,7 @@ impl BlockManager {
             .await;
         match res {
             Ok(_) => {
-                tracing::info!(
+                tracing::debug!(
                     "Block: {} written to storage ({}B)",
                     block.id,
                     block_bytes_len


### PR DESCRIPTION
This only affects a single log line that's quite spammy.
