### PR TITLE
[ENH] Add validation when multiple embedding functions set on client

### DIFF
--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -7,6 +7,8 @@ from chromadb.api import AdminAPI, ClientAPI, ServerAPI
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,
+    validate_embedding_function_conflict_on_create,
+    validate_embedding_function_conflict_on_get,
 )
 from chromadb.api.shared_system_client import SharedSystemClient
 from chromadb.api.types import (
@@ -151,11 +153,18 @@ class Client(SharedSystemClient, ClientAPI):
     ) -> Collection:
         if configuration is None:
             configuration = {}
-        if (
-            embedding_function is not None
-            and configuration.get("embedding_function") is None
-        ):
+
+        configuration_ef = configuration.get("embedding_function")
+
+        validate_embedding_function_conflict_on_create(
+            embedding_function, configuration_ef
+        )
+
+        # If ef provided in function params and collection config ef is None,
+        # set the collection config ef to the function params
+        if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
+
         model = self._server.create_collection(
             name=name,
             metadata=metadata,
@@ -185,6 +194,12 @@ class Client(SharedSystemClient, ClientAPI):
             tenant=self.tenant,
             database=self.database,
         )
+        persisted_ef_config = model.configuration_json.get("embedding_function")
+
+        validate_embedding_function_conflict_on_get(
+            embedding_function, persisted_ef_config
+        )
+
         return Collection(
             client=self._server,
             model=model,
@@ -205,10 +220,14 @@ class Client(SharedSystemClient, ClientAPI):
     ) -> Collection:
         if configuration is None:
             configuration = {}
-        if (
-            embedding_function is not None
-            and configuration.get("embedding_function") is None
-        ):
+
+        configuration_ef = configuration.get("embedding_function")
+
+        validate_embedding_function_conflict_on_create(
+            embedding_function, configuration_ef
+        )
+
+        if embedding_function is not None and configuration_ef is None:
             configuration["embedding_function"] = embedding_function
         model = self._server.get_or_create_collection(
             name=name,
@@ -217,6 +236,13 @@ class Client(SharedSystemClient, ClientAPI):
             database=self.database,
             configuration=configuration,
         )
+
+        persisted_ef_config = model.configuration_json.get("embedding_function")
+
+        validate_embedding_function_conflict_on_get(
+            embedding_function, persisted_ef_config
+        )
+
         return Collection(
             client=self._server,
             model=model,

--- a/clients/js/packages/chromadb-core/src/ChromaClient.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaClient.ts
@@ -18,7 +18,11 @@ import type {
   UserIdentity,
 } from "./types";
 import { validateTenantDatabase, wrapCollection } from "./utils";
-import { loadApiCollectionConfigurationFromCreateCollectionConfiguration } from "./CollectionConfiguration";
+import {
+  loadApiCollectionConfigurationFromCreateCollectionConfiguration,
+  loadCollectionConfigurationFromJson,
+  hasEmbeddingFunctionConflict,
+} from "./CollectionConfiguration";
 import { warn } from "console";
 const DEFAULT_TENANT = "default_tenant";
 const DEFAULT_DATABASE = "default_database";
@@ -231,6 +235,16 @@ export class ChromaClient {
     if (!configuration) {
       configuration = {};
     }
+    if (
+      hasEmbeddingFunctionConflict(
+        embeddingFunction,
+        configuration.embedding_function,
+      )
+    ) {
+      throw new Error(
+        "Multiple embedding functions provided. Please provide only one.",
+      );
+    }
     if (embeddingFunction && !configuration.embedding_function) {
       configuration.embedding_function = embeddingFunction;
     }
@@ -301,6 +315,16 @@ export class ChromaClient {
     await this.init();
     if (!configuration) {
       configuration = {};
+    }
+    if (
+      hasEmbeddingFunctionConflict(
+        embeddingFunction,
+        configuration.embedding_function,
+      )
+    ) {
+      throw new Error(
+        "Multiple embedding functions provided. Please provide only one.",
+      );
     }
     if (embeddingFunction && !configuration.embedding_function) {
       configuration.embedding_function = embeddingFunction;
@@ -471,14 +495,25 @@ export class ChromaClient {
       );
     }
 
+    const configObj = loadCollectionConfigurationFromJson(config);
+    if (
+      hasEmbeddingFunctionConflict(
+        embeddingFunction,
+        configObj.embedding_function,
+      )
+    ) {
+      throw new Error(
+        "Multiple embedding functions provided. Please provide only one.",
+      );
+    }
+
+    const ef = configObj.embedding_function ?? embeddingFunction;
+
     return wrapCollection(this, {
       id: response.id,
       name: response.name,
       metadata: response.metadata as CollectionMetadata | undefined,
-      embeddingFunction:
-        embeddingFunction !== undefined
-          ? embeddingFunction
-          : new DefaultEmbeddingFunction(),
+      embeddingFunction: ef ?? new DefaultEmbeddingFunction(),
       configuration: config,
     });
   }

--- a/clients/js/packages/chromadb-core/src/CollectionConfiguration.ts
+++ b/clients/js/packages/chromadb-core/src/CollectionConfiguration.ts
@@ -359,3 +359,33 @@ export function loadApiUpdateCollectionConfigurationFromUpdateCollectionConfigur
     config,
   ) as Api.UpdateCollectionConfiguration;
 }
+
+/**
+ * Checks if there are conflicting embedding functions between function parameter
+ * and collection configuration.
+ *
+ * @param embeddingFunction - The embedding function provided as a parameter
+ * @param configurationEmbeddingFunction - The embedding function from collection configuration
+ * @returns true if there is a conflict, false otherwise
+ */
+export function hasEmbeddingFunctionConflict(
+  embeddingFunction?: IEmbeddingFunction | null,
+  configurationEmbeddingFunction?: IEmbeddingFunction | null,
+): boolean {
+  // If ef provided in function params and collection config, check if they are the same
+  // If not, there's a conflict
+  // ef is by default "default" if not provided, so ignore that case.
+  if (
+    embeddingFunction &&
+    embeddingFunction.name !== "default" &&
+    configurationEmbeddingFunction
+  ) {
+    const efConfig = embeddingFunction.getConfig?.();
+    const collConfigEfConfig = configurationEmbeddingFunction.getConfig?.();
+
+    if (embeddingFunction.name !== configurationEmbeddingFunction.name) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Description of changes

This PR adds validation on create, get, and get_or_create collection to ensure that if embedding functions are provided in both places, it raises an error for the user if they are incompatible

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
