### PR TITLE
[BUG]  Add a test that irons out an OBO in the rust log/go log migration path.

### DIFF
--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -30,6 +30,8 @@ message ScoutLogsResponse {
 
 message PullLogsRequest {
   string collection_id = 1;
+  // The offset of the first record to be returned.  This should match
+  // PullLogsResponse.records[0].log_offset.
   int64 start_from_offset = 2;
   int32 batch_size = 3;
   int64 end_timestamp = 4;
@@ -51,7 +53,9 @@ message ForkLogsRequest {
 }
 
 message ForkLogsResponse {
+  // The offset of the last record that was compacted.
   uint64 compaction_offset = 1;
+  // The offset of the last record that was inserted.
   uint64 enumeration_offset = 2;
 }
 
@@ -75,6 +79,7 @@ message GetAllCollectionInfoToCompactResponse {
 
 message UpdateCollectionLogOffsetRequest {
   string collection_id = 1;
+  // The offset of the last record that was compacted.
   int64 log_offset = 2;
 }
 

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -480,7 +480,7 @@ impl DirtyMarker {
                 };
                 let maximum_log_position = manifest.maximum_log_position();
                 let record_enumeration_position = maximum_log_position.offset() as i64 - 1;
-                let record_compaction_position = cursor.position.offset() as i64;
+                let record_compaction_position = cursor.position.offset() as i64 - 1;
                 match record_enumeration_position.cmp(&record_compaction_position) {
                     Ordering::Equal => {
                         // Same as above.
@@ -1338,12 +1338,13 @@ impl LogService for LogServer {
         request: Request<UpdateCollectionLogOffsetRequest>,
     ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
         let request = request.into_inner();
+        let adjusted_log_offset = request.log_offset + 1;
         let collection_id = Uuid::parse_str(&request.collection_id)
             .map(CollectionUuid)
             .map_err(|_| Status::invalid_argument("Failed to parse collection id"))?;
         tracing::info!(
             "update_collection_log_offset for {collection_id} to {}",
-            request.log_offset
+            adjusted_log_offset
         );
         let storage_prefix = storage_prefix_for_log(collection_id);
         let log_reader = LogReader::new(
@@ -1372,11 +1373,15 @@ impl LogService for LogServer {
         })?;
         let default = Cursor::default();
         let cursor = witness.as_ref().map(|w| w.cursor()).unwrap_or(&default);
-        if cursor.position.offset() > request.log_offset as u64 {
-            return Err(Status::aborted("Invalid offset"));
+        if cursor.position.offset() > adjusted_log_offset as u64 {
+            return Err(Status::aborted(format!(
+                "Invalid offset: {} > {}",
+                cursor.position.offset(),
+                adjusted_log_offset as u64
+            )));
         }
         let cursor = Cursor {
-            position: LogPosition::from_offset(request.log_offset as u64),
+            position: LogPosition::from_offset(adjusted_log_offset as u64),
             epoch_us: SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .map_err(|_| wal3::Error::Internal)

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2263,7 +2263,7 @@ mod tests {
                     Ok(None)
                 } else if collection_id == collection_id_collected_clone {
                     Ok(Some(Witness::default_etag_with_cursor(Cursor {
-                        position: LogPosition::from_offset(100),
+                        position: LogPosition::from_offset(101),
                         epoch_us: 0,
                         writer: "TODO".to_string(),
                     })))

--- a/rust/log/tests/log-offsets.rs
+++ b/rust/log/tests/log-offsets.rs
@@ -1,0 +1,209 @@
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::{
+    GetAllCollectionInfoToCompactRequest, MigrateLogRequest, PullLogsRequest, PushLogsRequest,
+    ScoutLogsRequest, SealLogRequest, UpdateCollectionLogOffsetRequest,
+};
+use chroma_types::{Operation, OperationRecord};
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_k8s_integration_log_offsets_empty_log_50052() {
+    const ADDRESS: &str = "http://localhost:50052";
+    let collection_id = Uuid::new_v4().to_string();
+    eprintln!("processing {collection_id} on {ADDRESS}");
+    let logservice_channel = Channel::from_static(ADDRESS).connect().await.unwrap();
+    let mut log_service = LogServiceClient::new(logservice_channel);
+    // Insert one record.
+    let records = vec![OperationRecord {
+        id: "some-record".to_string(),
+        embedding: Some(vec![0.0, 0.0, 0.0]),
+        document: Some("some-document".to_string()),
+        encoding: None,
+        metadata: None,
+        operation: Operation::Add,
+    }];
+    let resp = log_service
+        .push_logs(PushLogsRequest {
+            collection_id: collection_id.clone(),
+            records: records
+                .into_iter()
+                .map(|r| r.try_into())
+                .collect::<Result<Vec<chroma_types::chroma_proto::OperationRecord>, _>>()
+                .unwrap(),
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    assert!(!resp.log_is_sealed);
+    assert_eq!(1, resp.record_count);
+    // Scout said record.
+    let resp = log_service
+        .scout_logs(ScoutLogsRequest {
+            collection_id: collection_id.clone(),
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    assert_eq!(1, resp.first_uncompacted_record_offset);
+    assert_eq!(2, resp.first_uninserted_record_offset);
+    // Pull said record.
+    let resp = log_service
+        .pull_logs(PullLogsRequest {
+            collection_id: collection_id.clone(),
+            batch_size: 2,
+            end_timestamp: i64::MAX,
+            start_from_offset: 1,
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    assert_eq!(1, resp.records.len());
+    assert_eq!(1, resp.records[0].log_offset);
+    // "compact" said record.
+    let resp = log_service
+        .get_all_collection_info_to_compact(GetAllCollectionInfoToCompactRequest {
+            min_compaction_size: 1,
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    let Some(coll) = resp
+        .all_collection_info
+        .iter()
+        .find(|c| c.collection_id == collection_id)
+    else {
+        panic!("collection not found");
+    };
+    assert_eq!(1, coll.first_log_offset);
+    // "finish" the compaction.
+    let _resp = log_service
+        .update_collection_log_offset(UpdateCollectionLogOffsetRequest {
+            collection_id: collection_id.clone(),
+            log_offset: 1,
+        })
+        .await
+        .unwrap();
+    // said record no longer shows in compaction.
+    let resp = log_service
+        .get_all_collection_info_to_compact(GetAllCollectionInfoToCompactRequest {
+            min_compaction_size: 1,
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    let coll = resp
+        .all_collection_info
+        .iter()
+        .find(|c| c.collection_id == collection_id);
+    assert!(coll.is_none());
+}
+
+#[tokio::test]
+async fn test_k8s_integration_log_offsets_empty_log_50054() {
+    const ADDRESS1: &str = "http://localhost:50052";
+    const ADDRESS2: &str = "http://localhost:50054";
+    let collection_id = Uuid::new_v4().to_string();
+    eprintln!("processing {collection_id} on {ADDRESS1} (go) and {ADDRESS2} (rust)");
+    let go_logservice_channel = Channel::from_static(ADDRESS1).connect().await.unwrap();
+    let mut go_log_service = LogServiceClient::new(go_logservice_channel);
+    let rust_logservice_channel = Channel::from_static(ADDRESS2).connect().await.unwrap();
+    let mut rust_log_service = LogServiceClient::new(rust_logservice_channel);
+    // Insert one record.
+    let records = vec![OperationRecord {
+        id: "some-record".to_string(),
+        embedding: Some(vec![0.0, 0.0, 0.0]),
+        document: Some("some-document".to_string()),
+        encoding: None,
+        metadata: None,
+        operation: Operation::Add,
+    }];
+    let resp = rust_log_service
+        .push_logs(PushLogsRequest {
+            collection_id: collection_id.clone(),
+            records: records
+                .into_iter()
+                .map(|r| r.try_into())
+                .collect::<Result<Vec<chroma_types::chroma_proto::OperationRecord>, _>>()
+                .unwrap(),
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    assert!(!resp.log_is_sealed);
+    assert_eq!(1, resp.record_count);
+    // Seal on the go log.  Do this after there's a record so the log is initialized in log db.
+    let _resp = go_log_service
+        .seal_log(SealLogRequest {
+            collection_id: collection_id.clone(),
+        })
+        .await
+        .unwrap();
+    // Migrate to the rust log
+    let _resp = rust_log_service
+        .migrate_log(MigrateLogRequest {
+            collection_id: collection_id.clone(),
+        })
+        .await
+        .unwrap();
+    // Scout said record.
+    let resp = rust_log_service
+        .scout_logs(ScoutLogsRequest {
+            collection_id: collection_id.clone(),
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    assert_eq!(1, resp.first_uncompacted_record_offset);
+    assert_eq!(2, resp.first_uninserted_record_offset);
+    // Pull said record.
+    let resp = rust_log_service
+        .pull_logs(PullLogsRequest {
+            collection_id: collection_id.clone(),
+            batch_size: 2,
+            end_timestamp: i64::MAX,
+            start_from_offset: 1,
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    assert_eq!(1, resp.records.len());
+    assert_eq!(1, resp.records[0].log_offset);
+    // "compact" said record.
+    let resp = rust_log_service
+        .get_all_collection_info_to_compact(GetAllCollectionInfoToCompactRequest {
+            min_compaction_size: 1,
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    let Some(coll) = resp
+        .all_collection_info
+        .iter()
+        .find(|c| c.collection_id == collection_id)
+    else {
+        panic!("collection not found");
+    };
+    assert_eq!(1, coll.first_log_offset);
+    // "finish" the compaction.
+    let _resp = rust_log_service
+        .update_collection_log_offset(UpdateCollectionLogOffsetRequest {
+            collection_id: collection_id.clone(),
+            log_offset: 1,
+        })
+        .await
+        .unwrap();
+    // said record no longer shows in compaction.
+    let resp = rust_log_service
+        .get_all_collection_info_to_compact(GetAllCollectionInfoToCompactRequest {
+            min_compaction_size: 1,
+        })
+        .await
+        .unwrap();
+    let resp = resp.into_inner();
+    let coll = resp
+        .all_collection_info
+        .iter()
+        .find(|c| c.collection_id == collection_id);
+    assert!(coll.is_none());
+}


### PR DESCRIPTION
## Description of changes

The rust log service handles cursors slightly differently from the go
log service.  Add two tests that are nearly identical to sus out
divergences in behavior between the two systems.

## Test plan

Add test.  Run test.  Leave the rest to CI.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
