### PR TITLE
[BUG] Create a bunch of collections and delete them and the dirty log will not roll up.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -364,6 +364,8 @@ pub enum DirtyMarker {
     },
     #[serde(rename = "purge")]
     Purge { collection_id: CollectionUuid },
+    // A Cleared marker is a no-op.  It exists so that a log consisting of mark-dirty markers that
+    // map onto purge markers will be cleared and can be erased.
     #[serde(rename = "clear")]
     Cleared,
 }


### PR DESCRIPTION
## Description of changes

When the coalesced dirty log was empty, it would do no adjusting of the
log offsets.  Thus the log would read longer and longer.

To trigger this, make many collections and then delete them all.  No
other writes.

## Test plan

CI

## Documentation Changes

N/A
