### PR TITLE
[ENH]  Add caching to rust log service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "async-trait",
  "bytemuck",
  "bytes",
+ "chroma-cache",
  "chroma-config",
  "chroma-error",
  "chroma-log",

--- a/rust/log-service/Cargo.toml
+++ b/rust/log-service/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { workspace = true }
 bytemuck = { workspace = true }
 futures = { workspace = true }
 
+chroma-cache = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true, features = ["sqlx"] }
 chroma-log = { workspace = true }

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
 use bytes::Bytes;
+use chroma_cache::CacheConfig;
 use chroma_config::Configurable;
 use chroma_error::ChromaError;
 use chroma_storage::config::StorageConfig;
@@ -221,6 +222,19 @@ async fn get_log_from_handle<'a>(
         log: opened,
         _phantom: std::marker::PhantomData,
     })
+}
+
+////////////////////////////////////////// CachedFragment //////////////////////////////////////////
+
+#[derive(Clone, Debug, Default)]
+pub struct CachedParquetFragment {
+    bytes: Vec<u8>,
+}
+
+impl chroma_cache::Weighted for CachedParquetFragment {
+    fn weight(&self) -> usize {
+        self.bytes.len()
+    }
 }
 
 ////////////////////////////////////////////// Rollup //////////////////////////////////////////////
@@ -593,6 +607,7 @@ pub struct LogServer {
     open_logs: Arc<StateHashTable<LogKey, LogStub>>,
     dirty_log: Arc<LogWriter>,
     compacting: tokio::sync::Mutex<()>,
+    cache: Option<Box<dyn chroma_cache::Cache<String, CachedParquetFragment>>>,
 }
 
 #[async_trait::async_trait]
@@ -736,7 +751,22 @@ impl LogService for LogServer {
             };
             let futures = fragments
                 .iter()
-                .map(|fragment| async { log_reader.fetch(fragment).await })
+                .map(|fragment| async {
+                    let cache_key = format!("{collection_id}::{}", fragment.path);
+                    if let Some(cache) = self.cache.as_ref() {
+                        if let Ok(Some(answer)) = cache.get(&cache_key).await {
+                            return Ok(Arc::new(answer.bytes));
+                        }
+                        let answer = log_reader.fetch(fragment).await?;
+                        let cache_value = CachedParquetFragment {
+                            bytes: Clone::clone(&*answer),
+                        };
+                        cache.insert(cache_key, cache_value).await;
+                        Ok(answer)
+                    } else {
+                        log_reader.fetch(fragment).await
+                    }
+                })
                 .collect::<Vec<_>>();
             let parquets = futures::future::try_join_all(futures)
                 .await
