### PR TITLE
[ENH] Add handling for ChromaQuotaExceededError

### DIFF
--- a/clients/js/packages/chromadb-core/src/ChromaFetch.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaFetch.ts
@@ -9,6 +9,7 @@ import {
   ChromaError,
   createErrorByType,
   ChromaUniqueError,
+  ChromaQuotaExceededError,
 } from "./Errors";
 import { FetchAPI } from "./generated";
 
@@ -74,6 +75,14 @@ export const chromaFetch: FetchAPI = async (
           );
         case 409:
           throw new ChromaUniqueError("The resource already exists");
+        case 422:
+          if (
+            respBody?.message &&
+            respBody?.message.startsWith("Quota exceeded")
+          ) {
+            throw new ChromaQuotaExceededError(respBody?.message);
+          }
+          break;
         case 500:
           throw parseServerError(respBody?.error);
         case 502:

--- a/clients/js/packages/chromadb-core/src/Errors.ts
+++ b/clients/js/packages/chromadb-core/src/Errors.ts
@@ -85,6 +85,13 @@ export class ChromaUniqueError extends Error {
   }
 }
 
+export class ChromaQuotaExceededError extends Error {
+  name = "ChromaQuotaExceededError";
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+  }
+}
+
 export function createErrorByType(type: string, message: string) {
   switch (type) {
     case "InvalidCollection":


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Handles the new quota errors (422 code and message starts with `Quota exceeded`) and returns a `ChromaQuotaExceededError`. The new error type includes the quota message where before this threw a generic Error without any quota specific messaging.
- New functionality
  - None

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

None
