### PR TITLE
[ENH]  Restore chroma-load's random-upsert ability for Reference datasets.

### DIFF
--- a/rust/load/src/data_sets.rs
+++ b/rust/load/src/data_sets.rs
@@ -836,12 +836,12 @@ impl DataSet for ReferencingDataSet {
         &self,
         client: &ChromaClient,
         uq: UpsertQuery,
-        _: &mut Guacamole,
+        guac: &mut Guacamole,
     ) -> Result<(), Box<dyn std::error::Error + Send>> {
         let collection = client.get_collection(&self.operates_on).await?;
         let mut keys = vec![];
-        for offset in 0..uq.batch_size {
-            let key = uq.key.select_from_reference(self, offset);
+        for _ in 0..uq.batch_size {
+            let key = uq.key.select(guac, self);
             if !keys.contains(&key) {
                 keys.push(key);
             }


### PR DESCRIPTION
## Description of changes

It was turned to be sequential-only, but this breaks wal3 testing.

I previously submitted this is #4424, but that merged into a closed branch, so resubmit.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
