### PR TITLE
[ENH] Bootstrap a wal3 log from existing content.

### DIFF
--- a/rust/wal3/examples/wal3-bootstrap-reasoner.rs
+++ b/rust/wal3/examples/wal3-bootstrap-reasoner.rs
@@ -165,7 +165,11 @@ pub fn main() {
                     println!("panic({fs:?}, {im:?}, {rm:?}) -> {reason}");
                     break;
                 }
-                Disposition::Drop(_, _, _, _) => {
+                Disposition::Drop(reason, fs, im, rm) => {
+                    _ = reason;
+                    _ = fs;
+                    _ = im;
+                    _ = rm;
                     break;
                 }
                 Disposition::Raise(reason, fs, im, rm) => {

--- a/rust/wal3/examples/wal3-bootstrap-reasoner.rs
+++ b/rust/wal3/examples/wal3-bootstrap-reasoner.rs
@@ -1,0 +1,178 @@
+//! This file is not intended for public consumption, but is kept for completeness.
+//!
+//! In this file you will find that we reason about the bootstrap process by completely exploring
+//! the state space and pruning known good states.  The goal is to prune every state or print a
+//! list of states that are bad.
+//!
+//! This is ad-hoc machine-assisted proving without an environment or theorem prover.
+
+#[derive(Clone, Copy, Debug)]
+enum FragmentState {
+    BenignRace,
+    Conflict,
+    Success,
+}
+
+impl FragmentState {
+    fn all_states() -> impl Iterator<Item = Self> {
+        vec![
+            FragmentState::BenignRace,
+            FragmentState::Conflict,
+            FragmentState::Success,
+        ]
+        .into_iter()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InitializeManifest {
+    Uninitialized,
+    AlreadyInitialized,
+    Success,
+}
+
+impl InitializeManifest {
+    fn all_states() -> impl Iterator<Item = Self> {
+        vec![
+            InitializeManifest::Uninitialized,
+            InitializeManifest::AlreadyInitialized,
+            InitializeManifest::Success,
+        ]
+        .into_iter()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RecoverManifest {
+    Uninitialized,
+    Failure,
+    Success,
+}
+
+impl RecoverManifest {
+    fn all_states() -> impl Iterator<Item = Self> {
+        vec![
+            RecoverManifest::Uninitialized,
+            RecoverManifest::Failure,
+            RecoverManifest::Success,
+        ]
+        .into_iter()
+    }
+}
+
+enum Disposition {
+    /// The combination of states is considered a good case.
+    Good,
+    /// The combination of states is not considered by the rule.
+    Pass,
+    /// The case can be dropped with good conscience for not mattering.  The string is the reason.
+    Drop(
+        &'static str,
+        FragmentState,
+        InitializeManifest,
+        RecoverManifest,
+    ),
+    /// The case must lead to an error at runtime.
+    Panic(
+        &'static str,
+        FragmentState,
+        InitializeManifest,
+        RecoverManifest,
+    ),
+    /// The case must be raised to the user for inspection.
+    Raise(
+        &'static str,
+        FragmentState,
+        InitializeManifest,
+        RecoverManifest,
+    ),
+}
+
+fn happy_paths(fs: FragmentState, im: InitializeManifest, rm: RecoverManifest) -> Disposition {
+    match (fs, im, rm) {
+        (
+            FragmentState::Success | FragmentState::BenignRace,
+            InitializeManifest::Uninitialized | InitializeManifest::Success,
+            RecoverManifest::Success,
+        ) => Disposition::Good,
+        _ => Disposition::Pass,
+    }
+}
+
+fn error_paths(fs: FragmentState, im: InitializeManifest, rm: RecoverManifest) -> Disposition {
+    match (fs, im, rm) {
+        (_, InitializeManifest::AlreadyInitialized, _) => {
+            Disposition::Panic("cannot double-initialize manifest", fs, im, rm)
+        }
+        (_, _, RecoverManifest::Uninitialized) => {
+            Disposition::Panic("cannot have manifest become uninitialized", fs, im, rm)
+        }
+        (_, _, RecoverManifest::Failure) => {
+            Disposition::Panic("failed to install recovered manifest", fs, im, rm)
+        }
+        _ => Disposition::Pass,
+    }
+}
+
+fn conflict_on_fragment(
+    fs: FragmentState,
+    im: InitializeManifest,
+    rm: RecoverManifest,
+) -> Disposition {
+    if matches!(fs, FragmentState::Conflict) {
+        Disposition::Drop(
+            "no need to touch manifest if fragment conflicts",
+            fs,
+            im,
+            rm,
+        )
+    } else {
+        Disposition::Pass
+    }
+}
+
+fn unconditionally_raise(
+    fs: FragmentState,
+    im: InitializeManifest,
+    rm: RecoverManifest,
+) -> Disposition {
+    Disposition::Raise("unconditional raise", fs, im, rm)
+}
+
+pub fn main() {
+    let mut states = vec![];
+    for fs in FragmentState::all_states() {
+        for im in InitializeManifest::all_states() {
+            for rm in RecoverManifest::all_states() {
+                states.push((fs, im, rm));
+            }
+        }
+    }
+    let rules = vec![
+        happy_paths,
+        conflict_on_fragment,
+        error_paths,
+        unconditionally_raise,
+    ];
+    for state in states.iter() {
+        for rule in &rules {
+            match (rule)(state.0, state.1, state.2) {
+                Disposition::Pass => {}
+                Disposition::Good => {
+                    break;
+                }
+                Disposition::Panic(reason, fs, im, rm) => {
+                    println!("panic({fs:?}, {im:?}, {rm:?}) -> {reason}");
+                    break;
+                }
+                Disposition::Drop(_, _, _, _) => {
+                    break;
+                }
+                Disposition::Raise(reason, fs, im, rm) => {
+                    println!("raise({fs:?}, {im:?}, {rm:?}) -> {reason}");
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// Limits allows encoding things like offset, timestamp, and byte size limits for the read.
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct Limits {
     pub max_files: Option<u64>,
     pub max_bytes: Option<u64>,

--- a/rust/wal3/tests/test_k8s_integration_83_bootstrap.rs
+++ b/rust/wal3/tests/test_k8s_integration_83_bootstrap.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use chroma_storage::s3_client_for_test_with_new_bucket;
+
+use wal3::{
+    Limits, LogPosition, LogReader, LogReaderOptions, LogWriter, LogWriterOptions, SnapshotOptions,
+};
+
+#[tokio::test]
+async fn test_k8s_integration_83_bootstrap() {
+    let options = LogWriterOptions {
+        snapshot_manifest: SnapshotOptions {
+            snapshot_rollover_threshold: 2,
+            fragment_rollover_threshold: 2,
+        },
+        ..LogWriterOptions::default()
+    };
+    let storage = Arc::new(s3_client_for_test_with_new_bucket().await);
+    const PREFIX: &str = "test_k8s_integration_83_bootstrap";
+    const WRITER: &str = "test_k8s_integration_83_bootstrap writer";
+    let mark_dirty = ();
+    let first_record_offset_position = LogPosition::from_offset(42);
+    let mut messages = Vec::with_capacity(1000);
+    for i in 0..100 {
+        for j in 0..10 {
+            messages.push(Vec::from(format!("key:i={},j={}", i, j)));
+        }
+    }
+    LogWriter::bootstrap(
+        &options,
+        &storage,
+        PREFIX,
+        WRITER,
+        mark_dirty,
+        first_record_offset_position,
+        messages.clone(),
+    )
+    .await
+    .unwrap();
+
+    let reader = LogReader::open(
+        LogReaderOptions::default(),
+        Arc::clone(&storage),
+        "test_k8s_integration_83_bootstrap".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let scan = reader
+        .scan(LogPosition::from_offset(42), Limits::default())
+        .await
+        .unwrap();
+    assert_eq!(1, scan.len());
+    let (_, records, _) = reader.read_parquet(&scan[0]).await.unwrap();
+    for (returned, expected) in std::iter::zip(records, messages) {
+        assert_eq!(returned.1, expected);
+    }
+}

--- a/rust/wal3/tests/test_k8s_integration_84_bootstrap_empty.rs
+++ b/rust/wal3/tests/test_k8s_integration_84_bootstrap_empty.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use chroma_storage::s3_client_for_test_with_new_bucket;
+
+use wal3::{
+    Limits, LogPosition, LogReader, LogReaderOptions, LogWriter, LogWriterOptions, SnapshotOptions,
+};
+
+#[tokio::test]
+async fn test_k8s_integration_84_bootstrap_empty() {
+    let options = LogWriterOptions {
+        snapshot_manifest: SnapshotOptions {
+            snapshot_rollover_threshold: 2,
+            fragment_rollover_threshold: 2,
+        },
+        ..LogWriterOptions::default()
+    };
+    let storage = Arc::new(s3_client_for_test_with_new_bucket().await);
+    const PREFIX: &str = "test_k8s_integration_84_bootstrap_empty";
+    const WRITER: &str = "test_k8s_integration_84_bootstrap writer";
+    let mark_dirty = ();
+    let first_record_offset_position = LogPosition::from_offset(42);
+    let messages = vec![];
+    LogWriter::bootstrap(
+        &options,
+        &storage,
+        PREFIX,
+        WRITER,
+        mark_dirty,
+        first_record_offset_position,
+        messages.clone(),
+    )
+    .await
+    .unwrap();
+
+    let reader = LogReader::open(
+        LogReaderOptions::default(),
+        Arc::clone(&storage),
+        "test_k8s_integration_84_bootstrap_empty".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let scan = reader
+        .scan(LogPosition::from_offset(42), Limits::default())
+        .await
+        .unwrap();
+    assert_eq!(0, scan.len());
+}


### PR DESCRIPTION
## Description of changes

This adds a "bootstrap" call to wal3 that copies the data semi-atomically.  It is reasoned to be
safe to do concurrent with all other log operations, but may leave a FragmentSeqNo(1) lying around
in the event that a log is initialized at the same time it's bootstrapping.  This should never
happen in our system so thankfully we can just leave the hole.

See #4558 for the reasoning.

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
