### PR TITLE
[BUG] Fix race between hnsw load and hnsw purge

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -241,7 +241,7 @@ impl Handler<TaskResult<FetchVersionFileOutput, FetchVersionFileError>>
         tracing::info!("Processing FetchVersionFile result");
 
         // Stage 1: Process fetched version file and initiate version computation
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => {
                 tracing::info!(
                     content_size = output.version_file_content().len(),
@@ -266,7 +266,7 @@ impl Handler<TaskResult<FetchVersionFileOutput, FetchVersionFileError>>
                     Err(GarbageCollectorError::ComputeVersionsToDelete(
                         ComputeVersionsToDeleteError::ParseError(e),
                     ));
-                self.ok_or_terminate(result, ctx);
+                self.ok_or_terminate(result, ctx).await;
                 return;
             }
         };
@@ -289,7 +289,8 @@ impl Handler<TaskResult<FetchVersionFileOutput, FetchVersionFileError>>
             .await
         {
             tracing::error!(error = ?e, "Failed to send compute task to dispatcher");
-            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx);
+            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx)
+                .await;
             return;
         }
         tracing::info!("Successfully sent compute versions task");
@@ -308,7 +309,7 @@ impl Handler<TaskResult<ComputeVersionsToDeleteOutput, ComputeVersionsToDeleteEr
         ctx: &ComponentContext<GarbageCollectorOrchestrator>,
     ) {
         // Stage 2: Process computed versions and initiate marking in SysDB
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -323,7 +324,7 @@ impl Handler<TaskResult<ComputeVersionsToDeleteOutput, ComputeVersionsToDeleteEr
                 deletion_list: Vec::new(),
             };
             tracing::info!(?response, "Garbage collection completed early");
-            self.terminate_with_result(Ok(response), ctx);
+            self.terminate_with_result(Ok(response), ctx).await;
             // Signal the dispatcher to shut down
             return;
         }
@@ -349,7 +350,8 @@ impl Handler<TaskResult<ComputeVersionsToDeleteOutput, ComputeVersionsToDeleteEr
             .send(mark_task, Some(Span::current()))
             .await
         {
-            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx);
+            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx)
+                .await;
             // Signal the dispatcher to shut down
             return;
         }
@@ -368,7 +370,7 @@ impl Handler<TaskResult<MarkVersionsAtSysDbOutput, MarkVersionsAtSysDbError>>
         ctx: &ComponentContext<GarbageCollectorOrchestrator>,
     ) {
         // Stage 3: After marking versions, compute unused files
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -392,7 +394,8 @@ impl Handler<TaskResult<MarkVersionsAtSysDbOutput, MarkVersionsAtSysDbError>>
             .send(compute_task, Some(Span::current()))
             .await
         {
-            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx);
+            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx)
+                .await;
             return;
         }
     }
@@ -410,7 +413,7 @@ impl Handler<TaskResult<ComputeUnusedFilesOutput, ComputeUnusedFilesError>>
         ctx: &ComponentContext<GarbageCollectorOrchestrator>,
     ) {
         // Stage 4: After identifying unused files, delete them
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -434,7 +437,8 @@ impl Handler<TaskResult<ComputeUnusedFilesOutput, ComputeUnusedFilesError>>
             .send(delete_task, Some(Span::current()))
             .await
         {
-            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx);
+            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx)
+                .await;
             return;
         }
 
@@ -455,7 +459,7 @@ impl Handler<TaskResult<DeleteUnusedFilesOutput, DeleteUnusedFilesError>>
         ctx: &ComponentContext<GarbageCollectorOrchestrator>,
     ) {
         // Stage 6: After deleting unused files, delete the versions
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -468,7 +472,7 @@ impl Handler<TaskResult<DeleteUnusedFilesOutput, DeleteUnusedFilesError>>
                 num_versions_deleted: 0,
                 deletion_list: Vec::new(),
             };
-            self.terminate_with_result(Ok(response), ctx);
+            self.terminate_with_result(Ok(response), ctx).await;
             return;
         }
 
@@ -508,7 +512,8 @@ impl Handler<TaskResult<DeleteUnusedFilesOutput, DeleteUnusedFilesError>>
             .send(delete_versions_task, Some(Span::current()))
             .await
         {
-            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx);
+            self.terminate_with_result(Err(GarbageCollectorError::Channel(e)), ctx)
+                .await;
             return;
         }
     }
@@ -526,7 +531,7 @@ impl Handler<TaskResult<DeleteVersionsAtSysDbOutput, DeleteVersionsAtSysDbError>
         ctx: &ComponentContext<GarbageCollectorOrchestrator>,
     ) {
         // Stage 6: Final stage - versions deleted, complete the garbage collection process
-        let _output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let _output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -538,7 +543,7 @@ impl Handler<TaskResult<DeleteVersionsAtSysDbOutput, DeleteVersionsAtSysDbError>
             deletion_list: self.deletion_list.clone(),
         };
 
-        self.terminate_with_result(Ok(response), ctx);
+        self.terminate_with_result(Ok(response), ctx).await;
     }
 }
 

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -5,7 +5,7 @@ use super::{HnswIndex, HnswIndexConfig, Index, IndexConfig, IndexUuid};
 
 use async_trait::async_trait;
 use chroma_cache::AysncPartitionedMutex;
-use chroma_cache::{Cache, Weighted};
+use chroma_cache::Cache;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
 use chroma_distance::DistanceFunction;
@@ -21,7 +21,7 @@ use std::time::Instant;
 use std::{path::PathBuf, sync::Arc};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
-use tracing::{instrument, Instrument, Span};
+use tracing::{instrument, Span};
 use uuid::Uuid;
 
 // These are the files hnswlib writes to disk. This is strong coupling, but we need to know
