### PR TITLE
[TST] Debug cli tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -14,243 +14,243 @@ on:
         type: string
 
 jobs:
-#  test-rust-bindings:
-#    timeout-minutes: 90
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python: ${{fromJson(inputs.python_versions)}}
-#        platform: [blacksmith-8vcpu-ubuntu-2204, 16core-64gb-windows-latest]
-#        test-globs:
-#          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
-#          - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-#          # TODO(@codetheweb): this test should be parallelized, but it frequently flakes in CI when parallelized. We have not been able to reproduce the failure locally. See https://github.com/chroma-core/chroma/issues/4263.
-#          - "chromadb/test/property/test_cross_version_persist.py"
-#        include:
-#          - test-globs: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-#            parallelized: true
-#
-#    runs-on: ${{ matrix.platform }}
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Setup Python
-#        uses: ./.github/actions/python
-#        with:
-#          python-version: ${{ matrix.python }}
-#      - name: Setup Rust
-#        uses: ./.github/actions/rust
-#        with:
-#          github-token: ${{ github.token }}
-#      - name: Build Rust bindings
-#        uses: PyO3/maturin-action@v1
-#        with:
-#          command: build
-#          sccache: true
-#      - name: Install built wheel
-#        shell: bash
-#        run: pip install --no-index --find-links target/wheels/ chromadb
-#      - name: Configure pytest to upload results to Datadog
-#        uses: datadog/test-visibility-github-action@v2
-#        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-#        if: ${{ !contains(matrix.platform, 'windows') }}
-#        with:
-#          languages: python
-#          api_key: ${{ secrets.DD_API_KEY }}
-#          site: ${{ vars.DD_SITE }}
-#      - name: Test
-#        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
-#        shell: bash
-#        env:
-#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-#          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
-#          RUST_BACKTRACE: 1
+  test-rust-bindings:
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{fromJson(inputs.python_versions)}}
+        platform: [blacksmith-8vcpu-ubuntu-2204, 16core-64gb-windows-latest]
+        test-globs:
+          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
+          - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
+          # TODO(@codetheweb): this test should be parallelized, but it frequently flakes in CI when parallelized. We have not been able to reproduce the failure locally. See https://github.com/chroma-core/chroma/issues/4263.
+          - "chromadb/test/property/test_cross_version_persist.py"
+        include:
+          - test-globs: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
+            parallelized: true
 
-#  test-rust-single-node-integration:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python: ${{fromJson(inputs.python_versions)}}
-#        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
-#        test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'",
-#                    "chromadb/test/property/test_add.py",
-#                    "chromadb/test/property/test_collections.py",
-#                    "chromadb/test/property/test_collections_with_database_tenant.py",
-#                    "chromadb/test/property/test_cross_version_persist.py",
-#                    "chromadb/test/property/test_embeddings.py",
-#                    "chromadb/test/property/test_filtering.py",
-#                    "chromadb/test/property/test_persist.py",
-#                    "chromadb/test/stress"]
-#        include:
-#          - platform: blacksmith-4vcpu-ubuntu-2204
-#            env-file: compose-env.linux
-#    runs-on: ${{ matrix.platform }}
-#    steps:
-#    - name: Checkout
-#      uses: actions/checkout@v4
-#    - name: Set up Python (${{ matrix.python }})
-#      uses: ./.github/actions/python
-#    - name: Setup Rust
-#      uses: ./.github/actions/rust
-#      with:
-#          github-token: ${{ github.token }}
-#    - name: Configure pytest to upload results to Datadog
-#      uses: datadog/test-visibility-github-action@v2
-#      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-#      if: ${{ !contains(matrix.platform, 'windows') }}
-#      with:
-#        languages: python
-#        api_key: ${{ secrets.DD_API_KEY }}
-#        site: ${{ vars.DD_SITE }}
-#    - name: Rust Integration Test
-#      run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
-#      shell: bash
-#      env:
-#        ENV_FILE: ${{ matrix.env-file }}
-#        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./.github/actions/python
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Build Rust bindings
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          sccache: true
+      - name: Install built wheel
+        shell: bash
+        run: pip install --no-index --find-links target/wheels/ chromadb
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+        if: ${{ !contains(matrix.platform, 'windows') }}
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
+      - name: Test
+        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
+        shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+          RUST_BACKTRACE: 1
 
