### PR TITLE
[ENH] Update auth contract to return an AuthzResource

### DIFF
--- a/rust/frontend/src/auth/mod.rs
+++ b/rust/frontend/src/auth/mod.rs
@@ -117,7 +117,7 @@ pub trait AuthenticateAndAuthorize: Send + Sync {
         _headers: &HeaderMap,
         action: AuthzAction,
         resource: AuthzResource,
-    ) -> Pin<Box<dyn Future<Output = Result<AuthzResource, AuthError>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>>;
 
     fn authenticate_and_authorize_collection(
         &self,
@@ -125,7 +125,7 @@ pub trait AuthenticateAndAuthorize: Send + Sync {
         action: AuthzAction,
         resource: AuthzResource,
         _collection: Collection,
-    ) -> Pin<Box<dyn Future<Output = Result<AuthzResource, AuthError>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>>;
 
     fn get_user_identity(
         &self,
@@ -138,27 +138,19 @@ impl AuthenticateAndAuthorize for () {
         &self,
         _headers: &HeaderMap,
         _action: AuthzAction,
-        resource: AuthzResource,
-    ) -> Pin<Box<dyn Future<Output = Result<AuthzResource, AuthError>> + Send>> {
-        Box::pin(ready(Ok::<AuthzResource, AuthError>(AuthzResource {
-            tenant: resource.tenant,
-            database: resource.database,
-            collection: resource.collection,
-        })))
+        _resource: AuthzResource,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>> {
+        Box::pin(ready(Ok::<(), AuthError>(())))
     }
 
     fn authenticate_and_authorize_collection(
         &self,
         _headers: &HeaderMap,
         _action: AuthzAction,
-        resource: AuthzResource,
+        _resource: AuthzResource,
         _collection: Collection,
-    ) -> Pin<Box<dyn Future<Output = Result<AuthzResource, AuthError>> + Send>> {
-        Box::pin(ready(Ok::<AuthzResource, AuthError>(AuthzResource {
-            tenant: resource.tenant,
-            database: resource.database,
-            collection: resource.collection,
-        })))
+    ) -> Pin<Box<dyn Future<Output = Result<(), AuthError>> + Send>> {
+        Box::pin(ready(Ok::<(), AuthError>(())))
     }
 
     fn get_user_identity(


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - Updates `AuthenticateAndAuthorize`'s `authenticate_and_authorize` and `authenticate_and_authorize_collection` methods to return an `AuthzResource` instead of an empty result. This is so that we may indicate that the authorized resource is something the same or different than the requested `AuthzResource`
  - Adds a `message` field to `AuthError` to allow for custom error messages

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
