### PR TITLE
[ENH]  Make explicit seal/migrate calls for the log service.

### DIFF
--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -213,11 +213,11 @@ impl Log {
 
     pub async fn seal_log(
         &mut self,
-        tenant: &str,
+        _: &str,
         collection_id: CollectionUuid,
     ) -> Result<(), GrpcSealLogError> {
         match self {
-            Log::Grpc(log) => log.seal_log(tenant, collection_id).await,
+            Log::Grpc(log) => log.seal_log(collection_id).await,
             Log::Sqlite(_) => unimplemented!(),
             Log::InMemory(_) => unimplemented!(),
         }


### PR DESCRIPTION
## Description of changes

This exposes `seal` and `migrate` to work the way they're expected/intended:
- seal always goes to the classic/go log service
- migrate always goes to the rust log service

## Test plan

CI + nextest run

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
