### PR TITLE
[ENH][chroma-load]  If no api key is present in env, do not auth.

### DIFF
--- a/rust/load/src/bin/chroma-load-start.rs
+++ b/rust/load/src/bin/chroma-load-start.rs
@@ -90,7 +90,7 @@ async fn main() {
     let args = Args::parse();
 
     // Read API key from environment variable.
-    let api_key = std::env::var("CHROMA_API_KEY").expect("CHROMA_API_KEY is not set");
+    let api_key = std::env::var("CHROMA_API_KEY").ok();
 
     let client = reqwest::Client::new();
     let throughput = args.throughput();


### PR DESCRIPTION
## Description of changes

chroma-load-start checks the environment for an auth key.  Make it optional and push the optionality down.

## Test plan

CI

## Documentation Changes

N/A
