### PR TITLE
[BUG] Retry chroma-load upserts when rate limited

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rand 0.8.5",
  "reqwest 0.12.9",
  "serde",
  "serde_json",

--- a/rust/load/Cargo.toml
+++ b/rust/load/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 figment = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Description of changes

When the upsert operations are rate-limited, the "block" of 100 records in the operation is never inserted. Therefore, the cardinality of the test data set can never grow beyond the point of the failed (rate limited) upsert.

Also, when starting a new workload, we need to reset the cardinality and heap for the data set, so that it starts again from cardinality of 0.

## Test plan

Tested locally in tilt. Verified that the cardinality of the test data set continues to grow, even after hitting rate limit errors on previous upsert attempts. Also verified that the cardinality is reset to 0 when initializing a new workload.
