### PR TITLE
[BUG]: Regex search returning documents that are deleted

### DIFF
--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -196,7 +196,7 @@ impl FullTextIndexWriter {
                 Some(offset) => {
                     let this_key = encoded_instance.omit_position();
                     if last_key != this_key {
-                        if last_key != TokenInstance::MAX {
+                        if last_key != TokenInstance::MAX && !posting_list.is_empty() {
                             let token = last_key.get_token();
                             let document_id = last_key.get_offset_id();
                             self.posting_lists_blockfile_writer
@@ -211,7 +211,7 @@ impl FullTextIndexWriter {
                     posting_list.push(offset);
                 }
                 None => {
-                    if last_key != TokenInstance::MAX {
+                    if last_key != TokenInstance::MAX && !posting_list.is_empty() {
                         let token = last_key.get_token();
                         let document_id = last_key.get_offset_id();
                         self.posting_lists_blockfile_writer
@@ -234,7 +234,7 @@ impl FullTextIndexWriter {
             }
         }
 
-        if last_key != TokenInstance::MAX {
+        if last_key != TokenInstance::MAX && !posting_list.is_empty() {
             let token = last_key.get_token();
             let document_id = last_key.get_offset_id();
             self.posting_lists_blockfile_writer

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -149,6 +149,9 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
 
             let suffix = ngram[1..].to_vec();
             for (_, doc_id, pos) in ngram_doc_pos {
+                if pos.is_empty() {
+                    continue;
+                }
                 if mask.is_none() || mask.is_some_and(|m| m.contains(&doc_id)) {
                     suffix_doc_pos
                         .entry(suffix.clone())

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -596,16 +596,31 @@ impl Operator<FilterInput, FilterOutput> for FilterOperator {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, str::FromStr};
+
+    use chroma_blockstore::{
+        arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
+        provider::BlockfileProvider,
+    };
+    use chroma_cache::new_cache_for_test;
     use chroma_log::test::{add_delete_generator, int_as_id, LoadFromGenerator, LogGenerator};
-    use chroma_segment::test::TestDistributedSegment;
+    use chroma_segment::{
+        blockfile_metadata::{MetadataSegmentReader, MetadataSegmentWriter},
+        blockfile_record::{
+            RecordSegmentReader, RecordSegmentReaderCreationError, RecordSegmentWriter,
+        },
+        test::TestDistributedSegment,
+        types::materialize_logs,
+    };
+    use chroma_storage::{local::LocalStorage, Storage};
     use chroma_system::Operator;
     use chroma_types::{
-        BooleanOperator, CompositeExpression, DocumentExpression, MetadataComparison,
-        MetadataExpression, MetadataSetValue, MetadataValue, PrimitiveOperator, SetOperator,
-        SignedRoaringBitmap, Where,
+        BooleanOperator, Chunk, CollectionUuid, CompositeExpression, DocumentExpression, LogRecord,
+        MetadataComparison, MetadataExpression, MetadataSetValue, MetadataValue, Operation,
+        OperationRecord, PrimitiveOperator, SegmentUuid, SetOperator, SignedRoaringBitmap, Where,
     };
 
-    use crate::execution::operators::filter::FilterOperator;
+    use crate::execution::operators::filter::{FilterOperator, MetadataProvider};
 
     use super::FilterInput;
 
@@ -1049,5 +1064,216 @@ mod tests {
             filter_output.compact_offset_ids,
             SignedRoaringBitmap::Include((21..=50).filter(|offset| offset % 5 != 0).collect())
         );
+    }
+
+    #[tokio::test]
+    async fn regex_empty_posting_list() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let block_cache = new_cache_for_test();
+        let sparse_index_cache = new_cache_for_test();
+        let arrow_blockfile_provider = ArrowBlockfileProvider::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            block_cache,
+            sparse_index_cache,
+        );
+        let blockfile_provider =
+            BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
+        let mut record_segment = chroma_types::Segment {
+            id: SegmentUuid::from_str("00000000-0000-0000-0000-000000000000").expect("parse error"),
+            r#type: chroma_types::SegmentType::BlockfileRecord,
+            scope: chroma_types::SegmentScope::RECORD,
+            collection: CollectionUuid::from_str("00000000-0000-0000-0000-000000000000")
+                .expect("parse error"),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        let mut metadata_segment = chroma_types::Segment {
+            id: SegmentUuid::from_str("00000000-0000-0000-0000-000000000001").expect("parse error"),
+            r#type: chroma_types::SegmentType::BlockfileMetadata,
+            scope: chroma_types::SegmentScope::METADATA,
+            collection: CollectionUuid::from_str("00000000-0000-0000-0000-000000000000")
+                .expect("parse error"),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        {
+            let segment_writer =
+                RecordSegmentWriter::from_segment(&record_segment, &blockfile_provider)
+                    .await
+                    .expect("Error creating segment writer");
+            let mut metadata_writer =
+                MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
+                    .await
+                    .expect("Error creating segment writer");
+            let data = vec![
+                LogRecord {
+                    log_offset: 1,
+                    record: OperationRecord {
+                        id: "embedding_id_1".to_string(),
+                        embedding: Some(vec![1.0, 2.0, 3.0]),
+                        encoding: None,
+                        metadata: None,
+                        document: Some(String::from("DEF")),
+                        operation: Operation::Add,
+                    },
+                },
+                LogRecord {
+                    log_offset: 2,
+                    record: OperationRecord {
+                        id: "embedding_id_2".to_string(),
+                        embedding: Some(vec![4.0, 5.0, 6.0]),
+                        encoding: None,
+                        metadata: None,
+                        document: Some(String::from("def")),
+                        operation: Operation::Add,
+                    },
+                },
+            ];
+            let data: Chunk<LogRecord> = Chunk::new(data.into());
+            let record_segment_reader: Option<RecordSegmentReader> =
+                match RecordSegmentReader::from_segment(&record_segment, &blockfile_provider).await
+                {
+                    Ok(reader) => Some(reader),
+                    Err(e) => {
+                        match *e {
+                            // Uninitialized segment is fine and means that the record
+                            // segment is not yet initialized in storage.
+                            RecordSegmentReaderCreationError::UninitializedSegment => None,
+                            RecordSegmentReaderCreationError::BlockfileOpenError(_) => {
+                                panic!("Error creating record segment reader");
+                            }
+                            RecordSegmentReaderCreationError::InvalidNumberOfFiles => {
+                                panic!("Error creating record segment reader");
+                            }
+                            RecordSegmentReaderCreationError::DataRecordNotFound(_) => {
+                                panic!("Error creating record segment reader");
+                            }
+                            RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
+                                panic!("Error creating record segment reader");
+                            }
+                        }
+                    }
+                };
+            let mat_records = materialize_logs(&record_segment_reader, data, None)
+                .await
+                .expect("Log materialization failed");
+            metadata_writer
+                .apply_materialized_log_chunk(&record_segment_reader, &mat_records)
+                .await
+                .expect("Apply materialized log to metadata segment failed");
+            metadata_writer
+                .finish()
+                .await
+                .expect("Write to blockfiles for metadata writer failed");
+            segment_writer
+                .apply_materialized_log_chunk(&record_segment_reader, &mat_records)
+                .await
+                .expect("Apply materialized log to record segment failed");
+            let record_flusher = segment_writer
+                .commit()
+                .await
+                .expect("Commit for segment writer failed");
+            let metadata_flusher = metadata_writer
+                .commit()
+                .await
+                .expect("Commit for metadata writer failed");
+            record_segment.file_path = record_flusher
+                .flush()
+                .await
+                .expect("Flush record segment writer failed");
+            metadata_segment.file_path = metadata_flusher
+                .flush()
+                .await
+                .expect("Flush metadata segment writer failed");
+        }
+        let data = vec![
+            LogRecord {
+                log_offset: 3,
+                record: OperationRecord {
+                    id: "embedding_id_3".to_string(),
+                    embedding: Some(vec![1.0, 2.0, 3.0]),
+                    encoding: None,
+                    metadata: None,
+                    document: Some(String::from("abc")),
+                    operation: Operation::Add,
+                },
+            },
+            LogRecord {
+                log_offset: 4,
+                record: OperationRecord {
+                    id: "embedding_id_2".to_string(),
+                    embedding: None,
+                    encoding: None,
+                    metadata: None,
+                    document: None,
+                    operation: Operation::Delete,
+                },
+            },
+        ];
+
+        let data: Chunk<LogRecord> = Chunk::new(data.into());
+        let record_segment_reader =
+            RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
+                .await
+                .expect("Reader should be initialized by now");
+        let segment_writer =
+            RecordSegmentWriter::from_segment(&record_segment, &blockfile_provider)
+                .await
+                .expect("Error creating segment writer");
+        let mut metadata_writer =
+            MetadataSegmentWriter::from_segment(&metadata_segment, &blockfile_provider)
+                .await
+                .expect("Error creating segment writer");
+        let some_reader = Some(record_segment_reader);
+        let mat_records = materialize_logs(&some_reader, data, None)
+            .await
+            .expect("Log materialization failed");
+        metadata_writer
+            .apply_materialized_log_chunk(&some_reader, &mat_records)
+            .await
+            .expect("Apply materialized log to metadata segment failed");
+        metadata_writer
+            .finish()
+            .await
+            .expect("Write to blockfiles for metadata writer failed");
+        segment_writer
+            .apply_materialized_log_chunk(&some_reader, &mat_records)
+            .await
+            .expect("Apply materialized log to record segment failed");
+        let record_flusher = segment_writer
+            .commit()
+            .await
+            .expect("Commit for segment writer failed");
+        let metadata_flusher = metadata_writer
+            .commit()
+            .await
+            .expect("Commit for metadata writer failed");
+        record_segment.file_path = record_flusher
+            .flush()
+            .await
+            .expect("Flush record segment writer failed");
+        metadata_segment.file_path = metadata_flusher
+            .flush()
+            .await
+            .expect("Flush metadata segment writer failed");
+        let metadata_segment_reader =
+            MetadataSegmentReader::from_segment(&metadata_segment, &blockfile_provider)
+                .await
+                .expect("Metadata segment reader construction failed");
+        let record_segment_reader =
+            RecordSegmentReader::from_segment(&record_segment, &blockfile_provider)
+                .await
+                .expect("Reader should be initialized by now");
+        let some_reader = Some(record_segment_reader);
+        let compact_metadata_provider =
+            MetadataProvider::CompactData(&metadata_segment_reader, &some_reader);
+        let res = compact_metadata_provider
+            .filter_by_document_regex("(?i)def")
+            .await
+            .expect("Expected regex to work");
+        assert_eq!(res.len(), 1);
+        assert_eq!(res.iter().next(), Some(1));
     }
 }

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -496,12 +496,13 @@ impl Operator<FilterInput, FilterOutput> for FilterOperator {
     type Error = FilterError;
 
     async fn run(&self, input: &FilterInput) -> Result<FilterOutput, FilterError> {
-        tracing::debug!("[{}]: {:?}", self.get_name(), input);
-
-        // NOTE: This is temporary traces to capture filter arguments
-        //       We suspect certain filters break the FTS algorithm
-        // TODO: Remove this after the bug is found
-        tracing::debug!("[DEBUG FILTER OPERATOR]: {:?}", self);
+        tracing::debug!(
+            "[{}]: Num log entries {:?}, metadata segment {:?}, record segment {:?}",
+            self.get_name(),
+            input.logs.len(),
+            input.metadata_segment,
+            input.record_segment
+        );
 
         let record_segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment,

--- a/rust/worker/src/execution/operators/limit.rs
+++ b/rust/worker/src/execution/operators/limit.rs
@@ -12,7 +12,7 @@ use chroma_types::{Chunk, LogRecord, MaterializedLogOperation, Segment, SignedRo
 use futures::StreamExt;
 use roaring::RoaringBitmap;
 use thiserror::Error;
-use tracing::{trace, Instrument, Span};
+use tracing::{Instrument, Span};
 
 /// The `LimitOperator` selects a range or records sorted by their offset ids
 ///
@@ -188,7 +188,8 @@ impl Operator<LimitInput, LimitOutput> for LimitOperator {
     type Error = LimitError;
 
     async fn run(&self, input: &LimitInput) -> Result<LimitOutput, LimitError> {
-        trace!("[{}]: {:?}", self.get_name(), input);
+        tracing::debug!("[{}]: num log entries {:?}, record segment {:?}, log offset ids {:?}, compact ids {:?}", self.get_name(),
+            input.logs.len(), input.record_segment, input.log_offset_ids, input.compact_offset_ids);
 
         let record_segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - A particular order of operations involving deletes on the log causes empty posting list for (token, doc) pairs of the deleted doc. Regex on a single trigram does not skip empty posting lists thereby returning documents that don't exist.
  - Fixed regex search algorithm for this case.
  - Fixed FTS algorithm to skip empty posting lists
- New functionality
  - ...

## Test plan

_How are these changes tested?_
Added unit test
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
