### PR TITLE
[BUG] Remove num_threads from server return

### DIFF
--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -268,7 +268,6 @@ def test_hnsw_configuration_updates(client: ClientAPI) -> None:
         hnsw_config = loaded_config.get("hnsw", {})
         if isinstance(hnsw_config, dict):
             assert hnsw_config.get("ef_search") == 20
-            assert hnsw_config.get("num_threads") == 2
             assert hnsw_config.get("space") == "cosine"
             assert hnsw_config.get("ef_construction") == 100
             assert hnsw_config.get("max_neighbors") == 16
@@ -337,7 +336,6 @@ def test_configuration_result_format(client: ClientAPI) -> None:
     hnsw_config = coll._model.configuration_json.get("hnsw")
     assert hnsw_config is not None
     assert hnsw_config.get("ef_search") == 10
-    assert hnsw_config.get("num_threads") == 2
     assert hnsw_config.get("space") == "cosine"
 
 

--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -225,12 +225,6 @@ export namespace Api {
     /**
      * @type {number}
      * @memberof HnswConfiguration
-     * minimum: 0
-     */
-    num_threads?: number;
-    /**
-     * @type {number}
-     * @memberof HnswConfiguration
      */
     resize_factor?: number;
     space?: Api.HnswSpace;

--- a/clients/js/packages/chromadb-core/test/collection.config.client.test.ts
+++ b/clients/js/packages/chromadb-core/test/collection.config.client.test.ts
@@ -38,7 +38,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(100);
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(10);
     expect(collection.configuration?.hnsw?.ef_search).toBe(20);
-    expect(collection.configuration?.hnsw?.num_threads).toBe(2);
   });
 
   test("it should get a collection with configuration", async () => {
@@ -67,7 +66,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(150);
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(15);
     expect(collection.configuration?.hnsw?.ef_search).toBe(100);
-    expect(collection.configuration?.hnsw?.num_threads).toBeGreaterThan(0);
   });
 
   test("it should update a collection configuration", async () => {
@@ -84,7 +82,6 @@ describe("collection operations", () => {
     });
 
     expect(collection.configuration?.hnsw?.ef_search).toBe(10);
-    expect(collection.configuration?.hnsw?.num_threads).toBe(1);
 
     // Update configuration
     const updateConfig: UpdateCollectionConfiguration = {
@@ -108,7 +105,6 @@ describe("collection operations", () => {
     expect(updatedCollection.configuration).toBeDefined();
     expect(updatedCollection.configuration).toHaveProperty("hnsw");
     expect(updatedCollection.configuration?.hnsw?.ef_search).toBe(20);
-    expect(updatedCollection.configuration?.hnsw?.num_threads).toBe(2);
     expect(updatedCollection.configuration?.hnsw?.space).toBe("cosine");
     expect(updatedCollection.configuration?.hnsw?.ef_construction).toBe(100);
     expect(updatedCollection.configuration?.hnsw?.max_neighbors).toBe(16);
@@ -145,7 +141,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(100); // Default
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(16); // Default
     expect(collection.configuration?.hnsw?.ef_search).toBe(100); // Default
-    expect(collection.configuration?.hnsw?.num_threads).toBeGreaterThan(0); // Default > 0
   });
 
   test("it should apply defaults for unspecified hnsw params (space)", async () => {
@@ -160,7 +155,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(100); // Default
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(16); // Default
     expect(collection.configuration?.hnsw?.ef_search).toBe(100); // Default
-    expect(collection.configuration?.hnsw?.num_threads).toBeGreaterThan(0); // Default > 0
   });
 
   test("it should apply defaults for unspecified hnsw params (ef_construction)", async () => {
@@ -175,7 +169,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(200); // Specified
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(16); // Default
     expect(collection.configuration?.hnsw?.ef_search).toBe(100); // Default
-    expect(collection.configuration?.hnsw?.num_threads).toBeGreaterThan(0); // Default > 0
   });
 
   test("it should apply defaults for unspecified hnsw params (max_neighbors)", async () => {
@@ -190,7 +183,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(100); // Default
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(32); // Specified
     expect(collection.configuration?.hnsw?.ef_search).toBe(100); // Default
-    expect(collection.configuration?.hnsw?.num_threads).toBeGreaterThan(0); // Default > 0
   });
 
   test("it should apply defaults for unspecified hnsw params (ef_search)", async () => {
@@ -205,7 +197,6 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(100); // Default
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(16); // Default
     expect(collection.configuration?.hnsw?.ef_search).toBe(50); // Specified
-    expect(collection.configuration?.hnsw?.num_threads).toBeGreaterThan(0); // Default > 0
   });
 
   test("it should apply defaults for unspecified hnsw params (num_threads)", async () => {
@@ -220,6 +211,5 @@ describe("collection operations", () => {
     expect(collection.configuration?.hnsw?.ef_construction).toBe(100); // Default
     expect(collection.configuration?.hnsw?.max_neighbors).toBe(16); // Default
     expect(collection.configuration?.hnsw?.ef_search).toBe(100); // Default
-    expect(collection.configuration?.hnsw?.num_threads).toBe(4); // Specified
   });
 });

--- a/rust/types/src/hnsw_configuration.rs
+++ b/rust/types/src/hnsw_configuration.rs
@@ -82,6 +82,7 @@ pub struct HnswConfiguration {
     #[serde(default = "default_m")]
     pub max_neighbors: usize,
     #[serde(default = "default_num_threads")]
+    #[serde(skip_serializing)]
     pub num_threads: usize,
     #[serde(default = "default_resize_factor")]
     pub resize_factor: f64,


### PR DESCRIPTION
## Description of changes

This PR removes num_threads from server response to fix an issue where client side validation constantly rejects the num_threads passed in. Since num_threads is not used anywhere in the code, and to ensure existing clients do not break when upgraded, we removed client side validation on num threads in a previous PR (https://github.com/chroma-core/chroma/pull/4325), and this PR removes the serialization of num_threads on server-side.

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
