### PR TITLE
[ENH]  Avoid LogContention on freshly sealed logs.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -215,8 +215,7 @@ async fn get_log_from_handle<'a>(
     prefix: &str,
     mark_dirty: MarkDirty,
 ) -> Result<LogRef<'a>, wal3::Error> {
-    let handle_clone = handle.clone();
-    let mut active = handle.active.lock().await;
+    let active = handle.active.lock().await;
     get_log_from_handle_with_mutex_held(handle, active, options, storage, prefix, mark_dirty).await
 }
 


### PR DESCRIPTION
## Description of changes

The first few parallel inserts could do the following:
- Race to the effectuate_log_transfer's mutex acquisition and pile up.
- First thread through bootstraps the log.
- Remaining threads try to bootstrap again which fails with
  LogContention.

## Test plan

CI + plan for staging.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
