### PR TITLE
[ENH]: add orchestrator to construct version graph for garbage collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,6 +2962,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3307,7 @@ name = "garbage_collector"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chroma-blockstore",
  "chroma-cache",
  "chroma-config",
@@ -3320,6 +3327,7 @@ dependencies = [
  "humantime",
  "itertools 0.13.0",
  "opentelemetry",
+ "petgraph 0.8.1",
  "proptest",
  "proptest-derive 0.3.0",
  "proptest-state-machine",
@@ -5692,8 +5700,20 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.6.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.2",
+ "indexmap 2.6.0",
+ "serde",
 ]
 
 [[package]]
@@ -5982,7 +6002,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.4",
  "prettyplease",
  "prost 0.12.3",
  "prost-types 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,8 @@ reqwest = { version = "0.12.9",  features = ["rustls-tls-native-roots", "http2"]
 random-port = "0.1.1"
 ndarray = { version = "0.16.1", features = ["approx"] }
 humantime = { version = "2.2.0" }
+petgraph = { version = "0.8.1" }
+base64 = "0.22"
 
 chroma-benchmark = { path = "rust/benchmark" }
 chroma-blockstore = { path = "rust/blockstore" }

--- a/rust/garbage_collector/Cargo.toml
+++ b/rust/garbage_collector/Cargo.toml
@@ -32,6 +32,8 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 humantime = { workspace = true }
 opentelemetry = { workspace = true }
+petgraph = { workspace = true }
+base64 = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }

