### PR TITLE
[ENH]: Add retry for add, update and upsert

### DIFF
--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -3,11 +3,13 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	log "github.com/chroma-core/chroma/go/pkg/log/store/db"
 	"github.com/chroma-core/chroma/go/pkg/log/sysdb"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	trace_log "github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -68,6 +70,12 @@ func (r *LogRepository) InsertRecords(ctx context.Context, collectionId string, 
 	}
 	insertCount, err = queriesWithTx.InsertRecord(ctx, params)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			trace_log.Error("Duplicate key error while inserting into record_log", zap.String("collectionId", collectionId), zap.String("detail", pgErr.Detail))
+			err = status.Error(codes.AlreadyExists, fmt.Sprintf("Duplicate key error while inserting into record_log: %s", pgErr.Detail))
+			return
+		}
 		trace_log.Error("Error in inserting records to record_log table", zap.Error(err), zap.String("collectionId", collectionId))
 		return
 	}

--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -71,6 +71,8 @@ func (r *LogRepository) InsertRecords(ctx context.Context, collectionId string, 
 	insertCount, err = queriesWithTx.InsertRecord(ctx, params)
 	if err != nil {
 		var pgErr *pgconn.PgError
+		// This is a retryable error and should be retried by upstream. It happens
+		// when two concurrent adds to the same collection happen.
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 			trace_log.Error("Duplicate key error while inserting into record_log", zap.String("collectionId", collectionId), zap.String("detail", pgErr.Detail))
 			err = status.Error(codes.AlreadyExists, fmt.Sprintf("Duplicate key error while inserting into record_log: %s", pgErr.Detail))

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -715,7 +715,7 @@ impl ServiceBasedFrontend {
         match res {
             Ok(()) => Ok(AddCollectionRecordsResponse {}),
             Err(e) => {
-                if e.code() == ErrorCodes::Unavailable {
+                if e.code() == ErrorCodes::AlreadyExists {
                     Err(AddCollectionRecordsError::Backoff)
                 } else {
                     Err(AddCollectionRecordsError::Other(Box::new(e) as _))

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -689,8 +689,7 @@ impl ServiceBasedFrontend {
         };
         let res = add_to_retry
             .retry(self.retries_builder)
-            // NOTE: Transport level errors will manifest as unknown errors, and they should also be retried
-            .when(|e| matches!(e.code(), ErrorCodes::Unavailable))
+            .when(|e| matches!(e.code(), ErrorCodes::AlreadyExists))
             .notify(|_, _| {
                 let retried = retries.fetch_add(1, Ordering::Relaxed);
                 if retried > 0 {

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -2,7 +2,7 @@ use crate::{
     config::FrontendConfig, executor::Executor, types::errors::ValidationError,
     CollectionsWithSegmentsProvider,
 };
-use backon::Retryable;
+use backon::{ExponentialBuilder, Retryable};
 use chroma_config::{registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::{LocalCompactionManager, LocalCompactionManagerConfig, Log};
@@ -35,10 +35,10 @@ use chroma_types::{
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
-use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::{collections::HashSet, time::Duration};
 
 use super::utils::to_records;
 
@@ -49,6 +49,7 @@ struct Metrics {
     count_retries_counter: Counter<u64>,
     query_retries_counter: Counter<u64>,
     get_retries_counter: Counter<u64>,
+    add_retries_counter: Counter<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -61,6 +62,7 @@ pub struct ServiceBasedFrontend {
     max_batch_size: u32,
     metrics: Arc<Metrics>,
     default_knn_index: KnnIndex,
+    retries_builder: ExponentialBuilder,
 }
 
 impl ServiceBasedFrontend {
@@ -78,14 +80,28 @@ impl ServiceBasedFrontend {
         let delete_retries_counter = meter.u64_counter("delete_retries").build();
         let count_retries_counter = meter.u64_counter("count_retries").build();
         let query_retries_counter = meter.u64_counter("query_retries").build();
-        let get_retries_counter = meter.u64_counter("query_retries").build();
+        let get_retries_counter = meter.u64_counter("get_retries").build();
+        let add_retries_counter = meter.u64_counter("add_retries").build();
         let metrics = Arc::new(Metrics {
             fork_retries_counter,
             delete_retries_counter,
             count_retries_counter,
             query_retries_counter,
             get_retries_counter,
+            add_retries_counter,
         });
+        // factor: 2.0,
+        // min_delay_ms: 100,
+        // max_delay_ms: 5000,
+        // max_attempts: 5,
+        // jitter: true,
+        // TODO(Sanket): Ideally config for this.
+        let retries_builder = ExponentialBuilder::default()
+            .with_max_times(5)
+            .with_factor(2.0)
+            .with_max_delay(Duration::from_millis(5000))
+            .with_min_delay(Duration::from_millis(100))
+            .with_jitter();
         ServiceBasedFrontend {
             allow_reset,
             executor,
@@ -95,6 +111,7 @@ impl ServiceBasedFrontend {
             max_batch_size,
             metrics,
             default_knn_index,
+            retries_builder,
         }
     }
 
@@ -630,6 +647,14 @@ impl ServiceBasedFrontend {
         res
     }
 
+    pub async fn retryable_add(
+        &mut self,
+        collection_id: CollectionUuid,
+        records: Vec<OperationRecord>,
+    ) -> Result<(), Box<dyn ChromaError>> {
+        self.log_client.push_logs(collection_id, records).await
+    }
+
     pub async fn add(
         &mut self,
         AddCollectionRecordsRequest {
@@ -656,16 +681,26 @@ impl ServiceBasedFrontend {
             to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)
                 .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
 
-        self.log_client
-            .push_logs(collection_id, records)
-            .await
-            .map_err(|err| {
-                if err.code() == ErrorCodes::Unavailable {
-                    AddCollectionRecordsError::Backoff
-                } else {
-                    AddCollectionRecordsError::Other(Box::new(err) as _)
+        let retries = Arc::new(AtomicUsize::new(0));
+        let add_to_retry = || {
+            let mut self_clone = self.clone();
+            let records_clone = records.clone();
+            async move { self_clone.retryable_add(collection_id, records_clone).await }
+        };
+        let res = add_to_retry
+            .retry(self.retries_builder)
+            // NOTE: Transport level errors will manifest as unknown errors, and they should also be retried
+            .when(|e| matches!(e.code(), ErrorCodes::Unavailable))
+            .notify(|_, _| {
+                let retried = retries.fetch_add(1, Ordering::Relaxed);
+                if retried > 0 {
+                    tracing::info!("Retrying add() request for collection {}", collection_id);
                 }
-            })?;
+            })
+            .await;
+        self.metrics
+            .add_retries_counter
+            .add(retries.load(Ordering::Relaxed) as u64, &[]);
 
         // TODO: Submit event after the response is sent
         MeterEvent::CollectionWrite {
@@ -678,7 +713,16 @@ impl ServiceBasedFrontend {
         .submit()
         .await;
 
-        Ok(AddCollectionRecordsResponse {})
+        match res {
+            Ok(()) => Ok(AddCollectionRecordsResponse {}),
+            Err(e) => {
+                if e.code() == ErrorCodes::Unavailable {
+                    Err(AddCollectionRecordsError::Backoff)
+                } else {
+                    Err(AddCollectionRecordsError::Other(Box::new(e) as _))
+                }
+            }
+        }
     }
 
     pub async fn update(

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -315,7 +315,9 @@ impl GrpcLog {
             .push_logs(request)
             .await
             .map_err(|err| {
-                if err.code() == ErrorCodes::Unavailable.into() {
+                if err.code() == ErrorCodes::Unavailable.into()
+                    || err.code() == ErrorCodes::Unknown.into()
+                {
                     GrpcPushLogsError::Backoff
                 } else {
                     err.into()

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -52,7 +52,7 @@ pub enum GrpcPushLogsError {
 impl ChromaError for GrpcPushLogsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            GrpcPushLogsError::Backoff => ErrorCodes::Unavailable,
+            GrpcPushLogsError::Backoff => ErrorCodes::AlreadyExists,
             GrpcPushLogsError::FailedToPushLogs(_) => ErrorCodes::Internal,
             GrpcPushLogsError::ConversionError(_) => ErrorCodes::Internal,
         }
@@ -316,7 +316,7 @@ impl GrpcLog {
             .await
             .map_err(|err| {
                 if err.code() == ErrorCodes::Unavailable.into()
-                    || err.code() == ErrorCodes::Unknown.into()
+                    || err.code() == ErrorCodes::AlreadyExists.into()
                 {
                     GrpcPushLogsError::Backoff
                 } else {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds exponential retry to coll.add(), coll.update() and coll.upsert() for duplicate key errors returned by postgres
- New functionality
  - ...

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
