### PR TITLE
[ENH]: Adds support for CORS wildcard origins

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -290,7 +290,11 @@ impl FrontendServer {
         if let Some(cors_allow_origins) = cors_allow_origins {
             let origins = cors_allow_origins
                 .into_iter()
-                .map(|origin| origin.parse().unwrap())
+                .map(|origin| {
+                    origin
+                        .parse()
+                        .unwrap_or_else(|_| panic!("Invalid origin: {}", origin))
+                })
                 .collect::<Vec<_>>();
 
             let mut cors_builder = CorsLayer::new()

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -293,11 +293,17 @@ impl FrontendServer {
                 .map(|origin| origin.parse().unwrap())
                 .collect::<Vec<_>>();
 
-            let cors = CorsLayer::new()
-                .allow_origin(origins)
+            let mut cors_builder = CorsLayer::new()
                 .allow_headers(tower_http::cors::Any)
                 .allow_methods(tower_http::cors::Any);
-            app = app.layer(cors);
+            if origins.len() == 1 && origins[0] == "*" {
+                println!("\x1b[38;5;203mWARNING:\x1b[0m CORS wildcard '*' is not recommended in production");
+                cors_builder = cors_builder.allow_origin(tower_http::cors::Any);
+            } else {
+                cors_builder = cors_builder.allow_origin(origins);
+            }
+
+            app = app.layer(cors_builder);
         }
 
         // TODO: tracing

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -301,7 +301,6 @@ impl FrontendServer {
                 .allow_headers(tower_http::cors::Any)
                 .allow_methods(tower_http::cors::Any);
             if origins.len() == 1 && origins[0] == "*" {
-                println!("\x1b[38;5;203mWARNING:\x1b[0m CORS wildcard '*' is not recommended in production");
                 cors_builder = cors_builder.allow_origin(tower_http::cors::Any);
             } else {
                 cors_builder = cors_builder.allow_origin(origins);


### PR DESCRIPTION
Closes #4620

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds support for `cors_allow_origins: ["*"]` and prevents Chroma from panicking when users supply a wildcard 

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
