### PR TITLE
[ENH]  A route and tool to inspect the dirty log.

### DIFF
--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -152,6 +152,12 @@ func (s *logServer) PurgeDirtyForCollection(ctx context.Context, req *logservice
 	return
 }
 
+func (s *logServer) InspectDirtyLog(ctx context.Context, req *logservicepb.InspectDirtyLogRequest) (res *logservicepb.InspectDirtyLogResponse, err error) {
+	// no-op for now
+	return
+}
+
+
 func NewLogServer(lr *repository.LogRepository) logservicepb.LogServiceServer {
 	return &logServer{
 		lr: lr,

--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -87,6 +87,14 @@ message PurgeDirtyForCollectionResponse {
   // Empty
 }
 
+message InspectDirtyLogRequest {
+  // Empty
+}
+
+message InspectDirtyLogResponse {
+  repeated string markers = 1;
+}
+
 service LogService {
   rpc PushLogs(PushLogsRequest) returns (PushLogsResponse) {}
   rpc ScoutLogs(ScoutLogsRequest) returns (ScoutLogsResponse) {}
@@ -95,4 +103,5 @@ service LogService {
   rpc GetAllCollectionInfoToCompact(GetAllCollectionInfoToCompactRequest) returns (GetAllCollectionInfoToCompactResponse) {}
   rpc UpdateCollectionLogOffset(UpdateCollectionLogOffsetRequest) returns (UpdateCollectionLogOffsetResponse) {}
   rpc PurgeDirtyForCollection(PurgeDirtyForCollectionRequest) returns (PurgeDirtyForCollectionResponse) {}
+  rpc InspectDirtyLog(InspectDirtyLogRequest) returns (InspectDirtyLogResponse) {}
 }

--- a/rust/log-service/src/bin/chroma-inspect-dirty-log.rs
+++ b/rust/log-service/src/bin/chroma-inspect-dirty-log.rs
@@ -1,0 +1,27 @@
+use tonic::transport::Channel;
+
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::InspectDirtyLogRequest;
+
+#[tokio::main]
+async fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 1 {
+        eprintln!("USAGE: chroma-inspect-dirty-log [HOST]");
+        std::process::exit(13);
+    }
+    let logservice = Channel::from_shared(args[0].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to log service");
+    let mut client = LogServiceClient::new(logservice);
+    let dirty = client
+        .inspect_dirty_log(InspectDirtyLogRequest {})
+        .await
+        .expect("could not inspect dirty log");
+    let dirty = dirty.into_inner();
+    for line in dirty.markers {
+        println!("{line}");
+    }
+}

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1081,10 +1081,10 @@ impl LogService for LogServer {
         Ok(Response::new(PurgeDirtyForCollectionResponse {}))
     }
 
-    #[tracing::instrument(skip(self, request))]
+    #[tracing::instrument(skip(self, _request))]
     async fn inspect_dirty_log(
         &self,
-        request: Request<InspectDirtyLogRequest>,
+        _request: Request<InspectDirtyLogRequest>,
     ) -> Result<Response<InspectDirtyLogResponse>, Status> {
         let Some(reader) = self.dirty_log.reader(LogReaderOptions::default()) else {
             return Err(Status::unavailable("Failed to get dirty log reader"));


### PR DESCRIPTION
## Description of changes

To get ground truth on the dirty log, add a tool that can print it as it
gets interpreted in the 'get all to compact' call.

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
