### PR TITLE
[BUG] Remove misleading log message

### DIFF
--- a/rust/load/src/data_sets.rs
+++ b/rust/load/src/data_sets.rs
@@ -1212,13 +1212,6 @@ impl DataSet for VerifyingDataSet {
             }
         };
 
-        event!(
-            Level::INFO,
-            "Upserting {} keys, new cardinality: {}",
-            uq.batch_size,
-            key_start_index + uq.batch_size
-        );
-
         for offset in 0..uq.batch_size {
             let key = uq.key.select_from_reference(self, offset);
             if !keys.contains(&key) {


### PR DESCRIPTION
## Description of changes

This change removes a misleading / incorrect event log message.

The cardinality value is actually computed by record_load, based on the largest contiguous chunk of records that have been loaded so far. We cannot assume the cardinality will increase by 100, just by loading in another chunk of size 100.

## Test plan

Untested
