### PR TITLE
[ENH]: add validation during garbage collection for empty file paths

### DIFF
--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -617,6 +617,28 @@ mod tests {
         let collection_id_c = CollectionUuid::new();
         let collection_id_d = CollectionUuid::new();
 
+        for collection_id in [
+            collection_id_a,
+            collection_id_b,
+            collection_id_c,
+            collection_id_d,
+        ] {
+            sysdb
+                .create_collection(
+                    "test_tenant".to_string(),
+                    "test_database".to_string(),
+                    collection_id,
+                    format!("test_collection_{}", collection_id),
+                    vec![],
+                    None,
+                    None,
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
         let version_file_a_path =
             create_version_file(collection_id_a, vec![0, 1], storage.clone()).await;
         let version_file_b_path =

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
@@ -293,8 +293,13 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
     fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
         match transition {
             Transition::CreateCollection { .. } => true,
-            Transition::IncrementCollectionVersion { collection_id, .. } => {
+            Transition::IncrementCollectionVersion {
+                collection_id,
+                next_segments,
+            } => {
+                // Check if the collection exists and if the new version has at least 1 file path
                 state.get_collection_ids().contains(collection_id)
+                    && !next_segments.get_all_file_paths().is_empty()
             }
             Transition::ForkCollection {
                 source_collection_id,

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1211,6 +1211,14 @@ mod tests {
 
         let mut expected_new_collection = old_cas.collection.clone();
         expected_new_collection.version += 1;
+        expected_new_collection.version_file_path = Some(
+            old_cas
+                .collection
+                .version_file_path
+                .clone()
+                .unwrap()
+                .replace("/1", "/2"),
+        );
         assert_eq!(new_cas.collection, expected_new_collection);
         assert_eq!(new_cas.metadata_segment.id, old_cas.metadata_segment.id);
         assert_eq!(new_cas.record_segment.id, old_cas.record_segment.id);


### PR DESCRIPTION
## Description of changes

Adds a defensive check that validates that the current version is v0 if there are no file paths.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added a test.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a