### PR TITLE
[DOC] Clarify some details about `where` and `where_document`

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
@@ -1,6 +1,6 @@
 # Full Text Search
 
-In order to filter on document contents, you must supply a `where_document` filter dictionary to the query. We support two filtering keys: `$contains` and `$not_contains`. The dictionary must have the following structure:
+In order to filter on document contents, you must supply a `where_document` filter dictionary to the query. (This will match on sub-strings, but is case-sensitive.) We support two filtering keys: `$contains` and `$not_contains`. The dictionary must have the following structure:
 
 ```python
 # Filtering for a search_string
@@ -19,6 +19,7 @@ You can combine full-text search with Chroma's metadata filtering.
 {% TabbedCodeBlock %}
 
 {% Tab label="python" %}
+
 ```python
 collection.query(
     query_texts=["doc10", "thus spake zarathustra", ...],
@@ -27,9 +28,11 @@ collection.query(
     where_document={"$contains":"search_string"}
 )
 ```
+
 {% /Tab %}
 
 {% Tab label="typescript" %}
+
 ```typescript
 await collection.query({
     queryTexts: ["doc10", "thus spake zarathustra", ...],
@@ -38,6 +41,7 @@ await collection.query({
     whereDocument: {"$contains": "search_string"}
 })
 ```
+
 {% /Tab %}
 
 {% /TabbedCodeBlock %}
@@ -56,6 +60,7 @@ You can also use the logical operators `$and` and `$or` to combine multiple filt
 ```
 
 An `$or` operator will return results that match any of the filters in the list
+
 ```python
 {
     "$or": [

--- a/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/full-text-search.md
@@ -1,6 +1,6 @@
 # Full Text Search
 
-In order to filter on document contents, you must supply a `where_document` filter dictionary to the query. (This will match on sub-strings, but is case-sensitive.) We support two filtering keys: `$contains` and `$not_contains`. The dictionary must have the following structure:
+In order to filter on document contents, you must supply a `where_document` filter dictionary to the query. (NOTE: The supplied value will match on sub-strings, but is case-sensitive.) We support two filtering keys: `$contains` and `$not_contains`. The dictionary must have the following structure:
 
 ```python
 # Filtering for a search_string

--- a/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/metadata-filtering.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/querying-collections/metadata-filtering.md
@@ -1,6 +1,6 @@
 # Metadata Filtering
 
-Chroma supports filtering queries by `metadata` and `document` contents. The `where` filter is used to filter by `metadata`.
+Chroma supports filtering queries by `metadata` and `document` contents. The `where` filter is used to filter by `metadata`. As usual, filtering is applied before the query; that is, the query is run against the filtered collection.
 
 In order to filter on metadata, you must supply a `where` filter dictionary to the query. The dictionary must have the following structure:
 
@@ -12,6 +12,18 @@ In order to filter on metadata, you must supply a `where` filter dictionary to t
 }
 ```
 
+#### NOTE:
+
+A `where` filter must have, at any level of nesting, one key (a string) and one key only. The following examples are not well-formed:
+
+```python
+{"topic": "history", "source": "wikipedia"}
+{"date": {"$gte": 2000, "$lte" 1900}}
+{123: {"$gt": 100}}
+```
+
+If you wish to perform more complex queries, you can use the logical operators described below.
+
 Filtering metadata supports the following operators:
 
 - `$eq` - equal to (string, int, float)
@@ -21,7 +33,7 @@ Filtering metadata supports the following operators:
 - `$lt` - less than (int, float)
 - `$lte` - less than or equal to (int, float)
 
-Using the `$eq` operator is equivalent to using the `where` filter.
+The syntax allows for a shorthand expression for the `$eq` operator as a simple key-value pair, as in the following example:
 
 ```python
 {
@@ -102,6 +114,18 @@ An `$nin` operator will return results where the metadata attribute is not part 
 {
   "metadata_field": {
     "$nin": ["value1", "value2", "value3"]
+  }
+}
+```
+
+#### NOTE:
+
+The values for the `$in` and `$nin` operators must be non-empty lists, and each value must be of the same _same type_. For example, the following is not valid:
+
+```json
+{
+  "metadata_field": {
+    "$in": ["value1", 2, True]
   }
 }
 ```


### PR DESCRIPTION
## Description of changes

Following up on #4280 

Adds some details about the filters, making clear that:
* filter dictionaries must have one key
* `$in`/`$nin` lists must contain one or more values of the same type.

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
