### PR TITLE
[BLD] Setup rust in pypi release, standardize protoc action

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -31,7 +31,7 @@ runs:
           exit 1
         }
     - name: Install Protoc
-      uses: arduino/setup-protoc@v2
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ inputs.github-token }}
     - name: Use sccache

--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -98,7 +98,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Add target
@@ -151,7 +151,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Add targets

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -73,8 +73,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Setup Rust
+        uses: ./.github/actions/rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - After #4337 this job fails due to not calling the rust setup action to get correct rust version
   - CLN: Standardize usage of 
 - New functionality
   - None

## Test plan
*How are these changes tested?*
Will have to test on main
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
