### PR TITLE
[ENH] Introduce + consume foyer.obtain()

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -274,7 +274,6 @@ pub(super) struct BlockManager {
     block_cache: Arc<dyn PersistentCache<Uuid, Block>>,
     storage: Storage,
     max_block_size_bytes: usize,
-    write_mutex: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl BlockManager {
@@ -288,7 +287,6 @@ impl BlockManager {
             block_cache,
             storage,
             max_block_size_bytes,
-            write_mutex: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -339,7 +337,7 @@ impl BlockManager {
         id: &Uuid,
         priority: StorageRequestPriority,
     ) -> Result<Option<Block>, GetError> {
-        let block = self.block_cache.get(id).await.ok().flatten();
+        let block = self.block_cache.obtain(*id).await.ok().flatten();
         match block {
             Some(block) => Ok(Some(block)),
             None => async {
@@ -358,20 +356,8 @@ impl BlockManager {
                             deserialization_span.in_scope(|| Block::from_bytes(&bytes, *id));
                         match block {
                             Ok(block) => {
-                                let _guard = self.write_mutex.lock().await;
-                                match self.block_cache.get(id).await {
-                                    Ok(Some(b)) => {
-                                        Ok(Some(b))
-                                    }
-                                    Ok(None) => {
-                                        self.block_cache.insert(*id, block.clone()).await;
-                                        Ok(Some(block))
-                                    }
-                                    Err(e) => {
-                                        tracing::error!("Error getting block from cache {:?}", e);
-                                        Err(GetError::BlockLoadError(e.into()))
-                                    }
-                                }
+                                self.block_cache.insert(*id, block.clone()).await;
+                                Ok(Some(block))
                             }
                             Err(e) => {
                                 tracing::error!(
@@ -497,7 +483,7 @@ impl RootManager {
         &self,
         id: &Uuid,
     ) -> Result<Option<RootReader>, RootManagerError> {
-        let index = self.cache.get(id).await.ok().flatten();
+        let index = self.cache.obtain(*id).await.ok().flatten();
         match index {
             Some(index) => Ok(Some(index)),
             None => {

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -314,6 +314,7 @@ where
     cache_hit: opentelemetry::metrics::Counter<u64>,
     cache_miss: opentelemetry::metrics::Counter<u64>,
     get_latency: opentelemetry::metrics::Histogram<u64>,
+    obtain_latency: opentelemetry::metrics::Histogram<u64>,
     insert_latency: opentelemetry::metrics::Histogram<u64>,
     remove_latency: opentelemetry::metrics::Histogram<u64>,
     clear_latency: opentelemetry::metrics::Histogram<u64>,
@@ -427,6 +428,7 @@ where
         let cache_hit = meter.u64_counter("cache_hit").build();
         let cache_miss = meter.u64_counter("cache_miss").build();
         let get_latency = meter.u64_histogram("get_latency").build();
+        let obtain_latency = meter.u64_histogram("obtain_latency").build();
         let insert_latency = meter.u64_histogram("insert_latency").build();
         let remove_latency = meter.u64_histogram("remove_latency").build();
         let clear_latency = meter.u64_histogram("clear_latency").build();
@@ -435,6 +437,7 @@ where
             cache_hit,
             cache_miss,
             get_latency,
+            obtain_latency,
             insert_latency,
             remove_latency,
             clear_latency,
@@ -480,7 +483,7 @@ where
     }
 
     async fn obtain(&self, key: K) -> Result<Option<V>, CacheError> {
-        let _stopwatch = Stopwatch::new(&self.get_latency);
+        let _stopwatch = Stopwatch::new(&self.obtain_latency);
         let res = self.cache.obtain(key).await?.map(|v| v.value().clone());
         if res.is_some() {
             self.cache_hit.add(1, &[]);
@@ -508,6 +511,7 @@ where
     cache_hit: opentelemetry::metrics::Counter<u64>,
     cache_miss: opentelemetry::metrics::Counter<u64>,
     get_latency: opentelemetry::metrics::Histogram<u64>,
+    obtain_latency: opentelemetry::metrics::Histogram<u64>,
     insert_latency: opentelemetry::metrics::Histogram<u64>,
     remove_latency: opentelemetry::metrics::Histogram<u64>,
     clear_latency: opentelemetry::metrics::Histogram<u64>,
@@ -540,6 +544,7 @@ where
         let cache_hit = meter.u64_counter("cache_hit").build();
         let cache_miss = meter.u64_counter("cache_miss").build();
         let get_latency = meter.u64_histogram("get_latency").build();
+        let obtain_latency = meter.u64_histogram("obtain_latency").build();
         let insert_latency = meter.u64_histogram("insert_latency").build();
         let remove_latency = meter.u64_histogram("remove_latency").build();
         let clear_latency = meter.u64_histogram("clear_latency").build();
@@ -548,6 +553,7 @@ where
             cache_hit,
             cache_miss,
             get_latency,
+            obtain_latency,
             insert_latency,
             remove_latency,
             clear_latency,
@@ -592,6 +598,7 @@ where
         let cache_hit = meter.u64_counter("cache_hit").build();
         let cache_miss = meter.u64_counter("cache_miss").build();
         let get_latency = meter.u64_histogram("get_latency").build();
+        let obtain_latency = meter.u64_histogram("obtain_latency").build();
         let insert_latency = meter.u64_histogram("insert_latency").build();
         let remove_latency = meter.u64_histogram("remove_latency").build();
         let clear_latency = meter.u64_histogram("clear_latency").build();
@@ -600,6 +607,7 @@ where
             cache_hit,
             cache_miss,
             get_latency,
+            obtain_latency,
             insert_latency,
             remove_latency,
             clear_latency,
@@ -641,7 +649,7 @@ where
     }
 
     async fn obtain(&self, key: K) -> Result<Option<V>, CacheError> {
-        let _stopwatch = Stopwatch::new(&self.get_latency);
+        let _stopwatch = Stopwatch::new(&self.obtain_latency);
         let res = self.cache.get(&key).map(|v| v.value().clone());
         if res.is_some() {
             self.cache_hit.add(1, &[]);

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -478,6 +478,17 @@ where
         let _stopwatch = Stopwatch::new(&self.clear_latency);
         Ok(self.cache.clear().await?)
     }
+
+    async fn obtain(&self, key: K) -> Result<Option<V>, CacheError> {
+        let _stopwatch = Stopwatch::new(&self.get_latency);
+        let res = self.cache.obtain(key).await?.map(|v| v.value().clone());
+        if res.is_some() {
+            self.cache_hit.add(1, &[]);
+        } else {
+            self.cache_miss.add(1, &[]);
+        }
+        Ok(res)
+    }
 }
 
 impl<K, V> super::PersistentCache<K, V> for FoyerHybridCache<K, V>
@@ -627,6 +638,17 @@ where
         let _stopwatch = Stopwatch::new(&self.clear_latency);
         self.cache.clear();
         Ok(())
+    }
+
+    async fn obtain(&self, key: K) -> Result<Option<V>, CacheError> {
+        let _stopwatch = Stopwatch::new(&self.get_latency);
+        let res = self.cache.get(&key).map(|v| v.value().clone());
+        if res.is_some() {
+            self.cache_hit.add(1, &[]);
+        } else {
+            self.cache_miss.add(1, &[]);
+        }
+        Ok(res)
     }
 }
 

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -71,6 +71,7 @@ where
     async fn get(&self, key: &K) -> Result<Option<V>, CacheError>;
     async fn remove(&self, key: &K);
     async fn clear(&self) -> Result<(), CacheError>;
+    async fn obtain(&self, key: K) -> Result<Option<V>, CacheError>;
 }
 
 /// A persistent cache extends the traits of a cache to require StorageKey and StorageValue.

--- a/rust/cache/src/nop.rs
+++ b/rust/cache/src/nop.rs
@@ -22,6 +22,10 @@ where
     async fn clear(&self) -> Result<(), CacheError> {
         Ok(())
     }
+
+    async fn obtain(&self, _: K) -> Result<Option<V>, CacheError> {
+        Ok(None)
+    }
 }
 
 impl Debug for NopCache {

--- a/rust/cache/src/unbounded.rs
+++ b/rust/cache/src/unbounded.rs
@@ -65,6 +65,12 @@ where
         self.cache.write().clear();
         Ok(())
     }
+
+    async fn obtain(&self, key: K) -> Result<Option<V>, CacheError> {
+        let read_guard = self.cache.read();
+        let value = read_guard.get(&key);
+        Ok(value.cloned())
+    }
 }
 
 impl<K, V> Debug for UnboundedCache<K, V>


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - Removed the write_mutex that block manager had. It does not have any correctness bearings. It was simply there so that we don't reinsert the same entry to the cache again. Because we clone and handout the block (internally a block is an Arc<> so clone is cheap) it should be fine to overwrite the cache with the same value again.
 - New functionality
   -  foyer.obtain() deduplicates disk access to the same key so might be more performant under concurrency. The trade-off is that you have to clone the key which for us is a 16 byte uuid.

## Test plan
*How are these changes tested?*
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
