### PR TITLE
[BUG]  Attempt to fix CI flakiness.

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -62,6 +62,7 @@ hypothesis.settings.register_profile(
         hypothesis.HealthCheck.large_base_example,
         hypothesis.HealthCheck.function_scoped_fixture,
     ],
+    verbosity=hypothesis.Verbosity.verbose
 )
 
 hypothesis.settings.register_profile(

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -65,11 +65,15 @@ hypothesis.settings.register_profile(
 )
 
 hypothesis.settings.register_profile(
-    "fast", hypothesis.settings.get_profile("base"), max_examples=50
+    "fast", hypothesis.settings.get_profile("base"), max_examples=50,
+    phases=[hypothesis.Phase.explicit, hypothesis.Phase.reuse, hypothesis.Phase.generate,
+            hypothesis.Phase.target, hypothesis.Phase.explain],
 )
 # Hypothesis's default max_examples is 100
 hypothesis.settings.register_profile(
-    "normal", hypothesis.settings.get_profile("base"), max_examples=100
+    "normal", hypothesis.settings.get_profile("base"), max_examples=100,
+    phases=[hypothesis.Phase.explicit, hypothesis.Phase.reuse, hypothesis.Phase.generate,
+            hypothesis.Phase.target, hypothesis.Phase.explain],
 )
 hypothesis.settings.register_profile(
     "slow",

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -23,7 +23,7 @@ log:
     host: "logservice.chroma"
     port: 50051
     connect_timeout_ms: 5000
-    request_timeout_ms: 5000
+    request_timeout_ms: 60000 # 1 minute
     alt_host: "rust-log-service.chroma"
     use_alt_host_for_everything: true
 

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -40,7 +40,7 @@ query_service:
             host: "logservice.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 5000
+            request_timeout_ms: 60000 # 1 minute
             alt_host: "rust-log-service.chroma"
             use_alt_host_for_everything: true
     dispatcher:
@@ -117,7 +117,7 @@ compaction_service:
             host: "logservice.chroma"
             port: 50051
             connect_timeout_ms: 5000
-            request_timeout_ms: 5000
+            request_timeout_ms: 60000 # 1 minute
             alt_host: "rust-log-service.chroma"
             use_alt_host_for_everything: true
     dispatcher:

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -78,7 +78,7 @@ query_service:
             weighted_lru:
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
-    fetch_log_batch_size: 4000
+    fetch_log_batch_size: 1000
 
 compaction_service:
     service_name: "compaction-service"
@@ -134,7 +134,7 @@ compaction_service:
         max_compaction_size: 10000
         max_partition_size: 5000
         disabled_collections: [] # uuids to disable compaction for
-        fetch_log_batch_size: 4000
+        fetch_log_batch_size: 1000
     blockfile_provider:
         arrow:
             block_manager_config:


### PR DESCRIPTION
I believe CI flakes due to a single request timeout.  I injected such
and get the same types of failures as I see in CI.  If I don't inject a
failure I get 10/10 pass on my laptop vs. 0/1 in CI.

Sending this through CI.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
