### PR TITLE
[ENH] Build chroma-load-start binary and add it to chroma-load container

### DIFF
--- a/rust/load/Dockerfile
+++ b/rust/load/Dockerfile
@@ -16,10 +16,16 @@ RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
     if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin chroma-load --release; else cargo build --bin chroma-load; fi && \
     if [ "$RELEASE_MODE" = "1" ]; then mv target/release/chroma-load ./chroma-load; else mv target/debug/chroma-load ./chroma-load; fi
 
+RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
+    --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+    if [ "$RELEASE_MODE" = "1" ]; then cargo build --bin chroma-load-start --release; else cargo build --bin chroma-load-start; fi && \
+    if [ "$RELEASE_MODE" = "1" ]; then mv target/release/chroma-load-start ./chroma-load-start; else mv target/debug/chroma-load-start ./chroma-load-start; fi
+
 FROM debian:bookworm-slim AS runner
 RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /chroma/rust/load/chroma_load_config.yaml .
 
 FROM runner AS load_service
 COPY --from=load_service_builder /chroma/chroma-load .
+COPY --from=load_service_builder /chroma/chroma-load-start .
 ENTRYPOINT [ "./chroma-load" ]


### PR DESCRIPTION
## Description of changes

This will be used to initialize new runs of the verification service, by executing the binary in the image.

## Test plan

Verify the built image contains the expected binary:

```
docker buildx build -f ./rust/load/Dockerfile --build-arg RELEASE_MODE=1 --target load_service -t load-service:local .

docker run --rm --entrypoint ./chroma-load-start load-service:local
```