### PR TITLE
[ENH] Limit the number of records pulled by pull logs

### DIFF
--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -156,7 +156,7 @@ impl LogReader {
                 > limits.max_records.unwrap_or(u64::MAX)
         {
             tracing::info!(
-                "truncating to {} files because bytes restrictions",
+                "truncating to {} files because records restrictions",
                 fragments.len() - 1
             );
             fragments.pop();

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -22,6 +22,7 @@ use crate::{
 pub struct Limits {
     pub max_files: Option<u64>,
     pub max_bytes: Option<u64>,
+    pub max_records: Option<u64>,
 }
 
 /// LogReader is a reader for the log.
@@ -90,16 +91,27 @@ impl LogReader {
         else {
             return Err(Error::UninitializedLog);
         };
+        let log_position_range = if let Some(max_records) = limits.max_records {
+            (from, from + max_records)
+        } else {
+            (from, LogPosition::MAX)
+        };
+        fn ranges_overlap(
+            lhs: (LogPosition, LogPosition),
+            rhs: (LogPosition, LogPosition),
+        ) -> bool {
+            lhs.0 <= rhs.1 && lhs.1 <= rhs.0
+        }
         let mut snapshots = manifest
             .snapshots
             .iter()
-            .filter(|s| s.limit.offset() > from.offset())
+            .filter(|s| ranges_overlap(log_position_range, (s.start, s.limit)))
             .cloned()
             .collect::<Vec<_>>();
         let mut fragments = manifest
             .fragments
             .iter()
-            .filter(|f| f.limit.offset() > from.offset())
+            .filter(|f| ranges_overlap(log_position_range, (f.start, f.limit)))
             .cloned()
             .collect::<Vec<_>>();
         while !snapshots.is_empty() {


### PR DESCRIPTION
## Description of changes

Here's the scenario:  A client is writing in batches to the log.  The
batches come in groups, and wal3 does de-amplification of batches.
Imagine running a pull logs.  Prior to this change, the pull logs can
only knows which files to fetch based upon the number of files or number
of bytes.

By pruning to number of records, we allow for the case where there's one
fragment that has BatchSize records, and so we only need to fetch one
fragment to read its records.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
