### PR TITLE
[ENH]  Display errors for all log calls.

### DIFF
--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -30,7 +30,7 @@ pub enum Log {
 }
 
 impl Log {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(Display))]
     pub async fn read(
         &mut self,
         collection_id: CollectionUuid,
@@ -54,7 +54,7 @@ impl Log {
     }
 
     // ScoutLogs returns the offset of the next record to be inserted into the log.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(Display))]
     pub async fn scout_logs(
         &mut self,
         collection_id: CollectionUuid,
@@ -76,7 +76,7 @@ impl Log {
         }
     }
 
-    #[tracing::instrument(skip(self, records))]
+    #[tracing::instrument(skip(self, records), err(Display))]
     pub async fn push_logs(
         &mut self,
         collection_id: CollectionUuid,
@@ -95,7 +95,7 @@ impl Log {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(Display))]
     pub async fn fork_logs(
         &mut self,
         source_collection_id: CollectionUuid,
@@ -111,7 +111,7 @@ impl Log {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(Display))]
     pub async fn get_collections_with_new_data(
         &mut self,
         min_compaction_size: u64,
@@ -129,7 +129,7 @@ impl Log {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(Display))]
     pub async fn update_collection_log_offset(
         &mut self,
         collection_id: CollectionUuid,
@@ -153,7 +153,7 @@ impl Log {
     }
 
     /// Only supported in distributed. Sqlite has a different workflow.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), err(Display))]
     pub async fn purge_dirty_for_collection(
         &mut self,
         collection_id: CollectionUuid,


### PR DESCRIPTION
## Description of changes

This will trace the return value of every log call when it takes an Err(_) variant.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
