### PR TITLE
[ENH]: Enable auth for forking

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1209,7 +1209,7 @@ pub struct ForkCollectionPayload {
     )
 )]
 async fn fork_collection(
-    _headers: HeaderMap,
+    headers: HeaderMap,
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
     Json(payload): Json<ForkCollectionPayload>,
@@ -1224,19 +1224,17 @@ async fn fork_collection(
     tracing::info!(
         "Forking collection [{collection_id}] in database [{database}] for tenant [{tenant}]"
     );
-    // NOTE: The quota check if skipped for fork collection for now, and we rely on the scorecard to limit access to certain tenents
-    // TODO: Unify the quota and scorecard
-    // server
-    //     .authenticate_and_authorize(
-    //         &headers,
-    //         AuthzAction::ForkCollection,
-    //         AuthzResource {
-    //             tenant: Some(tenant.clone()),
-    //             database: Some(database.clone()),
-    //             collection: Some(collection_id.clone()),
-    //         },
-    //     )
-    //     .await?;
+    server
+        .authenticate_and_authorize(
+            &headers,
+            AuthzAction::ForkCollection,
+            AuthzResource {
+                tenant: Some(tenant.clone()),
+                database: Some(database.clone()),
+                collection: Some(collection_id.clone()),
+            },
+        )
+        .await?;
     let _guard =
         server.scorecard_request(&["op:fork_collection", format!("tenant:{}", tenant).as_str()])?;
     let collection_id =


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Auth was missing for forking. Can be enabled now after https://github.com/chroma-core/hosted-chroma/commit/f180572dc9d44e5a9d05a5b3a1f729ab55bfff86 
- New functionality
  - ...

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
