### PR TITLE
[BUG]: fix dev k8s query-service-cache mount with subpath

### DIFF
--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -75,6 +75,7 @@ spec:
             {{if .Values.queryService.cache}}
             - name: query-service-cache
               mountPath: {{ .Values.queryService.cache.mountPath }}
+              subPathExpr: $(POD_NAME)
             {{ end }}
           ports:
             - containerPort: 50051
@@ -88,6 +89,10 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: CHROMA_QUERY_SERVICE__MY_MEMBER_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Fix dev k8s volume `query-service-cache` mount with `subPathExpr` to make sure each pod owns its exclusive cache directory.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
