### PR TITLE
[CHORE]  Disable rust log service because it flaked once landing.

### DIFF
--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -25,7 +25,7 @@ log:
     connect_timeout_ms: 5000
     request_timeout_ms: 60000 # 1 minute
     alt_host: "rust-log-service.chroma"
-    use_alt_host_for_everything: true
+    #use_alt_host_for_everything: true
 
 executor:
   distributed:

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -24,7 +24,7 @@ impl ChromaGrpcClients {
         let sysdb_channel = Channel::from_static("http://localhost:50051")
             .connect()
             .await?;
-        let logservice_channel = Channel::from_static("http://localhost:50054")
+        let logservice_channel = Channel::from_static("http://localhost:50052")
             .connect()
             .await?;
         let queryservice_channel = Channel::from_static("http://localhost:50053")

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -42,7 +42,7 @@ query_service:
             connect_timeout_ms: 5000
             request_timeout_ms: 60000 # 1 minute
             alt_host: "rust-log-service.chroma"
-            use_alt_host_for_everything: true
+            #use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100
@@ -119,7 +119,7 @@ compaction_service:
             connect_timeout_ms: 5000
             request_timeout_ms: 60000 # 1 minute
             alt_host: "rust-log-service.chroma"
-            use_alt_host_for_everything: true
+            #use_alt_host_for_everything: true
     dispatcher:
         num_worker_threads: 4
         dispatcher_queue_size: 100


### PR DESCRIPTION
## Description of changes

- Disable it, again.

## Test plan

Passed in PR CI.  Failed in main CI, so it's a revert.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
