### PR TITLE
[BUG] Default embedding function in JS did not create the correct config dict

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chromadb-root",
   "private": true,
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "A JavaScript interface for chroma",
   "keywords": [],
   "author": "",

--- a/clients/js/packages/chromadb-client/package.json
+++ b/clients/js/packages/chromadb-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb-client",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "A JavaScript interface for chroma with embedding functions as peer dependencies",
   "license": "Apache-2.0",
   "type": "module",

--- a/clients/js/packages/chromadb-core/package.json
+++ b/clients/js/packages/chromadb-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/chromadb-core",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "description": "Core functionality for ChromaDB JavaScript client",
   "license": "Apache-2.0",

--- a/clients/js/packages/chromadb-core/src/embeddings/DefaultEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/DefaultEmbeddingFunction.ts
@@ -6,7 +6,7 @@ import { IEmbeddingFunction } from "./IEmbeddingFunction";
 let TransformersApi: Promise<any>;
 
 interface StoredConfig {
-  model_name: string;
+  model: string;
   revision: string;
   quantized: boolean;
 }
@@ -77,7 +77,7 @@ export class DefaultEmbeddingFunction implements IEmbeddingFunction {
 
   getConfig(): StoredConfig {
     return {
-      model_name: this.model,
+      model: this.model,
       revision: this.revision,
       quantized: this.quantized,
     };
@@ -85,16 +85,16 @@ export class DefaultEmbeddingFunction implements IEmbeddingFunction {
 
   buildFromConfig(config: StoredConfig): DefaultEmbeddingFunction {
     return new DefaultEmbeddingFunction({
-      model: config.model_name,
+      model: config.model,
       revision: config.revision,
       quantized: config.quantized,
     });
   }
 
   validateConfigUpdate(oldConfig: StoredConfig, newConfig: StoredConfig): void {
-    if (oldConfig.model_name !== newConfig.model_name) {
+    if (oldConfig.model !== newConfig.model) {
       throw new Error(
-        "DefaultEmbeddingFunction model_name cannot be changed after initialization.",
+        "DefaultEmbeddingFunction model cannot be changed after initialization.",
       );
     }
   }

--- a/clients/js/packages/chromadb/package.json
+++ b/clients/js/packages/chromadb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "A JavaScript interface for chroma with embedding functions as bundled dependencies",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Description of changes

The Default EF in javascript incorrectly sets the config name to model_name, when the schema requires model. This PR fixes that.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
