### PR TITLE
[ENH]  Add a way to seal a tenant's Go log immediately upon collection creation.

### DIFF
--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -64,6 +64,8 @@ pub struct FrontendConfig {
     pub executor: ExecutorConfig,
     #[serde(default = "default_default_knn_index")]
     pub default_knn_index: KnnIndex,
+    #[serde(default = "Default::default")]
+    pub tenants_to_migrate_immediately: Vec<String>,
 }
 
 impl FrontendConfig {
@@ -80,6 +82,7 @@ impl FrontendConfig {
             log: default_log_config(),
             executor: default_executor_config(),
             default_knn_index: default_default_knn_index(),
+            tenants_to_migrate_immediately: vec![],
         }
     }
 }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -66,9 +66,11 @@ pub struct ServiceBasedFrontend {
     metrics: Arc<Metrics>,
     default_knn_index: KnnIndex,
     retries_builder: ExponentialBuilder,
+    tenants_to_migrate_immediately: HashSet<String>,
 }
 
 impl ServiceBasedFrontend {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         allow_reset: bool,
         sysdb_client: SysDb,
@@ -77,6 +79,7 @@ impl ServiceBasedFrontend {
         executor: Executor,
         max_batch_size: u32,
         default_knn_index: KnnIndex,
+        tenants_to_migrate_immediately: HashSet<String>,
     ) -> Self {
         let meter = global::meter("chroma");
         let fork_retries_counter = meter.u64_counter("fork_retries").build();
@@ -119,6 +122,7 @@ impl ServiceBasedFrontend {
             metrics,
             default_knn_index,
             retries_builder,
+            tenants_to_migrate_immediately,
         }
     }
 
@@ -489,7 +493,7 @@ impl ServiceBasedFrontend {
         let collection = self
             .sysdb_client
             .create_collection(
-                tenant_id,
+                tenant_id.clone(),
                 database_name,
                 collection_id,
                 name,
@@ -505,8 +509,16 @@ impl ServiceBasedFrontend {
             .collections_with_segments_cache
             .remove(&collection_id)
             .await;
-
+        if self.tenant_is_on_new_log_by_default(&tenant_id) {
+            if let Err(err) = self.log_client.seal_log(&tenant_id, collection_id).await {
+                tracing::error!("could not seal collection right away: {err}");
+            }
+        }
         Ok(collection)
+    }
+
+    fn tenant_is_on_new_log_by_default(&self, tenant_id: &str) -> bool {
+        self.tenants_to_migrate_immediately.contains(tenant_id)
     }
 
     pub async fn update_collection(
@@ -1471,6 +1483,11 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
         let executor =
             Executor::try_from_config(&(config.executor.clone(), system.clone()), registry).await?;
 
+        let tenants_to_migrate_immediately = config
+            .tenants_to_migrate_immediately
+            .iter()
+            .cloned()
+            .collect::<HashSet<String>>();
         Ok(ServiceBasedFrontend::new(
             config.allow_reset,
             sysdb,
@@ -1479,6 +1496,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             executor,
             max_batch_size,
             config.default_knn_index,
+            tenants_to_migrate_immediately,
         ))
     }
 }

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -1,4 +1,4 @@
-use crate::grpc_log::GrpcLog;
+use crate::grpc_log::{GrpcLog, GrpcSealLogError};
 use crate::in_memory_log::InMemoryLog;
 use crate::sqlite_log::SqliteLog;
 use crate::types::CollectionInfo;
@@ -208,6 +208,18 @@ impl Log {
             Log::Sqlite(log) => log.reset().await,
             Log::Grpc(_) => Ok(ResetResponse {}),
             Log::InMemory(_) => Ok(ResetResponse {}),
+        }
+    }
+
+    pub async fn seal_log(
+        &mut self,
+        tenant: &str,
+        collection_id: CollectionUuid,
+    ) -> Result<(), GrpcSealLogError> {
+        match self {
+            Log::Grpc(log) => log.seal_log(tenant, collection_id).await,
+            Log::Sqlite(_) => unimplemented!(),
+            Log::InMemory(_) => unimplemented!(),
         }
     }
 }

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -122,6 +122,7 @@ impl Bindings {
             log: log_config,
             executor: executor_config,
             default_knn_index: knn_index,
+            tenants_to_migrate_immediately: vec![],
         };
 
         let frontend = runtime.block_on(async {


### PR DESCRIPTION
## Description of changes

I want a way to make a tenant bound to the new log for all collections,
no matter when they are created.  One way to handle this would be to
make the log service tenant-aware and have it do the selection
intelligently on the fly.  This would require threading the tenant
information in the proto and trusting it all the way down.

The alternative taken in this PR is to deal with it entirely from the
frontend by sealing the collection on the critical path of collection
creation, opting to trace an error rather than fail the op entirely if
sealing the log fails.

## Test plan

CI

## Documentation Changes

N/A
