### PR TITLE
[CHORE] Increase default max batch size

### DIFF
--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -171,7 +171,10 @@ impl Log {
                 .get_max_batch_size()
                 .await
                 .map_err(|err| Box::new(err) as Box<dyn ChromaError>),
-            Log::Grpc(_) => Ok(100),
+            // NOTE(hammadb): This is set to a high value and may cause issues
+            // the quota system should be used to limit the number of records
+            // upstream.
+            Log::Grpc(_) => Ok(1000),
             Log::InMemory(_) => todo!(),
         }
     }


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Increases the default max batch size to be much higher since the quota system will be responsible for this.
   - TODO: We should deprecate the pre-flight-check here and prefer the server to just reject the request.
 - New functionality
   - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None