-#  test-rust-thin-client:
-#    strategy:
-#      matrix:
-#        python: ${{fromJson(inputs.python_versions)}}
-#        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
-#        test-globs: ["chromadb/test/property/test_add.py",
-#                    "chromadb/test/property/test_collections.py",
-#                    "chromadb/test/property/test_collections_with_database_tenant.py",
-#                    "chromadb/test/property/test_embeddings.py",
-#                    "chromadb/test/property/test_filtering.py"]
-#    runs-on: ${{ matrix.platform }}
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Set up Python (${{ matrix.python }})
-#        uses: ./.github/actions/python
-#        with:
-#          python-version: ${{ matrix.python }}
-#      - name: Setup Rust
-#        uses: ./.github/actions/rust
-#        with:
-#          github-token: ${{ github.token }}
-#      - name: Configure pytest to upload results to Datadog
-#        uses: datadog/test-visibility-github-action@v2
-#        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-#        if: ${{ !contains(matrix.platform, 'windows') }}
-#        with:
-#          languages: python
-#          api_key: ${{ secrets.DD_API_KEY }}
-#          site: ${{ vars.DD_SITE }}
-#      - name: Test
-#        run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
-#        shell: bash
-#        env:
-#          CHROMA_THIN_CLIENT: "1"
-#          ENV_FILE: ${{ matrix.env-file }}
-#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+  test-rust-single-node-integration:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{fromJson(inputs.python_versions)}}
+        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
+        test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'",
+                    "chromadb/test/property/test_add.py",
+                    "chromadb/test/property/test_collections.py",
+                    "chromadb/test/property/test_collections_with_database_tenant.py",
+                    "chromadb/test/property/test_cross_version_persist.py",
+                    "chromadb/test/property/test_embeddings.py",
+                    "chromadb/test/property/test_filtering.py",
+                    "chromadb/test/property/test_persist.py",
+                    "chromadb/test/stress"]
+        include:
+          - platform: blacksmith-4vcpu-ubuntu-2204
+            env-file: compose-env.linux
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up Python (${{ matrix.python }})
+      uses: ./.github/actions/python
+    - name: Setup Rust
+      uses: ./.github/actions/rust
+      with:
+          github-token: ${{ github.token }}
+    - name: Configure pytest to upload results to Datadog
+      uses: datadog/test-visibility-github-action@v2
+      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+      if: ${{ !contains(matrix.platform, 'windows') }}
+      with:
+        languages: python
+        api_key: ${{ secrets.DD_API_KEY }}
+        site: ${{ vars.DD_SITE }}
+    - name: Rust Integration Test
+      run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
+      shell: bash
+      env:
+        ENV_FILE: ${{ matrix.env-file }}
+        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-#  test-cluster-rust-frontend:
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python: ${{fromJson(inputs.python_versions)}}
-#        platform: ["blacksmith-16vcpu-ubuntu-2204"]
-#        test-globs: ["chromadb/test/api",
-#                    "chromadb/test/api/test_collection.py",
-#                    "chromadb/test/api/test_limit_offset.py",
-#                    "chromadb/test/property/test_collections.py",
-#                    "chromadb/test/property/test_add.py",
-#                    "chromadb/test/property/test_filtering.py",
-#                    "chromadb/test/property/test_fork.py",
-#                    "chromadb/test/property/test_embeddings.py",
-#                    "chromadb/test/property/test_collections_with_database_tenant.py",
-#                    "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
-#                    "chromadb/test/distributed/test_sanity.py"]
-#    runs-on: ${{ matrix.platform }}
-#    # OIDC token auth for AWS
-#    permissions:
-#      contents: read
-#      id-token: write
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: ./.github/actions/python
-#        with:
-#          python-version: ${{ matrix.python }}
-#      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
-#      # - name: Configure pytest to upload results to Datadog
-#      #   uses: datadog/test-visibility-github-action@v2
-#      #   with:
-#      #     languages: python
-#      #     api_key: ${{ secrets.DD_API_KEY }}
-#      #     site: ${{ vars.DD_SITE }}
-#      - uses: useblacksmith/build-push-action@v1.1
-#        with:
-#          setup-only: true
-#      - uses: ./.github/actions/tilt
-#      - name: Test
-#        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}"' --durations 10
-#        shell: bash
-#        env:
-#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-#          CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
-#          CHROMA_SERVER_HOST: "localhost:3000"
-#      - name: Compute artifact name
-#        if: always()
-#        id: compute-artifact-name
-#        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
-#      - name: Save service logs to artifact
-#        if: always()
-#        uses: ./.github/actions/export-tilt-logs
-#        with:
-#          artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
+  test-rust-thin-client:
+    strategy:
+      matrix:
+        python: ${{fromJson(inputs.python_versions)}}
+        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
+        test-globs: ["chromadb/test/property/test_add.py",
+                    "chromadb/test/property/test_collections.py",
+                    "chromadb/test/property/test_collections_with_database_tenant.py",
+                    "chromadb/test/property/test_embeddings.py",
+                    "chromadb/test/property/test_filtering.py"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python (${{ matrix.python }})
+        uses: ./.github/actions/python
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+        if: ${{ !contains(matrix.platform, 'windows') }}
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
+      - name: Test
+        run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
+        shell: bash
+        env:
+          CHROMA_THIN_CLIENT: "1"
+          ENV_FILE: ${{ matrix.env-file }}
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-#  merge-cluster-logs:
-#    runs-on: blacksmith-4vcpu-ubuntu-2204
-#    needs: test-cluster-rust-frontend
-#    steps:
-#      - name: Merge
-#        uses: actions/upload-artifact/merge@v4
-#        with:
-#          name: cluster_test_logs
-#          pattern: cluster_logs_*
+  test-cluster-rust-frontend:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{fromJson(inputs.python_versions)}}
+        platform: ["blacksmith-16vcpu-ubuntu-2204"]
+        test-globs: ["chromadb/test/api",
+                    "chromadb/test/api/test_collection.py",
+                    "chromadb/test/api/test_limit_offset.py",
+                    "chromadb/test/property/test_collections.py",
+                    "chromadb/test/property/test_add.py",
+                    "chromadb/test/property/test_filtering.py",
+                    "chromadb/test/property/test_fork.py",
+                    "chromadb/test/property/test_embeddings.py",
+                    "chromadb/test/property/test_collections_with_database_tenant.py",
+                    "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
+                    "chromadb/test/distributed/test_sanity.py"]
+    runs-on: ${{ matrix.platform }}
+    # OIDC token auth for AWS
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/python
+        with:
+          python-version: ${{ matrix.python }}
+      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
+      # - name: Configure pytest to upload results to Datadog
+      #   uses: datadog/test-visibility-github-action@v2
+      #   with:
+      #     languages: python
+      #     api_key: ${{ secrets.DD_API_KEY }}
+      #     site: ${{ vars.DD_SITE }}
+      - uses: useblacksmith/build-push-action@v1.1
+        with:
+          setup-only: true
+      - uses: ./.github/actions/tilt
+      - name: Test
+        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}"' --durations 10
+        shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+          CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
+          CHROMA_SERVER_HOST: "localhost:3000"
+      - name: Compute artifact name
+        if: always()
+        id: compute-artifact-name
+        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
+      - name: Save service logs to artifact
+        if: always()
+        uses: ./.github/actions/export-tilt-logs
+        with:
+          artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
 
