### PR TITLE
[CHORE]  Fix test-embeddings.py and test_sanity

### DIFF
--- a/chromadb/test/distributed/test_sanity.py
+++ b/chromadb/test/distributed/test_sanity.py
@@ -67,6 +67,7 @@ def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
         name="test_add_include_all_with_compaction_delay",
         metadata={"hnsw:construction_ef": 128, "hnsw:search_ef": 128, "hnsw:M": 128},
     )
+    initial_version = get_collection_version(client, collection.name)
 
     ids = []
     embeddings = []
@@ -81,7 +82,7 @@ def test_add_include_all_with_compaction_delay(client: ClientAPI) -> None:
             documents=[documents[-1]],
         )
 
-    wait_for_version_increase(client, collection.name, get_collection_version(client, collection.name), 120)
+    wait_for_version_increase(client, collection.name, initial_version, 120)
 
     random_query_1 = np.random.rand(1, 3)[0]
     random_query_2 = np.random.rand(1, 3)[0]

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -1464,6 +1464,7 @@ def test_encompassing_delete(client: ClientAPI) -> None:
     reset(client)
 
     col = client.create_collection("encompassing_delete")
+    initial_version = get_collection_version(client, col.name)
 
     id_start = 0
     # Add and then Delete 6 records
@@ -1476,8 +1477,9 @@ def test_encompassing_delete(client: ClientAPI) -> None:
 
     if not NOT_CLUSTER_ONLY:
         wait_for_version_increase(
-            client, col.name, get_collection_version(client, col.name), VERSION_INCREASE_WAIT_TIME
+            client, col.name, initial_version, VERSION_INCREASE_WAIT_TIME
         )
+    initial_version = get_collection_version(client, col.name)
 
     # Add and then delete and then add 16
     len_to_add = 16
@@ -1490,7 +1492,7 @@ def test_encompassing_delete(client: ClientAPI) -> None:
 
     if not NOT_CLUSTER_ONLY:
         wait_for_version_increase(
-            client, col.name, get_collection_version(client, col.name), VERSION_INCREASE_WAIT_TIME
+            client, col.name, initial_version, VERSION_INCREASE_WAIT_TIME
         )
 
     # Ensure we can get all


### PR DESCRIPTION
## Description of changes

It would add and delete items in such a way that it's theoretically
possible to have a version increase before checking the current version.
Waiting for "current", then, actually begs the question and waits for
itself.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
