### PR TITLE
[BUG]  Wire up the rust-log-service member ID to the dirty log.

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.40
+version: 0.1.41
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -82,6 +82,10 @@ spec:
           env:
             - name: CONFIG_PATH
               value: "/config/config.yaml"
+            - name: CHROMA_QUERY_SERVICE__MY_MEMBER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{ if .Values.rustLogService.otherEnvConfig }}
               {{ .Values.rustLogService.otherEnvConfig | nindent 12 }}
             {{ end }}

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -33,3 +33,6 @@ compactionService:
       value: 'value: "1"'
     - name: CONFIG_PATH
       value: 'value: "/tilt_config.yaml"'
+
+rustLogService:
+  replicaCount: 2

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1821,6 +1821,8 @@ pub struct OpenTelemetryConfig {
 pub struct LogServerConfig {
     #[serde(default = "default_port")]
     pub port: u16,
+    #[serde(default = "LogServerConfig::default_my_member_id")]
+    pub my_member_id: String,
     #[serde(default)]
     pub opentelemetry: Option<OpenTelemetryConfig>,
     #[serde(default)]
@@ -1849,6 +1851,10 @@ impl LogServerConfig {
         100
     }
 
+    fn default_my_member_id() -> String {
+        "rust-log-service-0".to_string()
+    }
+
     /// one million records on the log.
     fn default_num_records_before_backpressure() -> u64 {
         1_000_000
@@ -1869,6 +1875,7 @@ impl Default for LogServerConfig {
     fn default() -> Self {
         Self {
             port: default_port(),
+            my_member_id: LogServerConfig::default_my_member_id(),
             opentelemetry: None,
             storage: StorageConfig::default(),
             writer: LogWriterOptions::default(),
@@ -1909,7 +1916,7 @@ impl Configurable<LogServerConfig> for LogServer {
         let dirty_log = LogWriter::open_or_initialize(
             config.writer.clone(),
             Arc::clone(&storage),
-            "dirty",
+            &format!("dirty-{}", config.my_member_id),
             "dirty log writer",
             (),
         )
@@ -1952,6 +1959,7 @@ pub async fn log_entrypoint() {
         Err(_) => RootConfig::load(),
     };
     let config = config.log_service;
+    eprintln!("my_member_id: {}", config.my_member_id);
     let registry = chroma_config::registry::Registry::new();
     if let Some(otel_config) = &config.opentelemetry {
         eprintln!("enabling tracing");


### PR DESCRIPTION
## Description of changes

Putting two logs on the same dirty log wasn't incorrect but wasn't going
to perform.  This PR makes multiple log services possible now that the
frontend routes to them by collection ID.

This PR creates two rust-log-services and relies upon CI to uncover problems.

## Test plan

CI

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
