### PR TITLE
[BLD]: remove Datadog from CI, use blacksmith for Rust cache

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -20,10 +20,6 @@ runs:
     # https://github.com/docker/setup-qemu-action - for multiplatform builds
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
-    # https://github.com/docker/setup-buildx-action - for multiplatform builds
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
     - name: Log in to the Github Container registry
       uses: docker/login-action@v2.1.0
       if: ${{ inputs.ghcr-username != '' }}

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -8,29 +8,9 @@ runs:
   using: "composite"
   steps:
     - name: Setup Rust
-      shell: bash
-      # (reads from rust-toolchain.toml)
-      run: |
-        rustup --version
-        rustup toolchain install 1.81.0
-        rustup default 1.81.0
-    # Needed for sccache to work on Windows
-    - name: Set default toolchain to rust-toolchain.toml on Windows
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        # Read the file content as a single string
-        $toolchainToml = Get-Content .\rust-toolchain.toml -Raw
-
-        # Use regex to match the line 'channel = "<something>"'
-        if ($toolchainToml -match 'channel\s*=\s*"([^"]+)"') {
-          $channel = $matches[1]
-          Write-Host "Setting Rust default channel to: $channel"
-          rustup default $channel
-        } else {
-          Write-Error "Could not parse 'channel' from rust-toolchain.toml"
-          exit 1
-        }
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache: false # we use Blacksmith's cache package below
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -35,12 +35,7 @@ runs:
       uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ inputs.github-token }}
-    - name: Use sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Enable sccache
-      shell: bash
-      run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+    - name: Set up cache
+      uses: useblacksmith/rust-cache@v3
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -10,6 +10,7 @@ runs:
     - name: Cache Rust toolchain
       id: cache-rustup
       uses: useblacksmith/cache@v5
+      if: ${{ runner.os != 'windows' }}
       with:
         path: ~/.rustup
         key: toolchain-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}
@@ -24,5 +25,9 @@ runs:
         repo-token: ${{ inputs.github-token }}
     - name: Set up cache
       uses: useblacksmith/rust-cache@v3
+      if: ${{ runner.os != 'windows' }}
+    - name: Set up cache (Windows)
+      uses: Swatinem/rust-cache@v2
+      if: ${{ runner.os == 'windows' }}
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -7,7 +7,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Rust
+    - name: Cache Rust toolchain
+      id: cache-rustup
+      uses: useblacksmith/cache@v5
+      with:
+        path: ~/.rustup
+        key: toolchain-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml') }}
+    - name: Install Rust toolchain
+      if: ${{ steps.cache-rustup.outputs.cache-hit != 'true' }}
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         cache: false # we use Blacksmith's cache package below

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -117,7 +117,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: ${{ matrix.platform.os == 'linux' && '--zig' || '' }} --release --out dist
-          sccache: "true"
           container: "off"
 
       - name: Upload wheels

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -45,18 +45,9 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          sccache: true
       - name: Install built wheel
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Configure pytest to upload results to Datadog
-        uses: datadog/test-visibility-github-action@v2
-        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-        if: ${{ !contains(matrix.platform, 'windows') }}
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: ${{ vars.DD_SITE }}
       - name: Test
         run: python -m pytest ${{ matrix.test-globs }} ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
         shell: bash
@@ -93,14 +84,6 @@ jobs:
       uses: ./.github/actions/rust
       with:
           github-token: ${{ github.token }}
-    - name: Configure pytest to upload results to Datadog
-      uses: datadog/test-visibility-github-action@v2
-      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-      if: ${{ !contains(matrix.platform, 'windows') }}
-      with:
-        languages: python
-        api_key: ${{ secrets.DD_API_KEY }}
-        site: ${{ vars.DD_SITE }}
     - name: Rust Integration Test
       run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
       shell: bash
@@ -129,14 +112,6 @@ jobs:
         uses: ./.github/actions/rust
         with:
           github-token: ${{ github.token }}
-      - name: Configure pytest to upload results to Datadog
-        uses: datadog/test-visibility-github-action@v2
-        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-        if: ${{ !contains(matrix.platform, 'windows') }}
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: ${{ vars.DD_SITE }}
       - name: Test
         run: bin/rust-integration-test.sh ${{ matrix.test-globs }}
         shell: bash
@@ -172,13 +147,6 @@ jobs:
       - uses: ./.github/actions/python
         with:
           python-version: ${{ matrix.python }}