--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -1,0 +1,737 @@
+use crate::operators::{
+    fetch_lineage_file::{
+        FetchLineageFileError, FetchLineageFileInput, FetchLineageFileOperator,
+        FetchLineageFileOutput,
+    },
+    fetch_version_file::{
+        FetchVersionFileError, FetchVersionFileInput, FetchVersionFileOperator,
+        FetchVersionFileOutput,
+    },
+    get_version_file_paths::{
+        GetVersionFilePathsError, GetVersionFilePathsInput, GetVersionFilePathsOperator,
+        GetVersionFilePathsOutput,
+    },
+};
+use async_trait::async_trait;
+use base64::{prelude::BASE64_STANDARD, Engine};
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::Storage;
+use chroma_sysdb::SysDb;
+use chroma_system::{
+    wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
+    PanicError, TaskError, TaskMessage, TaskResult,
+};
+use chroma_types::{chroma_proto::CollectionVersionFile, CollectionUuid};
+use chrono::DateTime;
+use petgraph::{dot::Dot, graph::DiGraph};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+use thiserror::Error;
+use tokio::sync::oneshot::{error::RecvError, Sender};
+use tracing::Span;
+
+#[derive(Debug, Clone, Copy)]
+pub enum VersionStatus {
+    #[allow(dead_code)]
+    Alive {
+        created_at: DateTime<chrono::Utc>,
+    },
+    Deleted,
+}
+
+#[derive(Debug, Clone)]
+struct VersionDependency {
+    source_collection_id: CollectionUuid,
+    source_collection_version: i64,
+    target_collection_id: CollectionUuid,
+}
+
+#[derive(Debug)]
+pub struct ConstructVersionGraphOrchestrator {
+    dispatcher: ComponentHandle<Dispatcher>,
+    result_channel:
+        Option<Sender<Result<ConstructVersionGraphResponse, ConstructVersionGraphError>>>,
+    storage: Storage,
+    sysdb: SysDb,
+
+    collection_id: CollectionUuid,
+    version_file_path: String,
+    lineage_file_path: Option<String>,
+
+    version_dependencies: Vec<VersionDependency>,
+    version_files: HashMap<CollectionUuid, CollectionVersionFile>,
+    num_pending_tasks: usize,
+}
+
+impl ConstructVersionGraphOrchestrator {
+    #[allow(dead_code)]
+    pub fn new(
+        dispatcher: ComponentHandle<Dispatcher>,
+        storage: Storage,
+        sysdb: SysDb,
+        collection_id: CollectionUuid,
+        version_file_path: String,
+        lineage_file_path: Option<String>,
+    ) -> Self {
+        Self {
+            dispatcher,
+            storage,
+            sysdb,
+            result_channel: None,
+            collection_id,
+            version_file_path,
+            lineage_file_path,
+
+            version_dependencies: Vec::new(),
+            version_files: HashMap::new(),
+            num_pending_tasks: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VersionGraphNode {
+    pub collection_id: CollectionUuid,
+    pub version: i64,
+    #[allow(dead_code)]
+    pub status: VersionStatus,
+}
+
+pub type VersionGraph = DiGraph<VersionGraphNode, ()>;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ConstructVersionGraphResponse {
+    pub version_files: HashMap<CollectionUuid, CollectionVersionFile>,
+    pub graph: VersionGraph,
+}
+
+#[derive(Debug, Error)]
+pub enum ConstructVersionGraphError {
+    #[error("Error sending message through channel: {0}")]
+    Channel(#[from] ChannelError),
+    #[error("Error receiving final result: {0}")]
+    Result(#[from] RecvError),
+    #[error("Panic: {0}")]
+    Panic(#[from] PanicError),
+    #[error("Aborted")]
+    Aborted,
+
+    #[error("Error fetching version file: {0}")]
+    FetchVersionFile(#[from] FetchVersionFileError),
+    #[error("Error fetching lineage file: {0}")]
+    FetchLineageFile(#[from] FetchLineageFileError),
+    #[error("Error fetching version file paths: {0}")]
+    FetchVersionFilePaths(#[from] GetVersionFilePathsError),
+
+    #[error("Invalid UUID: {0}")]
+    InvalidUuid(#[from] uuid::Error),
+    #[error("Invalid timestamp: {0}")]
+    InvalidTimestamp(i64),
+    #[error("Expected node not found while constructing graph")]
+    ExpectedNodeNotFound,
+}
+
+impl<E> From<TaskError<E>> for ConstructVersionGraphError
+where
+    E: Into<ConstructVersionGraphError>,
+{
+    fn from(value: TaskError<E>) -> Self {
+        match value {
+            TaskError::Panic(e) => ConstructVersionGraphError::Panic(e),
+            TaskError::TaskFailed(e) => e.into(),
+            TaskError::Aborted => ConstructVersionGraphError::Aborted,
+        }
+    }
+}
+
+impl ChromaError for ConstructVersionGraphError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            ConstructVersionGraphError::Channel(_) => ErrorCodes::Internal,
+            ConstructVersionGraphError::Result(_) => ErrorCodes::Internal,
+            ConstructVersionGraphError::Panic(_) => ErrorCodes::Internal,
+            ConstructVersionGraphError::Aborted => ErrorCodes::Aborted,
+            ConstructVersionGraphError::FetchVersionFile(err) => err.code(),
+            ConstructVersionGraphError::FetchLineageFile(err) => err.code(),
+            ConstructVersionGraphError::FetchVersionFilePaths(err) => err.code(),
+            ConstructVersionGraphError::InvalidUuid(_) => ErrorCodes::Internal,
+            ConstructVersionGraphError::InvalidTimestamp(_) => ErrorCodes::InvalidArgument,
+            ConstructVersionGraphError::ExpectedNodeNotFound => ErrorCodes::Internal,
+        }
+    }
+}
+
+#[async_trait]
+impl Orchestrator for ConstructVersionGraphOrchestrator {
+    type Output = ConstructVersionGraphResponse;
+    type Error = ConstructVersionGraphError;
+
+    fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
+        self.dispatcher.clone()
+    }
+
+    async fn initial_tasks(
+        &mut self,
+        ctx: &ComponentContext<Self>,
+    ) -> Vec<(TaskMessage, Option<Span>)> {
+        tracing::info!(
+            path = %self.version_file_path,
+            "Creating initial fetch version file task"
+        );
+
+        let mut tasks = vec![(
+            wrap(
+                Box::new(FetchVersionFileOperator {}),
+                FetchVersionFileInput::new(self.version_file_path.clone(), self.storage.clone()),
+                ctx.receiver(),
+            ),
+            Some(Span::current()),
+        )];
+
+        if let Some(lineage_file_path) = &self.lineage_file_path {
+            tasks.push((
+                wrap(
+                    Box::new(FetchLineageFileOperator {}),
+                    FetchLineageFileInput::new(self.storage.clone(), lineage_file_path.clone()),
+                    ctx.receiver(),
+                ),
+                Some(Span::current()),
+            ));
+        }
+
+        self.num_pending_tasks = tasks.len();
+
+        tasks
+    }
+
+    fn set_result_channel(&mut self, sender: Sender<Result<Self::Output, Self::Error>>) {
+        self.result_channel = Some(sender);
+    }
+
+    fn take_result_channel(&mut self) -> Sender<Result<Self::Output, Self::Error>> {
+        self.result_channel
+            .take()
+            .expect("The result channel should be set before take")
+    }
+}
+
+impl ConstructVersionGraphOrchestrator {
+    async fn finish_if_no_pending_tasks(
+        &mut self,
+        ctx: &ComponentContext<ConstructVersionGraphOrchestrator>,
+    ) -> Result<(), ConstructVersionGraphError> {
+        if self.num_pending_tasks == 0 {
+            let mut versions_by_collection_id: HashMap<CollectionUuid, Vec<(i64, VersionStatus)>> =
+                HashMap::new();
+
+            for (collection_id, version_file) in self.version_files.iter() {
+                if let Some(versions) = &version_file.version_history {
+                    for version in versions.versions.iter() {
+                        versions_by_collection_id
+                            .entry(*collection_id)
+                            .or_default()
+                            .push((
+                                version.version,
+                                VersionStatus::Alive {
+                                    created_at: DateTime::from_timestamp(
+                                        version.created_at_secs,
+                                        0,
+                                    )
+                                    .ok_or(
+                                        ConstructVersionGraphError::InvalidTimestamp(
+                                            version.created_at_secs,
+                                        ),
+                                    )?,
+                                },
+                            ));
+                    }
+                }
+            }
+
+            for dependency in self.version_dependencies.iter() {
+                let source_collection_id = dependency.source_collection_id;
+                let source_collection_version = dependency.source_collection_version;
+
+                let versions = versions_by_collection_id
+                    .entry(source_collection_id)
+                    .or_default();
+
+                if !versions
+                    .iter()
+                    .any(|(v, _)| *v == source_collection_version)
+                {
+                    versions.push((source_collection_version, VersionStatus::Deleted));
+                }
+            }
+
+            // Sort
+            for versions in versions_by_collection_id.values_mut() {
+                versions.sort_unstable_by_key(|v| v.0);
+            }
+
+            let mut graph = DiGraph::new();
+            for (collection_id, versions) in versions_by_collection_id.iter() {
+                let mut prev_node = None;
+                for (version, status) in versions.iter() {
+                    let node = graph.add_node(VersionGraphNode {
+                        collection_id: *collection_id,
+                        version: *version,
+                        status: *status,
+                    });
+                    if let Some(prev) = prev_node {
+                        graph.add_edge(prev, node, ());
+                    }
+                    prev_node = Some(node);
+                }
+            }
+
+            for dependency in self.version_dependencies.iter() {
+                let source_node = graph
+                    .node_indices()
+                    .find(|n| {
+                        let node = graph.node_weight(*n).expect("node index should exist");
+                        node.collection_id == dependency.source_collection_id
+                            && node.version == dependency.source_collection_version
+                    })
+                    .ok_or(ConstructVersionGraphError::ExpectedNodeNotFound)?;
+
+                let target_node = graph
+                    .node_indices()
+                    .find(|n| {
+                        let node = graph.node_weight(*n).expect("node index should exist");
+                        node.collection_id == dependency.target_collection_id
+                    })
+                    .ok_or(ConstructVersionGraphError::ExpectedNodeNotFound)?;
+
+                graph.add_edge(source_node, target_node, ());
+            }
+
+            if tracing::level_enabled!(tracing::Level::DEBUG) {
+                let dot_viz = Dot::with_config(&graph, &[petgraph::dot::Config::EdgeNoLabel]);
+                let encoded = BASE64_STANDARD.encode(format!("{:?}", dot_viz));
+                tracing::debug!(base64_encoded_dot_graph = ?encoded, "Constructed graph.");
+            }
+
+            tracing::trace!("Version files: {:#?}", self.version_files);
+
+            self.terminate_with_result(
+                Ok(ConstructVersionGraphResponse {
+                    graph,
+                    version_files: self.version_files.clone(),
+                }),
+                ctx,
+            )
+            .await;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<TaskResult<FetchVersionFileOutput, FetchVersionFileError>>
+    for ConstructVersionGraphOrchestrator
+{
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: TaskResult<FetchVersionFileOutput, FetchVersionFileError>,
+        ctx: &ComponentContext<ConstructVersionGraphOrchestrator>,
+    ) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
+            Some(output) => output,
+            None => {
+                tracing::error!("Failed to get version file output");
+                return;
+            }
+        };
+        let collection_id = output.collection_id;
+        self.version_files.insert(collection_id, output.file);
+
+        self.num_pending_tasks -= 1;
+
+        let res = self.finish_if_no_pending_tasks(ctx).await;
+        self.ok_or_terminate(res, ctx).await;
+    }
+}
+
+#[async_trait]
+impl Handler<TaskResult<FetchLineageFileOutput, FetchLineageFileError>>
+    for ConstructVersionGraphOrchestrator
+{
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: TaskResult<FetchLineageFileOutput, FetchLineageFileError>,
+        ctx: &ComponentContext<ConstructVersionGraphOrchestrator>,
+    ) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
+            Some(output) => output,
+            None => {
+                return;
+            }
+        };
+
+        let mut collection_ids_to_fetch_version_files = HashSet::new();
+        for dependency in output.0.dependencies {
+            let source_collection_id = match self
+                .ok_or_terminate(
+                    CollectionUuid::from_str(&dependency.source_collection_id)
+                        .map_err(ConstructVersionGraphError::InvalidUuid),
+                    ctx,
+                )
+                .await
+            {
+                Some(id) => id,
+                None => {
+                    return;
+                }
+            };
+
+            let target_collection_id = match self
+                .ok_or_terminate(
+                    CollectionUuid::from_str(&dependency.target_collection_id)
+                        .map_err(ConstructVersionGraphError::InvalidUuid),
+                    ctx,
+                )
+                .await
+            {
+                Some(id) => id,
+                None => {
+                    return;
+                }
+            };
+
+            self.version_dependencies.push(VersionDependency {
+                source_collection_id,
+                source_collection_version: dependency.source_collection_version as i64,
+                target_collection_id,
+            });
+
+            if source_collection_id != self.collection_id {
+                collection_ids_to_fetch_version_files.insert(source_collection_id);
+            }
+            if target_collection_id != self.collection_id {
+                collection_ids_to_fetch_version_files.insert(target_collection_id);
+            }
+        }
+
+        if !collection_ids_to_fetch_version_files.is_empty() {
+            self.num_pending_tasks += 1;
+            let list_files_at_versions_task = wrap(
+                Box::new(GetVersionFilePathsOperator {}),
+                GetVersionFilePathsInput::new(
+                    collection_ids_to_fetch_version_files.into_iter().collect(),
+                    self.sysdb.clone(),
+                ),
+                ctx.receiver(),
+            );
+
+            if let Err(e) = self
+                .dispatcher()
+                .send(list_files_at_versions_task, Some(Span::current()))
+                .await
+            {
+                self.terminate_with_result(Err(ConstructVersionGraphError::Channel(e)), ctx)
+                    .await;
+                return;
+            }
+        }
+
+        self.num_pending_tasks -= 1;
+        let res = self.finish_if_no_pending_tasks(ctx).await;
+        self.ok_or_terminate(res, ctx).await;
+    }
+}
+
+#[async_trait]
+impl Handler<TaskResult<GetVersionFilePathsOutput, GetVersionFilePathsError>>
+    for ConstructVersionGraphOrchestrator
+{
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: TaskResult<GetVersionFilePathsOutput, GetVersionFilePathsError>,
+        ctx: &ComponentContext<ConstructVersionGraphOrchestrator>,
+    ) {
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
+            Some(output) => output,
+            None => {
+                return;
+            }
+        };
+
+        self.num_pending_tasks += output.0.len();
+
+        for path in output.0.values() {
+            let version_file = FetchVersionFileInput::new(path.clone(), self.storage.clone());
+            let fetch_version_file_task = wrap(
+                Box::new(FetchVersionFileOperator {}),
+                version_file,
+                ctx.receiver(),
+            );
+
+            if let Err(e) = self
+                .dispatcher()
+                .send(fetch_version_file_task, Some(Span::current()))
+                .await
+            {
+                self.terminate_with_result(Err(ConstructVersionGraphError::Channel(e)), ctx)
+                    .await;
+                return;
+            }
+        }
+
+        self.num_pending_tasks -= 1;
+        let res = self.finish_if_no_pending_tasks(ctx).await;
+        self.ok_or_terminate(res, ctx).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_storage::test_storage;
+    use chroma_sysdb::TestSysDb;
+    use chroma_system::{DispatcherConfig, System};
+    use chroma_types::chroma_proto::{
+        CollectionInfoImmutable, CollectionLineageFile, CollectionVersionDependency,
+        CollectionVersionFile, CollectionVersionHistory, CollectionVersionInfo,
+    };
+    use prost::Message;
+    use tracing_test::traced_test;
+
+    async fn create_version_file(
+        collection_id: CollectionUuid,
+        versions: Vec<i64>,
+        storage: Storage,
+    ) -> String {
+        let version_file = CollectionVersionFile {
+            collection_info_immutable: Some(CollectionInfoImmutable {
+                tenant_id: "test_tenant".to_string(),
+                database_id: "test_db".to_string(),
+                collection_id: collection_id.to_string(),
+                dimension: 0,
+                ..Default::default()
+            }),
+            version_history: Some(CollectionVersionHistory {
+                versions: versions
+                    .into_iter()
+                    .zip(0..)
+                    .map(|(version, created_at_secs)| CollectionVersionInfo {
+                        version,
+                        created_at_secs,
+                        marked_for_deletion: false,
+                        ..Default::default()
+                    })
+                    .collect(),
+            }),
+        };
+
+        let version_file_path = format!("test_version_file_{}.bin", collection_id);
+        storage
+            .put_bytes(
+                &version_file_path,
+                version_file.encode_to_vec(),
+                chroma_storage::PutOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        version_file_path
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_simple_graph() {
+        let storage = test_storage();
+
+        let system = System::new();
+        let sysdb = SysDb::Test(TestSysDb::new());
+        let dispatcher = Dispatcher::new(DispatcherConfig::default());
+        let dispatcher_handle = system.start_component(dispatcher);
+
+        let collection_id = CollectionUuid::new();
+        let version_file_path =
+            create_version_file(collection_id, vec![1, 2], storage.clone()).await;
+
+        let orchestrator = ConstructVersionGraphOrchestrator::new(
+            dispatcher_handle,
+            storage,
+            sysdb,
+            CollectionUuid::new(),
+            version_file_path.to_string(),
+            None,
+        );
+
+        let result = orchestrator.run(system).await.unwrap();
+
+        assert_eq!(result.graph.node_count(), 2);
+        assert_eq!(result.graph.edge_count(), 1);
+
+        let edges: Vec<_> = result
+            .graph
+            .raw_edges()
+            .iter()
+            .map(|edge| {
+                let source_node = result.graph.node_weight(edge.source()).unwrap();
+                let target_node = result.graph.node_weight(edge.target()).unwrap();
+
+                (source_node.version, target_node.version)
+            })
+            .collect();
+        assert_eq!(edges, vec![(1, 2)]);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_graph_with_lineage() {
+        let storage = test_storage();
+
+        let system = System::new();
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+        let dispatcher = Dispatcher::new(DispatcherConfig::default());
+        let dispatcher_handle = system.start_component(dispatcher);
+
+        /*
+         * Test graph:
+         *                A v0
+         *                 |
+         *                A v1
+         *                /   \
+         *              B v0  C v0
+         *               |
+         *              B v1
+         *               |
+         *              D v0
+         */
+
+        let collection_id_a = CollectionUuid::new();
+        let collection_id_b = CollectionUuid::new();
+        let collection_id_c = CollectionUuid::new();
+        let collection_id_d = CollectionUuid::new();
+
+        let version_file_a_path =
+            create_version_file(collection_id_a, vec![0, 1], storage.clone()).await;
+        let version_file_b_path =
+            create_version_file(collection_id_b, vec![0, 1], storage.clone()).await;
+        let version_file_c_path =
+            create_version_file(collection_id_c, vec![0], storage.clone()).await;
+        let version_file_d_path =
+            create_version_file(collection_id_d, vec![0], storage.clone()).await;
+
+        match sysdb {
+            SysDb::Test(ref mut test) => {
+                test.set_collection_version_file_path(collection_id_a, version_file_a_path.clone());
+                test.set_collection_version_file_path(collection_id_b, version_file_b_path.clone());
+                test.set_collection_version_file_path(collection_id_c, version_file_c_path.clone());
+                test.set_collection_version_file_path(collection_id_d, version_file_d_path.clone());
+            }
+            _ => panic!("Invalid sysdb"),
+        }
+
+        let lineage_file_a = CollectionLineageFile {
+            dependencies: vec![
+                CollectionVersionDependency {
+                    source_collection_id: collection_id_a.to_string(),
+                    source_collection_version: 1,
+                    target_collection_id: collection_id_b.to_string(),
+                },
+                CollectionVersionDependency {
+                    source_collection_id: collection_id_b.to_string(),
+                    source_collection_version: 1,
+                    target_collection_id: collection_id_d.to_string(),
+                },
+                CollectionVersionDependency {
+                    source_collection_id: collection_id_a.to_string(),
+                    source_collection_version: 1,
+                    target_collection_id: collection_id_c.to_string(),
+                },
+            ],
+        };
+        let lineage_file_a_path = format!("test_lineage_file_{}.bin", collection_id_a);
+        storage
+            .put_bytes(
+                &lineage_file_a_path,
+                lineage_file_a.encode_to_vec(),
+                chroma_storage::PutOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        let expected_nodes = vec![
+            (collection_id_a, 0),
+            (collection_id_a, 1),
+            (collection_id_b, 0),
+            (collection_id_b, 1),
+            (collection_id_c, 0),
+            (collection_id_d, 0),
+        ];
+
+        fn check_graph(graph: &VersionGraph, mut expected_nodes: Vec<(CollectionUuid, i64)>) {
+            assert_eq!(graph.node_count(), 6);
+            assert_eq!(graph.edge_count(), 5);
+
+            let mut expected_edges = vec![
+                (0, 1), // A
+                (1, 0), // B
+                (1, 0), // C
+                (1, 0), // D
+                (0, 1), // D
+            ];
+            expected_edges.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+            let mut edges: Vec<_> = graph
+                .raw_edges()
+                .iter()
+                .map(|edge| {
+                    let source_node = graph.node_weight(edge.source()).unwrap();
+                    let target_node = graph.node_weight(edge.target()).unwrap();
+
+                    (source_node.version, target_node.version)
+                })
+                .collect();
+            edges.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+            assert_eq!(edges, expected_edges,);
+
+            let mut nodes: Vec<_> = graph
+                .node_weights()
+                .map(|node| (node.collection_id, node.version))
+                .collect();
+            nodes.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+            expected_nodes.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+            assert_eq!(nodes, expected_nodes,);
+        }
+
+        // Starting construction of the graph at any point in the graph should yield the same graph
+        for collection_id in [
+            collection_id_a,
+            collection_id_b,
+            collection_id_c,
+            collection_id_d,
+        ] {
+            let version_file_path = match sysdb {
+                SysDb::Test(ref mut test) => test.get_version_file_name(collection_id),
+                _ => panic!("Invalid sysdb"),
+            };
+
+            let orchestrator = ConstructVersionGraphOrchestrator::new(
+                dispatcher_handle.clone(),
+                storage.clone(),
+                sysdb.clone(),
+                collection_id,
+                version_file_path,
+                Some(lineage_file_a_path.clone()),
+            );
+
+            let result = orchestrator.run(system.clone()).await.unwrap();
+            check_graph(&result.graph, expected_nodes.clone());
+        }
+    }
+}

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -79,8 +79,6 @@ use crate::operators::mark_versions_at_sysdb::{
     MarkVersionsAtSysDbOutput,
 };
 
-use prost::Message;
-
 pub struct GarbageCollectorOrchestrator {
     collection_id: CollectionUuid,
     version_file_path: String,
@@ -207,10 +205,7 @@ impl Orchestrator for GarbageCollectorOrchestrator {
         vec![(
             wrap(
                 Box::new(FetchVersionFileOperator {}),
-                FetchVersionFileInput {
-                    version_file_path: self.version_file_path.clone(),
-                    storage: self.storage.clone(),
-                },
+                FetchVersionFileInput::new(self.version_file_path.clone(), self.storage.clone()),
                 ctx.receiver(),
             ),
             Some(Span::current()),
@@ -248,34 +243,13 @@ impl Handler<TaskResult<FetchVersionFileOutput, FetchVersionFileError>>
 
         // Stage 1: Process fetched version file and initiate version computation
         let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
-            Some(output) => {
-                tracing::info!(
-                    content_size = output.version_file_content().len(),
-                    "Successfully got version file content"
-                );
-                output
-            }
+            Some(output) => output,
             None => {
                 tracing::error!("Failed to get version file output");
                 return;
             }
         };
-
-        let version_file = match CollectionVersionFile::decode(output.version_file_content()) {
-            Ok(file) => {
-                tracing::info!("Successfully decoded version file");
-                file
-            }
-            Err(e) => {
-                tracing::error!(error = ?e, "Failed to decode version file");
-                let result: Result<FetchVersionFileOutput, GarbageCollectorError> =
-                    Err(GarbageCollectorError::ComputeVersionsToDelete(
-                        ComputeVersionsToDeleteError::ParseError(e),
-                    ));
-                self.ok_or_terminate(result, ctx).await;
-                return;
-            }
-        };
+        let version_file = output.file;
 
         tracing::info!("Creating compute versions task");
         let compute_task = wrap(

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -12,6 +12,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tracing::{debug, error, info};
 
 mod config;
+mod construct_version_graph_orchestrator;
 mod garbage_collector_component;
 pub mod garbage_collector_orchestrator;
 #[cfg(test)]

--- a/rust/garbage_collector/src/operators/fetch_lineage_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_lineage_file.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+use chroma_error::ChromaError;
+use chroma_storage::{GetOptions, Storage};
+use chroma_system::{Operator, OperatorType};
+use chroma_types::chroma_proto::CollectionLineageFile;
+use prost::Message;
+use thiserror::Error;
+
+#[derive(Clone)]
+pub struct FetchLineageFileInput {
+    storage: Storage,
+    lineage_file_path: String,
+}
+
+impl std::fmt::Debug for FetchLineageFileInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FetchLineageFileInput")
+            .field("lineage_file_path", &self.lineage_file_path)
+            .finish()
+    }
+}
+
+impl FetchLineageFileInput {
+    pub fn new(storage: Storage, lineage_file_path: String) -> Self {
+        Self {
+            storage,
+            lineage_file_path,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FetchLineageFileOutput(pub CollectionLineageFile);
+
+#[derive(Debug, Error)]
+pub enum FetchLineageFileError {
+    #[error("Error fetching lineage file: {0}")]
+    Storage(#[from] chroma_storage::StorageError),
+    #[error("Error decoding lineage file: {0}")]
+    Decode(#[from] prost::DecodeError),
+}
+
+impl ChromaError for FetchLineageFileError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            FetchLineageFileError::Storage(err) => err.code(),
+            FetchLineageFileError::Decode(_) => chroma_error::ErrorCodes::Internal,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FetchLineageFileOperator {}
+
+impl FetchLineageFileOperator {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl Operator<FetchLineageFileInput, FetchLineageFileOutput> for FetchLineageFileOperator {
+    type Error = FetchLineageFileError;
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
+    }
+
+    async fn run(
+        &self,
+        input: &FetchLineageFileInput,
+    ) -> Result<FetchLineageFileOutput, Self::Error> {
+        let lineage_file = input
+            .storage
+            .get(&input.lineage_file_path, GetOptions::default())
+            .await?;
+        let lineage = CollectionLineageFile::decode(lineage_file.as_slice())?;
+        Ok(FetchLineageFileOutput(lineage))
+    }
+}

--- a/rust/garbage_collector/src/operators/get_version_file_paths.rs
+++ b/rust/garbage_collector/src/operators/get_version_file_paths.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use chroma_error::ChromaError;
+use chroma_sysdb::SysDb;
+use chroma_system::{Operator, OperatorType};
+use chroma_types::{BatchGetCollectionVersionFilePathsError, CollectionUuid};
+use std::collections::HashMap;
+use thiserror::Error;
+
+#[derive(Clone, Debug)]
+pub struct GetVersionFilePathsInput {
+    collection_ids: Vec<CollectionUuid>,
+    sysdb: SysDb,
+}
+
+impl GetVersionFilePathsInput {
+    pub fn new(collection_ids: Vec<CollectionUuid>, sysdb: SysDb) -> Self {
+        Self {
+            collection_ids,
+            sysdb,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GetVersionFilePathsOutput(pub HashMap<CollectionUuid, String>);
+
+#[derive(Debug, Error)]
+pub enum GetVersionFilePathsError {
+    #[error("Error fetching version file paths: {0}")]
+    SysDb(#[from] BatchGetCollectionVersionFilePathsError),
+}
+
+impl ChromaError for GetVersionFilePathsError {
+    fn code(&self) -> chroma_error::ErrorCodes {
+        match self {
+            GetVersionFilePathsError::SysDb(err) => err.code(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GetVersionFilePathsOperator {}
+
+impl GetVersionFilePathsOperator {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl Operator<GetVersionFilePathsInput, GetVersionFilePathsOutput> for GetVersionFilePathsOperator {
+    type Error = GetVersionFilePathsError;
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
+    }
+
+    async fn run(
+        &self,
+        input: &GetVersionFilePathsInput,
+    ) -> Result<GetVersionFilePathsOutput, Self::Error> {
+        let paths = input
+            .sysdb
+            .clone()
+            .batch_get_collection_version_file_paths(input.collection_ids.clone())
+            .await?;
+
+        Ok(GetVersionFilePathsOutput(paths))
+    }
+}

--- a/rust/garbage_collector/src/operators/mod.rs
+++ b/rust/garbage_collector/src/operators/mod.rs
@@ -3,6 +3,8 @@ pub mod compute_unused_files;
 pub mod compute_versions_to_delete;
 pub mod delete_unused_files;
 pub mod delete_versions_at_sysdb;
+pub mod fetch_lineage_file;
 pub mod fetch_sparse_index_files;
 pub mod fetch_version_file;
+pub mod get_version_file_paths;
 pub mod mark_versions_at_sysdb;

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -199,6 +199,17 @@ pub enum Storage {
     AdmissionControlledS3(admissioncontrolleds3::AdmissionControlledS3Storage),
 }
 
+impl std::fmt::Debug for Storage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Storage::ObjectStore(_) => f.debug_tuple("ObjectStore").finish(),
+            Storage::S3(_) => f.debug_tuple("S3").finish(),
+            Storage::Local(_) => f.debug_tuple("Local").finish(),
+            Storage::AdmissionControlledS3(_) => f.debug_tuple("AdmissionControlledS3").finish(),
+        }
+    }
+}
+
 impl ChromaError for StorageConfigError {
     fn code(&self) -> ErrorCodes {
         match self {


### PR DESCRIPTION
## Description of changes

Adds an orchestrator to construct the version graph for all collections in a fork tree to be used by garbage collection.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added tests for new orchestrator.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a