### PR TITLE
[CHORE] Make rust action set version to installed version

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -13,6 +13,7 @@ runs:
       run: |
         rustup --version
         rustup toolchain install 1.81.0
+        rustup default 1.81.0
     # Needed for sccache to work on Windows
     - name: Set default toolchain to rust-toolchain.toml on Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Make rust action set version to installed verison to help with things like - https://github.com/chroma-core/chroma/actions/runs/14605047733/job/40973984539 that are harder to express with the toolchain. Runners come with their own default version of rust so if we override it makes sense to default to that
 - New functionality
   - None

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None