### PR TITLE
[BUG]: fix missing tenant ID in version file

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1555,6 +1555,10 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 				return nil, err
 			}
 
+			// There was previously a bug that resulted in the tenant ID missing from some version files (https://github.com/chroma-core/chroma/pull/4408).
+			// This line can be removed once all corrupted version files are fixed.
+			existingVersionFilePb.CollectionInfoImmutable.TenantId = collectionEntry.Tenant
+
 			// Do a simple validation of the version file.
 			err = tc.validateVersionFile(existingVersionFilePb, collectionEntry.ID, existingVersion)
 			if err != nil {

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -30,7 +30,7 @@ func (s *collectionDb) DeleteAll() error {
 func (s *collectionDb) GetCollectionEntry(collectionID *string, databaseName *string) (*dbmodel.Collection, error) {
 	var collections []*dbmodel.Collection
 	query := s.db.Table("collections").
-		Select("collections.id, collections.name, collections.database_id, collections.is_deleted, databases.tenant_id, collections.version, collections.version_file_name, collections.root_collection_id").
+		Select("collections.id, collections.name, collections.database_id, collections.is_deleted, collections.tenant, collections.version, collections.version_file_name, collections.root_collection_id").
 		Joins("INNER JOIN databases ON collections.database_id = databases.id").
 		Where("collections.id = ?", collectionID)
 


### PR DESCRIPTION
## Description of changes

Upon compaction flush for a collection, the Sysdb [creates a version file if one does not exist](https://github.com/chroma-core/chroma/pull/4284/files). To do this, it populates fields in the file using the `GetCollectionEntry` method.

However, before this PR, the `GetCollectionEntry` method **always returned an empty string for the tenant**. This led to the field missing in the version file and version files being saved under the wrong bucket prefix.

## Test plan

_How are these changes tested?_

Validated that the tenant ID is now correctly populated by:

1. `tilt up` with version files disabled on Sysdb.
2. Created a collection and added data.
3. Enabled version files on Sydb.
4. Added more data to the collection.
5. Observed that the tenant ID was correctly populated in the created version files.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a