### PR TITLE
[ENH] QuotaExceededError can include an optional message

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -340,6 +340,7 @@ pub struct QuotaExceededError {
     pub action: Action,
     pub usage: usize,
     pub limit: usize,
+    pub remediation_url: Option<String>,
 }
 
 impl fmt::Display for QuotaExceededError {
@@ -348,7 +349,11 @@ impl fmt::Display for QuotaExceededError {
             f,
             "'{}' exceeded quota limit for action '{}': current usage of {} exceeds limit of {}",
             self.usage_type, self.action, self.usage, self.limit
-        )
+        )?;
+        if let Some(url) = &self.remediation_url {
+            write!(f, ". Request a quota increase: {}", url)?;
+        }
+        Ok(())
     }
 }
 

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -442,7 +442,12 @@ mod tests {
         };
         assert!(error.validate().is_ok());
         let error_string = format!("{}", error);
-        assert!(error_string.contains(custom_message));
+        let expected_base_message = format!(
+            "'{}' exceeded quota limit for action '{}': current usage of {} exceeds limit of {}",
+            error.usage_type, error.action, error.usage, error.limit
+        );
+        let expected_error_string = format!("{}. {}", expected_base_message, custom_message);
+        assert_eq!(error_string, expected_error_string);
     }
 
     #[test]

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -456,6 +456,6 @@ mod tests {
         };
         assert!(error.validate().is_ok());
         let error_string = format!("{}", error);
-        assert_eq!(error_string, "'NumRecords' exceeded quota limit for action 'Add': current usage of 100 exceeds limit of 50");
+        assert_eq!(error_string, "'Number of records' exceeded quota limit for action 'Add': current usage of 100 exceeds limit of 50");
     }
 }

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -350,7 +350,7 @@ impl fmt::Display for QuotaExceededError {
             "'{}' exceeded quota limit for action '{}': current usage of {} exceeds limit of {}",
             self.usage_type, self.action, self.usage, self.limit
         )?;
-        if let Some(url) = &self.remediation_url {
+        if let Some(url) = self.remediation_url.as_ref().filter(|s| !s.is_empty()) {
             write!(f, ". Request a quota increase: {}", url)?;
         }
         Ok(())

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -442,11 +442,7 @@ mod tests {
         };
         assert!(error.validate().is_ok());
         let error_string = format!("{}", error);
-        let expected_base_message = format!(
-            "'{}' exceeded quota limit for action '{}': current usage of {} exceeds limit of {}",
-            error.usage_type, error.action, error.usage, error.limit
-        );
-        let expected_error_string = format!("{}. {}", expected_base_message, custom_message);
+        let expected_error_string = "'Number of records' exceeded quota limit for action 'Add': current usage of 100 exceeds limit of 50. This is a valid message.";
         assert_eq!(error_string, expected_error_string);
     }
 


### PR DESCRIPTION
Adds an optional `message` to `QuotaExceededError`. This feature allows the quota system to give clients more info about an error.

<!-- Summary by @propel-code-bot -->

---

This PR enhances the QuotaExceededError struct by adding an optional 'message' field, allowing the quota system to provide more detailed information to clients when quota limits are exceeded. The implementation uses the Validate trait to ensure non-empty message strings and includes comprehensive test coverage.

**Key Changes:**
• Added an optional `message` field to QuotaExceededError struct
• Updated the Display implementation to include the message when present
• Added validation to ensure non-empty message strings
• Added comprehensive tests for the new functionality

**Affected Areas:**
• rust/frontend/src/quota/mod.rs

*This summary was automatically generated by @propel-code-bot*