### PR TITLE
[CHORE] Reduce default NUM_FORKS quota rule value

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -337,7 +337,7 @@ lazy_static::lazy_static! {
         m.insert(UsageType::NumDatabases, 10);
         m.insert(UsageType::NumQueryIDs, 1000);
         m.insert(UsageType::RegexPatternLength, 0);
-        m.insert(UsageType::NumForks, 10000);
+        m.insert(UsageType::NumForks, 256);
         m
     };
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Reduce default NUM_FORKS quota from 10000 to 256
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
