### PR TITLE
[ENH]: Minimal logging for single-node server

### DIFF
--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -72,7 +72,9 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
         init_tracing(tracing_layers);
         init_panic_tracing_hook();
     } else {
-        eprintln!("OpenTelemetry is not enabled because it is missing from the config.");
+        let tracing_layers = vec![init_global_filter_layer(), init_stdout_layer()];
+        init_tracing(tracing_layers);
+        init_panic_tracing_hook();
     }
 
     let mut fe_cfg = config.frontend.clone();

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -113,10 +113,45 @@ pub fn init_otel_layer(
         .with_filter(tracing_subscriber::filter::LevelFilter::TRACE)
         .boxed()
 }
+pub fn init_stdout_single_node() -> Box<dyn Layer<Registry> + Send + Sync> {
+    fmt::layer()
+        .with_writer(std::io::stdout)
+        .pretty()
+        .compact()
+        .with_target(false)
+        .with_filter(tracing_subscriber::filter::FilterFn::new(|metadata| {
+            // NOTE(rescrv):  This is a hack, too.  Not an uppercase hack, just a hack.  This
+            // one's localized to the cache module.  There's not much to do to unify it with
+            // the otel filter because these are different output layers from the tracing.
 
+            // This filter ensures that we don't cache calls for get/insert on stdout, but will
+            // still see the clear call.
+            !(metadata
+                .module_path()
+                .unwrap_or("")
+                .starts_with("chroma_cache")
+                && metadata.name() != "clear")
+        }))
+        .with_filter(tracing_subscriber::filter::FilterFn::new(|metadata| {
+            metadata.module_path().unwrap_or("").starts_with("chroma")
+                || metadata.module_path().unwrap_or("").starts_with("wal3")
+                || metadata.module_path().unwrap_or("").starts_with("worker")
+                || metadata
+                    .module_path()
+                    .unwrap_or("")
+                    .starts_with("garbage_collector")
+                || metadata
+                    .module_path()
+                    .unwrap_or("")
+                    .starts_with("opentelemetry_sdk")
+        }))
+        .with_filter(tracing_subscriber::filter::LevelFilter::INFO)
+        .boxed()
+}
 pub fn init_stdout_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
     fmt::layer()
         .pretty()
+        .compact()
         .with_target(false)
         .with_filter(tracing_subscriber::filter::FilterFn::new(|metadata| {
             // NOTE(rescrv):  This is a hack, too.  Not an uppercase hack, just a hack.  This


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Adds trace logs for single node server - this is a useful feedback for single-node/CLI users 
   - Makes log messages compact

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
