### PR TITLE
fix: unchecked key lookup in Python dict

### DIFF
--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -205,9 +205,14 @@ class ConfigurationInternal(JSONSerializable["ConfigurationInternal"]):
     def from_json(cls, json_map: Dict[str, Any]) -> Self:
         """Returns a configuration from the given JSON string."""
         if cls.__name__ != json_map.get("_type", None):
-            raise ValueError(
-                f"Trying to instantiate configuration of type {cls.__name__} from JSON with type {json_map['_type']}"
-            )
+            if '_type' in json_map:
+                raise ValueError(
+                    f"Trying to instantiate configuration of type {cls.__name__} from JSON with type {json_map.get('_type')}"
+                )
+            else:
+                raise ValueError(
+                    f"Trying to instantiate configuration of type {cls.__name__} from JSON, but no type found in json_map"
+                )
         parameters = []
         for name, value in json_map.items():
             # Type value is only for storage


### PR DESCRIPTION
## Description of changes

This pull request refines error handling in the `from_json` method of the `chromadb/api/configuration.py` file.

### Improvements to error handling:

* Enhanced the `from_json` method to raise a specific error message when the `_type` key is missing in the input `json_map`. This ensures clearer error reporting for debugging.

### Context

When I was playing around with the Chroma Cloud, I received the following error message when trying to create collection:

```
f"Trying to instantiate configuration of type {cls.__name__} from JSON with type {json_map['_type']}"
                                                                                  ~~~~~~~~^^^^^^^^^
KeyError: '_type'
```

The error arises from trying to grab the '_type' key from `json_map` via [] syntax without first checking if the key exists, which leads to the Python KeyError. It's unfortunate that the [] syntax is used instead of the .get() syntax which is safer because it returns `None` by default. 

The line above actually uses the correct .get() syntax:

```python
if cls.__name__ != json_map.get("_type", None):
```

and it's apparent that the '_type' key might not exist on `json_map`, so accessing `json_map['_type']` in the next line is dangerous.

My guess is that Chroma Cloud returns a config object when creating a collection, and sometimes that config schema can get out of sync with the client's version. I'm running `chromadb==0.6.3` locally.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
