### PR TITLE
[ENH] Add inner trace handler for requests

### DIFF
--- a/rust/frontend/src/tower_tracing.rs
+++ b/rust/frontend/src/tower_tracing.rs
@@ -90,7 +90,7 @@ where
             tracing::Level::DEBUG,
             "HTTP request handler",
             http.route = http_route,
-            http.version = ?req.version(),
+            otel.name = format!("Handler {} {}", req.method(), http_route),
         );
 
         let future = self.inner.call(req);


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds a inner trace handler for requests, the current span starts when clients connect, so it includes request upload. This will only include the inner type to handle the request
  - Pic of jaeger to demonstrate, only `HANDLER` actually includes the request processing time
<img width="1728" alt="Screenshot 2025-05-20 at 4 03 30 PM" src="https://github.com/user-attachments/assets/00d8c0d7-cae4-4154-92b0-544c12f004f5" />

- New functionality
  - ...

## Test plan

_How are these changes tested?_
I checked via jaeger, by trickling requests
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
