### PR TITLE
[ENH] Make connection configurable per running load-service workload

### DIFF
--- a/rust/load/src/bin/chroma-load-start.rs
+++ b/rust/load/src/bin/chroma-load-start.rs
@@ -3,7 +3,7 @@
 use clap::Parser;
 
 use chroma_load::rest::StartRequest;
-use chroma_load::{humanize_expires, Throughput, Workload};
+use chroma_load::{humanize_expires, Connection, Throughput, Workload};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -16,9 +16,15 @@ struct Args {
     #[arg(long)]
     delay: Option<String>,
     #[arg(long)]
+    workload: String,
+    #[arg(long)]
     data_set: String,
     #[arg(long)]
-    workload: String,
+    url: String,
+    #[arg(long)]
+    database: String,
+    #[arg(long)]
+    api_key: String,
     #[arg(long)]
     constant_throughput: Option<f64>,
     #[arg(long)]
@@ -98,8 +104,13 @@ async fn main() {
     let req = StartRequest {
         name: args.name,
         expires: humanize_expires(&args.expires).unwrap_or(args.expires),
-        data_set: args.data_set,
         workload,
+        data_set: args.data_set,
+        connection: Connection {
+            url: args.url,
+            api_key: args.api_key,
+            database: args.database,
+        },
         throughput,
     };
     match client

--- a/rust/load/src/rest.rs
+++ b/rust/load/src/rest.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-use crate::{Throughput, Workload, WorkloadSummary};
+use crate::{Connection, Throughput, Workload, WorkloadSummary};
 
 /// A description of a data set.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -45,6 +45,8 @@ pub struct StartRequest {
     pub workload: Workload,
     /// The data set to use.
     pub data_set: String,
+    /// The connection to use.
+    pub connection: Connection,
     /// When the workload should expire.
     pub expires: String,
     /// The throughput to use.


### PR DESCRIPTION
## Description of changes

This way, the same load service can be used to run workloads against multiple different environments. Also, there is no need to specify secrets when deploying the load-service.


## Test plan

Test by running locally, and configuring a workload with a remote connection.