### PR TITLE
[CHORE] Log frag count during scout

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1117,8 +1117,8 @@ impl LogServer {
 
             // NOTE(sicheng): This is temporary trace added for analyzing number of frags between the offsets
             match log_reader.scan(start_position, Default::default()).await {
-                Ok(frags) => tracing::info!("Number of live fragments: {}", frags.len()),
-                Err(e) => tracing::error!("Unable to scout number of live fragments: {e}"),
+                Ok(frags) => tracing::info!(name: "Counting live fragments", frag_count = frags.len()),
+                Err(e) => tracing::error!(name: "Unable to scout number of live fragments", error = e.to_string()),
             }
 
             let start_offset = start_position.offset() as i64;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Trace frag count in rust log service during scout log
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
