### PR TITLE
[ENH]: bump foyer to v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3b4e79fe76576b3970ada6437b30bee8cefe28685535290c3188d9b79b981e"
+checksum = "25b39eac8bbda09ae8bf9b65c9f81a3644cff845cab79953332fc382295a3dac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3069,11 +3069,12 @@ dependencies = [
 
 [[package]]
 name = "foyer-common"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e71666dc1f66539cc9a21668fa59d11dbf9e1fd7cb9048d3e2293e28080f5d0"
+checksum = "58bc1526450debd8e2189622b443c891d80e679d8088a673111f68ba26fdba6d"
 dependencies = [
  "ahash",
+ "bincode",
  "bytes",
  "cfg-if",
  "fastrace",
@@ -3083,6 +3084,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "serde",
+ "thiserror 2.0.4",
  "tokio",
 ]
 
@@ -3097,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9332460864db122775ef95b0603562288674daad7a8df0add81adaca7e5e09"
+checksum = "f9bb1c500379344e82472b8576767a71a58650bb669b31491c7b7f4e91eb9efc"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3123,16 +3125,15 @@ dependencies = [
 
 [[package]]
 name = "foyer-storage"
-version = "0.15.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfae1b6d15d65c014e72047939fcf937f964582c6561942e736fc5dec1fc8c3c"
+checksum = "fc512db7757a9b2162d43a0708608e0deec1768acf622ed1b0a3024c1351d268"
 dependencies = [
  "ahash",
  "allocator-api2",
  "anyhow",
  "array-util",
  "auto_enums",
- "bincode",
  "bytes",
  "clap",
  "equivalent",
@@ -4854,9 +4855,9 @@ dependencies = [
 
 [[package]]
 name = "mixtrics"
-version = "0.0.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285f6f175bfc4a068c0aa66d1fc48b6f4af0193d9577f8a86fa3a80014be9321"
+checksum = "749ed12bab176c8a42c13a679dd2de12876d5ad4abe7525548e31ae001a9ebbf"
 dependencies = [
  "itertools 0.14.0",
  "opentelemetry",

--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -863,3 +863,30 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Arc;
+
+    use arrow::{
+        array::Int32Array,
+        datatypes::{DataType, Field, Schema},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_block_serde() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)])),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]))],
+        )
+        .unwrap();
+        let b1 = Block::from_record_batch(Uuid::new_v4(), batch.clone());
+        let bytes = bincode::serialize(&b1).unwrap();
+        let b2 = bincode::deserialize::<Block>(&bytes).unwrap();
+        assert_eq!(b1.id, b2.id);
+        assert_eq!(b1.data.0, b2.data.0);
+    }
+}

--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -8,8 +8,8 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { workspace = true }
-foyer = { version = "0.15.3", features = ["tracing"] }
-mixtrics = { version = "0.0.4", features = ["opentelemetry_0_27"] }
+foyer = { version = "0.17.0", features = ["tracing", "serde"] }
+mixtrics = { version = "0.1.0", features = ["opentelemetry_0_27"] }
 anyhow = "1.0"
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -4,8 +4,8 @@ use chroma_error::ChromaError;
 use clap::Parser;
 use foyer::{
     CacheBuilder, DirectFsDeviceOptions, Engine, FifoConfig, FifoPicker, HybridCacheBuilder,
-    InvalidRatioPicker, LargeEngineOptions, LfuConfig, LruConfig, RateLimitPicker, S3FifoConfig,
-    StorageKey, StorageValue, TracingOptions,
+    InvalidRatioPicker, LargeEngineOptions, LfuConfig, LruConfig, S3FifoConfig, StorageKey,
+    StorageValue, Throttle, TracingOptions,
 };
 use opentelemetry::global;
 use serde::{Deserialize, Serialize};
@@ -391,14 +391,19 @@ where
             )));
         };
 
-        let mut builder = builder
+        let mut device_options = DirectFsDeviceOptions::new(dir)
+            .with_capacity(config.disk * MIB)
+            .with_file_size(config.file_size * MIB);
+        if config.admission_rate_limit > 0 {
+            device_options = device_options.with_throttle(
+                Throttle::new().with_write_throughput(config.admission_rate_limit * MIB),
+            );
+        }
+
+        let builder = builder
             .with_weighter(|_, v| v.weight())
             .storage(Engine::Large)
-            .with_device_options(
-                DirectFsDeviceOptions::new(dir)
-                    .with_capacity(config.disk * MIB)
-                    .with_file_size(config.file_size * MIB),
-            )
+            .with_device_options(device_options)
             .with_flush(config.flush)
             .with_recover_mode(foyer::RecoverMode::Strict)
             .with_large_object_disk_cache_options(
@@ -414,11 +419,6 @@ where
                     ]),
             );
 
-        if config.admission_rate_limit > 0 {
-            builder = builder.with_admission_picker(Arc::new(RateLimitPicker::new(
-                config.admission_rate_limit * MIB,
-            )));
-        }
         let cache = builder.build().await.map_err(|e| {
             CacheError::InvalidCacheConfig(format!("builder failed: {:?}", e)).boxed()
         })?;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Bump foyer to v0.17.0

Changes from v0.15.3 to v0.17.0:

- Add metrics for large object disk cache indexer conflicts.
- Refine the cache key/value serialization and deserializaion.
  - Support customized serialization and deserialization.
  - Support serialization and deserialization with `serde` and `bincode`. (optional)
- Make `serde` and `bincode` optional, and disabled by default. You can enable it with `serde` feature.
- Reduce verbose warning logs.
- Fix panic when building large object disk cache engine if `buffer_pool_size / flushers` is not 4K-aligned.
- Make CI run on release branches.
- Refine entry-level properties.
  - Packing `ephemeral`, `hint`, `location` into `CacheProperties` and `HybridCacheProperties`, use `insert_with_properties()` and `fetch_with_properties()` for setting them.
  - Migration from `foyer < v0.17.0`: Repleace `.insert_with_hint(..)`, `.insert_ephemeral(..)`, etc with `insert_with_properties(..)` and `fetch_with_properties(..)`.
- Refine disk cache insertion with entries populated from the disk cache.
  - Use an age-based FIFO policy to manager large object disk cache.
  - Track the source of in-memory cache entries.
  - When an in-memory cache entry is being inserted into the disk cache, the disk cache will determine if to skip it according to its resource and age. Entries populated from the disk cache and are not going to evicted soon will be skipped.
- Support flush entries in the in-memory cache to the disk cache on closing the hybrid cache.
  - Migration from `foyer < v0.17.0`: Enable by `.with_flush_on_close(true)` with the hybrid cache builder.
- Refine io throttling.
  - Support advanced io throttling by read/write IOPS/throughput, and support count IOs by IO count or by IO count with IO size.
  - Migration from `foyer < v0.17.0`: Please set io throttling for device, instead of using `RateLimiterAmissionPicker`.
- Support request deduplication and one-flight optimization with `fetch(..)` interface for the disk cache.
  - Migration from `foyer < v0.17.0`: Use `.fetch_with_properties(..)` API and set the `location` of `HybridCacheProperties` to `Location::OnDisk`.
- Miscs:
  - Add `builder()` API for `Cache` and `HybridCache` to create builders.
  - Opt-out tracing dependency by default, enable it by enabling `tracing` feature.
  - Bump `mixtrics` to `v0.1`.




## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
