### PR TITLE
[ENH]: When SPANN is enabled, route HNSW configuration to SPANN, remove enable_set_index_params

### DIFF
--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -338,13 +338,25 @@ def test_empty_spann_configuration(client: ClientAPI) -> None:
     }
 
     if is_spann_disabled_mode:
-        with pytest.raises(Exception) as excinfo:
-            client.create_collection(
-                name="test_spann_config",
-                configuration=config,
-            )
+        coll = client.create_collection(
+            name="test_spann_config",
+            configuration=config,
+        )
 
-        assert "SPANN is still in development" in str(excinfo.value)
+        # Verify configuration is preserved
+        loaded_config = load_collection_configuration_from_json(
+            coll._model.configuration_json
+        )
+        if loaded_config and isinstance(loaded_config, dict):
+            hnsw_config_loaded = cast(
+                CreateHNSWConfiguration, loaded_config.get("hnsw", {})
+            )
+            ef = loaded_config.get("embedding_function")
+            assert hnsw_config_loaded.get("space") == "l2"
+            assert hnsw_config_loaded.get("ef_construction") == 100
+            assert hnsw_config_loaded.get("ef_search") == 100
+            assert hnsw_config_loaded.get("max_neighbors") == 16
+            assert ef is not None
     else:
         coll = client.create_collection(
             name="test_spann_config",
@@ -388,13 +400,25 @@ def test_spann_configuration(client: ClientAPI) -> None:
     }
 
     if is_spann_disabled_mode:
-        with pytest.raises(Exception) as excinfo:
-            client.create_collection(
-                name="test_spann_config",
-                configuration=config,
-            )
+        coll = client.create_collection(
+            name="test_spann_config",
+            configuration=config,
+        )
 
-        assert "SPANN is still in development" in str(excinfo.value)
+        # Verify configuration is preserved
+        loaded_config = load_collection_configuration_from_json(
+            coll._model.configuration_json
+        )
+        if loaded_config and isinstance(loaded_config, dict):
+            hnsw_config_loaded = cast(
+                CreateHNSWConfiguration, loaded_config.get("hnsw", {})
+            )
+            ef = loaded_config.get("embedding_function")
+            assert hnsw_config_loaded.get("space") == "cosine"
+            assert hnsw_config_loaded.get("ef_construction") == 100
+            assert hnsw_config_loaded.get("ef_search") == 100
+            assert hnsw_config_loaded.get("max_neighbors") == 16
+            assert ef is not None
     else:
         coll = client.create_collection(
             name="test_spann_config",
@@ -502,13 +526,23 @@ def test_spann_default_parameters(client: ClientAPI) -> None:
     }
 
     if is_spann_disabled_mode:
-        with pytest.raises(Exception) as excinfo:
-            client.create_collection(
-                name="test_spann_defaults",
-                configuration=config,
-            )
+        coll = client.create_collection(
+            name="test_spann_defaults",
+            configuration=config,
+        )
 
-        assert "SPANN is still in development" in str(excinfo.value)
+        # Verify configuration is preserved
+        loaded_config = load_collection_configuration_from_json(
+            coll._model.configuration_json
+        )
+        if loaded_config and isinstance(loaded_config, dict):
+            hnsw_config_loaded = cast(
+                CreateHNSWConfiguration, loaded_config.get("hnsw", {})
+            )
+            assert hnsw_config_loaded.get("space") == "cosine"
+            assert hnsw_config_loaded.get("ef_construction") == 100
+            assert hnsw_config_loaded.get("ef_search") == 100
+            assert hnsw_config_loaded.get("max_neighbors") == 16
     else:
         coll = client.create_collection(
             name="test_spann_defaults",
@@ -570,13 +604,25 @@ def test_spann_json_serialization(client: ClientAPI) -> None:
         )
 
     if is_spann_disabled_mode:
-        with pytest.raises(Exception) as excinfo:
-            client.create_collection(
-                name="test_spann_json",
-                configuration=create_config,
-            )
+        coll = client.create_collection(
+            name="test_spann_json",
+            configuration=create_config,
+        )
 
