### PR TITLE
[ENH] Wire up regex filter from client to query node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rayon",
+ "regex",
  "roaring",
  "sea-query",
  "sea-query-binder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ parking_lot = { version = "0.12.3", features = ["serde"] }
 parquet = "52"
 prost = "0.13"
 prost-types = "0.13.5"
+regex = "1.11.1"
+regex_syntax = "0.8.5"
 roaring = "0.10.6"
 sea-query = "0.32"
 sea-query-binder = "0.7"
@@ -76,7 +78,6 @@ utoipa = { version = "5.0.0", features = ["macros", "axum_extras", "debug", "uui
 sqlx = { version = "0.8.3", features = ["runtime-tokio", "sqlite"] }
 sha2 = "0.10.8"
 md5 = "0.7.0"
-regex = "1.11.1"
 pyo3 = { version = "0.23.3", features = ["abi3-py39"] }
 http = "1.1.0"
 tower-http = { version = "0.6.2", features = ["trace", "cors"] }

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -313,7 +313,9 @@ class RustBindingsAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
-        raise NotImplementedError("Collection forking is not implemented for Local Chroma")
+        raise NotImplementedError(
+            "Collection forking is not implemented for Local Chroma"
+        )
 
     @override
     def _count(
@@ -333,7 +335,7 @@ class RustBindingsAPI(ServerAPI):
         database: str = DEFAULT_DATABASE,
     ) -> GetResult:
         return self._get(
-            str(collection_id),
+            collection_id,
             limit=n,
             tenant=tenant,
             database=database,

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -822,7 +822,14 @@ def validate_where_document(where_document: WhereDocument) -> None:
             f"Expected where document to have exactly one operator, got {where_document}"
         )
     for operator, operand in where_document.items():
-        if operator not in ["$contains", "$not_contains", "$and", "$or"]:
+        if operator not in [
+            "$contains",
+            "$not_contains",
+            "$matches",
+            "$not_matches",
+            "$and",
+            "$or",
+        ]:
             raise ValueError(
                 f"Expected where document operator to be one of $contains, $and, $or, got {operator}"
             )

--- a/chromadb/base_types.py
+++ b/chromadb/base_types.py
@@ -29,6 +29,10 @@ Where = Dict[
 ]
 
 WhereDocumentOperator = Union[
-    Literal["$contains"], Literal["$not_contains"], LogicalOperator
+    Literal["$contains"],
+    Literal["$not_contains"],
+    Literal["$matches"],
+    Literal["$not_matches"],
+    LogicalOperator,
 ]
 WhereDocument = Dict[WhereDocumentOperator, Union[str, List["WhereDocument"]]]

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -155,10 +155,8 @@ message WhereDocument {
 
 // A leaf-node `WhereDocument` clause may compare a document to a single value.
 message DirectWhereDocument {
-    // Reserve for deprecated fields
-    reserved 1;
+    string pattern = 1;
     WhereDocumentOperator operator = 2;
-    string pattern = 3;
 }
 
 // Types of operators for `WhereDocument` clauses. A `WhereDocument` clause can

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -155,8 +155,10 @@ message WhereDocument {
 
 // A leaf-node `WhereDocument` clause may compare a document to a single value.
 message DirectWhereDocument {
-    string document = 1;
+    // Reserve for deprecated fields
+    reserved 1;
     WhereDocumentOperator operator = 2;
+    string pattern = 3;
 }
 
 // Types of operators for `WhereDocument` clauses. A `WhereDocument` clause can
@@ -165,6 +167,8 @@ message DirectWhereDocument {
 enum WhereDocumentOperator {
     CONTAINS = 0;
     NOT_CONTAINS = 1;
+    MATCHES = 2;
+    NOT_MATCHES = 3;
 }
 
 // A branch-node `WhereDocument` node has a list of children.

--- a/rust/frontend/src/impls/in_memory_frontend.rs
+++ b/rust/frontend/src/impls/in_memory_frontend.rs
@@ -780,7 +780,7 @@ mod tests {
             None,
             Some(Where::Document(DocumentExpression {
                 operator: chroma_types::DocumentOperator::Contains,
-                text: "doc2".to_string(),
+                pattern: "doc2".to_string(),
             })),
             None,
             0,

--- a/rust/segment/Cargo.toml
+++ b/rust/segment/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-trait = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
+regex = { workspace = true }
 roaring = { workspace = true }
 sea-query = { workspace = true }
 sea-query-binder = { workspace = true, features = ["sqlx-sqlite"] }

--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -481,11 +481,13 @@ impl IntoSqliteExpr for DocumentExpression {
             EmbeddingFulltextSearch::StringValue,
         ));
         let doc_contains = doc_col
-            .like(format!("%{}%", self.text.replace("%", "")))
+            .like(format!("%{}%", self.pattern.replace("%", "")))
             .is(true);
         match self.operator {
             DocumentOperator::Contains => doc_contains,
             DocumentOperator::NotContains => doc_contains.not(),
+            DocumentOperator::Matches => todo!("Implement Regex matching. The result must be a not-nullable boolean (use `<expr>.is(true)`)"),
+            DocumentOperator::NotMatches => todo!("Implement negated Regex matching. This must be exact opposite of Regex matching (use `<expr>.not()`)"),
         }
     }
 }

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -20,6 +20,7 @@ use chroma_types::{
     PrimitiveOperator, Segment, SegmentScope, SegmentUuid, SetOperator, UpdateMetadata, Where,
     CHROMA_KEY,
 };
+use regex::Regex;
 use std::collections::BinaryHeap;
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
@@ -468,13 +469,20 @@ impl CheckRecord for CompositeExpression {
 
 impl CheckRecord for DocumentExpression {
     fn eval(&self, record: &ProjectionRecord) -> bool {
-        let contains = record
-            .document
-            .as_ref()
-            .is_some_and(|doc| doc.contains(&self.text.replace("%", "")));
+        let document = record.document.as_ref();
         match self.operator {
-            DocumentOperator::Contains => contains,
-            DocumentOperator::NotContains => !contains,
+            DocumentOperator::Contains => {
+                document.is_some_and(|doc| doc.contains(&self.pattern.replace("%", "")))
+            }
+            DocumentOperator::NotContains => {
+                document.is_some_and(|doc| !doc.contains(&self.pattern.replace("%", "")))
+            }
+            DocumentOperator::Matches => {
+                document.is_some_and(|doc| Regex::new(&self.pattern).unwrap().is_match(doc))
+            }
+            DocumentOperator::NotMatches => {
+                document.is_some_and(|doc| !Regex::new(&self.pattern).unwrap().is_match(doc))
+            }
         }
     }
 }

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -475,13 +475,13 @@ impl CheckRecord for DocumentExpression {
                 document.is_some_and(|doc| doc.contains(&self.pattern.replace("%", "")))
             }
             DocumentOperator::NotContains => {
-                document.is_some_and(|doc| !doc.contains(&self.pattern.replace("%", "")))
+                !document.is_some_and(|doc| doc.contains(&self.pattern.replace("%", "")))
             }
             DocumentOperator::Matches => {
                 document.is_some_and(|doc| Regex::new(&self.pattern).unwrap().is_match(doc))
             }
             DocumentOperator::NotMatches => {
-                document.is_some_and(|doc| !Regex::new(&self.pattern).unwrap().is_match(doc))
+                !document.is_some_and(|doc| Regex::new(&self.pattern).unwrap().is_match(doc))
             }
         }
     }

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -535,7 +535,7 @@ impl Where {
                 .sum(),
             // The query length is defined to be the number of trigram tokens
             Where::Document(document_expression) => {
-                document_expression.text.len().max(3) as u64 - 2
+                document_expression.pattern.len().max(3) as u64 - 2
             }
             Where::Metadata(_) => 0,
         }
@@ -668,14 +668,14 @@ impl From<BooleanOperator> for chroma_proto::BooleanOperator {
 #[derive(Clone, Debug, PartialEq, ToSchema)]
 pub struct DocumentExpression {
     pub operator: DocumentOperator,
-    pub text: String,
+    pub pattern: String,
 }
 
 impl From<chroma_proto::DirectWhereDocument> for DocumentExpression {
     fn from(value: chroma_proto::DirectWhereDocument) -> Self {
         Self {
             operator: value.operator().into(),
-            text: value.document,
+            pattern: value.pattern,
         }
     }
 }
@@ -683,7 +683,7 @@ impl From<chroma_proto::DirectWhereDocument> for DocumentExpression {
 impl From<DocumentExpression> for chroma_proto::DirectWhereDocument {
     fn from(value: DocumentExpression) -> Self {
         Self {
-            document: value.text,
+            pattern: value.pattern,
             operator: chroma_proto::WhereDocumentOperator::from(value.operator) as i32,
         }
     }
@@ -693,12 +693,16 @@ impl From<DocumentExpression> for chroma_proto::DirectWhereDocument {
 pub enum DocumentOperator {
     Contains,
     NotContains,
+    Matches,
+    NotMatches,
 }
 impl From<chroma_proto::WhereDocumentOperator> for DocumentOperator {
     fn from(value: chroma_proto::WhereDocumentOperator) -> Self {
         match value {
             chroma_proto::WhereDocumentOperator::Contains => Self::Contains,
             chroma_proto::WhereDocumentOperator::NotContains => Self::NotContains,
+            chroma_proto::WhereDocumentOperator::Matches => Self::Matches,
+            chroma_proto::WhereDocumentOperator::NotMatches => Self::NotMatches,
         }
     }
 }
@@ -708,6 +712,8 @@ impl From<DocumentOperator> for chroma_proto::WhereDocumentOperator {
         match value {
             DocumentOperator::Contains => Self::Contains,
             DocumentOperator::NotContains => Self::NotContains,
+            DocumentOperator::Matches => Self::Matches,
+            DocumentOperator::NotMatches => Self::NotMatches,
         }
     }
 }
@@ -970,7 +976,7 @@ impl TryFrom<chroma_proto::WhereDocument> for Where {
                     }
                 };
                 let comparison = DocumentExpression {
-                    text: proto_comparison.document,
+                    pattern: proto_comparison.pattern,
                     operator: operator.into(),
                 };
                 Ok(Where::Document(comparison))
@@ -1175,7 +1181,7 @@ mod tests {
         let proto_where = chroma_proto::WhereDocument {
             r#where_document: Some(chroma_proto::where_document::WhereDocument::Direct(
                 chroma_proto::DirectWhereDocument {
-                    document: "foo".to_string(),
+                    pattern: "foo".to_string(),
                     operator: chroma_proto::WhereDocumentOperator::Contains.into(),
                 },
             )),
@@ -1183,7 +1189,7 @@ mod tests {
         let where_document: Where = proto_where.try_into().unwrap();
         match where_document {
             Where::Document(comparison) => {
-                assert_eq!(comparison.text, "foo");
+                assert_eq!(comparison.pattern, "foo");
                 assert_eq!(comparison.operator, DocumentOperator::Contains);
             }
             _ => panic!("Invalid where document type"),
@@ -1200,7 +1206,7 @@ mod tests {
                             r#where_document: Some(
                                 chroma_proto::where_document::WhereDocument::Direct(
                                     chroma_proto::DirectWhereDocument {
-                                        document: "foo".to_string(),
+                                        pattern: "foo".to_string(),
                                         operator: chroma_proto::WhereDocumentOperator::Contains
                                             .into(),
                                     },
@@ -1211,7 +1217,7 @@ mod tests {
                             r#where_document: Some(
                                 chroma_proto::where_document::WhereDocument::Direct(
                                     chroma_proto::DirectWhereDocument {
-                                        document: "bar".to_string(),
+                                        pattern: "bar".to_string(),
                                         operator: chroma_proto::WhereDocumentOperator::Contains
                                             .into(),
                                     },

--- a/rust/types/src/strategies.rs
+++ b/rust/types/src/strategies.rs
@@ -308,7 +308,7 @@ impl Arbitrary for TestWhereFilter {
             (doc_string, doc_operator).prop_map(|(text, operator)| {
                 Where::Document(DocumentExpression {
                     operator,
-                    text: text.to_string(),
+                    pattern: text.to_string(),
                 })
             });
 

--- a/rust/types/src/where_parsing.rs
+++ b/rust/types/src/where_parsing.rs
@@ -137,17 +137,16 @@ pub fn parse_where_document(json_payload: &Value) -> Result<Where, WhereValidati
         return Err(WhereValidationError::WhereDocumentClause);
     }
     let value_str = value.as_str().unwrap();
-    let operator_type;
-    if key == "$contains" {
-        operator_type = DocumentOperator::Contains;
-    } else if key == "$not_contains" {
-        operator_type = DocumentOperator::NotContains;
-    } else {
-        return Err(WhereValidationError::WhereDocumentClause);
-    }
+    let operator_type = match key.as_str() {
+        "$contains" => DocumentOperator::Contains,
+        "$not_contains" => DocumentOperator::NotContains,
+        "$matches" => DocumentOperator::Matches,
+        "$not_matches" => DocumentOperator::NotMatches,
+        _ => return Err(WhereValidationError::WhereDocumentClause),
+    };
     Ok(Where::Document(crate::DocumentExpression {
         operator: operator_type,
-        text: value_str.to_string(),
+        pattern: value_str.to_string(),
     }))
 }
 
@@ -446,18 +445,18 @@ mod tests {
                 children: vec![
                     Where::Document(crate::DocumentExpression {
                         operator: DocumentOperator::Contains,
-                        text: "value1".to_string(),
+                        pattern: "value1".to_string(),
                     }),
                     Where::Composite(CompositeExpression {
                         operator: crate::BooleanOperator::Or,
                         children: vec![
                             Where::Document(crate::DocumentExpression {
                                 operator: DocumentOperator::Contains,
-                                text: "value2".to_string(),
+                                pattern: "value2".to_string(),
                             }),
                             Where::Document(crate::DocumentExpression {
                                 operator: DocumentOperator::Contains,
-                                text: "value3".to_string(),
+                                pattern: "value3".to_string(),
                             }),
                         ],
                     }),
@@ -466,7 +465,7 @@ mod tests {
             // $not_contains
             Where::Document(crate::DocumentExpression {
                 operator: DocumentOperator::NotContains,
-                text: "value1".to_string(),
+                pattern: "value1".to_string(),
             }),
         ];
 

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -22,8 +22,7 @@ opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 chroma-tracing = { workspace = true }
-
-regex = "1.11.1"
+regex = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -18,6 +18,7 @@ use chroma_types::{
     MaterializedLogOperation, MetadataComparison, MetadataExpression, MetadataSetValue,
     MetadataValue, PrimitiveOperator, Segment, SetOperator, SignedRoaringBitmap, Where,
 };
+use regex::Regex;
 use roaring::RoaringBitmap;
 use thiserror::Error;
 use tracing::{Instrument, Span};
@@ -71,6 +72,8 @@ pub enum FilterError {
     MetadataReader(#[from] MetadataSegmentError),
     #[error("Error creating record segment reader: {0}")]
     RecordReader(#[from] RecordSegmentReaderCreationError),
+    #[error("Error parsing regular expression: {0}")]
+    Regex(#[from] regex::Error),
     #[error("Error getting record: {0}")]
     GetError(Box<dyn ChromaError>),
 }
@@ -82,6 +85,7 @@ impl ChromaError for FilterError {
             FilterError::LogMaterializer(e) => e.code(),
             FilterError::MetadataReader(e) => e.code(),
             FilterError::RecordReader(e) => e.code(),
+            FilterError::Regex(_) => ErrorCodes::InvalidArgument,
             FilterError::GetError(e) => e.code(),
         }
     }
@@ -194,7 +198,7 @@ impl<'me> MetadataProvider<'me> {
         Self::Log(reader)
     }
 
-    pub(crate) async fn filter_by_document(
+    pub(crate) async fn filter_by_document_contains(
         &self,
         query: &str,
     ) -> Result<RoaringBitmap, FilterError> {
@@ -214,6 +218,27 @@ impl<'me> MetadataProvider<'me> {
                 .iter()
                 .filter_map(|(offset_id, document)| document.contains(query).then_some(offset_id))
                 .collect()),
+        }
+    }
+
+    pub(crate) async fn filter_by_document_matches(
+        &self,
+        query: &str,
+    ) -> Result<RoaringBitmap, FilterError> {
+        match self {
+            MetadataProvider::CompactData(_metadata_segment_reader) => {
+                todo!("Implement regex search on fts index")
+            }
+            MetadataProvider::Log(metadata_log_reader) => {
+                let regex = Regex::new(query)?;
+                Ok(metadata_log_reader
+                    .document
+                    .iter()
+                    .filter_map(|(offset_id, document)| {
+                        regex.is_match(&document).then_some(offset_id)
+                    })
+                    .collect())
+            }
         }
     }
 
@@ -367,12 +392,27 @@ impl<'me> RoaringMetadataFilter<'me> for DocumentExpression {
         &'me self,
         metadata_provider: &MetadataProvider<'me>,
     ) -> Result<SignedRoaringBitmap, FilterError> {
-        let contain = metadata_provider
-            .filter_by_document(self.text.as_str())
-            .await?;
         match self.operator {
-            DocumentOperator::Contains => Ok(SignedRoaringBitmap::Include(contain)),
-            DocumentOperator::NotContains => Ok(SignedRoaringBitmap::Exclude(contain)),
+            DocumentOperator::Contains => Ok(SignedRoaringBitmap::Include(
+                metadata_provider
+                    .filter_by_document_contains(self.pattern.as_str())
+                    .await?,
+            )),
+            DocumentOperator::NotContains => Ok(SignedRoaringBitmap::Exclude(
+                metadata_provider
+                    .filter_by_document_contains(self.pattern.as_str())
+                    .await?,
+            )),
+            DocumentOperator::Matches => Ok(SignedRoaringBitmap::Include(
+                metadata_provider
+                    .filter_by_document_matches(self.pattern.as_str())
+                    .await?,
+            )),
+            DocumentOperator::NotMatches => Ok(SignedRoaringBitmap::Exclude(
+                metadata_provider
+                    .filter_by_document_matches(self.pattern.as_str())
+                    .await?,
+            )),
         }
     }
 }
@@ -746,7 +786,7 @@ mod tests {
 
         let where_clause = Where::Document(DocumentExpression {
             operator: chroma_types::DocumentOperator::Contains,
-            text: "<cat>".to_string(),
+            pattern: "<cat>".to_string(),
         });
 
         let filter_operator = FilterOperator {
@@ -775,7 +815,7 @@ mod tests {
 
         let where_clause = Where::Document(DocumentExpression {
             operator: chroma_types::DocumentOperator::NotContains,
-            text: "<dog>".to_string(),
+            pattern: "<dog>".to_string(),
         });
 
         let filter_operator = FilterOperator {
@@ -899,7 +939,7 @@ mod tests {
 
         let where_sub_clause_1 = Where::Document(DocumentExpression {
             operator: chroma_types::DocumentOperator::NotContains,
-            text: "<dog>".to_string(),
+            pattern: "<dog>".to_string(),
         });
 
         let where_sub_clause_2 = Where::Metadata(MetadataExpression {

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -235,7 +235,7 @@ impl<'me> MetadataProvider<'me> {
                     .document
                     .iter()
                     .filter_map(|(offset_id, document)| {
-                        regex.is_match(&document).then_some(offset_id)
+                        regex.is_match(document).then_some(offset_id)
                     })
                     .collect())
             }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1140,7 +1140,7 @@ mod tests {
                 }),
                 Where::Document(DocumentExpression {
                     operator: DocumentOperator::Contains,
-                    text: "<cat>".to_string(),
+                    pattern: "<cat>".to_string(),
                 }),
             ])),
         };


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Introduce the regex filters for documents:
    - `{"$matches": "<regex>"}`: Evaluates to true for documents matching the regex
    - `{"$not_matches": "<regex>"}`: The exact opposite of `$matches`. (i.e. it will evaluate to true on records without documents)
  - Propagates the regex filters from the client to the query node. Current the implementation is `todo!()` for local and distributed chroma, and the code will panic when reached. The `todo!`s will be replaced with actual implementations with future impls.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
