### PR TITLE
[ENH]  Purge dirty for collection gets misrouted.

### DIFF
--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -383,9 +383,9 @@ impl GrpcLog {
         match &mut self.alt_client_assigner {
             Some(assigner) => assigner
                 .clients(&collection_id.to_string())
-                .unwrap_or_default()
-                .first()
-                .cloned(),
+                .ok()?
+                .drain(..)
+                .next(),
             None => None,
         }
     }


### PR DESCRIPTION
## Description of changes

One rls gets all the compactor hate and it's spinning.

Essentially, the dirty marker must be routed to the same location as the writes to said log.  Eventually.

Otherwise they get misrouted and garbage piles up.

## Test plan

CI

## Documentation Changes

N/A
