### PR TITLE
[BUG] Tag prefetch record as IO, fix spinloop in admissionController

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -548,9 +548,19 @@ impl CountBasedPolicy {
             match &mut channel_receiver {
                 Some(rx) => {
                     select! {
-                        _ = rx.recv() => {
+                        did_recv = rx.recv() => {
                             // Reevaluate priority if we got a notification.
-                            continue;
+                            match did_recv {
+                                Some(_) => {
+                                    // If we got a notification, continue to acquire.
+                                    continue;
+                                }
+                                None => {
+                                    // If the channel was closed, break out of the loop.
+                                    channel_receiver = None;
+                                    continue;
+                                }
+                            }
                         }
                         token = self.remaining_tokens[current_priority.as_usize()].acquire() => {
                             match token {

--- a/rust/worker/src/execution/operators/prefetch_record.rs
+++ b/rust/worker/src/execution/operators/prefetch_record.rs
@@ -6,7 +6,7 @@ use chroma_segment::{
     blockfile_record::{RecordSegmentReader, RecordSegmentReaderCreationError},
     types::{materialize_logs, LogMaterializerError},
 };
-use chroma_system::Operator;
+use chroma_system::{Operator, OperatorType};
 use thiserror::Error;
 use tracing::{trace, Instrument, Span};
 
@@ -93,5 +93,9 @@ impl Operator<PrefetchRecordInput, PrefetchRecordOutput> for PrefetchRecordOpera
     // We don't care if the sender is dropped since this is a prefetch
     fn errors_when_sender_dropped(&self) -> bool {
         false
+    }
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
     }
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._
- Improvements & Bug fixes
  - Tags the prefetch record segment operator as IO
  - Fixes a potential spinloop in the admission controller where .recv() returns None on sender drop. It is unclear why the sender could drop, and that needs to be investigated. But this change makes sense defensively at the function level. This could alternatively use `tokio::sync::Notify`
- New functionality
  - /

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
None
