### PR TITLE
[BUG]: Fix Voyage AI EF to match new API

### DIFF
--- a/chromadb/test/ef/test_voyageai_ef.py
+++ b/chromadb/test/ef/test_voyageai_ef.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+from chromadb.utils.embedding_functions.voyageai_embedding_function import (
+    VoyageAIEmbeddingFunction,
+)
+
+voyageai = pytest.importorskip("voyageai", reason="voyageai not installed")
+
+
+def test_with_embedding_dimensions() -> None:
+    if os.environ.get("CHROMA_VOYAGE_API_KEY") is None:
+        pytest.skip("CHROMA_VOYAGE_API_KEY not set")
+    ef = VoyageAIEmbeddingFunction(
+        api_key=os.environ["CHROMA_VOYAGE_API_KEY"]
+    )
+    embeddings = ef(["hello world"])
+    assert embeddings is not None
+    assert len(embeddings) == 1
+    assert len(embeddings[0]) == 1536

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -55,7 +55,9 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
         embeddings = self._client.embed(texts=input, model=self.model_name)
 
         # Convert to numpy arrays
-        return [np.array(embedding, dtype=np.float32) for embedding in embeddings]
+        return [
+            np.array(embedding, dtype=np.float32) for embedding in embeddings.embeddings
+        ]
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
Closes #4378

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Voyage AI client API seems to have changed and now returns [EmbeddingsObject](https://github.com/voyage-ai/voyageai-python/blob/012d16bd708c797766beb26555e56b10db8d09fd/voyageai/object/embeddings.py#L5-L16)
  - Added skippable Voyage AI EF basic test

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
