### PR TITLE
[ENH] Disable quota and add limit for collection fork

### DIFF
--- a/go/pkg/common/errors.go
+++ b/go/pkg/common/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrCollectionVersionInvalid              = errors.New("collection version invalid")
 	ErrCollectionVersionFileNameStale        = errors.New("collection version file name stale")
 	ErrCollectionEntryIsStale                = errors.New("collection entry is stale - one of version, version_file_name, or log_position is stale")
+	ErrCollectionTooManyFork                 = errors.New("collection entry has too many forks")
 
 	// Collection metadata errors
 	ErrUnknownCollectionMetadataType = errors.New("collection metadata value type not supported")

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1135,7 +1135,7 @@ pub struct ForkCollectionPayload {
     )
 )]
 async fn fork_collection(
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
     Json(payload): Json<ForkCollectionPayload>,
@@ -1150,17 +1150,19 @@ async fn fork_collection(
     tracing::info!(
         "Forking collection [{collection_id}] in database [{database}] for tenant [{tenant}]"
     );
-    server
-        .authenticate_and_authorize(
-            &headers,
-            AuthzAction::ForkCollection,
-            AuthzResource {
-                tenant: Some(tenant.clone()),
-                database: Some(database.clone()),
-                collection: Some(collection_id.clone()),
-            },
-        )
-        .await?;
+    // NOTE: The quota check if skipped for fork collection for now, and we rely on the scorecard to limit access to certain tenents
+    // TODO: Unify the quota and scorecard
+    // server
+    //     .authenticate_and_authorize(
+    //         &headers,
+    //         AuthzAction::ForkCollection,
+    //         AuthzResource {
+    //             tenant: Some(tenant.clone()),
+    //             database: Some(database.clone()),
+    //             collection: Some(collection_id.clone()),
+    //         },
+    //     )
+    //     .await?;
     let _guard =
         server.scorecard_request(&["op:fork_collection", format!("tenant:{}", tenant).as_str()]);
     let collection_id =


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Disable the quota system for collection fork. We rely on a properly configured scorecard for now to limit access to this feature.
   - Limit the maximum number of entries in the lineage file. 
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
