### PR TITLE
[BUG] Raise Error when can't deserialize configuration json from server, lazily load ef on CollectionModel, warn on api_key

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -82,12 +82,24 @@ def load_collection_configuration_from_json(
             ef = None
         else:
             try:
-                ef = known_embedding_functions[ef_config["name"]]
-                ef = ef.build_from_config(ef_config["config"])  # type: ignore
+                ef_name = ef_config["name"]
             except KeyError:
                 raise ValueError(
-                    f"Embedding function {ef_config['name']} not found. Add @register_embedding_function decorator to the class definition."
+                    f"Embedding function name not found in config: {ef_config}"
                 )
+            try:
+                ef = known_embedding_functions[ef_name]
+            except KeyError:
+                raise ValueError(
+                    f"Embedding function {ef_name} not found. Add @register_embedding_function decorator to the class definition."
+                )
+            try:
+                ef = ef.build_from_config(ef_config["config"])  # type: ignore
+            except Exception as e:
+                raise ValueError(
+                    f"Could not build embedding function {ef_config['name']} from config {ef_config['config']}: {e}"
+                )
+
     else:
         ef = None
 

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -17,7 +17,6 @@ from chromadb.api.collection_configuration import (
     UpdateCollectionConfiguration,
     create_collection_configuration_to_json_str,
     update_collection_configuration_to_json_str,
-    load_collection_configuration_from_json,
 )
 from chromadb.auth import UserIdentity
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
@@ -191,9 +190,7 @@ class RustBindingsAPI(ServerAPI):
             CollectionModel(
                 id=collection.id,
                 name=collection.name,
-                configuration=load_collection_configuration_from_json(
-                    collection.configuration
-                ),
+                configuration_json=collection.configuration,
                 metadata=collection.metadata,
                 dimension=collection.dimension,
                 tenant=collection.tenant,
@@ -233,9 +230,7 @@ class RustBindingsAPI(ServerAPI):
         collection_model = CollectionModel(
             id=collection.id,
             name=collection.name,
-            configuration=load_collection_configuration_from_json(
-                collection.configuration
-            ),
+            configuration_json=collection.configuration,
             metadata=collection.metadata,
             dimension=collection.dimension,
             tenant=collection.tenant,
@@ -254,9 +249,7 @@ class RustBindingsAPI(ServerAPI):
         return CollectionModel(
             id=collection.id,
             name=collection.name,
-            configuration=load_collection_configuration_from_json(
-                collection.configuration
-            ),
+            configuration_json=collection.configuration,
             metadata=collection.metadata,
             dimension=collection.dimension,
             tenant=collection.tenant,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -3,7 +3,7 @@ from chromadb.api import ServerAPI
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,
-    load_collection_configuration_from_create_collection_configuration,
+    create_collection_configuration_to_json,
 )
 from chromadb.auth import UserIdentity
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
@@ -235,7 +235,7 @@ class SegmentAPI(ServerAPI):
             id=id,
             name=name,
             metadata=metadata,
-            configuration=load_collection_configuration_from_create_collection_configuration(
+            configuration_json=create_collection_configuration_to_json(
                 configuration or CreateCollectionConfiguration()
             ),
             tenant=tenant,
@@ -413,7 +413,9 @@ class SegmentAPI(ServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> CollectionModel:
-        raise NotImplementedError("Collection forking is not implemented for SegmentAPI")
+        raise NotImplementedError(
+            "Collection forking is not implemented for SegmentAPI"
+        )
 
     @trace_method("SegmentAPI.delete_collection", OpenTelemetryGranularity.OPERATION)
     @override

--- a/chromadb/db/impl/grpc/server.py
+++ b/chromadb/db/impl/grpc/server.py
@@ -2,9 +2,8 @@ from concurrent import futures
 from typing import Any, Dict, List, cast
 from uuid import UUID
 from overrides import overrides
-from chromadb.api.collection_configuration import (
-    load_collection_configuration_from_json_str,
-)
+import json
+
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Component, System
 from chromadb.proto.convert import (
     from_proto_metadata,
@@ -286,15 +285,13 @@ class GrpcMockSysDB(SysDBServicer, Component):
                 f"Collection {collection_name} already exists",
             )
 
-        configuration = load_collection_configuration_from_json_str(
-            request.configuration_json_str
-        )
+        configuration_json = json.loads(request.configuration_json_str)
 
         id = UUID(hex=request.id)
         new_collection = Collection(
             id=id,
             name=request.name,
-            configuration=configuration,
+            configuration_json=configuration_json,
             metadata=from_proto_metadata(request.metadata),
             dimension=request.dimension,
             database=database,

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -38,7 +38,8 @@ from chromadb.api.collection_configuration import (
     create_collection_configuration_to_json_str,
     load_collection_configuration_from_json_str,
     CollectionConfiguration,
-    load_collection_configuration_from_create_collection_configuration,
+    create_collection_configuration_to_json,
+    collection_configuration_to_json,
     collection_configuration_to_json_str,
     overwrite_collection_configuration,
     update_collection_configuration_from_legacy_update_metadata,
@@ -310,9 +311,7 @@ class SqlSysDB(SqlDB, SysDB):
         collection = Collection(
             id=id,
             name=name,
-            configuration=load_collection_configuration_from_create_collection_configuration(
-                configuration
-            ),
+            configuration_json=create_collection_configuration_to_json(configuration),
             metadata=metadata,
             dimension=dimension,
             tenant=tenant,
@@ -541,7 +540,9 @@ class SqlSysDB(SqlDB, SysDB):
                     Collection(
                         id=cast(UUID, id),
                         name=name,
-                        configuration=configuration,
+                        configuration_json=collection_configuration_to_json(
+                            configuration
+                        ),
                         metadata=metadata,
                         dimension=dimension,
                         tenant=str(rows[0][5]),

--- a/chromadb/proto/convert.py
+++ b/chromadb/proto/convert.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Sequence, Tuple, TypedDict, Union, cast
 from uuid import UUID
+import json
 
 import numpy as np
 from numpy.typing import NDArray
@@ -7,7 +8,6 @@ from numpy.typing import NDArray
 import chromadb.proto.chroma_pb2 as chroma_pb
 import chromadb.proto.query_executor_pb2 as query_pb
 from chromadb.api.collection_configuration import (
-    load_collection_configuration_from_json_str,
     collection_configuration_to_json_str,
 )
 from chromadb.api.types import Embedding, Where, WhereDocument
@@ -239,9 +239,7 @@ def from_proto_collection(collection: chroma_pb.Collection) -> Collection:
     return Collection(
         id=UUID(hex=collection.id),
         name=collection.name,
-        configuration=load_collection_configuration_from_json_str(
-            collection.configuration_json_str
-        ),
+        configuration_json=json.loads(collection.configuration_json_str),
         metadata=from_proto_metadata(collection.metadata)
         if collection.HasField("metadata")
         else None,

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -109,7 +109,7 @@ def count(collection: Collection, record_set: RecordSet) -> None:
     count = collection.count()
     normalized_record_set = wrap_all(record_set)
     if count != len(normalized_record_set["ids"]):
-        print('count mismatch:', count, '=!', len(normalized_record_set["ids"]))
+        print("count mismatch:", count, "=!", len(normalized_record_set["ids"]))
     assert count == len(normalized_record_set["ids"])
 
 
@@ -245,6 +245,7 @@ def fd_not_exceeding_threadpool_size(threadpool_size: int) -> None:
         len([p.path for p in open_files if "sqlite3" in p.path]) - 1 <= threadpool_size
     )
 
+
 def get_space(collection: Collection):
     # TODO: this is a hack to get the space
     # We should update the tests to not pass space via metadata instead use collection
@@ -254,12 +255,21 @@ def get_space(collection: Collection):
         space = collection.metadata["hnsw:space"]
     if collection._model.configuration_json is None:
         return space
-    if 'spann' in collection._model.configuration_json and collection._model.configuration_json.get('spann') is not None and 'space' in collection._model.configuration_json.get('spann'):
-        space = collection._model.configuration_json.get('spann').get('space')
-    elif 'hnsw' in collection._model.configuration_json and collection._model.configuration_json.get('hnsw') is not None and 'space' in collection._model.configuration_json.get('hnsw'):
+    if (
+        "spann" in collection._model.configuration_json
+        and collection._model.configuration_json.get("spann") is not None
+        and "space" in collection._model.configuration_json.get("spann")
+    ):
+        space = collection._model.configuration_json.get("spann").get("space")
+    elif (
+        "hnsw" in collection._model.configuration_json
+        and collection._model.configuration_json.get("hnsw") is not None
+        and "space" in collection._model.configuration_json.get("hnsw")
+    ):
         if space is None:
-            space = collection._model.configuration_json.get('hnsw').get('space')
+            space = collection._model.configuration_json.get("hnsw").get("space")
     return space
+
 
 def ann_accuracy(
     collection: Collection,
@@ -284,7 +294,7 @@ def ann_accuracy(
         assert isinstance(normalized_record_set["documents"], list)
         # Compute the embeddings for the documents
         embeddings = embedding_function(normalized_record_set["documents"])
-    
+
     space = get_space(collection)
     if space is None:
         distance_function = distance_functions.l2

--- a/chromadb/utils/embedding_functions/baseten_embedding_function.py
+++ b/chromadb/utils/embedding_functions/baseten_embedding_function.py
@@ -1,16 +1,18 @@
 import os
-from chromadb.utils.embedding_functions.openai_embedding_function import OpenAIEmbeddingFunction
-from chromadb.api.types import Documents, EmbeddingFunction
+from chromadb.utils.embedding_functions.openai_embedding_function import (
+    OpenAIEmbeddingFunction,
+)
 from typing import Dict, Any, Optional
+import warnings
+
 
 class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
-
     def __init__(
-            self,
-            api_key: Optional[str],
-            api_base: str,
-            api_key_env_var: str = "CHROMA_BASETEN_API_KEY",
-            ):
+        self,
+        api_key: Optional[str],
+        api_base: str,
+        api_key_env_var: str = "CHROMA_BASETEN_API_KEY",
+    ):
         """
         Initialize the BasetenEmbeddingFunction.
         Args:
@@ -25,11 +27,20 @@ class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
                 "The openai python package is not installed. Please install it with `pip install openai`"
             )
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
+
         self.api_key_env_var = api_key_env_var
         # Prioritize api_key argument, then environment variable
         resolved_api_key = api_key or os.getenv(api_key_env_var)
         if not resolved_api_key:
-            raise ValueError(f"API key not provided and {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"API key not provided and {api_key_env_var} environment variable is not set."
+            )
         self.api_key = resolved_api_key
         if not api_base:
             raise ValueError("The api_base argument must be provided.")
@@ -37,21 +48,14 @@ class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
         self.model_name = "baseten-embedding-model"
         self.dimensions = None
 
-        self.client = openai.OpenAI(
-            api_key=self.api_key,
-            base_url=self.api_base
-        )
-        
+        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.api_base)
+
     @staticmethod
     def name() -> str:
         return "baseten"
-    
+
     def get_config(self) -> Dict[str, Any]:
-        return {
-            "api_base": self.api_base,
-            "api_key_env_var": self.api_key_env_var
-        }
-        
+        return {"api_base": self.api_base, "api_key_env_var": self.api_key_env_var}
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "BasetenEmbeddingFunction":
@@ -68,16 +72,20 @@ class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
         api_key_env_var = config.get("api_key_env_var")
         api_base = config.get("api_base")
         if api_key_env_var is None or api_base is None:
-            raise ValueError("Missing 'api_key_env_var' or 'api_base' in configuration for BasetenEmbeddingFunction.")
+            raise ValueError(
+                "Missing 'api_key_env_var' or 'api_base' in configuration for BasetenEmbeddingFunction."
+            )
 
         # Note: We rely on the __init__ method to handle potential missing api_key
         # by checking the environment variable if the config value is None.
         # However, api_base must be present either in config or have a default.
         if api_base is None:
-             raise ValueError("Missing 'api_base' in configuration for BasetenEmbeddingFunction.")
+            raise ValueError(
+                "Missing 'api_base' in configuration for BasetenEmbeddingFunction."
+            )
 
         return BasetenEmbeddingFunction(
-            api_key=None, # Pass None if not in config, __init__ will check env var
+            api_key=None,  # Pass None if not in config, __init__ will check env var
             api_base=api_base,
             api_key_env_var=api_key_env_var,
         )

--- a/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Any, Optional
 import os
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import cast
+import warnings
 
 BASE_URL = "https://api.cloudflare.com/client/v4/accounts"
 GATEWAY_BASE_URL = "https://gateway.ai.cloudflare.com/v1"
@@ -42,6 +43,13 @@ class CloudflareWorkersAIEmbeddingFunction(EmbeddingFunction[Documents]):
         except ImportError:
             raise ValueError(
                 "The httpx python package is not installed. Please install it with `pip install httpx`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
             )
         self.model_name = model_name
         self.account_id = account_id

--- a/chromadb/utils/embedding_functions/cohere_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cohere_embedding_function.py
@@ -13,6 +13,7 @@ from chromadb.utils.embedding_functions.schemas import validate_config_schema
 import base64
 import io
 import importlib
+import warnings
 
 
 class CohereEmbeddingFunction(EmbeddingFunction[Embeddable]):
@@ -36,6 +37,12 @@ class CohereEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "The PIL python package is not installed. Please install it with `pip install pillow`"
             )
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import numpy.typing as npt
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
+import warnings
 
 
 class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -31,6 +32,12 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
                 "The Google Generative AI python package is not installed. Please install it with `pip install google-generativeai`"
             )
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:
@@ -141,6 +148,12 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
                 "The Google Generative AI python package is not installed. Please install it with `pip install google-generativeai`"
             )
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:
@@ -270,6 +283,12 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
                 "The vertexai python package is not installed. Please install it with `pip install google-cloud-aiplatform`"
             )
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:

--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any, Optional
 import os
 import numpy as np
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
+import warnings
 
 
 class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -33,6 +34,12 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
                 "The httpx python package is not installed. Please install it with `pip install httpx`"
             )
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:
@@ -141,6 +148,13 @@ class HuggingFaceEmbeddingServer(EmbeddingFunction[Documents]):
         except ImportError:
             raise ValueError(
                 "The httpx python package is not installed. Please install it with `pip install httpx`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
             )
 
         self.url = url

--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -3,6 +3,7 @@ from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any, Union, Optional
 import os
 import numpy as np
+import warnings
 
 
 class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -50,6 +51,13 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
         except ImportError:
             raise ValueError(
                 "The httpx python package is not installed. Please install it with `pip install httpx`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
             )
 
         self.api_key_env_var = api_key_env_var

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any, Optional
 import os
 import numpy as np
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
+import warnings
 
 
 class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -47,6 +48,13 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
         except ImportError:
             raise ValueError(
                 "The openai python package is not installed. Please install it with `pip install openai`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
             )
 
         self.api_key_env_var = api_key_env_var

--- a/chromadb/utils/embedding_functions/roboflow_embedding_function.py
+++ b/chromadb/utils/embedding_functions/roboflow_embedding_function.py
@@ -15,6 +15,7 @@ import importlib
 import base64
 from io import BytesIO
 import numpy as np
+import warnings
 
 
 class RoboflowEmbeddingFunction(EmbeddingFunction[Embeddable]):
@@ -38,6 +39,12 @@ class RoboflowEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 Defaults to "https://infer.roboflow.com".
         """
 
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:

--- a/chromadb/utils/embedding_functions/together_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/together_ai_embedding_function.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Any, Optional
 import os
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import cast
+import warnings
 
 ENDPOINT = "https://api.together.xyz/v1/embeddings"
 
@@ -38,6 +39,14 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
             raise ValueError(
                 "The httpx python package is not installed. Please install it with `pip install httpx`"
             )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
+
         self.model_name = model_name
         self.api_key = api_key
         self.api_key_env_var = api_key_env_var

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -3,6 +3,7 @@ from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any, Optional
 import os
 import numpy as np
+import warnings
 
 
 class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
@@ -31,6 +32,13 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
         except ImportError:
             raise ValueError(
                 "The voyageai python package is not installed. Please install it with `pip install voyageai`"
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
             )
 
         self.api_key_env_var = api_key_env_var


### PR DESCRIPTION
## Description of changes

This PR fixes a bug where it warns users if the configuration is not deserializable rather than raising an error, giving the users an empty config. Now, it raises an error if the configuration is not deserializable. This will only happen when the client is ahead of the server, which we do not need to support.

EF's from the config are now lazily loaded. only when ._embed is invoked from the model is it tried to be built, and will take precedent over the provided ef.

This also fixes a bug with list_collections, where if the user tries to load collections without the proper embedding function parameters set up, like api key env var, etc it would throw an hnsw and spann not configured error, which is not the root cause. instead, it will now load only the configuration_json, and at embed time try to load the ef, so errors will only propogate at that point, and with much clearer error messages.

Now, using api_key directly in embedding_functions will give a deprecation warning saying it is not persisted.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
