### PR TITLE
[BUG]  Adjust the ping-pong test for wal3 to timeout longer and run less.

### DIFF
--- a/rust/wal3/tests/test_k8s_integration_99_ping_pong_contention.rs
+++ b/rust/wal3/tests/test_k8s_integration_99_ping_pong_contention.rs
@@ -115,7 +115,7 @@ async fn test_k8s_integration_ping_pong_contention() {
         .unwrap(),
     );
 
-    // Set a timer to make sure the test only runs for 2 minutes.
+    // Set a timer to make sure the test only runs for 3 minutes.
     let fail = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(180)).await;
         eprintln!("Taking down the test");

--- a/rust/wal3/tests/test_k8s_integration_99_ping_pong_contention.rs
+++ b/rust/wal3/tests/test_k8s_integration_99_ping_pong_contention.rs
@@ -117,7 +117,7 @@ async fn test_k8s_integration_ping_pong_contention() {
 
     // Set a timer to make sure the test only runs for 2 minutes.
     let fail = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(120)).await;
+        tokio::time::sleep(Duration::from_secs(180)).await;
         eprintln!("Taking down the test");
         std::process::exit(13);
     });
@@ -130,7 +130,7 @@ async fn test_k8s_integration_ping_pong_contention() {
         Arc::clone(&mutex),
         Arc::clone(&running),
         1,
-        30,
+        20,
     ));
 
     let handle2 = tokio::spawn(writer_thread(
@@ -138,7 +138,7 @@ async fn test_k8s_integration_ping_pong_contention() {
         Arc::clone(&mutex),
         Arc::clone(&running),
         2,
-        30,
+        20,
     ));
 
     // Wait for both threads to complete


### PR DESCRIPTION
## Description of changes

This should make it impervious to flakes.  What I saw was 26 in 2 min.
Changing to 20 in 3 min as the failure.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
