### PR TITLE
[BUG]: v0 in version file for forked collection missing segment file paths from source collection

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -97,7 +97,7 @@ func (s *Coordinator) GetTenant(ctx context.Context, getTenant *model.GetTenant)
 	return tenant, nil
 }
 
-func (s *Coordinator) CreateCollectionAndSegments(ctx context.Context, createCollection *model.CreateCollection, createSegments []*model.CreateSegment) (*model.Collection, bool, error) {
+func (s *Coordinator) CreateCollectionAndSegments(ctx context.Context, createCollection *model.CreateCollection, createSegments []*model.Segment) (*model.Collection, bool, error) {
 	collection, created, err := s.catalog.CreateCollectionAndSegments(ctx, createCollection, createSegments, createCollection.Ts)
 	if err != nil {
 		return nil, false, err
@@ -165,7 +165,7 @@ func (s *Coordinator) CountForks(ctx context.Context, sourceCollectionID types.U
 	return s.catalog.CountForks(ctx, sourceCollectionID)
 }
 
-func (s *Coordinator) CreateSegment(ctx context.Context, segment *model.CreateSegment) error {
+func (s *Coordinator) CreateSegment(ctx context.Context, segment *model.Segment) error {
 	if err := verifyCreateSegment(segment); err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func verifyCollectionMetadata(metadata *model.CollectionMetadata[model.Collectio
 	return nil
 }
 
-func verifyCreateSegment(segment *model.CreateSegment) error {
+func verifyCreateSegment(segment *model.Segment) error {
 	if err := verifySegmentMetadata(segment.Metadata); err != nil {
 		return err
 	}

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -179,8 +179,8 @@ func testSegment(t *rapid.T) {
 
 	t.Repeat(map[string]func(*rapid.T){
 		"create_segment": func(t *rapid.T) {
-			segment := rapid.Custom[*model.CreateSegment](func(t *rapid.T) *model.CreateSegment {
-				return &model.CreateSegment{
+			segment := rapid.Custom[*model.Segment](func(t *rapid.T) *model.Segment {
+				return &model.Segment{
 					ID:           types.MustParse(rapid.StringMatching(`[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`).Draw(t, "segment_id")),
 					Type:         "test-segment-type",
 					Scope:        "test-segment-scope",
@@ -294,7 +294,7 @@ func (suite *APIsTestSuite) TestCreateCollectionAndSegments() {
 		DatabaseName: suite.databaseName,
 	}
 
-	segments := []*model.CreateSegment{
+	segments := []*model.Segment{
 		{
 			ID:           types.NewUniqueID(),
 			Type:         "test_type",
@@ -486,7 +486,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	suite.Equal(createCollection.Metadata, results[0].Metadata)
 
 	// Create segments associated with collection
-	segment := &model.CreateSegment{
+	segment := &model.Segment{
 		ID:           types.MustParse("00000000-0000-0000-0000-000000000001"),
 		CollectionID: createCollection.ID,
 		Type:         "test_segment",
@@ -993,7 +993,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteSegments() {
 
 	sampleSegments := SampleSegments(suite.sampleCollections)
 	for _, segment := range sampleSegments {
-		errSegmentCreation := c.CreateSegment(ctx, &model.CreateSegment{
+		errSegmentCreation := c.CreateSegment(ctx, &model.Segment{
 			ID:           segment.ID,
 			Type:         segment.Type,
 			Scope:        segment.Scope,
@@ -1003,7 +1003,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteSegments() {
 		suite.NoError(errSegmentCreation)
 
 		// Create segment with empty collection id fails
-		errSegmentCreation = c.CreateSegment(ctx, &model.CreateSegment{
+		errSegmentCreation = c.CreateSegment(ctx, &model.Segment{
 			ID:           segment.ID,
 			Type:         segment.Type,
 			Scope:        segment.Scope,
@@ -1014,7 +1014,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteSegments() {
 
 		// Create segment to test unique constraint violation on segment.id.
 		// This should fail because the id is already taken.
-		errSegmentCreation = c.CreateSegment(ctx, &model.CreateSegment{
+		errSegmentCreation = c.CreateSegment(ctx, &model.Segment{
 			ID:           segment.ID,
 			Type:         segment.Type,
 			Scope:        segment.Scope,
@@ -1037,7 +1037,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteSegments() {
 	suite.Equal(sampleSegments, results)
 
 	// Duplicate create fails
-	err := c.CreateSegment(ctx, &model.CreateSegment{
+	err := c.CreateSegment(ctx, &model.Segment{
 		ID:           sampleSegments[0].ID,
 		Type:         sampleSegments[0].Type,
 		Scope:        sampleSegments[0].Scope,
@@ -1108,7 +1108,7 @@ func (suite *APIsTestSuite) TestUpdateSegment() {
 	}
 
 	ctx := context.Background()
-	errSegmentCreation := suite.coordinator.CreateSegment(ctx, &model.CreateSegment{
+	errSegmentCreation := suite.coordinator.CreateSegment(ctx, &model.Segment{
 		ID:           segment.ID,
 		Type:         segment.Type,
 		Scope:        segment.Scope,
@@ -1313,7 +1313,7 @@ func (suite *APIsTestSuite) TestCollectionVersioningWithMinio() {
 		DatabaseName: suite.databaseName,
 	}
 
-	segments := []*model.CreateSegment{
+	segments := []*model.Segment{
 		{
 			ID:           types.NewUniqueID(),
 			Type:         "test_type_a",
@@ -1363,28 +1363,28 @@ func (suite *APIsTestSuite) TestForkCollection() {
 		DatabaseName: suite.databaseName,
 	}
 
-	sourceCreateMetadataSegment := &model.CreateSegment{
+	sourceCreateMetadataSegment := &model.Segment{
 		ID:           types.NewUniqueID(),
 		Type:         "test_blockfile",
 		Scope:        "METADATA",
 		CollectionID: sourceCreateCollection.ID,
 	}
 
-	sourceCreateRecordSegment := &model.CreateSegment{
+	sourceCreateRecordSegment := &model.Segment{
 		ID:           types.NewUniqueID(),
 		Type:         "test_blockfile",
 		Scope:        "RECORD",
 		CollectionID: sourceCreateCollection.ID,
 	}
 
-	sourceCreateVectorSegment := &model.CreateSegment{
+	sourceCreateVectorSegment := &model.Segment{
 		ID:           types.NewUniqueID(),
 		Type:         "test_hnsw",
 		Scope:        "VECTOR",
 		CollectionID: sourceCreateCollection.ID,
 	}
 
-	segments := []*model.CreateSegment{
+	segments := []*model.Segment{
 		sourceCreateMetadataSegment,
 		sourceCreateRecordSegment,
 		sourceCreateVectorSegment,
@@ -1505,28 +1505,28 @@ func (suite *APIsTestSuite) TestCountForks() {
 		DatabaseName: suite.databaseName,
 	}
 
-	sourceCreateMetadataSegment := &model.CreateSegment{
+	sourceCreateMetadataSegment := &model.Segment{
 		ID:           types.NewUniqueID(),
 		Type:         "test_blockfile",
 		Scope:        "METADATA",
 		CollectionID: sourceCreateCollection.ID,
 	}
 
-	sourceCreateRecordSegment := &model.CreateSegment{
+	sourceCreateRecordSegment := &model.Segment{
 		ID:           types.NewUniqueID(),
 		Type:         "test_blockfile",
 		Scope:        "RECORD",
 		CollectionID: sourceCreateCollection.ID,
 	}
 
-	sourceCreateVectorSegment := &model.CreateSegment{
+	sourceCreateVectorSegment := &model.Segment{
 		ID:           types.NewUniqueID(),
 		Type:         "test_hnsw",
 		Scope:        "VECTOR",
 		CollectionID: sourceCreateCollection.ID,
 	}
 
-	segments := []*model.CreateSegment{
+	segments := []*model.Segment{
 		sourceCreateMetadataSegment,
 		sourceCreateRecordSegment,
 		sourceCreateVectorSegment,

--- a/go/pkg/sysdb/coordinator/model/segment.go
+++ b/go/pkg/sysdb/coordinator/model/segment.go
@@ -14,15 +14,6 @@ type Segment struct {
 	FilePaths    map[string][]string
 }
 
-type CreateSegment struct {
-	ID           types.UniqueID
-	Type         string
-	Scope        string
-	CollectionID types.UniqueID
-	Metadata     *SegmentMetadata[SegmentMetadataValueType]
-	Ts           types.Timestamp
-}
-
 type UpdateSegment struct {
 	ID            types.UniqueID
 	ResetTopic    bool

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -77,9 +77,9 @@ func (s *Server) CreateCollection(ctx context.Context, req *coordinatorpb.Create
 	}
 
 	// Convert the request segments to create segment models
-	createSegments := []*model.CreateSegment{}
+	createSegments := []*model.Segment{}
 	for _, segment := range req.Segments {
-		createSegment, err := convertSegmentToModel(segment)
+		createSegment, err := convertProtoSegment(segment)
 		if err != nil {
 			log.Error("Error in creating segments for the collection", zap.Error(err))
 			res.Collection = nil // We don't need to set the collection in case of error
@@ -90,6 +90,12 @@ func (s *Server) CreateCollection(ctx context.Context, req *coordinatorpb.Create
 			}
 			return res, grpcutils.BuildInternalGrpcError(err.Error())
 		}
+		filePaths := make(map[string][]string)
+		for key, filePath := range segment.FilePaths {
+			filePaths[key] = filePath.Paths
+		}
+		createSegment.FilePaths = filePaths
+
 		createSegments = append(createSegments, createSegment)
 	}
 

--- a/go/pkg/sysdb/grpc/proto_model_convert.go
+++ b/go/pkg/sysdb/grpc/proto_model_convert.go
@@ -216,7 +216,7 @@ func convertSegmentMetadataToProto(segmentMetadata *model.SegmentMetadata[model.
 	return metadatapb
 }
 
-func convertSegmentToModel(segmentpb *coordinatorpb.Segment) (*model.CreateSegment, error) {
+func convertProtoSegment(segmentpb *coordinatorpb.Segment) (*model.Segment, error) {
 	segmentID, err := types.ToUniqueID(&segmentpb.Id)
 	if err != nil {
 		log.Error("segment id format error", zap.String("segment.id", segmentpb.Id))
@@ -236,11 +236,17 @@ func convertSegmentToModel(segmentpb *coordinatorpb.Segment) (*model.CreateSegme
 		return nil, err
 	}
 
-	return &model.CreateSegment{
+	filePaths := make(map[string][]string)
+	for t, paths := range segmentpb.FilePaths {
+		filePaths[t] = paths.Paths
+	}
+
+	return &model.Segment{
 		ID:           segmentID,
 		Type:         segmentpb.Type,
 		Scope:        segmentpb.Scope.String(),
 		CollectionID: collectionID,
 		Metadata:     metadata,
+		FilePaths:    filePaths,
 	}, nil
 }

--- a/go/pkg/sysdb/grpc/segment_service.go
+++ b/go/pkg/sysdb/grpc/segment_service.go
@@ -17,7 +17,7 @@ func (s *Server) CreateSegment(ctx context.Context, req *coordinatorpb.CreateSeg
 
 	res := &coordinatorpb.CreateSegmentResponse{}
 
-	segment, err := convertSegmentToModel(segmentpb)
+	segment, err := convertProtoSegment(segmentpb)
 	if err != nil {
 		log.Error("CreateSegment failed. convert segment to model error", zap.Error(err), zap.String("request", segmentpb.String()))
 		return res, grpcutils.BuildInternalGrpcError(err.Error())


### PR DESCRIPTION
## Description of changes

Prior to this fix, `v0` in the version file for forked collections was missing the segment file paths from the source collection.

There was a similar bug where if segment file paths were provided during the creation of a new collection, those file paths would also be absent from `v0` in the version file (we currently never provide segment file paths upon creation, but seemed good to fix as well).

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Updated existing Go integration tests to check the created version file.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a