### PR TITLE
[ENH] Implement literal provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,7 @@ dependencies = [
 name = "chroma-types"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chroma-config",
  "chroma-error",
  "proptest",

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 roaring = { workspace = true }

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -145,10 +145,7 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
             let mut doc_pos = self.lookup_ngram(&ngram_string).await?;
 
             if let Some(whitelist) = mask {
-                doc_pos = doc_pos
-                    .into_iter()
-                    .filter(|(doc, _)| whitelist.contains(*doc))
-                    .collect();
+                doc_pos.retain(|doc, _| whitelist.contains(*doc));
             }
 
             if doc_pos.is_empty() {
@@ -205,10 +202,7 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
                         .await?;
 
                     if let Some(whitelist) = mask {
-                        ngram_doc_pos = ngram_doc_pos
-                            .into_iter()
-                            .filter(|(_, doc, _)| whitelist.contains(*doc))
-                            .collect();
+                        ngram_doc_pos.retain(|(_, doc, _)| whitelist.contains(*doc));
                     }
 
                     for (ngram, doc_id, new_pos) in ngram_doc_pos {

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -128,7 +128,7 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
 
             let suffix = ngram[1..].to_vec();
             for (_, doc_id, pos) in ngram_doc_pos {
-                if let Some(true) = mask.map(|m| m.contains(doc_id)) {
+                if mask.map(|m| m.contains(doc_id)).unwrap_or(mask.is_none()) {
                     *suffix_doc_pos
                         .entry(suffix.clone())
                         .or_default()

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -128,7 +128,7 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
 
             let suffix = ngram[1..].to_vec();
             for (_, doc_id, pos) in ngram_doc_pos {
-                if mask.is_none_or(|m| m.contains(doc_id)) {
+                if let Some(true) = mask.map(|m| m.contains(doc_id)) {
                     *suffix_doc_pos
                         .entry(suffix.clone())
                         .or_default()

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -75,8 +75,8 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
         doc_range: DocRange,
     ) -> Result<Vec<(&'me str, u32, RoaringBitmap)>, E>
     where
-        NgramRange: RangeBounds<&'me str>,
-        DocRange: RangeBounds<u32>;
+        NgramRange: RangeBounds<&'me str> + Send + Sync,
+        DocRange: RangeBounds<u32> + Send + Sync;
 
     // Return the documents containing the literals. The search space is restricted to the documents in the mask if specified
     // If all documents could contain the literals, Ok(None) is returned

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -1,4 +1,7 @@
+use std::{collections::HashMap, ops::RangeBounds};
+
 use regex_syntax::hir::ClassUnicode;
+use roaring::RoaringBitmap;
 
 use super::hir::ChromaHir;
 
@@ -6,6 +9,15 @@ use super::hir::ChromaHir;
 pub enum Literal {
     Char(char),
     Class(ClassUnicode),
+}
+
+impl Literal {
+    pub fn width(&self) -> usize {
+        match self {
+            Literal::Char(_) => 1,
+            Literal::Class(class_unicode) => class_unicode.iter().map(|range| range.len()).sum(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -45,5 +57,146 @@ impl From<ChromaHir> for LiteralExpr {
                 Self::Alternation(hirs.into_iter().map(Into::into).collect())
             }
         }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait NgramLiteralProvider<E, const N: usize = 3> {
+    // Return the maximum number of ngram to search on start
+    fn initial_beam_width(&self) -> usize;
+
+    // Return the documents containing the ngram and the positions of occurences
+    async fn lookup_ngram<'ngram>(
+        &self,
+        ngram: &'ngram [char; N],
+    ) -> Result<HashMap<u32, RoaringBitmap>, E>;
+
+    // Return the positions of occurences of a range of ngram in the document
+    async fn lookup_ngram_range_in_document<'ngram, NgramRange>(
+        &self,
+        ngram_range: NgramRange,
+        document_id: u32,
+    ) -> Result<Vec<([char; N], RoaringBitmap)>, E>
+    where
+        NgramRange: RangeBounds<&'ngram [char; N]>;
+
+    // Return the documents containing the literals and the potential matching positions
+    // If all documents could contain the literals, Ok(None) is returned
+    async fn match_literal(
+        &self,
+        mut literals: Vec<Literal>,
+    ) -> Result<Option<HashMap<u32, RoaringBitmap>>, E> {
+        let mut initial_ngrams = Vec::new();
+        let mut initial_position = None;
+        for (index, initial_literals) in literals.windows(N).enumerate() {
+            let volume = initial_literals
+                .iter()
+                .fold(1, |acc, lit| acc * lit.width());
+
+            // We would like to find a starting position where the space of ngrams to explore is small enough
+            if volume > self.initial_beam_width() {
+                continue;
+            }
+
+            initial_ngrams =
+                initial_literals
+                    .iter()
+                    .fold(Vec::<Vec<char>>::new(), |mut acc, lit| match lit {
+                        Literal::Char(c) => {
+                            acc.iter_mut().for_each(|s| s.push(*c));
+                            acc
+                        }
+                        Literal::Class(class_unicode) => acc
+                            .into_iter()
+                            .flat_map(|s| {
+                                class_unicode.iter().flat_map(|r| r.start()..r.end()).map(
+                                    move |c| {
+                                        let mut sc = s.clone();
+                                        sc.push(c);
+                                        sc
+                                    },
+                                )
+                            })
+                            .collect(),
+                    });
+            initial_position = Some(index);
+            break;
+        }
+
+        match initial_position {
+            // Drain the initial literals
+            Some(pos) => {
+                literals.drain(..pos);
+            }
+            // There is no initial ngrams to explore, by default we assume the all documents could contain these literals
+            None => return Ok(None),
+        }
+
+        // ngram suffix -> doc_id -> position
+        let mut ngram_suffix_mapping: HashMap<Vec<char>, HashMap<u32, RoaringBitmap>> =
+            HashMap::new();
+        for ngram in initial_ngrams {
+            // SAFETY(sicheng): The window function above guarantees each ngram should have exactly N chars
+            let ngram_doc_pos = self
+                .lookup_ngram(
+                    ngram
+                        .as_slice()
+                        .try_into()
+                        .expect("Ngram should have the right size"),
+                )
+                .await?;
+
+            if ngram_doc_pos.is_empty() {
+                continue;
+            }
+
+            let ngram_suffix = ngram[1..].to_vec();
+            ngram_suffix_mapping
+                .entry(ngram_suffix)
+                .and_modify(|doc_pos| {
+                    ngram_doc_pos
+                        .iter()
+                        .for_each(|(doc, pos)| *doc_pos.entry(*doc).or_default() |= pos);
+                })
+                .or_insert(ngram_doc_pos);
+        }
+
+        for literal in &literals {
+            let new_ngram_suffix_mapping = HashMap::new();
+            for (mut ngram_suffix, doc_pos) in ngram_suffix_mapping {
+                let ngram_ranges = match literal {
+                    Literal::Char(c) => {
+                        ngram_suffix.push(*c);
+                        vec![(ngram_suffix.clone(), ngram_suffix)]
+                    }
+                    Literal::Class(class_unicode) => class_unicode
+                        .iter()
+                        .map(|r| {
+                            let mut start = ngram_suffix.clone();
+                            start.push(r.start());
+                            let mut end = ngram_suffix.clone();
+                            end.push(r.end());
+                            (start, end)
+                        })
+                        .collect(),
+                };
+                for (start_ngram, end_ngram) in ngram_ranges {
+                    // SAFETY(sicheng): The ngram is always constructed from suffix with length N-1 and an additional char
+                    let start = <[char; N]>::try_from(start_ngram)
+                        .expect("Ngram should have the right size");
+                    let end =
+                        <[char; N]>::try_from(end_ngram).expect("Ngram should have the right size");
+                    for (doc_id, pos) in &doc_pos {
+                        for (ngram, doc_pos) in self
+                            .lookup_ngram_range_in_document(&start..&end, *doc_id)
+                            .await?
+                        {}
+                    }
+                }
+            }
+            ngram_suffix_mapping = new_ngram_suffix_mapping;
+        }
+
+        Ok(None)
     }
 }

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -75,8 +75,8 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
         doc_range: DocRange,
     ) -> Result<Vec<(&'me str, u32, RoaringBitmap)>, E>
     where
-        NgramRange: RangeBounds<&'me str> + Send + Sync,
-        DocRange: RangeBounds<u32> + Send + Sync;
+        NgramRange: Clone + RangeBounds<&'me str> + Send + Sync,
+        DocRange: Clone + RangeBounds<u32> + Send + Sync;
 
     // Return the documents containing the literals. The search space is restricted to the documents in the mask if specified
     // If all documents could contain the literals, Ok(None) is returned

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -101,38 +101,36 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
                 continue;
             }
 
-            initial_ngrams =
-                initial_literals
-                    .iter()
-                    .fold(
-                        Vec::<Vec<char>>::with_capacity(N),
-                        |mut acc, lit| match lit {
-                            Literal::Char(c) => {
-                                acc.iter_mut().for_each(|s| s.push(*c));
-                                acc
-                            }
-                            Literal::Class(class_unicode) => acc
-                                .into_iter()
-                                .flat_map(|s| {
-                                    class_unicode.iter().flat_map(|r| r.start()..=r.end()).map(
-                                        move |c| {
-                                            let mut sc = s.clone();
-                                            sc.push(c);
-                                            sc
-                                        },
-                                    )
-                                })
-                                .collect(),
-                        },
-                    );
+            initial_ngrams = initial_literals.iter().fold(
+                vec![Vec::with_capacity(N)],
+                |mut acc, lit| match lit {
+                    Literal::Char(c) => {
+                        acc.iter_mut().for_each(|s| s.push(*c));
+                        acc
+                    }
+                    Literal::Class(class_unicode) => {
+                        acc.into_iter()
+                            .flat_map(|s| {
+                                class_unicode.iter().flat_map(|r| r.start()..=r.end()).map(
+                                    move |c| {
+                                        let mut sc = s.clone();
+                                        sc.push(c);
+                                        sc
+                                    },
+                                )
+                            })
+                            .collect()
+                    }
+                },
+            );
             initial_position = Some(index);
             break;
         }
 
         match initial_position {
-            // Drain the initial literals
+            // Skip the initial literals
             Some(pos) => {
-                literals = &literals[pos..];
+                literals = &literals[pos + N..];
             }
             // There is no initial ngrams to explore, by default we assume the all documents could contain these literals
             None => return Ok(mask.cloned()),


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Implement the literal provider interface and default impls, which allows evaluation of literal expression to a set of documents.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
<!-- Summary by @propel-code-bot -->

---

This PR introduces a new NgramLiteralProvider trait and implementation that enables efficient evaluation of literal expressions against document collections. The implementation uses n-gram based matching to find documents containing specific literal patterns, with support for handling compound expressions (concatenation and alternation). The code includes optimizations for different literal types and large branching factors.

**Key Changes:**
• Added NgramLiteralProvider trait with methods for literal expression evaluation
• Implemented match_literal_with_mask for efficient n-gram based document matching
• Added support for evaluating compound literal expressions (concat, alternation)
• Enhanced Literal struct with width() method for optimization

**Affected Areas:**
• rust/types/src/regex/literal_expr.rs
• Dependencies (added async-trait)

*This summary was automatically generated by @propel-code-bot*