### PR TITLE
[ENH]  Change rust-log-service to a stateful set.

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.37
+version: 0.1.38
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -11,72 +11,6 @@ data:
 
 ---
 
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: rust-log-service
-  namespace: {{ .Values.namespace }}
-spec:
-  replicas: {{ .Values.rustLogService.replicaCount }}
-  selector:
-    matchLabels:
-      app: rust-log-service
-  template:
-    metadata:
-      labels:
-        app: rust-log-service
-    spec:
-      serviceAccountName: rust-log-service-serviceaccount
-      containers:
-        - name: rust-log-service
-          {{ if .Values.rustLogService.command }}
-          command: {{ .Values.rustLogService.command }}
-          {{ end }}
-          image: "{{ .Values.rustLogService.image.repository }}:{{ .Values.rustLogService.image.tag }}"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 50051
-          readinessProbe:
-            grpc:
-              port: 50051
-          {{ if .Values.rustLogService.resources }}
-          resources:
-            limits:
-              cpu: {{ .Values.rustLogService.resources.limits.cpu }}
-              memory: {{ .Values.rustLogService.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.rustLogService.resources.requests.cpu }}
-              memory: {{ .Values.rustLogService.resources.requests.memory }}
-          {{ end }}
-          env:
-            - name: CONFIG_PATH
-              value: "/config/config.yaml"
-            {{ if .Values.rustLogService.otherEnvConfig }}
-              {{ .Values.rustLogService.otherEnvConfig | nindent 12 }}
-            {{ end }}
-          {{if .Values.rustLogService.configuration}}
-          volumeMounts:
-            - name: rust-log-service-config
-              mountPath: /config/
-          {{ end }}
-
-      {{if .Values.rustLogService.tolerations}}
-      tolerations:
-        {{ toYaml .Values.rustLogService.tolerations | nindent 8 }}
-      {{ end }}
-      {{if .Values.rustLogService.nodeSelector}}
-      nodeSelector:
-        {{ toYaml .Values.rustLogService.nodeSelector | nindent 8 }}
-      {{ end }}
-      {{if .Values.rustLogService.configuration}}
-      volumes:
-        - name: rust-log-service-config
-          configMap:
-            name: rust-log-service-config
-      {{ end }}
-
----
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -87,10 +21,94 @@ spec:
     - name: server-port
       port: 50051
       targetPort: 50051
+  clusterIP: None
   selector:
     app: rust-log-service
   type: ClusterIP
 
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rust-log-service
+  namespace: {{ .Values.namespace }}
+spec:
+  serviceName: rust-log-service
+  replicas: {{ .Values.rustLogService.replicaCount }}
+  selector:
+    matchLabels:
+      app: rust-log-service
+  template:
+    metadata:
+      labels:
+        app: rust-log-service
+        member-type: rust-log-service
+    spec:
+      serviceAccountName: rust-log-service-serviceaccount
+      volumes:
+        {{if .Values.rustLogService.configuration}}
+        - name: rust-log-service-config
+          configMap:
+            name: rust-log-service-config
+        {{ end }}
+        {{if .Values.rustLogService.cache}}
+        - name: rust-log-service-cache
+          hostPath:
+            path: {{ .Values.rustLogService.cache.hostPath }}
+            type: DirectoryOrCreate
+        {{ end }}
+      containers:
+        - name: rust-log-service
+          {{ if .Values.rustLogService.command }}
+          command: {{ .Values.rustLogService.command }}
+          {{ end }}
+          image: "{{ .Values.rustLogService.image.repository }}:{{ .Values.rustLogService.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            grpc:
+              port: 50051
+          volumeMounts:
+            {{if .Values.rustLogService.configuration}}
+            - name: rust-log-service-config
+              mountPath: /config/
+            {{ end }}
+            {{if .Values.rustLogService.cache}}
+            - name: rust-log-service-cache
+              mountPath: {{ .Values.rustLogService.cache.mountPath }}
+            {{ end }}
+          ports:
+            - containerPort: 50051
+          env:
+            - name: CONFIG_PATH
+              value: "/config/config.yaml"
+            {{ if .Values.rustLogService.otherEnvConfig }}
+              {{ .Values.rustLogService.otherEnvConfig | nindent 12 }}
+            {{ end }}
+          {{ if .Values.rustLogService.resources }}
+          resources:
+            limits:
+              cpu: {{ .Values.rustLogService.resources.limits.cpu }}
+              memory: {{ .Values.rustLogService.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.rustLogService.resources.requests.cpu }}
+              memory: {{ .Values.rustLogService.resources.requests.memory }}
+          {{ end }}
+      {{if .Values.rustLogService.tolerations}}
+      tolerations:
+        {{ toYaml .Values.rustLogService.tolerations | nindent 8 }}
+      {{ end }}
+      {{if .Values.rustLogService.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.rustLogService.nodeSelector | nindent 8 }}
+      {{ end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              member-type: rust-log-service
 
 ---
 

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -21,7 +21,6 @@ spec:
     - name: server-port
       port: 50051
       targetPort: 50051
-  clusterIP: None
   selector:
     app: rust-log-service
   type: ClusterIP

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -21,6 +21,7 @@ spec:
     - name: server-port
       port: 50051
       targetPort: 50051
+  clusterIP: None
   selector:
     app: rust-log-service
   type: ClusterIP


### PR DESCRIPTION
## Description of changes

This PR changes the rust log service from a deployment to a stateful set
so that we can use the standard memberlist techniques with it.

## Test plan

tilt up works + CI

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
