### PR TITLE
[BUG] Send tenant/database in AsyncCollection.modify()

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -256,6 +256,8 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
             new_name=name,
             new_metadata=metadata,
             new_configuration=configuration,
+            tenant=self.tenant,
+            database=self.database,
         )
 
         self._update_model_after_modify_success(name, metadata, configuration)


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - `tenant` and `database` were not being sent in `AsyncCollection.modify()`, resulting in auth issues (it was present as of https://github.com/chroma-core/chroma/pull/2982).
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
