### PR TITLE
[CHORE] Move distributed to default collection configuration

### DIFF
--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -203,35 +203,35 @@ export namespace Api {
 
   export interface HnswConfiguration {
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof HnswConfiguration
      * minimum: 0
      */
-    ef_construction?: number;
+    ef_construction?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof HnswConfiguration
      * minimum: 0
      */
-    ef_search?: number;
+    ef_search?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof HnswConfiguration
      * minimum: 0
      */
-    max_neighbors?: number;
+    max_neighbors?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof HnswConfiguration
      */
-    resize_factor?: number;
+    resize_factor?: number | null;
     space?: Api.HnswSpace;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof HnswConfiguration
      * minimum: 0
      */
-    sync_threshold?: number;
+    sync_threshold?: number | null;
   }
 
   export enum HnswSpace {
@@ -279,54 +279,54 @@ export namespace Api {
 
   export interface SpannConfiguration {
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    ef_construction?: number;
+    ef_construction?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    ef_search?: number;
+    ef_search?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    max_neighbors?: number;
+    max_neighbors?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    merge_threshold?: number;
+    merge_threshold?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    reassign_neighbor_count?: number;
+    reassign_neighbor_count?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    search_nprobe?: number;
+    search_nprobe?: number | null;
     space?: Api.HnswSpace;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    split_threshold?: number;
+    split_threshold?: number | null;
     /**
-     * @type {number}
+     * @type {number | null}
      * @memberof SpannConfiguration
      * minimum: 0
      */
-    write_nprobe?: number;
+    write_nprobe?: number | null;
   }
 
   export interface UpdateCollectionConfiguration {

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -47,3 +47,4 @@ scorecard:
     score: 100
 enable_span_indexing: true
 default_knn_index: "spann"
+enable_set_index_params: false

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -55,3 +55,4 @@ circuit_breaker:
   requests: 1000
 enable_span_indexing: true
 default_knn_index: "spann"
+enable_set_index_params: true

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -119,6 +119,10 @@ fn default_enable_span_indexing() -> bool {
     false
 }
 
+fn default_enable_set_index_params() -> bool {
+    true
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct FrontendServerConfig {
     #[serde(flatten)]
@@ -144,6 +148,8 @@ pub struct FrontendServerConfig {
     pub cors_allow_origins: Option<Vec<String>>,
     #[serde(default = "default_enable_span_indexing")]
     pub enable_span_indexing: bool,
+    #[serde(default = "default_enable_set_index_params")]
+    pub enable_set_index_params: bool,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "sample_configs/distributed.yaml";

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -26,6 +26,8 @@ pub enum ValidationError {
     UpdateCollection(#[from] UpdateCollectionError),
     #[error("Error parsing collection configuration: {0}")]
     ParseCollectionConfiguration(#[from] CollectionConfigurationToInternalConfigurationError),
+    #[error("For optimal performance and accuracy, can't set parameters other than space for index type {0}")]
+    SpaceConfigurationForVectorIndexType(String),
 }
 
 impl ChromaError for ValidationError {
@@ -37,6 +39,7 @@ impl ChromaError for ValidationError {
             ValidationError::GetCollection(err) => err.code(),
             ValidationError::UpdateCollection(err) => err.code(),
             ValidationError::ParseCollectionConfiguration(_) => ErrorCodes::InvalidArgument,
+            ValidationError::SpaceConfigurationForVectorIndexType(_) => ErrorCodes::InvalidArgument,
         }
     }
 }

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -623,7 +623,7 @@ mod tests {
     use super::*;
     use chroma_cache::new_non_persistent_cache_for_test;
     use chroma_storage::local::LocalStorage;
-    use chroma_types::HnswConfiguration;
+    use chroma_types::InternalHnswConfiguration;
 
     #[tokio::test]
     async fn test_fork() {
@@ -640,7 +640,7 @@ mod tests {
 
         let dimensionality = 128;
         let distance_function = DistanceFunction::Euclidean;
-        let default_hnsw_params = HnswConfiguration::default();
+        let default_hnsw_params = InternalHnswConfiguration::default();
         let created_index = provider
             .create(
                 &collection_id,
@@ -683,7 +683,7 @@ mod tests {
 
         let dimensionality = 2;
         let distance_function = DistanceFunction::Euclidean;
-        let default_hnsw_params = HnswConfiguration::default();
+        let default_hnsw_params = InternalHnswConfiguration::default();
         let created_index = provider
             .create(
                 &collection_id,

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -379,8 +379,8 @@ pub mod test {
 
     use chroma_index::{HnswIndexConfig, DEFAULT_MAX_ELEMENTS};
     use chroma_types::{
-        Collection, CollectionUuid, HnswConfiguration, InternalCollectionConfiguration, Segment,
-        SegmentUuid,
+        Collection, CollectionUuid, InternalCollectionConfiguration, InternalHnswConfiguration,
+        Segment, SegmentUuid,
     };
     use tempfile::tempdir;
     use uuid::Uuid;
@@ -389,7 +389,7 @@ pub mod test {
     fn parameter_defaults() {
         let persist_path = tempdir().unwrap().path().to_owned();
 
-        let hnsw_configuration = HnswConfiguration::default();
+        let hnsw_configuration = InternalHnswConfiguration::default();
         let config = HnswIndexConfig::new_persistent(
             hnsw_configuration.max_neighbors,
             hnsw_configuration.ef_construction,
@@ -398,7 +398,7 @@ pub mod test {
         )
         .expect("Error creating hnsw index config");
 
-        let default_hnsw_params = HnswConfiguration::default();
+        let default_hnsw_params = InternalHnswConfiguration::default();
 
         assert_eq!(config.max_elements, DEFAULT_MAX_ELEMENTS);
         assert_eq!(config.m, default_hnsw_params.max_neighbors);
@@ -413,10 +413,12 @@ pub mod test {
         // Try partial override
         let collection = Collection {
             config: InternalCollectionConfiguration {
-                vector_index: chroma_types::VectorIndexConfiguration::Hnsw(HnswConfiguration {
-                    max_neighbors: 10,
-                    ..Default::default()
-                }),
+                vector_index: chroma_types::VectorIndexConfiguration::Hnsw(
+                    InternalHnswConfiguration {
+                        max_neighbors: 10,
+                        ..Default::default()
+                    },
+                ),
                 embedding_function: None,
             },
             ..Default::default()

--- a/rust/types/src/spann_configuration.rs
+++ b/rust/types/src/spann_configuration.rs
@@ -136,47 +136,32 @@ impl Default for InternalSpannConfiguration {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SpannConfiguration {
-    #[serde(default = "default_search_nprobe")]
-    #[validate(range(max = 128))]
-    pub search_nprobe: u32,
-    #[serde(default = "default_write_nprobe")]
-    #[validate(range(max = 128))]
-    pub write_nprobe: u32,
+    pub search_nprobe: Option<u32>,
+    pub write_nprobe: Option<u32>,
     #[serde(default)]
     pub space: HnswSpace,
-    #[serde(default = "default_construction_ef_spann")]
-    #[validate(range(max = 200))]
-    pub ef_construction: usize,
-    #[serde(default = "default_search_ef_spann")]
-    #[validate(range(max = 200))]
-    pub ef_search: usize,
-    #[serde(default = "default_m_spann")]
-    #[validate(range(max = 100))]
-    pub max_neighbors: usize,
-    #[serde(default = "default_reassign_neighbor_count")]
-    #[validate(range(max = 100))]
-    pub reassign_neighbor_count: u32,
-    #[serde(default = "default_split_threshold")]
-    #[validate(range(min = 100, max = 200))]
-    pub split_threshold: u32,
-    #[serde(default = "default_merge_threshold")]
-    #[validate(range(min = 50, max = 100))]
-    pub merge_threshold: u32,
+    pub ef_construction: Option<usize>,
+    pub ef_search: Option<usize>,
+    pub max_neighbors: Option<usize>,
+    pub reassign_neighbor_count: Option<u32>,
+    pub split_threshold: Option<u32>,
+    pub merge_threshold: Option<u32>,
 }
 
 impl From<InternalSpannConfiguration> for SpannConfiguration {
     fn from(config: InternalSpannConfiguration) -> Self {
         Self {
-            search_nprobe: config.search_nprobe,
-            write_nprobe: config.write_nprobe,
+            search_nprobe: Some(config.search_nprobe),
+            write_nprobe: Some(config.write_nprobe),
             space: config.space,
-            ef_construction: config.ef_construction,
-            ef_search: config.ef_search,
-            max_neighbors: config.max_neighbors,
-            reassign_neighbor_count: config.reassign_neighbor_count,
-            split_threshold: config.split_threshold,
-            merge_threshold: config.merge_threshold,
+            ef_construction: Some(config.ef_construction),
+            ef_search: Some(config.ef_search),
+            max_neighbors: Some(config.max_neighbors),
+            reassign_neighbor_count: Some(config.reassign_neighbor_count),
+            split_threshold: Some(config.split_threshold),
+            merge_threshold: Some(config.merge_threshold),
         }
     }
 }
@@ -184,15 +169,19 @@ impl From<InternalSpannConfiguration> for SpannConfiguration {
 impl From<SpannConfiguration> for InternalSpannConfiguration {
     fn from(config: SpannConfiguration) -> Self {
         Self {
-            search_nprobe: config.search_nprobe,
-            write_nprobe: config.write_nprobe,
+            search_nprobe: config.search_nprobe.unwrap_or(default_search_nprobe()),
+            write_nprobe: config.write_nprobe.unwrap_or(default_write_nprobe()),
             space: config.space,
-            ef_construction: config.ef_construction,
-            ef_search: config.ef_search,
-            max_neighbors: config.max_neighbors,
-            reassign_neighbor_count: config.reassign_neighbor_count,
-            split_threshold: config.split_threshold,
-            merge_threshold: config.merge_threshold,
+            ef_construction: config
+                .ef_construction
+                .unwrap_or(default_construction_ef_spann()),
+            ef_search: config.ef_search.unwrap_or(default_search_ef_spann()),
+            max_neighbors: config.max_neighbors.unwrap_or(default_m_spann()),
+            reassign_neighbor_count: config
+                .reassign_neighbor_count
+                .unwrap_or(default_reassign_neighbor_count()),
+            split_threshold: config.split_threshold.unwrap_or(default_split_threshold()),
+            merge_threshold: config.merge_threshold.unwrap_or(default_merge_threshold()),
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Description of changes

This PR removes the ability to set collection configuration on distributed chroma. If the user sets any configuration other than space, it will error in distributed chroma

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
