### PR TITLE
[CLN] Split get orchestrator

### DIFF
--- a/rust/types/src/execution/operator.rs
+++ b/rust/types/src/execution/operator.rs
@@ -435,12 +435,12 @@ impl TryFrom<ProjectionRecord> for chroma_proto::ProjectionRecord {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ProjectionOutput {
     pub records: Vec<ProjectionRecord>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct GetResult {
     pub pulled_log_bytes: u64,
     pub result: ProjectionOutput,

--- a/rust/worker/benches/get.rs
+++ b/rust/worker/benches/get.rs
@@ -5,110 +5,52 @@ use chroma_benchmark::benchmark::{bench_run, tokio_multi_thread};
 use chroma_config::{registry::Registry, Configurable};
 use chroma_segment::test::TestDistributedSegment;
 use chroma_system::{ComponentHandle, Dispatcher, Orchestrator, System};
+use chroma_types::operator::{Filter, Limit, Projection};
 use criterion::{criterion_group, criterion_main, Criterion};
 use load::{
     all_projection, always_false_filter_for_modulo_metadata,
     always_true_filter_for_modulo_metadata, empty_fetch_log, offset_limit, sift1m_segments,
     trivial_filter, trivial_limit, trivial_projection,
 };
-use worker::{config::RootConfig, execution::orchestration::get::GetOrchestrator};
+use worker::{
+    config::RootConfig,
+    execution::orchestration::{filter::FilterOrchestrator, get::GetOrchestrator},
+};
 
-fn trivial_get(
-    test_segments: &TestDistributedSegment,
-    dispatcher_handle: ComponentHandle<Dispatcher>,
-) -> GetOrchestrator {
-    let blockfile_provider = test_segments.blockfile_provider.clone();
-    let collection_uuid = test_segments.collection.collection_id;
-    GetOrchestrator::new(
-        blockfile_provider,
-        dispatcher_handle,
+async fn bench_routine(
+    (system, dispatcher, test_segments, filter, limit, projection, expected_ids): (
+        System,
+        ComponentHandle<Dispatcher>,
+        &TestDistributedSegment,
+        Filter,
+        Limit,
+        Projection,
+        Vec<String>,
+    ),
+) {
+    let matching_records = FilterOrchestrator::new(
+        test_segments.blockfile_provider.clone(),
+        dispatcher.clone(),
+        test_segments.hnsw_provider.clone(),
         1000,
         test_segments.into(),
-        empty_fetch_log(collection_uuid),
-        trivial_filter(),
-        trivial_limit(),
-        trivial_projection(),
+        empty_fetch_log(test_segments.collection.collection_id),
+        filter,
     )
-}
-
-fn get_false_filter(
-    test_segments: &TestDistributedSegment,
-    dispatcher_handle: ComponentHandle<Dispatcher>,
-) -> GetOrchestrator {
-    let blockfile_provider = test_segments.blockfile_provider.clone();
-    let collection_uuid = test_segments.collection.collection_id;
-    GetOrchestrator::new(
-        blockfile_provider,
-        dispatcher_handle,
+    .run(system.clone())
+    .await
+    .expect("Filter orchestrator should not fail");
+    let output = GetOrchestrator::new(
+        test_segments.blockfile_provider.clone(),
+        dispatcher,
         1000,
-        test_segments.into(),
-        empty_fetch_log(collection_uuid),
-        always_false_filter_for_modulo_metadata(),
-        trivial_limit(),
-        trivial_projection(),
+        matching_records,
+        limit,
+        projection,
     )
-}
-
-fn get_true_filter(
-    test_segments: &TestDistributedSegment,
-    dispatcher_handle: ComponentHandle<Dispatcher>,
-) -> GetOrchestrator {
-    let blockfile_provider = test_segments.blockfile_provider.clone();
-    let collection_uuid = test_segments.collection.collection_id;
-    GetOrchestrator::new(
-        blockfile_provider,
-        dispatcher_handle,
-        1000,
-        test_segments.into(),
-        empty_fetch_log(collection_uuid),
-        always_true_filter_for_modulo_metadata(),
-        trivial_limit(),
-        trivial_projection(),
-    )
-}
-
-fn get_true_filter_limit(
-    test_segments: &TestDistributedSegment,
-    dispatcher_handle: ComponentHandle<Dispatcher>,
-) -> GetOrchestrator {
-    let blockfile_provider = test_segments.blockfile_provider.clone();
-    let collection_uuid = test_segments.collection.collection_id;
-    GetOrchestrator::new(
-        blockfile_provider,
-        dispatcher_handle,
-        1000,
-        test_segments.into(),
-        empty_fetch_log(collection_uuid),
-        always_true_filter_for_modulo_metadata(),
-        offset_limit(),
-        trivial_projection(),
-    )
-}
-
-fn get_true_filter_limit_projection(
-    test_segments: &TestDistributedSegment,
-    dispatcher_handle: ComponentHandle<Dispatcher>,
-) -> GetOrchestrator {
-    let blockfile_provider = test_segments.blockfile_provider.clone();
-    let collection_uuid = test_segments.collection.collection_id;
-    GetOrchestrator::new(
-        blockfile_provider,
-        dispatcher_handle,
-        1000,
-        test_segments.into(),
-        empty_fetch_log(collection_uuid),
-        always_true_filter_for_modulo_metadata(),
-        offset_limit(),
-        all_projection(),
-    )
-}
-
-async fn bench_routine(input: (System, GetOrchestrator, Vec<String>)) {
-    let (system, orchestrator, expected_ids) = input;
-    let output = orchestrator
-        .run(system)
-        .await
-        .expect("Orchestrator should not fail");
+    .run(system)
+    .await
+    .expect("Get orchestrator should not fail");
     assert_eq!(
         output
             .result
@@ -138,35 +80,55 @@ fn bench_get(criterion: &mut Criterion) {
     let trivial_get_setup = || {
         (
             system.clone(),
-            trivial_get(&test_segments, dispatcher_handle.clone()),
+            dispatcher_handle.clone(),
+            &test_segments,
+            trivial_filter(),
+            trivial_limit(),
+            trivial_projection(),
             (0..100).map(|id| id.to_string()).collect(),
         )
     };
     let get_false_filter_setup = || {
         (
             system.clone(),
-            get_false_filter(&test_segments, dispatcher_handle.clone()),
+            dispatcher_handle.clone(),
+            &test_segments,
+            always_false_filter_for_modulo_metadata(),
+            trivial_limit(),
+            trivial_projection(),
             Vec::new(),
         )
     };
     let get_true_filter_setup = || {
         (
             system.clone(),
-            get_true_filter(&test_segments, dispatcher_handle.clone()),
+            dispatcher_handle.clone(),
+            &test_segments,
+            always_true_filter_for_modulo_metadata(),
+            trivial_limit(),
+            trivial_projection(),
             (0..100).map(|id| id.to_string()).collect(),
         )
     };
     let get_true_filter_limit_setup = || {
         (
             system.clone(),
-            get_true_filter_limit(&test_segments, dispatcher_handle.clone()),
+            dispatcher_handle.clone(),
+            &test_segments,
+            always_true_filter_for_modulo_metadata(),
+            offset_limit(),
+            trivial_projection(),
             (100..200).map(|id| id.to_string()).collect(),
         )
     };
     let get_true_filter_limit_projection_setup = || {
         (
             system.clone(),
-            get_true_filter_limit_projection(&test_segments, dispatcher_handle.clone()),
+            dispatcher_handle.clone(),
+            &test_segments,
+            always_true_filter_for_modulo_metadata(),
+            offset_limit(),
+            all_projection(),
             (100..200).map(|id| id.to_string()).collect(),
         )
     };

--- a/rust/worker/src/execution/orchestration/knn_hnsw.rs
+++ b/rust/worker/src/execution/orchestration/knn_hnsw.rs
@@ -163,7 +163,7 @@ pub struct KnnHnswOrchestrator {
     dispatcher: ComponentHandle<Dispatcher>,
     queue: usize,
 
-    // Output from KnnFilterOrchestrator
+    // Output from FilterOrchestrator
     filter_output: FilterOrchestratorOutput,
 
     // Knn operator shared between log and segments

--- a/rust/worker/src/execution/orchestration/mod.rs
+++ b/rust/worker/src/execution/orchestration/mod.rs
@@ -1,9 +1,9 @@
+mod compact;
 mod count;
-pub mod spann_knn;
 pub(crate) use compact::*;
 pub(crate) use count::*;
 
-mod compact;
+pub mod filter;
 pub mod get;
-pub mod knn;
-pub mod knn_filter;
+pub mod knn_hnsw;
+pub mod knn_spann;

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -27,8 +27,8 @@ use crate::{
     execution::{
         operators::fetch_log::FetchLogOperator,
         orchestration::{
-            get::GetOrchestrator, knn::KnnOrchestrator, knn_filter::KnnFilterOrchestrator,
-            spann_knn::SpannKnnOrchestrator, CountOrchestrator,
+            filter::FilterOrchestrator, get::GetOrchestrator, knn_hnsw::KnnHnswOrchestrator,
+            knn_spann::KnnSpannOrchestrator, CountOrchestrator,
         },
     },
 };
@@ -289,7 +289,7 @@ impl WorkerServer {
         }
 
         let vector_segment_type = collection_and_segments.vector_segment.r#type;
-        let knn_filter_orchestrator = KnnFilterOrchestrator::new(
+        let knn_filter_orchestrator = FilterOrchestrator::new(
             self.blockfile_provider.clone(),
             dispatcher.clone(),
             self.hnsw_index_provider.clone(),
@@ -320,7 +320,7 @@ impl WorkerServer {
             let knn_orchestrator_futures = Vec::from(KnnBatch::try_from(knn)?)
                 .into_iter()
                 .map(|knn| {
-                    SpannKnnOrchestrator::new(
+                    KnnSpannOrchestrator::new(
                         spann_provider.clone(),
                         dispatcher.clone(),
                         1000,
@@ -350,7 +350,7 @@ impl WorkerServer {
             let knn_orchestrator_futures = Vec::from(KnnBatch::try_from(knn)?)
                 .into_iter()
                 .map(|knn| {
-                    KnnOrchestrator::new(
+                    KnnHnswOrchestrator::new(
                         self.blockfile_provider.clone(),
                         dispatcher.clone(),
                         // TODO: Make this configurable


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Renamed the `KnnFilterOrchestrator` to `FilterOrchestrator`
  - Seperated the `KnnError` type into error types for each individual orchestrators
  - Simplify `GetOrchestrator` to reuse the `FilterOrchestrator`
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