-      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
-      # - name: Configure pytest to upload results to Datadog
-      #   uses: datadog/test-visibility-github-action@v2
-      #   with:
-      #     languages: python
-      #     api_key: ${{ secrets.DD_API_KEY }}
-      #     site: ${{ vars.DD_SITE }}
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:
@@ -235,18 +203,9 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          sccache: true
       - name: Install built wheel
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
-      - name: Configure pytest to upload results to Datadog
-        uses: datadog/test-visibility-github-action@v2
-        # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-        if: ${{ !contains(matrix.platform, 'windows') }}
-        with:
-          languages: python
-          api_key: ${{ secrets.DD_API_KEY }}
-          site: ${{ vars.DD_SITE }}
       - name: Test
         run: python -m pytest ${{ matrix.test-globs }} --durations 10
         shell: bash
@@ -280,18 +239,9 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         command: build
-        sccache: true
     - name: Install built wheel
       shell: bash
       run: pip install --no-index --find-links target/wheels/ chromadb
-    - name: Configure pytest to upload results to Datadog
-      uses: datadog/test-visibility-github-action@v2
-      # This action currently fails on Windows (https://github.com/DataDog/test-visibility-github-action/issues/36)
-      if: ${{ !contains(matrix.platform, 'windows') }}
-      with:
-        languages: python
-        api_key: ${{ secrets.DD_API_KEY }}
-        site: ${{ vars.DD_SITE }}
     - name: Integration Test
       run: python -m pytest ${{ matrix.test-globs }}
       shell: bash

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -23,15 +23,6 @@ jobs:
         run: cargo build --bin chroma
       - name: Test
         run: cargo nextest run --no-capture --profile ci
-      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
-      # - name: Upload test results
-      #   uses: datadog/junit-upload-github-action@v1
-      #   with:
-      #       api_key: ${{ secrets.DD_API_KEY }}
-      #       site: ${{ vars.DD_SITE }}
-      #       service: chroma
-      #       files: target/nextest/ci/junit.xml
-      #       logs: true
   test-long:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
@@ -48,15 +39,6 @@ jobs:
         run: cargo build --bin chroma
       - name: Test
         run: cargo nextest run --no-capture --profile ci_long_running
-      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
-      # - name: Upload test results
-      #   uses: datadog/junit-upload-github-action@v1
-      #   with:
-      #       api_key: ${{ secrets.DD_API_KEY }}
-      #       site: ${{ vars.DD_SITE }}
-      #       service: chroma
-      #       files: target/nextest/ci/junit.xml
-      #       logs: true
 
   test-integration:
     strategy:
@@ -87,15 +69,6 @@ jobs:
         run: cargo build --bin chroma
       - name: Run tests
         run: cargo nextest run --profile ci_k8s_integration
-      # TODO(adityamaru): Add Datadog test visibility when running in Chroma's repo.
-      # - name: Upload test results
-      #   uses: datadog/junit-upload-github-action@v1
-      #   with:
-      #       api_key: ${{ secrets.DD_API_KEY }}
-      #       site: ${{ vars.DD_SITE }}
-      #       service: chroma
-      #       files: target/nextest/ci/junit.xml
-      #       logs: true
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Keep this version in sync with rust/Dockerfile.
 channel = "1.81.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
## Description of changes

Cleans up our workflows by removing the unused Datadog integration, and substantially speeds up Rust-based workflows by using the `rust-cache` action instead of sccache & caching the Rust toolchain. Times below are total Rust setup & compile time:

|                                               | before | after | speedup |
|-----------------------------------------------|--------|-------|---------|
| `test-rust-bindings`                          | 1m57s  | 1m11s | 1.6x    |
| `test-rust-single-node-integration`           | 2m45s  | 1m8s  | 2.4x    |
| `test-rust-single-node-integration` (Windows) | 6m36s  | 58s   | 6.8x    |
| `test-rust-thin-client`                       | 2m43s  | 1m17s | 2.1x    |
| `test-rust-bindings-stress`                   | 1m42s  | 1m12s | 1.4x    |
| `test-rust-bindings-stress` (Windows)         | 3m32s  | 2m18s | 1.5x    |
| `test-python-cli`                             | 2m22s  | 1m36s | 1.5x    |
| Rust `test`                                   | 2m42s  | 1m18s | 2.1x    |

(comparing [this run](https://github.com/chroma-core/chroma/actions/runs/15169101778/job/42657024355?pr=4591) against [this run](https://github.com/chroma-core/chroma/actions/runs/15168164591/job/42651370837?pr=4588))

Caching the Rust toolchain should also make workflows more reliable by adding some protection against rate limits/flaky external networks.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a