### PR TITLE
[BUG] Fix where validation bug

### DIFF
--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -350,7 +350,8 @@ export const validateWhere = (where: Where) => {
         );
       }
 
-      Object.values(where).forEach((w: Where) => validateWhere(w));
+      value.forEach((w: Where) => validateWhere(w));
+      return;
     }
 
     if (typeof value === "object") {


### PR DESCRIPTION
## Description of changes

Fix bug in 'where' clause validation for the JS client. Previously, the validation function recursed on the array of `$and` or `$or`, instead of the array elements themselves.