### PR TITLE
[BUG] removed the masked err from ForkLogs

### DIFF
--- a/go/pkg/log/repository/log.go
+++ b/go/pkg/log/repository/log.go
@@ -168,7 +168,8 @@ func (r *LogRepository) ForkRecords(ctx context.Context, sourceCollectionID stri
 		}
 	}()
 
-	sourceBounds, err := queriesWithTx.GetBoundsForCollection(ctx, sourceCollectionID)
+	var sourceBounds GetBoundsForCollectionRow
+	sourceBounds, err = queriesWithTx.GetBoundsForCollection(ctx, sourceCollectionID)
 	if err != nil {
 		trace_log.Error("Error in getting compaction and enumeration offset for source collection", zap.Error(err), zap.String("collectionId", sourceCollectionID))
 		return


### PR DESCRIPTION
## Description of changes

This creates a variable named err, then within the function creates a new variable named err and
returns nil when the function exits.

```go
func foo() (err error) {
    x, err := some_func()
    return
}
```

## Test plan

Eyeballs and elbow grease to get it to CI.

## Documentation Changes

N/A