@@ -55,8 +55,6 @@ pub struct HnswIndexProvider {
     pub temporary_storage_path: PathBuf,
     storage: Storage,
     pub write_mutex: AysncPartitionedMutex<IndexUuid>,
-    #[allow(dead_code)]
-    purger: Option<Arc<tokio::task::JoinHandle<()>>>,
 }
 
 #[derive(Clone)]
@@ -88,17 +86,12 @@ impl Configurable<(HnswProviderConfig, Storage)> for HnswIndexProvider {
         _registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (hnsw_config, storage) = config;
-        // TODO(rescrv):  Long-term we should migrate this to the component API.
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let cache =
-            chroma_cache::from_config_with_event_listener(&hnsw_config.hnsw_cache_config, tx)
-                .await?;
+        let cache = chroma_cache::from_config(&hnsw_config.hnsw_cache_config).await?;
         Ok(Self::new(
             storage.clone(),
             PathBuf::from(&hnsw_config.hnsw_temporary_path),
             cache,
             hnsw_config.permitted_parallelism,
-            rx,
         ))
     }
 }
@@ -125,33 +118,8 @@ impl HnswIndexProvider {
         storage_path: PathBuf,
         cache: Box<dyn Cache<CollectionUuid, HnswIndexRef>>,
         permitted_parallelism: u32,
-        mut evicted: tokio::sync::mpsc::UnboundedReceiver<(CollectionUuid, HnswIndexRef)>,
     ) -> Self {
         let cache: Arc<dyn Cache<CollectionUuid, HnswIndexRef>> = cache.into();
-        let temporary_storage_path = storage_path.to_path_buf();
-        let task = async move {
-            while let Some((collection_id, index_ref)) = evicted.recv().await {
-                let index_id = {
-                    let index = index_ref.inner.read();
-                    index.id
-                };
-                let weight = index_ref.weight();
-                tracing::info!(
-                    "[Cache Eviction] Purging index: {} for collection {} with weight: {} at ts {}",
-                    index_id,
-                    collection_id,
-                    weight,
-                    Instant::now().elapsed().as_nanos()
-                );
-                let _ = Self::purge_one_id(&temporary_storage_path, index_id).await;
-            }
-        };
-        let purger = Some(Arc::new(tokio::task::spawn(task.instrument(
-            tracing::info_span!(
-                "HnswIndex Cache Eviction Purger",
-                tag = "hnsw_cache_eviction_purger"
-            ),
-        ))));
         Self {
             cache,
             storage,
@@ -160,7 +128,6 @@ impl HnswIndexProvider {
                 permitted_parallelism as usize,
                 (),
             ),
-            purger,
         }
     }
 
@@ -364,7 +331,7 @@ impl HnswIndexProvider {
 
         // Check if the entry is in the cache, if it is, we assume
         // another thread has loaded the index and we return it.
-        match self.get(id, cache_key).await {
+        let index = match self.get(id, cache_key).await {
             Some(index) => Ok(index.clone()),
             None => match HnswIndex::load(index_storage_path_str, &index_config, ef_search, *id) {
                 Ok(index) => {
@@ -376,7 +343,17 @@ impl HnswIndexProvider {
                 }
                 Err(e) => Err(Box::new(HnswIndexProviderOpenError::IndexLoadError(e))),
             },
-        }
+        };
+
+        // Cleanup directory.
+        Self::purge_one_id(&self.temporary_storage_path, *id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to cleanup files: {}", e);
+                Box::new(HnswIndexProviderOpenError::CleanupError(e))
+            })?;
+
+        index
     }
 
     // Compactor
@@ -479,39 +456,6 @@ impl HnswIndexProvider {
         Ok(())
     }
 
