### PR TITLE
[CHORE] set verbosity for hypothesis to verbose.

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -62,6 +62,7 @@ hypothesis.settings.register_profile(
         hypothesis.HealthCheck.large_base_example,
         hypothesis.HealthCheck.function_scoped_fixture,
     ],
+    verbosity=hypothesis.Verbosity.verbose
 )
 
 hypothesis.settings.register_profile(


### PR DESCRIPTION
This affects CI and makes it so we get some debug output from
Hypothesis.  For example, when it fails the test because the deadline
was exceeded and then met.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
