### PR TITLE
[ENH]  Support custom data sets for chroma load.

### DIFF
--- a/rust/load/src/data_sets.rs
+++ b/rust/load/src/data_sets.rs
@@ -1496,9 +1496,9 @@ pub fn all_data_sets() -> Vec<Arc<dyn DataSet>> {
 
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct References {
-    references: serde_json::Value,
-    operates_on: String,
-    cardinality: usize,
+    pub references: serde_json::Value,
+    pub operates_on: String,
+    pub cardinality: usize,
 }
 
 /// Get a data set from a particular JSON value.

--- a/rust/load/src/rest.rs
+++ b/rust/load/src/rest.rs
@@ -43,8 +43,10 @@ pub struct StartRequest {
     pub name: String,
     /// The workload to run.
     pub workload: Workload,
-    /// The data set to use.
-    pub data_set: String,
+    /// The data set to use, referred to by name.
+    pub data_set: Option<String>,
+    /// The custom data set to use.
+    pub custom_data_set: Option<serde_json::Value>,
     /// The connection to use.
     pub connection: Connection,
     /// When the workload should expire.


### PR DESCRIPTION
## Description of changes

This exposes the already-existing ability to shove a data set into
chroma-load.  The `/start` endpoint now takes a json blob xor a data set
name.  If the `/start` endpoint is given just the name, it resorts to
the old behavior so as not to break anything.

If given a JSON blob, it will interpret that as the data set and try to
run it.  Right now the only supported workloads would be to pass a blob
that's pre-configured, or to pass a `References` struct serialized to a
data set.  The chroma-load-start command has been updated to facilitate
this.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

- [X] --help for chroma-load-start has been updated
