### PR TITLE
[ENH] Robustly handle errors on the compaction path of the log.

### DIFF
--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -618,7 +618,7 @@ impl GrpcLog {
 
         if let Some(status) = error {
             if combined_response.is_empty() {
-                return Err(status);
+                return Err(status.into());
             }
         }
 


### PR DESCRIPTION
## Description of changes

One path is timing out in staging.  Add tolerance for that and some
debugging.

## Test plan

Compiles

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