-#  test-rust-bindings-stress:
-#    timeout-minutes: 90
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python: ${{fromJson(inputs.python_versions)}}
-#        platform: [blacksmith-16vcpu-ubuntu-2204, 16core-64gb-windows-latest]
-#        test-globs: ["chromadb/test/stress"]
-#    runs-on: ${{ matrix.platform }}
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Setup Python
-#        uses: ./.github/actions/python
-#        with:
-#          python-version: ${{ matrix.python }}
-#      - name: Setup Rust
-#        uses: ./.github/actions/rust
-#        with:
-#          github-token: ${{ github.token }}
-#      - name: Build Rust bindings
-#        uses: PyO3/maturin-action@v1
-#        with:
-#          command: build
-#          sccache: true
-#      - name: Install built wheel
-#        shell: bash
-#        run: pip install --no-index --find-links target/wheels/ chromadb
-#      - name: Configure pytest to upload results to Datadog
-#        uses: datadog/test-visibility-github-action@v2
-#        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-#        if: ${{ !contains(matrix.platform, 'windows') }}
-#        with:
-#          languages: python
-#          api_key: ${{ secrets.DD_API_KEY }}
-#          site: ${{ vars.DD_SITE }}
-#      - name: Test
-#        run: python -m pytest ${{ matrix.test-globs }} --durations 10
-#        shell: bash
-#        env:
-#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-#          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+  merge-cluster-logs:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs: test-cluster-rust-frontend
+    steps:
+      - name: Merge
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cluster_test_logs
+          pattern: cluster_logs_*
+
+  test-rust-bindings-stress:
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ${{fromJson(inputs.python_versions)}}
+        platform: [blacksmith-16vcpu-ubuntu-2204, 16core-64gb-windows-latest]
+        test-globs: ["chromadb/test/stress"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./.github/actions/python
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Build Rust bindings
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          sccache: true
+      - name: Install built wheel
+        shell: bash
+        run: pip install --no-index --find-links target/wheels/ chromadb
+      - name: Configure pytest to upload results to Datadog
+        uses: datadog/test-visibility-github-action@v2
+        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+        if: ${{ !contains(matrix.platform, 'windows') }}
+        with:
+          languages: python
+          api_key: ${{ secrets.DD_API_KEY }}
+          site: ${{ vars.DD_SITE }}
+      - name: Test
+        run: python -m pytest ${{ matrix.test-globs }} --durations 10
+        shell: bash
+        env:
+          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
 
   test-python-cli:
     strategy:

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -291,7 +291,7 @@ jobs:
         api_key: ${{ secrets.DD_API_KEY }}
         site: ${{ vars.DD_SITE }}
     - name: Integration Test
-      run: bin/python-integration-test ${{ matrix.test-globs }}
+      run: python -m pytest ${{ matrix.test-globs }}
       shell: bash
       env:
         ENV_FILE: ${{ matrix.env-file }}

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -14,243 +14,243 @@ on:
         type: string
 
 jobs:
-  test-rust-bindings:
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{fromJson(inputs.python_versions)}}
-        platform: [blacksmith-8vcpu-ubuntu-2204, 16core-64gb-windows-latest]
-        test-globs:
-          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
-          - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-          # TODO(@codetheweb): this test should be parallelized, but it frequently flakes in CI when parallelized. We have not been able to reproduce the failure locally. See https://github.com/chroma-core/chroma/issues/4263.
-          - "chromadb/test/property/test_cross_version_persist.py"
-        include:
-          - test-globs: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-            parallelized: true
+#  test-rust-bindings:
+#    timeout-minutes: 90
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python: ${{fromJson(inputs.python_versions)}}
+#        platform: [blacksmith-8vcpu-ubuntu-2204, 16core-64gb-windows-latest]
+#        test-globs:
+#          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
+#          - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
+#          # TODO(@codetheweb): this test should be parallelized, but it frequently flakes in CI when parallelized. We have not been able to reproduce the failure locally. See https://github.com/chroma-core/chroma/issues/4263.
+#          - "chromadb/test/property/test_cross_version_persist.py"
+#        include:
+#          - test-globs: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
+#            parallelized: true
+#
+#    runs-on: ${{ matrix.platform }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Setup Python
+#        uses: ./.github/actions/python
+#        with:
+#          python-version: ${{ matrix.python }}
+#      - name: Setup Rust
+#        uses: ./.github/actions/rust
+#        with:
+#          github-token: ${{ github.token }}
+#      - name: Build Rust bindings
+#        uses: PyO3/maturin-action@v1
+#        with:
+#          command: build
+#          sccache: true
+#      - name: Install built wheel
+#        shell: bash
+#        run: pip install --no-index --find-links target/wheels/ chromadb
+#      - name: Configure pytest to upload results to Datadog
+#        uses: datadog/test-visibility-github-action@v2
+#        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+#        if: ${{ !contains(matrix.platform, 'windows') }}
+#        with:
+#          languages: python
+#          api_key: ${{ secrets.DD_API_KEY }}
+#          site: ${{ vars.DD_SITE }}
+#      - name: Test
+#        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
+#        shell: bash
+#        env:
+#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+#          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+#          RUST_BACKTRACE: 1
 
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Build Rust bindings
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          sccache: true
-      - name: Install built wheel
-        shell: bash
-        run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Configure pytest to upload results to Datadog
-        uses: datadog/test-visibility-github-action@v2
-        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-        if: ${{ !contains(matrix.platform, 'windows') }}
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: ${{ vars.DD_SITE }}
-      - name: Test
-        run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
-        shell: bash
-        env:
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
-          RUST_BACKTRACE: 1
+#  test-rust-single-node-integration:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python: ${{fromJson(inputs.python_versions)}}
+#        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
+#        test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'",
+#                    "chromadb/test/property/test_add.py",
+#                    "chromadb/test/property/test_collections.py",
+#                    "chromadb/test/property/test_collections_with_database_tenant.py",
+#                    "chromadb/test/property/test_cross_version_persist.py",
+#                    "chromadb/test/property/test_embeddings.py",
+#                    "chromadb/test/property/test_filtering.py",
+#                    "chromadb/test/property/test_persist.py",
+#                    "chromadb/test/stress"]
+#        include:
+#          - platform: blacksmith-4vcpu-ubuntu-2204
+#            env-file: compose-env.linux
+#    runs-on: ${{ matrix.platform }}
+#    steps:
+#    - name: Checkout
+#      uses: actions/checkout@v4
+#    - name: Set up Python (${{ matrix.python }})
+#      uses: ./.github/actions/python
+#    - name: Setup Rust
+#      uses: ./.github/actions/rust
+#      with:
+#          github-token: ${{ github.token }}
+#    - name: Configure pytest to upload results to Datadog
+#      uses: datadog/test-visibility-github-action@v2
+#      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+#      if: ${{ !contains(matrix.platform, 'windows') }}
+#      with:
+#        languages: python
+#        api_key: ${{ secrets.DD_API_KEY }}
+#        site: ${{ vars.DD_SITE }}
+#    - name: Rust Integration Test
+#      run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
+#      shell: bash
+#      env:
+#        ENV_FILE: ${{ matrix.env-file }}
+#        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-  test-rust-single-node-integration:
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{fromJson(inputs.python_versions)}}
-        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
-        test-globs: ["--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'",
-                    "chromadb/test/property/test_add.py",
-                    "chromadb/test/property/test_collections.py",
-                    "chromadb/test/property/test_collections_with_database_tenant.py",
-                    "chromadb/test/property/test_cross_version_persist.py",
-                    "chromadb/test/property/test_embeddings.py",
-                    "chromadb/test/property/test_filtering.py",
-                    "chromadb/test/property/test_persist.py",
-                    "chromadb/test/stress"]
-        include:
-          - platform: blacksmith-4vcpu-ubuntu-2204
-            env-file: compose-env.linux
-    runs-on: ${{ matrix.platform }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up Python (${{ matrix.python }})
-      uses: ./.github/actions/python
-    - name: Setup Rust
-      uses: ./.github/actions/rust
-      with:
-          github-token: ${{ github.token }}
-    - name: Configure pytest to upload results to Datadog
-      uses: datadog/test-visibility-github-action@v2
-      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-      if: ${{ !contains(matrix.platform, 'windows') }}
-      with:
-        languages: python
-        api_key: ${{ secrets.DD_API_KEY }}
-        site: ${{ vars.DD_SITE }}
-    - name: Rust Integration Test
-      run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
-      shell: bash
-      env:
-        ENV_FILE: ${{ matrix.env-file }}
-        PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+#  test-rust-thin-client:
+#    strategy:
+#      matrix:
+#        python: ${{fromJson(inputs.python_versions)}}
+#        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
+#        test-globs: ["chromadb/test/property/test_add.py",
+#                    "chromadb/test/property/test_collections.py",
+#                    "chromadb/test/property/test_collections_with_database_tenant.py",
+#                    "chromadb/test/property/test_embeddings.py",
+#                    "chromadb/test/property/test_filtering.py"]
+#    runs-on: ${{ matrix.platform }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Set up Python (${{ matrix.python }})
+#        uses: ./.github/actions/python
+#        with:
+#          python-version: ${{ matrix.python }}
+#      - name: Setup Rust
+#        uses: ./.github/actions/rust
+#        with:
+#          github-token: ${{ github.token }}
+#      - name: Configure pytest to upload results to Datadog
+#        uses: datadog/test-visibility-github-action@v2
+#        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+#        if: ${{ !contains(matrix.platform, 'windows') }}
+#        with:
+#          languages: python
+#          api_key: ${{ secrets.DD_API_KEY }}
+#          site: ${{ vars.DD_SITE }}
+#      - name: Test
+#        run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
+#        shell: bash
+#        env:
+#          CHROMA_THIN_CLIENT: "1"
+#          ENV_FILE: ${{ matrix.env-file }}
+#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
-  test-rust-thin-client:
-    strategy:
-      matrix:
-        python: ${{fromJson(inputs.python_versions)}}
-        platform: [blacksmith-4vcpu-ubuntu-2204, windows-latest]
-        test-globs: ["chromadb/test/property/test_add.py",
-                    "chromadb/test/property/test_collections.py",
-                    "chromadb/test/property/test_collections_with_database_tenant.py",
-                    "chromadb/test/property/test_embeddings.py",
-                    "chromadb/test/property/test_filtering.py"]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python (${{ matrix.python }})
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Configure pytest to upload results to Datadog
-        uses: datadog/test-visibility-github-action@v2
-        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-        if: ${{ !contains(matrix.platform, 'windows') }}
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: ${{ vars.DD_SITE }}
-      - name: Test
-        run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
-        shell: bash
-        env:
-          CHROMA_THIN_CLIENT: "1"
-          ENV_FILE: ${{ matrix.env-file }}
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+#  test-cluster-rust-frontend:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python: ${{fromJson(inputs.python_versions)}}
+#        platform: ["blacksmith-16vcpu-ubuntu-2204"]
+#        test-globs: ["chromadb/test/api",
+#                    "chromadb/test/api/test_collection.py",
+#                    "chromadb/test/api/test_limit_offset.py",
+#                    "chromadb/test/property/test_collections.py",
+#                    "chromadb/test/property/test_add.py",
+#                    "chromadb/test/property/test_filtering.py",
+#                    "chromadb/test/property/test_fork.py",
+#                    "chromadb/test/property/test_embeddings.py",
+#                    "chromadb/test/property/test_collections_with_database_tenant.py",
+#                    "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
+#                    "chromadb/test/distributed/test_sanity.py"]
+#    runs-on: ${{ matrix.platform }}
+#    # OIDC token auth for AWS
+#    permissions:
+#      contents: read
+#      id-token: write
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: ./.github/actions/python
+#        with:
+#          python-version: ${{ matrix.python }}
+#      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
+#      # - name: Configure pytest to upload results to Datadog
+#      #   uses: datadog/test-visibility-github-action@v2
+#      #   with:
+#      #     languages: python
+#      #     api_key: ${{ secrets.DD_API_KEY }}
+#      #     site: ${{ vars.DD_SITE }}
+#      - uses: useblacksmith/build-push-action@v1.1
+#        with:
+#          setup-only: true
+#      - uses: ./.github/actions/tilt
+#      - name: Test
+#        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}"' --durations 10
+#        shell: bash
+#        env:
+#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+#          CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
+#          CHROMA_SERVER_HOST: "localhost:3000"
+#      - name: Compute artifact name
+#        if: always()
+#        id: compute-artifact-name
+#        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
+#      - name: Save service logs to artifact
+#        if: always()
+#        uses: ./.github/actions/export-tilt-logs
+#        with:
+#          artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
 
-  test-cluster-rust-frontend:
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{fromJson(inputs.python_versions)}}
-        platform: ["blacksmith-16vcpu-ubuntu-2204"]
-        test-globs: ["chromadb/test/api",
-                    "chromadb/test/api/test_collection.py",
-                    "chromadb/test/api/test_limit_offset.py",
-                    "chromadb/test/property/test_collections.py",
-                    "chromadb/test/property/test_add.py",
-                    "chromadb/test/property/test_filtering.py",
-                    "chromadb/test/property/test_fork.py",
-                    "chromadb/test/property/test_embeddings.py",
-                    "chromadb/test/property/test_collections_with_database_tenant.py",
-                    "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
-                    "chromadb/test/distributed/test_sanity.py"]
-    runs-on: ${{ matrix.platform }}
-    # OIDC token auth for AWS
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
-      # - name: Configure pytest to upload results to Datadog
-      #   uses: datadog/test-visibility-github-action@v2
-      #   with:
-      #     languages: python
-      #     api_key: ${{ secrets.DD_API_KEY }}
-      #     site: ${{ vars.DD_SITE }}
-      - uses: useblacksmith/build-push-action@v1.1
-        with:
-          setup-only: true
-      - uses: ./.github/actions/tilt
-      - name: Test
-        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}"' --durations 10
-        shell: bash
-        env:
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-          CHROMA_RUST_FRONTEND_TEST_ONLY: "1"
-          CHROMA_SERVER_HOST: "localhost:3000"
-      - name: Compute artifact name
-        if: always()
-        id: compute-artifact-name
-        run: echo "artifact_name=cluster_logs_rust_frontend_$(basename "${{ matrix.test-globs }}" .py)_${{ matrix.python }}" >> $GITHUB_OUTPUT
-      - name: Save service logs to artifact
-        if: always()
-        uses: ./.github/actions/export-tilt-logs
-        with:
-          artifact-name: ${{ steps.compute-artifact-name.outputs.artifact_name }}
+#  merge-cluster-logs:
+#    runs-on: blacksmith-4vcpu-ubuntu-2204
+#    needs: test-cluster-rust-frontend
+#    steps:
+#      - name: Merge
+#        uses: actions/upload-artifact/merge@v4
+#        with:
+#          name: cluster_test_logs
+#          pattern: cluster_logs_*
 
