### PR TITLE
[ENH] Turn on spann by default

### DIFF
--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -246,16 +246,19 @@ def fd_not_exceeding_threadpool_size(threadpool_size: int) -> None:
     )
 
 def get_space(collection: Collection):
+    # TODO: this is a hack to get the space
+    # We should update the tests to not pass space via metadata instead use collection
+    # configuration_json
+    space = None
     if "hnsw:space" in collection.metadata:
-        return collection.metadata["hnsw:space"]
+        space = collection.metadata["hnsw:space"]
     if collection._model.configuration_json is None:
-        return None
+        return space
     if 'spann' in collection._model.configuration_json and collection._model.configuration_json.get('spann') is not None and 'space' in collection._model.configuration_json.get('spann'):
-        return collection._model.configuration_json.get('spann').get('space')
+        space = collection._model.configuration_json.get('spann').get('space')
     elif 'hnsw' in collection._model.configuration_json and collection._model.configuration_json.get('hnsw') is not None and 'space' in collection._model.configuration_json.get('hnsw'):
-        return collection._model.configuration_json.get('hnsw').get('space')
-    else:
-        return None
+        space = collection._model.configuration_json.get('hnsw').get('space')
+    return space
 
 def ann_accuracy(
     collection: Collection,

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -257,7 +257,8 @@ def get_space(collection: Collection):
     if 'spann' in collection._model.configuration_json and collection._model.configuration_json.get('spann') is not None and 'space' in collection._model.configuration_json.get('spann'):
         space = collection._model.configuration_json.get('spann').get('space')
     elif 'hnsw' in collection._model.configuration_json and collection._model.configuration_json.get('hnsw') is not None and 'space' in collection._model.configuration_json.get('hnsw'):
-        space = collection._model.configuration_json.get('hnsw').get('space')
+        if space is None:
+            space = collection._model.configuration_json.get('hnsw').get('space')
     return space
 
 def ann_accuracy(

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -46,4 +46,4 @@ scorecard:
       - "collection_id:*"
     score: 100
 enable_span_indexing: true
-default_knn_index: "hnsw"
+default_knn_index: "spann"

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -54,4 +54,4 @@ scorecard:
 circuit_breaker:
   requests: 1000
 enable_span_indexing: true
-default_knn_index: "hnsw"
+default_knn_index: "spann"

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -1438,9 +1438,13 @@ mod tests {
         assert!(segments.iter().any(
             |s| s.r#type == SegmentType::BlockfileMetadata && s.scope == SegmentScope::METADATA
         ));
-        assert!(segments
-            .iter()
-            .any(|s| s.r#type == SegmentType::HnswDistributed && s.scope == SegmentScope::VECTOR));
+        assert!(
+            segments.iter().any(
+                |s| s.r#type == SegmentType::HnswDistributed && s.scope == SegmentScope::VECTOR
+            ) || segments
+                .iter()
+                .any(|s| s.r#type == SegmentType::Spann && s.scope == SegmentScope::VECTOR)
+        );
         assert!(segments
             .iter()
             .any(|s| s.r#type == SegmentType::BlockfileRecord && s.scope == SegmentScope::RECORD));


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - This is a placeholder PR that enables spann by default. It is just for testing if CI is green after all fixes have gone in.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None