### PR TITLE
[DOC] fix docs for list_collections

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
@@ -272,7 +272,7 @@ List all collections.
 
 **Returns**:
 
-- `Sequence[CollectionName]` - A list of collection names. `CollectionName` is a string.
+- `Sequence[Collection]` - A list of collection objects.
 
 
 **Examples**:

--- a/docs/docs.trychroma.com/markdoc/content/updates/migration.md
+++ b/docs/docs.trychroma.com/markdoc/content/updates/migration.md
@@ -26,6 +26,8 @@ In this release, we've rewritten much of Chroma in Rust. Performance has signifi
 
 Chroma no longer provides built-in authentication implementations.
 
+`list_collections` now reverts back to returning `Collection` objects.
+
 **Chroma in-process changes**
 
 This section is applicable to you if you use Chroma via


### PR DESCRIPTION
## Description of changes

The docs for list_collections had a discrepancy, where the code block showed it returning a Sequence[Collection], while the documentation below said it returned CollectionName. They are reconciled to show list_collections now returns Collection objects. The migration guide has also been udpated

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
