### PR TITLE
[BUG]: increase max payload size of log service (Go)

### DIFF
--- a/go/cmd/logservice/main.go
+++ b/go/cmd/logservice/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"net"
 
+	"github.com/chroma-core/chroma/go/pkg/grpcutils"
 	"github.com/chroma-core/chroma/go/pkg/log/configuration"
 	"github.com/chroma-core/chroma/go/pkg/log/leader"
 	"github.com/chroma-core/chroma/go/pkg/log/metrics"
@@ -15,7 +15,6 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/utils"
 	libs "github.com/chroma-core/chroma/go/shared/libs"
 	"github.com/chroma-core/chroma/go/shared/otel"
-	sharedOtel "github.com/chroma-core/chroma/go/shared/otel"
 	"github.com/pingcap/log"
 	"github.com/rs/zerolog"
 	"go.uber.org/automaxprocs/maxprocs"
@@ -50,22 +49,21 @@ func main() {
 	sysDb := sysdb.NewSysDB(config.SYSDB_CONN)
 	lr := repository.NewLogRepository(conn, sysDb)
 	server := server.NewLogServer(lr)
-	var listener net.Listener
-	listener, err = net.Listen("tcp", ":"+config.PORT)
-	if err != nil {
-		log.Fatal("failed to listen", zap.Error(err))
-	}
-	s := grpc.NewServer(grpc.UnaryInterceptor(sharedOtel.ServerGrpcInterceptor))
-	healthcheck := health.NewServer()
-	healthgrpc.RegisterHealthServer(s, healthcheck)
 
-	logservicepb.RegisterLogServiceServer(s, server)
-	log.Info("log service started", zap.String("address", listener.Addr().String()))
+	_, err = grpcutils.Default.StartGrpcServer("log-service", &grpcutils.GrpcConfig{
+		BindAddress: ":" + config.PORT,
+	}, func(registrar grpc.ServiceRegistrar) {
+		healthcheck := health.NewServer()
+		healthgrpc.RegisterHealthServer(registrar, healthcheck)
+		logservicepb.RegisterLogServiceServer(registrar, server)
+	})
+	if err != nil {
+		log.Fatal("failed to create grpc server", zap.Error(err))
+	}
+
+	log.Info("log service started")
 	go leader.AcquireLeaderLock(ctx, func(ctx context.Context) {
 		go purging.PerformPurgingLoop(ctx, lr)
 		go metrics.PerformMetricsLoop(ctx, lr)
 	})
-	if err := s.Serve(listener); err != nil {
-		log.Fatal("failed to serve", zap.Error(err))
-	}
 }

--- a/go/pkg/grpcutils/service.go
+++ b/go/pkg/grpcutils/service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/chroma-core/chroma/go/shared/otel"
 	"io"
 	"net"
 	"os"
+
+	"github.com/chroma-core/chroma/go/shared/otel"
 
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -82,7 +83,7 @@ func newDefaultGrpcProvider(name string, grpcConfig *GrpcConfig, registerFunc fu
 	OPTL_TRACING_ENDPOINT := os.Getenv("OPTL_TRACING_ENDPOINT")
 	if OPTL_TRACING_ENDPOINT != "" {
 		otel.InitTracing(context.Background(), &otel.TracingConfig{
-			Service:  "sysdb-service",
+			Service:  name,
 			Endpoint: OPTL_TRACING_ENDPOINT,
 		})
 	}

--- a/go/pkg/sysdb/grpc/server.go
+++ b/go/pkg/sysdb/grpc/server.go
@@ -158,7 +158,7 @@ func NewWithGrpcProvider(config Config, provider grpcutils.GrpcProvider) (*Serve
 		s.softDeleteCleaner.Start()
 
 		log.Info("Starting GRPC server")
-		s.grpcServer, err = provider.StartGrpcServer("coordinator", config.GrpcConfig, func(registrar grpc.ServiceRegistrar) {
+		s.grpcServer, err = provider.StartGrpcServer("sysdb-service", config.GrpcConfig, func(registrar grpc.ServiceRegistrar) {
 			coordinatorpb.RegisterSysDBServer(registrar, s)
 			healthgrpc.RegisterHealthServer(registrar, s.healthServer)
 		})


### PR DESCRIPTION
## Description of changes

The max gRPC payload/response sizes were updated for the Rust log client, but were never updated for the log service. So the `PushLogs` method was still failing when the request was > 4MB.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a