-    /// Purge entries from the cache by index ID and remove temporary files from disk.
-    pub async fn purge_by_id(&mut self, cache_keys: &[CacheKey]) {
-        for collection_uuid in cache_keys {
-            let Some(index_id) = self
-                .cache
-                .get(collection_uuid)
-                .await
-                .ok()
-                .flatten()
-                .map(|r| r.inner.read().id)
-            else {
-                tracing::info!(
-                    "[End of compaction purging] No index found for collection: {} at ts {}",
-                    collection_uuid,
-                    Instant::now().elapsed().as_nanos()
-                );
-                continue;
-            };
-            tracing::info!(
-                "[End of compaction purging] Purging index: {} for collection {} at ts {}",
-                index_id,
-                collection_uuid,
-                Instant::now().elapsed().as_nanos()
-            );
-            match Self::purge_one_id(&self.temporary_storage_path, index_id).await {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::error!("Failed to remove temporary files for {index_id}: {e}");
-                }
-            }
-        }
-    }
-
     pub async fn purge_one_id(path: &Path, id: IndexUuid) -> tokio::io::Result<()> {
         let index_storage_path = path.join(id.to_string());
         tracing::info!(
@@ -559,6 +503,8 @@ pub enum HnswIndexProviderOpenError {
     IndexLoadError(#[from] Box<dyn ChromaError>),
     #[error("Path: {0} could not be converted to string")]
     PathToStringError(PathBuf),
+    #[error("Failed to cleanup files")]
+    CleanupError(#[from] tokio::io::Error),
 }
 
 impl ChromaError for HnswIndexProviderOpenError {
@@ -567,6 +513,7 @@ impl ChromaError for HnswIndexProviderOpenError {
             HnswIndexProviderOpenError::FileError(_) => ErrorCodes::Internal,
             HnswIndexProviderOpenError::IndexLoadError(e) => e.code(),
             HnswIndexProviderOpenError::PathToStringError(_) => ErrorCodes::InvalidArgument,
+            HnswIndexProviderOpenError::CleanupError(_) => ErrorCodes::Internal,
         }
     }
 }
@@ -675,8 +622,7 @@ mod tests {
 
         let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
         let cache = new_non_persistent_cache_for_test();
-        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache, 16, rx);
+        let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache, 16);
         let collection_id = CollectionUuid(Uuid::new_v4());
 
         let dimensionality = 128;
@@ -708,5 +654,79 @@ mod tests {
         let forked_index_id = forked_index.inner.read().id;
 
         assert_ne!(created_index_id, forked_index_id);
+    }
+
+    #[tokio::test]
+    async fn test_open() {
+        let storage_dir = tempfile::tempdir().unwrap().path().to_path_buf();
+
+        // Create the directories needed
+        tokio::fs::create_dir_all(&storage_dir).await.unwrap();
+
+        let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
+        let cache = new_non_persistent_cache_for_test();
+        let provider = HnswIndexProvider::new(storage, storage_dir.clone(), cache, 16);
+        let collection_id = CollectionUuid(Uuid::new_v4());
+
+        let dimensionality = 2;
+        let distance_function = DistanceFunction::Euclidean;
+        let default_hnsw_params = HnswConfiguration::default();
+        let created_index = provider
+            .create(
+                &collection_id,
+                default_hnsw_params.max_neighbors,
+                default_hnsw_params.ef_construction,
+                default_hnsw_params.ef_search,
+                dimensionality,
+                distance_function.clone(),
+            )
+            .await
+            .unwrap();
+        created_index
+            .inner
+            .write()
+            .add(1, &[1.0, 3.0])
+            .expect("Expected to add");
+        let created_index_id = created_index.inner.read().id;
+        provider.commit(created_index).expect("Expected to commit");
+        provider
+            .flush(&created_index_id)
+            .await
+            .expect("Expected to flush");
+        let open_index = provider
+            .open(
+                &created_index_id,
+                &collection_id,
+                dimensionality,
+                distance_function,
+                default_hnsw_params.ef_search,
+            )
+            .await
+            .expect("Expect open to succeed");
+        let opened_index_id = open_index.inner.read().id;
+
+        assert_eq!(opened_index_id, created_index_id);
+        check_purge_successful(storage_dir.clone()).await;
+    }
+
+    pub async fn check_purge_successful(path: impl AsRef<Path>) {
+        let mut entries = tokio::fs::read_dir(&path)
+            .await
+            .expect("Failed to read dir");
+
+        while let Some(entry) = entries.next_entry().await.expect("Failed to read next dir") {
+            let path = entry.path();
+            let metadata = entry.metadata().await.expect("Failed to read metadata");
+
+            if metadata.is_dir() {
+                assert!(
+                    path.ends_with("hnsw")
+                        || path.ends_with("block")
+                        || path.ends_with("sparse_index")
+                );
+            } else {
+                panic!("Expected hnsw purge to be successful")
+            }
+        }
     }
 }

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -346,6 +346,8 @@ impl HnswIndexProvider {
         };
 
         // Cleanup directory.
+        // Readers don't modify the index, so we can delete the files on disk
+        // once the index is fully loaded in memory.
         Self::purge_one_id(&self.temporary_storage_path, *id)
             .await
             .map_err(|e| {

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -19,7 +19,6 @@ use tempfile::tempdir;
 pub use types::*;
 
 pub fn test_hnsw_index_provider() -> HnswIndexProvider {
-    let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
     HnswIndexProvider::new(
         test_storage(),
         tempdir()
@@ -27,6 +26,5 @@ pub fn test_hnsw_index_provider() -> HnswIndexProvider {
             .into_path(),
         new_non_persistent_cache_for_test(),
         16,
-        rx,
     )
 }

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2298,13 +2298,11 @@ mod tests {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -2504,13 +2502,11 @@ mod tests {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -2752,13 +2748,11 @@ mod tests {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -2975,13 +2969,11 @@ mod tests {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -3227,13 +3219,11 @@ mod tests {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -3509,13 +3499,11 @@ mod tests {
 
     fn new_hnsw_provider_for_tests(storage: Storage, temp_dir: &TempDir) -> HnswIndexProvider {
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         HnswIndexProvider::new(
             storage,
             PathBuf::from(temp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         )
     }
 

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -264,6 +264,10 @@ impl DistributedHNSWSegmentWriter {
         flushed_files.insert(HNSW_INDEX.to_string(), vec![hnsw_index_id.to_string()]);
         Ok(flushed_files)
     }
+
+    pub fn index_uuid(&self) -> IndexUuid {
+        self.index.inner.read().id
+    }
 }
 
 #[derive(Clone)]

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -316,6 +316,10 @@ impl SpannSegmentWriter {
             }),
         }
     }
+
+    pub fn hnsw_index_uuid(&self) -> IndexUuid {
+        self.index.hnsw_index.inner.read().id
+    }
 }
 
 pub struct SpannSegmentFlusher {
@@ -589,13 +593,11 @@ mod test {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
@@ -702,13 +704,11 @@ mod test {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage,
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
@@ -812,13 +812,11 @@ mod test {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
@@ -916,13 +914,11 @@ mod test {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage,
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let spann_reader = SpannSegmentReader::from_segment(
             &collection,
@@ -979,13 +975,11 @@ mod test {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
 
@@ -1087,13 +1081,11 @@ mod test {
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage,
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let gc_context = GarbageCollectionContext::try_from_config(
             &(

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -49,8 +49,7 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     /// Takes the result channel of the orchestrator. The channel should have been set when this is invoked
     fn take_result_channel(&mut self) -> Sender<Result<Self::Output, Self::Error>>;
 
-    /// Terminate the orchestrator with a result
-    async fn terminate_with_result(
+    async fn default_terminate_with_result(
         &mut self,
         res: Result<Self::Output, Self::Error>,
         ctx: &ComponentContext<Self>,
@@ -70,6 +69,15 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
         if cancel {
             ctx.cancellation_token.cancel();
         }
+    }
+
+    /// Terminate the orchestrator with a result
+    async fn terminate_with_result(
+        &mut self,
+        res: Result<Self::Output, Self::Error>,
+        ctx: &ComponentContext<Self>,
+    ) {
+        self.default_terminate_with_result(res, ctx).await
     }
 
     /// Terminate the orchestrator if the result is an error. Returns the output if any.

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -68,13 +68,11 @@ fn add_to_index_and_get_reader<'a>(
         let blockfile_provider =
             BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let hnsw_provider = HnswIndexProvider::new(
             storage.clone(),
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 128;

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -349,8 +349,7 @@ impl Handler<ScheduledCompactMessage> for CompactionManager {
         ctx: &ComponentContext<CompactionManager>,
     ) {
         tracing::info!("CompactionManager: Performing scheduled compaction");
-        let ids = self.compact_batch().await;
-        self.hnsw_index_provider.purge_by_id(&ids).await;
+        let _ = self.compact_batch().await;
 
         // Compaction is done, schedule the next compaction
         ctx.scheduler.schedule(
@@ -456,7 +455,8 @@ mod tests {
     use chroma_types::SegmentUuid;
     use chroma_types::{Collection, LogRecord, Operation, OperationRecord, Segment};
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use tokio::fs;
 
     #[tokio::test]
     async fn test_compaction_manager() {
@@ -466,6 +466,10 @@ mod tests {
             _ => panic!("Expected InMemoryLog"),
         };
         let tmpdir = tempfile::tempdir().unwrap();
+        // Clear temp dir.
+        tokio::fs::remove_dir_all(tmpdir.path())
+            .await
+            .expect("Failed to remove temp dir");
         let storage = Storage::Local(LocalStorage::new(tmpdir.path().to_str().unwrap()));
 
         let tenant_1 = "tenant_1".to_string();
@@ -643,7 +647,6 @@ mod tests {
         let block_cache = new_cache_for_test();
         let sparse_index_cache = new_cache_for_test();
         let hnsw_cache = new_non_persistent_cache_for_test();
-        let (_, rx) = tokio::sync::mpsc::unbounded_channel();
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
                 PlGarbageCollectionConfig::default(),
@@ -664,7 +667,6 @@ mod tests {
             PathBuf::from(tmpdir.path().to_str().unwrap()),
             hnsw_cache,
             16,
-            rx,
         );
         let spann_provider = SpannProvider {
             hnsw_provider: hnsw_provider.clone(),
@@ -703,5 +705,25 @@ mod tests {
             (compacted == vec![collection_uuid_1, collection_uuid_2])
                 || (compacted == vec![collection_uuid_2, collection_uuid_1])
         );
+        check_purge_successful(tmpdir.path()).await;
+    }
+
+    pub async fn check_purge_successful(path: impl AsRef<Path>) {
+        let mut entries = fs::read_dir(&path).await.expect("Failed to read dir");
+
+        while let Some(entry) = entries.next_entry().await.expect("Failed to read next dir") {
+            let path = entry.path();
+            let metadata = entry.metadata().await.expect("Failed to read metadata");
+
+            if metadata.is_dir() {
+                assert!(
+                    path.ends_with("hnsw")
+                        || path.ends_with("block")
+                        || path.ends_with("sparse_index")
+                );
+            } else {
+                panic!("Expected hnsw purge to be successful")
+            }
+        }
     }
 }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1,13 +1,14 @@
 use std::{
     cell::OnceCell,
     collections::HashMap,
+    path::Path,
     sync::{atomic::AtomicU32, Arc},
 };
 
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_index::hnsw_provider::HnswIndexProvider;
+use chroma_index::{hnsw_provider::HnswIndexProvider, IndexUuid};
 use chroma_log::Log;
 use chroma_segment::{
     blockfile_metadata::{MetadataSegmentError, MetadataSegmentWriter},
@@ -104,6 +105,7 @@ pub(crate) struct CompactWriters {
 #[derive(Debug)]
 pub struct CompactOrchestrator {
     collection_id: CollectionUuid,
+    hnsw_index_uuid: Option<IndexUuid>,
     rebuild: bool,
     fetch_log_batch_size: u32,
     max_compaction_size: usize,
@@ -224,6 +226,7 @@ impl CompactOrchestrator {
     ) -> Self {
         CompactOrchestrator {
             collection_id,
+            hnsw_index_uuid: None,
             rebuild,
             fetch_log_batch_size,
             max_compaction_size,
@@ -248,6 +251,31 @@ impl CompactOrchestrator {
         }
     }
 
+    async fn try_purge_hnsw(path: &Path, hnsw_index_uuid: Option<IndexUuid>) {
+        if let Some(hnsw_index_uuid) = hnsw_index_uuid {
+            let _ = HnswIndexProvider::purge_one_id(path, hnsw_index_uuid).await;
+        }
+    }
+
+    async fn ok_or_terminate_with_purge<O, E: Into<CompactionError>>(
+        &mut self,
+        res: Result<O, E>,
+        ctx: &ComponentContext<Self>,
+    ) -> Option<O> {
+        match res {
+            Ok(output) => Some(output),
+            Err(error) => {
+                Self::try_purge_hnsw(
+                    &self.hnsw_provider.temporary_storage_path,
+                    self.hnsw_index_uuid,
+                )
+                .await;
+                self.terminate_with_result(Err(error.into()), ctx);
+                None
+            }
+        }
+    }
+
     async fn partition(
         &mut self,
         records: Chunk<LogRecord>,
@@ -258,7 +286,8 @@ impl CompactOrchestrator {
         tracing::info!("Sending N Records: {:?}", records.len());
         let input = PartitionInput::new(records, self.max_partition_size);
         let task = wrap(operator, input, ctx.receiver());
-        self.send(task, ctx).await;
+        let res = self.dispatcher().send(task, Some(Span::current())).await;
+        self.ok_or_terminate_with_purge(res, ctx).await;
     }
 
     async fn materialize_log(
@@ -290,7 +319,8 @@ impl CompactOrchestrator {
                 next_max_offset_id.clone(),
             );
             let task = wrap(operator, input, ctx.receiver());
-            self.send(task, ctx).await;
+            let res = self.dispatcher().send(task, Some(Span::current())).await;
+            self.ok_or_terminate_with_purge(res, ctx).await;
         }
     }
 
@@ -299,7 +329,10 @@ impl CompactOrchestrator {
         materialized_logs: MaterializeLogsResult,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let writers = match self.ok_or_terminate(self.get_segment_writers(), ctx) {
+        let writers = match self
+            .ok_or_terminate_with_purge(self.get_segment_writers(), ctx)
+            .await
+        {
             Some(writers) => writers,
             None => return,
         };
@@ -322,7 +355,7 @@ impl CompactOrchestrator {
             );
             let task = wrap(operator, input, ctx.receiver());
             let res = self.dispatcher().send(task, Some(span)).await;
-            if self.ok_or_terminate(res, ctx).is_none() {
+            if self.ok_or_terminate_with_purge(res, ctx).await.is_none() {
                 return;
             }
         }
@@ -345,7 +378,7 @@ impl CompactOrchestrator {
             );
             let task = wrap(operator, input, ctx.receiver());
             let res = self.dispatcher().send(task, Some(span)).await;
-            if self.ok_or_terminate(res, ctx).is_none() {
+            if self.ok_or_terminate_with_purge(res, ctx).await.is_none() {
                 return;
             }
         }
@@ -365,7 +398,7 @@ impl CompactOrchestrator {
                 ApplyLogToSegmentWriterInput::new(writer, materialized_logs, writers.record_reader);
             let task = wrap(operator, input, ctx.receiver());
             let res = self.dispatcher().send(task, Some(span)).await;
-            self.ok_or_terminate(res, ctx);
+            self.ok_or_terminate_with_purge(res, ctx).await;
         }
     }
 
@@ -379,7 +412,7 @@ impl CompactOrchestrator {
         let input = CommitSegmentWriterInput::new(segment_writer);
         let task = wrap(operator, input, ctx.receiver());
         let res = self.dispatcher().send(task, Some(span)).await;
-        self.ok_or_terminate(res, ctx);
+        self.ok_or_terminate_with_purge(res, ctx).await;
     }
 
     async fn dispatch_segment_flush(
@@ -392,7 +425,7 @@ impl CompactOrchestrator {
         let input = FlushSegmentWriterInput::new(segment_flusher);
         let task = wrap(operator, input, ctx.receiver());
         let res = self.dispatcher().send(task, Some(span)).await;
-        self.ok_or_terminate(res, ctx);
+        self.ok_or_terminate_with_purge(res, ctx).await;
     }
 
     async fn register(&mut self, ctx: &ComponentContext<CompactOrchestrator>) {
@@ -404,7 +437,7 @@ impl CompactOrchestrator {
                 .ok_or(CompactionError::InvariantViolation(
                     "Collection information should have been obtained",
                 ));
-        let collection = match self.ok_or_terminate(collection_cell, ctx) {
+        let collection = match self.ok_or_terminate_with_purge(collection_cell, ctx).await {
             Some(collection) => collection,
             None => return,
         };
@@ -412,6 +445,11 @@ impl CompactOrchestrator {
             match u64::try_from(self.collection_logical_size_delta_bytes) {
                 Ok(size_bytes) => size_bytes,
                 _ => {
+                    Self::try_purge_hnsw(
+                        &self.hnsw_provider.temporary_storage_path,
+                        self.hnsw_index_uuid,
+                    )
+                    .await;
                     self.terminate_with_result(
                         Err(CompactionError::InvariantViolation(
                             "The collection size delta after rebuild should be non-negative",
@@ -440,7 +478,8 @@ impl CompactOrchestrator {
         );
 
         let task = wrap(operator, input, ctx.receiver());
-        self.send(task, ctx).await;
+        let res = self.dispatcher().send(task, Some(Span::current())).await;
+        self.ok_or_terminate_with_purge(res, ctx).await;
     }
 
     fn get_segment_writers(&self) -> Result<CompactWriters, CompactionError> {
@@ -550,13 +589,21 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         message: TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegmentsError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(output) => output,
             None => return,
         };
 
         let collection = output.collection.clone();
         if self.collection.set(collection.clone()).is_err() {
+            Self::try_purge_hnsw(
+                &self.hnsw_provider.temporary_storage_path,
+                self.hnsw_index_uuid,
+            )
+            .await;
             self.terminate_with_result(
                 Err(CompactionError::InvariantViolation(
                     "Collection information should not have been initialized",
@@ -568,21 +615,24 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
 
         self.pulled_log_offset = collection.log_position;
 
-        let record_reader = match self.ok_or_terminate(
-            match RecordSegmentReader::from_segment(
-                &output.record_segment,
-                &self.blockfile_provider,
+        let record_reader = match self
+            .ok_or_terminate_with_purge(
+                match RecordSegmentReader::from_segment(
+                    &output.record_segment,
+                    &self.blockfile_provider,
+                )
+                .await
+                {
+                    Ok(reader) => Ok(Some(reader)),
+                    Err(err) => match *err {
+                        RecordSegmentReaderCreationError::UninitializedSegment => Ok(None),
+                        _ => Err(*err),
+                    },
+                },
+                ctx,
             )
             .await
-            {
-                Ok(reader) => Ok(Some(reader)),
-                Err(err) => match *err {
-                    RecordSegmentReaderCreationError::UninitializedSegment => Ok(None),
-                    _ => Err(*err),
-                },
-            },
-            ctx,
-        ) {
+        {
             Some(reader) => reader,
             None => return,
         };
@@ -615,7 +665,11 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             None => {
                 // Collection is not yet initialized, there is no need to initialize the writers
                 // Future handlers should return early on empty materialized logs without using writers
-                self.send(log_task, ctx).await;
+                let res = self
+                    .dispatcher()
+                    .send(log_task, Some(Span::current()))
+                    .await;
+                self.ok_or_terminate_with_purge(res, ctx).await;
                 return;
             }
         };
@@ -630,42 +684,64 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             vector_segment.file_path = Default::default();
         }
 
-        let record_writer = match self.ok_or_terminate(
-            RecordSegmentWriter::from_segment(&record_segment, &self.blockfile_provider).await,
-            ctx,
-        ) {
+        let record_writer = match self
+            .ok_or_terminate_with_purge(
+                RecordSegmentWriter::from_segment(&record_segment, &self.blockfile_provider).await,
+                ctx,
+            )
+            .await
+        {
             Some(writer) => writer,
             None => return,
         };
-        let metadata_writer = match self.ok_or_terminate(
-            MetadataSegmentWriter::from_segment(&metadata_segment, &self.blockfile_provider).await,
-            ctx,
-        ) {
-            Some(writer) => writer,
-            None => return,
-        };
-        let (vector_writer, is_vector_segment_spann) = match vector_segment.r#type {
-            SegmentType::Spann => match self.ok_or_terminate(
-                self.spann_provider
-                    .write(&collection, &vector_segment, dimension)
+        let metadata_writer = match self
+            .ok_or_terminate_with_purge(
+                MetadataSegmentWriter::from_segment(&metadata_segment, &self.blockfile_provider)
                     .await,
                 ctx,
-            ) {
-                Some(writer) => (VectorSegmentWriter::Spann(writer), true),
-                None => return,
-            },
-            _ => match self.ok_or_terminate(
-                DistributedHNSWSegmentWriter::from_segment(
-                    &collection,
-                    &vector_segment,
-                    dimension,
-                    self.hnsw_provider.clone(),
+            )
+            .await
+        {
+            Some(writer) => writer,
+            None => return,
+        };
+        let (hnsw_index_uuid, vector_writer, is_vector_segment_spann) = match vector_segment.r#type
+        {
+            SegmentType::Spann => match self
+                .ok_or_terminate_with_purge(
+                    self.spann_provider
+                        .write(&collection, &vector_segment, dimension)
+                        .await,
+                    ctx,
                 )
                 .await
-                .map_err(|err| *err),
-                ctx,
-            ) {
-                Some(writer) => (VectorSegmentWriter::Hnsw(writer), false),
+            {
+                Some(writer) => (
+                    writer.hnsw_index_uuid(),
+                    VectorSegmentWriter::Spann(writer),
+                    true,
+                ),
+                None => return,
+            },
+            _ => match self
+                .ok_or_terminate_with_purge(
+                    DistributedHNSWSegmentWriter::from_segment(
+                        &collection,
+                        &vector_segment,
+                        dimension,
+                        self.hnsw_provider.clone(),
+                    )
+                    .await
+                    .map_err(|err| *err),
+                    ctx,
+                )
+                .await
+            {
+                Some(writer) => (
+                    writer.index_uuid(),
+                    VectorSegmentWriter::Hnsw(writer),
+                    false,
+                ),
                 None => return,
             },
         };
@@ -678,6 +754,11 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
         };
 
         if self.writers.set(writers).is_err() {
+            Self::try_purge_hnsw(
+                &self.hnsw_provider.temporary_storage_path,
+                self.hnsw_index_uuid,
+            )
+            .await;
             self.terminate_with_result(
                 Err(CompactionError::InvariantViolation(
                     "Segment writers should not have been initialized",
@@ -686,6 +767,8 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             );
             return;
         }
+
+        self.hnsw_index_uuid = Some(hnsw_index_uuid);
 
         // Prefetch segments
         let prefetch_segments = match self.rebuild {
@@ -704,10 +787,18 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                 PrefetchSegmentInput::new(segment, self.blockfile_provider.clone()),
                 ctx.receiver(),
             );
-            self.send(prefetch_task, ctx).await;
+            let res = self
+                .dispatcher()
+                .send(prefetch_task, Some(Span::current()))
+                .await;
+            self.ok_or_terminate_with_purge(res, ctx).await;
         }
 
-        self.send(log_task, ctx).await;
+        let res = self
+            .dispatcher()
+            .send(log_task, Some(Span::current()))
+            .await;
+        self.ok_or_terminate_with_purge(res, ctx).await;
     }
 }
 
@@ -720,7 +811,8 @@ impl Handler<TaskResult<PrefetchSegmentOutput, PrefetchSegmentError>> for Compac
         message: TaskResult<PrefetchSegmentOutput, PrefetchSegmentError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        self.ok_or_terminate(message.into_inner(), ctx);
+        self.ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await;
     }
 }
 
@@ -733,7 +825,10 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CompactOrchestrator 
         message: TaskResult<FetchLogOutput, FetchLogError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(recs) => recs,
             None => {
                 tracing::info!("cancelled fetch log task");
@@ -747,6 +842,11 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CompactOrchestrator 
                 tracing::info!("Pulled Logs Up To Offset: {:?}", self.pulled_log_offset);
             }
             None => {
+                Self::try_purge_hnsw(
+                    &self.hnsw_provider.temporary_storage_path,
+                    self.hnsw_index_uuid,
+                )
+                .await;
                 self.terminate_with_result(
                     Err(CompactionError::InvariantViolation(
                         "Logs should be present for compaction",
@@ -771,7 +871,10 @@ impl Handler<TaskResult<SourceRecordSegmentOutput, SourceRecordSegmentError>>
         message: TaskResult<SourceRecordSegmentOutput, SourceRecordSegmentError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(output) => output,
             None => return,
         };
@@ -779,7 +882,10 @@ impl Handler<TaskResult<SourceRecordSegmentOutput, SourceRecordSegmentError>>
         // Each record should corresond to a log
         self.total_records_post_compaction = output.len() as u64;
         if output.is_empty() {
-            let writers = match self.ok_or_terminate(self.get_segment_writers(), ctx) {
+            let writers = match self
+                .ok_or_terminate_with_purge(self.get_segment_writers(), ctx)
+                .await
+            {
                 Some(writer) => writer,
                 None => return,
             };
@@ -808,7 +914,10 @@ impl Handler<TaskResult<PartitionOutput, PartitionError>> for CompactOrchestrato
         message: TaskResult<PartitionOutput, PartitionError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(recs) => recs.records,
             None => return,
         };
@@ -827,7 +936,10 @@ impl Handler<TaskResult<MaterializeLogOutput, MaterializeLogOperatorError>>
         message: TaskResult<MaterializeLogOutput, MaterializeLogOperatorError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(res) => res,
             None => return,
         };
@@ -861,7 +973,10 @@ impl Handler<TaskResult<ApplyLogToSegmentWriterOutput, ApplyLogToSegmentWriterOp
         message: TaskResult<ApplyLogToSegmentWriterOutput, ApplyLogToSegmentWriterOperatorError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let message = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let message = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(message) => message,
             None => return,
         };
@@ -880,7 +995,7 @@ impl Handler<TaskResult<ApplyLogToSegmentWriterOutput, ApplyLogToSegmentWriterOp
                     "Invariant violation: segment writer task count not found",
                 ))
                 .cloned();
-            match self.ok_or_terminate(num_tasks_left, ctx) {
+            match self.ok_or_terminate_with_purge(num_tasks_left, ctx).await {
                 Some(num_tasks_left) => num_tasks_left,
                 None => return,
             }
@@ -888,7 +1003,7 @@ impl Handler<TaskResult<ApplyLogToSegmentWriterOutput, ApplyLogToSegmentWriterOp
 
         if num_tasks_left == 0 && self.num_uncompleted_materialization_tasks == 0 {
             let segment_writer = self.get_segment_writer_by_id(message.segment_id).await;
-            let segment_writer = match self.ok_or_terminate(segment_writer, ctx) {
+            let segment_writer = match self.ok_or_terminate_with_purge(segment_writer, ctx).await {
                 Some(writer) => writer,
                 None => return,
             };
@@ -910,7 +1025,10 @@ impl Handler<TaskResult<CommitSegmentWriterOutput, CommitSegmentWriterOperatorEr
         message: TaskResult<CommitSegmentWriterOutput, CommitSegmentWriterOperatorError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let message = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let message = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(message) => message,
             None => return,
         };
@@ -935,7 +1053,10 @@ impl Handler<TaskResult<FlushSegmentWriterOutput, FlushSegmentWriterOperatorErro
         message: TaskResult<FlushSegmentWriterOutput, FlushSegmentWriterOperatorError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
-        let message = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let message = match self
+            .ok_or_terminate_with_purge(message.into_inner(), ctx)
+            .await
+        {
             Some(message) => message,
             None => return,
         };
@@ -963,6 +1084,11 @@ impl Handler<TaskResult<RegisterOutput, RegisterError>> for CompactOrchestrator 
         message: TaskResult<RegisterOutput, RegisterError>,
         ctx: &ComponentContext<CompactOrchestrator>,
     ) {
+        Self::try_purge_hnsw(
+            &self.hnsw_provider.temporary_storage_path,
+            self.hnsw_index_uuid,
+        )
+        .await;
         self.terminate_with_result(
             message
                 .into_inner()

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -558,7 +558,7 @@ impl Orchestrator for CompactOrchestrator {
             self.hnsw_index_uuid,
         )
         .await;
-        Orchestrator::terminate_with_result(self, res, ctx).await;
+        self.default_terminate_with_result(res, ctx).await
     }
 }
 

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -547,18 +547,12 @@ impl Orchestrator for CompactOrchestrator {
             .expect("The result channel should be set before take")
     }
 
-    async fn terminate_with_result(
-        &mut self,
-        res: Result<CompactionResponse, CompactionError>,
-        ctx: &ComponentContext<Self>,
-    ) {
-        // Cleanup first.
+    async fn cleanup(&mut self) {
         Self::try_purge_hnsw(
             &self.hnsw_provider.temporary_storage_path,
             self.hnsw_index_uuid,
         )
-        .await;
-        self.default_terminate_with_result(res, ctx).await
+        .await
     }
 }
 

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -138,7 +138,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CountOrchestrator {
         message: TaskResult<FetchLogOutput, FetchLogError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -175,6 +175,7 @@ impl Handler<TaskResult<CountRecordsOutput, CountRecordsError>> for CountOrchest
                 )
             }),
             ctx,
-        );
+        )
+        .await;
     }
 }

--- a/rust/worker/src/execution/orchestration/get.rs
+++ b/rust/worker/src/execution/orchestration/get.rs
@@ -204,7 +204,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for GetOrchestrator {
         message: TaskResult<FetchLogOutput, FetchLogError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -234,7 +234,7 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for GetOrchestrator {
         message: TaskResult<FilterOutput, FilterError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -266,7 +266,7 @@ impl Handler<TaskResult<LimitOutput, LimitError>> for GetOrchestrator {
         message: TaskResult<LimitOutput, LimitError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -320,7 +320,7 @@ impl Handler<TaskResult<ProjectionOutput, ProjectionError>> for GetOrchestrator 
         message: TaskResult<ProjectionOutput, ProjectionError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -333,6 +333,7 @@ impl Handler<TaskResult<ProjectionOutput, ProjectionError>> for GetOrchestrator 
             .map(|(l, _)| l.size_bytes())
             .sum();
 
-        self.terminate_with_result(Ok((output, fetch_log_size_bytes)), ctx);
+        self.terminate_with_result(Ok((output, fetch_log_size_bytes)), ctx)
+            .await;
     }
 }

--- a/rust/worker/src/execution/orchestration/knn.rs
+++ b/rust/worker/src/execution/orchestration/knn.rs
@@ -246,7 +246,7 @@ impl Handler<TaskResult<KnnLogOutput, KnnLogError>> for KnnOrchestrator {
         message: TaskResult<KnnLogOutput, KnnLogError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -264,7 +264,7 @@ impl Handler<TaskResult<KnnHnswOutput, KnnHnswError>> for KnnOrchestrator {
         message: TaskResult<KnnHnswOutput, KnnHnswError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -282,7 +282,7 @@ impl Handler<TaskResult<KnnMergeOutput, KnnMergeError>> for KnnOrchestrator {
         message: TaskResult<KnnMergeOutput, KnnMergeError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -340,6 +340,7 @@ impl Handler<TaskResult<KnnProjectionOutput, KnnProjectionError>> for KnnOrchest
         message: TaskResult<KnnProjectionOutput, KnnProjectionError>,
         ctx: &ComponentContext<Self>,
     ) {
-        self.terminate_with_result(message.into_inner().map_err(|e| e.into()), ctx);
+        self.terminate_with_result(message.into_inner().map_err(|e| e.into()), ctx)
+            .await;
     }
 }

--- a/rust/worker/src/execution/orchestration/knn_filter.rs
+++ b/rust/worker/src/execution/orchestration/knn_filter.rs
@@ -240,7 +240,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for KnnFilterOrchestrato
         message: TaskResult<FetchLogOutput, FetchLogError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -270,17 +270,20 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for KnnFilterOrchestrator {
         message: TaskResult<FilterOutput, FilterError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
-        let collection_dimension = match self.ok_or_terminate(
-            self.collection_and_segments
-                .collection
-                .dimension
-                .ok_or(KnnError::NoCollectionDimension),
-            ctx,
-        ) {
+        let collection_dimension = match self
+            .ok_or_terminate(
+                self.collection_and_segments
+                    .collection
+                    .dimension
+                    .ok_or(KnnError::NoCollectionDimension),
+                ctx,
+            )
+            .await
+        {
             Some(dim) => dim as u32,
             None => return,
         };
@@ -298,6 +301,7 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for KnnFilterOrchestrator {
                         ),
                     ctx,
                 )
+                .await
                 .flatten()
             {
                 Some(hnsw_configuration) => hnsw_configuration,
@@ -319,19 +323,22 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for KnnFilterOrchestrator {
                 }
 
                 Err(err) => {
-                    self.terminate_with_result(Err((*err).into()), ctx);
+                    self.terminate_with_result(Err((*err).into()), ctx).await;
                     return;
                 }
             }
         } else {
-            let params = match self.ok_or_terminate(
-                self.collection_and_segments
-                    .collection
-                    .config
-                    .get_spann_config()
-                    .ok_or(KnnError::InvalidDistanceFunction),
-                ctx,
-            ) {
+            let params = match self
+                .ok_or_terminate(
+                    self.collection_and_segments
+                        .collection
+                        .config
+                        .get_spann_config()
+                        .ok_or(KnnError::InvalidDistanceFunction),
+                    ctx,
+                )
+                .await
+            {
                 Some(params) => params,
                 None => return,
             };
@@ -355,7 +362,7 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for KnnFilterOrchestrator {
             dimension: collection_dimension as usize,
             fetch_log_bytes,
         };
-        self.terminate_with_result(Ok(output), ctx);
+        self.terminate_with_result(Ok(output), ctx).await;
     }
 }
 

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -141,7 +141,7 @@ impl SpannKnnOrchestrator {
             self.knn_filter_output.dimension,
         )
         .await;
-        let reader = match self.ok_or_terminate(reader_res, ctx) {
+        let reader = match self.ok_or_terminate(reader_res, ctx).await {
             Some(reader) => reader,
             None => {
                 tracing::error!("Failed to create SpannSegmentReader");
@@ -247,7 +247,7 @@ impl Handler<TaskResult<KnnLogOutput, KnnLogError>> for SpannKnnOrchestrator {
         message: TaskResult<KnnLogOutput, KnnLogError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -268,7 +268,7 @@ impl Handler<TaskResult<SpannCentersSearchOutput, SpannCentersSearchError>>
         message: TaskResult<SpannCentersSearchOutput, SpannCentersSearchError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -301,7 +301,7 @@ impl Handler<TaskResult<SpannFetchPlOutput, SpannFetchPlError>> for SpannKnnOrch
         message: TaskResult<SpannFetchPlOutput, SpannFetchPlError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -335,7 +335,7 @@ impl Handler<TaskResult<SpannBfPlOutput, SpannBfPlError>> for SpannKnnOrchestrat
         message: TaskResult<SpannBfPlOutput, SpannBfPlError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -356,7 +356,7 @@ impl Handler<TaskResult<SpannKnnMergeOutput, SpannKnnMergeError>> for SpannKnnOr
         message: TaskResult<SpannKnnMergeOutput, SpannKnnMergeError>,
         ctx: &ComponentContext<Self>,
     ) {
-        let output = match self.ok_or_terminate(message.into_inner(), ctx) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
             Some(output) => output,
             None => return,
         };
@@ -414,6 +414,7 @@ impl Handler<TaskResult<KnnProjectionOutput, KnnProjectionError>> for SpannKnnOr
         message: TaskResult<KnnProjectionOutput, KnnProjectionError>,
         ctx: &ComponentContext<Self>,
     ) {
-        self.terminate_with_result(message.into_inner().map_err(|e| e.into()), ctx);
+        self.terminate_with_result(message.into_inner().map_err(|e| e.into()), ctx)
+            .await;
     }
 }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - If hnsw cache evicts and purger is called concurrently with provider.open() then there is a race and can cause deletion of files that is being loaded concurrently
   - Fixes it by removing the purger and purging at the end of provider.open(). For provider.fork() or provider.create(), we purge at the end of compaction and also in case of failures
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
