### PR TITLE
[CHORE] Add pathlib support to path for persistence

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 import logging
 from chromadb.api.client import Client as ClientCreator
 from chromadb.api.client import AdminClient as AdminClientCreator
@@ -26,6 +26,7 @@ from chromadb.api.types import (
     WhereDocument,
     UpdateCollectionMetadata,
 )
+from pathlib import Path
 
 # Re-export types from chromadb.types
 __all__ = [
@@ -135,7 +136,7 @@ def EphemeralClient(
 
 
 def PersistentClient(
-    path: str = "./chroma",
+    path: Union[str, Path] = "./chroma",
     settings: Optional[Settings] = None,
     tenant: str = DEFAULT_TENANT,
     database: str = DEFAULT_DATABASE,
@@ -151,7 +152,7 @@ def PersistentClient(
     """
     if settings is None:
         settings = Settings()
-    settings.persist_directory = path
+    settings.persist_directory = str(path)
     settings.is_persistent = True
 
     # Make sure paramaters are the correct types -- users can pass anything.


### PR DESCRIPTION
## Description of changes

Adds support to pass pathlib.Path for persistence
https://github.com/chroma-core/chroma/issues/4704

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
