### PR TITLE
[ENH]  Add RPC endpoints for sealing and migrating logs.

### DIFF
--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -162,6 +162,15 @@ func (s *logServer) InspectDirtyLog(ctx context.Context, req *logservicepb.Inspe
 	return
 }
 
+func (s *logServer) SealLog(ctx context.Context, req *logservicepb.SealLogRequest) (res *logservicepb.SealLogResponse, err error) {
+	// no-op for now
+	return
+}
+
+func (s *logServer) MigrateLog(ctx context.Context, req *logservicepb.MigrateLogRequest) (res *logservicepb.MigrateLogResponse, err error) {
+	// no-op for now
+	return
+}
 
 func NewLogServer(lr *repository.LogRepository) logservicepb.LogServiceServer {
 	return &logServer{

--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -96,6 +96,22 @@ message InspectDirtyLogResponse {
   repeated string markers = 1;
 }
 
+message SealLogRequest {
+  string collection_id = 1;
+}
+
+message SealLogResponse {
+  // Empty
+}
+
+message MigrateLogRequest {
+  string collection_id = 1;
+}
+
+message MigrateLogResponse {
+  // Empty
+}
+
 service LogService {
   rpc PushLogs(PushLogsRequest) returns (PushLogsResponse) {}
   rpc ScoutLogs(ScoutLogsRequest) returns (ScoutLogsResponse) {}
@@ -104,5 +120,11 @@ service LogService {
   rpc GetAllCollectionInfoToCompact(GetAllCollectionInfoToCompactRequest) returns (GetAllCollectionInfoToCompactResponse) {}
   rpc UpdateCollectionLogOffset(UpdateCollectionLogOffsetRequest) returns (UpdateCollectionLogOffsetResponse) {}
   rpc PurgeDirtyForCollection(PurgeDirtyForCollectionRequest) returns (PurgeDirtyForCollectionResponse) {}
+  // RPC endpoints to expose for operator debuggability.
+  // This endpoint must route to the rust log service.
   rpc InspectDirtyLog(InspectDirtyLogRequest) returns (InspectDirtyLogResponse) {}
+  // This endpoint must route to the go log service.
+  rpc SealLog(SealLogRequest) returns (SealLogResponse) {}
+  // This endpoint must route to the rust log service.
+  rpc MigrateLog(MigrateLogRequest) returns (MigrateLogResponse) {}
 }

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -16,9 +16,10 @@ use chroma_storage::Storage;
 use chroma_types::chroma_proto::{
     log_service_server::LogService, CollectionInfo, GetAllCollectionInfoToCompactRequest,
     GetAllCollectionInfoToCompactResponse, InspectDirtyLogRequest, InspectDirtyLogResponse,
-    LogRecord, OperationRecord, PullLogsRequest, PullLogsResponse, PurgeDirtyForCollectionRequest,
-    PurgeDirtyForCollectionResponse, PushLogsRequest, PushLogsResponse, ScoutLogsRequest,
-    ScoutLogsResponse, UpdateCollectionLogOffsetRequest, UpdateCollectionLogOffsetResponse,
+    LogRecord, MigrateLogRequest, MigrateLogResponse, OperationRecord, PullLogsRequest,
+    PullLogsResponse, PurgeDirtyForCollectionRequest, PurgeDirtyForCollectionResponse,
+    PushLogsRequest, PushLogsResponse, ScoutLogsRequest, ScoutLogsResponse, SealLogRequest,
+    SealLogResponse, UpdateCollectionLogOffsetRequest, UpdateCollectionLogOffsetResponse,
 };
 use chroma_types::chroma_proto::{ForkLogsRequest, ForkLogsResponse};
 use chroma_types::CollectionUuid;
@@ -1229,6 +1230,24 @@ impl LogService for LogServer {
             markers.extend(records);
         }
         Ok(Response::new(InspectDirtyLogResponse { markers }))
+    }
+
+    async fn seal_log(
+        &self,
+        _request: Request<SealLogRequest>,
+    ) -> Result<Response<SealLogResponse>, Status> {
+        Err(Status::failed_precondition(
+            "rust log service doesn't do sealing",
+        ))
+    }
+
+    async fn migrate_log(
+        &self,
+        _request: Request<MigrateLogRequest>,
+    ) -> Result<Response<MigrateLogResponse>, Status> {
+        Err(Status::failed_precondition(
+            "rust log service doesn't do migrating yet",
+        ))
     }
 }
 


### PR DESCRIPTION
## Description of changes

This updates the IDL for the log service to have two new methods:
SealLog and MigrateLog.  They each take a collection ID and trigger the
two phase transitions for the go-to-rust migration that's coming.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

IDL includes comments.
