### PR TITLE
[ENH]: soft delete databases, add `FinishDatabaseDeletion` gRPC method to hard delete databases

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"time"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
 	"github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb"
@@ -254,4 +255,16 @@ func (s *Coordinator) BatchGetCollectionVersionFilePaths(ctx context.Context, re
 
 func (s *Coordinator) BatchGetCollectionSoftDeleteStatus(ctx context.Context, req *coordinatorpb.BatchGetCollectionSoftDeleteStatusRequest) (*coordinatorpb.BatchGetCollectionSoftDeleteStatusResponse, error) {
 	return s.catalog.BatchGetCollectionSoftDeleteStatus(ctx, req.CollectionIds)
+}
+
+func (s *Coordinator) FinishDatabaseDeletion(ctx context.Context, req *coordinatorpb.FinishDatabaseDeletionRequest) (*coordinatorpb.FinishDatabaseDeletionResponse, error) {
+	numDeleted, err := s.catalog.FinishDatabaseDeletion(ctx, time.Unix(req.CutoffTime.Seconds, int64(req.CutoffTime.Nanos)))
+	if err != nil {
+		return nil, err
+	}
+
+	res := &coordinatorpb.FinishDatabaseDeletionResponse{
+		NumDeleted: numDeleted,
+	}
+	return res, nil
 }

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -253,7 +253,7 @@ func (s *Server) GetCollectionWithSegments(ctx context.Context, req *coordinator
 	collection, segments, err := s.coordinator.GetCollectionWithSegments(ctx, parsedCollectionID)
 	if err != nil {
 		log.Error("GetCollectionWithSegments failed. ", zap.Error(err), zap.String("collection_id", collectionID))
-		if err == common.ErrCollectionNotFound {
+		if err == common.ErrCollectionNotFound || err == common.ErrCollectionSoftDeleted {
 			return res, grpcutils.BuildNotFoundGrpcError(err.Error())
 		}
 		return res, grpcutils.BuildInternalGrpcError(err.Error())
@@ -404,7 +404,7 @@ func (s *Server) ForkCollection(ctx context.Context, req *coordinatorpb.ForkColl
 	collection, segments, err := s.coordinator.ForkCollection(ctx, forkCollection)
 	if err != nil {
 		log.Error("ForkCollection failed. ", zap.Error(err), zap.String("collection_id", sourceCollectionID))
-		if err == common.ErrCollectionNotFound {
+		if err == common.ErrCollectionNotFound || err == common.ErrCollectionSoftDeleted {
 			return res, grpcutils.BuildNotFoundGrpcError(err.Error())
 		}
 		if err == common.ErrCollectionLogPositionStale {

--- a/go/pkg/sysdb/grpc/tenant_database_service.go
+++ b/go/pkg/sysdb/grpc/tenant_database_service.go
@@ -158,3 +158,11 @@ func (s *Server) GetLastCompactionTimeForTenant(ctx context.Context, req *coordi
 	}
 	return res, nil
 }
+
+func (s *Server) FinishDatabaseDeletion(ctx context.Context, req *coordinatorpb.FinishDatabaseDeletionRequest) (*coordinatorpb.FinishDatabaseDeletionResponse, error) {
+	res, err := s.coordinator.FinishDatabaseDeletion(ctx, req)
+	if err != nil {
+		return nil, grpcutils.BuildInternalGrpcError(err.Error())
+	}
+	return res, nil
+}

--- a/go/pkg/sysdb/metastore/db/dbmodel/database.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/database.go
@@ -22,10 +22,10 @@ func (v Database) TableName() string {
 
 //go:generate mockery --name=IDatabaseDb
 type IDatabaseDb interface {
-	GetAllDatabases() ([]*Database, error)
 	GetDatabases(tenantID string, databaseName string) ([]*Database, error)
 	ListDatabases(limit *int32, offset *int32, tenantID string) ([]*Database, error)
 	Insert(in *Database) error
 	DeleteAll() error
-	Delete(databaseID string) error
+	SoftDelete(databaseID string) error
+	FinishDatabaseDeletion(cutoffTime time.Time) (uint64, error)
 }

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -46,6 +46,14 @@ message DeleteDatabaseRequest {
 
 message DeleteDatabaseResponse {}
 
+message FinishDatabaseDeletionRequest {
+  google.protobuf.Timestamp cutoff_time = 1;
+}
+
+message FinishDatabaseDeletionResponse {
+  uint64 num_deleted = 1;
+}
+
 message CreateTenantRequest {
   string name = 2; // Names are globally unique
 }
@@ -496,6 +504,7 @@ service SysDB {
   rpc GetDatabase(GetDatabaseRequest) returns (GetDatabaseResponse) {}
   rpc ListDatabases(ListDatabasesRequest) returns (ListDatabasesResponse) {}
   rpc DeleteDatabase(DeleteDatabaseRequest) returns (DeleteDatabaseResponse) {}
+  rpc FinishDatabaseDeletion(FinishDatabaseDeletionRequest) returns (FinishDatabaseDeletionResponse) {}
   rpc CreateTenant(CreateTenantRequest) returns (CreateTenantResponse) {}
   rpc GetTenant(GetTenantRequest) returns (GetTenantResponse) {}
   rpc CreateSegment(CreateSegmentRequest) returns (CreateSegmentResponse) {}

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -476,6 +476,20 @@ impl ChromaError for DeleteDatabaseError {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum FinishDatabaseDeletionError {
+    #[error(transparent)]
+    Internal(#[from] Box<dyn ChromaError>),
+}
+
+impl ChromaError for FinishDatabaseDeletionError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            FinishDatabaseDeletionError::Internal(err) => err.code(),
+        }
+    }
+}
+
 #[non_exhaustive]
 #[derive(Validate, Debug, Serialize, ToSchema)]
 pub struct ListCollectionsRequest {


### PR DESCRIPTION
## Description of changes

Databases are now always soft deleted instead of being hard deleted. Databases are hard deleted when the new `FinishDatabaseDeletion` method is called (the garbage collector calls this in the next PR).

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Updated existing test to cover soft delete behavior.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a