### PR TITLE
[BUG] Prevent unconditional unwrap of collection config

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -915,57 +915,67 @@ async fn create_collection(
     let payload_clone = payload.clone();
 
     let configuration = if !server.config.enable_set_index_params {
-        let mut new_configuration = payload.configuration.clone().unwrap();
-        let hnsw_config = new_configuration.hnsw.clone();
-        let spann_config = new_configuration.spann.clone();
+        if let Some(mut new_configuration) = payload.configuration.clone() {
+            let hnsw_config = new_configuration.hnsw.clone();
+            let spann_config = new_configuration.spann.clone();
 
-        if let Some(hnsw) = &hnsw_config {
-            let space = hnsw.space.clone();
-            if hnsw.ef_construction.is_some()
-                || hnsw.ef_search.is_some()
-                || hnsw.max_neighbors.is_some()
-                || hnsw.num_threads.is_some()
-                || hnsw.resize_factor.is_some()
-                || hnsw.sync_threshold.is_some()
-                || hnsw.batch_size.is_some()
-            {
-                return Err(ValidationError::SpaceConfigurationForVectorIndexType(
-                    "HNSW".to_string(),
-                )
-                .into());
+            if let Some(hnsw) = &hnsw_config {
+                let space = hnsw.space.clone();
+                if hnsw.ef_construction.is_some()
+                    || hnsw.ef_search.is_some()
+                    || hnsw.max_neighbors.is_some()
+                    || hnsw.num_threads.is_some()
+                    || hnsw.resize_factor.is_some()
+                    || hnsw.sync_threshold.is_some()
+                    || hnsw.batch_size.is_some()
+                {
+                    return Err(ValidationError::SpaceConfigurationForVectorIndexType(
+                        "HNSW".to_string(),
+                    )
+                    .into());
+                }
+                let new_hnsw = HnswConfiguration {
+                    space,
+                    ..Default::default()
+                };
+                new_configuration.hnsw = Some(new_hnsw);
+            } else if let Some(spann) = &spann_config {
+                let space = spann.space.clone();
+                if spann.search_nprobe.is_some()
+                    || spann.write_nprobe.is_some()
+                    || spann.ef_construction.is_some()
+                    || spann.ef_search.is_some()
+                    || spann.max_neighbors.is_some()
+                    || spann.reassign_neighbor_count.is_some()
+                    || spann.split_threshold.is_some()
+                    || spann.merge_threshold.is_some()
+                {
+                    return Err(ValidationError::SpaceConfigurationForVectorIndexType(
+                        "SPANN".to_string(),
+                    )
+                    .into());
+                }
+                let new_spann = SpannConfiguration {
+                    space,
+                    ..Default::default()
+                };
+                new_configuration.spann = Some(new_spann);
             }
-            let new_hnsw = HnswConfiguration {
-                space,
-                ..Default::default()
-            };
-            new_configuration.hnsw = Some(new_hnsw);
-        } else if let Some(spann) = &spann_config {
-            let space = spann.space.clone();
-            if spann.search_nprobe.is_some()
-                || spann.write_nprobe.is_some()
-                || spann.ef_construction.is_some()
-                || spann.ef_search.is_some()
-                || spann.max_neighbors.is_some()
-                || spann.reassign_neighbor_count.is_some()
-                || spann.split_threshold.is_some()
-                || spann.merge_threshold.is_some()
-            {
-                return Err(ValidationError::SpaceConfigurationForVectorIndexType(
-                    "SPANN".to_string(),
-                )
-                .into());
-            }
-            let new_spann = SpannConfiguration {
-                space,
-                ..Default::default()
-            };
-            new_configuration.spann = Some(new_spann);
+
+            Some(InternalCollectionConfiguration::try_from_config(
+                new_configuration,
+                server.config.frontend.default_knn_index,
+            )?)
+        } else {
+            Some(InternalCollectionConfiguration::try_from_config(
+                CollectionConfiguration {
+                    hnsw: None,
+                    spann: None,
+                    embedding_function: None,
+                },
+                server.config.frontend.default_knn_index,
+            )?)
         }
-
-        Some(InternalCollectionConfiguration::try_from_config(
-            new_configuration,
-            server.config.frontend.default_knn_index,
-        )?)
     } else {
         match payload_clone.configuration {
             Some(c) => Some(InternalCollectionConfiguration::try_from_config(


### PR DESCRIPTION
## Description of changes

Previously, the frontend was unconditionally attempting to unwrap the collection config, even if it was None. This wasn't caught before because all of the popular clients are actually passing in a collection config. However, it should be optional.

## Test plan

Not tested yet, will check in staging after it merges.

## Documentation Changes

n/a
