### PR TITLE
[ENH] add Mistral embedding function, fix some naming mismatches across clients

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -36,6 +36,7 @@ def test_get_builtins_holds() -> None:
         "HuggingFaceEmbeddingServer",
         "InstructorEmbeddingFunction",
         "JinaEmbeddingFunction",
+        "MistralEmbeddingFunction",
         "ONNXMiniLM_L6_V2",
         "OllamaEmbeddingFunction",
         "OpenAIEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -61,6 +61,9 @@ from chromadb.utils.embedding_functions.cloudflare_workers_ai_embedding_function
 from chromadb.utils.embedding_functions.together_ai_embedding_function import (
     TogetherAIEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.mistral_embedding_function import (
+    MistralEmbeddingFunction,
+)
 
 try:
     from chromadb.is_thin_client import is_thin_client
@@ -80,6 +83,7 @@ _all_classes: Set[str] = {
     "OllamaEmbeddingFunction",
     "InstructorEmbeddingFunction",
     "JinaEmbeddingFunction",
+    "MistralEmbeddingFunction",
     "VoyageAIEmbeddingFunction",
     "ONNXMiniLM_L6_V2",
     "OpenCLIPEmbeddingFunction",
@@ -140,6 +144,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "ollama": OllamaEmbeddingFunction,
     "instructor": InstructorEmbeddingFunction,
     "jina": JinaEmbeddingFunction,
+    "mistral": MistralEmbeddingFunction,
     "voyageai": VoyageAIEmbeddingFunction,
     "onnx_mini_lm_l6_v2": ONNXMiniLM_L6_V2,
     "open_clip": OpenCLIPEmbeddingFunction,
@@ -227,6 +232,7 @@ __all__ = [
     "OllamaEmbeddingFunction",
     "InstructorEmbeddingFunction",
     "JinaEmbeddingFunction",
+    "MistralEmbeddingFunction",
     "VoyageAIEmbeddingFunction",
     "ONNXMiniLM_L6_V2",
     "OpenCLIPEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/mistral_embedding_function.py
+++ b/chromadb/utils/embedding_functions/mistral_embedding_function.py
@@ -1,0 +1,92 @@
+from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+from typing import List, Dict, Any
+import os
+import numpy as np
+
+
+class MistralEmbeddingFunction(EmbeddingFunction[Documents]):
+    def __init__(
+        self,
+        model: str,
+        api_key_env_var: str = "MISTRAL_API_KEY",
+    ):
+        """
+        Initialize the MistralEmbeddingFunction.
+
+        Args:
+            model (str): The name of the model to use for text embeddings.
+            api_key_env_var (str): The environment variable name for the Mistral API key.
+        """
+        try:
+            from mistralai import Mistral
+        except ImportError:
+            raise ValueError(
+                "The mistralai python package is not installed. Please install it with `pip install mistralai`"
+            )
+        self.model = model
+        self.api_key_env_var = api_key_env_var
+        self.api_key = os.getenv(api_key_env_var)
+        if not self.api_key:
+            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+        self.client = Mistral(api_key=self.api_key)
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """
+        Get the embeddings for a list of texts.
+
+        Args:
+            input (Documents): A list of texts to get embeddings for.
+        """
+        if not all(isinstance(item, str) for item in input):
+            raise ValueError("Mistral only supports text documents, not images")
+        output = self.client.embeddings.create(
+            model=self.model,
+            inputs=input,
+        )
+
+        # Extract embeddings from the response
+        return [np.array(data.embedding) for data in output.data]
+
+    @staticmethod
+    def name() -> str:
+        return "mistral"
+
+    def default_space(self) -> Space:
+        return "cosine"
+
+    def supported_spaces(self) -> List[Space]:
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+        model = config.get("model")
+        api_key_env_var = config.get("api_key_env_var")
+
+        if model is None or api_key_env_var is None:
+            assert False, "This code should not be reached"  # this is for type checking
+        return MistralEmbeddingFunction(model=model, api_key_env_var=api_key_env_var)
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "model": self.model,
+            "api_key_env_var": self.api_key_env_var,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        if "model" in new_config:
+            raise ValueError(
+                "The model cannot be changed after the embedding function has been initialized."
+            )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+        """
+        validate_config_schema(config, "mistral")

--- a/clients/js/packages/chromadb-core/src/embeddings/HuggingFaceEmbeddingServerFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/HuggingFaceEmbeddingServerFunction.ts
@@ -15,7 +15,7 @@ export class HuggingFaceEmbeddingServerFunction implements IEmbeddingFunction {
   constructor({
     api_key,
     url,
-    api_key_env_var,
+    api_key_env_var = "CHROMA_HUGGINGFACE_API_KEY",
   }: {
     url: string;
     api_key?: string;

--- a/clients/js/packages/chromadb-core/src/embeddings/JinaEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/JinaEmbeddingFunction.ts
@@ -39,7 +39,7 @@ export class JinaEmbeddingFunction implements IEmbeddingFunction {
   constructor({
     jinaai_api_key,
     model_name = "jina-embeddings-v2-base-en",
-    api_key_env_var = "JINAAI_API_KEY",
+    api_key_env_var = "CHROMA_JINA_API_KEY",
     task,
     late_chunking,
     truncate,

--- a/clients/js/packages/chromadb-core/src/embeddings/OpenAIEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/OpenAIEmbeddingFunction.ts
@@ -97,7 +97,7 @@ export class OpenAIEmbeddingFunction implements IEmbeddingFunction {
     openai_model = "text-embedding-ada-002",
     openai_organization_id,
     openai_embedding_dimensions,
-    openai_api_key_env_var = "OPENAI_API_KEY",
+    openai_api_key_env_var = "CHROMA_OPENAI_API_KEY",
   }: {
     openai_api_key?: string;
     openai_model?: string;

--- a/clients/js/packages/chromadb-core/src/embeddings/VoyageAIEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/VoyageAIEmbeddingFunction.ts
@@ -50,7 +50,7 @@ export class VoyageAIEmbeddingFunction implements IEmbeddingFunction {
   constructor({
     api_key,
     model,
-    api_key_env_var = "VOYAGE_API_KEY",
+    api_key_env_var = "CHROMA_VOYAGE_API_KEY",
   }: {
     api_key?: string;
     model: string;

--- a/clients/js/packages/chromadb-core/test/schemas.test.ts
+++ b/clients/js/packages/chromadb-core/test/schemas.test.ts
@@ -36,13 +36,13 @@ describe("Schema Validation", () => {
   });
 
   test("should validate an embedding function", () => {
-    process.env.OPENAI_API_KEY = "test-key";
+    process.env.CHROMA_OPENAI_API_KEY = "test-key";
 
     const embeddingFunction = new OpenAIEmbeddingFunction({});
     expect(() =>
       embeddingFunction.validateConfig(embeddingFunction.getConfig()),
     ).not.toThrow();
 
-    process.env.OPENAI_API_KEY = undefined;
+    process.env.CHROMA_OPENAI_API_KEY = undefined;
   });
 });

--- a/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
@@ -15,6 +15,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Jina AI](../../integrations/embedding-models/jina-ai)                                   | ✓      | ✓          |
 | [Cloudflare Workers AI](../../integrations/embedding-models/cloudflare-workers-ai.md)    | ✓      | ✓          |
 | [Together AI](../../integrations/embedding-models/together-ai.md)                        | ✓      | ✓          |
+| [Mistral](../../integrations/embedding-models/mistral.md)                                | ✓      | -          |
 
 We welcome pull requests to add new Embedding Functions to the community.
 

--- a/docs/docs.trychroma.com/markdoc/content/integrations/chroma-integrations.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/chroma-integrations.md
@@ -23,6 +23,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Ollama Embeddings](./embedding-models/ollama)                          | ✓      | ✓          |
 | [Cloudflare Workers AI](./embedding-models/cloudflare-workers-ai.md)    | ✓      | ✓          |
 | [Together AI](./embedding-models/together-ai.md)                        | ✓      | ✓          |
+| [Mistral](./embedding-models/mistral.md)                                | ✓      | -          |
 
 ---
 

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/cloudflare-workers-ai.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/cloudflare-workers-ai.md
@@ -19,7 +19,7 @@ from chromadb.utils.embedding_functions import CloudflareWorkersAIEmbeddingFunct
 os.environ["CHROMA_CLOUDFLARE_API_KEY"] = "<INSERT API KEY HERE>"
 
 ef = CloudflareWorkersAIEmbeddingFunction(
-                account_id="bd4502421ad9c8e8931d02a616e6845a",
+                account_id="<INSERT ACCOUNTID HERE>",
                 model_name="@cf/baai/bge-m3",
             )
 ef(input=["This is my first text to embed", "This is my second document"])
@@ -30,12 +30,12 @@ ef(input=["This is my first text to embed", "This is my second document"])
 {% Tab label="typescript" %}
 
 ```typescript
-import { JinaEmbeddingFunction } from 'chromadb';
+import { CloudflareWorkersAIEmbeddingFunction } from 'chromadb';
 
 process.env.CHROMA_CLOUDFLARE_API_KEY = "<INSERT API KEY HERE>"
 
 const embedder = new CloudflareWorkersAIEmbeddingFunction({
-    account_id="bd4502421ad9c8e8931d02a616e6845a",
+    account_id="<INSERT ACCOUNT ID HERE>",
     model_name="@cf/baai/bge-m3",
 });
 

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/mistral.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/mistral.md
@@ -1,0 +1,27 @@
+---
+id: 'mistral'
+name: 'Mistral'
+---
+
+# Mistral
+
+Chroma provides a convenient wrapper around Mistral's embedding API. This embedding function runs remotely on Mistral's servers, and requires an API key. You can get an API key by signing up for an account at [Mistral](https://mistral.ai/).
+
+{% Tabs %}
+{% Tab label="python" %}
+
+This embedding function relies on the `mistralai` python package, which you can install with `pip install mistralai`.
+
+```python
+from chromadb.utils.embedding_functions import MistralEmbeddingFunction
+import os
+
+os.environ["MISTRAL_API_KEY"] = "************"
+mistral_ef  = MistralEmbeddingFunction(model="mistral-embed")
+mistral_ef(input=["document1","document2"])
+```
+
+{% /Tab %}
+{% /Tabs %}
+
+You must pass in a `model` argument, which selects the Mistral embedding model to use. You can see the supported embedding types and models in Mistral's docs [here](https://docs.mistral.ai/capabilities/embeddings/overview/)


### PR DESCRIPTION
## Description of changes

This PR adds a new MistralEmbeddingFunction, and normalizes dfeault env var names across clients.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
