### PR TITLE
[CFG] Disable quota for forking

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1135,7 +1135,7 @@ pub struct ForkCollectionPayload {
     )
 )]
 async fn fork_collection(
-    headers: HeaderMap,
+    _headers: HeaderMap,
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
     Json(payload): Json<ForkCollectionPayload>,
@@ -1152,17 +1152,17 @@ async fn fork_collection(
     );
     // NOTE: The quota check if skipped for fork collection for now, and we rely on the scorecard to limit access to certain tenents
     // TODO: Unify the quota and scorecard
-    server
-        .authenticate_and_authorize(
-            &headers,
-            AuthzAction::ForkCollection,
-            AuthzResource {
-                tenant: Some(tenant.clone()),
-                database: Some(database.clone()),
-                collection: Some(collection_id.clone()),
-            },
-        )
-        .await?;
+    // server
+    //     .authenticate_and_authorize(
+    //         &headers,
+    //         AuthzAction::ForkCollection,
+    //         AuthzResource {
+    //             tenant: Some(tenant.clone()),
+    //             database: Some(database.clone()),
+    //             collection: Some(collection_id.clone()),
+    //         },
+    //     )
+    //     .await?;
     let _guard =
         server.scorecard_request(&["op:fork_collection", format!("tenant:{}", tenant).as_str()])?;
     let collection_id =


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - A previous PR enabled quota to prevent access to fork on prod. This PR disables the quota for testing on staging after deployment to prod
 - New functionality
   - N/A

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
