### PR TITLE
[ENH]: GCv2: add grace period for transitioning soft deleted collections -> hard deleted

### DIFF
--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -38,6 +38,7 @@ func convertCollectionToModel(collectionAndMetadataList []*dbmodel.CollectionAnd
 			IsDeleted:                  collectionAndMetadata.Collection.IsDeleted,
 			VersionFileName:            collectionAndMetadata.Collection.VersionFileName,
 			CreatedAt:                  collectionAndMetadata.Collection.CreatedAt,
+			UpdatedAt:                  collectionAndMetadata.Collection.UpdatedAt.Unix(),
 			DatabaseId:                 types.MustParse(collectionAndMetadata.Collection.DatabaseID),
 		}
 		collection.Metadata = convertCollectionMetadataToModel(collectionAndMetadata.CollectionMetadata)

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -462,9 +462,12 @@ func (tc *Catalog) GetCollections(ctx context.Context, collectionIDs []types.Uni
 		defer span.End()
 	}
 
-	ids := make([]string, 0, len(collectionIDs))
-	for _, id := range collectionIDs {
-		ids = append(ids, id.String())
+	ids := ([]string)(nil)
+	if collectionIDs != nil {
+		ids = make([]string, 0, len(collectionIDs))
+		for _, id := range collectionIDs {
+			ids = append(ids, id.String())
+		}
 	}
 
 	collectionAndMetadataList, err := tc.metaDomain.CollectionDb(ctx).GetCollections(ids, collectionName, tenantID, databaseName, limit, offset, includeSoftDeleted)

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -92,6 +92,7 @@ func TestCatalog_GetCollections(t *testing.T) {
 	collectionName := "test_collection"
 
 	// create a mock collection and metadata list
+	now := time.Now()
 	name := "test_collection"
 	testKey := "test_key"
 	testValue := "test_value"
@@ -105,6 +106,7 @@ func TestCatalog_GetCollections(t *testing.T) {
 				ConfigurationJsonStr: &collectionConfigurationJsonStr,
 				Ts:                   types.Timestamp(1234567890),
 				DatabaseID:           dbId.String(),
+				UpdatedAt:            now,
 			},
 			CollectionMetadata: []*dbmodel.CollectionMetadata{
 				{
@@ -139,6 +141,7 @@ func TestCatalog_GetCollections(t *testing.T) {
 			Ts:                   types.Timestamp(1234567890),
 			Metadata:             metadata,
 			DatabaseId:           dbId,
+			UpdatedAt:            now.Unix(),
 		},
 	}, collections)
 

--- a/go/pkg/sysdb/grpc/proto_model_convert.go
+++ b/go/pkg/sysdb/grpc/proto_model_convert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/types"
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func convertCollectionMetadataToModel(collectionMetadata *coordinatorpb.UpdateMetadata) (*model.CollectionMetadata[model.CollectionMetadataValueType], error) {
@@ -55,6 +56,10 @@ func convertCollectionToProto(collection *model.Collection) *coordinatorpb.Colle
 		LastCompactionTimeSecs:     collection.LastCompactionTimeSecs,
 		VersionFilePath:            &collection.VersionFileName,
 		LineageFilePath:            collection.LineageFileName,
+		UpdatedAt: &timestamppb.Timestamp{
+			Seconds: collection.UpdatedAt,
+			Nanos:   0,
+		},
 	}
 
 	if collection.RootCollectionID != nil {

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -160,7 +160,7 @@ func (s *collectionDb) getCollections(ids []string, name *string, tenantID strin
 	if tenantID != "" {
 		query = query.Where("databases.tenant_id = ?", tenantID)
 	}
-	if ids != nil && len(ids) > 0 {
+	if ids != nil {
 		query = query.Where("collections.id IN ?", ids)
 	}
 	if name != nil {
@@ -219,6 +219,8 @@ func (s *collectionDb) getCollections(ids []string, name *string, tenantID strin
 				SizeBytesPostCompaction:    r.SizeBytesPostCompaction,
 				LastCompactionTimeSecs:     r.LastCompactionTimeSecs,
 				Tenant:                     r.Tenant,
+				UpdatedAt:                  *r.CollectionUpdatedAt,
+				CreatedAt:                  *r.CollectionCreatedAt,
 			}
 			if r.CollectionTs != nil {
 				col.Ts = *r.CollectionTs
@@ -336,9 +338,9 @@ func (s *collectionDb) GetCollectionSize(id string) (uint64, error) {
 
 func (s *collectionDb) GetSoftDeletedCollections(collectionID *string, tenantID string, databaseName string, limit int32) ([]*dbmodel.CollectionAndMetadata, error) {
 	isDeleted := true
-	ids := []string{}
+	ids := ([]string)(nil)
 	if collectionID != nil {
-		ids = append(ids, *collectionID)
+		ids = []string{*collectionID}
 	}
 	return s.getCollections(ids, nil, tenantID, databaseName, &limit, nil, &isDeleted)
 }

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -4,6 +4,8 @@ package chroma;
 
 option go_package = "github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb";
 
+import "google/protobuf/timestamp.proto";
+
 // Types here should mirror chromadb/types.py
 enum Operation {
     ADD = 0;
@@ -61,6 +63,7 @@ message Collection {
   optional string version_file_path = 13;
   optional string root_collection_id = 14;
   optional string lineage_file_path = 15;
+  google.protobuf.Timestamp updated_at = 16;
 }
 
 message Database {

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -175,6 +175,10 @@ message GetCollectionResponse {
   Collection collection = 1;
 }
 
+message CollectionIdsFilter {
+  repeated string ids = 1;
+}
+
 message GetCollectionsRequest {
   optional string id = 1;
   optional string name = 2;
@@ -182,7 +186,7 @@ message GetCollectionsRequest {
   string database = 5;
   optional int32 limit = 6;
   optional int32 offset = 7;
-  repeated string ids = 8;
+  optional CollectionIdsFilter ids_filter = 8;
   optional bool include_soft_deleted = 9;
 }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -29,19 +29,18 @@ use async_trait::async_trait;
 use chroma_blockstore::RootManager;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
-use chroma_sysdb::SysDb;
+use chroma_sysdb::{GetCollectionsOptions, SysDb};
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
     PanicError, System, TaskError, TaskResult,
 };
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
-use chroma_types::{
-    BatchGetCollectionSoftDeleteStatusError, CollectionUuid, DeleteCollectionError,
-};
+use chroma_types::{CollectionUuid, DeleteCollectionError};
 use chrono::{DateTime, Utc};
 use petgraph::algo::toposort;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
+use std::time::SystemTime;
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
@@ -51,7 +50,8 @@ pub struct GarbageCollectorOrchestrator {
     collection_id: CollectionUuid,
     version_file_path: String,
     lineage_file_path: Option<String>,
-    absolute_cutoff_time: DateTime<Utc>,
+    version_absolute_cutoff_time: DateTime<Utc>,
+    collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
     sysdb_client: SysDb,
     dispatcher: ComponentHandle<Dispatcher>,
     system: System,
@@ -81,7 +81,8 @@ impl GarbageCollectorOrchestrator {
         collection_id: CollectionUuid,
         version_file_path: String,
         lineage_file_path: Option<String>,
-        absolute_cutoff_time: DateTime<Utc>,
+        version_absolute_cutoff_time: DateTime<Utc>,
+        collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
         sysdb_client: SysDb,
         dispatcher: ComponentHandle<Dispatcher>,
         system: System,
@@ -94,7 +95,8 @@ impl GarbageCollectorOrchestrator {
             collection_id,
             version_file_path,
             lineage_file_path,
-            absolute_cutoff_time,
+            version_absolute_cutoff_time,
+            collection_soft_delete_absolute_cutoff_time,
             sysdb_client,
             dispatcher,
             system,
@@ -133,8 +135,6 @@ pub enum GarbageCollectorError {
     #[error("The task was aborted because resources were exhausted")]
     Aborted,
 
-    #[error("Failed to get collection soft delete status: {0}")]
-    BatchGetCollectionSoftDeleteStatus(#[from] BatchGetCollectionSoftDeleteStatusError),
     #[error("Failed to construct version graph: {0}")]
     ConstructVersionGraph(#[from] ConstructVersionGraphError),
     #[error("Failed to compute versions to delete: {0}")]
@@ -156,6 +156,8 @@ pub enum GarbageCollectorError {
     UnparsableUuid(#[from] uuid::Error),
     #[error("Collection deletion failed: {0}")]
     CollectionDeletionFailed(#[from] DeleteCollectionError),
+    #[error("SysDb method failed: {0}")]
+    SysDbMethodFailed(String),
 }
 
 impl ChromaError for GarbageCollectorError {
@@ -213,6 +215,55 @@ impl Orchestrator for GarbageCollectorOrchestrator {
 }
 
 impl GarbageCollectorOrchestrator {
+    async fn get_eligible_soft_deleted_collections_to_gc(
+        &mut self,
+        all_collection_ids: Vec<CollectionUuid>,
+    ) -> Result<HashSet<CollectionUuid>, GarbageCollectorError> {
+        let soft_delete_statuses = self
+            .sysdb_client
+            .batch_get_collection_soft_delete_status(all_collection_ids.clone())
+            .await
+            .map_err(|e| GarbageCollectorError::SysDbMethodFailed(e.to_string()))?;
+
+        let all_collection_ids: HashSet<CollectionUuid> = all_collection_ids.into_iter().collect();
+
+        let soft_deleted_collections_to_gc = soft_delete_statuses
+            .iter()
+            .filter_map(|(collection_id, status)| {
+                if *status && all_collection_ids.contains(collection_id) {
+                    Some(*collection_id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let collections = self
+            .sysdb_client
+            .get_collections(GetCollectionsOptions {
+                collection_ids: Some(soft_deleted_collections_to_gc),
+                include_soft_deleted: true,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| GarbageCollectorError::SysDbMethodFailed(e.to_string()))?;
+
+        let mut eligible_ids = HashSet::new();
+        let cutoff_time: SystemTime = self.collection_soft_delete_absolute_cutoff_time.into();
+        for collection in collections {
+            if collection.updated_at < cutoff_time {
+                eligible_ids.insert(collection.collection_id);
+            } else {
+                tracing::trace!(
+                    "Will not transition soft-deleted collection {} because it was updated after the cutoff time.",
+                    collection.collection_id
+                );
+            }
+        }
+
+        Ok(eligible_ids)
+    }
+
     async fn handle_construct_version_graph_request(
         &mut self,
         ctx: &ComponentContext<Self>,
@@ -228,22 +279,15 @@ impl GarbageCollectorOrchestrator {
         let output = orchestrator.run(self.system.clone()).await?;
 
         let collection_ids = output.version_files.keys().cloned().collect::<Vec<_>>();
-        let soft_delete_statuses = self
-            .sysdb_client
-            .batch_get_collection_soft_delete_status(collection_ids)
+
+        self.soft_deleted_collections_to_gc = self
+            .get_eligible_soft_deleted_collections_to_gc(collection_ids)
             .await?;
-        self.soft_deleted_collections_to_gc = soft_delete_statuses
-            .iter()
-            .filter_map(
-                |(collection_id, status)| {
-                    if *status {
-                        Some(*collection_id)
-                    } else {
-                        None
-                    }
-                },
-            )
-            .collect();
+
+        tracing::debug!(
+            "Soft deleted collections to GC: {:#?}",
+            self.soft_deleted_collections_to_gc
+        );
 
         self.version_files = output.version_files;
         self.graph = Some(output.graph.clone());
@@ -253,7 +297,7 @@ impl GarbageCollectorOrchestrator {
             ComputeVersionsToDeleteInput {
                 graph: output.graph,
                 soft_deleted_collections: self.soft_deleted_collections_to_gc.clone(),
-                cutoff_time: self.absolute_cutoff_time,
+                cutoff_time: self.version_absolute_cutoff_time,
                 min_versions_to_keep: self.min_versions_to_keep,
             },
             ctx.receiver(),
@@ -995,18 +1039,20 @@ mod tests {
             .await
             .unwrap();
         let root_collection = collections.pop().unwrap();
+        let now = DateTime::from_timestamp(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64,
+            0,
+        )
+        .unwrap();
         let orchestrator = GarbageCollectorOrchestrator::new(
             root_collection_id,
             root_collection.version_file_path.unwrap(),
             None,
-            DateTime::from_timestamp(
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs() as i64,
-                0,
-            )
-            .unwrap(),
+            now,
+            now,
             sysdb,
             dispatcher_handle,
             system.clone(),

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -193,6 +193,7 @@ impl ChromaGrpcClients {
                     version_file_path: None,
                     root_collection_id: None,
                     lineage_file_path: None,
+                    updated_at: None,
                 }),
                 knn: None,
                 metadata: None,

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -300,20 +300,23 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                             let dispatcher = Dispatcher::new(DispatcherConfig::default());
                             let mut dispatcher_handle = system.start_component(dispatcher);
 
+                            let one_second_from_now = DateTime::from_timestamp(
+                                SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap()
+                                    .as_secs() as i64
+                                    + 1,
+                                0,
+                            )
+                            .unwrap();
+
                             let orchestrator = GarbageCollectorOrchestrator::new(
                                 collection_id,
                                 collection_to_gc.version_file_path.clone(),
                                 collection_to_gc.lineage_file_path.clone(),
                                 // This proptest does not test the cutoff time as the timestamps created by the SysDb (e.g. collection.created_at and timestamps in version files) cannot currently be faked/overridden.
-                                DateTime::from_timestamp(
-                                    SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .unwrap()
-                                        .as_secs() as i64
-                                        + 1,
-                                    0,
-                                )
-                                .unwrap(),
+                                one_second_from_now,
+                                one_second_from_now,
                                 state.sysdb.clone(),
                                 dispatcher_handle.clone(),
                                 system.clone(),

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -22,6 +22,7 @@ use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::time::SystemTime;
 use uuid::Uuid;
 
 //////////////////////// SqliteSysDb ////////////////////////
@@ -341,6 +342,7 @@ impl SqliteSysDb {
             version_file_path: None,
             root_collection_id: None,
             lineage_file_path: None,
+            updated_at: SystemTime::UNIX_EPOCH,
         })
     }
 
@@ -735,6 +737,7 @@ impl SqliteSysDb {
                     version_file_path: None,
                     root_collection_id: None,
                     lineage_file_path: None,
+                    updated_at: SystemTime::UNIX_EPOCH,
                 }))
             })
             .collect::<Result<Vec<_>, GetCollectionsError>>()?;

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -265,6 +265,7 @@ impl SysDb {
                     version_file_path: None,
                     root_collection_id: None,
                     lineage_file_path: None,
+                    updated_at: SystemTime::now(),
                 };
 
                 test_sysdb.add_collection(collection.clone());
@@ -847,9 +848,10 @@ impl GrpcSysDb {
             .client
             .get_collections(chroma_proto::GetCollectionsRequest {
                 id: collection_id_str,
-                ids: collection_ids
-                    .map(|ids| ids.into_iter().map(|id| id.0.to_string()).collect())
-                    .unwrap_or_default(),
+                ids_filter: collection_ids.map(|ids| {
+                    let ids = ids.into_iter().map(|id| id.0.to_string()).collect();
+                    chroma_proto::CollectionIdsFilter { ids }
+                }),
                 name,
                 include_soft_deleted: Some(include_soft_deleted),
                 limit: limit.map(|l| l as i32),

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use chroma_error::{ChromaError, ErrorCodes};
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime};
 use thiserror::Error;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -100,6 +101,8 @@ pub struct Collection {
     pub root_collection_id: Option<CollectionUuid>,
     #[serde(skip)]
     pub lineage_file_path: Option<String>,
+    #[serde(skip, default = "SystemTime::now")]
+    pub updated_at: SystemTime,
 }
 
 impl Default for Collection {
@@ -120,6 +123,7 @@ impl Default for Collection {
             version_file_path: None,
             root_collection_id: None,
             lineage_file_path: None,
+            updated_at: SystemTime::now(),
         }
     }
 }
@@ -222,6 +226,14 @@ impl TryFrom<chroma_proto::Collection> for Collection {
             },
             None => None,
         };
+        // TODO(@codetheweb): this be updated to error with "missing field" once all SysDb deployments are up-to-date
+        let updated_at = match proto_collection.updated_at {
+            Some(updated_at) => {
+                SystemTime::UNIX_EPOCH
+                    + Duration::new(updated_at.seconds as u64, updated_at.nanos as u32)
+            }
+            None => SystemTime::now(),
+        };
         Ok(Collection {
             collection_id,
             name: proto_collection.name,
@@ -240,6 +252,7 @@ impl TryFrom<chroma_proto::Collection> for Collection {
                 .root_collection_id
                 .map(|uuid| CollectionUuid(Uuid::try_parse(&uuid).unwrap())),
             lineage_file_path: proto_collection.lineage_file_path,
+            updated_at,
         })
     }
 }
@@ -278,6 +291,7 @@ impl TryFrom<Collection> for chroma_proto::Collection {
             version_file_path: value.version_file_path,
             root_collection_id: value.root_collection_id.map(|uuid| uuid.0.to_string()),
             lineage_file_path: value.lineage_file_path,
+            updated_at: Some(value.updated_at.into()),
         })
     }
 }
@@ -326,6 +340,10 @@ mod test {
             version_file_path: Some("version_file_path".to_string()),
             root_collection_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
             lineage_file_path: Some("lineage_file_path".to_string()),
+            updated_at: Some(prost_types::Timestamp {
+                seconds: 1,
+                nanos: 1,
+            }),
         };
         let converted_collection: Collection = proto_collection.try_into().unwrap();
         assert_eq!(
@@ -351,6 +369,10 @@ mod test {
         assert_eq!(
             converted_collection.lineage_file_path,
             Some("lineage_file_path".to_string())
+        );
+        assert_eq!(
+            converted_collection.updated_at,
+            SystemTime::UNIX_EPOCH + Duration::new(1, 1)
         );
     }
 }


### PR DESCRIPTION
## Description of changes

- Return collection `updated_at` timestamp from the SysDb.
- Added a new `collection_soft_delete_grace_period` config parameter, defaults to 1 day.
- GCv2 will now ignore soft-deleted collections that are newer than the grace period (instead of immediately hard deleting them).

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Updated existing test to validate that collections are not deleted when inside grace period.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a