### PR TITLE
[ENH] write embedding function to config if provided

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -184,8 +184,11 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     ) -> AsyncCollection:
         if configuration is None:
             configuration = {}
-            if embedding_function is not None:
-                configuration["embedding_function"] = embedding_function
+        if (
+            embedding_function is not None
+            and configuration.get("embedding_function") is None
+        ):
+            configuration["embedding_function"] = embedding_function
         model = await self._server.create_collection(
             name=name,
             configuration=configuration,
@@ -235,8 +238,11 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
     ) -> AsyncCollection:
         if configuration is None:
             configuration = {}
-            if embedding_function is not None:
-                configuration["embedding_function"] = embedding_function
+        if (
+            embedding_function is not None
+            and configuration.get("embedding_function") is None
+        ):
+            configuration["embedding_function"] = embedding_function
         model = await self._server.get_or_create_collection(
             name=name,
             configuration=configuration,

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -151,8 +151,11 @@ class Client(SharedSystemClient, ClientAPI):
     ) -> Collection:
         if configuration is None:
             configuration = {}
-            if embedding_function is not None:
-                configuration["embedding_function"] = embedding_function
+        if (
+            embedding_function is not None
+            and configuration.get("embedding_function") is None
+        ):
+            configuration["embedding_function"] = embedding_function
         model = self._server.create_collection(
             name=name,
             metadata=metadata,
@@ -202,8 +205,11 @@ class Client(SharedSystemClient, ClientAPI):
     ) -> Collection:
         if configuration is None:
             configuration = {}
-            if embedding_function is not None:
-                configuration["embedding_function"] = embedding_function
+        if (
+            embedding_function is not None
+            and configuration.get("embedding_function") is None
+        ):
+            configuration["embedding_function"] = embedding_function
         model = self._server.get_or_create_collection(
             name=name,
             metadata=metadata,

--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -543,6 +543,10 @@ def test_spann_default_parameters(client: ClientAPI) -> None:
             assert hnsw_config_loaded.get("ef_construction") == 100
             assert hnsw_config_loaded.get("ef_search") == 100
             assert hnsw_config_loaded.get("max_neighbors") == 16
+
+            ef = loaded_config.get("embedding_function")
+            assert ef is not None
+            assert ef.name() == "default"
     else:
         coll = client.create_collection(
             name="test_spann_defaults",
@@ -558,11 +562,15 @@ def test_spann_default_parameters(client: ClientAPI) -> None:
                 CreateSpannConfiguration, loaded_config.get("spann", {})
             )
             assert spann_config_loaded.get("space") == "cosine"
-            assert spann_config_loaded.get("ef_construction") == 200  # default
-            assert spann_config_loaded.get("max_neighbors") == 16  # default
-            assert spann_config_loaded.get("ef_search") == 200  # default
-            assert spann_config_loaded.get("search_nprobe") == 128  # default
-            assert spann_config_loaded.get("write_nprobe") == 128  # default
+            assert spann_config_loaded.get("ef_construction") == 200
+            assert spann_config_loaded.get("max_neighbors") == 16
+            assert spann_config_loaded.get("ef_search") == 200
+            assert spann_config_loaded.get("search_nprobe") == 128
+            assert spann_config_loaded.get("write_nprobe") == 128
+
+            ef = loaded_config.get("embedding_function")
+            assert ef is not None
+            assert ef.name() == "default"
 
 
 def test_spann_json_serialization(client: ClientAPI) -> None:

--- a/clients/js/packages/chromadb-core/src/ChromaClient.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaClient.ts
@@ -228,6 +228,12 @@ export class ChromaClient {
     configuration,
   }: CreateCollectionParams): Promise<Collection> {
     await this.init();
+    if (!configuration) {
+      configuration = {};
+    }
+    if (embeddingFunction && !configuration.embedding_function) {
+      configuration.embedding_function = embeddingFunction;
+    }
     let collectionConfiguration: Api.CollectionConfiguration | undefined =
       undefined;
     if (configuration) {
@@ -293,10 +299,14 @@ export class ChromaClient {
     configuration,
   }: GetOrCreateCollectionParams): Promise<Collection> {
     await this.init();
-
+    if (!configuration) {
+      configuration = {};
+    }
+    if (embeddingFunction && !configuration.embedding_function) {
+      configuration.embedding_function = embeddingFunction;
+    }
     let collectionConfiguration: Api.CollectionConfiguration | undefined =
       undefined;
-
     if (configuration) {
       collectionConfiguration =
         loadApiCollectionConfigurationFromCreateCollectionConfiguration(


### PR DESCRIPTION
## Description of changes

We had previously decided that providing embedding functions would now be done via the config. This PR makes it so that embedding functions, even if provided via the existing embedding function parameter, would still be routed to the config in the case where the user does not specify an EF in the config. So priority would be
1. config provided EF
2. parameter level EF

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
