### PR TITLE
[BUG]  Use the right path for my_member_id in rust-log-service.

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.42
+version: 0.1.43
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -82,7 +82,7 @@ spec:
           env:
             - name: CONFIG_PATH
               value: "/config/config.yaml"
-            - name: CHROMA_QUERY_SERVICE__MY_MEMBER_ID
+            - name: CHROMA_LOG_SERVICE__MY_MEMBER_ID
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name


### PR DESCRIPTION
## Description of changes

This PR properly sets my_member_id for rust-log-service nodes.

## Test plan

I bumped to two replicas and observed the log of the second one say
this:

From the log:  my_member_id: rust-log-service-1

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
