### PR TITLE
[DOC] - Saves preferred language in the docs

### DIFF
--- a/docs/docs.trychroma.com/components/markdoc/tabs.tsx
+++ b/docs/docs.trychroma.com/components/markdoc/tabs.tsx
@@ -7,11 +7,10 @@ import {
   TabsList,
   TabsTrigger as UITabsTrigger,
 } from "@/components/ui/tabs";
-import { capitalize, cn } from "@/lib/utils";
+import { capitalize, cn, PreferredLanguage } from "@/lib/utils";
 import { tabLabelStyle } from "@/components/markdoc/code-block-header";
 import AppContext from "@/context/app-context";
 import CodeBlock from "@/components/markdoc/code-block";
-import { Playfair_Display } from "next/font/google";
 
 export interface TabProps {
   label: string;
@@ -31,7 +30,7 @@ export const TabsTrigger = React.forwardRef<
       value={value}
       {...props}
       onClick={() => {
-        setLanguage(value);
+        setLanguage(value as PreferredLanguage);
       }}
     />
   );

--- a/docs/docs.trychroma.com/context/app-context.tsx
+++ b/docs/docs.trychroma.com/context/app-context.tsx
@@ -1,22 +1,25 @@
 import React, { createContext, useState, ReactNode, useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { getLocalStoragePreferredLanguage, PreferredLanguage, setLocalStoragePreferredLanguage } from "@/lib/utils";
 
 export interface AppContextValue {
   language: string;
-  setLanguage: (language: string) => void;
+  setLanguage: (language: PreferredLanguage) => void;
 }
 
 const AppContextDefaultValue: AppContextValue = {
-  language: "python",
+  language: getLocalStoragePreferredLanguage(),
   setLanguage: () => {},
 };
 
 const AppContext = createContext<AppContextValue>(AppContextDefaultValue);
 
 export const AppContextProvider = ({ children }: { children: ReactNode }) => {
-  const searchParams = useSearchParams();
-  const [language, setLanguage] = useState<string>(
-    searchParams?.get("lang") || "python",
+  const params = useSearchParams();
+  const paramsLanguage = params.get("lang") as PreferredLanguage | null;
+  const [language, setLanguage] = useState<PreferredLanguage>(
+    // due to hydration issues, we can't use the local storage value directly here
+    paramsLanguage || "python"
   );
   const router = useRouter();
   const pathname = usePathname();
@@ -25,15 +28,30 @@ export const AppContextProvider = ({ children }: { children: ReactNode }) => {
     const anchor =
       pathname === window.location.pathname ? window.location.hash : "";
 
-    if (language === "typescript") {
+    if (paramsLanguage === "typescript") {
       router.replace(`${pathname}?lang=typescript${anchor}`);
+      setLocalStoragePreferredLanguage("typescript");
+    } else if (paramsLanguage === "python") {
+      router.replace(pathname + anchor);
+      setLocalStoragePreferredLanguage("python");
     } else {
       router.replace(pathname + anchor);
     }
-  }, [language, pathname]);
+  }, [paramsLanguage, pathname]);
+
+  useEffect(() => {
+    const language = getLocalStoragePreferredLanguage();
+    setLanguage(language);
+  }, []);
 
   return (
-    <AppContext.Provider value={{ language, setLanguage }}>
+    <AppContext.Provider value={{ language, setLanguage: (language: string) => {
+        if (language === "python" || language === "typescript") {
+          setLanguage(language);
+          setLocalStoragePreferredLanguage(language);
+        }
+      }
+    }}>
       {children}
     </AppContext.Provider>
   );

--- a/docs/docs.trychroma.com/lib/utils.ts
+++ b/docs/docs.trychroma.com/lib/utils.ts
@@ -12,3 +12,21 @@ export const formatToK = (num: number) => {
 export const capitalize = (str: string) => {
   return `${str.charAt(0).toUpperCase()}${str.slice(1)}`;
 };
+
+export type PreferredLanguage = "python" | "typescript";
+
+const LANGUAGE_STORAGE_KEY = "chroma_docs_language";
+
+export const setLocalStoragePreferredLanguage = (language: PreferredLanguage) => {
+  if (typeof window !== "undefined") {
+    return window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language) 
+  }
+  return "python";
+};
+
+export const getLocalStoragePreferredLanguage = (): PreferredLanguage => {
+  if (typeof window !== "undefined") {
+    return window.localStorage.getItem(LANGUAGE_STORAGE_KEY) as PreferredLanguage || "python";
+  }
+  return "python";
+}

--- a/docs/docs.trychroma.com/markdoc/content/docs/collections/create-get-delete.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/collections/create-get-delete.md
@@ -51,7 +51,7 @@ Collections have a few useful convenience methods.
 
 {% /Tab %}
 
-{% Tab label="Typescript" %}
+{% Tab label="typescript" %}
 
 Chroma collections are created with a name and an optional embedding function.
 


### PR DESCRIPTION
Also will check the url for `lang` parameter and use that instead.

## Description of changes

The AppContext will save what language a user clicks on for the duration of the session. However, across page loads, the language defaults to python. This change saves the language the user clicks on or defaults to python.