### PR TITLE
[BUG]: Handle version file creation with empty file paths

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -131,7 +131,7 @@ func (s *Coordinator) GetCollectionSize(ctx context.Context, collectionID types.
 }
 
 func (s *Coordinator) GetCollectionWithSegments(ctx context.Context, collectionID types.UniqueID) (*model.Collection, []*model.Segment, error) {
-	return s.catalog.GetCollectionWithSegments(ctx, collectionID)
+	return s.catalog.GetCollectionWithSegments(ctx, collectionID, false)
 }
 
 func (s *Coordinator) CheckCollection(ctx context.Context, collectionID types.UniqueID) (bool, error) {

--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/chroma-core/chroma/go/pkg/types"
 )
 
@@ -21,6 +23,10 @@ type Collection struct {
 	TotalRecordsPostCompaction uint64
 	SizeBytesPostCompaction    uint64 // Note: This represents the size of the records off the log
 	LastCompactionTimeSecs     uint64
+	IsDeleted                  bool
+	VersionFileName            string
+	CreatedAt                  time.Time
+	DatabaseId                 types.UniqueID
 }
 
 type CollectionToGc struct {

--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -33,6 +33,10 @@ func convertCollectionToModel(collectionAndMetadataList []*dbmodel.CollectionAnd
 			LastCompactionTimeSecs:     collectionAndMetadata.Collection.LastCompactionTimeSecs,
 			RootCollectionID:           rootCollectionID,
 			LineageFileName:            collectionAndMetadata.Collection.LineageFileName,
+			IsDeleted:                  collectionAndMetadata.Collection.IsDeleted,
+			VersionFileName:            collectionAndMetadata.Collection.VersionFileName,
+			CreatedAt:                  collectionAndMetadata.Collection.CreatedAt,
+			DatabaseId:                 types.MustParse(collectionAndMetadata.Collection.DatabaseID),
 		}
 		collection.Metadata = convertCollectionMetadataToModel(collectionAndMetadata.CollectionMetadata)
 		collections = append(collections, collection)

--- a/go/pkg/sysdb/coordinator/model_db_convert_test.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert_test.go
@@ -138,6 +138,7 @@ func TestConvertCollectionToModel(t *testing.T) {
 	collectionTotalRecordsPostCompaction := uint64(100)
 	collectionSizeBytesPostCompaction := uint64(500000)
 	collectionLastCompactionTimeSecs := uint64(1741037006)
+	dbId := types.NewUniqueID()
 	collectionAndMetadata := &dbmodel.CollectionAndMetadata{
 		Collection: &dbmodel.Collection{
 			ID:                         collectionID.String(),
@@ -147,6 +148,7 @@ func TestConvertCollectionToModel(t *testing.T) {
 			TotalRecordsPostCompaction: collectionTotalRecordsPostCompaction,
 			SizeBytesPostCompaction:    collectionSizeBytesPostCompaction,
 			LastCompactionTimeSecs:     collectionLastCompactionTimeSecs,
+			DatabaseID:                 dbId.String(),
 		},
 		CollectionMetadata: []*dbmodel.CollectionMetadata{},
 	}
@@ -161,4 +163,5 @@ func TestConvertCollectionToModel(t *testing.T) {
 	assert.Equal(t, collectionSizeBytesPostCompaction, modelCollections[0].SizeBytesPostCompaction)
 	assert.Equal(t, collectionLastCompactionTimeSecs, modelCollections[0].LastCompactionTimeSecs)
 	assert.Nil(t, modelCollections[0].Metadata)
+	assert.Equal(t, dbId, modelCollections[0].DatabaseId)
 }

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1407,20 +1407,35 @@ func (tc *Catalog) ListCollectionVersions(ctx context.Context,
 	return filteredVersions, nil
 }
 
-func (tc *Catalog) updateVersionFileInS3(ctx context.Context, existingVersionFilePb *coordinatorpb.CollectionVersionFile, flushCollectionCompaction *model.FlushCollectionCompaction, ts_secs int64) (string, error) {
+func (tc *Catalog) updateVersionFileInS3(existingVersionFilePb *coordinatorpb.CollectionVersionFile, flushCollectionCompaction *model.FlushCollectionCompaction, previousSegmentInfo []*model.Segment, ts_secs int64) (string, error) {
 	segmentCompactionInfos := make([]*coordinatorpb.FlushSegmentCompactionInfo, 0, len(flushCollectionCompaction.FlushSegmentCompactions))
-	for _, compaction := range flushCollectionCompaction.FlushSegmentCompactions {
-		// Convert map[string][]string to map[string]*coordinatorpb.FilePaths
-		convertedPaths := make(map[string]*coordinatorpb.FilePaths)
-		for k, v := range compaction.FilePaths {
-			convertedPaths[k] = &coordinatorpb.FilePaths{Paths: v}
+	// If flushCollectionCompaction.FlushSegmentCompactions is empty then use previousSegmentInfo.
+	if len(flushCollectionCompaction.FlushSegmentCompactions) == 0 {
+		for _, segment := range previousSegmentInfo {
+			convertedPaths := make(map[string]*coordinatorpb.FilePaths)
+			for k, v := range segment.FilePaths {
+				convertedPaths[k] = &coordinatorpb.FilePaths{Paths: v}
+			}
+			info := &coordinatorpb.FlushSegmentCompactionInfo{
+				SegmentId: segment.ID.String(),
+				FilePaths: convertedPaths,
+			}
+			segmentCompactionInfos = append(segmentCompactionInfos, info)
 		}
+	} else {
+		for _, compaction := range flushCollectionCompaction.FlushSegmentCompactions {
+			// Convert map[string][]string to map[string]*coordinatorpb.FilePaths
+			convertedPaths := make(map[string]*coordinatorpb.FilePaths)
+			for k, v := range compaction.FilePaths {
+				convertedPaths[k] = &coordinatorpb.FilePaths{Paths: v}
+			}
 
-		info := &coordinatorpb.FlushSegmentCompactionInfo{
-			SegmentId: compaction.ID.String(),
-			FilePaths: convertedPaths,
+			info := &coordinatorpb.FlushSegmentCompactionInfo{
+				SegmentId: compaction.ID.String(),
+				FilePaths: convertedPaths,
+			}
+			segmentCompactionInfos = append(segmentCompactionInfos, info)
 		}
-		segmentCompactionInfos = append(segmentCompactionInfos, info)
 	}
 
 	existingVersionFilePb.GetVersionHistory().Versions = append(existingVersionFilePb.GetVersionHistory().Versions, &coordinatorpb.CollectionVersionInfo{
@@ -1562,7 +1577,8 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 	for numAttempts < maxAttempts {
 		numAttempts++
 		// Get the current version info and the version file from the table.
-		collectionEntry, err := tc.metaDomain.CollectionDb(ctx).GetCollectionEntry(types.FromUniqueID(flushCollectionCompaction.ID), nil)
+		collectionEntry, segments, err := tc.GetCollectionWithSegments(ctx, flushCollectionCompaction.ID)
+		// collectionEntry, err := tc.metaDomain.CollectionDb(ctx).GetCollectionEntry(types.FromUniqueID(flushCollectionCompaction.ID), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1592,15 +1608,16 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 		}
 
 		existingVersionFileName := collectionEntry.VersionFileName
+		// existingSegments := segments
 		var existingVersionFilePb *coordinatorpb.CollectionVersionFile
 		if existingVersionFileName == "" {
 			// The VersionFile has not been created.
 			existingVersionFilePb = &coordinatorpb.CollectionVersionFile{
 				CollectionInfoImmutable: &coordinatorpb.CollectionInfoImmutable{
-					TenantId:               collectionEntry.Tenant,
-					DatabaseId:             collectionEntry.DatabaseID,
-					CollectionId:           collectionEntry.ID,
-					CollectionName:         *collectionEntry.Name,
+					TenantId:               collectionEntry.TenantID,
+					DatabaseId:             collectionEntry.DatabaseId.String(),
+					CollectionId:           collectionEntry.ID.String(),
+					CollectionName:         collectionEntry.Name,
 					CollectionCreationSecs: collectionEntry.CreatedAt.Unix(),
 				},
 				VersionHistory: &coordinatorpb.CollectionVersionHistory{
@@ -1616,10 +1633,10 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 
 			// There was previously a bug that resulted in the tenant ID missing from some version files (https://github.com/chroma-core/chroma/pull/4408).
 			// This line can be removed once all corrupted version files are fixed.
-			existingVersionFilePb.CollectionInfoImmutable.TenantId = collectionEntry.Tenant
+			existingVersionFilePb.CollectionInfoImmutable.TenantId = collectionEntry.TenantID
 
 			// Do a simple validation of the version file.
-			err = tc.validateVersionFile(existingVersionFilePb, collectionEntry.ID, existingVersion)
+			err = tc.validateVersionFile(existingVersionFilePb, collectionEntry.ID.String(), existingVersion)
 			if err != nil {
 				log.Error("version file validation failed", zap.Error(err))
 				return nil, err
@@ -1629,7 +1646,7 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 		// The update function takes the content of the existing version file,
 		// and the set of segments that are part of the new version file.
 		// NEW VersionFile is created in S3 at this step.
-		newVersionFileName, err := tc.updateVersionFileInS3(ctx, existingVersionFilePb, flushCollectionCompaction, time.Now().Unix())
+		newVersionFileName, err := tc.updateVersionFileInS3(existingVersionFilePb, flushCollectionCompaction, segments, time.Now().Unix())
 		if err != nil {
 			return nil, err
 		}

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -95,6 +95,7 @@ func TestCatalog_GetCollections(t *testing.T) {
 	name := "test_collection"
 	testKey := "test_key"
 	testValue := "test_value"
+	dbId := types.NewUniqueID()
 	collectionConfigurationJsonStr := "{\"a\": \"param\", \"b\": \"param2\", \"3\": true}"
 	collectionAndMetadataList := []*dbmodel.CollectionAndMetadata{
 		{
@@ -103,6 +104,7 @@ func TestCatalog_GetCollections(t *testing.T) {
 				Name:                 &name,
 				ConfigurationJsonStr: &collectionConfigurationJsonStr,
 				Ts:                   types.Timestamp(1234567890),
+				DatabaseID:           dbId.String(),
 			},
 			CollectionMetadata: []*dbmodel.CollectionMetadata{
 				{
@@ -136,6 +138,7 @@ func TestCatalog_GetCollections(t *testing.T) {
 			ConfigurationJsonStr: collectionConfigurationJsonStr,
 			Ts:                   types.Timestamp(1234567890),
 			Metadata:             metadata,
+			DatabaseId:           dbId,
 		},
 	}, collections)
 
@@ -345,7 +348,7 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollection(t *testing.T) {
 	mockMetaDomain.On("TenantDb", mock.Anything).Return(mockTenantDb)
 	mockMetaDomain.On("SegmentDb", mock.Anything).Return(mockSegmentDb)
 
-	mockCollectionDb.On("GetCollections", types.FromUniqueID(collectionID), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockCollectionsAndMetadata, nil)
+	mockCollectionDb.On("GetCollectionEntries", types.FromUniqueID(collectionID), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockCollectionsAndMetadata, nil)
 	mockSegmentDb.On("GetSegments", mock.Anything, mock.Anything, mock.Anything, collectionID).Return(mockSegments, nil)
 	mockCollectionDb.On("UpdateLogPositionAndVersionInfo",
 		collectionID.String(),
@@ -549,7 +552,7 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollectionWithEmptyFilePat
 	mockMetaDomain.On("TenantDb", mock.Anything).Return(mockTenantDb)
 	mockMetaDomain.On("SegmentDb", mock.Anything).Return(mockSegmentDb)
 
-	mockCollectionDb.On("GetCollections", types.FromUniqueID(collectionID), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockCollectionsAndMetadata, nil)
+	mockCollectionDb.On("GetCollectionEntries", types.FromUniqueID(collectionID), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockCollectionsAndMetadata, nil)
 	mockSegmentDb.On("GetSegments", mock.Anything, mock.Anything, mock.Anything, collectionID).Return(mockSegments, nil)
 	mockCollectionDb.On("UpdateLogPositionAndVersionInfo",
 		collectionID.String(),

--- a/go/pkg/sysdb/grpc/tenant_database_service_test.go
+++ b/go/pkg/sysdb/grpc/tenant_database_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
 	s3metastore "github.com/chroma-core/chroma/go/pkg/sysdb/metastore/s3"
+	"github.com/google/uuid"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/genproto/googleapis/rpc/code"
@@ -114,6 +115,8 @@ func (suite *TenantDatabaseServiceTestSuite) TestServer_TenantLastCompactionTime
 func (suite *TenantDatabaseServiceTestSuite) TestServer_DeleteDatabase() {
 	tenantName := "TestDeleteDatabase"
 	databaseName := "TestDeleteDatabase"
+	// Generate random uuid for db id
+	databaseeId := uuid.New().String()
 
 	_, err := suite.catalog.CreateTenant(context.Background(), &model.CreateTenant{
 		Name: tenantName,
@@ -124,6 +127,8 @@ func (suite *TenantDatabaseServiceTestSuite) TestServer_DeleteDatabase() {
 	_, err = suite.catalog.CreateDatabase(context.Background(), &model.CreateDatabase{
 		Tenant: tenantName,
 		Name:   databaseName,
+		ID:     databaseeId,
+		Ts:     time.Now().Unix(),
 	}, time.Now().Unix())
 	suite.NoError(err)
 


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - It can happen that compaction flushes to sysdb with empty file paths. This happens when there are no changes to the segments after applying the logs.
  - The sysdb handles this by keeping the previous segment file paths
  - However versioning missed handling this case in the version file. This led to creation of versions with empty file paths in the version file.
  - Consequently, after GC deletes all old versions and only leaves this version with empty file paths, there is no data on S3.

- New functionality

## Test plan
  - Added a local test with mock s3

## Documentation Changes
None