### PR TITLE
[ENH] Add TracedJson handler, unify and add detail to request tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-cli"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "arboard",
  "axum 0.8.1",
@@ -1525,6 +1525,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.1",
  "backon",
+ "bytes",
  "chroma-cache",
  "chroma-config",
  "chroma-distance",
@@ -1539,6 +1540,7 @@ dependencies = [
  "chroma-types",
  "figment",
  "futures",
+ "http-body-util",
  "lazy_static",
  "mdac",
  "ndarray",
@@ -3682,12 +3684,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.1.0",
  "http-body 1.0.1",
  "pin-project-lite",
@@ -4508,7 +4510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7044,9 +7046,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -7308,7 +7310,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.92",
  "quote 1.0.37",
  "syn 2.0.101",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ figment = { version = "0.10.12", features = ["env", "yaml", "test"] }
 flatbuffers = "24.3.25"
 futures = "0.3"
 futures-core = "0.3"
+http-body-util = "0.1.3"
 lazy_static = { version = "1.4" }
 num_cpus = "1.16.0"
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -8,12 +8,14 @@ name = "frontend_service"
 path = "src/bin/frontend_service.rs"
 
 [dependencies]
+bytes = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
 figment = { workspace = true }
+http-body-util = { workspace = true }
 lazy_static.workspace = true
 uuid = { workspace = true }
 tonic = { workspace = true }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -11,6 +11,7 @@ pub mod quota;
 pub mod server;
 mod server_middleware;
 mod tower_tracing;
+mod traced_json;
 mod types;
 
 use chroma_config::{registry::Registry, Configurable};

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -46,6 +46,7 @@ use crate::{
     quota::{Action, QuotaEnforcer, QuotaPayload},
     server_middleware::{always_json_errors_middleware, default_json_content_type_middleware},
     tower_tracing::add_tracing_middleware,
+    traced_json::TracedJson,
     types::errors::{ErrorResponse, ServerError, ValidationError},
     Frontend,
 };
@@ -493,7 +494,7 @@ async fn create_tenant(
     Json(request): Json<CreateTenantPayload>,
 ) -> Result<Json<CreateTenantResponse>, ServerError> {
     server.metrics.create_tenant.add(1, &[]);
-    tracing::info!("Creating tenant [{}]", request.name);
+    tracing::info!(name: "create_tenant", tenant_name = %request.name);
     server
         .authenticate_and_authorize(
             &headers,
@@ -529,7 +530,7 @@ async fn get_tenant(
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<GetTenantResponse>, ServerError> {
     server.metrics.get_tenant.add(1, &[]);
-    tracing::info!("Getting tenant [{}]", name);
+    tracing::info!(name: "get_tenant", tenant_name = %name);
     server
         .authenticate_and_authorize(
             &headers,
@@ -574,7 +575,7 @@ async fn create_database(
         .metrics
         .create_database
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!("Creating database [{}] for tenant [{}]", name, tenant);
+    tracing::info!(name: "create_database", tenant_name = %tenant, database_name = %name);
     server
         .authenticate_and_authorize(
             &headers,
@@ -636,7 +637,7 @@ async fn list_databases(
         .metrics
         .list_databases
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!("Listing database for tenant [{}]", tenant);
+    tracing::info!(name: "list_databases", tenant_name = %tenant);
     server
         .authenticate_and_authorize(
             &headers,
@@ -679,7 +680,7 @@ async fn get_database(
         .metrics
         .get_database
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!("Getting database [{}] for tenant [{}]", database, tenant);
+    tracing::info!(name: "get_database", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
             &headers,
@@ -722,7 +723,7 @@ async fn delete_database(
         .metrics
         .delete_database
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!("Deleting database [{}] for tenant [{}]", database, tenant);
+    tracing::info!(name: "delete_database", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
             &headers,
@@ -773,13 +774,7 @@ async fn list_collections(
         .metrics
         .list_collections
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!(
-        "Listing collections in database [{}] for tenant [{}] with limit [{:?}] and offset [{:?}]",
-        database,
-        tenant,
-        limit,
-        offset
-    );
+    tracing::info!(name: "list_collections", tenant_name = %tenant, database_name = %database, limit = ?limit, offset = ?offset);
     server
         .authenticate_and_authorize(
             &headers,
@@ -829,7 +824,7 @@ async fn count_collections(
         .metrics
         .count_collections
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!("Counting number of collections in database [{database}] for tenant [{tenant}]",);
+    tracing::info!(name: "count_collections", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
             &headers,
@@ -884,7 +879,7 @@ async fn create_collection(
         .metrics
         .create_collection
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!("Creating collection in database [{database}] for tenant [{tenant}]");
+    tracing::info!(name: "create_collection", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
             &headers,
@@ -962,9 +957,7 @@ async fn get_collection(
         .metrics
         .get_collection
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!(
-        "Getting collection [{collection_name}] in database [{database}] for tenant [{tenant}]"
-    );
+    tracing::info!(name: "get_collection", tenant_name = %tenant, database_name = %database, collection_name = %collection_name);
     server
         .authenticate_and_authorize(
             &headers,
@@ -1020,9 +1013,7 @@ async fn update_collection(
             KeyValue::new("collection_id", collection_id.clone()),
         ],
     );
-    tracing::info!(
-        "Updating collection [{collection_id}] in database [{database}] for tenant [{tenant}]"
-    );
+    tracing::info!(name: "update_collection", tenant_name = %tenant, database_name = %database, collection_id = %collection_id);
     server
         .authenticate_and_authorize(
             &headers,
@@ -1092,9 +1083,7 @@ async fn delete_collection(
         .metrics
         .delete_collection
         .add(1, &[KeyValue::new("tenant", tenant.clone())]);
-    tracing::info!(
-        "Deleting collection [{collection_name}] in database [{database}] for tenant [{tenant}]"
-    );
+    tracing::info!(name: "delete_collection", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
             &headers,
@@ -1152,9 +1141,7 @@ async fn fork_collection(
             KeyValue::new("collection_id", collection_id.clone()),
         ],
     );
-    tracing::info!(
-        "Forking collection [{collection_id}] in database [{database}] for tenant [{tenant}]"
-    );
+    tracing::info!(name: "fork_collection", tenant_name = %tenant, database_name = %database, collection_id = %collection_id);
     server
         .authenticate_and_authorize(
             &headers,
@@ -1232,7 +1219,7 @@ async fn collection_add(
     headers: HeaderMap,
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
-    Json(payload): Json<AddCollectionRecordsPayload>,
+    TracedJson(payload): TracedJson<AddCollectionRecordsPayload>,
 ) -> Result<(StatusCode, Json<AddCollectionRecordsResponse>), ServerError> {
     server.metrics.collection_add.add(
         1,
@@ -1280,6 +1267,7 @@ async fn collection_add(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    tracing::info!(name: "collection_add", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.len());
     let request = chroma_types::AddCollectionRecordsRequest::try_new(
         tenant,
         database,
@@ -1366,6 +1354,7 @@ async fn collection_update(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    tracing::info!(name: "collection_update", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.len());
     let request = chroma_types::UpdateCollectionRecordsRequest::try_new(
         tenant,
         database,
@@ -1458,6 +1447,7 @@ async fn collection_upsert(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    tracing::info!(name: "collection_upsert", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.len());
     let request = chroma_types::UpsertCollectionRecordsRequest::try_new(
         tenant,
         database,
@@ -1540,7 +1530,7 @@ async fn collection_delete(
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
     ])?;
-
+    tracing::info!(name: "collection_delete", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.as_ref().map_or(0, |ids| ids.len()), has_where = r#where.is_some());
     let request = chroma_types::DeleteCollectionRecordsRequest::try_new(
         tenant,
         database,
@@ -1583,7 +1573,10 @@ async fn collection_count(
         ],
     );
     tracing::info!(
-        "Counting number of records in collection [{collection_id}] in database [{database}] for tenant [{tenant}]",
+        name: "collection_count",
+        tenant = tenant,
+        database = database,
+        collection_id = collection_id
     );
     server
         .authenticate_and_authorize(
@@ -1681,14 +1674,18 @@ async fn collection_get(
         quota_payload = quota_payload.with_limit(limit);
     }
     server.quota_enforcer.enforce(&quota_payload).await?;
-    tracing::info!(
-        "Getting records from collection [{collection_id}] in database [{database}] for tenant [{tenant}]",
-    );
     let _guard = server.scorecard_request(&[
         "op:read",
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
     ])?;
+
+    tracing::info!(
+        name: "collection_get",
+        num_ids = payload.ids.as_ref().map_or(0, |ids| ids.len()),
+        include = ?payload.include,
+        has_where = parsed_where.is_some(),
+    );
     let request = GetRequest::try_new(
         tenant,
         database,
@@ -1737,7 +1734,7 @@ async fn collection_query(
     headers: HeaderMap,
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
-    Json(payload): Json<QueryRequestPayload>,
+    TracedJson(payload): TracedJson<QueryRequestPayload>,
 ) -> Result<Json<QueryResponse>, ServerError> {
     server.metrics.collection_query.add(
         1,
@@ -1779,16 +1776,19 @@ async fn collection_query(
         quota_payload = quota_payload.with_query_ids(ids);
     }
     server.quota_enforcer.enforce(&quota_payload).await?;
-    tracing::info!(
-        "Querying records from collection [{collection_id}] in database [{database}] for tenant [{tenant}]",
-    );
-
     let _guard = server.scorecard_request(&[
         "op:read",
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    tracing::info!(
+        name: "collection_query",
+        num_ids = payload.ids.as_ref().map_or(0, |ids| ids.len()),
+        num_embeddings = payload.query_embeddings.len(),
+        include = ?payload.include,
+        has_where = parsed_where.is_some(),
+    );
     let request = QueryRequest::try_new(
         tenant,
         database,

--- a/rust/frontend/src/tower_tracing.rs
+++ b/rust/frontend/src/tower_tracing.rs
@@ -16,8 +16,7 @@ impl<B> MakeSpan<B> for RequestTracing {
         let http_route = request
             .extensions()
             .get::<MatchedPath>()
-            .map_or_else(|| "(unknown route)", |mp| mp.as_str())
-            .to_owned();
+            .map_or_else(|| "(unknown route)", |mp| mp.as_str());
 
         let host = request
             .headers()

--- a/rust/frontend/src/traced_json.rs
+++ b/rust/frontend/src/traced_json.rs
@@ -1,0 +1,85 @@
+use axum::body::Body;
+use axum::extract::{rejection::JsonRejection, FromRequest, Request};
+use axum::response::IntoResponse;
+use axum::{BoxError, RequestExt};
+use http_body_util::BodyExt;
+use tracing::Instrument;
+
+/// TracedJson is a thing wrapper around axum::Json that allows us to trace the request body buffering
+/// as well as the JSON parsing.
+/// The error behavior has parity with axum::Json, but the error type is different because those types
+/// are private to axum.
+pub(crate) struct TracedJson<T>(pub T);
+
+pub(crate) enum TracingJsonRejection {
+    JsonRejection(JsonRejection),
+    LengthLimitError,
+    UnknownBodyError,
+}
+
+impl IntoResponse for TracingJsonRejection {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            TracingJsonRejection::JsonRejection(rejection) => rejection.into_response(),
+            TracingJsonRejection::LengthLimitError => axum::response::Response::builder()
+                .status(axum::http::StatusCode::PAYLOAD_TOO_LARGE)
+                .body(axum::body::Body::from("Payload too large"))
+                // SAFETY(hammadb): This unwrap is safe because I have verified that this builder turns
+                // into a valid response.
+                .unwrap(),
+            TracingJsonRejection::UnknownBodyError => axum::response::Response::builder()
+                .status(axum::http::StatusCode::BAD_REQUEST)
+                .body(axum::body::Body::from(
+                    "Unknown error while buffering the request body",
+                ))
+                // SAFETY(hammadb): This unwrap is safe because I have verified that this builder turns
+                // into a valid response.
+                .unwrap(),
+        }
+    }
+}
+
+impl<S, T> FromRequest<S> for TracedJson<T>
+where
+    axum::Json<T>: FromRequest<S, Rejection = JsonRejection>,
+    S: Send + Sync,
+{
+    type Rejection = TracingJsonRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let (parts, body) = req.with_limited_body().into_parts();
+
+        let bytes = body
+            .collect()
+            .instrument(tracing::debug_span!("buffering_request_body"))
+            .await;
+        let buffered_req = match bytes {
+            Ok(bytes) => Request::from_parts(parts, Body::from(bytes.to_bytes())),
+            Err(err) => {
+                // two layers of boxes here because `with_limited_body`
+                // wraps the `http_body_util::Limited` in a `axum_core::Body`
+                // which also wraps the error type
+                let box_error = match BoxError::from(err).downcast::<axum::Error>() {
+                    Ok(err) => err.into_inner(),
+                    Err(err) => err,
+                };
+                let box_error = match box_error.downcast::<axum::Error>() {
+                    Ok(err) => err.into_inner(),
+                    Err(err) => err,
+                };
+                match box_error.downcast::<http_body_util::LengthLimitError>() {
+                    Ok(_) => return Err(TracingJsonRejection::LengthLimitError),
+                    Err(_) => return Err(TracingJsonRejection::UnknownBodyError),
+                };
+            }
+        };
+
+        match axum::Json::<T>::from_request(buffered_req, state)
+            .instrument(tracing::debug_span!("parsing_json"))
+            .await
+        {
+            Ok(value) => Ok(Self(value.0)),
+            Err(rejection) => Err(TracingJsonRejection::JsonRejection(rejection)),
+        }
+    }
+}

--- a/rust/frontend/src/traced_json.rs
+++ b/rust/frontend/src/traced_json.rs
@@ -5,7 +5,7 @@ use axum::{BoxError, RequestExt};
 use http_body_util::BodyExt;
 use tracing::Instrument;
 
-/// TracedJson is a thing wrapper around axum::Json that allows us to trace the request body buffering
+/// TracedJson is a thin wrapper around axum::Json that allows us to trace the request body buffering
 /// as well as the JSON parsing.
 /// The error behavior has parity with axum::Json, but the error type is different because those types
 /// are private to axum.

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -38,6 +38,7 @@ pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                 "wal3",
                 "worker",
                 "garbage_collector",
+                "axum",
             ]
             .into_iter()
             .map(|s| s.to_string() + "=trace")

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -38,7 +38,6 @@ pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                 "wal3",
                 "worker",
                 "garbage_collector",
-                "axum",
             ]
             .into_iter()
             .map(|s| s.to_string() + "=trace")


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds a new TracedJson handler which can separately trace the request buffering time, as well as the json parse time.
  - Unifies all tracing inside of handlers to be structured, I used the existing pattern of events, since some things cannot be known until we parse the body.
- New functionality
  - None

## Test plan

_How are these changes tested?_
I manually verified the body length error, its the same as before
<img width="661" alt="Screenshot 2025-05-22 at 9 55 03 AM" src="https://github.com/user-attachments/assets/7df04c4a-db50-4aee-9071-284d3da473eb" />

I checked the traces in jaeger, they are as expected
<img width="1728" alt="Screenshot 2025-05-22 at 9 59 23 AM" src="https://github.com/user-attachments/assets/5b8ea8a2-768a-4cd2-851c-a221caad71e7" />

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None