### PR TITLE
[BLD]: Setup long running rust tests in release-chromadb gh actions workflow

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,9 +27,5 @@ path = "junit.xml"
 [profile.ci_long_running]
 default-filter = "test(/test_long_running_/)"
 
-[[profile.ci_long_running.overrides]]
-filter = "all()"
-test-group = "against-tilt"
-
 [profile.ci_long_running.junit]
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,7 +2,7 @@
 against-tilt = { max-threads = 1 }
 
 [profile.default]
-default-filter = "not test(/test_k8s_integration_/)"
+default-filter = "not test(/test_k8s_integration_/) and not test(/test_long_running_/)"
 
 [profile.k8s_integration]
 default-filter = "test(/test_k8s_integration_/)"
@@ -22,4 +22,14 @@ filter = "all()"
 test-group = "against-tilt"
 
 [profile.ci_k8s_integration.junit]
+path = "junit.xml"
+
+[profile.ci_long_running]
+default-filter = "test(/test_long_running_/)"
+
+[[profile.ci_long_running.overrides]]
+filter = "all()"
+test-group = "against-tilt"
+
+[profile.ci_long_running.junit]
 path = "junit.xml"

--- a/.github/workflows/_rust-release-tests.yml
+++ b/.github/workflows/_rust-release-tests.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        platform: [blacksmith-4vcpu-ubuntu-2204]
-    runs-on: ${{ matrix.platform }}
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
@@ -33,10 +30,7 @@ jobs:
       #       files: target/nextest/ci/junit.xml
       #       logs: true
   test-long:
-    strategy:
-      matrix:
-        platform: [blacksmith-4vcpu-ubuntu-2204]
-    runs-on: ${{ matrix.platform }}
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
@@ -62,10 +56,7 @@ jobs:
       #       logs: true
 
   test-integration:
-    strategy:
-      matrix:
-        platform: [blacksmith-16vcpu-ubuntu-2204]
-    runs-on: ${{ matrix.platform }}
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     # OIDC token auth for AWS
     permissions:
       contents: read

--- a/.github/workflows/_rust-release-tests.yml
+++ b/.github/workflows/_rust-release-tests.yml
@@ -1,0 +1,142 @@
+name: Rust release tests
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        platform: [blacksmith-4vcpu-ubuntu-2204]
+    runs-on: ${{ matrix.platform }}
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Build CLI
+        run: cargo build --bin chroma
+      - name: Test
+        run: cargo nextest run --no-capture --profile ci
+      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
+      # - name: Upload test results
+      #   uses: datadog/junit-upload-github-action@v1
+      #   with:
+      #       api_key: ${{ secrets.DD_API_KEY }}
+      #       site: ${{ vars.DD_SITE }}
+      #       service: chroma
+      #       files: target/nextest/ci/junit.xml
+      #       logs: true
+  test-long:
+    strategy:
+      matrix:
+        platform: [blacksmith-4vcpu-ubuntu-2204]
+    runs-on: ${{ matrix.platform }}
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Build CLI
+        run: cargo build --bin chroma
+      - name: Test
+        run: cargo nextest run --no-capture --profile ci_long_running
+      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
+      # - name: Upload test results
+      #   uses: datadog/junit-upload-github-action@v1
+      #   with:
+      #       api_key: ${{ secrets.DD_API_KEY }}
+      #       site: ${{ vars.DD_SITE }}
+      #       service: chroma
+      #       files: target/nextest/ci/junit.xml
+      #       logs: true
+
+  test-integration:
+    strategy:
+      matrix:
+        platform: [blacksmith-16vcpu-ubuntu-2204]
+    runs-on: ${{ matrix.platform }}
+    # OIDC token auth for AWS
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - uses: useblacksmith/build-push-action@v1.1
+        with:
+          setup-only: true
+      - name: Start services in Tilt
+        uses: ./.github/actions/tilt
+      - name: Build CLI
+        run: cargo build --bin chroma
+      - name: Run tests
+        run: cargo nextest run --profile ci_k8s_integration
+      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
+      # - name: Upload test results
+      #   uses: datadog/junit-upload-github-action@v1
+      #   with:
+      #       api_key: ${{ secrets.DD_API_KEY }}
+      #       site: ${{ vars.DD_SITE }}
+      #       service: chroma
+      #       files: target/nextest/ci/junit.xml
+      #       logs: true
+      - name: Save service logs to artifact
+        if: always()
+        uses: ./.github/actions/export-tilt-logs
+        with:
+          artifact-name: "rust-integration-test"
+  test-benches:
+    strategy:
+      matrix:
+        platform: [blacksmith-16vcpu-ubuntu-2204]
+        bench-command:
+          - "--bench blockfile_writer -- --sample-size 10"
+          - "--bench distance_metrics"
+          - "--bench filter"
+          - "--bench get"
+          - "--bench limit"
+          - "--bench query"
+    runs-on: ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE: 1
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Run benchmark
+        run: cargo bench ${{ matrix.bench-command }}
+
+  can-build-release:
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Build in release mode
+        run: cargo build --release

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -53,9 +53,9 @@ jobs:
     name: JavaScript client tests
     uses: ./.github/workflows/_javascript-client-tests.yml
 
