### PR TITLE
[BUG]  Bump testing back to one rust log service replica.

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.41
+version: 0.1.42
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -35,4 +35,4 @@ compactionService:
       value: 'value: "/tilt_config.yaml"'
 
 rustLogService:
-  replicaCount: 2
+  replicaCount: 1


### PR DESCRIPTION
## Description of changes

It demonstrates that the configuration works, but doesn't guarantee that
the log failover test is actually failing over anything.  Moving back to
one replica gives us that assurance on each CI run rather than 50% of
them.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
