### PR TITLE
[ENH][chroma-load]  Allow reference data sets to reference minilm6v2.

### DIFF
--- a/rust/load/src/data_sets.rs
+++ b/rust/load/src/data_sets.rs
@@ -1484,6 +1484,7 @@ pub fn all_data_sets() -> Vec<Arc<dyn DataSet>> {
         ALL_MINILM_L6_V2,
         1_000_000,
     )));
+    data_sets.push(Arc::clone(&reference_data_set) as _);
     data_sets.push(Arc::new(VerifyingDataSet {
         reference_data_set,
         test_data_set: "test-all-MiniLM-L6-v2".to_string(),


### PR DESCRIPTION
## Description of changes

The reference data set isn't usable from the command line.  This makes it so.

## Test plan

Locally.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
