### PR TITLE
[ENH] Expose may_contain for disk cache, use in prefetch

### DIFF
--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -494,7 +494,7 @@ where
     }
 
     async fn may_contain(&self, key: &K) -> bool {
-        self.may_contain(key).await
+        self.cache.contains(key)
     }
 }
 
@@ -823,5 +823,26 @@ mod test {
             .expect("Expected to be able to get value")
             .expect("Value should not be None");
         assert_eq!(value, "foo");
+    }
+
+    #[tokio::test]
+    async fn test_may_contains() {
+        let dir = tempfile::tempdir()
+            .expect("To be able to create temp path")
+            .path()
+            .to_str()
+            .expect("To be able to parse path")
+            .to_string();
+        let cache = FoyerCacheConfig {
+            dir: Some(dir.clone()),
+            flush: true,
+            ..Default::default()
+        }
+        .build_hybrid_test::<String, String>()
+        .await
+        .unwrap();
+
+        cache.insert("key1".to_string(), "foo".to_string()).await;
+        assert!(cache.may_contain(&"key1".to_string()).await);
     }
 }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -826,7 +826,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_may_contains() {
+    async fn test_may_contain() {
         let dir = tempfile::tempdir()
             .expect("To be able to create temp path")
             .path()
@@ -844,5 +844,6 @@ mod test {
 
         cache.insert("key1".to_string(), "foo".to_string()).await;
         assert!(cache.may_contain(&"key1".to_string()).await);
+        assert!(!cache.may_contain(&"key2".to_string()).await);
     }
 }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -492,6 +492,10 @@ where
         }
         Ok(res)
     }
+
+    async fn may_contain(&self, key: &K) -> bool {
+        self.may_contain(key).await
+    }
 }
 
 impl<K, V> super::PersistentCache<K, V> for FoyerHybridCache<K, V>

--- a/rust/cache/src/lib.rs
+++ b/rust/cache/src/lib.rs
@@ -69,6 +69,11 @@ where
 {
     async fn insert(&self, key: K, value: V);
     async fn get(&self, key: &K) -> Result<Option<V>, CacheError>;
+    // Returns true if the cache contains the key. This method may return a
+    // false-positive.
+    async fn may_contain(&self, key: &K) -> bool {
+        self.get(key).await.map(|v| v.is_some()).unwrap_or(false)
+    }
     async fn remove(&self, key: &K);
     async fn clear(&self) -> Result<(), CacheError>;
     async fn obtain(&self, key: K) -> Result<Option<V>, CacheError>;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - /
- New functionality
  - `contains` in foyer is an approximate contains operation (for the disk cache) and has better performance. Additionally, it does not affect lru bookeeping. Prefetching currently uses `get()` for its `cached()` check. This change introduces `may_contain` which is a potentially false-positive check on if a cache contains a key. 

## Test plan
Basic unit test of proxied functionality. 
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None