### PR TITLE
[ENH] Add VerifyingDataSet that verifies loaded data

### DIFF
--- a/rust/load/src/workloads.rs
+++ b/rust/load/src/workloads.rs
@@ -109,5 +109,20 @@ pub fn all_workloads() -> HashMap<String, Workload> {
             "random-upsert".to_string(),
             Workload::RandomUpsert(KeySelector::Random(Skew::Zipf { theta: 0.999 })),
         ),
+        (
+            "verify".to_string(),
+            Workload::Hybrid(vec![
+                (
+                    0.9,
+                    Workload::Get(GetQuery {
+                        skew: Skew::Uniform,
+                        limit: Distribution::Constant(10),
+                        metadata: None,
+                        document: None,
+                    }),
+                ),
+                (0.1, Workload::Load),
+            ]),
+        ),
     ])
 }


### PR DESCRIPTION
## Description of changes

Upsert sequentially from the reference data set. Verify data by getting from the subset of already-loaded keys and checking results against the reference data set.

## Test plan

1. Create reference dataset using loader script:

```
export CHROMA_TENANT_ID="abc"
export CHROMA_DATABASE="chroma-load"
export CHROMA_API_KEY="xyz"

pipenv run -- python script/import_dataset.py \
--tenant $CHROMA_TENANT_ID \
--database $CHROMA_DATABASE \
--collection reference-all-MiniLM-L6-v2 \
--dataset roneneldan/TinyStories \
--dataset-split train \
--sentence-transformer-model all-MiniLM-L6-v2 \
--max-rows 1000000 \
--max-rps 120 \
--sequential-keys
```

2. (manually) Create (or reset via delete+recreate) the test collection: `test-all-MiniLM-L6-v2`
 
3.  Start the chroma-load service:

```
export CHROMA_HOST="https://staging.chroma.api:8000"
export CHROMA_DATABASE="chroma-load"
export CHROMA_TOKEN="xyz"

RUST_LOG=debug cargo run --bin chroma-load
```

4. Kick-off a verification workload, with 10 operations / second.

```
cargo run --bin chroma-load-start -- \
--host http://localhost:3001 \
--name my-test \
--expires "2min" \
--data-set "test-all-MiniLM-L6-v2" \
--workload verify \
--constant-throughput "10"
```

5. Ensure no failures are recorded by the workload.