### PR TITLE
[BUG]: <100 items, >20% delete Wrong distance comparison in local HNSW

### DIFF
--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -327,7 +327,7 @@ impl LocalHnswSegmentReader {
                                     // SAFETY(hammadb): We are sure that the heap has at least one element
                                     // because we insert until we have k elements.
                                     let top = max_heap.peek().unwrap();
-                                    if top.measure < curr_distance {
+                                    if top.measure > curr_distance {
                                         max_heap.pop();
                                         max_heap.push(RecordDistance {
                                             offset_id: *curr_id as u32,


### PR DESCRIPTION
Fixes: #4275

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Fixes an issue a logical error in distance comparison when adding RecordDistance to heap. We're looking for minimal no maximal distance
   - When traversing a index with less than 100 items and more than 20% of the data deleted

## Test plan
*How are these changes tested?*

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
