### PR TITLE
[BUG]  You must ask for strong consistency from S3 GET.

### DIFF
--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -599,7 +599,10 @@ impl Manifest {
         let path = manifest_path(prefix);
         loop {
             match storage
-                .get_with_e_tag(&path, GetOptions::new(StorageRequestPriority::P0))
+                .get_with_e_tag(
+                    &path,
+                    GetOptions::new(StorageRequestPriority::P0).with_strong_consistency(),
+                )
                 .await
                 .map_err(Arc::new)
             {


### PR DESCRIPTION
## Description of changes

In a prior PR I refactored the code to give a strongly-consistent S3 get.

I didn't use it.

Now tests are flaking, but this should fix it.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
