### PR TITLE
[ENH] CLI - Set Chroma env variables

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/cli/commands/db.md
+++ b/docs/docs.trychroma.com/markdoc/content/cli/commands/db.md
@@ -12,6 +12,20 @@ The output code snippet will already have the API key of your profile set for th
 chroma db connect [db_name] [--language python/JS/TS]
 ```
 
+The `connect` command can also add Chroma environment variables (`CHROMA_API_KEY`, `CHROMA_TENANT`, and `CHROMA_DATABASE`) to a `.env` file in your current working directory. It will create a `.env` file for you if it doesn't exist:
+
+```terminal
+chroma db connect [db_name] --env-file
+```
+
+If you prefer to simply output these variables to your terminal use:
+
+```terminal
+chroma db connect [db_name] --env-vars
+```
+
+Setting these environment variables will allow you to consiscely instantiate the `CloudClient` with no arguments.
+
 ### Create
 
 The `create` command lets you create a database on Chroma Cloud. It has the `name` argument, which is the name of the DB you want to create. If you don't provide it, the CLI will prompt you to choose a name.

--- a/docs/docs.trychroma.com/markdoc/content/cli/commands/db.md
+++ b/docs/docs.trychroma.com/markdoc/content/cli/commands/db.md
@@ -24,7 +24,7 @@ If you prefer to simply output these variables to your terminal use:
 chroma db connect [db_name] --env-vars
 ```
 
-Setting these environment variables will allow you to consiscely instantiate the `CloudClient` with no arguments.
+Setting these environment variables will allow you to concisely instantiate the `CloudClient` with no arguments.
 
 ### Create
 

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -34,6 +34,9 @@ pub const CHROMA_DIR: &str = ".chroma";
 pub const CREDENTIALS_FILE: &str = "credentials";
 const CONFIG_FILE: &str = "config.json";
 pub const SELECTION_LIMIT: usize = 5;
+pub const CHROMA_API_KEY_ENV_VAR: &str = "CHROMA_API_KEY";
+pub const CHROMA_TENANT_ENV_VAR: &str = "CHROMA_TENANT";
+pub const CHROMA_DATABASE_ENV_VAR: &str = "CHROMA_DATABASE";
 
 #[derive(Debug, Error)]
 pub enum CliError {


### PR DESCRIPTION
## Description of changes

Adding `chroma db connect --env-file` which sets environment variables required for connecting to ChromaCloud in the `.env` file in the current directory (or create it). The `chroma db connect --env-vars` option will output to the terminal.

## Test plan

Manual testing.

## Documentation Changes

Included in this PR under CLI docs.
