### PR TITLE
[BUG] Correctly check arguments for chroma cli for chroma update

### DIFF
--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -47,7 +47,7 @@ def update():
 
 def app():
     args = sys.argv
-    if ["chroma", "update"] in args:
+    if len(args) >= 2 and args[0] == "chroma" and args[1] == "update":
         update()
         return
     try:


### PR DESCRIPTION
## Description of changes

When a user runs chroma update from the command line, the code should detect this command and run the update() function to check for newer versions of Chroma. It is incorrectly checking for the command line arguments


## Test plan

`pip install -e .`

`python3 -c "import sys; from chromadb.cli import cli; sys.argv = ['chroma', 'update']; cli.app()"` 

- Doesn't trigger chroma update. You will see a wrong message:
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/653c922e-4748-4bcb-9c27-45057b85a4ab" />


- Run the above with fix, you will see update run correctly.
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/16f91a73-df30-4638-bfff-7ea9d3e696df" />


- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Fixes https://github.com/chroma-core/chroma/issues/4474