### PR TITLE
[ENH] Cleanup the single most spammy log line in rls.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -497,11 +497,6 @@ impl DirtyMarker {
                         None
                     }
                     Ordering::Greater => {
-                        tracing::info!(
-                            "{collection_id} has range ({}, {}]",
-                            record_compaction_position,
-                            record_enumeration_position,
-                        );
                         uncompacted += maximum_log_position - cursor.position;
                         if maximum_log_position - cursor.position >= record_count_backpressure {
                             backpressure.push(*collection_id);


### PR DESCRIPTION
## Description of changes

This line is logged once per collection on the dirty log.

## Test plan

I removed a line, relying upon CI.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
