### PR TITLE
[CLN] fork_collection quota cleanup

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -967,11 +967,7 @@ func (tc *Catalog) ForkCollection(ctx context.Context, forkCollection *model.For
 		if err != nil {
 			return err
 		}
-		// NOTE: This is a temporary hardcoded limit for the size of the lineage file
-		// TODO: Load the limit value from quota / scorecard, and/or improve the lineage file design to avoid large lineage file
-		if len(lineageFile.Dependencies) > 1000000 {
-			return common.ErrCollectionTooManyFork
-		}
+
 		lineageFile.Dependencies = append(lineageFile.Dependencies, &coordinatorpb.CollectionVersionDependency{
 			SourceCollectionId:      sourceCollectionIDStr,
 			SourceCollectionVersion: uint64(sourceCollection.Version),

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -336,7 +336,7 @@ lazy_static::lazy_static! {
         m.insert(UsageType::NumDatabases, 10);
         m.insert(UsageType::NumQueryIDs, 1000);
         m.insert(UsageType::RegexPatternLength, 0);
-        m.insert(UsageType::NumForks, 1_000_000);
+        m.insert(UsageType::NumForks, 10000);
         m
     };
 }

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1175,6 +1175,7 @@ async fn fork_collection(
         CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?;
     let mut quota_payload = QuotaPayload::new(Action::ForkCollection, tenant.clone(), api_token);
     quota_payload = quota_payload.with_collection_uuid(collection_id);
+    quota_payload = quota_payload.with_collection_name(&payload.new_name);
     server.quota_enforcer.enforce(&quota_payload).await?;
 
     let _guard =


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Default hardcoded `NUM_FORKS` value 1000000 --> 10000
  - Send fork collection name to quota enforcer
  - Remove hardcoded fork tree check in SysDB
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
