### PR TITLE
[ENH] When embedding functions have defined default_space, use them if the user hasn't specified

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -424,6 +424,14 @@ def create_collection_configuration_to_json(
                 "config": ef.get_config(),
             }
             register_embedding_function(type(ef))  # type: ignore
+            if hnsw_config is None:
+                hnsw_config = CreateHNSWConfiguration(space=ef.default_space())
+            elif hnsw_config.get("space") is None:
+                hnsw_config["space"] = ef.default_space()
+            if spann_config is None:
+                spann_config = CreateSpannConfiguration(space=ef.default_space())
+            elif spann_config.get("space") is None:
+                spann_config["space"] = ef.default_space()
     except Exception as e:
         warnings.warn(
             f"legacy embedding function config: {e}",


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - ...
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