-  merge-cluster-logs:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    needs: test-cluster-rust-frontend
-    steps:
-      - name: Merge
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: cluster_test_logs
-          pattern: cluster_logs_*
-
-  test-rust-bindings-stress:
-    timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        python: ${{fromJson(inputs.python_versions)}}
-        platform: [blacksmith-16vcpu-ubuntu-2204, 16core-64gb-windows-latest]
-        test-globs: ["chromadb/test/stress"]
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: ./.github/actions/python
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Build Rust bindings
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          sccache: true
-      - name: Install built wheel
-        shell: bash
-        run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Configure pytest to upload results to Datadog
-        uses: datadog/test-visibility-github-action@v2
-        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-        if: ${{ !contains(matrix.platform, 'windows') }}
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: ${{ vars.DD_SITE }}
-      - name: Test
-        run: python -m pytest ${{ matrix.test-globs }} --durations 10
-        shell: bash
-        env:
-          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
-          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
+#  test-rust-bindings-stress:
+#    timeout-minutes: 90
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python: ${{fromJson(inputs.python_versions)}}
+#        platform: [blacksmith-16vcpu-ubuntu-2204, 16core-64gb-windows-latest]
+#        test-globs: ["chromadb/test/stress"]
+#    runs-on: ${{ matrix.platform }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Setup Python
+#        uses: ./.github/actions/python
+#        with:
+#          python-version: ${{ matrix.python }}
+#      - name: Setup Rust
+#        uses: ./.github/actions/rust
+#        with:
+#          github-token: ${{ github.token }}
+#      - name: Build Rust bindings
+#        uses: PyO3/maturin-action@v1
+#        with:
+#          command: build
+#          sccache: true
+#      - name: Install built wheel
+#        shell: bash
+#        run: pip install --no-index --find-links target/wheels/ chromadb
+#      - name: Configure pytest to upload results to Datadog
+#        uses: datadog/test-visibility-github-action@v2
+#        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
+#        if: ${{ !contains(matrix.platform, 'windows') }}
+#        with:
+#          languages: python
+#          api_key: ${{ secrets.DD_API_KEY }}
+#          site: ${{ vars.DD_SITE }}
+#      - name: Test
+#        run: python -m pytest ${{ matrix.test-globs }} --durations 10
+#        shell: bash
+#        env:
+#          PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
+#          CHROMA_RUST_BINDINGS_TEST_ONLY: "1"
 
   test-python-cli:
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,30 +167,30 @@ jobs:
     with:
       property_testing_preset: 'normal'
 
