### PR TITLE
[ENH]: Add quota on regex pattern length

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -243,7 +243,7 @@ pub enum UsageType {
     NumCollections,        // Total number of collections for a tenant
     NumDatabases,          // Total number of databases for a tenant
     NumQueryIDs,           // Number of IDs to filter by in a query
-    NumRegexPredicates,    // Number of regex predicates in the where_document
+    RegexPatternLength,    // Length of regex pattern specified in filter
     NumForks,              // Number of forks a root collection may have
 }
 
@@ -274,7 +274,7 @@ impl fmt::Display for UsageType {
             UsageType::NumCollections => write!(f, "Number of collections"),
             UsageType::NumDatabases => write!(f, "Number of databases"),
             UsageType::NumQueryIDs => write!(f, "Number of IDs to filter by in a query"),
-            UsageType::NumRegexPredicates => write!(f, "Number of regex predicates"),
+            UsageType::RegexPatternLength => write!(f, "Length of regex pattern"),
             UsageType::NumForks => write!(f, "Number of forks"),
         }
     }
@@ -305,7 +305,7 @@ impl TryFrom<&str> for UsageType {
             "num_collections" => Ok(UsageType::NumCollections),
             "num_databases" => Ok(UsageType::NumDatabases),
             "num_query_ids" => Ok(UsageType::NumQueryIDs),
-            "num_regex_predicates" => Ok(UsageType::NumRegexPredicates),
+            "regex_pattern_length" => Ok(UsageType::RegexPatternLength),
             "num_forks" => Ok(UsageType::NumForks),
             _ => Err(format!("Invalid UsageType: {}", value)),
         }
@@ -335,7 +335,7 @@ lazy_static::lazy_static! {
         m.insert(UsageType::NumCollections, 1_000_000);
         m.insert(UsageType::NumDatabases, 10);
         m.insert(UsageType::NumQueryIDs, 1000);
-        m.insert(UsageType::NumRegexPredicates, 0);
+        m.insert(UsageType::RegexPatternLength, 0);
         m.insert(UsageType::NumForks, 1_000_000);
         m
     };


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Removed the num regex predicates
  - Added the regex pattern length with a default of 0
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
