### PR TITLE
[TST] Do two log services work?

### DIFF
--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -33,3 +33,6 @@ compactionService:
       value: 'value: "1"'
     - name: CONFIG_PATH
       value: 'value: "/tilt_config.yaml"'
+
+rustLogService:
+  replicaCount: 2


### PR DESCRIPTION
## Description of changes

This PR creates two rust-log-services and relies upon CI to uncover problems.

## Test plan

I'm depending on CI to run cluster-rust-frontend tests.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
