### PR TITLE
[ENH]: `ListCollectionsToGc` returns lineage file path, group by fork tree, accept optional tenant for filtering

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -247,8 +247,8 @@ func (s *Coordinator) FlushCollectionCompaction(ctx context.Context, flushCollec
 	return s.catalog.FlushCollectionCompaction(ctx, flushCollectionCompaction)
 }
 
-func (s *Coordinator) ListCollectionsToGc(ctx context.Context, cutoffTimeSecs *uint64, limit *uint64) ([]*model.CollectionToGc, error) {
-	return s.catalog.ListCollectionsToGc(ctx, cutoffTimeSecs, limit)
+func (s *Coordinator) ListCollectionsToGc(ctx context.Context, cutoffTimeSecs *uint64, limit *uint64, tenantID *string) ([]*model.CollectionToGc, error) {
+	return s.catalog.ListCollectionsToGc(ctx, cutoffTimeSecs, limit, tenantID)
 }
 
 func (s *Coordinator) ListCollectionVersions(ctx context.Context, collectionID types.UniqueID, tenantID string, maxCount *int64, versionsBefore *int64, versionsAtOrAfter *int64, includeMarkedForDeletion bool) ([]*coordinatorpb.CollectionVersionInfo, error) {

--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -28,7 +28,7 @@ type CollectionToGc struct {
 	TenantID        string
 	Name            string
 	VersionFilePath string
-	LatestVersion   int64
+	LineageFilePath *string
 }
 
 type CreateCollection struct {

--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -51,8 +51,8 @@ func convertCollectionToGcToModel(collectionToGc []*dbmodel.CollectionToGc) []*m
 			ID:              types.MustParse(collectionInfo.ID),
 			Name:            collectionInfo.Name,
 			VersionFilePath: collectionInfo.VersionFileName,
-			LatestVersion:   int64(collectionInfo.Version),
 			TenantID:        collectionInfo.TenantID,
+			LineageFilePath: collectionInfo.LineageFileName,
 		}
 		collections = append(collections, &collection)
 	}

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -444,14 +444,14 @@ func (tc *Catalog) GetCollectionSize(ctx context.Context, collectionID types.Uni
 	return total_records_post_compaction, nil
 }
 
-func (tc *Catalog) ListCollectionsToGc(ctx context.Context, cutoffTimeSecs *uint64, limit *uint64) ([]*model.CollectionToGc, error) {
+func (tc *Catalog) ListCollectionsToGc(ctx context.Context, cutoffTimeSecs *uint64, limit *uint64, tenantID *string) ([]*model.CollectionToGc, error) {
 	tracer := otel.Tracer
 	if tracer != nil {
 		_, span := tracer.Start(ctx, "Catalog.ListCollectionsToGc")
 		defer span.End()
 	}
 
-	collectionsToGc, err := tc.metaDomain.CollectionDb(ctx).ListCollectionsToGc(cutoffTimeSecs, limit)
+	collectionsToGc, err := tc.metaDomain.CollectionDb(ctx).ListCollectionsToGc(cutoffTimeSecs, limit, tenantID)
 
 	if err != nil {
 		return nil, err

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -495,7 +495,7 @@ func (s *Server) ListCollectionsToGc(ctx context.Context, req *coordinatorpb.Lis
 		absoluteCutoffTimeSecs = &cutoffTime
 	}
 
-	collectionsToGc, err := s.coordinator.ListCollectionsToGc(ctx, absoluteCutoffTimeSecs, req.Limit)
+	collectionsToGc, err := s.coordinator.ListCollectionsToGc(ctx, absoluteCutoffTimeSecs, req.Limit, req.TenantId)
 	if err != nil {
 		log.Error("ListCollectionsToGc failed", zap.Error(err))
 		return nil, grpcutils.BuildInternalGrpcError(err.Error())
@@ -507,6 +507,7 @@ func (s *Server) ListCollectionsToGc(ctx context.Context, req *coordinatorpb.Lis
 			Name:            collectionToGc.Name,
 			VersionFilePath: collectionToGc.VersionFilePath,
 			TenantId:        collectionToGc.TenantID,
+			LineageFilePath: collectionToGc.LineageFilePath,
 		})
 	}
 	return res, nil

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -33,10 +33,9 @@ type CollectionToGc struct {
 	ID              string    `gorm:"id;primaryKey"`
 	TenantID        string    `gorm:"tenant_id;not null;index:idx_tenant_id"`
 	Name            string    `gorm:"name;not null;index:idx_name,unique;"`
-	Version         int32     `gorm:"version;default:0"`
 	VersionFileName string    `gorm:"version_file_name"`
 	OldestVersionTs time.Time `gorm:"oldest_version_ts;type:timestamp"`
-	NumVersions     uint32    `gorm:"num_versions;default:0"`
+	LineageFileName *string   `gorm:"lineage_file_name"`
 }
 
 func (v Collection) TableName() string {
@@ -65,7 +64,7 @@ type ICollectionDb interface {
 		sizeBytesPostCompaction uint64, lastCompactionTimeSecs uint64) (int64, error)
 	GetCollectionEntry(collectionID *string, databaseName *string) (*Collection, error)
 	GetCollectionSize(collectionID string) (uint64, error)
-	ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64) ([]*CollectionToGc, error)
+	ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64, tenantID *string) ([]*CollectionToGc, error)
 	UpdateVersionRelatedFields(collectionID, existingVersionFileName, newVersionFileName string, oldestVersionTs *time.Time, numActiveVersions *int) (int64, error)
 	LockCollection(collectionID string) error
 	UpdateCollectionLineageFilePath(collectionID string, currentLineageFilePath string, newLineageFilePath string) error

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -254,9 +254,9 @@ func (_m *ICollectionDb) Insert(in *dbmodel.Collection) error {
 	return r0
 }
 
-// ListCollectionsToGc provides a mock function with given fields: cutoffTimeSecs, limit
-func (_m *ICollectionDb) ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64) ([]*dbmodel.CollectionToGc, error) {
-	ret := _m.Called(cutoffTimeSecs, limit)
+// ListCollectionsToGc provides a mock function with given fields: cutoffTimeSecs, limit, tenantID
+func (_m *ICollectionDb) ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64, tenantID *string) ([]*dbmodel.CollectionToGc, error) {
+	ret := _m.Called(cutoffTimeSecs, limit, tenantID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListCollectionsToGc")
@@ -264,19 +264,19 @@ func (_m *ICollectionDb) ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint
 
 	var r0 []*dbmodel.CollectionToGc
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*uint64, *uint64) ([]*dbmodel.CollectionToGc, error)); ok {
-		return rf(cutoffTimeSecs, limit)
+	if rf, ok := ret.Get(0).(func(*uint64, *uint64, *string) ([]*dbmodel.CollectionToGc, error)); ok {
+		return rf(cutoffTimeSecs, limit, tenantID)
 	}
-	if rf, ok := ret.Get(0).(func(*uint64, *uint64) []*dbmodel.CollectionToGc); ok {
-		r0 = rf(cutoffTimeSecs, limit)
+	if rf, ok := ret.Get(0).(func(*uint64, *uint64, *string) []*dbmodel.CollectionToGc); ok {
+		r0 = rf(cutoffTimeSecs, limit, tenantID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*dbmodel.CollectionToGc)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*uint64, *uint64) error); ok {
-		r1 = rf(cutoffTimeSecs, limit)
+	if rf, ok := ret.Get(1).(func(*uint64, *uint64, *string) error); ok {
+		r1 = rf(cutoffTimeSecs, limit, tenantID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -429,6 +429,8 @@ message ListCollectionsToGcRequest {
   // This also allows for a cheap and stateless pagination without using offsets.
   optional uint64 limit = 2;
 
+  optional string tenant_id = 3;
+
   // Design NOTE: When GC calls DeleteCollectionVersion, sysdb will update the
   // time associated with the oldest version of the collection. This allows
   // sysdb to return the collections that have not been GCed for a long time.
@@ -438,8 +440,9 @@ message CollectionToGcInfo {
   string id = 1;
   string name = 2;
   string version_file_path = 3;
-  int64 latest_version = 4;
+  reserved 4; // used to be "latest_version"
   string tenant_id = 5;
+  optional string lineage_file_path = 6;
 }
 
 message ListCollectionsToGcResponse {

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -183,7 +183,7 @@ impl Component for GarbageCollector {
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
         ctx.scheduler.schedule(
-            GarbageCollectMessage {},
+            GarbageCollectMessage { tenant: None },
             Duration::from_secs(self.gc_interval_mins * 60),
             ctx,
             || Some(span!(parent: None, tracing::Level::INFO, "Scheduled garbage collection")),
@@ -245,16 +245,26 @@ impl Handler<Memberlist> for GarbageCollector {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+struct GarbageCollectResult {
+    num_completed_jobs: u32,
+    num_failed_jobs: u32,
+    num_skipped_jobs: u32,
+}
+
 #[derive(Debug)]
-struct GarbageCollectMessage {}
+struct GarbageCollectMessage {
+    tenant: Option<String>,
+}
 
 #[async_trait]
 impl Handler<GarbageCollectMessage> for GarbageCollector {
-    type Result = ();
+    type Result = GarbageCollectResult;
 
     async fn handle(
         &mut self,
-        _message: GarbageCollectMessage,
+        message: GarbageCollectMessage,
         ctx: &ComponentContext<Self>,
     ) -> Self::Result {
         let absolute_cutoff_time =
@@ -272,6 +282,7 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
             .get_collections_to_gc(
                 Some(absolute_cutoff_time.into()),
                 Some(self.max_collections_to_gc.into()),
+                message.tenant.clone(),
             )
             .await
             .expect("Failed to get collections to gc");
@@ -284,12 +295,23 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
 
         let mut jobs = FuturesUnordered::new();
 
+        let mut num_skipped_jobs = 0;
         for collection in collections_to_gc {
             if self.disabled_collections.contains(&collection.id) {
                 tracing::warn!(
                     "Skipping garbage collection for disabled collection: {}",
                     collection.id
                 );
+                num_skipped_jobs += 1;
+                continue;
+            }
+
+            if collection.lineage_file_path.is_some() {
+                tracing::debug!(
+                    "Skipping garbage collection for root of fork tree: {}",
+                    collection.id
+                );
+                num_skipped_jobs += 1;
                 continue;
             }
 
@@ -351,11 +373,19 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
 
         // Schedule next run
         ctx.scheduler.schedule(
-            GarbageCollectMessage {},
+            GarbageCollectMessage {
+                tenant: message.tenant.clone(),
+            },
             Duration::from_secs(self.gc_interval_mins * 60),
             ctx,
             || Some(span!(parent: None, tracing::Level::INFO, "Scheduled garbage collection")),
         );
+
+        return GarbageCollectResult {
+            num_completed_jobs,
+            num_failed_jobs,
+            num_skipped_jobs,
+        };
     }
 }
 
@@ -409,7 +439,7 @@ mod tests {
     use chroma_storage::config::{
         ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
     };
-    use chroma_sysdb::GrpcSysDbConfig;
+    use chroma_sysdb::{GrpcSysDb, GrpcSysDbConfig};
     use chroma_system::{DispatcherConfig, System};
     use tracing_test::traced_test;
 
@@ -570,6 +600,122 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
+    async fn test_k8s_integration_ignores_forked_collections() {
+        let tenant_id = format!("tenant-{}", Uuid::new_v4());
+        let tenant_mode_overrides = HashMap::from([(tenant_id.clone(), CleanupMode::Delete)]);
+
+        let config = GarbageCollectorConfig {
+            service_name: "gc".to_string(),
+            otel_endpoint: "none".to_string(),
+            relative_cutoff_time: Duration::from_secs(1),
+            max_collections_to_gc: 100,
+            gc_interval_mins: 10,
+            disallow_collections: vec![],
+            sysdb_config: GrpcSysDbConfig {
+                host: "localhost".to_string(),
+                port: 50051,
+                connect_timeout_ms: 5000,
+                request_timeout_ms: 10000,
+                num_channels: 1,
+            },
+            dispatcher_config: DispatcherConfig::default(),
+            storage_config: StorageConfig::ObjectStore(ObjectStoreConfig {
+                bucket: ObjectStoreBucketConfig {
+                    name: "chroma-storage".to_string(),
+                    r#type: ObjectStoreType::Minio,
+                },
+                upload_part_size_bytes: 1024 * 1024,   // 1MB
+                download_part_size_bytes: 1024 * 1024, // 1MB
+                max_concurrent_requests: 10,
+            }),
+            default_mode: CleanupMode::DryRun,
+            tenant_mode_overrides: Some(tenant_mode_overrides),
+            assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),
+            my_member_id: "test-gc".to_string(),
+            memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig::default(),
+        };
+        let registry = Registry::new();
+
+        // Create collection
+        let mut clients = ChromaGrpcClients::new().await.unwrap();
+
+        let (collection_id, _) = create_test_collection(tenant_id.clone(), &mut clients).await;
+        let mut sysdb = SysDb::Grpc(
+            GrpcSysDb::try_from_config(&config.sysdb_config, &registry)
+                .await
+                .unwrap(),
+        );
+        let collections = sysdb
+            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .await
+            .unwrap();
+        let collection = collections.first().unwrap();
+        // Fork collection
+        sysdb
+            .fork_collection(
+                collection_id,
+                collection.log_position as u64,
+                collection.log_position as u64,
+                CollectionUuid::new(),
+                "test-fork".to_string(),
+            )
+            .await
+            .unwrap();
+
+        // Wait 1 second for cutoff time
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Run garbage collection
+        let mut garbage_collector_component = GarbageCollector::try_from_config(&config, &registry)
+            .await
+            .unwrap();
+
+        let dispatcher = Dispatcher::try_from_config(&config.dispatcher_config, &registry)
+            .await
+            .unwrap();
+
+        let system = System::new();
+        let dispatcher_handle = system.start_component(dispatcher);
+
+        garbage_collector_component.set_dispatcher(dispatcher_handle);
+        garbage_collector_component.set_system(system.clone());
+        let mut garbage_collector_handle = system.start_component(garbage_collector_component);
+
+        garbage_collector_handle
+            .send(
+                vec![Member {
+                    member_id: "test-gc".to_string(),
+                    member_ip: "0.0.0.0".to_string(),
+                    member_node_name: "test-gc-node".to_string(),
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let result = garbage_collector_handle
+            .request(
+                GarbageCollectMessage {
+                    tenant: Some(tenant_id.clone()),
+                },
+                Some(Span::current()),
+            )
+            .await
+            .unwrap();
+
+        // Should have skipped
+        assert_eq!(
+            result,
+            GarbageCollectResult {
+                num_completed_jobs: 0,
+                num_failed_jobs: 0,
+                num_skipped_jobs: 1
+            }
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
     async fn test_k8s_integration_tenant_mode_override() {
         // Setup
         let tenant_id_for_delete_mode = format!("tenant-delete-mode-{}", Uuid::new_v4());
@@ -657,7 +803,10 @@ mod tests {
             .unwrap();
 
         garbage_collector_handle
-            .request(GarbageCollectMessage {}, Some(Span::current()))
+            .request(
+                GarbageCollectMessage { tenant: None },
+                Some(Span::current()),
+            )
             .await
             .unwrap();
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -861,7 +861,7 @@ mod tests {
             .unwrap();
 
         // Get collection info for GC from sysdb
-        let collections_to_gc = sysdb.get_collections_to_gc(None, None).await.unwrap();
+        let collections_to_gc = sysdb.get_collections_to_gc(None, None, None).await.unwrap();
         let collection_info = collections_to_gc
             .iter()
             .find(|c| c.id == collection_id)
@@ -1017,7 +1017,7 @@ mod tests {
             .unwrap();
 
         // Get collection info for GC from sysdb
-        let collections_to_gc = sysdb.get_collections_to_gc(None, None).await.unwrap();
+        let collections_to_gc = sysdb.get_collections_to_gc(None, None, None).await.unwrap();
         let collection_info = collections_to_gc
             .iter()
             .find(|c| c.id == collection_id)
@@ -1175,7 +1175,7 @@ mod tests {
             .unwrap();
 
         // Get collection info for GC from sysdb
-        let collections_to_gc = sysdb.get_collections_to_gc(None, None).await.unwrap();
+        let collections_to_gc = sysdb.get_collections_to_gc(None, None, None).await.unwrap();
         let collection_info = collections_to_gc
             .iter()
             .find(|c| c.id == collection_id)

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -355,9 +355,10 @@ impl SysDb {
         &mut self,
         cutoff_time: Option<SystemTime>,
         limit: Option<u64>,
+        tenant: Option<String>,
     ) -> Result<Vec<CollectionToGcInfo>, GetCollectionsToGcError> {
         match self {
-            SysDb::Grpc(grpc) => grpc.get_collections_to_gc(cutoff_time, limit).await,
+            SysDb::Grpc(grpc) => grpc.get_collections_to_gc(cutoff_time, limit, tenant).await,
             SysDb::Sqlite(_) => unimplemented!("Garbage collection does not work for local chroma"),
             SysDb::Test(_) => todo!(),
         }
@@ -564,7 +565,7 @@ pub struct CollectionToGcInfo {
     pub tenant: String,
     pub name: String,
     pub version_file_path: String,
-    pub latest_version: i64,
+    pub lineage_file_path: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -598,7 +599,7 @@ impl TryFrom<chroma_proto::CollectionToGcInfo> for CollectionToGcInfo {
             tenant: value.tenant_id,
             name: value.name,
             version_file_path: value.version_file_path,
-            latest_version: value.latest_version,
+            lineage_file_path: value.lineage_file_path,
         })
     }
 }
@@ -1009,12 +1010,14 @@ impl GrpcSysDb {
         &mut self,
         cutoff_time: Option<SystemTime>,
         limit: Option<u64>,
+        tenant: Option<String>,
     ) -> Result<Vec<CollectionToGcInfo>, GetCollectionsToGcError> {
         let res = self
             .client
             .list_collections_to_gc(chroma_proto::ListCollectionsToGcRequest {
                 cutoff_time: cutoff_time.map(|t| t.into()),
                 limit,
+                tenant_id: tenant,
             })
             .await;
 


### PR DESCRIPTION
## Description of changes

Includes several updates to the `ListCollectionsToGc` gRPC method:

- returns the lineage file path, if present
- only returns the root collection for fork trees
- accepts an optional tenant parameter for test isolation.

Because `ListCollectionsToGc` now returns collections that are part of fork trees, I also updated GC to skip collections with a populated `lineage_file_path` (i.e. the root collection in a fork tree).

## Test plan

_How are these changes tested?_

Added tests covering the fork tree grouping and GC behavior on forked collections.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a