### PR TITLE
[ENH]: Add name to various foyer caches

### DIFF
--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -12,6 +12,7 @@ sysdb:
 collections_with_segments_provider:
   cache:
     lru:
+      name: "collections_with_segments_cache"
       capacity: 1000
   cache_ttl_secs: 60
   permitted_parallelism: 180

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -12,6 +12,7 @@ sysdb:
 collections_with_segments_provider:
   cache:
     lru:
+      name: "collections_with_segments_cache"
       capacity: 1000
   cache_ttl_secs: 60
   permitted_parallelism: 180

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -56,6 +56,7 @@ query_service:
                 max_block_size_bytes: 8388608 # 8MB
                 block_cache_config:
                     disk:
+                        name: "block_cache"
                         dir: "/cache/chroma/query-service/block-cache"
                         # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
                         capacity: 1000
@@ -72,11 +73,13 @@ query_service:
             sparse_index_manager_config:
                 sparse_index_cache_config:
                     lru:
+                        name: "sparse_index_cache"
                         capacity: 1000
     hnsw_provider:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
+                name: "hnsw_cache"
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
 
@@ -138,15 +141,18 @@ compaction_service:
                 max_block_size_bytes: 8388608 # 8MB
                 block_cache_config:
                     lru:
+                        name: "block_cache"
                         capacity: 1000
             sparse_index_manager_config:
                 sparse_index_cache_config:
                     lru:
+                        name: "sparse_index_cache"
                         capacity: 1000
     hnsw_provider:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
+                name: "hnsw_cache"
                 capacity: 8192 # 8192 MiB = 8GB
         permitted_parallelism: 180
     spann_provider:

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -56,6 +56,7 @@ query_service:
                 block_cache_config:
                     disk:
                         dir: "/cache/chroma/query-service/block-cache"
+                        name: "block_cache"
                         # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
                         capacity: 1000
                         mem: 8000 # 8GiB
@@ -71,11 +72,13 @@ query_service:
             sparse_index_manager_config:
                 sparse_index_cache_config:
                     lru:
+                        name: "sparse_index_cache"
                         capacity: 1000
     hnsw_provider:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
+                name: "hnsw_cache"
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
     fetch_log_batch_size: 1000
@@ -141,15 +144,18 @@ compaction_service:
                 max_block_size_bytes: 8388608 # 8MB
                 block_cache_config:
                     lru:
+                        name: "block_cache"
                         capacity: 1000
             sparse_index_manager_config:
                 sparse_index_cache_config:
                     lru:
+                        name: "sparse_index_cache"
                         capacity: 1000
     hnsw_provider:
         hnsw_temporary_path: "~/tmp"
         hnsw_cache_config:
             weighted_lru:
+                name: "hnsw_cache"
                 capacity: 8192 # 8192 MiB = 8GB
         permitted_parallelism: 180
     spann_provider:


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - All the foyer caches are named as "foyer" currently. This clobbers the metrics since each metric is prefixed with "<name>_.*". Introduces name in the config and passes it down to the cache builder
- New functionality
  - ...

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
