### PR TITLE
[ENH]  Tools to manually seal and migrate the log.

### DIFF
--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -213,6 +213,11 @@ func (r *LogRepository) ForkRecords(ctx context.Context, sourceCollectionID stri
 	return
 }
 
+func (r *LogRepository) SealCollection(ctx context.Context, collectionID string) (err error) {
+	_, err = r.queries.SealLog(ctx, collectionID)
+	return
+}
+
 func (r *LogRepository) GetAllCollectionInfoToCompact(ctx context.Context, minCompactionSize uint64) (collectionToCompact []log.GetAllCollectionsToCompactRow, err error) {
 	collectionToCompact, err = r.queries.GetAllCollectionsToCompact(ctx, int64(minCompactionSize))
 	if collectionToCompact == nil {
@@ -223,6 +228,7 @@ func (r *LogRepository) GetAllCollectionInfoToCompact(ctx context.Context, minCo
 	}
 	return
 }
+
 func (r *LogRepository) UpdateCollectionCompactionOffsetPosition(ctx context.Context, collectionId string, offsetPosition int64) (err error) {
 	err = r.queries.UpdateCollectionCompactionOffsetPosition(ctx, log.UpdateCollectionCompactionOffsetPositionParams{
 		ID:                             collectionId,

--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -155,22 +155,28 @@ func (s *logServer) UpdateCollectionLogOffset(ctx context.Context, req *logservi
 }
 
 func (s *logServer) PurgeDirtyForCollection(ctx context.Context, req *logservicepb.PurgeDirtyForCollectionRequest) (res *logservicepb.PurgeDirtyForCollectionResponse, err error) {
-	// no-op for now
 	return
 }
 
 func (s *logServer) InspectDirtyLog(ctx context.Context, req *logservicepb.InspectDirtyLogRequest) (res *logservicepb.InspectDirtyLogResponse, err error) {
-	// no-op for now
 	return
 }
 
 func (s *logServer) SealLog(ctx context.Context, req *logservicepb.SealLogRequest) (res *logservicepb.SealLogResponse, err error) {
-	// no-op for now
+	var collectionID types.UniqueID
+	collectionID, err = types.ToUniqueID(&req.CollectionId)
+	if err != nil {
+		return
+	}
+	err = s.lr.SealCollection(ctx, collectionID.String())
 	return
 }
 
 func (s *logServer) MigrateLog(ctx context.Context, req *logservicepb.MigrateLogRequest) (res *logservicepb.MigrateLogResponse, err error) {
-	// no-op for now
+	return
+}
+
+func (s *logServer) InspectLogState(ctx context.Context, req *logservicepb.InspectLogStateRequest) (res *logservicepb.InspectLogStateResponse, err error) {
 	return
 }
 

--- a/go/pkg/log/store/db/queries.sql.go
+++ b/go/pkg/log/store/db/queries.sql.go
@@ -80,6 +80,7 @@ with summary as (
     from record_log r, collection c
     where r.collection_id = c.id
     and (c.record_enumeration_offset_position - c.record_compaction_offset_position) >= $1
+    and not c.is_sealed
     and r.offset > c.record_compaction_offset_position
 )
 select collection_id, "offset", timestamp, rank from summary

--- a/go/pkg/log/store/queries/queries.sql
+++ b/go/pkg/log/store/queries/queries.sql
@@ -16,6 +16,7 @@ with summary as (
     from record_log r, collection c
     where r.collection_id = c.id
     and (c.record_enumeration_offset_position - c.record_compaction_offset_position) >= sqlc.arg(min_compaction_size)
+    and not c.is_sealed
     and r.offset > c.record_compaction_offset_position
 )
 select * from summary

--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -114,6 +114,14 @@ message MigrateLogResponse {
   // Empty
 }
 
+message InspectLogStateRequest {
+  string collection_id = 1;
+}
+
+message InspectLogStateResponse {
+  string debug = 1;
+}
+
 service LogService {
   rpc PushLogs(PushLogsRequest) returns (PushLogsResponse) {}
   rpc ScoutLogs(ScoutLogsRequest) returns (ScoutLogsResponse) {}
@@ -129,4 +137,6 @@ service LogService {
   rpc SealLog(SealLogRequest) returns (SealLogResponse) {}
   // This endpoint must route to the rust log service.
   rpc MigrateLog(MigrateLogRequest) returns (MigrateLogResponse) {}
+  // This endpoint can be supported by any log service.
+  rpc InspectLogState(InspectLogStateRequest) returns (InspectLogStateResponse) {}
 }

--- a/rust/log-service/src/bin/chroma-inspect-log-state.rs
+++ b/rust/log-service/src/bin/chroma-inspect-log-state.rs
@@ -1,0 +1,27 @@
+use tonic::transport::Channel;
+
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::InspectLogStateRequest;
+
+#[tokio::main]
+async fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        eprintln!("USAGE: chroma-inspect-log-state [HOST] [COLLECTION_UUID]");
+        std::process::exit(13);
+    }
+    let logservice = Channel::from_shared(args[0].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to log service");
+    let mut client = LogServiceClient::new(logservice);
+    let state = client
+        .inspect_log_state(InspectLogStateRequest {
+            collection_id: args[1].clone(),
+        })
+        .await
+        .expect("could not inspect log state");
+    let state = state.into_inner();
+    println!("{}", state.debug);
+}

--- a/rust/log-service/src/bin/chroma-migrate-log.rs
+++ b/rust/log-service/src/bin/chroma-migrate-log.rs
@@ -1,0 +1,30 @@
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::MigrateLogRequest;
+use chroma_types::CollectionUuid;
+
+#[tokio::main]
+async fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        eprintln!("USAGE: chroma-migrate-log [HOST] [COLLECTION-UUID]");
+        std::process::exit(13);
+    }
+    let logservice = Channel::from_shared(args[0].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to log service");
+    let collection_id = Uuid::parse_str(&args[1])
+        .map(CollectionUuid)
+        .expect("Failed to parse collection_id");
+    let mut client = LogServiceClient::new(logservice);
+    let _resp = client
+        .migrate_log(MigrateLogRequest {
+            collection_id: collection_id.to_string(),
+        })
+        .await
+        .expect("migrate log request should succeed");
+}

--- a/rust/log-service/src/bin/chroma-seal-go-log.rs
+++ b/rust/log-service/src/bin/chroma-seal-go-log.rs
@@ -1,0 +1,30 @@
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::SealLogRequest;
+use chroma_types::CollectionUuid;
+
+#[tokio::main]
+async fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        eprintln!("USAGE: chroma-seal-log [HOST] [COLLECTION-UUID]");
+        std::process::exit(13);
+    }
+    let logservice = Channel::from_shared(args[0].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to log service");
+    let collection_id = Uuid::parse_str(&args[1])
+        .map(CollectionUuid)
+        .expect("Failed to parse collection_id");
+    let mut client = LogServiceClient::new(logservice);
+    let _resp = client
+        .seal_log(SealLogRequest {
+            collection_id: collection_id.to_string(),
+        })
+        .await
+        .expect("seal log request should succeed");
+}

--- a/rust/log-service/src/bin/log.rs
+++ b/rust/log-service/src/bin/log.rs
@@ -1,4 +1,9 @@
-#[tokio::main]
-async fn main() {
-    chroma_log_service::log_entrypoint().await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        // NOTE(rescrv):  Default stack size overflows on request to move logs.
+        .thread_stack_size(16 * 1024 * 1024)
+        .build()
+        .unwrap()
+        .block_on(chroma_log_service::log_entrypoint());
 }

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -421,6 +421,8 @@ impl GrpcLog {
                 .await?;
             norm.extend(alt)
         }
+        norm.sort_by_key(|n| n.collection_id);
+        norm.dedup_by_key(|n| n.collection_id);
         Ok(norm)
     }
 


### PR DESCRIPTION
## Description of changes

- Implement the `migrate_log` endpoint.
- Add tool for sealing the go log.
- Add tool for triggering the go->rust migration (if there is no write to trigger it)


## Test plan

Tested in tilt manually.  Working on a plan to test in depth.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
