### PR TITLE
[BLD]: fix secret usage for Go test reusable workflow

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -61,6 +61,7 @@ jobs:
   go-tests:
     name: Go tests
     uses: ./.github/workflows/_go-tests.yml
+    secrets: inherit
 
   release-docker:
     name: Publish to DockerHub and GHCR


### PR DESCRIPTION
## Description of changes

https://github.com/chroma-core/chroma/pull/4479 added auth against DockerHub for higher rate limits when pulling, but I forgot to update the release workflow to properly propogate the secrets down.
