### PR TITLE
[RELEASE] js client v2.3.0 with collection config and forking

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chromadb-root",
   "private": true,
-  "version": "3.0.0",
+  "version": "2.3.0",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",

--- a/clients/js/packages/chromadb-client/package.json
+++ b/clients/js/packages/chromadb-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb-client",
-  "version": "3.0.0",
+  "version": "2.3.0",
   "description": "A JavaScript interface for chroma with embedding functions as peer dependencies",
   "license": "Apache-2.0",
   "type": "module",

--- a/clients/js/packages/chromadb-core/package.json
+++ b/clients/js/packages/chromadb-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/chromadb-core",
-  "version": "3.0.0",
+  "version": "2.3.0",
   "private": true,
   "description": "Core functionality for ChromaDB JavaScript client",
   "license": "Apache-2.0",

--- a/clients/js/packages/chromadb/package.json
+++ b/clients/js/packages/chromadb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "3.0.0",
+  "version": "2.3.0",
   "description": "A JavaScript interface for chroma with embedding functions as bundled dependencies",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bumps JS client to v2.3.0

Code lists an unreleased 3.0.0 version. After talking with @jairad26 , we concluded that a major version release was no longer necessary because we updated the changes to be backwards-compatible. 

This release includes:
- Collection config
- Forking support