### PR TITLE
[DOC] - Fixes various css isssues

### DIFF
--- a/docs/docs.trychroma.com/components/header/header-nav.tsx
+++ b/docs/docs.trychroma.com/components/header/header-nav.tsx
@@ -1,17 +1,8 @@
 'use client'
 
 import React from "react";
-import Logo from "@/components/header/logo";
-import ThemeToggle from "@/components/header/theme-toggle";
-import GithubLink from "@/components/header/github-link";
-import XLink from "@/components/header/x-link";
-import DiscordLink from "@/components/header/discord-link";
-import Link from "next/link";
-import SearchBox from "@/components/header/search-box";
-import UpdatesLink from "@/components/header/updates-link";
 import sidebarConfig from "@/markdoc/content/sidebar-config";
 import MenuItem from "../sidebar/menu-item";
-import { useRouter } from "next/router";
 import { useParams } from "next/navigation";
 
 const HeaderNav: React.FC = () => {
@@ -22,7 +13,7 @@ const HeaderNav: React.FC = () => {
   );
 
   return (
-    <div className="flex items-center flex-shrink-0 px-5 border-b-[1px] dark:border-gray-700 ">
+    <div className="flex items-center flex-shrink-0 px-5 border-b-[1px] dark:border-gray-700 w-full overflow-x-auto">
       {sidebarConfig.map((section) => (
       <MenuItem
       key={section.id}

--- a/docs/docs.trychroma.com/components/markdoc/table.tsx
+++ b/docs/docs.trychroma.com/components/markdoc/table.tsx
@@ -13,7 +13,7 @@ export const Table = React.forwardRef<
   React.HTMLAttributes<HTMLTableElement>
 >(({ ...props }, ref) => {
   return (
-    <div className="relative w-full overflow-auto rounded-md my-5 border-[0.5px] border-gray-300">
+    <div className="relative w-full overflow-auto rounded-md my-5 border-[0.5px] border-gray-300 dark:border-gray-700">
       <UITable ref={ref} className="m-0" {...props} />
     </div>
   );

--- a/docs/docs.trychroma.com/components/sidebar/menu-item.tsx
+++ b/docs/docs.trychroma.com/components/sidebar/menu-item.tsx
@@ -10,7 +10,7 @@ const MenuItem: React.FC<{ section: AppSection; active: boolean }> = ({
 
   return (
     <Link
-     className={`border-b-4 h-12 px-3 pt-3 pr-5 text-gray-700/80 ${active ? "border-chroma-orange " : "border-transparent hover:border-gray-100"} ${!section.disable && "hover:text-gray-800"} dark:text-gray-400/80 dark:hover:text-gray-300`}
+     className={`border-b-4 h-12 px-3 pt-3 pr-5 text-gray-700/80 ${active ? "border-chroma-orange " : "border-transparent hover:border-gray-100 dark:hover:border-gray-300"} ${!section.disable && "hover:text-gray-800"} dark:text-gray-400/80 dark:hover:text-gray-300 text-nowrap`}
       href={
         section.disable
           ? ""

--- a/docs/docs.trychroma.com/components/ui/table.tsx
+++ b/docs/docs.trychroma.com/components/ui/table.tsx
@@ -58,7 +58,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors data-[state=selected]:bg-zinc-100 dark:data-[state=selected]:bg-zinc-800",
+      "border-b transition-colors data-[state=selected]:bg-zinc-100 dark:data-[state=selected]:bg-zinc-800 dark:border-gray-700",
       className,
     )}
     {...props}


### PR DESCRIPTION
In darkmode, markdoc table borders did not have a dark mode color assignment.

Likewise, in dark mode, the hover state of the HeaderNav MenuItems had no darkmode assignment.

Finally, this adds overflow to the HeaderNav and prevents MenuItems from wrapping.
<img width="499" alt="Screenshot 2025-06-03 at 3 08 40 PM" src="https://github.com/user-attachments/assets/503b69e5-82f1-4767-b5a0-b999ab325e58" />
