### PR TITLE
[BLD] Setup rust, correct var name for token

### DIFF
--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # On Windows, we want to set up Python with the correct architecture
       - name: Set up Python on Windows
@@ -132,10 +132,10 @@ jobs:
     needs: version
     steps:
       - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Setup Rust
+        uses: ./.github/actions/rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set version in pyproject.toml
         shell: bash
         run: |


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Use the correct arg name for `github-token` to prevent rate limits against GH api
   - Setup-rust in another action missing it
 - New functionality
   - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None