### PR TITLE
[ENH]  Allow collections to shunt to the alt log by tenant.

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -659,7 +659,9 @@ impl ServiceBasedFrontend {
         collection_id: CollectionUuid,
         records: Vec<OperationRecord>,
     ) -> Result<(), Box<dyn ChromaError>> {
-        self.log_client.push_logs(tenant_id, collection_id, records).await
+        self.log_client
+            .push_logs(tenant_id, collection_id, records)
+            .await
     }
 
     pub async fn add(

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -582,7 +582,7 @@ impl ServiceBasedFrontend {
         let target_collection_id = CollectionUuid::new();
         let log_offsets = self
             .log_client
-            .fork_logs(source_collection_id, target_collection_id)
+            .fork_logs(&tenant_id, source_collection_id, target_collection_id)
             .await?;
         let collection_and_segments = self
             .sysdb_client
@@ -655,10 +655,11 @@ impl ServiceBasedFrontend {
 
     pub async fn retryable_push_logs(
         &mut self,
+        tenant_id: &str,
         collection_id: CollectionUuid,
         records: Vec<OperationRecord>,
     ) -> Result<(), Box<dyn ChromaError>> {
-        self.log_client.push_logs(collection_id, records).await
+        self.log_client.push_logs(tenant_id, collection_id, records).await
     }
 
     pub async fn add(
@@ -691,9 +692,10 @@ impl ServiceBasedFrontend {
         let add_to_retry = || {
             let mut self_clone = self.clone();
             let records_clone = records.clone();
+            let tenant_id_clone = tenant_id.clone();
             async move {
                 self_clone
-                    .retryable_push_logs(collection_id, records_clone)
+                    .retryable_push_logs(&tenant_id_clone, collection_id, records_clone)
                     .await
             }
         };
@@ -768,9 +770,10 @@ impl ServiceBasedFrontend {
         let add_to_retry = || {
             let mut self_clone = self.clone();
             let records_clone = records.clone();
+            let tenant_id_clone = tenant_id.clone();
             async move {
                 self_clone
-                    .retryable_push_logs(collection_id, records_clone)
+                    .retryable_push_logs(&tenant_id_clone, collection_id, records_clone)
                     .await
             }
         };
@@ -847,9 +850,10 @@ impl ServiceBasedFrontend {
         let add_to_retry = || {
             let mut self_clone = self.clone();
             let records_clone = records.clone();
+            let tenant_id_clone = tenant_id.clone();
             async move {
                 self_clone
-                    .retryable_push_logs(collection_id, records_clone)
+                    .retryable_push_logs(&tenant_id_clone, collection_id, records_clone)
                     .await
             }
         };
@@ -986,7 +990,7 @@ impl ServiceBasedFrontend {
         let log_size_bytes = records.iter().map(OperationRecord::size_bytes).sum();
 
         self.log_client
-            .push_logs(collection_id, records)
+            .push_logs(&tenant_id, collection_id, records)
             .await
             .map_err(|err| {
                 if err.code() == ErrorCodes::Unavailable {

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -24,6 +24,8 @@ pub struct GrpcLogConfig {
     #[serde(default)]
     pub use_alt_host_for_everything: bool,
     #[serde(default)]
+    pub use_alt_for_tenants: Vec<String>,
+    #[serde(default)]
     pub use_alt_for_collections: Vec<String>,
 }
 
@@ -64,6 +66,7 @@ impl Default for GrpcLogConfig {
             max_decoding_message_size: GrpcLogConfig::default_max_decoding_message_size(),
             alt_host: None,
             use_alt_host_for_everything: false,
+            use_alt_for_tenants: vec![],
             use_alt_for_collections: vec![],
         }
     }

--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -168,6 +168,7 @@ impl Handler<BackfillMessage> for LocalCompactionManager {
         let logs = self
             .log
             .read(
+                &collection_and_segments.collection.tenant,
                 collection_and_segments.collection.collection_id,
                 mt_max_seq_id.min(hnsw_max_seq_id) as i64,
                 -1,

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -33,6 +33,7 @@ impl Log {
     #[tracing::instrument(skip(self))]
     pub async fn read(
         &mut self,
+        tenant: &str,
         collection_id: CollectionUuid,
         offset: i64,
         batch_size: i32,
@@ -44,7 +45,7 @@ impl Log {
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::Grpc(log) => log
-                .read(collection_id, offset, batch_size, end_timestamp)
+                .read(tenant, collection_id, offset, batch_size, end_timestamp)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::InMemory(log) => Ok(log
@@ -57,6 +58,7 @@ impl Log {
     #[tracing::instrument(skip(self))]
     pub async fn scout_logs(
         &mut self,
+        tenant: &str,
         collection_id: CollectionUuid,
         starting_offset: u64,
     ) -> Result<u64, Box<dyn ChromaError>> {
@@ -66,7 +68,7 @@ impl Log {
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::Grpc(log) => log
-                .scout_logs(collection_id, starting_offset)
+                .scout_logs(tenant, collection_id, starting_offset)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::InMemory(log) => log
@@ -79,6 +81,7 @@ impl Log {
     #[tracing::instrument(skip(self, records))]
     pub async fn push_logs(
         &mut self,
+        tenant: &str,
         collection_id: CollectionUuid,
         records: Vec<OperationRecord>,
     ) -> Result<(), Box<dyn ChromaError>> {
@@ -88,7 +91,7 @@ impl Log {
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::Grpc(log) => log
-                .push_logs(collection_id, records)
+                .push_logs(tenant, collection_id, records)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::InMemory(_) => unimplemented!(),
@@ -98,13 +101,14 @@ impl Log {
     #[tracing::instrument(skip(self))]
     pub async fn fork_logs(
         &mut self,
+        tenant: &str,
         source_collection_id: CollectionUuid,
         target_collection_id: CollectionUuid,
     ) -> Result<ForkLogsResponse, ForkCollectionError> {
         match self {
             Log::Sqlite(_) => Err(ForkCollectionError::Local),
             Log::Grpc(log) => log
-                .fork_logs(source_collection_id, target_collection_id)
+                .fork_logs(tenant, source_collection_id, target_collection_id)
                 .await
                 .map_err(|err| err.boxed().into()),
             Log::InMemory(_) => Err(ForkCollectionError::Local),
@@ -132,6 +136,7 @@ impl Log {
     #[tracing::instrument(skip(self))]
     pub async fn update_collection_log_offset(
         &mut self,
+        tenant: &str,
         collection_id: CollectionUuid,
         new_offset: i64,
     ) -> Result<(), Box<dyn ChromaError>> {
@@ -141,7 +146,7 @@ impl Log {
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::Grpc(log) => log
-                .update_collection_log_offset(collection_id, new_offset)
+                .update_collection_log_offset(tenant, collection_id, new_offset)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn ChromaError>),
             Log::InMemory(log) => {

--- a/rust/worker/benches/load.rs
+++ b/rust/worker/benches/load.rs
@@ -58,6 +58,7 @@ pub fn empty_fetch_log(collection_uuid: CollectionUuid) -> FetchLogOperator {
         start_log_offset_id: 0,
         maximum_fetch_count: Some(0),
         collection_uuid,
+        tenant: "default_tenant".to_string(),
     }
 }
 

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -592,7 +592,9 @@ mod tests {
                 },
             },
         );
-        let _ = log.update_collection_log_offset(&tenant_1, collection_uuid_1, 2).await;
+        let _ = log
+            .update_collection_log_offset(&tenant_1, collection_uuid_1, 2)
+            .await;
 
         let mut sysdb = SysDb::Test(TestSysDb::new());
 

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -592,7 +592,7 @@ mod tests {
                 },
             },
         );
-        let _ = log.update_collection_log_offset(collection_uuid_1, 2).await;
+        let _ = log.update_collection_log_offset(&tenant_1, collection_uuid_1, 2).await;
 
         let mut sysdb = SysDb::Test(TestSysDb::new());
 

--- a/rust/worker/src/execution/operators/fetch_log.rs
+++ b/rust/worker/src/execution/operators/fetch_log.rs
@@ -34,6 +34,7 @@ pub struct FetchLogOperator {
     pub start_log_offset_id: u64,
     pub maximum_fetch_count: Option<u32>,
     pub collection_uuid: CollectionUuid,
+    pub tenant: String,
 }
 
 type FetchLogInput = ();
@@ -77,7 +78,7 @@ impl Operator<FetchLogInput, FetchLogOutput> for FetchLogOperator {
 
         let mut log_client = self.log_client.clone();
         let limit_offset = log_client
-            .scout_logs(self.collection_uuid, self.start_log_offset_id)
+            .scout_logs(&self.tenant, self.collection_uuid, self.start_log_offset_id)
             .await
             .ok();
         let mut fetched = Vec::new();
@@ -112,7 +113,7 @@ impl Operator<FetchLogInput, FetchLogOutput> for FetchLogOperator {
                     async move {
                         let _permit = sema.acquire().await.unwrap();
                         log_client
-                            .read(collection_uuid, start, num_records, Some(timestamp))
+                            .read(&self.tenant, collection_uuid, start, num_records, Some(timestamp))
                             .await
                     }
                 })
@@ -134,6 +135,7 @@ impl Operator<FetchLogInput, FetchLogOutput> for FetchLogOperator {
             loop {
                 let mut log_batch = log_client
                     .read(
+                        &self.tenant,
                         self.collection_uuid,
                         offset,
                         self.batch_size as i32,
@@ -209,6 +211,7 @@ mod tests {
             start_log_offset_id: 0,
             maximum_fetch_count: None,
             collection_uuid,
+            tenant: "test-tenant".to_string(),
         };
 
         let logs = fetch_log_operator
@@ -233,6 +236,7 @@ mod tests {
             start_log_offset_id: 3,
             maximum_fetch_count: Some(3),
             collection_uuid,
+            tenant: "test-tenant".to_string(),
         };
 
         let logs = fetch_log_operator

--- a/rust/worker/src/execution/operators/fetch_log.rs
+++ b/rust/worker/src/execution/operators/fetch_log.rs
@@ -113,7 +113,13 @@ impl Operator<FetchLogInput, FetchLogOutput> for FetchLogOperator {
                     async move {
                         let _permit = sema.acquire().await.unwrap();
                         log_client
-                            .read(&self.tenant, collection_uuid, start, num_records, Some(timestamp))
+                            .read(
+                                &self.tenant,
+                                collection_uuid,
+                                start,
+                                num_records,
+                                Some(timestamp),
+                            )
                             .await
                     }
                 })

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -133,7 +133,7 @@ impl Operator<RegisterInput, RegisterOutput> for RegisterOperator {
         };
 
         let result = log
-            .update_collection_log_offset(input.collection_id, input.log_position)
+            .update_collection_log_offset(&input.tenant, input.collection_id, input.log_position)
             .await;
 
         match result {

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -626,6 +626,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                         .unwrap_or_default(),
                     maximum_fetch_count: Some(self.max_compaction_size as u32),
                     collection_uuid: self.collection_id,
+                    tenant: collection.tenant.clone(),
                 }),
                 (),
                 ctx.receiver(),
@@ -1131,6 +1132,7 @@ mod tests {
                 .unwrap_or_default(),
             maximum_fetch_count: None,
             collection_uuid: collection_id,
+            tenant: old_cas.collection.tenant.clone(),
         };
         let filter = FilterOperator {
             query_ids: None,

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -142,6 +142,7 @@ impl WorkerServer {
                 .unwrap_or_default(),
             maximum_fetch_count: None,
             collection_uuid: collection_and_segments.collection.collection_id,
+            tenant: collection_and_segments.collection.tenant.clone(),
         }
     }
 


### PR DESCRIPTION
## Description of changes

This adds an additional shunt path where a tenant can be listed for
access to the alt log.  This should make it possible to move a smoke
test tenant to the log.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A