-  python-vulnerability-scan:
-    name: Python vulnerability scan
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
-    uses: ./.github/workflows/_python-vulnerability-scan.yml
+#  python-vulnerability-scan:
+#    name: Python vulnerability scan
+#    needs: change-detection
+#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+#    uses: ./.github/workflows/_python-vulnerability-scan.yml
 
-  javascript-client-tests:
-    name: JavaScript client tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
-    uses: ./.github/workflows/_javascript-client-tests.yml
+#  javascript-client-tests:
+#    name: JavaScript client tests
+#    needs: change-detection
+#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
+#    uses: ./.github/workflows/_javascript-client-tests.yml
 
-  rust-tests:
-    name: Rust tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
-    uses: ./.github/workflows/_rust-tests.yml
-    secrets: inherit
-
-  go-tests:
-    name: Go tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
-    uses: ./.github/workflows/_go-tests.yml
+#  rust-tests:
+#    name: Rust tests
+#    needs: change-detection
+#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+#    uses: ./.github/workflows/_rust-tests.yml
+#    secrets: inherit
+#
+#  go-tests:
+#    name: Go tests
+#    needs: change-detection
+#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
+#    uses: ./.github/workflows/_go-tests.yml
 
   check-title:
     name: Check PR Title
@@ -258,10 +258,10 @@ jobs:
     if: always()
     needs:
     - python-tests
