### PR TITLE
[ENH] Use tracing util to set root span on rust log service.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -200,7 +200,9 @@ async fn get_log_from_handle<'a>(
     mark_dirty: MarkDirty,
 ) -> Result<LogRef<'a>, wal3::Error> {
     let mut active = handle.active.lock().await;
-    active.keep_alive(Duration::from_secs(60));
+    if active.log.is_some() {
+        active.keep_alive(Duration::from_secs(60));
+    }
     if let Some(log) = active.log.as_ref() {
         return Ok(LogRef {
             log: Arc::clone(log),
@@ -216,6 +218,7 @@ async fn get_log_from_handle<'a>(
         mark_dirty.clone(),
     )
     .await?;
+    active.keep_alive(Duration::from_secs(60));
     tracing::info!("Opened log at {}", prefix);
     let opened = Arc::new(opened);
     active.log = Some(Arc::clone(&opened));

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1554,9 +1554,13 @@ impl LogService for LogServer {
         let span =
             wrap_span_with_parent_context(tracing::trace_span!("SealLog",), request.metadata());
 
-        Err(Status::failed_precondition(
-            "rust log service doesn't do sealing",
-        ))
+        async {
+            Err(Status::failed_precondition(
+                "rust log service doesn't do sealing",
+            ))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn migrate_log(


### PR DESCRIPTION
## Description of changes

The logging was done manually.  wrap_span_with_parent_context should attach services in Honeycomb.

## Test plan

CI

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
