### PR TITLE
[CLN] CLI - Refactor webbrowser commands

### DIFF
--- a/rust/cli/src/commands/mod.rs
+++ b/rust/cli/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod profile;
 pub mod run;
 pub mod update;
 pub mod vacuum;
+pub mod webpage;

--- a/rust/cli/src/commands/webpage.rs
+++ b/rust/cli/src/commands/webpage.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use crate::utils::CliError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum WebPageError {
@@ -9,14 +9,14 @@ pub enum WebPageError {
 
 pub enum WebPageCommand {
     Discord,
-    Docs
+    Docs,
 }
 
 impl WebPageCommand {
     fn url(&self) -> &'static str {
         match self {
             WebPageCommand::Discord => "https://discord.gg/MMeYNTmh3x",
-            WebPageCommand::Docs => "https://docs.trychroma.com"
+            WebPageCommand::Docs => "https://docs.trychroma.com",
         }
     }
 }

--- a/rust/cli/src/commands/webpage.rs
+++ b/rust/cli/src/commands/webpage.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+use crate::utils::CliError;
+
+#[derive(Debug, Error)]
+pub enum WebPageError {
+    #[error("Failed to open browser. {0}")]
+    BrowserOpenFailed(String),
+}
+
+pub enum WebPageCommand {
+    Discord,
+    Docs
+}
+
+impl WebPageCommand {
+    fn url(&self) -> &'static str {
+        match self {
+            WebPageCommand::Discord => "https://discord.gg/MMeYNTmh3x",
+            WebPageCommand::Docs => "https://docs.trychroma.com"
+        }
+    }
+}
+
+pub fn open_browser(command: WebPageCommand) -> Result<(), CliError> {
+    let url = command.url();
+    let error_message = format!("Visit {}", url);
+    webbrowser::open(url).map_err(|_| WebPageError::BrowserOpenFailed(error_message))?;
+    Ok(())
+}

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -13,9 +13,9 @@ use crate::commands::profile::{profile_command, ProfileCommand};
 use crate::commands::run::{run, RunArgs};
 use crate::commands::update::update;
 use crate::commands::vacuum::{vacuum, VacuumArgs};
+use crate::commands::webpage::{open_browser, WebPageCommand};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use crate::commands::webpage::{open_browser, WebPageCommand};
 
 #[derive(Subcommand, Debug)]
 enum Command {

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -15,8 +15,7 @@ use crate::commands::update::update;
 use crate::commands::vacuum::{vacuum, VacuumArgs};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use utils::CliError;
-use utils::UtilsError;
+use crate::commands::webpage::{open_browser, WebPageCommand};
 
 #[derive(Subcommand, Debug)]
 enum Command {
@@ -44,12 +43,6 @@ struct Cli {
     command: Command,
 }
 
-fn open_browser(url: &str) -> Result<(), CliError> {
-    let error_message = format!("Visit {}", url);
-    webbrowser::open(url).map_err(|_| UtilsError::BrowserOpenFailed(error_message))?;
-    Ok(())
-}
-
 pub fn chroma_cli(args: Vec<String>) {
     let cli = Cli::parse_from(args);
 
@@ -59,18 +52,12 @@ pub fn chroma_cli(args: Vec<String>) {
         Command::Browse(args) => browse(args),
         Command::Copy(args) => copy(args),
         Command::Db(db_subcommand) => db_command(db_subcommand),
-        Command::Docs => {
-            let url = "https://docs.trychroma.com";
-            open_browser(url)
-        }
+        Command::Docs => open_browser(WebPageCommand::Docs),
         Command::Install(args) => install(args),
         Command::Login(args) => login(args),
         Command::Profile(profile_subcommand) => profile_command(profile_subcommand),
         Command::Run(args) => run(args),
-        Command::Support => {
-            let url = "https://discord.gg/MMeYNTmh3x";
-            open_browser(url)
-        }
+        Command::Support => open_browser(WebPageCommand::Discord),
         Command::Update => update(),
         Command::Vacuum(args) => vacuum(args),
     };

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::spawn;
 use tokio::task::JoinHandle;
+use crate::commands::webpage::WebPageError;
 
 pub const CHROMA_DIR: &str = ".chroma";
 pub const CREDENTIALS_FILE: &str = "credentials";
@@ -64,6 +65,8 @@ pub enum CliError {
     Copy(#[from] CopyError),
     #[error("{0}")]
     Collection(#[from] CollectionAPIError),
+    #[error("{0}")]
+    WebPage(#[from] WebPageError),
 }
 
 #[derive(Debug, Error)]
@@ -90,8 +93,6 @@ pub enum UtilsError {
     ConfigFileWriteFailed,
     #[error("Failed to get user input")]
     UserInputFailed,
-    #[error("Failed to open browser. {0}")]
-    BrowserOpenFailed(String),
     #[error("Failed to copy to clipboard")]
     CopyToClipboardFailed,
     #[error("Input validation failed")]

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -11,6 +11,7 @@ use crate::commands::profile::ProfileError;
 use crate::commands::run::RunError;
 use crate::commands::update::UpdateError;
 use crate::commands::vacuum::VacuumError;
+use crate::commands::webpage::WebPageError;
 use crate::ui_utils::Theme;
 use chroma_frontend::config::FrontendServerConfig;
 use chroma_frontend::frontend_service_entrypoint_with_config;
@@ -28,7 +29,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::spawn;
 use tokio::task::JoinHandle;
-use crate::commands::webpage::WebPageError;
 
 pub const CHROMA_DIR: &str = ".chroma";
 pub const CREDENTIALS_FILE: &str = "credentials";


### PR DESCRIPTION
## Description of changes

Refactor web browser commands (open docs and discord) to their own module.

## Test plan
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
N/A