### PR TITLE
[ENH]: add 2 params to GetCollections: include soft deleted & collection IDs

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator.go
+++ b/go/pkg/sysdb/coordinator/coordinator.go
@@ -107,8 +107,8 @@ func (s *Coordinator) GetCollection(ctx context.Context, collectionID types.Uniq
 	return s.catalog.GetCollection(ctx, collectionID, collectionName, tenantID, databaseName)
 }
 
-func (s *Coordinator) GetCollections(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*model.Collection, error) {
-	return s.catalog.GetCollections(ctx, collectionID, collectionName, tenantID, databaseName, limit, offset)
+func (s *Coordinator) GetCollections(ctx context.Context, collectionIDs []types.UniqueID, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32, includeSoftDeleted bool) ([]*model.Collection, error) {
+	return s.catalog.GetCollections(ctx, collectionIDs, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)
 }
 
 func (s *Coordinator) CountCollections(ctx context.Context, tenantID string, databaseName *string) (uint64, error) {

--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -144,7 +144,7 @@ func testCollection(t *rapid.T) {
 			}
 			if err == nil {
 				// verify the correctness
-				collectionList, err := c.GetCollections(ctx, collection.ID, nil, common.DefaultTenant, common.DefaultDatabase, nil, nil)
+				collectionList, err := c.GetCollections(ctx, []types.UniqueID{collection.ID}, nil, common.DefaultTenant, common.DefaultDatabase, nil, nil, false)
 				if err != nil {
 					t.Fatalf("error getting collections: %v", err)
 				}
@@ -323,7 +323,7 @@ func (suite *APIsTestSuite) TestCreateCollectionAndSegments() {
 	// suite.Equal(len(segments), len(createdSegments))
 
 	// Verify the collection was created
-	result, err := suite.coordinator.GetCollections(ctx, newCollection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	result, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{newCollection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(result, 1)
 	suite.Equal(newCollection.ID, result[0].ID)
@@ -380,7 +380,7 @@ func (suite *APIsTestSuite) TestCreateCollectionAndSegments() {
 	suite.Error(err)
 
 	// Check that the collection was not created
-	collections, err := suite.coordinator.GetCollections(ctx, newCollection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	collections, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{newCollection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Empty(collections)
 
@@ -402,7 +402,7 @@ func (suite *APIsTestSuite) TestCreateCollectionAndSegments() {
 // the APIs are working as expected. i.e. Get does not return deleted collections.
 func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	ctx := context.Background()
-	results, err := suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err := suite.coordinator.GetCollections(ctx, nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 
 	sort.Slice(results, func(i, j int) bool {
@@ -455,7 +455,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 
 	// Find by name
 	for _, collection := range suite.sampleCollections {
-		result, err := suite.coordinator.GetCollections(ctx, types.NilUniqueID(), &collection.Name, suite.tenantName, suite.databaseName, nil, nil)
+		result, err := suite.coordinator.GetCollections(ctx, nil, &collection.Name, suite.tenantName, suite.databaseName, nil, nil, false)
 		suite.NoError(err)
 		suite.Equal(len(result), 1)
 		suite.Equal(collection.ID, result[0].ID)
@@ -468,7 +468,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 
 	// Find by id
 	for _, collection := range suite.sampleCollections {
-		result, err := suite.coordinator.GetCollections(ctx, collection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+		result, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{collection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 		suite.NoError(err)
 		suite.Equal(len(result), 1)
 		suite.Equal(collection.ID, result[0].ID)
@@ -489,7 +489,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	err = suite.coordinator.SoftDeleteCollection(ctx, deleteCollection)
 	suite.NoError(err)
 
-	results, err = suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err = suite.coordinator.GetCollections(ctx, nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	result_ids := make([]types.UniqueID, len(results))
 	for i, result := range results {
@@ -503,7 +503,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	suite.NotContains(result_ids, c1.ID)
 	suite.Len(results, len(suite.sampleCollections)-1)
 	suite.ElementsMatch(result_ids, sample_ids[1:])
-	byIDResult, err := suite.coordinator.GetCollections(ctx, c1.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	byIDResult, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{c1.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Empty(byIDResult)
 
@@ -526,7 +526,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	suite.NoError(err)
 
 	// Verify collection was re-created
-	results, err = suite.coordinator.GetCollections(ctx, createCollection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{createCollection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(results, 1)
 	suite.Equal(createCollection.ID, results[0].ID)
@@ -564,7 +564,7 @@ func (suite *APIsTestSuite) TestCreateGetDeleteCollections() {
 	suite.NoError(err)
 
 	// Verify collection and segment were deleted
-	results, err = suite.coordinator.GetCollections(ctx, createCollection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{createCollection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Empty(results)
 	// Segments will not be deleted since the collection is only soft deleted.
@@ -611,7 +611,7 @@ func (suite *APIsTestSuite) TestUpdateCollections() {
 	suite.Equal(coll.Dimension, result.Dimension)
 	suite.Equal(coll.Metadata, result.Metadata)
 
-	resultList, err := suite.coordinator.GetCollections(ctx, types.NilUniqueID(), &coll.Name, suite.tenantName, suite.databaseName, nil, nil)
+	resultList, err := suite.coordinator.GetCollections(ctx, nil, &coll.Name, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(len(resultList), 1)
 	suite.Equal(coll.ID, resultList[0].ID)
@@ -633,7 +633,7 @@ func (suite *APIsTestSuite) TestUpdateCollections() {
 	suite.Equal(coll.Dimension, result.Dimension)
 	suite.Equal(coll.Metadata, result.Metadata)
 
-	resultList, err = suite.coordinator.GetCollections(ctx, coll.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	resultList, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{coll.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(len(resultList), 1)
 	suite.Equal(coll.ID, resultList[0].ID)
@@ -656,7 +656,7 @@ func (suite *APIsTestSuite) TestUpdateCollections() {
 	suite.Equal(coll.Dimension, result.Dimension)
 	suite.Equal(coll.Metadata, result.Metadata)
 
-	resultList, err = suite.coordinator.GetCollections(ctx, coll.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	resultList, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{coll.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(len(resultList), 1)
 	suite.Equal(coll.ID, resultList[0].ID)
@@ -677,7 +677,7 @@ func (suite *APIsTestSuite) TestUpdateCollections() {
 	suite.Equal(coll.Dimension, result.Dimension)
 	suite.Equal(coll.Metadata, result.Metadata)
 
-	resultList, err = suite.coordinator.GetCollections(ctx, coll.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	resultList, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{coll.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(len(resultList), 1)
 	suite.Equal(coll.ID, resultList[0].ID)
@@ -758,7 +758,7 @@ func (suite *APIsTestSuite) TestCreateUpdateWithDatabase() {
 		Name: &newName1,
 	})
 	suite.NoError(err)
-	result, err := suite.coordinator.GetCollections(ctx, suite.sampleCollections[1].ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	result, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{suite.sampleCollections[1].ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(result, 1)
 	suite.Equal(newName1, result[0].Name)
@@ -770,7 +770,7 @@ func (suite *APIsTestSuite) TestCreateUpdateWithDatabase() {
 	})
 	suite.NoError(err)
 	//suite.Equal(newName0, collection.Name)
-	result, err = suite.coordinator.GetCollections(ctx, suite.sampleCollections[0].ID, nil, suite.tenantName, newDatabaseName, nil, nil)
+	result, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{suite.sampleCollections[0].ID}, nil, suite.tenantName, newDatabaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(result, 1)
 	suite.Equal(newName0, result[0].Name)
@@ -808,7 +808,7 @@ func (suite *APIsTestSuite) TestGetMultipleWithDatabase() {
 		suite.NoError(err)
 		suite.sampleCollections[index] = collection
 	}
-	result, err := suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, suite.tenantName, newDatabaseName, nil, nil)
+	result, err := suite.coordinator.GetCollections(ctx, nil, nil, suite.tenantName, newDatabaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(len(suite.sampleCollections), len(result))
 	sort.Slice(result, func(i, j int) bool {
@@ -823,7 +823,7 @@ func (suite *APIsTestSuite) TestGetMultipleWithDatabase() {
 		suite.Equal(suite.sampleCollections[index].Metadata, collection.Metadata)
 	}
 
-	result, err = suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, suite.tenantName, suite.databaseName, nil, nil)
+	result, err = suite.coordinator.GetCollections(ctx, nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(len(suite.sampleCollections), len(result))
 
@@ -900,7 +900,7 @@ func (suite *APIsTestSuite) TestCreateDatabaseWithTenants() {
 	expected := []*model.Collection{suite.sampleCollections[0]}
 	expected[0].TenantID = newTenantName
 	expected[0].DatabaseName = newDatabaseName
-	result, err := suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, newTenantName, newDatabaseName, nil, nil)
+	result, err := suite.coordinator.GetCollections(ctx, nil, nil, newTenantName, newDatabaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(result, 1)
 	suite.Equal(expected[0].ID, result[0].ID)
@@ -913,7 +913,7 @@ func (suite *APIsTestSuite) TestCreateDatabaseWithTenants() {
 	expected = []*model.Collection{suite.sampleCollections[1]}
 	expected[0].TenantID = suite.tenantName
 	expected[0].DatabaseName = newDatabaseName
-	result, err = suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, suite.tenantName, newDatabaseName, nil, nil)
+	result, err = suite.coordinator.GetCollections(ctx, nil, nil, suite.tenantName, newDatabaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(result, 1)
 	suite.Equal(expected[0].ID, result[0].ID)
@@ -925,7 +925,7 @@ func (suite *APIsTestSuite) TestCreateDatabaseWithTenants() {
 
 	// A new tenant DOES NOT have a default database. This does not error, instead 0
 	// results are returned
-	result, err = suite.coordinator.GetCollections(ctx, types.NilUniqueID(), nil, newTenantName, suite.databaseName, nil, nil)
+	result, err = suite.coordinator.GetCollections(ctx, nil, nil, newTenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(0, len(result))
 
@@ -1280,7 +1280,7 @@ func (suite *APIsTestSuite) TestSoftAndHardDeleteCollection() {
 	suite.NoError(err)
 
 	// Verify collection is not returned in normal get
-	results, err := suite.coordinator.GetCollections(ctx, testCollection2.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{testCollection2.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Empty(results)
 
@@ -1312,7 +1312,7 @@ func (suite *APIsTestSuite) TestSoftAndHardDeleteCollection() {
 	suite.NoError(err)
 
 	// Verify collection is not returned in normal get
-	results, err = suite.coordinator.GetCollections(ctx, testCollection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{testCollection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Empty(results)
 
@@ -1348,7 +1348,7 @@ func (suite *APIsTestSuite) TestSoftAndHardDeleteCollection() {
 	suite.NoError(err)
 
 	// Get the newly created collection to verify it exists
-	results, err = suite.coordinator.GetCollections(ctx, newTestCollection.ID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	results, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{newTestCollection.ID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(results, 1)
 	suite.Equal(newTestCollection.Name, results[0].Name)
@@ -1592,7 +1592,7 @@ func (suite *APIsTestSuite) TestForkCollection() {
 	suite.Error(err)
 
 	// Check that the collection was not created
-	collections, err := suite.coordinator.GetCollections(ctx, forkCollectionWithSameName.TargetCollectionID, nil, suite.tenantName, suite.databaseName, nil, nil)
+	collections, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{forkCollectionWithSameName.TargetCollectionID}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Empty(collections)
 
@@ -1604,7 +1604,7 @@ func (suite *APIsTestSuite) TestForkCollection() {
 	suite.Equal(forkCollectionWithSameName.SourceCollectionID, res[0].ID)
 
 	// Get source collection to grab lineage path and validate it exists
-	sourceCollection, err := suite.coordinator.GetCollections(ctx, sourceCreateCollection.ID, nil, sourceCreateCollection.TenantID, sourceCreateCollection.DatabaseName, nil, nil)
+	sourceCollection, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{sourceCreateCollection.ID}, nil, sourceCreateCollection.TenantID, sourceCreateCollection.DatabaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Equal(1, len(sourceCollection))
 	exists, err := suite.s3MetaStore.HasObjectWithPrefix(ctx, *sourceCollection[0].LineageFileName)
@@ -1762,6 +1762,50 @@ func (suite *APIsTestSuite) TestCountForks() {
 		suite.NoError(err)
 		suite.Equal(uint64(10), count)
 	}
+}
+
+func (suite *APIsTestSuite) TestGetCollections() {
+	ctx := context.Background()
+
+	// Does not error if collection is not found
+	result, err := suite.coordinator.GetCollections(ctx, []types.UniqueID{types.NewUniqueID()}, nil, suite.tenantName, suite.databaseName, nil, nil, false)
+	suite.NoError(err)
+	suite.Len(result, 0)
+
+	createCollection := &model.CreateCollection{
+		ID:           types.NewUniqueID(),
+		Name:         "collection_1",
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	}
+
+	_, _, err = suite.coordinator.CreateCollectionAndSegments(ctx, createCollection, []*model.Segment{})
+	suite.NoError(err)
+
+	// Can fetch the collection by ID
+	result, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{createCollection.ID}, nil, createCollection.TenantID, createCollection.DatabaseName, nil, nil, false)
+	suite.NoError(err)
+	suite.Len(result, 1)
+	suite.Equal(createCollection.ID, result[0].ID)
+
+	// Soft delete collection
+	err = suite.coordinator.SoftDeleteCollection(ctx, &model.DeleteCollection{
+		ID:           createCollection.ID,
+		TenantID:     createCollection.TenantID,
+		DatabaseName: createCollection.DatabaseName,
+	})
+	suite.NoError(err)
+
+	// Is not returned when include soft deleted is false
+	result, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{createCollection.ID}, nil, createCollection.TenantID, createCollection.DatabaseName, nil, nil, false)
+	suite.NoError(err)
+	suite.Len(result, 0)
+
+	// Is returned when include soft deleted is true
+	result, err = suite.coordinator.GetCollections(ctx, []types.UniqueID{createCollection.ID}, nil, createCollection.TenantID, createCollection.DatabaseName, nil, nil, true)
+	suite.NoError(err)
+	suite.Len(result, 1)
+	suite.Equal(createCollection.ID, result[0].ID)
 }
 
 func TestAPIsTestSuite(t *testing.T) {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -188,7 +188,7 @@ func (tc *Catalog) DeleteDatabase(ctx context.Context, deleteDatabase *model.Del
 			return err
 		}
 
-		collections, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, nil, deleteDatabase.Tenant, deleteDatabase.Name, nil, nil)
+		collections, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, nil, deleteDatabase.Tenant, deleteDatabase.Name, nil, nil, false)
 		if err != nil {
 			return err
 		}
@@ -285,7 +285,7 @@ func (tc *Catalog) createCollectionImpl(txCtx context.Context, createCollection 
 	}
 
 	collectionName := createCollection.Name
-	existing, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, &collectionName, tenantID, databaseName, nil, nil)
+	existing, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, &collectionName, tenantID, databaseName, nil, nil, false)
 	if err != nil {
 		log.Error("error getting collection", zap.Error(err))
 		return nil, false, err
@@ -367,7 +367,7 @@ func (tc *Catalog) createCollectionImpl(txCtx context.Context, createCollection 
 	}
 
 	// Get the inserted collection (by name, to handle the case where some other request created the collection)
-	collectionList, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, &collectionName, tenantID, databaseName, nil, nil)
+	collectionList, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(nil, &collectionName, tenantID, databaseName, nil, nil, false)
 	// It is possible, under read-commited isolation that someone else deleted the collection
 	// in between writing the collection and reading it back, in that case this will return empty, and we should throw an error
 	if err != nil {
@@ -455,14 +455,19 @@ func (tc *Catalog) GetCollection(ctx context.Context, collectionID types.UniqueI
 	return collection[0], nil
 }
 
-func (tc *Catalog) GetCollections(ctx context.Context, collectionID types.UniqueID, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*model.Collection, error) {
+func (tc *Catalog) GetCollections(ctx context.Context, collectionIDs []types.UniqueID, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32, includeSoftDeleted bool) ([]*model.Collection, error) {
 	tracer := otel.Tracer
 	if tracer != nil {
 		_, span := tracer.Start(ctx, "Catalog.GetCollections")
 		defer span.End()
 	}
 
-	collectionAndMetadataList, err := tc.metaDomain.CollectionDb(ctx).GetCollections(types.FromUniqueID(collectionID), collectionName, tenantID, databaseName, limit, offset)
+	ids := make([]string, 0, len(collectionIDs))
+	for _, id := range collectionIDs {
+		ids = append(ids, id.String())
+	}
+
+	collectionAndMetadataList, err := tc.metaDomain.CollectionDb(ctx).GetCollections(ids, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +685,7 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 	log.Info("Soft deleting collection", zap.Any("softDeleteCollection", deleteCollection))
 	return tc.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		// Check if collection exists
-		collections, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(types.FromUniqueID(deleteCollection.ID), nil, deleteCollection.TenantID, deleteCollection.DatabaseName, nil, nil)
+		collections, err := tc.metaDomain.CollectionDb(txCtx).GetCollections([]string{deleteCollection.ID.String()}, nil, deleteCollection.TenantID, deleteCollection.DatabaseName, nil, nil, false)
 		if err != nil {
 			return err
 		}
@@ -849,12 +854,13 @@ func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model
 	err := tc.txImpl.Transaction(ctx, func(txCtx context.Context) error {
 		// Check if collection exists
 		collections, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(
-			types.FromUniqueID(updateCollection.ID),
+			[]string{updateCollection.ID.String()},
 			nil,
 			updateCollection.TenantID,
 			updateCollection.DatabaseName,
 			nil,
 			nil,
+			false,
 		)
 		if err != nil {
 			return err
@@ -918,7 +924,7 @@ func (tc *Catalog) UpdateCollection(ctx context.Context, updateCollection *model
 		}
 		databaseName := updateCollection.DatabaseName
 		tenantID := updateCollection.TenantID
-		collectionList, err := tc.metaDomain.CollectionDb(txCtx).GetCollections(types.FromUniqueID(updateCollection.ID), nil, tenantID, databaseName, nil, nil)
+		collectionList, err := tc.metaDomain.CollectionDb(txCtx).GetCollections([]string{updateCollection.ID.String()}, nil, tenantID, databaseName, nil, nil, false)
 		if err != nil {
 			return err
 		}
@@ -1167,7 +1173,7 @@ func (tc *Catalog) CountForks(ctx context.Context, sourceCollectionID types.Uniq
 	}
 
 	limit := int32(1)
-	collections, err := tc.GetCollections(ctx, rootCollectionID, nil, "", "", &limit, nil)
+	collections, err := tc.GetCollections(ctx, []types.UniqueID{rootCollectionID}, nil, "", "", &limit, nil, false)
 	if err != nil {
 		return 0, err
 	}

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -120,10 +120,10 @@ func TestCatalog_GetCollections(t *testing.T) {
 	// mock the get collections method
 	mockMetaDomain.On("CollectionDb", context.Background()).Return(&mocks.ICollectionDb{})
 	var n *int32
-	mockMetaDomain.CollectionDb(context.Background()).(*mocks.ICollectionDb).On("GetCollections", types.FromUniqueID(collectionID), &collectionName, common.DefaultTenant, common.DefaultDatabase, n, n).Return(collectionAndMetadataList, nil)
+	mockMetaDomain.CollectionDb(context.Background()).(*mocks.ICollectionDb).On("GetCollections", []string{*types.FromUniqueID(collectionID)}, &collectionName, common.DefaultTenant, common.DefaultDatabase, n, n, false).Return(collectionAndMetadataList, nil)
 
 	// call the GetCollections method
-	collections, err := catalog.GetCollections(context.Background(), collectionID, &collectionName, defaultTenant, defaultDatabase, nil, nil)
+	collections, err := catalog.GetCollections(context.Background(), []types.UniqueID{collectionID}, &collectionName, defaultTenant, defaultDatabase, nil, nil, false)
 
 	// assert that the method returned no error
 	assert.NoError(t, err)

--- a/go/pkg/sysdb/metastore/db/dao/collection_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_test.go
@@ -70,7 +70,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 		suite.NoError(err)
 		suite.Equal(collectionID, scanedCollectionID)
 	}
-	collections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
+	collections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(collectionID, collections[0].Collection.ID)
@@ -92,13 +92,13 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	suite.Equal(collections[0].Collection.IsDeleted, false)
 
 	// Test when filtering by ID
-	collections, err = suite.collectionDb.GetCollections(&collectionID, nil, "", "", nil, nil)
+	collections, err = suite.collectionDb.GetCollections([]string{collectionID}, nil, "", "", nil, nil, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(collectionID, collections[0].Collection.ID)
 
 	// Test when filtering by name
-	collections, err = suite.collectionDb.GetCollections(nil, &collectionName, suite.tenantName, suite.databaseName, nil, nil)
+	collections, err = suite.collectionDb.GetCollections(nil, &collectionName, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(collectionID, collections[0].Collection.ID)
@@ -107,7 +107,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	suite.NoError(err)
 
 	// Test order by. Collections are ordered by create time so collectionID2 should be second
-	allCollections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
+	allCollections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(allCollections, 2)
 	suite.Equal(collectionID, allCollections[0].Collection.ID)
@@ -116,18 +116,18 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	// Test limit and offset
 	limit := int32(1)
 	offset := int32(1)
-	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, nil)
+	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, nil, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(allCollections[0].Collection.ID, collections[0].Collection.ID)
 
-	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset)
+	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(allCollections[1].Collection.ID, collections[0].Collection.ID)
 
 	offset = int32(2)
-	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset)
+	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, &limit, &offset, false)
 	suite.NoError(err)
 	suite.Equal(len(collections), 0)
 
@@ -175,8 +175,9 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 func (suite *CollectionDbTestSuite) TestCollectionDb_UpdateLogPositionVersionTotalRecordsAndLogicalSize() {
 	collectionName := "test_collection_get_collections"
 	collectionID, _ := CreateTestCollection(suite.db, collectionName, 128, suite.databaseId, nil)
+	ids := []string{collectionID}
 	// verify default values
-	collections, err := suite.collectionDb.GetCollections(&collectionID, nil, "", "", nil, nil)
+	collections, err := suite.collectionDb.GetCollections(ids, nil, "", "", nil, nil, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(int64(0), collections[0].Collection.LogPosition)
@@ -186,7 +187,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_UpdateLogPositionVersionTot
 	version, err := suite.collectionDb.UpdateLogPositionVersionTotalRecordsAndLogicalSize(collectionID, int64(10), 0, uint64(100), uint64(1000), uint64(10), "test_tenant2")
 	suite.NoError(err)
 	suite.Equal(int32(1), version)
-	collections, _ = suite.collectionDb.GetCollections(&collectionID, nil, "", "", nil, nil)
+	collections, _ = suite.collectionDb.GetCollections(ids, nil, "", "", nil, nil, false)
 	suite.Len(collections, 1)
 	suite.Equal(int64(10), collections[0].Collection.LogPosition)
 	suite.Equal(int32(1), collections[0].Collection.Version)
@@ -212,7 +213,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_UpdateLogPositionVersionTot
 
 func (suite *CollectionDbTestSuite) TestCollectionDb_SoftDelete() {
 	// Ensure there are no collections from before.
-	collections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
+	collections, err := suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	if len(collections) != 0 {
 		suite.FailNow(fmt.Sprintf(
@@ -242,7 +243,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_SoftDelete() {
 	suite.NoError(err)
 
 	// Verify normal get collections only returns non-deleted collection
-	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil)
+	collections, err = suite.collectionDb.GetCollections(nil, nil, suite.tenantName, suite.databaseName, nil, nil, false)
 	suite.NoError(err)
 	suite.Len(collections, 1)
 	suite.Equal(collectionID2, collections[0].Collection.ID)

--- a/go/pkg/sysdb/metastore/db/dao/test_utils.go
+++ b/go/pkg/sysdb/metastore/db/dao/test_utils.go
@@ -71,7 +71,7 @@ func CleanUpTestDatabase(db *gorm.DB, tenantName string, databaseName string) er
 	collectionDb := &collectionDb{
 		db: db,
 	}
-	collections, err := collectionDb.GetCollections(nil, nil, tenantName, databaseName, nil, nil)
+	collections, err := collectionDb.GetCollections(nil, nil, tenantName, databaseName, nil, nil, false)
 	log.Info("clean up test database", zap.Int("collections", len(collections)))
 	if err != nil {
 		return err

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -51,7 +51,7 @@ type CollectionAndMetadata struct {
 
 //go:generate mockery --name=ICollectionDb
 type ICollectionDb interface {
-	GetCollections(collectionID *string, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*CollectionAndMetadata, error)
+	GetCollections(collectionIDs []string, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32, includeSoftDeleted bool) ([]*CollectionAndMetadata, error)
 	GetCollectionEntries(id *string, name *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*CollectionAndMetadata, error)
 	CountCollections(tenantID string, databaseName *string) (uint64, error)
 	DeleteCollectionByID(collectionID string) (int, error)

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -236,9 +236,9 @@ func (_m *ICollectionDb) GetCollectionWithoutMetadata(collectionID *string, data
 	return r0, r1
 }
 
-// GetCollections provides a mock function with given fields: collectionID, collectionName, tenantID, databaseName, limit, offset
-func (_m *ICollectionDb) GetCollections(collectionID *string, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32) ([]*dbmodel.CollectionAndMetadata, error) {
-	ret := _m.Called(collectionID, collectionName, tenantID, databaseName, limit, offset)
+// GetCollections provides a mock function with given fields: collectionIDs, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted
+func (_m *ICollectionDb) GetCollections(collectionIDs []string, collectionName *string, tenantID string, databaseName string, limit *int32, offset *int32, includeSoftDeleted bool) ([]*dbmodel.CollectionAndMetadata, error) {
+	ret := _m.Called(collectionIDs, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCollections")
@@ -246,19 +246,19 @@ func (_m *ICollectionDb) GetCollections(collectionID *string, collectionName *st
 
 	var r0 []*dbmodel.CollectionAndMetadata
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*string, *string, string, string, *int32, *int32) ([]*dbmodel.CollectionAndMetadata, error)); ok {
-		return rf(collectionID, collectionName, tenantID, databaseName, limit, offset)
+	if rf, ok := ret.Get(0).(func([]string, *string, string, string, *int32, *int32, bool) ([]*dbmodel.CollectionAndMetadata, error)); ok {
+		return rf(collectionIDs, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)
 	}
-	if rf, ok := ret.Get(0).(func(*string, *string, string, string, *int32, *int32) []*dbmodel.CollectionAndMetadata); ok {
-		r0 = rf(collectionID, collectionName, tenantID, databaseName, limit, offset)
+	if rf, ok := ret.Get(0).(func([]string, *string, string, string, *int32, *int32, bool) []*dbmodel.CollectionAndMetadata); ok {
+		r0 = rf(collectionIDs, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*dbmodel.CollectionAndMetadata)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*string, *string, string, string, *int32, *int32) error); ok {
-		r1 = rf(collectionID, collectionName, tenantID, databaseName, limit, offset)
+	if rf, ok := ret.Get(1).(func([]string, *string, string, string, *int32, *int32, bool) error); ok {
+		r1 = rf(collectionIDs, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -182,6 +182,8 @@ message GetCollectionsRequest {
   string database = 5;
   optional int32 limit = 6;
   optional int32 offset = 7;
+  repeated string ids = 8;
+  optional bool include_soft_deleted = 9;
 }
 
 message GetCollectionsResponse {

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -8,7 +8,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::{LocalCompactionManager, LocalCompactionManagerConfig, Log};
 use chroma_segment::local_segment_manager::LocalSegmentManager;
 use chroma_sqlite::db::SqliteDb;
-use chroma_sysdb::SysDb;
+use chroma_sysdb::{GetCollectionsOptions, SysDb};
 use chroma_system::System;
 use chroma_tracing::meter_event::{MeterEvent, ReadAction, WriteAction};
 use chroma_types::{
@@ -329,14 +329,13 @@ impl ServiceBasedFrontend {
         }: ListCollectionsRequest,
     ) -> Result<ListCollectionsResponse, GetCollectionsError> {
         self.sysdb_client
-            .get_collections(
-                None,
-                None,
-                Some(tenant_id),
-                Some(database_name),
+            .get_collections(GetCollectionsOptions {
+                tenant: Some(tenant_id.clone()),
+                database: Some(database_name.clone()),
                 limit,
                 offset,
-            )
+                ..Default::default()
+            })
             .await
     }
 
@@ -365,14 +364,13 @@ impl ServiceBasedFrontend {
     ) -> Result<GetCollectionResponse, GetCollectionError> {
         let mut collections = self
             .sysdb_client
-            .get_collections(
-                None,
-                Some(collection_name.clone()),
-                Some(tenant_id),
-                Some(database_name),
-                None,
-                0,
-            )
+            .get_collections(GetCollectionsOptions {
+                name: Some(collection_name.clone()),
+                tenant: Some(tenant_id.clone()),
+                database: Some(database_name.clone()),
+                limit: Some(1),
+                ..Default::default()
+            })
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         collections

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -505,7 +505,7 @@ mod tests {
     use chroma_storage::config::{
         ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
     };
-    use chroma_sysdb::{GrpcSysDb, GrpcSysDbConfig};
+    use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig};
     use chroma_system::{DispatcherConfig, System};
     use tracing_test::traced_test;
 
@@ -714,7 +714,10 @@ mod tests {
                 .unwrap(),
         );
         let collections = sysdb
-            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
         let collection = collections.first().unwrap();
@@ -1006,7 +1009,10 @@ mod tests {
         // Fork collection in delete mode to give it a lineage file (only GC v2 can handle fork trees)
         {
             let source_collection = sysdb
-                .get_collections(Some(collection_in_delete_mode), None, None, None, None, 0)
+                .get_collections(GetCollectionsOptions {
+                    collection_id: Some(collection_in_delete_mode),
+                    ..Default::default()
+                })
                 .await
                 .unwrap();
             let source_collection = source_collection.first().unwrap();

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -920,7 +920,7 @@ mod tests {
     use chroma_blockstore::RootManager;
     use chroma_cache::nop::NopCache;
     use chroma_storage::test_storage;
-    use chroma_sysdb::TestSysDb;
+    use chroma_sysdb::{GetCollectionsOptions, TestSysDb};
     use chroma_system::{Dispatcher, Orchestrator, System};
     use chroma_types::{
         CollectionUuid, Segment, SegmentFlushInfo, SegmentScope, SegmentType, SegmentUuid,
@@ -988,7 +988,10 @@ mod tests {
 
         // Should fail
         let mut collections = sysdb
-            .get_collections(Some(root_collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(root_collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
         let root_collection = collections.pop().unwrap();

--- a/rust/garbage_collector/tests/prop_test_local_files.rs
+++ b/rust/garbage_collector/tests/prop_test_local_files.rs
@@ -39,6 +39,7 @@
 use chroma_blockstore::test_utils::sparse_index_test_utils::create_test_sparse_index;
 use chroma_storage::local::LocalStorage;
 use chroma_storage::Storage;
+use chroma_sysdb::GetCollectionsOptions;
 use chroma_sysdb::TestSysDb;
 use chroma_system::Orchestrator;
 use chroma_types::chroma_proto::FilePaths;
@@ -577,7 +578,10 @@ impl GcTest {
         let collection_id = CollectionUuid::from_str(&id).unwrap();
         let collections = self
             .sysdb
-            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
 
@@ -734,14 +738,10 @@ impl GcTest {
 
         let collection_id = Uuid::parse_str(&id).unwrap();
         let collections = sysdb
-            .get_collections(
-                Some(CollectionUuid(collection_id)),
-                None,
-                None,
-                None,
-                None,
-                0,
-            )
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(CollectionUuid(collection_id)),
+                ..Default::default()
+            })
             .await
             .unwrap();
 

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -9,7 +9,7 @@ use chroma_storage::config::{
     ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
 };
 use chroma_storage::{GetOptions, Storage};
-use chroma_sysdb::{GrpcSysDb, GrpcSysDbConfig, SysDb};
+use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig, SysDb};
 use chroma_system::Orchestrator;
 use chroma_system::{Dispatcher, DispatcherConfig, System};
 use chroma_types::chroma_proto::CollectionVersionFile;
@@ -410,7 +410,11 @@ impl StateMachineTest for GarbageCollectorUnderTest {
 
                         async move {
                             let collections = sysdb
-                                .get_collections(Some(collection_id), None, None, None, None, 0)
+                                .get_collections(
+                                   GetCollectionsOptions {
+                                        collection_id: Some(collection_id),
+                                        ..Default::default()
+                                })
                                 .await
                                 .unwrap();
 

--- a/rust/sysdb/src/lib.rs
+++ b/rust/sysdb/src/lib.rs
@@ -4,6 +4,8 @@ pub mod sqlite;
 #[allow(clippy::module_inception)]
 pub mod sysdb;
 pub mod test_sysdb;
+pub mod types;
 pub use config::*;
 pub use sysdb::*;
 pub use test_sysdb::*;
+pub use types::*;

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -1,4 +1,4 @@
-use crate::SqliteSysDbConfig;
+use crate::{GetCollectionsOptions, SqliteSysDbConfig};
 use async_trait::async_trait;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
@@ -477,13 +477,18 @@ impl SqliteSysDb {
 
     pub(crate) async fn get_collections(
         &self,
-        collection_id: Option<CollectionUuid>,
-        name: Option<String>,
-        tenant: Option<String>,
-        database: Option<String>,
-        limit: Option<u32>,
-        offset: u32,
+        options: GetCollectionsOptions,
     ) -> Result<Vec<Collection>, GetCollectionsError> {
+        let GetCollectionsOptions {
+            collection_id,
+            name,
+            tenant,
+            database,
+            limit,
+            offset,
+            ..
+        } = options;
+
         self.get_collections_with_conn(
             self.db.get_conn(),
             collection_id,
@@ -1145,7 +1150,10 @@ mod tests {
             .unwrap();
 
         let collections = sysdb
-            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
         let collection = collections.first().unwrap();
@@ -1297,7 +1305,10 @@ mod tests {
             .unwrap();
 
         let collections = sysdb
-            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
         let collection = collections.first().unwrap();
@@ -1365,7 +1376,10 @@ mod tests {
 
         // Should no longer exist
         let result = sysdb
-            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
@@ -1512,7 +1526,10 @@ mod tests {
 
         // Fetching the collection should not error and the config should be the default
         let collections = sysdb
-            .get_collections(Some(collection_id), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_id),
+                ..Default::default()
+            })
             .await
             .unwrap();
         let collection = collections.first().unwrap();

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -1,6 +1,6 @@
 use super::test_sysdb::TestSysDb;
 use crate::sqlite::SqliteSysDb;
-use crate::GrpcSysDbConfig;
+use crate::{GetCollectionsOptions, GrpcSysDbConfig};
 use async_trait::async_trait;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
@@ -139,27 +139,12 @@ impl SysDb {
 
     pub async fn get_collections(
         &mut self,
-        collection_id: Option<CollectionUuid>,
-        name: Option<String>,
-        tenant: Option<String>,
-        database: Option<String>,
-        limit: Option<u32>,
-        offset: u32,
+        options: GetCollectionsOptions,
     ) -> Result<Vec<Collection>, GetCollectionsError> {
         match self {
-            SysDb::Grpc(grpc) => {
-                grpc.get_collections(collection_id, name, tenant, database, limit, offset)
-                    .await
-            }
-            SysDb::Sqlite(sqlite) => {
-                sqlite
-                    .get_collections(collection_id, name, tenant, database, limit, offset)
-                    .await
-            }
-            SysDb::Test(test) => {
-                test.get_collections(collection_id, name, tenant, database)
-                    .await
-            }
+            SysDb::Grpc(grpc) => grpc.get_collections(options).await,
+            SysDb::Sqlite(sqlite) => sqlite.get_collections(options).await,
+            SysDb::Test(test) => test.get_collections(options).await,
         }
     }
 
@@ -172,12 +157,20 @@ impl SysDb {
         match self {
             SysDb::Grpc(grpc) => grpc.count_collections(tenant, database).await,
             SysDb::Sqlite(sqlite) => Ok(sqlite
-                .get_collections(None, None, Some(tenant), database, None, 0)
+                .get_collections(GetCollectionsOptions {
+                    tenant: Some(tenant),
+                    database,
+                    ..Default::default()
+                })
                 .await
                 .map_err(|_| CountCollectionsError::Internal)?
                 .len()),
             SysDb::Test(test) => Ok(test
-                .get_collections(None, None, Some(tenant), database)
+                .get_collections(GetCollectionsOptions {
+                    tenant: Some(tenant),
+                    database,
+                    ..Default::default()
+                })
                 .await
                 .map_err(|_| CountCollectionsError::Internal)?
                 .len()),
@@ -835,20 +828,30 @@ impl GrpcSysDb {
 
     async fn get_collections(
         &mut self,
-        collection_id: Option<CollectionUuid>,
-        name: Option<String>,
-        tenant: Option<String>,
-        database: Option<String>,
-        limit: Option<u32>,
-        offset: u32,
+        options: GetCollectionsOptions,
     ) -> Result<Vec<Collection>, GetCollectionsError> {
+        let GetCollectionsOptions {
+            collection_id,
+            collection_ids,
+            include_soft_deleted,
+            name,
+            tenant,
+            database,
+            limit,
+            offset,
+        } = options;
+
         // TODO: move off of status into our own error type
         let collection_id_str = collection_id.map(|id| String::from(id.0));
         let res = self
             .client
             .get_collections(chroma_proto::GetCollectionsRequest {
                 id: collection_id_str,
+                ids: collection_ids
+                    .map(|ids| ids.into_iter().map(|id| id.0.to_string()).collect())
+                    .unwrap_or_default(),
                 name,
+                include_soft_deleted: Some(include_soft_deleted),
                 limit: limit.map(|l| l as i32),
                 offset: Some(offset as i32),
                 tenant: tenant.unwrap_or("".to_string()),

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use super::sysdb::FlushCompactionError;
 use super::sysdb::GetLastCompactionTimeError;
 use crate::sysdb::VERSION_FILE_S3_PREFIX;
+use crate::GetCollectionsOptions;
 use chroma_storage::PutOptions;
 use chroma_types::chroma_proto::collection_version_info::VersionChangeReason;
 use chroma_types::chroma_proto::CollectionInfoImmutable;
@@ -150,11 +151,19 @@ impl TestSysDb {
 
     pub(crate) async fn get_collections(
         &mut self,
-        collection_id: Option<CollectionUuid>,
-        name: Option<String>,
-        tenant: Option<String>,
-        database: Option<String>,
+        options: GetCollectionsOptions,
     ) -> Result<Vec<Collection>, GetCollectionsError> {
+        let GetCollectionsOptions {
+            collection_id,
+            collection_ids: _,
+            include_soft_deleted: _,
+            name,
+            tenant,
+            database,
+            limit: _,
+            offset: _,
+        } = options;
+
         let inner = self.inner.lock();
         let mut collections = Vec::new();
         for collection in inner.collections.values() {

--- a/rust/sysdb/src/types.rs
+++ b/rust/sysdb/src/types.rs
@@ -1,0 +1,13 @@
+use chroma_types::CollectionUuid;
+
+#[derive(Default, Debug)]
+pub struct GetCollectionsOptions {
+    pub collection_id: Option<CollectionUuid>,
+    pub collection_ids: Option<Vec<CollectionUuid>>,
+    pub include_soft_deleted: bool,
+    pub name: Option<String>,
+    pub tenant: Option<String>,
+    pub database: Option<String>,
+    pub limit: Option<u32>,
+    pub offset: u32,
+}

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use chroma_config::assignment::assignment_policy::AssignmentPolicy;
 use chroma_log::{CollectionInfo, CollectionRecord, Log};
 use chroma_memberlist::memberlist_provider::Memberlist;
-use chroma_sysdb::SysDb;
+use chroma_sysdb::{GetCollectionsOptions, SysDb};
 use chroma_types::CollectionUuid;
 use figment::providers::Env;
 use figment::Figment;
@@ -99,11 +99,13 @@ impl Scheduler {
                 );
                 continue;
             }
-            let collection_id = Some(collection_info.collection_id);
             // TODO: add a cache to avoid fetching the same collection multiple times
             let result = self
                 .sysdb
-                .get_collections(collection_id, None, None, None, None, 0)
+                .get_collections(GetCollectionsOptions {
+                    collection_id: Some(collection_info.collection_id),
+                    ..Default::default()
+                })
                 .await;
 
             match result {

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -149,7 +149,7 @@ impl Operator<RegisterInput, RegisterOutput> for RegisterOperator {
 mod tests {
     use super::*;
     use chroma_log::in_memory_log::InMemoryLog;
-    use chroma_sysdb::TestSysDb;
+    use chroma_sysdb::{GetCollectionsOptions, TestSysDb};
     use chroma_types::{Collection, Segment, SegmentScope, SegmentType, SegmentUuid};
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -273,7 +273,10 @@ mod tests {
         );
 
         let collections = sysdb
-            .get_collections(Some(collection_uuid_1), None, None, None, None, 0)
+            .get_collections(GetCollectionsOptions {
+                collection_id: Some(collection_uuid_1),
+                ..Default::default()
+            })
             .await;
 
         assert!(collections.is_ok());


### PR DESCRIPTION
## Description of changes

Adds two parameters to the SysDb `GetCollections` method: `ids` and `include_soft_deleted`.

I also added a new `GetCollectionsOptions` on the Rust client side as the number of parameters was becoming unwieldy. 

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Added a new SysDb test.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a