### PR TITLE
[CLN] Pass Chroma API key via env var for chroma-load-start

### DIFF
--- a/rust/load/src/bin/chroma-load-start.rs
+++ b/rust/load/src/bin/chroma-load-start.rs
@@ -24,8 +24,6 @@ struct Args {
     #[arg(long)]
     database: String,
     #[arg(long)]
-    api_key: String,
-    #[arg(long)]
     constant_throughput: Option<f64>,
     #[arg(long)]
     sinusoid_throughput: Option<String>,
@@ -90,6 +88,10 @@ impl Args {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
+
+    // Read API key from environment variable.
+    let api_key = std::env::var("CHROMA_API_KEY").expect("CHROMA_API_KEY is not set");
+
     let client = reqwest::Client::new();
     let throughput = args.throughput();
     let mut workload = Workload::ByName(args.workload);
@@ -108,7 +110,7 @@ async fn main() {
         data_set: args.data_set,
         connection: Connection {
             url: args.url,
-            api_key: args.api_key,
+            api_key,
             database: args.database,
         },
         throughput,

--- a/rust/load/src/lib.rs
+++ b/rust/load/src/lib.rs
@@ -1026,8 +1026,16 @@ pub struct LoadHarness {
 
 impl LoadHarness {
     /// The status of the load harness.
+    /// This returns the list of running workloads with secrets redacted.
     pub fn status(&self) -> Vec<RunningWorkload> {
-        self.running.clone()
+        self.running
+            .iter()
+            .map(|w| {
+                let mut w = w.clone();
+                w.connection.api_key = "REDACTED".to_string();
+                w
+            })
+            .collect()
     }
 
     /// Start a workload on the load harness.


### PR DESCRIPTION
## Description of changes

This change updates chroma-load-start to read the APi key from the environment. It is a bit more secure than passing the API key via the process arguments, which is potentially readable by other processes on the system.

## Test plan

Tested locally via tilt.
