### PR TITLE
[ENH]: Detach prefetch span from the rest of query

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -195,19 +195,25 @@ impl Orchestrator for GarbageCollectorOrchestrator {
         self.dispatcher.clone()
     }
 
-    async fn initial_tasks(&mut self, ctx: &ComponentContext<Self>) -> Vec<TaskMessage> {
+    async fn initial_tasks(
+        &mut self,
+        ctx: &ComponentContext<Self>,
+    ) -> Vec<(TaskMessage, Option<Span>)> {
         tracing::info!(
             path = %self.version_file_path,
             "Creating initial fetch version file task"
         );
 
-        vec![wrap(
-            Box::new(FetchVersionFileOperator {}),
-            FetchVersionFileInput {
-                version_file_path: self.version_file_path.clone(),
-                storage: self.storage.clone(),
-            },
-            ctx.receiver(),
+        vec![(
+            wrap(
+                Box::new(FetchVersionFileOperator {}),
+                FetchVersionFileInput {
+                    version_file_path: self.version_file_path.clone(),
+                    storage: self.storage.clone(),
+                },
+                ctx.receiver(),
+            ),
+            Some(Span::current()),
         )]
     }
 

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -17,7 +17,10 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     fn dispatcher(&self) -> ComponentHandle<Dispatcher>;
 
     /// Returns a vector of starting tasks that should be run in sequence
-    async fn initial_tasks(&mut self, ctx: &ComponentContext<Self>) -> Vec<TaskMessage>;
+    async fn initial_tasks(
+        &mut self,
+        ctx: &ComponentContext<Self>,
+    ) -> Vec<(TaskMessage, Option<Span>)>;
 
     fn name() -> &'static str {
         type_name::<Self>()
@@ -38,8 +41,13 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     }
 
     /// Sends a task to the dispatcher and return whether the task is successfully sent
-    async fn send(&mut self, task: TaskMessage, ctx: &ComponentContext<Self>) -> bool {
-        let res = self.dispatcher().send(task, Some(Span::current())).await;
+    async fn send(
+        &mut self,
+        task: TaskMessage,
+        ctx: &ComponentContext<Self>,
+        tracing_context: Option<Span>,
+    ) -> bool {
+        let res = self.dispatcher().send(task, tracing_context).await;
         self.ok_or_terminate(res, ctx).await.is_some()
     }
 
@@ -128,8 +136,8 @@ impl<O: Orchestrator> Component for O {
     }
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
-        for task in self.initial_tasks(ctx).await {
-            if !self.send(task, ctx).await {
+        for (task, tracing_context) in self.initial_tasks(ctx).await {
+            if !self.send(task, ctx, tracing_context).await {
                 break;
             }
         }

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -14,6 +14,7 @@ pub(crate) struct SpannFetchPlInput<'referred_data> {
 #[derive(Debug)]
 pub(crate) struct SpannFetchPlOutput {
     pub(crate) posting_list: Vec<SpannPosting>,
+    pub(crate) head_id: u32,
 }
 
 #[derive(Error, Debug)]
@@ -59,7 +60,10 @@ impl<'referred_data> Operator<SpannFetchPlInput<'referred_data>, SpannFetchPlOut
                     .fetch_posting_list(input.head_id)
                     .await
                     .map_err(|_| SpannFetchPlError::SpannSegmentReaderError)?;
-                Ok(SpannFetchPlOutput { posting_list })
+                Ok(SpannFetchPlOutput {
+                    posting_list,
+                    head_id: input.head_id,
+                })
             }
             None => {
                 return Err(SpannFetchPlError::SpannSegmentReaderCreationError);

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -267,7 +267,7 @@ impl CompactOrchestrator {
         tracing::info!("Sending N Records: {:?}", records.len());
         let input = PartitionInput::new(records, self.max_partition_size);
         let task = wrap(operator, input, ctx.receiver());
-        self.send(task, ctx).await;
+        self.send(task, ctx, Some(Span::current())).await;
     }
 
     async fn materialize_log(
@@ -299,7 +299,7 @@ impl CompactOrchestrator {
                 next_max_offset_id.clone(),
             );
             let task = wrap(operator, input, ctx.receiver());
-            self.send(task, ctx).await;
+            self.send(task, ctx, Some(Span::current())).await;
         }
     }
 
@@ -450,7 +450,7 @@ impl CompactOrchestrator {
         );
 
         let task = wrap(operator, input, ctx.receiver());
-        self.send(task, ctx).await;
+        self.send(task, ctx, Some(Span::current())).await;
     }
 
     fn get_segment_writers(&self) -> Result<CompactWriters, CompactionError> {
@@ -526,14 +526,20 @@ impl Orchestrator for CompactOrchestrator {
         self.dispatcher.clone()
     }
 
-    async fn initial_tasks(&mut self, ctx: &ComponentContext<Self>) -> Vec<TaskMessage> {
-        vec![wrap(
-            Box::new(GetCollectionAndSegmentsOperator {
-                sysdb: self.sysdb.clone(),
-                collection_id: self.collection_id,
-            }),
-            (),
-            ctx.receiver(),
+    async fn initial_tasks(
+        &mut self,
+        ctx: &ComponentContext<Self>,
+    ) -> Vec<(TaskMessage, Option<Span>)> {
+        vec![(
+            wrap(
+                Box::new(GetCollectionAndSegmentsOperator {
+                    sysdb: self.sysdb.clone(),
+                    collection_id: self.collection_id,
+                }),
+                (),
+                ctx.receiver(),
+            ),
+            Some(Span::current()),
         )]
     }
 
@@ -638,7 +644,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             None => {
                 // Collection is not yet initialized, there is no need to initialize the writers
                 // Future handlers should return early on empty materialized logs without using writers
-                self.send(log_task, ctx).await;
+                self.send(log_task, ctx, Some(Span::current())).await;
                 return;
             }
         };
@@ -747,15 +753,19 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
             }
         };
         for segment in prefetch_segments {
+            let segment_id = segment.id;
             let prefetch_task = wrap(
                 Box::new(PrefetchSegmentOperator::new()),
                 PrefetchSegmentInput::new(segment, self.blockfile_provider.clone()),
                 ctx.receiver(),
             );
-            self.send(prefetch_task, ctx).await;
+            // Prefetch task is detached from the orchestrator
+            let prefetch_span =
+                tracing::info_span!(parent: None, "Prefetch segment", segment_id = %segment_id);
+            self.send(prefetch_task, ctx, Some(prefetch_span)).await;
         }
 
-        self.send(log_task, ctx).await;
+        self.send(log_task, ctx, Some(Span::current())).await;
     }
 }
 

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -337,7 +337,7 @@ impl Handler<TaskResult<SpannFetchPlOutput, SpannFetchPlError>> for SpannKnnOrch
         };
         let pl_span = self
             .pl_spans
-            .remove(&(output.head_id as u32))
+            .remove(&output.head_id)
             .unwrap_or_else(Span::current);
         // Spawn brute force posting list task.
         let bf_pl_task = wrap(


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Traces become very noisy when prefetch is a part of the request span. Removed it and made its own independent root
  - Also, pipeline the spans of fetch posting list with bf posting list
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None