### PR TITLE
[BUG]  Sealing a collection right away fails.

### DIFF
--- a/chromadb/test/distributed/test_log_failover.py
+++ b/chromadb/test/distributed/test_log_failover.py
@@ -24,6 +24,50 @@ from chromadb.test.utils.wait_for_version_increase import wait_for_version_incre
 RECORDS = 100
 
 @skip_if_not_cluster()
+def test_log_immediate_failover(
+    client: ClientAPI,
+) -> None:
+    seed = time.time()
+    random.seed(seed)
+    print("Generating data with seed ", seed)
+    reset(client)
+    collection = client.create_collection(
+        name="test",
+        metadata={"hnsw:construction_ef": 128, "hnsw:search_ef": 128, "hnsw:M": 128},
+    )
+
+    time.sleep(1)
+
+    print('failing over for', collection.id)
+    channel = grpc.insecure_channel('localhost:50052')
+    log_service_stub = LogServiceStub(channel)
+
+    request = SealLogRequest(collection_id=str(collection.id))
+    response = log_service_stub.SealLog(request, timeout=60)
+
+    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    ids = []
+    embeddings = []
+    for i in range(RECORDS + RECORDS):
+        ids.append(str(i))
+        embeddings.append(np.random.rand(1, 3)[0])
+        collection.add(
+            ids=[str(i)],
+            embeddings=[embeddings[-1]],
+        )
+    results = []
+    for i in range(RECORDS + RECORDS):
+        result = collection.get(ids=[str(i)], include=["embeddings"])
+        if len(result["embeddings"]) == 0:
+            print("missing result", i)
+        results.append(result)
+    for (i, result) in enumerate(results):
+        if len(result["embeddings"]):
+            assert all([math.fabs(x - y) < 0.001 for (x, y) in zip(result["embeddings"][0], embeddings[i])])
+        else:
+            assert False, "missing a result"
+
+@skip_if_not_cluster()
 def test_log_failover(
     client: ClientAPI,
 ) -> None:

--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/chroma-core/chroma/go/pkg/log/store/db"
@@ -215,6 +216,9 @@ func (r *LogRepository) ForkRecords(ctx context.Context, sourceCollectionID stri
 
 func (r *LogRepository) SealCollection(ctx context.Context, collectionID string) (err error) {
 	_, err = r.queries.SealLog(ctx, collectionID)
+	if err != nil && strings.Contains(err.Error(), "no rows in result set") {
+		_, err = r.queries.SealLogInsert(ctx, collectionID)
+	}
 	return
 }
 

--- a/go/pkg/log/store/db/queries.sql.go
+++ b/go/pkg/log/store/db/queries.sql.go
@@ -292,6 +292,22 @@ func (q *Queries) SealLog(ctx context.Context, id string) (Collection, error) {
 	return i, err
 }
 
+const sealLogInsert = `-- name: SealLogInsert :one
+INSERT INTO collection(id, is_sealed, record_compaction_offset_position, record_enumeration_offset_position) VALUES ($1, true, 0, 0) returning id, record_compaction_offset_position, record_enumeration_offset_position, is_sealed
+`
+
+func (q *Queries) SealLogInsert(ctx context.Context, id string) (Collection, error) {
+	row := q.db.QueryRow(ctx, sealLogInsert, id)
+	var i Collection
+	err := row.Scan(
+		&i.ID,
+		&i.RecordCompactionOffsetPosition,
+		&i.RecordEnumerationOffsetPosition,
+		&i.IsSealed,
+	)
+	return i, err
+}
+
 const updateCollectionCompactionOffsetPosition = `-- name: UpdateCollectionCompactionOffsetPosition :exec
 UPDATE collection set record_compaction_offset_position = $2 where id = $1
 `

--- a/go/pkg/log/store/queries/queries.sql
+++ b/go/pkg/log/store/queries/queries.sql
@@ -68,3 +68,6 @@ INSERT INTO record_log ("offset", collection_id, timestamp, record)
 
 -- name: SealLog :one
 UPDATE collection SET is_sealed = true WHERE id = $1 returning *;
+
+-- name: SealLogInsert :one
+INSERT INTO collection(id, is_sealed, record_compaction_offset_position, record_enumeration_offset_position) VALUES ($1, true, 0, 0) returning *;


### PR DESCRIPTION
## Description of changes

Because there would be no row in the DB, sealing the collection fails to
update is_sealed to true.   Add a fallback to insert a sealed row if the
update fails.  Add a test to capture that this works.

## Test plan

CI.  Ran the new test locally.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
