### PR TITLE
[BUG] Add hosted-frontend to OTel stdout layer

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -143,6 +143,10 @@ pub fn init_stdout_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                     .module_path()
                     .unwrap_or("")
                     .starts_with("opentelemetry_sdk")
+                || metadata
+                    .module_path()
+                    .unwrap_or("")
+                    .starts_with("hosted-frontend")
         }))
         .with_filter(tracing_subscriber::filter::LevelFilter::INFO)
         .boxed()


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds `hosted-frontend` to stdout layer in tracing
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
