### PR TITLE
Update fastapi to 0.115.12 to avoid dep conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bcrypt>=4.0.1
-fastapi==0.115.9
+fastapi==0.115.12
 graphlib_backport==1.0.3; python_version < '3.9'
 grpcio>=1.58.0
 httpx>=0.27.0


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

We are hitting a dependency update conflicts due to 
```
7.586 The conflict is caused by:
7.586     The user requested fastapi~=0.115.12
7.586     chromadb 1.0.9 depends on fastapi==0.115.9
```

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
