### PR TITLE
[BLD]: fix: set default channel of rust from rust-toolchain.toml

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -19,6 +19,10 @@ runs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         cache: false # we use Blacksmith's cache package below
+    - name: Set channel in rust-toolchain.toml as default
+      shell: bash
+      run: |
+        rustup default $(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:


### PR DESCRIPTION
## Description of changes

The `build-sdist` release job [is failing](https://github.com/chroma-core/chroma/actions/runs/15193462410/job/42739524860) because it's using the version of Rust provided in the runner image (1.80) instead of the version we install with rustup (1.81). This change sets the global default to 1.81, from our `rust-toolchain.toml`, so it should resolve the build issue.