### PR TITLE
[DBG] Add temporary trace for filter argument

### DIFF
--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -498,6 +498,11 @@ impl Operator<FilterInput, FilterOutput> for FilterOperator {
     async fn run(&self, input: &FilterInput) -> Result<FilterOutput, FilterError> {
         tracing::debug!("[{}]: {:?}", self.get_name(), input);
 
+        // NOTE: This is temporary traces to capture filter arguments
+        //       We suspect certain filters break the FTS algorithm
+        // TODO: Remove this after the bug is found
+        tracing::debug!("[DEBUG FILTER OPERATOR]: {:?}", self);
+
         let record_segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment,
             &input.blockfile_provider,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Add temporary traces to log filter arguments. We suspect certain filters are not handled properly.
  - Add projection error variant for clarity
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
