### PR TITLE
[CHORE] Fix flaky default_ef test

### DIFF
--- a/chromadb/test/ef/test_default_ef.py
+++ b/chromadb/test/ef/test_default_ef.py
@@ -37,9 +37,7 @@ def test_unavailable_provider_multiple(providers: List[str]) -> None:
 
 @given(
     providers=st.lists(
-        st.sampled_from(onnxruntime.get_all_providers()).filter(
-            lambda x: x in onnxruntime.get_available_providers()
-        ),
+        st.sampled_from(onnxruntime.get_available_providers()),
         min_size=1,
         unique_by=unique_by,
     )
@@ -56,9 +54,7 @@ def test_warning_no_providers_supplied() -> None:
 
 @given(
     providers=st.lists(
-        st.sampled_from(onnxruntime.get_all_providers()).filter(
-            lambda x: x in onnxruntime.get_available_providers()
-        ),
+        st.sampled_from(onnxruntime.get_available_providers()),
         min_size=1,
     ).filter(lambda x: len(x) > len(set(x)))
 )


### PR DESCRIPTION
## Description of changes
https://github.com/chroma-core/chroma/actions/runs/14651962766/job/41119672498

In this run, hypothesis fails this test because too much has been filtered out. this is because the test fetches all providers, and then filters to the available ones. a better solution would be to directly access the available providers

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
