### PR TITLE
[BUG] disable alt-host shunt

### DIFF
--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -25,7 +25,7 @@ log:
     connect_timeout_ms: 5000
     request_timeout_ms: 5000
     alt_host: "rust-log-service.chroma"
-    use_alt_host_for_everything: true
+    #use_alt_host_for_everything: true
 
 executor:
   distributed:

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -24,7 +24,7 @@ impl ChromaGrpcClients {
         let sysdb_channel = Channel::from_static("http://localhost:50051")
             .connect()
             .await?;
-        let logservice_channel = Channel::from_static("http://localhost:50054")
+        let logservice_channel = Channel::from_static("http://localhost:50052")
             .connect()
             .await?;
         let queryservice_channel = Channel::from_static("http://localhost:50053")

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -42,7 +42,7 @@ query_service:
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
             alt_host: "rust-log-service.chroma"
-            use_alt_host_for_everything: true
+            #use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -119,7 +119,7 @@ compaction_service:
             connect_timeout_ms: 5000
             request_timeout_ms: 5000
             alt_host: "rust-log-service.chroma"
-            use_alt_host_for_everything: true
+            #use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100


### PR DESCRIPTION
I don't know where it is or what the flake is, but I cannot rule out it
being this code without trying this minimal commit to disable
use_alt_host_for_everything in tilt.

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
