### PR TITLE
[ENH]  Add feature to the rust log service to proxy the go log service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-cli"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arboard",
  "axum 0.8.1",

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -191,3 +191,10 @@ log_service:
             batch_size_bytes: 8388608 # 8MiB
             throughput: 3300
             headroom: 200
+    proxy_to:
+        host: "logservice.chroma"
+        port: 50051
+        connect_timeout_ms: 5000
+        request_timeout_ms: 60000 # 1 minute
+        alt_host: "rust-log-service.chroma"
+        use_alt_host_for_everything: true


### PR DESCRIPTION
## Description of changes

Following the rollout ADR, this will encode table to go
classic->transitioning->transitioned.

|            | **inactive**  | **active**   |
|------------|---------------|--------------|
| **open**   | classic       | BUG          |
| **sealed** | transitioning | transitioned |

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
