### PR TITLE
[ENH] Add getCollectionById to JS

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -411,7 +411,7 @@ export class ChromaClient {
    * @param options.embeddingFunction - Optional embedding function to use
    * @returns A CollectionAPI instance for the specified collection
    */
-  public collection({
+  public getCollectionById({
     id,
     embeddingFunction,
   }: {
@@ -431,7 +431,7 @@ export class ChromaClient {
    * @param items - Array of collection IDs or objects with ID and optional embedding function
    * @returns Array of CollectionAPI instances
    */
-  public collections(
+  public getCollectionsById(
     items: string[] | { id: string; embeddingFunction?: EmbeddingFunction }[],
   ) {
     if (items.length === 0) return [];

--- a/docs/docs.trychroma.com/markdoc/content/docs/collections/create-get-delete.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/collections/create-get-delete.md
@@ -109,10 +109,10 @@ const [col1, col2] = client.getCollections([
 ])
 ```
 
-The `getCollection` and `getCollections` methods issue an API call to a Chroma server to get collections with all their fields. If you only need access to collection actions on records and want to save the API call, you can get a "thin" collection object using the `collection` method. It takes in a collection **ID** and an embedding function.
+The `getCollection` and `getCollections` methods issue an API call to a Chroma server to get collections with all their fields. If you only need access to collection actions on records, and want to save the API call, you can get a "thin" collection object using the `getCollectionById` method (and `getCollectionsById`). It takes in a collection **ID** and an embedding function.
 
 ```typescript
-const collection = client.collection({ id: 'abc', embeddingFunction: openaiEF })
+const collection = client.getCollectionById({ id: 'abc', embeddingFunction: openaiEF })
 ```
 
 You can also delete collections by name using `deleteCollection`:


### PR DESCRIPTION
Rename `collection` method to `getCollectionById` for clarity.