### PR TITLE
[ENH] Prefetch block by prefixes

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -471,6 +471,15 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         self.load_blocks(&target_block_ids).await;
     }
 
+    pub(crate) async fn load_blocks_for_prefixes(&self, prefixes: impl IntoIterator<Item = &str>) {
+        let prefix_vec = prefixes.into_iter().collect();
+        let target_block_ids = self
+            .root
+            .sparse_index
+            .get_block_ids_for_prefixes(prefix_vec);
+        self.load_blocks(&target_block_ids).await;
+    }
+
     pub(crate) async fn get(
         &'me self,
         prefix: &str,

--- a/rust/blockstore/src/arrow/sparse_index.rs
+++ b/rust/blockstore/src/arrow/sparse_index.rs
@@ -362,10 +362,7 @@ impl SparseIndexReader {
         result_uuids
     }
 
-    pub(super) fn get_block_ids_for_prefixes<'prefix>(
-        &self,
-        mut prefixes: Vec<&'prefix str>,
-    ) -> Vec<Uuid> {
+    pub(super) fn get_block_ids_for_prefixes(&self, mut prefixes: Vec<&str>) -> Vec<Uuid> {
         prefixes.sort();
         let mut result_uuids = Vec::new();
         let block_start = self.data.forward.iter();

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -125,6 +125,18 @@ impl<
         }
     }
 
+    pub async fn load_blocks_for_prefixes<'prefix>(
+        &self,
+        prefixes: impl IntoIterator<Item = &'prefix str>,
+    ) {
+        match self {
+            BlockfileReader::MemoryBlockfileReader(_reader) => unimplemented!(),
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.load_blocks_for_prefixes(prefixes).await
+            }
+        }
+    }
+
     pub async fn rank(
         &'referred_data self,
         prefix: &'referred_data str,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Implements blockfile prefetch by prefix

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
