### PR TITLE
[BUG]: correctly update `collections.num_versions` upon compaction flush

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -1406,6 +1406,14 @@ func (suite *APIsTestSuite) TestCollectionVersioningWithMinio() {
 	suite.NoError(err)
 	suite.NotNil(flushInfo)
 
+	// Assert that num_versions is 2
+	type NumVersions struct {
+		NumVersions int64 `gorm:"column:num_versions"`
+	}
+	res := &NumVersions{}
+	suite.db.Select("num_versions").Table("collections").Find(&res, "id = ?", newCollection.ID.String())
+	suite.Equal(int64(2), res.NumVersions)
+
 	// TODO(rohitcp): Add these tests back once version file is enabled.
 	// Verify version file exists in S3
 	// versionFilePathPrefix := suite.s3MetaStore.GetVersionFilePath(newCollection.TenantID, newCollection.ID.String(), "")

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1806,6 +1806,8 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 			return nil, err
 		}
 
+		numActiveVersions := tc.getNumberOfActiveVersions(existingVersionFilePb)
+
 		txErr := tc.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 			// NOTE: DO NOT move UpdateTenantLastCompactionTime & RegisterFilePaths to the end of the transaction.
 			//		 Keep both these operations before the UpdateLogPositionAndVersionInfo.
@@ -1849,6 +1851,7 @@ func (tc *Catalog) FlushCollectionCompactionForVersionedCollection(ctx context.C
 				// SAFETY(hammadb): This int64 to uint64 conversion is ok because we always are in post-epoch time.
 				// and the value is always positive.
 				uint64(lastCompactionTime),
+				uint64(numActiveVersions),
 			)
 			if err != nil {
 				return err

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -360,6 +360,7 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollection(t *testing.T) {
 		uint64(1),
 		uint64(1),
 		mock.Anything,
+		mock.Anything,
 	).Return(int64(1), nil)
 
 	mockTenantDb.On("UpdateTenantLastCompactionTime", tenantID, mock.Anything).Return(nil)
@@ -563,6 +564,7 @@ func TestCatalog_FlushCollectionCompactionForVersionedCollectionWithEmptyFilePat
 		mock.Anything,
 		uint64(1),
 		uint64(1),
+		mock.Anything,
 		mock.Anything,
 	).Return(int64(1), nil)
 

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -428,6 +428,7 @@ func (s *collectionDb) UpdateLogPositionAndVersionInfo(
 	totalRecordsPostCompaction uint64,
 	sizeBytesPostCompaction uint64,
 	lastCompactionTimeSecs uint64,
+	numVersions uint64,
 ) (int64, error) {
 	// TODO(rohitcp): Investigate if we need to hold the lock using "UPDATE"
 	// strength, or if we can use "SELECT FOR UPDATE" or some other less
@@ -445,6 +446,7 @@ func (s *collectionDb) UpdateLogPositionAndVersionInfo(
 			"total_records_post_compaction": totalRecordsPostCompaction,
 			"size_bytes_post_compaction":    sizeBytesPostCompaction,
 			"last_compaction_time_secs":     lastCompactionTimeSecs,
+			"num_versions":                  numVersions,
 		})
 	if result.Error != nil {
 		return 0, result.Error

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -62,7 +62,7 @@ type ICollectionDb interface {
 	DeleteAll() error
 	UpdateLogPositionVersionTotalRecordsAndLogicalSize(collectionID string, logPosition int64, currentCollectionVersion int32, totalRecordsPostCompaction uint64, sizeBytesPostCompaction uint64, lastCompactionTimeSecs uint64, tenant string) (int32, error)
 	UpdateLogPositionAndVersionInfo(collectionID string, logPosition int64, currentCollectionVersion int32, currentVersionFilePath string, newCollectionVersion int32, newVersionFilePath string, totalRecordsPostCompaction uint64,
-		sizeBytesPostCompaction uint64, lastCompactionTimeSecs uint64) (int64, error)
+		sizeBytesPostCompaction uint64, lastCompactionTimeSecs uint64, numVersions uint64) (int64, error)
 	GetCollectionWithoutMetadata(collectionID *string, databaseName *string, softDeletedFlag *bool) (*Collection, error)
 	GetCollectionSize(collectionID string) (uint64, error)
 	ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64, tenantID *string) ([]*CollectionToGc, error)

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -438,9 +438,9 @@ func (_m *ICollectionDb) UpdateCollectionLineageFilePath(collectionID string, cu
 	return r0
 }
 
-// UpdateLogPositionAndVersionInfo provides a mock function with given fields: collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs
-func (_m *ICollectionDb) UpdateLogPositionAndVersionInfo(collectionID string, logPosition int64, currentCollectionVersion int32, currentVersionFilePath string, newCollectionVersion int32, newVersionFilePath string, totalRecordsPostCompaction uint64, sizeBytesPostCompaction uint64, lastCompactionTimeSecs uint64) (int64, error) {
-	ret := _m.Called(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs)
+// UpdateLogPositionAndVersionInfo provides a mock function with given fields: collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs, numVersions
+func (_m *ICollectionDb) UpdateLogPositionAndVersionInfo(collectionID string, logPosition int64, currentCollectionVersion int32, currentVersionFilePath string, newCollectionVersion int32, newVersionFilePath string, totalRecordsPostCompaction uint64, sizeBytesPostCompaction uint64, lastCompactionTimeSecs uint64, numVersions uint64) (int64, error) {
+	ret := _m.Called(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs, numVersions)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateLogPositionAndVersionInfo")
@@ -448,17 +448,17 @@ func (_m *ICollectionDb) UpdateLogPositionAndVersionInfo(collectionID string, lo
 
 	var r0 int64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, int64, int32, string, int32, string, uint64, uint64, uint64) (int64, error)); ok {
-		return rf(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs)
+	if rf, ok := ret.Get(0).(func(string, int64, int32, string, int32, string, uint64, uint64, uint64, uint64) (int64, error)); ok {
+		return rf(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs, numVersions)
 	}
-	if rf, ok := ret.Get(0).(func(string, int64, int32, string, int32, string, uint64, uint64, uint64) int64); ok {
-		r0 = rf(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs)
+	if rf, ok := ret.Get(0).(func(string, int64, int32, string, int32, string, uint64, uint64, uint64, uint64) int64); ok {
+		r0 = rf(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs, numVersions)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, int64, int32, string, int32, string, uint64, uint64, uint64) error); ok {
-		r1 = rf(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs)
+	if rf, ok := ret.Get(1).(func(string, int64, int32, string, int32, string, uint64, uint64, uint64, uint64) error); ok {
+		r1 = rf(collectionID, logPosition, currentCollectionVersion, currentVersionFilePath, newCollectionVersion, newVersionFilePath, totalRecordsPostCompaction, sizeBytesPostCompaction, lastCompactionTimeSecs, numVersions)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
## Description of changes

This field was previously only updated during version deletion.

## Test plan

_How are these changes tested?_

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Updated test to add assertion for this column.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_


n/a