### PR TITLE
[ENH] Make metadata optional to allow deleting metadata in python client

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -687,9 +687,11 @@ def validate_metadata(metadata: Metadata) -> Metadata:
                 f"Expected metadata key to be a str, got {key} which is a {type(key).__name__}"
             )
         # isinstance(True, int) evaluates to True, so we need to check for bools separately
-        if not isinstance(value, bool) and not isinstance(value, (str, int, float)):
+        if not isinstance(value, bool) and not isinstance(
+            value, (str, int, float, type(None))
+        ):
             raise ValueError(
-                f"Expected metadata value to be a str, int, float or bool, got {value} which is a {type(value).__name__}"
+                f"Expected metadata value to be a str, int, float, bool, or None, got {value} which is a {type(value).__name__}"
             )
     return metadata
 

--- a/chromadb/base_types.py
+++ b/chromadb/base_types.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Mapping, Sequence, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Union
 from typing_extensions import Literal
 import numpy as np
 from numpy.typing import NDArray
 
-Metadata = Mapping[str, Union[str, int, float, bool]]
+Metadata = Mapping[str, Optional[Union[str, int, float, bool]]]
 UpdateMetadata = Mapping[str, Union[int, float, str, bool, None]]
 PyVector = Union[Sequence[float], Sequence[int]]
 Vector = NDArray[Union[np.int32, np.float32]]  # TODO: Specify that the vector is 1D


### PR DESCRIPTION
## Description of changes

This PRs allows setting metadata to None in the python client to allow deleting metadatas after creation.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
<!-- Summary by @propel-code-bot -->

---

This PR enhances the Python client by allowing metadata values to be set to None, which enables users to delete metadata after creation. The change modifies the metadata type definition and validation logic to accept None as a valid value type.

*This summary was automatically generated by @propel-code-bot*