### PR TITLE
[CLN]: Move hnsw_provider.open() lock inside the call itself

### DIFF
--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -706,6 +706,12 @@ mod tests {
             .flush(&created_index_id)
             .await
             .expect("Expected to flush");
+        // clear the cache.
+        provider
+            .cache
+            .clear()
+            .await
+            .expect("Expected to clear cache");
         let open_index = provider
             .open(
                 &created_index_id,

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2022,30 +2022,20 @@ impl<'me> SpannIndexReader<'me> {
         dimensionality: usize,
         ef_search: usize,
     ) -> Result<HnswIndexRef, SpannIndexReaderError> {
-        // We take a lock here to synchronize concurrent open of the same index.
-        // Otherwise, we could end up with a corrupted index since the filesystem
-        // operations are not guaranteed to be atomic.
-        // The lock is a partitioned mutex to allow for higher concurrency across collections.
-        let _guard = hnsw_provider.write_mutex.lock(id).await;
-        match hnsw_provider.get(id, cache_key).await {
-            Some(index) => Ok(index),
-            None => {
-                match hnsw_provider
-                    .open(
-                        id,
-                        cache_key,
-                        dimensionality as i32,
-                        distance_function,
-                        ef_search,
-                    )
-                    .await
-                {
-                    Ok(index) => Ok(index),
-                    Err(e) => {
-                        tracing::error!("Error opening hnsw index{}: {}", id, e);
-                        Err(SpannIndexReaderError::HnswIndexConstructionError(*e))
-                    }
-                }
+        match hnsw_provider
+            .open(
+                id,
+                cache_key,
+                dimensionality as i32,
+                distance_function,
+                ef_search,
+            )
+            .await
+        {
+            Ok(index) => Ok(index),
+            Err(e) => {
+                tracing::error!("Error opening hnsw index{}: {}", id, e);
+                Err(SpannIndexReaderError::HnswIndexConstructionError(*e))
             }
         }
     }

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -333,37 +333,23 @@ impl DistributedHNSWSegmentReader {
                 }
             };
             let index_uuid = IndexUuid(index_uuid);
-            // We take a lock here to synchronize concurrent forks of the same index.
-            // Otherwise, we could end up with a corrupted index since the filesystem
-            // operations are not guaranteed to be atomic.
-            // The lock is a partitioned mutex to allow for higher concurrency across collections.
-            let _guard = hnsw_index_provider.write_mutex.lock(&index_uuid).await;
-            let index =
-                match hnsw_index_provider
-                    .get(&index_uuid, &segment.collection)
-                    .await
-                {
-                    Some(index) => index,
-                    None => {
-                        match hnsw_index_provider
-                            .open(
-                                &index_uuid,
-                                &segment.collection,
-                                dimensionality as i32,
-                                hnsw_configuration.space.clone().into(),
-                                hnsw_configuration.ef_search,
-                            )
-                            .await
-                        {
-                            Ok(index) => index,
-                            Err(e) => return Err(Box::new(
-                                DistributedHNSWSegmentFromSegmentError::HnswIndexProviderOpenError(
-                                    *e,
-                                ),
-                            )),
-                        }
-                    }
-                };
+            let index = match hnsw_index_provider
+                .open(
+                    &index_uuid,
+                    &segment.collection,
+                    dimensionality as i32,
+                    hnsw_configuration.space.clone().into(),
+                    hnsw_configuration.ef_search,
+                )
+                .await
+            {
+                Ok(index) => index,
+                Err(e) => {
+                    return Err(Box::new(
+                        DistributedHNSWSegmentFromSegmentError::HnswIndexProviderOpenError(*e),
+                    ))
+                }
+            };
 
             Ok(Box::new(DistributedHNSWSegmentReader::new(
                 index, segment.id,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Previously, the caller was expected to lock before calling hnsw_provider.open(). This is leaky. Moved it inside.
  - Also, used the double checked locking pattern to avoid taking the partitioned mutex in the happy path when the index is cached
- New functionality
  - ...

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
