### PR TITLE
[CHORE] Fix typing on empty configuration json returned, remove validation on num_threads in python

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -475,10 +475,6 @@ def validate_create_hnsw_config(
         if config["batch_size"] > config["sync_threshold"]:
             raise ValueError("batch_size must be less than or equal to sync_threshold")
     if "num_threads" in config:
-        if config["num_threads"] > cpu_count():
-            raise ValueError(
-                "num_threads must be less than or equal to the number of available threads"
-            )
         if config["num_threads"] <= 0:
             raise ValueError("num_threads must be greater than 0")
     if "resize_factor" in config:
@@ -535,10 +531,6 @@ def validate_update_hnsw_config(
         if config["ef_search"] <= 0:
             raise ValueError("ef_search must be greater than 0")
     if "num_threads" in config:
-        if config["num_threads"] > cpu_count():
-            raise ValueError(
-                "num_threads must be less than or equal to the number of available threads"
-            )
         if config["num_threads"] <= 0:
             raise ValueError("num_threads must be greater than 0")
     if "batch_size" in config and "sync_threshold" in config:

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -16,6 +16,8 @@ from chromadb.api.configuration import (
 from chromadb.serde import BaseModelJSONSerializable
 from chromadb.api.collection_configuration import (
     CollectionConfiguration,
+    HNSWConfiguration,
+    SpannConfiguration,
     collection_configuration_to_json,
     load_collection_configuration_from_json,
 )
@@ -153,7 +155,8 @@ class Collection(
                 stacklevel=2,
             )
             return CollectionConfiguration(
-                hnsw={},
+                hnsw=HNSWConfiguration(),
+                spann=SpannConfiguration(),
                 embedding_function=None,
             )
 


### PR DESCRIPTION
## Description of changes

This PR fixes a typing error when an empty configuration json is returned during get_configuration and removes validation on num_threads in python

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
