### PR TITLE
[BUG] Fix failing fork on empty collection

### DIFF
--- a/go/pkg/log/store/db/queries.sql.go
+++ b/go/pkg/log/store/db/queries.sql.go
@@ -120,7 +120,7 @@ func (q *Queries) GetAllCollectionsToCompact(ctx context.Context, minCompactionS
 }
 
 const getBoundsForCollection = `-- name: GetBoundsForCollection :one
-SELECT record_compaction_offset_position, record_enumeration_offset_position
+SELECT CAST(COALESCE(MIN(record_compaction_offset_position), 0) as bigint) AS record_compaction_offset_position, CAST(COALESCE(MAX(record_enumeration_offset_position), 0) as bigint) AS record_enumeration_offset_position
 FROM collection
 WHERE id = $1
 `

--- a/go/pkg/log/store/queries/queries.sql
+++ b/go/pkg/log/store/queries/queries.sql
@@ -46,9 +46,7 @@ FROM record_log r
 WHERE r.collection_id = $1;
 
 -- name: GetBoundsForCollection :one
-SELECT
-	COALESCE(record_compaction_offset_position, 0) AS record_compaction_offset_position,
-	COALESCE(record_enumeration_offset_position, 0) AS record_enumeration_offset_position
+SELECT CAST(COALESCE(MIN(record_compaction_offset_position), 0) as bigint) AS record_compaction_offset_position, CAST(COALESCE(MAX(record_enumeration_offset_position), 0) as bigint) AS record_enumeration_offset_position
 FROM collection
 WHERE id = $1;
 


### PR DESCRIPTION
## Description of changes

*Summarize the changes made by this PR.*
 - Improvements & Bug fixes
   - The log service will error during fork if the source colletion is not initialized yet (i.e. no data is added yet), because the compaction and enumeration offset does not exist. This PR fixes this edge case.
 - New functionality
   - ...

## Test plan
*How are these changes tested?*

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*
