### PR TITLE
[CHORE] Remove validation on ef config update for model path

### DIFF
--- a/chromadb/utils/embedding_functions/instructor_embedding_function.py
+++ b/chromadb/utils/embedding_functions/instructor_embedding_function.py
@@ -39,7 +39,7 @@ class InstructorEmbeddingFunction(EmbeddingFunction[Documents]):
         self.device = device
         self.instruction = instruction
 
-        self._model = INSTRUCTOR(model_name, device=device)
+        self._model = INSTRUCTOR(model_name_or_path=model_name, device=device)
 
     def __call__(self, input: Documents) -> Embeddings:
         """
@@ -99,10 +99,10 @@ class InstructorEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
-            raise ValueError(
-                "The model name cannot be changed after the embedding function has been initialized."
-            )
+        # model_name is also used as the identifier for model path if stored locally.
+        # Users should be able to change the path if needed, so we should not validate that.
+        # e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
+        return
 
     @staticmethod
     def validate_config(config: Dict[str, Any]) -> None:

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -42,7 +42,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
 
         if model_name not in self.models:
             self.models[model_name] = SentenceTransformer(
-                model_name, device=device, **kwargs
+                model_name_or_path=model_name, device=device, **kwargs
             )
         self._model = self.models[model_name]
 
@@ -102,10 +102,10 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
-            raise ValueError(
-                "The model name cannot be changed after the embedding function has been initialized."
-            )
+        # model_name is also used as the identifier for model path if stored locally.
+        # Users should be able to change the path if needed, so we should not validate that.
+        # e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
+        return
 
     @staticmethod
     def validate_config(config: Dict[str, Any]) -> None:

--- a/chromadb/utils/embedding_functions/text2vec_embedding_function.py
+++ b/chromadb/utils/embedding_functions/text2vec_embedding_function.py
@@ -71,10 +71,10 @@ class Text2VecEmbeddingFunction(EmbeddingFunction[Documents]):
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        if "model_name" in new_config:
-            raise ValueError(
-                "The model name cannot be changed after the embedding function has been initialized."
-            )
+        # model_name is also used as the identifier for model path if stored locally.
+        # Users should be able to change the path if needed, so we should not validate that.
+        # e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
+        return
 
     @staticmethod
     def validate_config(config: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Description of changes

Some embedding functions allow the user to pass a path for their embedding function. We should not be validating that the user is trying to update the model path, as that could be too restrictive.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
