### PR TITLE
[CHORE] Fix JS release to support platform specific bindings

### DIFF
--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -64,7 +64,7 @@ jobs:
         cache: 'pnpm'
         cache-dependency-path: 'clients/js/pnpm-lock.yaml'
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: pnpm install --no-frozen-lockfile
       working-directory: ./clients/js/
     - name: Build packages
       run: pnpm build


### PR DESCRIPTION
## Description of changes

Since the JS client now uses optional dependencies that are platform specific, we can't use a checked-in lock file and `pnpm install --frozen-lockfile`, since the bindings platform-specific package installed by the test runners will not match the one generated on a dev's machine.

## Test plan
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
