### PR TITLE
[PERF]: skip document mutation in full-text index writer if old and new documents are same

### DIFF
--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -106,6 +106,11 @@ impl FullTextIndexWriter {
                     old_document,
                     new_document,
                 } => {
+                    if old_document == new_document {
+                        // Don't need to do anything if document is identical
+                        continue;
+                    }
+
                     // Remove old version
                     let mut trigrams_to_delete = HashSet::new(); // (need to filter out duplicates, each trigram may appear multiple times in a document)
                     self.tokenizer


### PR DESCRIPTION
## Description of changes

If the old and new documents are identical, we can save compute by ignoring the update.

A customer on Chroma Cloud seems to have a workload with a lot of no-op updates, so this should improve compaction speed for their collections.

## Test plan

_How are these changes tested?_

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a