### PR TITLE
[BUG]: don't create duplicate segments for collection under concurrent get_or_create requests

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -374,7 +374,7 @@ func (tc *Catalog) createCollectionImpl(txCtx context.Context, createCollection 
 		return nil, false, common.ErrConcurrentDeleteCollection
 	}
 	result := convertCollectionToModel(collectionList)[0]
-	return result, true, nil
+	return result, created, nil
 }
 
 func (tc *Catalog) CreateCollection(ctx context.Context, createCollection *model.CreateCollection, ts types.Timestamp) (*model.Collection, bool, error) {
@@ -1251,7 +1251,6 @@ func (tc *Catalog) CreateCollectionAndSegments(ctx context.Context, createCollec
 		}
 
 		// If collection already exists, then do not create segments.
-		// TODO: Should we check to see if segments does not exist? and create them?
 		if !created {
 			return nil
 		}


### PR DESCRIPTION
## Description of changes

Prior to this change, the `was_created` flag was not correctly propagated up to the caller of `createCollectionImpl()`. This resulted in two concurrent create collection requests with `get_or_create: true` creating duplicate segments.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Did not add a new test.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a