@@ -1290,6 +1320,8 @@ pub struct LogServerConfig {
     pub writer: LogWriterOptions,
     #[serde(default)]
     pub reader: LogReaderOptions,
+    #[serde(default)]
+    pub cache: Option<CacheConfig>,
     #[serde(default = "LogServerConfig::default_record_count_threshold")]
     pub record_count_threshold: u64,
     #[serde(default = "LogServerConfig::default_reinsert_threshold")]
@@ -1323,6 +1355,7 @@ impl Default for LogServerConfig {
             storage: StorageConfig::default(),
             writer: LogWriterOptions::default(),
             reader: LogReaderOptions::default(),
+            cache: None,
             record_count_threshold: Self::default_record_count_threshold(),
             reinsert_threshold: Self::default_reinsert_threshold(),
             timeout_us: Self::default_timeout_us(),
@@ -1336,6 +1369,17 @@ impl Configurable<LogServerConfig> for LogServer {
         config: &LogServerConfig,
         registry: &chroma_config::registry::Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
+        let cache = if let Some(cache_config) = &config.cache {
+            match chroma_cache::from_config::<String, CachedParquetFragment>(cache_config).await {
+                Ok(cache) => Some(cache),
+                Err(err) => {
+                    tracing::error!("cache not configured: {err}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let storage = Storage::try_from_config(&config.storage, registry).await?;
         let storage = Arc::new(storage);
         let dirty_log = LogWriter::open_or_initialize(
@@ -1355,6 +1399,7 @@ impl Configurable<LogServerConfig> for LogServer {
             storage,
             dirty_log,
             compacting,
+            cache,
         })
     }
 }

--- a/rust/wal3/tests/test_k8s_integration_99_ping_pong_contention.rs
+++ b/rust/wal3/tests/test_k8s_integration_99_ping_pong_contention.rs
@@ -1,0 +1,178 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+
+use chroma_storage::s3_client_for_test_with_new_bucket;
+
+use wal3::{Error, LogWriter, LogWriterOptions, Manifest};
+
+pub mod common;
+
+async fn writer_thread(
+    writer: Arc<LogWriter>,
+    mutex: Arc<Mutex<()>>,
+    running: Arc<AtomicUsize>,
+    thread_id: usize,
+    iterations: usize,
+) -> (usize, usize) {
+    let mut successful_writes = 0;
+    let mut contention_errors = 0;
+    println!(
+        "writer {thread_id} also known as {:?}",
+        &*writer as *const LogWriter
+    );
+
+    for i in 0..iterations {
+        let message = format!("Message from writer{}: {}", thread_id, i).into_bytes();
+
+        // Acquire the mutex, do a write, release the mutex
+        loop {
+            // Using tokio::sync::Mutex which is safe to use with .await
+            let _guard = mutex.lock().await;
+            println!("writer {thread_id} grabs lock in iteration {i}");
+            // We have the lock, do a write
+            match writer.append(message.clone()).await {
+                Ok(_) => {
+                    println!("writer {thread_id} succeeds in iteration {i}");
+                    successful_writes += 1;
+                    // Release mutex (implicit) and break
+                    break;
+                }
+                Err(Error::LogContention) => {
+                    println!("writer {thread_id} sees contention preventing {i}");
+                    contention_errors += 1;
+                }
+                Err(e) => panic!("Unexpected error: {:?}", e),
+            }
+        }
+
+        println!("writer {thread_id} goes for contention {i}");
+
+        // Now write until we hit LogContention
+        while i + 1 < iterations && running.load(Ordering::Relaxed) > 1 {
+            // NOTE(rescrv):
+            // Default batching interval is 100ms.
+            // This must be at least that to prevent waste.
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            match writer.append(message.clone()).await {
+                Ok(_) => {
+                    successful_writes += 1;
+                }
+                Err(Error::LogContention) => {
+                    println!("writer {thread_id} contends without lock in iteration {i}");
+                    contention_errors += 1;
+                    // Got contention, now we go back to the top and wait for mutex
+                    break;
+                }
+                Err(e) => panic!("Unexpected error: {:?}", e),
+            }
+        }
+    }
+
+    running.fetch_sub(1, Ordering::Relaxed);
+    (successful_writes, contention_errors)
+}
+
+#[tokio::test]
+async fn test_k8s_integration_ping_pong_contention() {
+    // Create a shared storage for both threads to use
+    let storage = Arc::new(s3_client_for_test_with_new_bucket().await);
+    let prefix = "test_k8s_integration_ping_pong_contention";
+    let writer_name = "init";
+
+    // Initialize the log
+    Manifest::initialize(&LogWriterOptions::default(), &storage, prefix, writer_name)
+        .await
+        .unwrap();
+
+    // Create a shared mutex that our two threads will use to coordinate access
+    let mutex = Arc::new(Mutex::new(()));
+
+    // Create two writers that will contend with each other
+    let writer1 = Arc::new(
+        LogWriter::open(
+            LogWriterOptions::default(),
+            Arc::clone(&storage),
+            prefix,
+            "writer1",
+            (),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let writer2 = Arc::new(
+        LogWriter::open(
+            LogWriterOptions::default(),
+            Arc::clone(&storage),
+            prefix,
+            "writer2",
+            (),
+        )
+        .await
+        .unwrap(),
+    );
+
+    // Set a timer to make sure the test only runs for 2 minutes.
+    let fail = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(120)).await;
+        eprintln!("Taking down the test");
+        std::process::exit(13);
+    });
+
+    let running = Arc::new(AtomicUsize::new(2));
+
+    // Launch both threads using the same writer_thread function
+    let handle1 = tokio::spawn(writer_thread(
+        Arc::clone(&writer1),
+        Arc::clone(&mutex),
+        Arc::clone(&running),
+        1,
+        30,
+    ));
+
+    let handle2 = tokio::spawn(writer_thread(
+        Arc::clone(&writer2),
+        Arc::clone(&mutex),
+        Arc::clone(&running),
+        2,
+        30,
+    ));
+
+    // Wait for both threads to complete
+    let (writer1_results, writer2_results) = tokio::join!(handle1, handle2);
+    fail.abort();
+
+    // Examine results
+    let (writer1_successes, writer1_contentions) = writer1_results.unwrap();
+    let (writer2_successes, writer2_contentions) = writer2_results.unwrap();
+
+    println!(
+        "Writer 1: {} successful writes, {} contentions",
+        writer1_successes, writer1_contentions
+    );
+    println!(
+        "Writer 2: {} successful writes, {} contentions",
+        writer2_successes, writer2_contentions
+    );
+
+    // Assert some things about the test
+    assert!(
+        writer1_successes > 0,
+        "Writer 1 should have some successful writes"
+    );
+    assert!(
+        writer2_successes > 0,
+        "Writer 2 should have some successful writes"
+    );
+    assert!(
+        writer1_contentions > 0,
+        "Writer 1 should encounter contention"
+    );
+    assert!(
+        writer2_contentions > 0,
+        "Writer 2 should encounter contention"
+    );
+}


### PR DESCRIPTION
## Description of changes

Using foyer, add caching to the rust log service.  This caches parquet
fragments listed to be fetched to complete a call to pull_logs.

Caching isn't used for the dirty log or forking logs, just pull logs.
It gets populated by a key that is (collection_id, path), and then gets
immutably served from that point forward.

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
