### PR TITLE
[CHORE] address logger deprecation warnings

### DIFF
--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -108,7 +108,7 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
             self._settings.require("migrations") == "apply"
             and self.config.get_parameter("automatically_purge").value is False
         ):
-            logger.warn(
+            logger.warning(
                 "⚠️ It looks like you upgraded from a version below 0.5.6 and could benefit from vacuuming your database. Run chromadb utils vacuum --help for more information."
             )
 


### PR DESCRIPTION
## Description of changes
This small PR resolves the annoying deprecation warnings of the `logger` library which you can also find in the [CI logs](https://github.com/chroma-core/chroma/actions/runs/15312492452):
```python
D:\a\chroma\chroma\chromadb\db\impl\sqlite.py:111: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes