### PR TITLE
[CHORE] Support count_forks/num_forks in TestSysDB/Quotas

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -336,7 +336,7 @@ lazy_static::lazy_static! {
         m.insert(UsageType::NumDatabases, 10);
         m.insert(UsageType::NumQueryIDs, 1000);
         m.insert(UsageType::NumRegexPredicates, 0);
-        m.insert(UsageType::NumForks, 1000);
+        m.insert(UsageType::NumForks, 1_000_000);
         m
     };
 }

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -20,6 +20,7 @@ pub enum Action {
     Update,
     Upsert,
     Query,
+    ForkCollection,
 }
 
 impl fmt::Display for Action {
@@ -35,6 +36,7 @@ impl fmt::Display for Action {
             Action::Update => write!(f, "Update"),
             Action::Upsert => write!(f, "Upsert"),
             Action::Query => write!(f, "Query"),
+            Action::ForkCollection => write!(f, "Fork Collection"),
         }
     }
 }
@@ -54,6 +56,7 @@ impl TryFrom<&str> for Action {
             "update" => Ok(Action::Update),
             "upsert" => Ok(Action::Upsert),
             "query" => Ok(Action::Query),
+            "fork_collection" => Ok(Action::ForkCollection),
             _ => Err(format!("Invalid Action: {}", value)),
         }
     }
@@ -241,6 +244,7 @@ pub enum UsageType {
     NumDatabases,          // Total number of databases for a tenant
     NumQueryIDs,           // Number of IDs to filter by in a query
     NumRegexPredicates,    // Number of regex predicates in the where_document
+    NumForks,              // Number of forks a root collection may have
 }
 
 impl fmt::Display for UsageType {
@@ -271,6 +275,7 @@ impl fmt::Display for UsageType {
             UsageType::NumDatabases => write!(f, "Number of databases"),
             UsageType::NumQueryIDs => write!(f, "Number of IDs to filter by in a query"),
             UsageType::NumRegexPredicates => write!(f, "Number of regex predicates"),
+            UsageType::NumForks => write!(f, "Number of forks"),
         }
     }
 }
@@ -301,6 +306,7 @@ impl TryFrom<&str> for UsageType {
             "num_databases" => Ok(UsageType::NumDatabases),
             "num_query_ids" => Ok(UsageType::NumQueryIDs),
             "num_regex_predicates" => Ok(UsageType::NumRegexPredicates),
+            "num_forks" => Ok(UsageType::NumForks),
             _ => Err(format!("Invalid UsageType: {}", value)),
         }
     }
@@ -330,6 +336,7 @@ lazy_static::lazy_static! {
         m.insert(UsageType::NumDatabases, 10);
         m.insert(UsageType::NumQueryIDs, 1000);
         m.insert(UsageType::NumRegexPredicates, 0);
+        m.insert(UsageType::NumForks, 1000);
         m
     };
 }

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -347,7 +347,7 @@ impl SysDb {
         match self {
             SysDb::Grpc(grpc) => grpc.count_forks(source_collection_id).await,
             SysDb::Sqlite(_) => Err(CountForksError::Local),
-            SysDb::Test(_) => Err(CountForksError::Local),
+            SysDb::Test(test) => test.count_forks(source_collection_id).await,
         }
     }
 

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -343,7 +343,7 @@ impl SysDb {
     pub async fn count_forks(
         &mut self,
         source_collection_id: CollectionUuid,
-    ) -> Result<u64, CountForksError> {
+    ) -> Result<usize, CountForksError> {
         match self {
             SysDb::Grpc(grpc) => grpc.count_forks(source_collection_id).await,
             SysDb::Sqlite(_) => Err(CountForksError::Local),
@@ -989,7 +989,7 @@ impl GrpcSysDb {
     pub async fn count_forks(
         &mut self,
         source_collection_id: CollectionUuid,
-    ) -> Result<u64, CountForksError> {
+    ) -> Result<usize, CountForksError> {
         let res = self
             .client
             .count_forks(chroma_proto::CountForksRequest {
@@ -1002,7 +1002,7 @@ impl GrpcSysDb {
             })?
             .into_inner();
 
-        Ok(res.count)
+        Ok(res.count as usize)
     }
 
     pub async fn get_collections_to_gc(

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -1,7 +1,8 @@
 use chroma_types::{
-    Collection, CollectionAndSegments, CollectionUuid, Database, FlushCompactionResponse,
-    GetCollectionSizeError, GetCollectionWithSegmentsError, GetSegmentsError, ListDatabasesError,
-    ListDatabasesResponse, Segment, SegmentFlushInfo, SegmentScope, SegmentType, Tenant,
+    Collection, CollectionAndSegments, CollectionUuid, CountForksError, Database,
+    FlushCompactionResponse, GetCollectionSizeError, GetCollectionWithSegmentsError,
+    GetSegmentsError, ListDatabasesError, ListDatabasesResponse, Segment, SegmentFlushInfo,
+    SegmentScope, SegmentType, Tenant,
 };
 use chroma_types::{GetCollectionsError, SegmentUuid};
 use parking_lot::Mutex;
@@ -540,5 +541,12 @@ impl TestSysDb {
             record_segment,
             vector_segment,
         })
+    }
+
+    pub(crate) async fn count_forks(
+        &mut self,
+        _source_collection_id: CollectionUuid,
+    ) -> Result<u64, CountForksError> {
+        Ok(10)
     }
 }

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -546,7 +546,7 @@ impl TestSysDb {
     pub(crate) async fn count_forks(
         &mut self,
         _source_collection_id: CollectionUuid,
-    ) -> Result<u64, CountForksError> {
+    ) -> Result<usize, CountForksError> {
         Ok(10)
     }
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - Implements the `count_forks` method on `TestSysDb`
  - Updates quotas to support a `UsageType::NumForks` `Action::ForkCollection`
  - Updates `fork_collection` API to enforce quotas on `Action::ForkCollection`

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
<!-- Summary by @propel-code-bot -->

---

This PR implements the `count_forks` method in the `TestSysDb` class and adds fork collection support to the quota system. The implementation returns a fixed value of 10 for testing purposes, and changes the return type from `u64` to `usize` for consistency.

*This summary was automatically generated by @propel-code-bot*