### PR TITLE
[ENH] Auth path with collection info

### DIFF
--- a/rust/frontend/src/auth/mod.rs
+++ b/rust/frontend/src/auth/mod.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
 
-use chroma_types::GetUserIdentityResponse;
+use chroma_types::{Collection, GetUserIdentityResponse};
 
 #[derive(Clone, Copy, Debug)]
 pub enum AuthzAction {
@@ -91,6 +91,14 @@ pub trait AuthenticateAndAuthorize: Send + Sync {
         resource: AuthzResource,
     ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>>;
 
+    fn authenticate_and_authorize_collection(
+        &self,
+        _headers: &HeaderMap,
+        action: AuthzAction,
+        resource: AuthzResource,
+        _collection: Collection,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>>;
+
     fn get_user_identity(
         &self,
         _headers: &HeaderMap,
@@ -103,6 +111,16 @@ impl AuthenticateAndAuthorize for () {
         _headers: &HeaderMap,
         _action: AuthzAction,
         _resource: AuthzResource,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>> {
+        Box::pin(ready(Ok::<(), AuthError>(())))
+    }
+
+    fn authenticate_and_authorize_collection(
+        &self,
+        _headers: &HeaderMap,
+        _action: AuthzAction,
+        _resource: AuthzResource,
+        _collection: Collection,
     ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>> {
         Box::pin(ready(Ok::<(), AuthError>(())))
     }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -15,23 +15,24 @@ use chroma_types::{
     operator::{Filter, KnnBatch, KnnProjection, Limit, Projection, Scan},
     plan::{Count, Get, Knn},
     AddCollectionRecordsError, AddCollectionRecordsRequest, AddCollectionRecordsResponse,
-    CollectionUuid, CountCollectionsError, CountCollectionsRequest, CountCollectionsResponse,
-    CountRequest, CountResponse, CreateCollectionError, CreateCollectionRequest,
-    CreateCollectionResponse, CreateDatabaseError, CreateDatabaseRequest, CreateDatabaseResponse,
-    CreateTenantError, CreateTenantRequest, CreateTenantResponse, DeleteCollectionError,
-    DeleteCollectionRecordsError, DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse,
-    DeleteCollectionRequest, DeleteDatabaseError, DeleteDatabaseRequest, DeleteDatabaseResponse,
-    ForkCollectionError, ForkCollectionRequest, ForkCollectionResponse, GetCollectionError,
-    GetCollectionRequest, GetCollectionResponse, GetCollectionsError, GetDatabaseError,
-    GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse, GetTenantError,
-    GetTenantRequest, GetTenantResponse, HealthCheckResponse, HeartbeatError, HeartbeatResponse,
-    Include, KnnIndex, ListCollectionsRequest, ListCollectionsResponse, ListDatabasesError,
-    ListDatabasesRequest, ListDatabasesResponse, Operation, OperationRecord, QueryError,
-    QueryRequest, QueryResponse, ResetError, ResetResponse, Segment, SegmentScope, SegmentType,
-    SegmentUuid, UpdateCollectionError, UpdateCollectionRecordsError,
-    UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse, UpdateCollectionRequest,
-    UpdateCollectionResponse, UpsertCollectionRecordsError, UpsertCollectionRecordsRequest,
-    UpsertCollectionRecordsResponse, VectorIndexConfiguration, Where,
+    Collection, CollectionUuid, CountCollectionsError, CountCollectionsRequest,
+    CountCollectionsResponse, CountRequest, CountResponse, CreateCollectionError,
+    CreateCollectionRequest, CreateCollectionResponse, CreateDatabaseError, CreateDatabaseRequest,
+    CreateDatabaseResponse, CreateTenantError, CreateTenantRequest, CreateTenantResponse,
+    DeleteCollectionError, DeleteCollectionRecordsError, DeleteCollectionRecordsRequest,
+    DeleteCollectionRecordsResponse, DeleteCollectionRequest, DeleteDatabaseError,
+    DeleteDatabaseRequest, DeleteDatabaseResponse, ForkCollectionError, ForkCollectionRequest,
+    ForkCollectionResponse, GetCollectionError, GetCollectionRequest, GetCollectionResponse,
+    GetCollectionsError, GetDatabaseError, GetDatabaseRequest, GetDatabaseResponse, GetRequest,
+    GetResponse, GetTenantError, GetTenantRequest, GetTenantResponse, HealthCheckResponse,
+    HeartbeatError, HeartbeatResponse, Include, KnnIndex, ListCollectionsRequest,
+    ListCollectionsResponse, ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse,
+    Operation, OperationRecord, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse,
+    Segment, SegmentScope, SegmentType, SegmentUuid, UpdateCollectionError,
+    UpdateCollectionRecordsError, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateCollectionRequest, UpdateCollectionResponse, UpsertCollectionRecordsError,
+    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, VectorIndexConfiguration,
+    Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
@@ -60,7 +61,7 @@ pub struct ServiceBasedFrontend {
     executor: Executor,
     log_client: Log,
     sysdb_client: SysDb,
-    collections_with_segments_provider: CollectionsWithSegmentsProvider,
+    pub collections_with_segments_provider: CollectionsWithSegmentsProvider,
     max_batch_size: u32,
     metrics: Arc<Metrics>,
     default_knn_index: KnnIndex,
@@ -137,6 +138,18 @@ impl ServiceBasedFrontend {
 
     pub fn get_supported_segment_types(&self) -> Vec<SegmentType> {
         self.executor.get_supported_segment_types()
+    }
+
+    pub async fn get_cached_collection(
+        &mut self,
+        collection_id: CollectionUuid,
+    ) -> Result<Collection, GetCollectionError> {
+        Ok(self
+            .collections_with_segments_provider
+            .get_collection_with_segments(collection_id)
+            .await
+            .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?
+            .collection)
     }
 
     async fn get_collection_dimension(

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -61,7 +61,7 @@ pub struct ServiceBasedFrontend {
     executor: Executor,
     log_client: Log,
     sysdb_client: SysDb,
-    pub collections_with_segments_provider: CollectionsWithSegmentsProvider,
+    collections_with_segments_provider: CollectionsWithSegmentsProvider,
     max_batch_size: u32,
     metrics: Arc<Metrics>,
     default_knn_index: KnnIndex,

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1038,7 +1038,7 @@ async fn update_collection(
         "Updating collection [{collection_id}] in database [{database}] for tenant [{tenant}]"
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::UpdateCollection,
             AuthzResource {
@@ -1046,6 +1046,7 @@ async fn update_collection(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let api_token = headers
@@ -1264,9 +1265,7 @@ async fn collection_add(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let collection_id =
@@ -1354,9 +1353,7 @@ async fn collection_update(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let collection_id =
@@ -1448,9 +1445,7 @@ async fn collection_upsert(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let collection_id =
@@ -1541,9 +1536,7 @@ async fn collection_delete(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let collection_id =
@@ -1620,9 +1613,7 @@ async fn collection_count(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let _guard = server.scorecard_request(&[
@@ -1690,9 +1681,7 @@ async fn collection_get(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let collection_id =
@@ -1787,9 +1776,7 @@ async fn collection_query(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
-            CollectionUuid::from_str(&collection_id)
-                .map_err(|_| ValidationError::CollectionId)?
-                .clone(),
+            CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
         )
         .await?;
     let collection_id =

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -351,6 +351,8 @@ impl FrontendServer {
             .await?)
     }
 
+    // This is used to authenticate API operations that are collection-specific.
+    // We need to send additional collection info to the auth service.
     async fn authenticate_and_authorize_collection(
         &mut self,
         headers: &HeaderMap,

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -350,6 +350,20 @@ impl FrontendServer {
             .authenticate_and_authorize(headers, action, resource)
             .await?)
     }
+
+    async fn authenticate_and_authorize_collection(
+        &mut self,
+        headers: &HeaderMap,
+        action: AuthzAction,
+        resource: AuthzResource,
+        collection_id: CollectionUuid,
+    ) -> Result<(), ServerError> {
+        let collection = self.frontend.get_cached_collection(collection_id).await?;
+        Ok(self
+            .auth
+            .authenticate_and_authorize_collection(headers, action, resource, collection)
+            .await?)
+    }
 }
 
 ////////////////////////// Method Handlers //////////////////////////
@@ -1242,7 +1256,7 @@ async fn collection_add(
         ],
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Add,
             AuthzResource {
@@ -1250,6 +1264,9 @@ async fn collection_add(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let collection_id =
@@ -1329,7 +1346,7 @@ async fn collection_update(
         ],
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Update,
             AuthzResource {
@@ -1337,6 +1354,9 @@ async fn collection_update(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let collection_id =
@@ -1420,7 +1440,7 @@ async fn collection_upsert(
         ],
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Update,
             AuthzResource {
@@ -1428,6 +1448,9 @@ async fn collection_upsert(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let collection_id =
@@ -1510,7 +1533,7 @@ async fn collection_delete(
         ],
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Delete,
             AuthzResource {
@@ -1518,6 +1541,9 @@ async fn collection_delete(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let collection_id =
@@ -1586,7 +1612,7 @@ async fn collection_count(
         "Counting number of records in collection [{collection_id}] in database [{database}] for tenant [{tenant}]",
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Count,
             AuthzResource {
@@ -1594,6 +1620,9 @@ async fn collection_count(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let _guard = server.scorecard_request(&[
@@ -1653,7 +1682,7 @@ async fn collection_get(
         ],
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Get,
             AuthzResource {
@@ -1661,6 +1690,9 @@ async fn collection_get(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let collection_id =
@@ -1747,7 +1779,7 @@ async fn collection_query(
         ],
     );
     server
-        .authenticate_and_authorize(
+        .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Query,
             AuthzResource {
@@ -1755,6 +1787,9 @@ async fn collection_query(
                 database: Some(database.clone()),
                 collection: Some(collection_id.clone()),
             },
+            CollectionUuid::from_str(&collection_id)
+                .map_err(|_| ValidationError::CollectionId)?
+                .clone(),
         )
         .await?;
     let collection_id =


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Adds an auth path that allows for sending granular collection info

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
