### PR TITLE
[ENH] Remove custom regex validation

### DIFF
--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -30,22 +30,6 @@ pub enum LiteralExpr {
     Alternation(Vec<LiteralExpr>),
 }
 
-impl LiteralExpr {
-    pub fn contains_ngram_literal(&self, n: usize, max_literal_width: usize) -> bool {
-        match self {
-            LiteralExpr::Literal(literals) => literals
-                .split(|lit| lit.width() > max_literal_width)
-                .any(|chunk| chunk.len() >= n),
-            LiteralExpr::Concat(literal_exprs) => literal_exprs
-                .iter()
-                .any(|expr| expr.contains_ngram_literal(n, max_literal_width)),
-            LiteralExpr::Alternation(literal_exprs) => literal_exprs
-                .iter()
-                .all(|expr| expr.contains_ngram_literal(n, max_literal_width)),
-        }
-    }
-}
-
 impl From<ChromaHir> for LiteralExpr {
     fn from(value: ChromaHir) -> Self {
         match value {

--- a/rust/types/src/regex/mod.rs
+++ b/rust/types/src/regex/mod.rs
@@ -26,8 +26,6 @@ pub struct ChromaRegex {
 pub enum ChromaRegexError {
     #[error("Byte pattern is not allowed")]
     BytePattern,
-    #[error("Pattern is too permissive: {0}")]
-    PermissivePattern(String),
     // NOTE: regex::Error is a large type, so we only store its error message here.
     #[error("Unexpected regex error: {0}")]
     Regex(String),
@@ -58,11 +56,6 @@ impl TryFrom<String> for ChromaRegex {
     fn try_from(value: String) -> Result<Self, Self::Error> {
         let hir = parse(&value).map_err(|e| ChromaRegexError::RegexSyntax(e.to_string()))?;
         let properties = hir.properties().clone();
-        if let Some(0) = properties.minimum_len() {
-            return Err(ChromaRegexError::PermissivePattern(format!(
-                "[{value}] can match empty string"
-            )));
-        }
         Ok(Self {
             hir: hir.try_into()?,
             pattern: value,

--- a/rust/types/src/where_parsing.rs
+++ b/rust/types/src/where_parsing.rs
@@ -1,4 +1,3 @@
-use crate::regex::literal_expr::LiteralExpr;
 use crate::regex::{ChromaRegex, ChromaRegexError};
 use crate::{CompositeExpression, DocumentOperator, MetadataExpression, PrimitiveOperator, Where};
 use chroma_error::{ChromaError, ErrorCodes};
@@ -149,10 +148,7 @@ pub fn parse_where_document(json_payload: &Value) -> Result<Where, WhereValidati
         operator_type,
         DocumentOperator::Regex | DocumentOperator::NotRegex
     ) {
-        let regex = ChromaRegex::try_from(value_str.to_string())?;
-        if !LiteralExpr::from(regex.hir().clone()).contains_ngram_literal(3, 6) {
-            return Err(ChromaRegexError::PermissivePattern.into());
-        }
+        ChromaRegex::try_from(value_str.to_string())?;
     }
     Ok(Where::Document(crate::DocumentExpression {
         operator: operator_type,

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -231,6 +231,10 @@ impl<'me> MetadataProvider<'me> {
                     metadata_segment_reader.full_text_index_reader.as_ref(),
                     record_segment_reader,
                 ) {
+                    // The pattern can match empty string and thus match any document
+                    if let Some(0) = chroma_regex.properties().minimum_len() {
+                        return Ok(rec_reader.get_offset_stream(..).try_collect().await?);
+                    }
                     let literal_expr = LiteralExpr::from(chroma_regex.hir().clone());
                     let approximate_matching_offset_ids = fti_reader
                         .match_literal_expression(&literal_expr)
@@ -284,6 +288,10 @@ impl<'me> MetadataProvider<'me> {
                 }
             }
             MetadataProvider::Log(metadata_log_reader) => {
+                // The pattern can match empty string and thus match any document
+                if let Some(0) = chroma_regex.properties().minimum_len() {
+                    return Ok(metadata_log_reader.document.keys().collect());
+                }
                 let regex = chroma_regex.regex()?;
                 Ok(metadata_log_reader
                     .document


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Remove the regex requirement that it must contain at least three literals
  - Short circuit on pattern that can match empty string
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
