### PR TITLE
[ENH] Add RPC on SysDB to get fork count for a collection

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -161,6 +161,10 @@ func (s *Coordinator) ForkCollection(ctx context.Context, forkCollection *model.
 	return s.catalog.ForkCollection(ctx, forkCollection)
 }
 
+func (s *Coordinator) CountForks(ctx context.Context, sourceCollectionID types.UniqueID) (uint64, error) {
+	return s.catalog.CountForks(ctx, sourceCollectionID)
+}
+
 func (s *Coordinator) CreateSegment(ctx context.Context, segment *model.CreateSegment) error {
 	if err := verifyCreateSegment(segment); err != nil {
 		return err

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -1574,7 +1574,8 @@ func (suite *APIsTestSuite) TestCountForks() {
 			TargetCollectionID:                   types.NewUniqueID(),
 			TargetCollectionName:                 fmt.Sprintf("test_fork_collection_fork_source%d", i),
 		}
-		forkedCollection, _, _ := suite.coordinator.ForkCollection(ctx, forkCollection)
+		forkedCollection, _, err := suite.coordinator.ForkCollection(ctx, forkCollection)
+		suite.NoError(err)
 		forkedCollectionId = forkedCollection.ID
 	}
 
@@ -1587,7 +1588,8 @@ func (suite *APIsTestSuite) TestCountForks() {
 			TargetCollectionID:                   types.NewUniqueID(),
 			TargetCollectionName:                 fmt.Sprintf("test_fork_collection_fork_forked%d", i),
 		}
-		_, _, _ = suite.coordinator.ForkCollection(ctx, forkCollection)
+		_, _, err = suite.coordinator.ForkCollection(ctx, forkCollection)
+		suite.NoError(err)
 	}
 
 	count, err := suite.coordinator.CountForks(ctx, sourceCreateCollection.ID)

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -994,7 +994,6 @@ func (tc *Catalog) ForkCollection(ctx context.Context, forkCollection *model.For
 }
 
 func (tc *Catalog) CountForks(ctx context.Context, sourceCollectionID types.UniqueID) (uint64, error) {
-	var rootCollection *model.Collection
 	var rootCollectionID types.UniqueID
 
 	sourceCollectionIDStr := sourceCollectionID.String()
@@ -1020,7 +1019,7 @@ func (tc *Catalog) CountForks(ctx context.Context, sourceCollectionID types.Uniq
 	if len(collections) == 0 {
 		return 0, common.ErrCollectionNotFound
 	}
-	rootCollection = collections[0]
+	rootCollection := collections[0]
 
 	lineageFile, err := tc.getLineageFile(ctx, rootCollection)
 	if err != nil {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1027,6 +1027,9 @@ func (tc *Catalog) CountForks(ctx context.Context, sourceCollectionID types.Uniq
 		return 0, err
 	}
 
+	if lineageFile == nil || lineageFile.Dependencies == nil {
+		return 0, nil
+	}
 	return uint64(len(lineageFile.Dependencies)), nil
 }
 

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1001,6 +1001,9 @@ func (tc *Catalog) CountForks(ctx context.Context, sourceCollectionID types.Uniq
 	if err != nil {
 		return 0, err
 	}
+	if sourceCollectionDb == nil {
+		return 0, common.ErrCollectionNotFound
+	}
 
 	if len(sourceCollectionDb.RootCollectionId) > 0 {
 		rootCollectionID, err = types.Parse(sourceCollectionDb.RootCollectionId)

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -993,6 +993,53 @@ func (tc *Catalog) ForkCollection(ctx context.Context, forkCollection *model.For
 	return tc.GetCollectionWithSegments(ctx, forkCollection.TargetCollectionID)
 }
 
+func (tc *Catalog) CountForks(ctx context.Context, sourceCollectionID types.UniqueID) (uint64, error) {
+	var rootCollection *model.Collection
+	var rootCollectionID types.UniqueID
+	var sourceCollection *model.Collection
+
+	sourceCollectionIDStr := sourceCollectionID.String()
+
+	sourceCollectionDb, err := tc.metaDomain.CollectionDb(ctx).GetCollectionEntry(&sourceCollectionIDStr, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(sourceCollectionDb.RootCollectionId) > 0 {
+		rootCollectionID, err = types.Parse(sourceCollectionDb.RootCollectionId)
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		rootCollectionID = sourceCollectionID
+	}
+
+	sourceCollection, _, err = tc.GetCollectionWithSegments(ctx, sourceCollectionID)
+	if err != nil {
+		return 0, err
+	}
+	if rootCollectionID != sourceCollectionID {
+		limit := int32(1)
+		collections, err := tc.GetCollections(ctx, rootCollectionID, nil, "", "", &limit, nil)
+		if err != nil {
+			return 0, err
+		}
+		if len(collections) == 0 {
+			return 0, common.ErrCollectionNotFound
+		}
+		rootCollection = collections[0]
+	} else {
+		rootCollection = sourceCollection
+	}
+
+	lineageFile, err := tc.getLineageFile(ctx, rootCollection)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(len(lineageFile.Dependencies)), nil
+}
+
 func (tc *Catalog) CreateSegment(ctx context.Context, createSegment *model.CreateSegment, ts types.Timestamp) (*model.Segment, error) {
 	var result *model.Segment
 

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -3,7 +3,6 @@ package coordinator
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -1027,30 +1026,6 @@ func TestUpdateCollectionConfiguration(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestCatalog_CountForks(t *testing.T) {
-	mockMetaDomain := &mocks.IMetaDomain{}
-	catalog := NewTableCatalog(nil, mockMetaDomain, nil, false)
-	collectionID := types.MustParse("00000000-0000-0000-0000-000000000001")
-
-	// Create 5 forks
-	for i := 0; i < 5; i++ {
-		forkCollection := &model.ForkCollection{
-			SourceCollectionID:                   collectionID,
-			SourceCollectionLogCompactionOffset:  0,
-			SourceCollectionLogEnumerationOffset: 0,
-			TargetCollectionID:                   types.NewUniqueID(),
-			TargetCollectionName:                 fmt.Sprintf("test_fork_collection_fork_1_%d", i),
-		}
-		_, _, err := catalog.ForkCollection(context.Background(), forkCollection)
-		assert.NoError(t, err)
-	}
-
-	count, err := catalog.CountForks(context.Background(), collectionID)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(5), count)
-	mockMetaDomain.AssertExpectations(t)
 }
 
 // Helper functions

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -1026,6 +1027,30 @@ func TestUpdateCollectionConfiguration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCatalog_CountForks(t *testing.T) {
+	mockMetaDomain := &mocks.IMetaDomain{}
+	catalog := NewTableCatalog(nil, mockMetaDomain, nil, false)
+	collectionID := types.MustParse("00000000-0000-0000-0000-000000000001")
+
+	// Create 5 forks
+	for i := 0; i < 5; i++ {
+		forkCollection := &model.ForkCollection{
+			SourceCollectionID:                   collectionID,
+			SourceCollectionLogCompactionOffset:  0,
+			SourceCollectionLogEnumerationOffset: 0,
+			TargetCollectionID:                   types.NewUniqueID(),
+			TargetCollectionName:                 fmt.Sprintf("test_fork_collection_fork_1_%d", i),
+		}
+		_, _, err := catalog.ForkCollection(context.Background(), forkCollection)
+		assert.NoError(t, err)
+	}
+
+	count, err := catalog.CountForks(context.Background(), collectionID)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(5), count)
+	mockMetaDomain.AssertExpectations(t)
 }
 
 // Helper functions

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -405,6 +405,9 @@ func (s *Server) CountForks(ctx context.Context, req *coordinatorpb.CountForksRe
 
 	count, err := s.coordinator.CountForks(ctx, parsedSourceCollectionID)
 	if err != nil {
+		if err == common.ErrCollectionNotFound {
+			return res, grpcutils.BuildNotFoundGrpcError(err.Error())
+		}
 		return res, grpcutils.BuildInternalGrpcError(err.Error())
 	}
 	res.Count = count

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -393,6 +393,24 @@ func (s *Server) ForkCollection(ctx context.Context, req *coordinatorpb.ForkColl
 	return res, nil
 }
 
+func (s *Server) CountForks(ctx context.Context, req *coordinatorpb.CountForksRequest) (*coordinatorpb.CountForksResponse, error) {
+	res := &coordinatorpb.CountForksResponse{}
+
+	sourceCollectionID := req.SourceCollectionId
+	parsedSourceCollectionID, err := types.ToUniqueID(&sourceCollectionID)
+	if err != nil {
+		log.Error("ForkCollection failed. Failed to parse source collection id", zap.Error(err), zap.String("collection_id", sourceCollectionID))
+		return res, grpcutils.BuildInternalGrpcError(err.Error())
+	}
+
+	count, err := s.coordinator.CountForks(ctx, parsedSourceCollectionID)
+	if err != nil {
+		return res, grpcutils.BuildInternalGrpcError(err.Error())
+	}
+	res.Count = count
+	return res, nil
+}
+
 func (s *Server) ListCollectionVersions(ctx context.Context, req *coordinatorpb.ListCollectionVersionsRequest) (*coordinatorpb.ListCollectionVersionsResponse, error) {
 	collectionID, err := types.ToUniqueID(&req.CollectionId)
 	if err != nil {

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -399,7 +399,7 @@ func (s *Server) CountForks(ctx context.Context, req *coordinatorpb.CountForksRe
 	sourceCollectionID := req.SourceCollectionId
 	parsedSourceCollectionID, err := types.ToUniqueID(&sourceCollectionID)
 	if err != nil {
-		log.Error("ForkCollection failed. Failed to parse source collection id", zap.Error(err), zap.String("collection_id", sourceCollectionID))
+		log.Error("CountForks failed. Failed to parse source collection id", zap.Error(err), zap.String("collection_id", sourceCollectionID))
 		return res, grpcutils.BuildInternalGrpcError(err.Error())
 	}
 

--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -567,6 +568,39 @@ func (suite *CollectionServiceTestSuite) TestGetCollectionSize() {
 	res, err := suite.s.GetCollectionSize(context.Background(), &req)
 	suite.NoError(err)
 	suite.Equal(uint64(100), res.TotalRecordsPostCompaction)
+
+	err = dao.CleanUpTestCollection(suite.db, collectionID)
+	suite.NoError(err)
+}
+
+func (suite *CollectionServiceTestSuite) TestCountForks() {
+	collectionName := "collection_service_test_count_forks"
+	collectionID, err := dao.CreateTestCollection(suite.db, collectionName, 128, suite.databaseId)
+	suite.NoError(err)
+
+	req := coordinatorpb.CountForksRequest{
+		SourceCollectionId: collectionID,
+	}
+	res, err := suite.s.CountForks(context.Background(), &req)
+	suite.NoError(err)
+	suite.Equal(uint64(0), res.Count)
+
+	// Create 5 forks
+	for i := 0; i < 5; i++ {
+		forkCollectionReq := &coordinatorpb.ForkCollectionRequest{
+			SourceCollectionId:                   collectionID,
+			SourceCollectionLogCompactionOffset:  0,
+			SourceCollectionLogEnumerationOffset: 0,
+			TargetCollectionId:                   types.NewUniqueID().String(),
+			TargetCollectionName:                 fmt.Sprintf("test_fork_collection_fork_%d", i),
+		}
+		_, err = suite.s.ForkCollection(context.Background(), forkCollectionReq)
+		suite.NoError(err)
+	}
+
+	res, err = suite.s.CountForks(context.Background(), &req)
+	suite.NoError(err)
+	suite.Equal(uint64(5), res.Count)
 
 	err = dao.CleanUpTestCollection(suite.db, collectionID)
 	suite.NoError(err)

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -229,6 +229,14 @@ message ForkCollectionResponse {
   repeated Segment segments = 2;
 }
 
+message CountForksRequest {
+  string source_collection_id = 1;
+}
+
+message CountForksResponse {
+  uint64 count = 1;
+}
+
 message ResetStateResponse {
   reserved 1;
   reserved "status";
@@ -476,6 +484,7 @@ service SysDB {
   rpc CheckCollections(CheckCollectionsRequest) returns (CheckCollectionsResponse) {}
   rpc UpdateCollection(UpdateCollectionRequest) returns (UpdateCollectionResponse) {}
   rpc ForkCollection(ForkCollectionRequest) returns (ForkCollectionResponse) {}
+  rpc CountForks(CountForksRequest) returns (CountForksResponse) {}
   rpc ResetState(google.protobuf.Empty) returns (ResetStateResponse) {}
   rpc GetLastCompactionTimeForTenant(GetLastCompactionTimeForTenantRequest) returns (GetLastCompactionTimeForTenantResponse) {}
   rpc SetLastCompactionTimeForTenant(SetLastCompactionTimeForTenantRequest) returns (google.protobuf.Empty) {}

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -842,6 +842,26 @@ impl ChromaError for ForkCollectionError {
 }
 
 #[derive(Debug, Error)]
+pub enum CountForksError {
+    #[error("Collection [{0}] does not exist")]
+    NotFound(String),
+    #[error(transparent)]
+    Internal(#[from] Box<dyn ChromaError>),
+    #[error("Count forks is unsupported for local chroma")]
+    Local,
+}
+
+impl ChromaError for CountForksError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            CountForksError::NotFound(_) => ErrorCodes::NotFound,
+            CountForksError::Internal(chroma_error) => chroma_error.code(),
+            CountForksError::Local => ErrorCodes::Unimplemented,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
 pub enum GetCollectionSizeError {
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Adds a new RPC to the SysDB, `CountForks`, that returns the number of forks for a given collection.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
