### PR TITLE
[TST]  Check for an off-by-one in local_compaction_manager.rs

### DIFF
--- a/rust/log/src/local_compaction_manager.rs
+++ b/rust/log/src/local_compaction_manager.rs
@@ -171,7 +171,7 @@ impl Handler<BackfillMessage> for LocalCompactionManager {
                 &collection_and_segments.collection.tenant,
                 collection_and_segments.collection.collection_id,
                 mt_max_seq_id.min(hnsw_max_seq_id) as i64,
-                -1,
+                0,
                 None,
             )
             .await


### PR DESCRIPTION
## Description of changes

It passes -1, but 0 is the first valid log enumeration offset, making 1 the first valid log record.

## Test plan

I'm sending it through CI and will add a test if it passes with the obo corrected.

## Documentation Changes

N/A
