### PR TITLE
[ENH] Refactor dirty log rollup for async implementation (#4700)

### DIFF
--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -230,6 +230,7 @@ func (r *LogRepository) GetAllCollectionInfoToCompact(ctx context.Context, minCo
 	if err != nil {
 		trace_log.Error("Error in getting collections to compact from record_log table", zap.Error(err))
 	}
+	trace_log.Info("GetAllCollectionInfoToCompact", zap.Int64("collections", int64(len(collectionToCompact))))
 	return
 }
 

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -531,17 +531,31 @@ impl GrpcLog {
         &mut self,
         min_compaction_size: u64,
     ) -> Result<Vec<CollectionInfo>, GrpcGetCollectionsWithNewDataError> {
-        let mut norm = self
+        let mut norm = match self
             ._get_collections_with_new_data(false, min_compaction_size)
-            .await?;
+            .await
+        {
+            Ok(colls) => colls,
+            Err(err) => {
+                tracing::error!("could not contact old log: {err:?}");
+                vec![]
+            }
+        };
         if self.config.alt_host_threshold.is_some()
             || !self.config.use_alt_for_tenants.is_empty()
             || !self.config.use_alt_for_collections.is_empty()
         {
-            let alt = self
+            let alt = match self
                 ._get_collections_with_new_data(true, min_compaction_size)
-                .await?;
-            norm.extend(alt)
+                .await
+            {
+                Ok(alt) => alt,
+                Err(err) => {
+                    tracing::error!("could not contact new log: {err:?}");
+                    vec![]
+                }
+            };
+            norm.extend(alt);
         }
         norm.sort_by_key(|n| n.collection_id);
         norm.dedup_by_key(|n| n.collection_id);

--- a/rust/log/tests/log-offsets.rs
+++ b/rust/log/tests/log-offsets.rs
@@ -169,6 +169,8 @@ async fn test_k8s_integration_log_offsets_empty_log_50054() {
     let resp = resp.into_inner();
     assert_eq!(1, resp.records.len());
     assert_eq!(1, resp.records[0].log_offset);
+    // Wait 15 seconds for the background interval.  It's a magic constant in log service code.
+    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
     // "compact" said record.
     let resp = rust_log_service
         .get_all_collection_info_to_compact(GetAllCollectionInfoToCompactRequest {
@@ -193,6 +195,8 @@ async fn test_k8s_integration_log_offsets_empty_log_50054() {
         })
         .await
         .unwrap();
+    // Wait 15 seconds for the background interval.  It's a magic constant in log service code.
+    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
     // said record no longer shows in compaction.
     let resp = rust_log_service
         .get_all_collection_info_to_compact(GetAllCollectionInfoToCompactRequest {

--- a/rust/wal3/src/copy.rs
+++ b/rust/wal3/src/copy.rs
@@ -124,6 +124,7 @@ pub async fn copy(
         writer: "copy task".to_string(),
         snapshots,
         fragments,
+        initial_offset: manifest.initial_offset,
     };
     Manifest::initialize_from_manifest(options, storage, &target, manifest).await?;
     Ok(())

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -370,6 +370,7 @@ mod tests {
                 acc_bytes: 0,
                 snapshots: vec![],
                 fragments: vec![],
+                initial_offset: None,
             },
             work.0
         );
@@ -397,6 +398,7 @@ mod tests {
                         setsum: Setsum::default(),
                     }
                 ],
+                initial_offset: None,
             },
             work.2
         );

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -131,7 +131,7 @@ impl Scheduler {
                     }
 
                     // TODO: make querying the last compaction time in batch
-                    let log_position_in_collecion = collection[0].log_position;
+                    let log_position_in_collection = collection[0].log_position;
                     let tenant_ids = vec![collection[0].tenant.clone()];
                     let tenant = self.sysdb.get_last_compaction_time(tenant_ids).await;
 
@@ -152,14 +152,17 @@ impl Scheduler {
                     // offset in log is the first offset in the log that has not been compacted. Note that
                     // since the offset is the first offset of log we get from the log service, we should
                     // use this offset to pull data from the log service.
-                    if log_position_in_collecion + 1 < offset {
+                    if log_position_in_collection + 1 < offset {
                         panic!(
-                            "offset in sysdb is less than offset in log, this should not happen!"
+                            "offset in sysdb ({}) is less than offset in log ({}) for {}",
+                            log_position_in_collection + 1,
+                            offset,
+                            collection[0].collection_id,
                         )
                     } else {
                         // The offset in sysdb is the last offset that has been compacted.
                         // We need to start from the next offset.
-                        offset = log_position_in_collecion + 1;
+                        offset = log_position_in_collection + 1;
                     }
 
                     collection_records.push(CollectionRecord {
@@ -498,9 +501,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[should_panic(
-        expected = "offset in sysdb is less than offset in log, this should not happen!"
-    )]
+    #[should_panic(expected = "is less than offset")]
     async fn test_scheduler_panic() {
         let mut log = Log::InMemory(InMemoryLog::new());
         let in_memory_log = match log {


### PR DESCRIPTION
- Add Error enum with WAL3, JSON, and dirty log specific error types
- Refactor RollupPerCollection to be Copy + Clone with new observation
methods
- Remove large static rollup method from DirtyMarker in favor of modular
approach
- Add rolling_up mutex and need_to_compact HashMap to LogServer for
async operations
- Clean up unused imports and simplify overall structure

This change prepares the foundation for implementing async dirty log
rollup
functionality while maintaining core rollup logic in a more maintainable
form.

Includes #4701 and #4702.

CI

- [X] Tests pass locally with `pytest` for python, `yarn test` for js,
`cargo test` for rust

Internal documentation updated.
