### PR TITLE
[BUG]: don't try reading HNSW files as sparse indices when performing garbage collection on SPANN collections

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -464,7 +464,7 @@ mod tests {
         let collection_name = format!("test_collection_{}", test_uuid);
 
         let collection_id = clients
-            .create_database_and_collection(&tenant_id, &database_name, &collection_name)
+            .create_database_and_collection(&tenant_id, &database_name, &collection_name, true)
             .await
             .unwrap();
 

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -8,6 +8,7 @@ use chroma_types::chroma_proto::{
     ListCollectionVersionsResponse, OperationRecord, ProjectionOperator, PushLogsRequest,
     ScanOperator, Segment, SegmentScope, Vector,
 };
+use chroma_types::InternalCollectionConfiguration;
 use std::collections::HashMap;
 use tonic::transport::Channel;
 use uuid::Uuid;
@@ -43,6 +44,7 @@ impl ChromaGrpcClients {
         tenant_id: &str,
         database_name: &str,
         collection_name: &str,
+        enable_spann: bool,
     ) -> Result<String, Box<dyn std::error::Error>> {
         // Create tenant first
         let tenant_req = CreateTenantRequest {
@@ -64,7 +66,11 @@ impl ChromaGrpcClients {
             // Vector segment
             Segment {
                 id: Uuid::new_v4().to_string(),
-                r#type: "urn:chroma:segment/vector/hnsw-distributed".to_string(),
+                r#type: if enable_spann {
+                    "urn:chroma:segment/vector/spann".to_string()
+                } else {
+                    "urn:chroma:segment/vector/hnsw-distributed".to_string()
+                },
                 scope: SegmentScope::Vector as i32,
                 collection: collection_id.clone(),
                 metadata: None,
@@ -90,6 +96,12 @@ impl ChromaGrpcClients {
             },
         ];
 
+        let config_str = if enable_spann {
+            serde_json::to_string(&InternalCollectionConfiguration::default_spann())?
+        } else {
+            "{}".to_string()
+        };
+
         // Create collection with segments
         let coll_req = CreateCollectionRequest {
             id: collection_id.clone(),
@@ -97,7 +109,7 @@ impl ChromaGrpcClients {
             tenant: tenant_id.to_string(),
             database: database_name.to_string(),
             dimension: Some(3),
-            configuration_json_str: "{}".to_string(),
+            configuration_json_str: config_str,
             get_or_create: Some(true),
             metadata: None,
             segments,

--- a/rust/garbage_collector/src/operators/compute_unused_files.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_files.rs
@@ -4,8 +4,9 @@ use chroma_cache::nop::NopCache;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::chroma_proto::{
-    CollectionSegmentInfo, CollectionVersionFile, VersionListForCollection,
+use chroma_types::{
+    chroma_proto::{CollectionSegmentInfo, CollectionVersionFile, VersionListForCollection},
+    HNSW_PATH,
 };
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
@@ -73,7 +74,7 @@ impl ComputeUnusedFilesOperator {
         for segment_compaction_info in older_segment_info.segment_compaction_info.iter() {
             for (file_type, file_paths) in &segment_compaction_info.file_paths {
                 // For hnsw_index files, just add it without comparing with newer version.
-                if file_type == "hnsw_index" {
+                if file_type == "hnsw_index" || file_type == HNSW_PATH {
                     unused_hnsw_prefixes.extend(file_paths.paths.clone());
                     continue;
                 }
@@ -92,7 +93,7 @@ impl ComputeUnusedFilesOperator {
         let mut newer_si_ids = Vec::new();
         for segment_compaction_info in newer_segment_info.segment_compaction_info.iter() {
             for (file_type, file_paths) in &segment_compaction_info.file_paths {
-                if file_type == "hnsw_index" {
+                if file_type == "hnsw_index" || file_type == HNSW_PATH {
                     continue;
                 }
 

--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -3,7 +3,10 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
+use chroma_types::{
+    chroma_proto::{CollectionVersionFile, VersionListForCollection},
+    HNSW_PATH,
+};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -114,7 +117,7 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                                 file_type
                             );
                             // Skip hnsw_index files
-                            if file_type == "hnsw_index" {
+                            if file_type == "hnsw_index" || file_type == HNSW_PATH {
                                 if *version == input.oldest_version_to_keep {
                                     continue;
                                 }


### PR DESCRIPTION
## Description of changes

Collections that use a HNSW index have a segment file path called `hnsw_index`. However, collections with a SPANN index have a segment file path called `hnsw_path`. Currently garbage collection logic treats `hnsw_index` as HNSW files but was treating `hnsw_path` as sparse indices because we never match on that file type name.

This PR fixes the logic so that both `hnsw_index` and `hnsw_path` file types are treated as HNSW files.

## Test plan

_How are these changes tested?_

Added test fails on main.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a