### PR TITLE
[BLD]: significantly speed up dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,10 @@ tempfile = "3.14.0"
 itertools = "0.13.0"
 serial_test = "3.2.0"
 
+[profile.dev]
+# Significantly reduces compile times
+split-debuginfo = "unpacked"
+
 [profile.release]
 debug = 2
 lto = "thin"


### PR DESCRIPTION
## Description of changes

This change significantly speeds up dev builds. Timings when adding a comment to a specific file and observing the incremental build time in `tilt`:

|                                            | before | after | speedup |
|--------------------------------------------|--------|-------|---------|
| `rust/sqlite/src/db.rs`                    | 41s    | 18s   | 2.3x    |
| `rust/log-service/src/state_hash_table.rs` | 15s    | 9s    | 1.7x    |

`split-debuginfo = unpacked` is the default on macOS, however because we build inside Docker the Linux default (off) is used instead.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a