### PR TITLE
[CLN] Warn on log pull failure instead of error

### DIFF
--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -794,7 +794,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CompactOrchestrator 
                 tracing::info!("Pulled Logs Up To Offset: {:?}", self.pulled_log_offset);
             }
             None => {
-                tracing::warn!("No logs were pulled from the log service, this can happen due to a recent fork or if the log failed to be updated.");
+                tracing::warn!("No logs were pulled from the log service, this can happen when the log compaction offset is behing the sysdb.");
                 // TODO(hammadb): We can repair the log service's understanding of the offset here, as this only happens
                 // when the log service is not up to date on the latest compacted offset, which leads it to schedule an already
                 // compacted collection.

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -795,6 +795,9 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CompactOrchestrator 
             }
             None => {
                 tracing::warn!("No logs were pulled from the log service, this can happen due to a recent fork or if the log failed to be updated.");
+                // TODO(hammadb): We can repair the log service's understanding of the offset here, as this only happens
+                // when the log service is not up to date on the latest compacted offset, which leads it to schedule an already
+                // compacted collection.
                 self.terminate_with_result(
                     Ok(CompactionResponse {
                         collection_id: self.collection_id,

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -794,10 +794,11 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CompactOrchestrator 
                 tracing::info!("Pulled Logs Up To Offset: {:?}", self.pulled_log_offset);
             }
             None => {
+                tracing::warn!("No logs were pulled from the log service, this can happen due to a recent fork or if the log failed to be updated.");
                 self.terminate_with_result(
-                    Err(CompactionError::InvariantViolation(
-                        "Logs should be present for compaction",
-                    )),
+                    Ok(CompactionResponse {
+                        collection_id: self.collection_id,
+                    }),
                     ctx,
                 )
                 .await;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - There are valid cases for this log pull to fail, it is not an invariant violation as stated.
  - If the log is failed to be updated with the latest compaction offset (Which is best-effort), but the sysdb was, the log may schedule a collection for compaction that has no records outstanding. This leads to hitting this case, which is valid. In the future we could repair the log.
  - Forked collections will also run into this as the fork() call may copy the old log offset, but a compaction happens after, this leads to them disagreeing but progression is always forward, it manifests as the same issue above which is that the log is behind the sysdb.
  - Keeping this as a `warn` because its worth monitoring this as it implies log service may be failing to get updated. Or that the fork race is commonly copying unnecessary data.
- New functionality
  - None

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