-  rust-tests:
+  rust-release-tests:
     name: Rust tests
-    uses: ./.github/workflows/_rust-tests.yml
+    uses: ./.github/workflows/_rust-release-tests.yml
     secrets: inherit
 
   go-tests:
@@ -69,7 +69,7 @@ jobs:
       - get-version
       - python-tests
       - javascript-client-tests
-      - rust-tests
+      - rust-release-tests
       - go-tests
     uses: ./.github/workflows/_build_release_container.yml
     secrets: inherit
@@ -84,7 +84,7 @@ jobs:
       - get-version
       - python-tests
       - javascript-client-tests
-      - rust-tests
+      - rust-release-tests
       - go-tests
     uses: ./.github/workflows/_build_release_pypi.yml
     secrets: inherit
@@ -100,7 +100,7 @@ jobs:
       - check-tag
       - python-tests
       - javascript-client-tests
-      - rust-tests
+      - rust-release-tests
       - go-tests
     steps:
       - name: Checkout

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -3503,8 +3503,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
-    async fn test_data_integrity() {
+    async fn test_long_running_data_integrity() {
         // Inserts 10k randomly generated embeddings each of 1000 dimensions.
         // Commits and flushes the data to disk. Then reads the data back using scan api
         // and verifies that all the data is present and correct.
@@ -3607,8 +3606,7 @@ mod tests {
     // the construction of hnsw provider calls async tokio filesystem apis that also need
     // a runtime which is not supported by shuttle.
     #[tokio::test]
-    #[ignore]
-    async fn test_data_integrity_parallel() {
+    async fn test_long_running_data_integrity_parallel() {
         // Inserts 10k randomly generated embeddings each of 1000 dimensions using 500 parallel tasks.
         // Commits and flushes the data to disk. Then reads the data back using scan api
         // and verifies that all the data is present and correct.
@@ -3729,8 +3727,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
-    async fn test_data_integrity_multiple_runs() {
+    async fn test_long_running_integrity_multiple_runs() {
         // Inserts 10k randomly generated embeddings each of 1000 dimensions in batches of 1k.
         // After each batch of 1k, it commits and flushes to disk. Then reads the data back using scan api
         // and verifies that all the data is present and correct.
@@ -3847,8 +3844,7 @@ mod tests {
     // the construction of hnsw provider calls async tokio filesystem apis that also need
     // a runtime which is not supported by shuttle.
     #[tokio::test]
-    #[ignore]
-    async fn test_data_integrity_multiple_parallel_runs() {
+    async fn test_long_running_data_integrity_multiple_parallel_runs() {
         // Inserts 10k randomly generated embeddings each of 1000 dimensions in batches of 1k.
         // Each batch of 1k records is inserted in parallel using 10 tokio tasks.
         // After each batch of 1k, it commits and flushes to disk. Then reads the data back using scan api
@@ -3988,8 +3984,7 @@ mod tests {
     // the construction of hnsw provider calls async tokio filesystem apis that also need
     // a runtime which is not supported by shuttle.
     #[tokio::test]
-    #[ignore]
-    async fn test_data_integrity_multiple_parallel_runs_with_updates_deletes() {
+    async fn test_long_running_data_integrity_multiple_parallel_runs_with_updates_deletes() {
         // Inserts 5k randomly generated embeddings each of 1000 dimensions in batches of 1k.
         // Each batch of 1k records is inserted in parallel using 10 tokio tasks.
         // After each batch of 1k, it commits and flushes to disk.


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Spann has rust tests that take longer than usual tests (4-5 mins). Running those on the pr checks workflow slows down dev time. I move those into the release-chromadb workflow
  - Also introduced a profile in nextest called ci_long_running that I tag these tests with. Any future tests of this nature can be tagged similarly and they would skip the pr checks workflow and run in the release-chromadb workflow
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