-    - python-vulnerability-scan
-    - javascript-client-tests
-    - rust-tests
-    - go-tests
+#    - python-vulnerability-scan
+#    - javascript-client-tests
+#    - rust-tests
+#    - go-tests
     - check-title
     - lint
     - check-helm-version-bump

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,30 +167,30 @@ jobs:
     with:
       property_testing_preset: 'normal'
 
-#  python-vulnerability-scan:
-#    name: Python vulnerability scan
-#    needs: change-detection
-#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
-#    uses: ./.github/workflows/_python-vulnerability-scan.yml
+  python-vulnerability-scan:
+    name: Python vulnerability scan
+    needs: change-detection
+    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+    uses: ./.github/workflows/_python-vulnerability-scan.yml
 
-#  javascript-client-tests:
-#    name: JavaScript client tests
-#    needs: change-detection
-#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
-#    uses: ./.github/workflows/_javascript-client-tests.yml
+  javascript-client-tests:
+    name: JavaScript client tests
+    needs: change-detection
+    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'js-client')
+    uses: ./.github/workflows/_javascript-client-tests.yml
 
-#  rust-tests:
-#    name: Rust tests
-#    needs: change-detection
-#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
-#    uses: ./.github/workflows/_rust-tests.yml
-#    secrets: inherit
-#
-#  go-tests:
-#    name: Go tests
-#    needs: change-detection
-#    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
-#    uses: ./.github/workflows/_go-tests.yml
+  rust-tests:
+    name: Rust tests
+    needs: change-detection
+    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+    uses: ./.github/workflows/_rust-tests.yml
+    secrets: inherit
+
+  go-tests:
+    name: Go tests
+    needs: change-detection
+    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'go')
+    uses: ./.github/workflows/_go-tests.yml
 
   check-title:
     name: Check PR Title
