### PR TITLE
[BUG]: Setting max_lifetime and max_timeout to None for in-memory DB

### DIFF
--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -115,6 +115,8 @@ impl Configurable<SqliteDBConfig, SqliteCreationError> for SqliteDb {
                 .await?
         } else {
             SqlitePoolOptions::new()
+                .max_lifetime(None)
+                .idle_timeout(None)
                 .max_connections(1)
                 .connect_with(conn_options.in_memory(true).shared_cache(true))
                 .await?

--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -114,6 +114,7 @@ impl Configurable<SqliteDBConfig, SqliteCreationError> for SqliteDb {
                 .connect_with(conn_options.filename(path).create_if_missing(true))
                 .await?
         } else {
+
             SqlitePoolOptions::new()
                 .max_lifetime(None)
                 .idle_timeout(None)

--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -114,7 +114,6 @@ impl Configurable<SqliteDBConfig, SqliteCreationError> for SqliteDb {
                 .connect_with(conn_options.filename(path).create_if_missing(true))
                 .await?
         } else {
-
             SqlitePoolOptions::new()
                 .max_lifetime(None)
                 .idle_timeout(None)


### PR DESCRIPTION
#4332

## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Default sqlx pool options close idle connections for in-memory DB after 10mins which clears the data in the DB causing subsequent client calls to fail with sqlite errors. This PR sets max_lifetime and idle_timeout for in-memmory DB to None which prevents connection from being reaped

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

