### PR TITLE
[ENH]: allow dynamically sized structs to be sent via ReceiverForMessage

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -191,7 +191,10 @@ impl Orchestrator for GarbageCollectorOrchestrator {
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
         ctx.receiver()
-            .send(ConstructVersionGraphRequest, Some(Span::current()))
+            .send(
+                Box::new(ConstructVersionGraphRequest),
+                Some(Span::current()),
+            )
             .await
             .expect("Failed to send ConstructVersionGraphRequest");
     }

--- a/rust/memberlist/src/memberlist_provider.rs
+++ b/rust/memberlist/src/memberlist_provider.rs
@@ -170,7 +170,9 @@ impl CustomResourceMemberlistProvider {
         let curr_memberlist = self.current_memberlist.read().clone();
 
         for subscriber in self.subscribers.iter() {
-            let _ = subscriber.send(curr_memberlist.clone(), None).await;
+            let _ = subscriber
+                .send(Box::new(curr_memberlist.clone()), None)
+                .await;
         }
     }
 }

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -158,10 +158,10 @@ where
                 match self
                     .reply_channel
                     .send(
-                        TaskResult {
+                        Box::new(TaskResult {
                             result: result.map_err(|e| TaskError::TaskFailed(e)),
                             task_id: self.task_id,
-                        },
+                        }),
                         None,
                     )
                     .await
@@ -190,10 +190,10 @@ where
                 match self
                     .reply_channel
                     .send(
-                        TaskResult {
+                        Box::new(TaskResult {
                             result: Err(TaskError::Panic(PanicError::new(panic_value))),
                             task_id: self.task_id,
-                        },
+                        }),
                         None,
                     )
                     .await
@@ -233,10 +233,10 @@ where
         match self
             .reply_channel
             .send(
-                TaskResult {
+                Box::new(TaskResult {
                     result: Err(TaskError::Aborted),
                     task_id: self.task_id,
-                },
+                }),
                 None,
             )
             .await

--- a/rust/system/src/execution/worker_thread.rs
+++ b/rust/system/src/execution/worker_thread.rs
@@ -47,7 +47,7 @@ impl Component for WorkerThread {
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
         let req = TaskRequestMessage::new(ctx.receiver());
-        let _req = self.dispatcher.send(req, None).await;
+        let _req = self.dispatcher.send(Box::new(req), None).await;
         // TODO: what to do with resp?
     }
 }
@@ -61,7 +61,7 @@ impl Handler<TaskMessage> for WorkerThread {
             trace_span!(parent: Span::current(), "Task execution", name = task.get_name());
         task.run().instrument(child_span).await;
         let req: TaskRequestMessage = TaskRequestMessage::new(ctx.receiver());
-        let _res = self.dispatcher.send(req, None).await;
+        let _res = self.dispatcher.send(Box::new(req), None).await;
         // TODO: task run should be able to error and we should send it as part of the result
     }
 }

--- a/rust/system/src/receiver.rs
+++ b/rust/system/src/receiver.rs
@@ -6,7 +6,9 @@ use thiserror::Error;
 
 /// A ReceiverForMessage is generic over a message type, and useful if you want to send a given message type to any component that can handle it.
 #[async_trait]
-pub trait ReceiverForMessage<M: ?Sized>: Send + Sync + Debug + ReceiverForMessageClone<M> {
+pub trait ReceiverForMessage<M: ?Sized + Send>:
+    Send + Sync + Debug + ReceiverForMessageClone<M>
+{
     async fn send(
         &self,
         message: Box<M>,
@@ -14,17 +16,17 @@ pub trait ReceiverForMessage<M: ?Sized>: Send + Sync + Debug + ReceiverForMessag
     ) -> Result<(), ChannelError>;
 }
 
-pub trait ReceiverForMessageClone<M: ?Sized> {
+pub trait ReceiverForMessageClone<M: ?Sized + Send> {
     fn clone_box(&self) -> Box<dyn ReceiverForMessage<M>>;
 }
 
-impl<M> Clone for Box<dyn ReceiverForMessage<M>> {
+impl<M: ?Sized + Send> Clone for Box<dyn ReceiverForMessage<M>> {
     fn clone(&self) -> Box<dyn ReceiverForMessage<M>> {
         self.clone_box()
     }
 }
 
-impl<M: ?Sized, T> ReceiverForMessageClone<M> for T
+impl<M: ?Sized + Send, T> ReceiverForMessageClone<M> for T
 where
     T: 'static + ReceiverForMessage<M> + Clone,
 {

--- a/rust/system/src/scheduler.rs
+++ b/rust/system/src/scheduler.rs
@@ -47,7 +47,7 @@ impl Scheduler {
                 _ = cancel.cancelled() => {}
                 _ = tokio::time::sleep(duration) => {
                     let span = span_factory();
-                    match sender.send(message, span).await {
+                    match sender.send(Box::new(message), span).await {
                         Ok(_) => {
                         },
                         Err(e) => {
@@ -93,7 +93,7 @@ impl Scheduler {
                     }
                     _ = tokio::time::sleep(duration) => {
                         let span = span_factory();
-                        match sender.send(message.clone(), span).await {
+                        match sender.send(Box::new(message.clone()), span).await {
                             Ok(_) => {
                             },
                             Err(e) => {

--- a/rust/tracing/src/meter_event.rs
+++ b/rust/tracing/src/meter_event.rs
@@ -67,7 +67,7 @@ impl MeterEvent {
 
     pub async fn submit(self) {
         if let Some(handler) = METER_EVENT_RECEIVER.get() {
-            if let Err(err) = handler.send(self, Some(Span::current())).await {
+            if let Err(err) = handler.send(Box::new(self), Some(Span::current())).await {
                 tracing::error!("Unable to send meter event: {err}")
             }
         }

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -72,8 +72,10 @@ impl Compactor for CompactionServer {
         self.manager
             .receiver()
             .send(
-                OneOffCompactMessage::try_from(request.into_inner())
-                    .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                Box::new(
+                    OneOffCompactMessage::try_from(request.into_inner())
+                        .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                ),
                 Some(compact_span),
             )
             .await
@@ -89,8 +91,10 @@ impl Compactor for CompactionServer {
         self.manager
             .receiver()
             .send(
-                RebuildMessage::try_from(request.into_inner())
-                    .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                Box::new(
+                    RebuildMessage::try_from(request.into_inner())
+                        .map_err(|e| Status::invalid_argument(e.to_string()))?,
+                ),
                 Some(rebuild_span),
             )
             .await


### PR DESCRIPTION
## Description of changes

This modifies the `ReceiverForMessage` trait to allow dynamically-sized (heap-allocated) structs to be sent as messages. This feature will be used in an imminent PR that upgrades Chroma's metering library, but we wish to break up the changes into separate PRs to minimize the blast radius of any single PR.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

None