@@ -258,10 +258,10 @@ jobs:
     if: always()
     needs:
     - python-tests
-#    - python-vulnerability-scan
-#    - javascript-client-tests
-#    - rust-tests
-#    - go-tests
+    - python-vulnerability-scan
+    - javascript-client-tests
+    - rust-tests
+    - go-tests
     - check-title
     - lint
     - check-helm-version-bump

--- a/chromadb/test/test_cli.py
+++ b/chromadb/test/test_cli.py
@@ -1,12 +1,10 @@
 import multiprocessing
 import multiprocessing.context
-import os
 import sys
 import time
 from multiprocessing.synchronize import Event
 
 import chromadb
-from chromadb import ClientAPI
 from chromadb.api.client import Client
 from chromadb.api.models.Collection import Collection
 from chromadb.cli import cli
@@ -21,7 +19,7 @@ from chromadb.test.property import invariants
 
 
 def wait_for_server(
-    client: ClientAPI, max_retries: int = 5, initial_delay: float = 1.0
+    client, max_retries: int = 5, initial_delay: float = 1.0
 ) -> bool:
     """Wait for server to be ready using exponential backoff.
     Args:
@@ -60,11 +58,7 @@ def test_app() -> None:
     server_process.start()
     time.sleep(5)
 
-    host = os.getenv("CHROMA_SERVER_HOST", kwargs.get("host", "localhost"))
-    port = os.getenv("CHROMA_SERVER_HTTP_PORT", kwargs.get("port", 8000))
-    port = int(os.getenv("CHROMA_SERVER_HTTP_PORT", kwargs.get("port", 8000)))
-
-    client = chromadb.HttpClient(host=host, port=port)
+    client = chromadb.HttpClient(host=kwargs["host"], port=int(kwargs["port"]))
     heartbeat = client.heartbeat()
     assert wait_for_server(
         client

--- a/chromadb/test/test_cli.py
+++ b/chromadb/test/test_cli.py
@@ -6,11 +6,11 @@ import time
 from multiprocessing.synchronize import Event
 
 import chromadb
+from chromadb import ClientAPI
 from chromadb.api.client import Client
 from chromadb.api.models.Collection import Collection
 from chromadb.cli import cli
 from chromadb.cli.cli import build_cli_args
-from chromadb.cli.utils import set_log_file_path
 from chromadb.config import Settings, System
 from chromadb.db.base import get_sql
 from chromadb.db.impl.sqlite import SqliteDB
@@ -18,6 +18,34 @@ from pypika import Table
 import numpy as np
 
 from chromadb.test.property import invariants
+
+
+def wait_for_server(
+    client: ClientAPI, max_retries: int = 5, initial_delay: float = 1.0
+) -> bool:
+    """Wait for server to be ready using exponential backoff.
+    Args:
+        client: ChromaDB client instance
+        max_retries: Maximum number of retry attempts
+        initial_delay: Initial delay in seconds before first retry
+    Returns:
+        bool: True if server is ready, False if max retries exceeded
+    """
+    delay = initial_delay
+    for attempt in range(max_retries):
+        try:
+            heartbeat = client.heartbeat()
+            if heartbeat > 0:
+                return True
+        except Exception:
+            print("Heartbeat failed, trying again...")
+            pass
+
+        if attempt < max_retries - 1:
+            time.sleep(delay)
+            delay *= 2
+
+    return False
 
 def start_app(args: list[str]) -> None:
     sys.argv = args
@@ -34,9 +62,14 @@ def test_app() -> None:
 
     host = os.getenv("CHROMA_SERVER_HOST", kwargs.get("host", "localhost"))
     port = os.getenv("CHROMA_SERVER_HTTP_PORT", kwargs.get("port", 8000))
+    port = int(os.getenv("CHROMA_SERVER_HTTP_PORT", kwargs.get("port", 8000)))
 
     client = chromadb.HttpClient(host=host, port=port)
     heartbeat = client.heartbeat()
+    assert wait_for_server(
+        client
+    ), "Server failed to start within maximum retry attempts"
+
     server_process.terminate()
     server_process.join()
     assert heartbeat > 0

--- a/rust/cli/src/commands/vacuum.rs
+++ b/rust/cli/src/commands/vacuum.rs
@@ -21,7 +21,9 @@ use std::error::Error;
 use std::path::Path;
 use std::str::FromStr;
 use std::{fs, io};
+use std::time::Duration;
 use thiserror::Error;
+use tokio::time::timeout;
 
 #[derive(Debug, Error)]
 pub enum VacuumError {
@@ -43,6 +45,8 @@ pub struct VacuumArgs {
     path: Option<String>,
     #[clap(long, default_value_t = false, help = "Skip vacuum confirmation")]
     force: bool,
+    #[clap(long, help = "Maximum time (in seconds) to wait for vacuum")]
+    timeout: Option<u64>,
 }
 
 fn sizeof_fmt(num: u64, suffix: Option<&str>) -> String {
@@ -194,11 +198,7 @@ pub async fn vacuum_chroma(config: FrontendConfig) -> Result<(), Box<dyn Error>>
     }
 
     println!("Vacuuming (this may take a while)...\n");
-
-    sqlx::query(&format!("PRAGMA busy_timeout = {}", 5000))
-        .execute(sqlite.get_conn())
-        .await?;
-
+    
     sqlx::query("VACUUM").execute(sqlite.get_conn()).await?;
 
     sqlx::query(
@@ -264,10 +264,16 @@ pub fn vacuum(args: VacuumArgs) -> Result<(), CliError> {
     };
 
     let runtime = tokio::runtime::Runtime::new().expect("Failed to start Chroma");
-    runtime
-        .block_on(vacuum_chroma(config.frontend))
-        .map_err(|_| VacuumError::VacuumFailed)?;
 
+    let res = if let Some(secs) = args.timeout {
+        runtime.block_on(async {
+            timeout(Duration::from_secs(secs), vacuum_chroma(config.frontend)).await.unwrap_or_else(|_elapsed| Err(Box::new(VacuumError::VacuumFailed) as Box<dyn std::error::Error>))
+        })
+    } else {
+        runtime.block_on(vacuum_chroma(config.frontend))
+    };
+    res.map_err(|_| VacuumError::VacuumFailed)?;
+    
     let post_vacuum_size =
         get_dir_size(Path::new(&persistent_path)).map_err(|_| VacuumError::DirSizeFailed)?;
 


### PR DESCRIPTION
## Description of changes

Speed up python CLI wrapper tests:
* Run tests directly instead of setting up the integration test environment.
* Previously, vacuum set its own timeout for SQLite connections, however now we have a default timeout of 1000 seconds (~17 minutes) on all connections. The last test in `test_cli` checks that we abort long standing vacuum operations (when the DB file is locked). To work around the 1000 timeout, added a `timeout` argument to the CLI command to override the default long timeout. The DB set up by the test would have been vacuumed in a matter of seconds.

## Test plan
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A