-        assert "SPANN is still in development" in str(excinfo.value)
+        # Verify configuration is preserved
+        loaded_config = load_collection_configuration_from_json(
+            coll._model.configuration_json
+        )
+        if loaded_config and isinstance(loaded_config, dict):
+            hnsw_config_loaded = cast(
+                CreateHNSWConfiguration, loaded_config.get("hnsw", {})
+            )
+            ef = loaded_config.get("embedding_function")
+            assert hnsw_config_loaded.get("space") == "cosine"
+            assert hnsw_config_loaded.get("ef_construction") == 100
+            assert hnsw_config_loaded.get("ef_search") == 100
+            assert hnsw_config_loaded.get("max_neighbors") == 16
+            assert ef is not None
     else:
         # Create collection with the converted configuration
         coll = client.create_collection(

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -47,4 +47,3 @@ scorecard:
     score: 100
 enable_span_indexing: true
 default_knn_index: "spann"
-enable_set_index_params: false

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -55,4 +55,3 @@ circuit_breaker:
   requests: 1000
 enable_span_indexing: true
 default_knn_index: "spann"
-enable_set_index_params: true

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -119,10 +119,6 @@ fn default_enable_span_indexing() -> bool {
     false
 }
 
-fn default_enable_set_index_params() -> bool {
-    true
-}
-
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct FrontendServerConfig {
     #[serde(flatten)]
@@ -148,8 +144,6 @@ pub struct FrontendServerConfig {
     pub cors_allow_origins: Option<Vec<String>>,
     #[serde(default = "default_enable_span_indexing")]
     pub enable_span_indexing: bool,
-    #[serde(default = "default_enable_set_index_params")]
-    pub enable_set_index_params: bool,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "sample_configs/distributed.yaml";

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -921,22 +921,15 @@ async fn create_collection(
 
             if let Some(hnsw) = &hnsw_config {
                 let space = hnsw.space.clone();
-                if hnsw.ef_construction.is_some()
-                    || hnsw.ef_search.is_some()
-                    || hnsw.max_neighbors.is_some()
-                    || hnsw.num_threads.is_some()
-                    || hnsw.resize_factor.is_some()
-                    || hnsw.sync_threshold.is_some()
-                    || hnsw.batch_size.is_some()
-                {
-                    return Err(ValidationError::SpaceConfigurationForVectorIndexType(
-                        "HNSW".to_string(),
-                    )
-                    .into());
-                }
                 let new_hnsw = HnswConfiguration {
                     space,
-                    ..Default::default()
+                    ef_construction: hnsw.ef_construction,
+                    ef_search: hnsw.ef_search,
+                    max_neighbors: hnsw.max_neighbors,
+                    num_threads: hnsw.num_threads,
+                    resize_factor: hnsw.resize_factor,
+                    sync_threshold: hnsw.sync_threshold,
+                    batch_size: hnsw.batch_size,
                 };
                 new_configuration.hnsw = Some(new_hnsw);
             } else if let Some(spann) = &spann_config {

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -13,12 +13,11 @@ use chroma_types::{
     CreateDatabaseResponse, CreateTenantRequest, CreateTenantResponse,
     DeleteCollectionRecordsResponse, DeleteDatabaseRequest, DeleteDatabaseResponse,
     GetCollectionRequest, GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse,
-    GetTenantRequest, GetTenantResponse, GetUserIdentityResponse, HeartbeatResponse,
-    HnswConfiguration, IncludeList, InternalCollectionConfiguration, ListCollectionsRequest,
-    ListCollectionsResponse, ListDatabasesRequest, ListDatabasesResponse, Metadata, QueryRequest,
-    QueryResponse, SpannConfiguration, UpdateCollectionConfiguration,
-    UpdateCollectionRecordsResponse, UpdateCollectionResponse, UpdateMetadata,
-    UpsertCollectionRecordsResponse,
+    GetTenantRequest, GetTenantResponse, GetUserIdentityResponse, HeartbeatResponse, IncludeList,
+    InternalCollectionConfiguration, ListCollectionsRequest, ListCollectionsResponse,
+    ListDatabasesRequest, ListDatabasesResponse, Metadata, QueryRequest, QueryResponse,
+    UpdateCollectionConfiguration, UpdateCollectionRecordsResponse, UpdateCollectionResponse,
+    UpdateMetadata, UpsertCollectionRecordsResponse,
 };
 use chroma_types::{ForkCollectionResponse, RawWhereFields};
 use mdac::{Rule, Scorecard, ScorecardTicket};
@@ -914,76 +913,15 @@ async fn create_collection(
 
     let payload_clone = payload.clone();
 
-    let configuration = if !server.config.enable_set_index_params {
-        if let Some(mut new_configuration) = payload.configuration.clone() {
-            let hnsw_config = new_configuration.hnsw.clone();
-            let spann_config = new_configuration.spann.clone();
-
-            if let Some(hnsw) = &hnsw_config {
-                let space = hnsw.space.clone();
-                let new_hnsw = HnswConfiguration {
-                    space,
-                    ef_construction: hnsw.ef_construction,
-                    ef_search: hnsw.ef_search,
-                    max_neighbors: hnsw.max_neighbors,
-                    num_threads: hnsw.num_threads,
-                    resize_factor: hnsw.resize_factor,
-                    sync_threshold: hnsw.sync_threshold,
-                    batch_size: hnsw.batch_size,
-                };
-                new_configuration.hnsw = Some(new_hnsw);
-            } else if let Some(spann) = &spann_config {
-                let space = spann.space.clone();
-                if spann.search_nprobe.is_some()
-                    || spann.write_nprobe.is_some()
-                    || spann.ef_construction.is_some()
-                    || spann.ef_search.is_some()
-                    || spann.max_neighbors.is_some()
-                    || spann.reassign_neighbor_count.is_some()
-                    || spann.split_threshold.is_some()
-                    || spann.merge_threshold.is_some()
-                {
-                    return Err(ValidationError::SpaceConfigurationForVectorIndexType(
-                        "SPANN".to_string(),
-                    )
-                    .into());
-                }
-                let new_spann = SpannConfiguration {
-                    space,
-                    ..Default::default()
-                };
-                new_configuration.spann = Some(new_spann);
-            }
-
-            Some(InternalCollectionConfiguration::try_from_config(
-                new_configuration,
-                server.config.frontend.default_knn_index,
-            )?)
-        } else {
-            Some(InternalCollectionConfiguration::try_from_config(
-                CollectionConfiguration {
-                    hnsw: None,
-                    spann: None,
-                    embedding_function: None,
-                },
-                server.config.frontend.default_knn_index,
-            )?)
-        }
-    } else {
-        match payload_clone.configuration {
-            Some(c) => Some(InternalCollectionConfiguration::try_from_config(
-                c,
-                server.config.frontend.default_knn_index,
-            )?),
-            None => Some(InternalCollectionConfiguration::try_from_config(
-                CollectionConfiguration {
-                    hnsw: None,
-                    spann: None,
-                    embedding_function: None,
-                },
-                server.config.frontend.default_knn_index,
-            )?),
-        }
+    let configuration = match payload_clone.configuration {
+        Some(c) => Some(InternalCollectionConfiguration::try_from_config(
+            c,
+            server.config.frontend.default_knn_index,
+        )?),
+        None => Some(InternalCollectionConfiguration::try_from_config(
+            CollectionConfiguration::default(),
+            server.config.frontend.default_knn_index,
+        )?),
     };
 
     let request = CreateCollectionRequest::try_new(

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -26,8 +26,6 @@ pub enum ValidationError {
     UpdateCollection(#[from] UpdateCollectionError),
     #[error("Error parsing collection configuration: {0}")]
     ParseCollectionConfiguration(#[from] CollectionConfigurationToInternalConfigurationError),
-    #[error("For optimal performance and accuracy, can't set parameters other than space for index type {0}")]
-    SpaceConfigurationForVectorIndexType(String),
 }
 
 impl ChromaError for ValidationError {
@@ -39,7 +37,6 @@ impl ChromaError for ValidationError {
             ValidationError::GetCollection(err) => err.code(),
             ValidationError::UpdateCollection(err) => err.code(),
             ValidationError::ParseCollectionConfiguration(_) => ErrorCodes::InvalidArgument,
-            ValidationError::SpaceConfigurationForVectorIndexType(_) => ErrorCodes::InvalidArgument,
         }
     }
 }

--- a/rust/types/src/collection_configuration.rs
+++ b/rust/types/src/collection_configuration.rs
@@ -211,24 +211,52 @@ impl InternalCollectionConfiguration {
         match (value.hnsw, value.spann) {
             (Some(_), Some(_)) => Err(CollectionConfigurationToInternalConfigurationError::MultipleVectorIndexConfigurations),
             (Some(hnsw), None) => {
-                if let KnnIndex::Spann = default_knn_index{
-                    return Err(CollectionConfigurationToInternalConfigurationError::HnswIndexNotSupported);   
+                match default_knn_index {
+                    // Create a spann index. Only inherit the space if it exists in the hnsw config.
+                    // This is for backwards compatibility so that users who migrate to distributed
+                    // from local don't break their code.
+                    KnnIndex::Spann => {
+                        let internal_config = InternalSpannConfiguration {
+                            space: hnsw.space,
+                            ..Default::default()
+                        };
+                        Ok(InternalCollectionConfiguration {
+                            vector_index: VectorIndexConfiguration::Spann(internal_config),
+                            embedding_function: value.embedding_function,
+                        })
+                    },
+                    KnnIndex::Hnsw => {
+                        let hnsw: InternalHnswConfiguration = hnsw.into();
+                        Ok(InternalCollectionConfiguration {
+                            vector_index: hnsw.into(),
+                            embedding_function: value.embedding_function,
+                        })
+                    }
                 }
-                let hnsw: InternalHnswConfiguration = hnsw.into();
-                Ok(InternalCollectionConfiguration {
-                    vector_index: hnsw.into(),
-                    embedding_function: value.embedding_function,
-                })
             }
             (None, Some(spann)) => {
-                let spann: InternalSpannConfiguration = spann.into();
-                if let KnnIndex::Hnsw = default_knn_index {
-                    return Err(CollectionConfigurationToInternalConfigurationError::SpannIndexNotSupported);
+                match default_knn_index {
+                    // Create a hnsw index. Only inherit the space if it exists in the spann config.
+                    // This is for backwards compatibility so that users who migrate to local
+                    // from distributed don't break their code.
+                    KnnIndex::Hnsw => {
+                        let internal_config = InternalHnswConfiguration {
+                            space: spann.space,
+                            ..Default::default()
+                        };
+                        Ok(InternalCollectionConfiguration {
+                            vector_index: VectorIndexConfiguration::Hnsw(internal_config),
+                            embedding_function: value.embedding_function,
+                        })
+                    }
+                    KnnIndex::Spann => {
+                        let spann: InternalSpannConfiguration = spann.into();
+                        Ok(InternalCollectionConfiguration {
+                            vector_index: spann.into(),
+                            embedding_function: value.embedding_function,
+                        })
+                    }
                 }
-                Ok(InternalCollectionConfiguration {
-                    vector_index: spann.into(),
-                    embedding_function: value.embedding_function,
-                })
             }
             (None, None) => {
                 let vector_index = match default_knn_index {
@@ -276,23 +304,17 @@ impl TryFrom<CollectionConfiguration> for InternalCollectionConfiguration {
 pub enum CollectionConfigurationToInternalConfigurationError {
     #[error("Multiple vector index configurations provided")]
     MultipleVectorIndexConfigurations,
-    #[error("HNSW indexes are deprecated. We moved to SPANN which is a better algorithm for both accuracy and performance")]
-    HnswIndexNotSupported,
-    #[error("Spann index is not supported")]
-    SpannIndexNotSupported,
 }
 
 impl ChromaError for CollectionConfigurationToInternalConfigurationError {
     fn code(&self) -> ErrorCodes {
         match self {
             Self::MultipleVectorIndexConfigurations => ErrorCodes::InvalidArgument,
-            Self::HnswIndexNotSupported => ErrorCodes::InvalidArgument,
-            Self::SpannIndexNotSupported => ErrorCodes::InvalidArgument,
         }
     }
 }
 
-#[derive(Deserialize, Serialize, ToSchema, Debug, Clone)]
+#[derive(Default, Deserialize, Serialize, ToSchema, Debug, Clone)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct CollectionConfiguration {
     pub hnsw: Option<HnswConfiguration>,
@@ -359,6 +381,9 @@ pub struct UpdateCollectionConfiguration {
 
 #[cfg(test)]
 mod tests {
+    use crate::hnsw_configuration::HnswConfiguration;
+    use crate::hnsw_configuration::HnswSpace;
+    use crate::spann_configuration::SpannConfiguration;
     use crate::{test_segment, CollectionUuid, Metadata};
 
     use super::*;
@@ -409,5 +434,129 @@ mod tests {
 
         // Setting from metadata is ignored since the config is not default
         assert_eq!(overridden_config.ef_construction, 2);
+    }
+
+    #[test]
+    fn test_hnsw_config_with_hnsw_default() {
+        let hnsw_config = HnswConfiguration {
+            max_neighbors: Some(16),
+            ef_construction: Some(100),
+            ef_search: Some(10),
+            batch_size: Some(100),
+            num_threads: Some(4),
+            sync_threshold: Some(500),
+            resize_factor: Some(1.2),
+            space: HnswSpace::Cosine,
+        };
+
+        let collection_config = CollectionConfiguration {
+            hnsw: Some(hnsw_config.clone()),
+            spann: None,
+            embedding_function: None,
+        };
+
+        let internal_config_result =
+            InternalCollectionConfiguration::try_from_config(collection_config, KnnIndex::Hnsw);
+
+        assert!(internal_config_result.is_ok());
+        let internal_config = internal_config_result.unwrap();
+
+        let expected_vector_index = VectorIndexConfiguration::Hnsw(hnsw_config.into());
+        assert_eq!(internal_config.vector_index, expected_vector_index);
+    }
+
+    #[test]
+    fn test_hnsw_config_with_spann_default() {
+        let hnsw_config = HnswConfiguration {
+            max_neighbors: Some(16),
+            ef_construction: Some(100),
+            ef_search: Some(10),
+            batch_size: Some(100),
+            num_threads: Some(4),
+            sync_threshold: Some(500),
+            resize_factor: Some(1.2),
+            space: HnswSpace::Cosine,
+        };
+
+        let collection_config = CollectionConfiguration {
+            hnsw: Some(hnsw_config.clone()),
+            spann: None,
+            embedding_function: None,
+        };
+
+        let internal_config_result =
+            InternalCollectionConfiguration::try_from_config(collection_config, KnnIndex::Spann);
+
+        assert!(internal_config_result.is_ok());
+        let internal_config = internal_config_result.unwrap();
+
+        let expected_vector_index = VectorIndexConfiguration::Spann(InternalSpannConfiguration {
+            space: hnsw_config.space,
+            ..Default::default()
+        });
+        assert_eq!(internal_config.vector_index, expected_vector_index);
+    }
+
+    #[test]
+    fn test_spann_config_with_spann_default() {
+        let spann_config = SpannConfiguration {
+            ef_construction: Some(100),
+            ef_search: Some(10),
+            max_neighbors: Some(16),
+            search_nprobe: Some(1),
+            write_nprobe: Some(1),
+            space: HnswSpace::Cosine,
+            reassign_neighbor_count: Some(64),
+            split_threshold: Some(200),
+            merge_threshold: Some(100),
+        };
+
+        let collection_config = CollectionConfiguration {
+            hnsw: None,
+            spann: Some(spann_config.clone()),
+            embedding_function: None,
+        };
+
+        let internal_config_result =
+            InternalCollectionConfiguration::try_from_config(collection_config, KnnIndex::Spann);
+
+        assert!(internal_config_result.is_ok());
+        let internal_config = internal_config_result.unwrap();
+
+        let expected_vector_index = VectorIndexConfiguration::Spann(spann_config.into());
+        assert_eq!(internal_config.vector_index, expected_vector_index);
+    }
+
+    #[test]
+    fn test_spann_config_with_hnsw_default() {
+        let spann_config = SpannConfiguration {
+            ef_construction: Some(100),
+            ef_search: Some(10),
+            max_neighbors: Some(16),
+            search_nprobe: Some(1),
+            write_nprobe: Some(1),
+            space: HnswSpace::Cosine,
+            reassign_neighbor_count: Some(64),
+            split_threshold: Some(200),
+            merge_threshold: Some(100),
+        };
+
+        let collection_config = CollectionConfiguration {
+            hnsw: None,
+            spann: Some(spann_config.clone()),
+            embedding_function: None,
+        };
+
+        let internal_config_result =
+            InternalCollectionConfiguration::try_from_config(collection_config, KnnIndex::Hnsw);
+
+        let expected_vector_index = VectorIndexConfiguration::Hnsw(InternalHnswConfiguration {
+            space: spann_config.space,
+            ..Default::default()
+        });
+        assert_eq!(
+            internal_config_result.unwrap().vector_index,
+            expected_vector_index
+        );
     }
 }

--- a/rust/types/src/spann_configuration.rs
+++ b/rust/types/src/spann_configuration.rs
@@ -109,6 +109,7 @@ pub struct InternalSpannConfiguration {
     #[serde(default = "default_initial_lambda")]
     pub initial_lambda: f32,
     #[serde(default = "default_reassign_neighbor_count")]
+    #[validate(range(max = 64))]
     pub reassign_neighbor_count: u32,
     #[serde(default = "default_merge_threshold")]
     #[validate(range(min = 50, max = 100))]
@@ -125,7 +126,7 @@ pub struct InternalSpannConfiguration {
     #[validate(range(max = 200))]
     pub ef_search: usize,
     #[serde(default = "default_m_spann")]
-    #[validate(range(max = 100))]
+    #[validate(range(max = 64))]
     pub max_neighbors: usize,
 }
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Users can now set hnsw params without failing. This is to support migrations from local to cloud. Setting hnsw configuration when SPANN is enabled will only take the space config and use in the spann, others will be discarded in place of default spann configuration
  - Even if they explicitly try to create hnsw index, we disallow it now
  - Users can set spann configuration, validation on ranges already handled internally
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
