### PR TITLE
[PERF] Tune keepalive for chroma cloud

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -123,10 +123,12 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 + " (https://github.com/chroma-core/chroma)"
             )
 
+            limits = httpx.Limits(max_keepalive_connections=self.keepalive_secs)
             self._clients[loop_hash] = httpx.AsyncClient(
                 timeout=None,
                 headers=headers,
                 verify=self._settings.chroma_server_ssl_verify or False,
+                limits=limits,
             )
 
         return self._clients[loop_hash]

--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class BaseHTTPClient:
     _settings: Settings
     _max_batch_size: int = -1
+    keepalive_secs: int = 40
 
     @staticmethod
     def _validate_host(host: str) -> None:

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -54,7 +54,6 @@ logger = logging.getLogger(__name__)
 
 class FastAPI(BaseHTTPClient, ServerAPI):
     def __init__(self, system: System):
-        print("RUNNING THIS CODE MAN!")
         super().__init__(system)
         system.settings.require("chroma_server_host")
         system.settings.require("chroma_server_http_port")

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -54,6 +54,7 @@ logger = logging.getLogger(__name__)
 
 class FastAPI(BaseHTTPClient, ServerAPI):
     def __init__(self, system: System):
+        print("RUNNING THIS CODE MAN!")
         super().__init__(system)
         system.settings.require("chroma_server_host")
         system.settings.require("chroma_server_http_port")
@@ -69,7 +70,8 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             default_api_path=system.settings.chroma_server_api_default_path,
         )
 
-        self._session = httpx.Client(timeout=None)
+        limits = httpx.Limits(max_keepalive_connections=self.keepalive_secs)
+        self._session = httpx.Client(timeout=None, limits=limits)
 
         self._header = system.settings.chroma_server_headers or {}
         self._header["Content-Type"] = "application/json"


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - By default Chroma Cloud allows keepalive (we use HAProxy and it is on by default) and uses the http-request timeout if the keepalive timeout is not set - which for us is 50s. This raises the keepalive timeout from default 5s to < the haproxy timeout. We choose to not make this configurable for now, since the bottleneck will be the downstream config. This at least allows reusing the connection in a larger window
- New functionality
  - None

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None