### PR TITLE
[CHORE] unpin fastapi, move to dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ description = "Chroma."
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = ["Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent"]
-dependencies = ['build >= 1.0.3', 'pydantic >= 1.9', 'fastapi==0.115.9', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-instrumentation-fastapi>=0.41b0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
+dependencies = ['build >= 1.0.3', 'pydantic >= 1.9', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
 
 [project.optional-dependencies]
-dev = ['chroma-hnswlib==0.7.6']
+dev = ['chroma-hnswlib==0.7.6', 'fastapi>=0.115.9', 'opentelemetry-instrumentation-fastapi>=0.41b0']
 
 [tool.black]
 line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bcrypt>=4.0.1
-fastapi==0.115.9
 graphlib_backport==1.0.3; python_version < '3.9'
 grpcio>=1.58.0
 httpx>=0.27.0
@@ -11,7 +10,6 @@ numpy>=1.22.5
 onnxruntime>=1.14.1
 opentelemetry-api>=1.24.0
 opentelemetry-exporter-otlp-proto-grpc>=1.24.0
-opentelemetry-instrumentation-fastapi>=0.41b0
 opentelemetry-sdk>=1.24.0
 orjson>=3.9.12
 overrides>=7.3.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,13 @@
 black==23.3.0 # match what's in pyproject.toml
 build
 chroma-hnswlib==0.7.6
+fastapi>=0.115.9
 grpcio-tools==1.67.1 # Later version not compatible with protobuf 4.25.5
 httpx
 hypothesis==6.112.2 # TODO: Resolve breaking changes and bump version
 hypothesis[numpy]==6.112.2 # TODO: Resolve breaking changes and bump version
 mypy-protobuf
+opentelemetry-instrumentation-fastapi>=0.41b0
 pandas
 pre-commit
 protobuf==5.28.0 # Later version not compatible with opentelemetry 1.27.0


### PR DESCRIPTION
## Description of changes

Unpins fastapi and moves to dev dependency. only use of it is in python fastapi server.
https://github.com/chroma-core/chroma/issues/4243

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
