### PR TITLE
[ENH]  Do not keep around logs that get passed through.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -199,7 +199,9 @@ async fn get_log_from_handle<'a>(
     mark_dirty: MarkDirty,
 ) -> Result<LogRef<'a>, wal3::Error> {
     let mut active = handle.active.lock().await;
-    active.keep_alive(Duration::from_secs(60));
+    if active.log.is_some() {
+        active.keep_alive(Duration::from_secs(60));
+    }
     if let Some(log) = active.log.as_ref() {
         return Ok(LogRef {
             log: Arc::clone(log),
@@ -215,6 +217,7 @@ async fn get_log_from_handle<'a>(
         mark_dirty.clone(),
     )
     .await?;
+    active.keep_alive(Duration::from_secs(60));
     tracing::info!("Opened log at {}", prefix);
     let opened = Arc::new(opened);
     active.log = Some(Arc::clone(&opened));


### PR DESCRIPTION
## Description of changes

There's an explicit assumption in wal3 that logs will be bound to a
single writer.  To make concurrent writes possible we use the state hash
table to get to a single log.

If there was a case of serial writes, we would end up creating an entry in
the hash table, do the write, and then tear down the entry in the hash
table as part of the RAII-driven return.  This means every operation
would be a re-opening.

Instead we keep the logs around for 60 seconds.  This could be made
configurable.

This PR makes it so we only keep logs around for collections that are
already initialized.

## Test plan

CI

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
