### PR TITLE
Revert "[BUG]: increase max payload size of log service (Go) (#4534)"

### DIFF
--- a/go/cmd/logservice/main.go
+++ b/go/cmd/logservice/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
+	"net"
 
-	"github.com/chroma-core/chroma/go/pkg/grpcutils"
 	"github.com/chroma-core/chroma/go/pkg/log/configuration"
 	"github.com/chroma-core/chroma/go/pkg/log/leader"
 	"github.com/chroma-core/chroma/go/pkg/log/metrics"
@@ -15,6 +15,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/utils"
 	libs "github.com/chroma-core/chroma/go/shared/libs"
 	"github.com/chroma-core/chroma/go/shared/otel"
+	sharedOtel "github.com/chroma-core/chroma/go/shared/otel"
 	"github.com/pingcap/log"
 	"github.com/rs/zerolog"
 	"go.uber.org/automaxprocs/maxprocs"
@@ -49,21 +50,22 @@ func main() {
 	sysDb := sysdb.NewSysDB(config.SYSDB_CONN)
 	lr := repository.NewLogRepository(conn, sysDb)
 	server := server.NewLogServer(lr)
-
-	_, err = grpcutils.Default.StartGrpcServer("log-service", &grpcutils.GrpcConfig{
-		BindAddress: ":" + config.PORT,
-	}, func(registrar grpc.ServiceRegistrar) {
-		healthcheck := health.NewServer()
-		healthgrpc.RegisterHealthServer(registrar, healthcheck)
-		logservicepb.RegisterLogServiceServer(registrar, server)
-	})
+	var listener net.Listener
+	listener, err = net.Listen("tcp", ":"+config.PORT)
 	if err != nil {
-		log.Fatal("failed to create grpc server", zap.Error(err))
+		log.Fatal("failed to listen", zap.Error(err))
 	}
+	s := grpc.NewServer(grpc.UnaryInterceptor(sharedOtel.ServerGrpcInterceptor))
+	healthcheck := health.NewServer()
+	healthgrpc.RegisterHealthServer(s, healthcheck)
 
-	log.Info("log service started")
+	logservicepb.RegisterLogServiceServer(s, server)
+	log.Info("log service started", zap.String("address", listener.Addr().String()))
 	go leader.AcquireLeaderLock(ctx, func(ctx context.Context) {
 		go purging.PerformPurgingLoop(ctx, lr)
 		go metrics.PerformMetricsLoop(ctx, lr)
 	})
+	if err := s.Serve(listener); err != nil {
+		log.Fatal("failed to serve", zap.Error(err))
+	}
 }

--- a/go/pkg/grpcutils/service.go
+++ b/go/pkg/grpcutils/service.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"github.com/chroma-core/chroma/go/shared/otel"
 	"io"
 	"net"
 	"os"
-
-	"github.com/chroma-core/chroma/go/shared/otel"
 
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -83,7 +82,7 @@ func newDefaultGrpcProvider(name string, grpcConfig *GrpcConfig, registerFunc fu
 	OPTL_TRACING_ENDPOINT := os.Getenv("OPTL_TRACING_ENDPOINT")
 	if OPTL_TRACING_ENDPOINT != "" {
 		otel.InitTracing(context.Background(), &otel.TracingConfig{
-			Service:  name,
+			Service:  "sysdb-service",
 			Endpoint: OPTL_TRACING_ENDPOINT,
 		})
 	}

--- a/go/pkg/sysdb/grpc/server.go
+++ b/go/pkg/sysdb/grpc/server.go
@@ -158,7 +158,7 @@ func NewWithGrpcProvider(config Config, provider grpcutils.GrpcProvider) (*Serve
 		s.softDeleteCleaner.Start()
 
 		log.Info("Starting GRPC server")
-		s.grpcServer, err = provider.StartGrpcServer("sysdb-service", config.GrpcConfig, func(registrar grpc.ServiceRegistrar) {
+		s.grpcServer, err = provider.StartGrpcServer("coordinator", config.GrpcConfig, func(registrar grpc.ServiceRegistrar) {
 			coordinatorpb.RegisterSysDBServer(registrar, s)
 			healthgrpc.RegisterHealthServer(registrar, s.healthServer)
 		})


### PR DESCRIPTION
This reverts commit 3028a39384589393489ac7ece9dedf38a0eea663.

After we deployed this commit, we lost metrics for log-service, so we suspect it has something to do with it. I will re-enable the payload size fix one way or the other, but want to get back to working observability for the time being.