### PR TITLE
[ENH]: Support writing data to separate prefixes in s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,6 +3327,7 @@ dependencies = [
  "chroma-index",
  "chroma-jemalloc-pprof-server",
  "chroma-memberlist",
+ "chroma-segment",
  "chroma-storage",
  "chroma-sysdb",
  "chroma-system",

--- a/rust/blockstore/src/arrow/block/delta/unordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/unordered_block_delta.rs
@@ -195,9 +195,10 @@ mod test {
             let read = block.get::<&str, &[u32]>("prefix", &key).unwrap();
             values_before_flush.push(read.to_vec());
         }
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let block = block_manager
-            .get(&block.id, StorageRequestPriority::P0)
+            .get(prefix_path, &block.id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -238,10 +239,11 @@ mod test {
             let read = block.get::<&str, &str>("prefix", &key);
             values_before_flush.push(read.unwrap().to_string());
         }
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
 
         let block = block_manager
-            .get(&delta_id, StorageRequestPriority::P0)
+            .get(prefix_path, &delta_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -265,14 +267,14 @@ mod test {
 
         // test fork
         let forked_block = block_manager
-            .fork::<&str, String, UnorderedBlockDelta>(&delta_id)
+            .fork::<&str, String, UnorderedBlockDelta>(&delta_id, prefix_path)
             .await
             .unwrap();
         let new_id = forked_block.id;
         let block = block_manager.commit::<&str, String>(forked_block).await;
-        block_manager.flush(&block).await.unwrap();
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let forked_block = block_manager
-            .get(&new_id, StorageRequestPriority::P0)
+            .get(prefix_path, &new_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -309,9 +311,10 @@ mod test {
             let read = block.get::<f32, &str>("prefix", key).unwrap();
             values_before_flush.push(read);
         }
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let block = block_manager
-            .get(&delta_id, StorageRequestPriority::P0)
+            .get(prefix_path, &delta_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -346,9 +349,10 @@ mod test {
         let size = delta.get_size::<&str, RoaringBitmap>();
         let delta_id = delta.id;
         let block = block_manager.commit::<&str, RoaringBitmap>(delta).await;
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let block = block_manager
-            .get(&delta_id, StorageRequestPriority::P0)
+            .get(prefix_path, &delta_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -415,9 +419,10 @@ mod test {
         let size = delta.get_size::<&str, &DataRecord>();
         let delta_id = delta.id;
         let block = block_manager.commit::<&str, &DataRecord>(delta).await;
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let block = block_manager
-            .get(&delta_id, StorageRequestPriority::P0)
+            .get(prefix_path, &delta_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -454,9 +459,10 @@ mod test {
         let size = delta.get_size::<u32, String>();
         let delta_id = delta.id;
         let block = block_manager.commit::<u32, String>(delta).await;
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let block = block_manager
-            .get(&delta_id, StorageRequestPriority::P0)
+            .get(prefix_path, &delta_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -493,10 +499,11 @@ mod test {
             let read = block.get::<u32, u32>("prefix", key);
             values_before_flush.push(read.unwrap().to_string());
         }
-        block_manager.flush(&block).await.unwrap();
+        let prefix_path = "";
+        block_manager.flush(&block, prefix_path).await.unwrap();
 
         let block = block_manager
-            .get(&delta_id, StorageRequestPriority::P0)
+            .get(prefix_path, &delta_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();
@@ -520,14 +527,14 @@ mod test {
 
         // test fork
         let forked_block = block_manager
-            .fork::<u32, u32, UnorderedBlockDelta>(&delta_id)
+            .fork::<u32, u32, UnorderedBlockDelta>(&delta_id, prefix_path)
             .await
             .unwrap();
         let new_id = forked_block.id;
         let block = block_manager.commit::<u32, u32>(forked_block).await;
-        block_manager.flush(&block).await.unwrap();
+        block_manager.flush(&block, prefix_path).await.unwrap();
         let forked_block = block_manager
-            .get(&new_id, StorageRequestPriority::P0)
+            .get(prefix_path, &new_id, StorageRequestPriority::P0)
             .await
             .unwrap()
             .unwrap();

--- a/rust/blockstore/src/arrow/concurrency_test.rs
+++ b/rust/blockstore/src/arrow/concurrency_test.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        arrow::{config::TEST_MAX_BLOCK_SIZE_BYTES, provider::ArrowBlockfileProvider},
+        arrow::{
+            config::TEST_MAX_BLOCK_SIZE_BYTES,
+            provider::{ArrowBlockfileProvider, BlockfileReaderOptions},
+        },
         BlockfileWriterOptions,
     };
     use chroma_cache::new_cache_for_test;
@@ -72,8 +75,12 @@ mod tests {
                 flusher.flush::<&str, u32>().await.unwrap();
             });
 
+            let read_options = BlockfileReaderOptions::new(id, "".to_string());
             let reader = future::block_on(async {
-                blockfile_provider.read::<&str, u32>(&id).await.unwrap()
+                blockfile_provider
+                    .read::<&str, u32>(read_options)
+                    .await
+                    .unwrap()
             });
             // Read the data back
             for i in 0..n {
@@ -123,7 +130,11 @@ mod tests {
                 // Clear cache.
                 blockfile_provider.clear().await.expect("Clear bf provider");
 
-                blockfile_provider.read::<&str, u32>(&id).await.unwrap()
+                let read_options = BlockfileReaderOptions::new(id, "".to_string());
+                blockfile_provider
+                    .read::<&str, u32>(read_options)
+                    .await
+                    .unwrap()
             });
             // Make the max threads the number of cores * 2
             let max_threads = num_cpus::get() * 2;

--- a/rust/blockstore/src/arrow/flusher.rs
+++ b/rust/blockstore/src/arrow/flusher.rs
@@ -50,7 +50,7 @@ impl ArrowBlockfileFlusher {
         // number of futures is high.
         let mut futures = Vec::new();
         for block in &self.blocks {
-            futures.push(self.block_manager.flush(block));
+            futures.push(self.block_manager.flush(block, &self.root.prefix_path));
         }
         let num_futures = futures.len();
         // buffer_unordered hangs with 0 futures.

--- a/rust/blockstore/src/arrow/flusher.rs
+++ b/rust/blockstore/src/arrow/flusher.rs
@@ -79,4 +79,8 @@ impl ArrowBlockfileFlusher {
     pub(crate) fn num_entries(&self) -> usize {
         self.blocks.iter().fold(0, |acc, block| acc + block.len())
     }
+
+    pub(crate) fn prefix_path(&self) -> String {
+        self.root.prefix_path.clone()
+    }
 }

--- a/rust/blockstore/src/arrow/flusher.rs
+++ b/rust/blockstore/src/arrow/flusher.rs
@@ -80,7 +80,7 @@ impl ArrowBlockfileFlusher {
         self.blocks.iter().fold(0, |acc, block| acc + block.len())
     }
 
-    pub(crate) fn prefix_path(&self) -> String {
-        self.root.prefix_path.clone()
+    pub(crate) fn prefix_path(&self) -> &str {
+        &self.root.prefix_path
     }
 }

--- a/rust/blockstore/src/arrow/migrations.rs
+++ b/rust/blockstore/src/arrow/migrations.rs
@@ -52,7 +52,7 @@ async fn migrate_v1_to_v1_1(
         }
         for block_id in block_ids.iter() {
             let block = block_manager
-                .get(block_id, StorageRequestPriority::P0)
+                .get(&root.prefix_path, block_id, StorageRequestPriority::P0)
                 .await;
             match block {
                 Ok(Some(block)) => {

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -57,6 +57,21 @@ pub struct ArrowBlockfileProvider {
     root_manager: RootManager,
 }
 
+pub struct BlockfileReaderOptions {
+    id: uuid::Uuid,
+    prefix_path: String,
+}
+
+impl BlockfileReaderOptions {
+    pub fn new(id: Uuid, prefix_path: String) -> Self {
+        BlockfileReaderOptions { id, prefix_path }
+    }
+
+    pub fn id(&self) -> &Uuid {
+        &self.id
+    }
+}
+
 impl ArrowBlockfileProvider {
     pub fn new(
         storage: Storage,
@@ -76,9 +91,12 @@ impl ArrowBlockfileProvider {
         V: Value + Readable<'new> + ArrowReadableValue<'new> + 'new,
     >(
         &self,
-        id: &uuid::Uuid,
+        options: BlockfileReaderOptions,
     ) -> Result<BlockfileReader<'new, K, V>, Box<OpenError>> {
-        let root = self.root_manager.get::<K>(id).await;
+        let root = self
+            .root_manager
+            .get::<K>(&options.id, &options.prefix_path)
+            .await;
         match root {
             Ok(Some(root)) => Ok(BlockfileReader::ArrowBlockfileReader(
                 ArrowBlockfileReader::new(self.block_manager.clone(), root),
@@ -88,14 +106,18 @@ impl ArrowBlockfileProvider {
         }
     }
 
-    pub async fn prefetch(&self, id: &Uuid) -> Result<usize, ArrowBlockfileProviderPrefetchError> {
+    pub async fn prefetch(
+        &self,
+        id: &Uuid,
+        prefix_path: &str,
+    ) -> Result<usize, ArrowBlockfileProviderPrefetchError> {
         if !self.root_manager.should_prefetch(id) {
             return Ok(0);
         }
         // We call .get_all_block_ids() here instead of just reading the root because reading the root requires a concrete Key type.
         let block_ids = self
             .root_manager
-            .get_all_block_ids(id)
+            .get_all_block_ids(id, prefix_path)
             .await
             .map_err(|e| ArrowBlockfileProviderPrefetchError::RootManager(Box::new(e)))?;
 
@@ -103,7 +125,11 @@ impl ArrowBlockfileProvider {
         for block_id in block_ids.iter() {
             // Don't prefetch if already cached.
             if !self.block_manager.cached(block_id).await {
-                futures.push(self.block_manager.get(block_id, StorageRequestPriority::P1));
+                futures.push(self.block_manager.get(
+                    prefix_path,
+                    block_id,
+                    StorageRequestPriority::P1,
+                ));
             }
         }
         let count = futures.len();
@@ -131,7 +157,7 @@ impl ArrowBlockfileProvider {
             let new_id = Uuid::new_v4();
             let new_root = self
                 .root_manager
-                .fork::<K>(&fork_from, new_id)
+                .fork::<K>(&fork_from, new_id, &options.prefix_path)
                 .await
                 .map_err(|e| {
                     tracing::error!("Error forking root: {:?}", e);
@@ -166,6 +192,7 @@ impl ArrowBlockfileProvider {
                 BlockfileWriterMutationOrdering::Ordered => {
                     let file = ArrowOrderedBlockfileWriter::new::<K, V>(
                         new_id,
+                        &options.prefix_path,
                         self.block_manager.clone(),
                         self.root_manager.clone(),
                     );
@@ -175,6 +202,7 @@ impl ArrowBlockfileProvider {
                 BlockfileWriterMutationOrdering::Unordered => {
                     let file = ArrowUnorderedBlockfileWriter::new::<K, V>(
                         new_id,
+                        &options.prefix_path,
                         self.block_manager.clone(),
                         self.root_manager.clone(),
                     );
@@ -270,7 +298,7 @@ impl ChromaError for ForkError {
 /// introduce a more sophisticated cache that can handle tiered eviction and other features. This interface
 /// is a placeholder for that.
 #[derive(Clone)]
-pub(super) struct BlockManager {
+pub struct BlockManager {
     block_cache: Arc<dyn PersistentCache<Uuid, Block>>,
     storage: Storage,
     max_block_size_bytes: usize,
@@ -298,8 +326,11 @@ impl BlockManager {
     pub(super) async fn fork<K: ArrowWriteableKey, V: ArrowWriteableValue, D: Delta>(
         &self,
         block_id: &Uuid,
+        prefix_path: &str,
     ) -> Result<D, ForkError> {
-        let block = self.get(block_id, StorageRequestPriority::P0).await;
+        let block = self
+            .get(prefix_path, block_id, StorageRequestPriority::P0)
+            .await;
         let block = match block {
             Ok(Some(block)) => block,
             Ok(None) => {
@@ -332,8 +363,17 @@ impl BlockManager {
             .unwrap_or(false)
     }
 
+    pub fn format_key(prefix_path: &str, id: &Uuid) -> String {
+        // For legacy collections, prefix_path is empty.
+        if prefix_path.is_empty() {
+            return format!("block/{}", id);
+        }
+        format!("{}/block/{}", prefix_path, id)
+    }
+
     pub(super) async fn get(
         &self,
+        prefix_path: &str,
         id: &Uuid,
         priority: StorageRequestPriority,
     ) -> Result<Option<Block>, GetError> {
@@ -341,7 +381,7 @@ impl BlockManager {
         match block {
             Some(block) => Ok(Some(block)),
             None => async {
-                let key = format!("block/{}", id);
+                let key = Self::format_key(prefix_path, id);
                 let bytes_res = self
                     .storage
                     .get(&key, GetOptions::new(priority))
@@ -378,7 +418,11 @@ impl BlockManager {
         }
     }
 
-    pub(super) async fn flush(&self, block: &Block) -> Result<(), Box<dyn ChromaError>> {
+    pub(super) async fn flush(
+        &self,
+        block: &Block,
+        prefix_path: &str,
+    ) -> Result<(), Box<dyn ChromaError>> {
         let bytes = match block.to_bytes() {
             Ok(bytes) => bytes,
             Err(e) => {
@@ -386,7 +430,7 @@ impl BlockManager {
                 return Err(Box::new(e));
             }
         };
-        let key = format!("block/{}", block.id);
+        let key = Self::format_key(prefix_path, &block.id);
         let block_bytes_len = bytes.len();
         let res = self
             .storage
@@ -491,20 +535,21 @@ impl RootManager {
     pub async fn get<'new, K: ArrowReadableKey<'new> + 'new>(
         &self,
         id: &Uuid,
+        prefix_path: &str,
     ) -> Result<Option<RootReader>, RootManagerError> {
         let index = self.cache.obtain(*id).await.ok().flatten();
         match index {
             Some(index) => Ok(Some(index)),
             None => {
                 tracing::info!("Cache miss - fetching root from storage");
-                let key = Self::get_storage_key(id);
+                let key = Self::get_storage_key(prefix_path, id);
                 tracing::debug!("Reading root from storage with key: {}", key);
                 match self
                     .storage
                     .get(&key, GetOptions::new(StorageRequestPriority::P0))
                     .await
                 {
-                    Ok(bytes) => match RootReader::from_bytes::<K>(&bytes, *id) {
+                    Ok(bytes) => match RootReader::from_bytes::<K>(&bytes, prefix_path, *id) {
                         Ok(root) => {
                             self.cache.insert(*id, root.clone()).await;
                             Ok(Some(root))
@@ -523,8 +568,12 @@ impl RootManager {
         }
     }
 
-    pub async fn get_all_block_ids(&self, id: &Uuid) -> Result<Vec<Uuid>, RootManagerError> {
-        let key = Self::get_storage_key(id);
+    pub async fn get_all_block_ids(
+        &self,
+        id: &Uuid,
+        prefix_path: &str,
+    ) -> Result<Vec<Uuid>, RootManagerError> {
+        let key = Self::get_storage_key(prefix_path, id);
         tracing::debug!("Reading root from storage with key: {}", key);
         match self
             .storage
@@ -551,7 +600,7 @@ impl RootManager {
                 return Err(Box::new(e));
             }
         };
-        let key = format!("sparse_index/{}", root.id);
+        let key = Self::get_storage_key(&root.prefix_path, &root.id);
         let res = self
             .storage
             .put_bytes(
@@ -576,9 +625,12 @@ impl RootManager {
         &self,
         old_id: &Uuid,
         new_id: Uuid,
+        prefix_path: &str,
     ) -> Result<RootWriter, RootManagerError> {
         tracing::info!("Forking root from {:?}", old_id);
-        let original = self.get::<K::ReadableKey<'key>>(old_id).await?;
+        let original = self
+            .get::<K::ReadableKey<'key>>(old_id, prefix_path)
+            .await?;
         match original {
             Some(original) => {
                 let forked = original.fork(new_id);
@@ -588,11 +640,12 @@ impl RootManager {
         }
     }
 
-    fn get_storage_key(id: &Uuid) -> String {
-        // TODO(hammadb): For legacy and temporary development purposes, we are reading the file
-        // from a fixed location. The path is sparse_index/ for legacy reasons.
-        // This will be replaced with a full prefix-based storage shortly
-        format!("sparse_index/{}", id)
+    pub fn get_storage_key(prefix_path: &str, id: &Uuid) -> String {
+        // For legacy collections, prefix_path is empty.
+        if prefix_path.is_empty() {
+            return format!("sparse_index/{}", id);
+        }
+        format!("{}/sparse_index/{}", prefix_path, id)
     }
 
     fn should_prefetch(&self, id: &Uuid) -> bool {

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -645,7 +645,7 @@ impl RootManager {
         if prefix_path.is_empty() {
             return format!("sparse_index/{}", id);
         }
-        format!("{}/sparse_index/{}", prefix_path, id)
+        format!("{}/root/{}", prefix_path, id)
     }
 
     fn should_prefetch(&self, id: &Uuid) -> bool {

--- a/rust/blockstore/src/memory/reader_writer.rs
+++ b/rust/blockstore/src/memory/reader_writer.rs
@@ -22,6 +22,10 @@ impl MemoryBlockfileFlusher {
     pub(crate) fn id(&self) -> uuid::Uuid {
         self.id
     }
+
+    pub(crate) fn prefix_path(&self) -> String {
+        String::from("")
+    }
 }
 
 impl MemoryBlockfileWriter {

--- a/rust/blockstore/src/memory/reader_writer.rs
+++ b/rust/blockstore/src/memory/reader_writer.rs
@@ -23,8 +23,8 @@ impl MemoryBlockfileFlusher {
         self.id
     }
 
-    pub(crate) fn prefix_path(&self) -> String {
-        String::from("")
+    pub(crate) fn prefix_path(&self) -> &str {
+        ""
     }
 }
 

--- a/rust/blockstore/src/test_utils/sparse_index_test_utils.rs
+++ b/rust/blockstore/src/test_utils/sparse_index_test_utils.rs
@@ -24,6 +24,7 @@ pub async fn create_test_sparse_index(
     root_id: Uuid,
     block_ids: Vec<Uuid>,
     prefix: Option<String>,
+    prefix_path: String,
 ) -> Result<Uuid, Box<dyn ChromaError>> {
     if block_ids.is_empty() {
         return Err(Box::new(TestSparseIndexError::EmptyBlockIds));
@@ -44,7 +45,6 @@ pub async fn create_test_sparse_index(
     sparse_index.set_count(block_ids[0], 1)?;
 
     // Create and save the sparse index file
-    let prefix_path = String::from("");
     let root_writer = RootWriter::new(Version::V1_1, root_id, sparse_index, prefix_path);
     let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
     root_manager.flush::<&str>(&root_writer).await?;
@@ -87,9 +87,16 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
 
+        let prefix_path = "";
         let block_ids = vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
-        let result =
-            create_test_sparse_index(&storage, Uuid::new_v4(), block_ids.clone(), None).await;
+        let result = create_test_sparse_index(
+            &storage,
+            Uuid::new_v4(),
+            block_ids.clone(),
+            None,
+            prefix_path.to_string(),
+        )
+        .await;
         assert!(result.is_ok());
 
         // Verify the sparse index was created by trying to read it
@@ -97,7 +104,6 @@ mod tests {
         let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
 
         // Verify all block IDs are present in the sparse index
-        let prefix_path = "";
         let stored_block_ids = root_manager
             .get_all_block_ids(&root_id, prefix_path)
             .await
@@ -113,7 +119,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(temp_dir.path().to_str().unwrap()));
 
-        let result = create_test_sparse_index(&storage, Uuid::new_v4(), vec![], None).await;
+        let result =
+            create_test_sparse_index(&storage, Uuid::new_v4(), vec![], None, "".to_string()).await;
         assert!(matches!(
             result,
             Err(e) if e.to_string().contains("Cannot create sparse index with empty block IDs")
@@ -127,7 +134,9 @@ mod tests {
 
         let block_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
         let prefix = Some("custom".to_string());
-        let result = create_test_sparse_index(&storage, Uuid::new_v4(), block_ids, prefix).await;
+        let result =
+            create_test_sparse_index(&storage, Uuid::new_v4(), block_ids, prefix, "".to_string())
+                .await;
         assert!(result.is_ok());
     }
 }

--- a/rust/blockstore/src/test_utils/sparse_index_test_utils.rs
+++ b/rust/blockstore/src/test_utils/sparse_index_test_utils.rs
@@ -44,7 +44,8 @@ pub async fn create_test_sparse_index(
     sparse_index.set_count(block_ids[0], 1)?;
 
     // Create and save the sparse index file
-    let root_writer = RootWriter::new(Version::V1_1, root_id, sparse_index);
+    let prefix_path = String::from("");
+    let root_writer = RootWriter::new(Version::V1_1, root_id, sparse_index, prefix_path);
     let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
     root_manager.flush::<&str>(&root_writer).await?;
 
@@ -96,7 +97,11 @@ mod tests {
         let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
 
         // Verify all block IDs are present in the sparse index
-        let stored_block_ids = root_manager.get_all_block_ids(&root_id).await.unwrap();
+        let prefix_path = "";
+        let stored_block_ids = root_manager
+            .get_all_block_ids(&root_id, prefix_path)
+            .await
+            .unwrap();
         assert_eq!(stored_block_ids.len(), block_ids.len());
         for block_id in block_ids {
             assert!(stored_block_ids.contains(&block_id));

--- a/rust/blockstore/src/types/flusher.rs
+++ b/rust/blockstore/src/types/flusher.rs
@@ -46,7 +46,7 @@ impl BlockfileFlusher {
         }
     }
 
-    pub fn prefix_path(&self) -> String {
+    pub fn prefix_path(&self) -> &str {
         match self {
             BlockfileFlusher::MemoryBlockfileFlusher(flusher) => flusher.prefix_path(),
             BlockfileFlusher::ArrowBlockfileFlusher(flusher) => flusher.prefix_path(),

--- a/rust/blockstore/src/types/flusher.rs
+++ b/rust/blockstore/src/types/flusher.rs
@@ -45,4 +45,11 @@ impl BlockfileFlusher {
             BlockfileFlusher::ArrowBlockfileFlusher(flusher) => flusher.num_entries(),
         }
     }
+
+    pub fn prefix_path(&self) -> String {
+        match self {
+            BlockfileFlusher::MemoryBlockfileFlusher(flusher) => flusher.prefix_path(),
+            BlockfileFlusher::ArrowBlockfileFlusher(flusher) => flusher.prefix_path(),
+        }
+    }
 }

--- a/rust/blockstore/tests/blockfile_writer_test.rs
+++ b/rust/blockstore/tests/blockfile_writer_test.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use chroma_blockstore::arrow::provider::ArrowBlockfileProvider;
+    use chroma_blockstore::arrow::provider::{ArrowBlockfileProvider, BlockfileReaderOptions};
     use chroma_blockstore::{
         BlockfileReader, BlockfileWriter, BlockfileWriterMutationOrdering, BlockfileWriterOptions,
     };
@@ -271,7 +271,8 @@ mod tests {
             let ref_last_commit = ref_state.last_commit.as_ref().unwrap();
             let last_blockfile_id = state.last_blockfile_id.unwrap();
 
-            let reader = block_on(state.provider.read::<&str, &[u32]>(&last_blockfile_id)).unwrap();
+            let read_options = BlockfileReaderOptions::new(last_blockfile_id, "".to_string());
+            let reader = block_on(state.provider.read::<&str, &[u32]>(read_options)).unwrap();
 
             // Check count
             assert_eq!(block_on(reader.count()).unwrap(), ref_last_commit.len());

--- a/rust/garbage_collector/Cargo.toml
+++ b/rust/garbage_collector/Cargo.toml
@@ -37,6 +37,7 @@ base64 = { workspace = true }
 
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
+chroma-segment = { workspace = true }
 chroma-system = { workspace = true }
 chroma-types = { workspace = true }
 chroma-sysdb = { workspace = true }

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -748,6 +748,8 @@ mod tests {
         (collection_id, tenant_id)
     }
 
+    // NOTE(Sanket): This orchestrator should be deleted.
+    // Prefix path has not been changed here due to this reason.
     async fn get_hnsw_index_ids(storage: &Storage) -> Vec<Uuid> {
         storage
             .list_prefix("hnsw", GetOptions::default())

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -749,13 +749,12 @@ mod tests {
             .get_collection_with_segments(collection_id.to_string())
             .await
             .unwrap();
-        let db_id = Uuid::from_str(
-            &collection_with_segments
-                .collection
-                .expect("Expected collection to be found")
-                .database_id,
-        )
-        .expect("Failed to parse database ID");
+        let db_id = collection_with_segments
+            .collection
+            .expect("Expected collection to be found")
+            .database_id
+            .expect("Expected database ID to be present");
+        let db_id = Uuid::from_str(&db_id).expect("Failed to parse database ID");
 
         let mut segment_id_str = String::from("");
         for segment in collection_with_segments.segments {

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -780,12 +780,11 @@ mod tests {
             .into_iter()
             .filter(|path| path.contains(&format!("{}/", s3_path)))
             .map(|path| {
-                Uuid::from_str(
-                    path.split("/")
-                        .nth(1) // Get the prefix part after "hnsw/"
-                        .unwrap(),
-                )
-                .unwrap()
+                let id = match path.rfind('/') {
+                    Some(pos) => &path[pos + 1..],
+                    None => panic!("Invalid path format: {}", path),
+                };
+                Uuid::from_str(id).unwrap()
             })
             .collect::<std::collections::HashSet<_>>() // de-dupe
             .into_iter()

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -771,7 +771,6 @@ mod tests {
         (collection_id, tenant_id, db_id, segment_id)
     }
 
-    // Prefix path has not been changed here due to this reason.
     async fn get_hnsw_index_ids(storage: &Storage, s3_path: &str) -> Vec<Uuid> {
         storage
             .list_prefix(s3_path, GetOptions::default())
@@ -779,13 +778,7 @@ mod tests {
             .unwrap()
             .into_iter()
             .filter(|path| path.contains(&format!("{}/", s3_path)))
-            .map(|path| {
-                let id = match path.rfind('/') {
-                    Some(pos) => &path[pos + 1..],
-                    None => panic!("Invalid path format: {}", path),
-                };
-                Uuid::from_str(id).unwrap()
-            })
+            .map(|path| Uuid::from_str(path.split("/").nth(9).unwrap()).unwrap())
             .collect::<std::collections::HashSet<_>>() // de-dupe
             .into_iter()
             .collect()

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -3,9 +3,9 @@ use chroma_types::chroma_proto::query_executor_client::QueryExecutorClient;
 use chroma_types::chroma_proto::sys_db_client::SysDbClient;
 use chroma_types::chroma_proto::{
     CreateCollectionRequest, CreateDatabaseRequest, CreateTenantRequest, FilterOperator,
-    GetCollectionWithSegmentsRequest, GetPlan, LimitOperator, ListCollectionVersionsRequest,
-    ListCollectionVersionsResponse, OperationRecord, ProjectionOperator, PushLogsRequest,
-    ScanOperator, Segment, SegmentScope, Vector,
+    GetCollectionWithSegmentsRequest, GetCollectionWithSegmentsResponse, GetPlan, LimitOperator,
+    ListCollectionVersionsRequest, ListCollectionVersionsResponse, OperationRecord,
+    ProjectionOperator, PushLogsRequest, ScanOperator, Segment, SegmentScope, Vector,
 };
 use chroma_types::InternalCollectionConfiguration;
 use std::collections::HashMap;
@@ -315,6 +315,16 @@ impl ChromaGrpcClients {
         };
 
         let response = self.sysdb.list_collection_versions(request).await?;
+        Ok(response.into_inner())
+    }
+
+    pub async fn get_collection_with_segments(
+        &mut self,
+        collection_id: String,
+    ) -> Result<GetCollectionWithSegmentsResponse, Box<dyn std::error::Error>> {
+        let request = GetCollectionWithSegmentsRequest { id: collection_id };
+
+        let response = self.sysdb.get_collection_with_segments(request).await?;
         Ok(response.into_inner())
     }
 }

--- a/rust/garbage_collector/src/operators/compute_unused_between_versions.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_between_versions.rs
@@ -11,7 +11,6 @@ use chroma_types::{
 };
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct ComputeUnusedBetweenVersionsOperator {
@@ -41,10 +40,9 @@ impl ComputeUnusedBetweenVersionsOperator {
         for file_path in version_files.keys() {
             tracing::info!(file_path = %file_path, "Processing sparse index file");
 
-            let (prefix, id) = Segment::extract_prefix_and_id(file_path);
-            let id = match Uuid::parse_str(id) {
+            let (prefix, id) = match Segment::extract_prefix_and_id(file_path) {
                 Ok(id) => {
-                    tracing::debug!(uuid = %id, "Successfully parsed UUID from file path");
+                    tracing::debug!(uuid = %id.1, "Successfully parsed UUID from file path");
                     id
                 }
                 Err(e) => {
@@ -337,6 +335,7 @@ mod tests {
     use chroma_cache::UnboundedCacheConfig;
     use chroma_storage::{local::LocalStorage, Storage};
     use chroma_sysdb::{SysDb, TestSysDb};
+    use uuid::Uuid;
 
     async fn _create_sparse_index(storage: &Storage, keys: Vec<String>) -> Uuid {
         let block_cache = Box::new(UnboundedCacheConfig {}.build());

--- a/rust/garbage_collector/src/operators/compute_unused_files.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_files.rs
@@ -363,6 +363,7 @@ mod tests {
             Uuid::new_v4(),
             block_ids,
             None, // Use default "test" prefix
+            "".to_string(),
         )
         .await?;
 

--- a/rust/garbage_collector/src/operators/compute_unused_files.rs
+++ b/rust/garbage_collector/src/operators/compute_unused_files.rs
@@ -5,7 +5,10 @@ use chroma_blockstore::{
 };
 use chroma_cache::nop::NopCache;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_index::{hnsw_provider::HnswIndexProvider, IndexUuid};
+use chroma_index::{
+    hnsw_provider::{HnswIndexProvider, FILES},
+    IndexUuid,
+};
 use chroma_storage::Storage;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::{
@@ -88,14 +91,7 @@ impl ComputeUnusedFilesOperator {
                             tracing::error!(error = %e, "Failed to parse UUID");
                             ComputeUnusedFilesError::InvalidUuid(e, hnsw_id.to_string())
                         })?);
-                        for file in [
-                            "header.bin",
-                            "data_level0.bin",
-                            "length.bin",
-                            "link_lists.bin",
-                        ]
-                        .iter()
-                        {
+                        for file in FILES.iter() {
                             let hnsw_prefix =
                                 HnswIndexProvider::format_key(prefix, &hnsw_uuid, file);
                             tracing::debug!(

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -2,7 +2,6 @@ use crate::types::CleanupMode;
 use crate::types::RENAMED_FILE_PREFIX;
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_index::HNSW_INDEX_S3_PREFIX;
 use chroma_storage::Storage;
 use chroma_storage::{DeleteOptions, StorageError};
 use chroma_system::{Operator, OperatorType};
@@ -92,6 +91,8 @@ impl Operator<DeleteUnusedFilesInput, DeleteUnusedFilesOutput> for DeleteUnusedF
         );
 
         // Generate list of HNSW files
+        // NOTE(Sanket): input.hnsw_prefixes_for_deletion is no longer used
+        // hence not overriding prefix changes here. We should remove this param.
         let hnsw_files: Vec<String> = input
             .hnsw_prefixes_for_deletion
             .iter()
@@ -103,7 +104,7 @@ impl Operator<DeleteUnusedFilesInput, DeleteUnusedFilesOutput> for DeleteUnusedF
                     "link_lists.bin",
                 ]
                 .iter()
-                .map(|file| format!("{}{}/{}", HNSW_INDEX_S3_PREFIX, prefix, file))
+                .map(|file| format!("hnsw/{}/{}", prefix, file))
                 .collect::<Vec<String>>()
             })
             .collect();
@@ -198,10 +199,10 @@ mod tests {
 
         // Create HNSW test files
         let hnsw_files = vec![
-            format!("{}{}/header.bin", HNSW_INDEX_S3_PREFIX, "prefix1"),
-            format!("{}{}/data_level0.bin", HNSW_INDEX_S3_PREFIX, "prefix1"),
-            format!("{}{}/length.bin", HNSW_INDEX_S3_PREFIX, "prefix1"),
-            format!("{}{}/link_lists.bin", HNSW_INDEX_S3_PREFIX, "prefix1"),
+            format!("hnsw/{}/header.bin", "prefix1"),
+            format!("hnsw/{}/data_level0.bin", "prefix1"),
+            format!("hnsw/{}/length.bin", "prefix1"),
+            format!("hnsw/{}/link_lists.bin", "prefix1"),
         ];
         for file in &hnsw_files {
             create_test_file(storage, file, b"test content").await;

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -90,28 +90,9 @@ impl Operator<DeleteUnusedFilesInput, DeleteUnusedFilesOutput> for DeleteUnusedF
             "Starting deletion of unused files"
         );
 
-        // Generate list of HNSW files
-        // NOTE(Sanket): input.hnsw_prefixes_for_deletion is no longer used
-        // hence not overriding prefix changes here. We should remove this param.
-        let hnsw_files: Vec<String> = input
-            .hnsw_prefixes_for_deletion
-            .iter()
-            .flat_map(|prefix| {
-                [
-                    "header.bin",
-                    "data_level0.bin",
-                    "length.bin",
-                    "link_lists.bin",
-                ]
-                .iter()
-                .map(|file| format!("hnsw/{}/{}", prefix, file))
-                .collect::<Vec<String>>()
-            })
-            .collect();
-
         // Create a list that contains all files that will be deleted.
         let mut all_files = input.unused_s3_files.clone();
-        all_files.extend(hnsw_files);
+        all_files.extend(input.hnsw_prefixes_for_deletion.clone());
 
         // NOTE(rohit):
         // We don't want to fail the entire operation if one file fails to rename or delete.

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -159,6 +159,7 @@ impl DeleteUnusedFilesOperator {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chroma_index::hnsw_provider::FILES;
     use chroma_storage::local::LocalStorage;
     use chroma_storage::PutOptions;
     use std::path::Path;
@@ -179,12 +180,10 @@ mod tests {
         }
 
         // Create HNSW test files
-        let hnsw_files = vec![
-            format!("hnsw/{}/header.bin", "prefix1"),
-            format!("hnsw/{}/data_level0.bin", "prefix1"),
-            format!("hnsw/{}/length.bin", "prefix1"),
-            format!("hnsw/{}/link_lists.bin", "prefix1"),
-        ];
+        let hnsw_files = FILES
+            .iter()
+            .map(|file_name| format!("hnsw/prefix1/{}", file_name))
+            .collect::<Vec<String>>();
         for file in &hnsw_files {
             create_test_file(storage, file, b"test content").await;
         }

--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -199,7 +199,7 @@ mod tests {
     async fn test_dry_run_mode() {
         let tmp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
-        let (test_files, _) = setup_test_files(&storage).await;
+        let (test_files, hnsw_files) = setup_test_files(&storage).await;
 
         let operator = DeleteUnusedFilesOperator::new(
             storage.clone(),
@@ -208,13 +208,18 @@ mod tests {
         );
         let input = DeleteUnusedFilesInput {
             unused_s3_files: test_files.clone(),
-            hnsw_prefixes_for_deletion: vec!["prefix1".to_string()],
+            hnsw_prefixes_for_deletion: hnsw_files.clone(),
         };
 
         let result = operator.run(&input).await.unwrap();
 
         // Verify original files still exist
         for file in &test_files {
+            assert!(result.deleted_files.contains(file));
+            assert!(Path::new(&tmp_dir.path().join(file)).exists());
+        }
+
+        for file in &hnsw_files {
             assert!(result.deleted_files.contains(file));
             assert!(Path::new(&tmp_dir.path().join(file)).exists());
         }
@@ -233,7 +238,7 @@ mod tests {
         );
         let input = DeleteUnusedFilesInput {
             unused_s3_files: test_files.clone(),
-            hnsw_prefixes_for_deletion: vec!["prefix1".to_string()],
+            hnsw_prefixes_for_deletion: hnsw_files.clone(),
         };
 
         let result = operator.run(&input).await.unwrap();
@@ -274,7 +279,7 @@ mod tests {
         );
         let input = DeleteUnusedFilesInput {
             unused_s3_files: test_files.clone(),
-            hnsw_prefixes_for_deletion: vec!["prefix1".to_string()],
+            hnsw_prefixes_for_deletion: hnsw_files.clone(),
         };
 
         let result = operator.run(&input).await.unwrap();

--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -10,7 +10,6 @@ use chroma_types::{
 };
 use std::collections::HashMap;
 use thiserror::Error;
-use uuid::Uuid;
 
 impl std::fmt::Debug for FetchSparseIndexFilesOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -132,8 +131,7 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                             }
                             // Attempt to fetch each file
                             for file_path in &file_paths.paths {
-                                let (prefix, file_id) = Segment::extract_prefix_and_id(file_path);
-                                let file_uuid = Uuid::parse_str(file_id)
+                                let (prefix, file_uuid) = Segment::extract_prefix_and_id(file_path)
                                     .map_err(|_| FetchSparseIndexFilesError::ParsingIdFailed)?;
                                 let s3_key = RootManager::get_storage_key(prefix, &file_uuid);
                                 match self

--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -1,14 +1,16 @@
 use async_trait::async_trait;
+use chroma_blockstore::RootManager;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::{
     chroma_proto::{CollectionVersionFile, VersionListForCollection},
-    HNSW_PATH,
+    Segment, HNSW_PATH,
 };
 use std::collections::HashMap;
 use thiserror::Error;
+use uuid::Uuid;
 
 impl std::fmt::Debug for FetchSparseIndexFilesOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -46,6 +48,8 @@ pub enum FetchSparseIndexFilesError {
     S3Error(String),
     #[error("File not found for version: {0}")]
     FileNotFound(i64),
+    #[error("Error parsing id")]
+    ParsingIdFailed,
 }
 
 impl ChromaError for FetchSparseIndexFilesError {
@@ -53,6 +57,7 @@ impl ChromaError for FetchSparseIndexFilesError {
         match self {
             FetchSparseIndexFilesError::S3Error(_) => ErrorCodes::Internal,
             FetchSparseIndexFilesError::FileNotFound(_) => ErrorCodes::NotFound,
+            FetchSparseIndexFilesError::ParsingIdFailed => ErrorCodes::Internal,
         }
     }
 }
@@ -127,13 +132,13 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                             }
                             // Attempt to fetch each file
                             for file_path in &file_paths.paths {
-                                let prefixed_path = format!("sparse_index/{}", file_path);
+                                let (prefix, file_id) = Segment::extract_prefix_and_id(file_path);
+                                let file_uuid = Uuid::parse_str(file_id)
+                                    .map_err(|_| FetchSparseIndexFilesError::ParsingIdFailed)?;
+                                let s3_key = RootManager::get_storage_key(prefix, &file_uuid);
                                 match self
                                     .storage
-                                    .get(
-                                        &prefixed_path,
-                                        GetOptions::new(StorageRequestPriority::P0),
-                                    )
+                                    .get(&s3_key, GetOptions::new(StorageRequestPriority::P0))
                                     .await
                                 {
                                     Ok(content) => {
@@ -141,7 +146,7 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                                         total_bytes_fetched += content.len();
                                         tracing::info!(
                                             "      ✓ Fetched:  {} ({} bytes)",
-                                            prefixed_path,
+                                            s3_key,
                                             content.len()
                                         );
                                         version_files
@@ -150,13 +155,13 @@ impl Operator<FetchSparseIndexFilesInput, FetchSparseIndexFilesOutput>
                                     Err(e) => {
                                         tracing::error!(
                                             "Failed to fetch file {} for version {}: {}",
-                                            prefixed_path,
+                                            s3_key,
                                             version,
                                             e
                                         );
                                         return Err(FetchSparseIndexFilesError::S3Error(format!(
                                             "Failed to fetch file {} for version {}: {}",
-                                            prefixed_path, version, e
+                                            s3_key, version, e
                                         )));
                                     }
                                 }

--- a/rust/garbage_collector/src/operators/list_files_at_version.rs
+++ b/rust/garbage_collector/src/operators/list_files_at_version.rs
@@ -3,7 +3,10 @@ use chroma_blockstore::{
     arrow::provider::{BlockManager, RootManagerError},
     RootManager,
 };
-use chroma_index::{hnsw_provider::HnswIndexProvider, IndexUuid};
+use chroma_index::{
+    hnsw_provider::{HnswIndexProvider, FILES},
+    IndexUuid,
+};
 use chroma_storage::StorageError;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::{chroma_proto::CollectionVersionFile, CollectionUuid, Segment, HNSW_PATH};
@@ -113,12 +116,7 @@ impl Operator<ListFilesAtVersionInput, ListFilesAtVersionOutput> for ListFilesAt
                         for path in &segment_paths.paths {
                             let (prefix, hnsw_index_id) = Segment::extract_prefix_and_id(path);
                             file_prefix = prefix.to_string();
-                            for hnsw_file in [
-                                "header.bin",
-                                "data_level0.bin",
-                                "length.bin",
-                                "link_lists.bin",
-                            ] {
+                            for hnsw_file in FILES {
                                 let hnsw_index_uuid = IndexUuid(
                                     Uuid::parse_str(hnsw_index_id)
                                         .map_err(ListFilesAtVersionError::InvalidUuid)?,

--- a/rust/garbage_collector/tests/prop_test_local_files.rs
+++ b/rust/garbage_collector/tests/prop_test_local_files.rs
@@ -604,6 +604,7 @@ impl GcTest {
             Uuid::new_v4(),
             record_segment_info.block_ids.clone(),
             Some("test_si_rec_".to_string()),
+            "".to_string(),
         )
         .await
         .unwrap();
@@ -632,6 +633,7 @@ impl GcTest {
             Uuid::new_v4(),
             metadata_segment_info.block_ids.clone(),
             Some("test_si_meta_".to_string()),
+            "".to_string(),
         )
         .await
         .unwrap();

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
@@ -11,7 +11,7 @@
  */
 use super::proptest_types::Transition;
 use super::segment_file_strategies::SegmentGroup;
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionUuid, DatabaseUuid};
 use petgraph::graph::{DiGraph, NodeIndex};
 use proptest::prelude::{any, BoxedStrategy};
 use proptest::strategy::Strategy;
@@ -19,6 +19,7 @@ use proptest::{prelude::Just, prop_oneof};
 use proptest_state_machine::ReferenceStateMachine;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
+use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CollectionStatus {
@@ -73,6 +74,9 @@ impl CollectionVersionGraphNode {
 pub struct ReferenceState {
     pub runtime: Arc<tokio::runtime::Runtime>,
     pub collection_status: HashMap<CollectionUuid, CollectionStatus>,
+    pub tenant: String,
+    pub db_name: String,
+    pub db_id: DatabaseUuid,
     version_graph: DiGraph<CollectionVersionGraphNode, ()>,
     root_collection_id: Option<CollectionUuid>,
 }
@@ -196,9 +200,17 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
             .get_or_init(|| Arc::new(tokio::runtime::Runtime::new().unwrap()))
             .clone();
 
+        let tenant_id = Uuid::new_v4();
+        let tenant_name = format!("test_tenant_{}", tenant_id);
+        let database_id = Uuid::new_v4();
+        let database_name = format!("test_database_{}", database_id);
+
         Just(ReferenceState {
             runtime,
             version_graph: DiGraph::new(),
+            tenant: tenant_name,
+            db_name: database_name,
+            db_id: DatabaseUuid(database_id),
             collection_status: HashMap::new(),
             root_collection_id: None,
         })

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_reference.rs
@@ -13,7 +13,7 @@ use super::proptest_types::Transition;
 use super::segment_file_strategies::SegmentGroup;
 use chroma_types::{CollectionUuid, DatabaseUuid};
 use petgraph::graph::{DiGraph, NodeIndex};
-use proptest::prelude::{any, BoxedStrategy};
+use proptest::prelude::{any, any_with, BoxedStrategy};
 use proptest::strategy::Strategy;
 use proptest::{prelude::Just, prop_oneof};
 use proptest_state_machine::ReferenceStateMachine;
@@ -239,10 +239,11 @@ impl ReferenceStateMachine for ReferenceGarbageCollector {
 
         let create_collection_id = CollectionUuid::new();
         let create_collection_transition =
-            any::<SegmentGroup>().prop_map(move |segment_group| Transition::CreateCollection {
-                collection_id: create_collection_id,
-                segments: segment_group,
-            });
+            any_with::<SegmentGroup>((state.tenant.clone(), state.db_id, create_collection_id))
+                .prop_map(move |segment_group| Transition::CreateCollection {
+                    collection_id: create_collection_id,
+                    segments: segment_group,
+                });
 
         let _delete_collection_transition = alive_collection_id_strategy
             .clone()

--- a/rust/garbage_collector/tests/proptest_helpers/proptest_types.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/proptest_types.rs
@@ -1,5 +1,5 @@
 use super::segment_file_strategies::SegmentGroup;
-use chroma_types::{CollectionAndSegments, CollectionUuid, SegmentUuid};
+use chroma_types::CollectionUuid;
 
 #[derive(Clone, Debug)]
 pub enum Transition {
@@ -21,20 +21,4 @@ pub enum Transition {
         min_versions_to_keep: usize,
     },
     NoOp,
-}
-
-pub struct SegmentIds {
-    pub vector: SegmentUuid,
-    pub metadata: SegmentUuid,
-    pub record: SegmentUuid,
-}
-
-impl From<CollectionAndSegments> for SegmentIds {
-    fn from(segments: CollectionAndSegments) -> Self {
-        SegmentIds {
-            vector: segments.vector_segment.id,
-            metadata: segments.metadata_segment.id,
-            record: segments.record_segment.id,
-        }
-    }
 }

--- a/rust/garbage_collector/tests/proptest_helpers/proptest_types.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/proptest_types.rs
@@ -1,5 +1,5 @@
 use super::segment_file_strategies::SegmentGroup;
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionAndSegments, CollectionUuid, SegmentUuid};
 
 #[derive(Clone, Debug)]
 pub enum Transition {
@@ -21,4 +21,20 @@ pub enum Transition {
         min_versions_to_keep: usize,
     },
     NoOp,
+}
+
+pub struct SegmentIds {
+    pub vector: SegmentUuid,
+    pub metadata: SegmentUuid,
+    pub record: SegmentUuid,
+}
+
+impl From<CollectionAndSegments> for SegmentIds {
+    fn from(segments: CollectionAndSegments) -> Self {
+        SegmentIds {
+            vector: segments.vector_segment.id,
+            metadata: segments.metadata_segment.id,
+            record: segments.record_segment.id,
+        }
+    }
 }

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -138,7 +138,7 @@ fn new_or_forked_sparse_index_strategy(
             let sparse_index_id = Uuid::new_v4();
             // TODO(Sanket-temp): Update this.
             let sparse_index = FileReference::SparseIndex {
-                path: format!("sparse_index/{}", sparse_index_id),
+                path: format!("root/{}", sparse_index_id),
                 block_paths: block_paths.into_iter().collect(),
             };
             SegmentFileReference {

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -1,5 +1,6 @@
 use chroma_blockstore::test_utils::sparse_index_test_utils::create_test_sparse_index;
 use chroma_index::hnsw_provider::FILES;
+use chroma_segment::types::ChromaSegmentFlusher;
 use chroma_storage::Storage;
 use chroma_types::{CollectionUuid, DatabaseUuid, SegmentFlushInfo, SegmentUuid};
 use futures::StreamExt;
@@ -201,7 +202,15 @@ impl From<SegmentFilePaths> for HashMap<String, Vec<String>> {
         for (key, value) in segment_file_paths.paths {
             file_paths.insert(
                 key.name().to_string(),
-                value.iter().map(|f| f.reference_id.to_string()).collect(),
+                value
+                    .iter()
+                    .map(|f| {
+                        ChromaSegmentFlusher::flush_key(
+                            &segment_file_paths.prefix_path,
+                            &f.reference_id,
+                        )
+                    })
+                    .collect(),
             );
         }
         file_paths

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -99,6 +99,7 @@ fn new_or_forked_sparse_index_strategy(
     let new_block_paths_strategy = (1..10).prop_map(|num| {
         let mut block_paths = vec![];
         for _ in 0..num {
+            // TODO(Sanket-temp): Update this to use prefix.
             block_paths.push(format!("block/{}", Uuid::new_v4()));
         }
         block_paths
@@ -135,6 +136,7 @@ fn new_or_forked_sparse_index_strategy(
     block_paths_strategy
         .prop_map(|block_paths| {
             let sparse_index_id = Uuid::new_v4();
+            // TODO(Sanket-temp): Update this.
             let sparse_index = FileReference::SparseIndex {
                 path: format!("sparse_index/{}", sparse_index_id),
                 block_paths: block_paths.into_iter().collect(),

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -1,9 +1,8 @@
-use super::proptest_types::SegmentIds;
 use chroma_blockstore::test_utils::sparse_index_test_utils::create_test_sparse_index;
 use chroma_storage::Storage;
-use chroma_types::{SegmentFlushInfo, SegmentUuid};
+use chroma_types::{CollectionUuid, DatabaseUuid, SegmentFlushInfo, SegmentUuid};
 use futures::StreamExt;
-use proptest::prelude::{any, Arbitrary, BoxedStrategy};
+use proptest::prelude::{any, any_with, Arbitrary, BoxedStrategy};
 use proptest::strategy::Strategy;
 use proptest::{prelude::Just, prop_oneof};
 use std::collections::{HashMap, HashSet};
@@ -76,14 +75,14 @@ struct SegmentFileReference {
     reference: FileReference,
 }
 
-fn new_hnsw_index_strategy() -> BoxedStrategy<SegmentFileReference> {
+fn new_hnsw_index_strategy(prefix_path: String) -> BoxedStrategy<SegmentFileReference> {
     let hnsw_index_id = Uuid::new_v4();
     let hnsw_index = FileReference::Hnsw {
         file_paths: vec![
-            format!("hnsw/{}/header.bin", hnsw_index_id),
-            format!("hnsw/{}/data_level0.bin", hnsw_index_id),
-            format!("hnsw/{}/length.bin", hnsw_index_id),
-            format!("hnsw/{}/link_lists.bin", hnsw_index_id),
+            format!("{}/hnsw/{}/header.bin", prefix_path, hnsw_index_id),
+            format!("{}/hnsw/{}/data_level0.bin", prefix_path, hnsw_index_id),
+            format!("{}/hnsw/{}/length.bin", prefix_path, hnsw_index_id),
+            format!("{}/hnsw/{}/link_lists.bin", prefix_path, hnsw_index_id),
         ],
     };
     Just(SegmentFileReference {
@@ -95,12 +94,13 @@ fn new_hnsw_index_strategy() -> BoxedStrategy<SegmentFileReference> {
 
 fn new_or_forked_sparse_index_strategy(
     existing_sparse_index: Option<SegmentFileReference>,
+    prefix_path: String,
 ) -> BoxedStrategy<SegmentFileReference> {
-    let new_block_paths_strategy = (1..10).prop_map(|num| {
+    let prefix_path_clone = prefix_path.clone();
+    let new_block_paths_strategy = (1..10).prop_map(move |num| {
         let mut block_paths = vec![];
         for _ in 0..num {
-            // TODO(Sanket-temp): Update this to use prefix.
-            block_paths.push(format!("block/{}", Uuid::new_v4()));
+            block_paths.push(format!("{}/block/{}", prefix_path_clone, Uuid::new_v4()));
         }
         block_paths
     });
@@ -134,11 +134,10 @@ fn new_or_forked_sparse_index_strategy(
         });
 
     block_paths_strategy
-        .prop_map(|block_paths| {
+        .prop_map(move |block_paths| {
             let sparse_index_id = Uuid::new_v4();
-            // TODO(Sanket-temp): Update this.
             let sparse_index = FileReference::SparseIndex {
-                path: format!("root/{}", sparse_index_id),
+                path: format!("{}/root/{}", prefix_path, sparse_index_id),
                 block_paths: block_paths.into_iter().collect(),
             };
             SegmentFileReference {
@@ -151,33 +150,47 @@ fn new_or_forked_sparse_index_strategy(
 
 /// A collection of file references for a segment.
 #[derive(Clone, Debug)]
-pub struct SegmentFilePaths(HashMap<SegmentFileReferenceType, Vec<SegmentFileReference>>);
+pub struct SegmentFilePaths {
+    paths: HashMap<SegmentFileReferenceType, Vec<SegmentFileReference>>,
+    pub segment_id: SegmentUuid,
+    pub prefix_path: String,
+}
 
 impl Arbitrary for SegmentFilePaths {
-    type Parameters = ();
+    type Parameters = (String, DatabaseUuid, CollectionUuid);
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
+        let segment_id = SegmentUuid::new();
+        let prefix_path = format!(
+            "tenant/{}/database/{}/collection/{}/segment/{}",
+            params.0, params.1, params.2, segment_id
+        );
+        let prefix_path_clone = prefix_path.clone();
         proptest::collection::vec(
-            any::<SegmentFileReferenceType>().prop_flat_map(|segment_file_reference_type| {
+            any::<SegmentFileReferenceType>().prop_flat_map(move |segment_file_reference_type| {
                 let refs = match segment_file_reference_type.clone() {
-                    SegmentFileReferenceType::HNSWIndex => new_hnsw_index_strategy(),
-                    SegmentFileReferenceType::HNSWPath => new_hnsw_index_strategy(),
+                    SegmentFileReferenceType::HNSWIndex => {
+                        new_hnsw_index_strategy(prefix_path.clone())
+                    }
+                    SegmentFileReferenceType::HNSWPath => {
+                        new_hnsw_index_strategy(prefix_path.clone())
+                    }
                     SegmentFileReferenceType::SparseIndex { .. } => {
-                        new_or_forked_sparse_index_strategy(None)
+                        new_or_forked_sparse_index_strategy(None, prefix_path.clone())
                     }
                 };
                 (Just(segment_file_reference_type), refs)
             }),
             0..10,
         )
-        .prop_map(|elements| {
-            SegmentFilePaths(
-                elements
-                    .into_iter()
-                    .map(|(k, v)| (k, vec![v]))
-                    .collect::<HashMap<_, _>>(),
-            )
+        .prop_map(move |elements| SegmentFilePaths {
+            paths: elements
+                .into_iter()
+                .map(|(k, v)| (k, vec![v]))
+                .collect::<HashMap<_, _>>(),
+            segment_id,
+            prefix_path: prefix_path_clone.clone(),
         })
         .boxed()
     }
@@ -186,7 +199,7 @@ impl Arbitrary for SegmentFilePaths {
 impl From<SegmentFilePaths> for HashMap<String, Vec<String>> {
     fn from(segment_file_paths: SegmentFilePaths) -> Self {
         let mut file_paths = HashMap::new();
-        for (key, value) in segment_file_paths.0 {
+        for (key, value) in segment_file_paths.paths {
             file_paths.insert(
                 key.name().to_string(),
                 value.iter().map(|f| f.reference_id.to_string()).collect(),
@@ -199,7 +212,7 @@ impl From<SegmentFilePaths> for HashMap<String, Vec<String>> {
 impl SegmentFilePaths {
     fn paths(&self) -> Vec<String> {
         let mut paths = vec![];
-        for file_reference in self.0.values() {
+        for file_reference in self.paths.values() {
             for file_ref in file_reference {
                 paths.extend(file_ref.reference.paths());
             }
@@ -207,14 +220,15 @@ impl SegmentFilePaths {
         paths
     }
 
-    fn into_segment_flush_info(self, segment_id: SegmentUuid) -> SegmentFlushInfo {
+    fn into_segment_flush_info(self) -> SegmentFlushInfo {
         SegmentFlushInfo {
-            segment_id,
+            segment_id: self.segment_id,
             file_paths: self.into(),
         }
     }
 
     pub fn next_version_strategy(&self) -> BoxedStrategy<Self> {
+        let prefix_path = self.prefix_path.clone();
         let hnsw_references_strategy = (
             any::<Option<bool>>(),
             prop_oneof![
@@ -223,7 +237,7 @@ impl SegmentFilePaths {
             ],
         )
             .prop_map({
-                let current_refs = self.0.clone();
+                let current_refs = self.paths.clone();
                 move |(hnsw_index, ref_type)| {
                     let mut refs = HashMap::new();
                     match hnsw_index {
@@ -238,10 +252,16 @@ impl SegmentFilePaths {
                             let hnsw_index_id = Uuid::new_v4();
                             let hnsw_index = FileReference::Hnsw {
                                 file_paths: vec![
-                                    format!("hnsw/{}/header.bin", hnsw_index_id),
-                                    format!("hnsw/{}/data_level0.bin", hnsw_index_id),
-                                    format!("hnsw/{}/length.bin", hnsw_index_id),
-                                    format!("hnsw/{}/link_lists.bin", hnsw_index_id),
+                                    format!("{}/hnsw/{}/header.bin", prefix_path, hnsw_index_id),
+                                    format!(
+                                        "{}/hnsw/{}/data_level0.bin",
+                                        prefix_path, hnsw_index_id
+                                    ),
+                                    format!("{}/hnsw/{}/length.bin", prefix_path, hnsw_index_id),
+                                    format!(
+                                        "{}/hnsw/{}/link_lists.bin",
+                                        prefix_path, hnsw_index_id
+                                    ),
                                 ],
                             };
 
@@ -261,12 +281,13 @@ impl SegmentFilePaths {
             });
 
         let sparse_indices = self
-            .0
+            .paths
             .iter()
             .filter(|(k, _)| matches!(k, SegmentFileReferenceType::SparseIndex { .. }))
             .flat_map(|(k, v)| v.iter().map(|v| (k.clone(), v.clone())))
             .collect::<Vec<_>>();
 
+        let prefix_path = self.prefix_path.clone();
         let current_sparse_indices_strategy = if sparse_indices.is_empty() {
             Just(HashMap::new()).boxed()
         } else {
@@ -274,8 +295,11 @@ impl SegmentFilePaths {
             // proptest does not yet support `Vec<BoxedStrategy<T>> -> BoxedStrategy<Vec<T>>`, so instead we first sample a subset of Vec<T> and apply the desired flat map while sampling. We then reject the generated Vec<T> if it contains duplicates.
             proptest::collection::vec(
                 proptest::sample::select(sparse_indices).prop_flat_map(
-                    |(sparse_index_name, sparse_index)| {
-                        let sparse_index = new_or_forked_sparse_index_strategy(Some(sparse_index));
+                    move |(sparse_index_name, sparse_index)| {
+                        let sparse_index = new_or_forked_sparse_index_strategy(
+                            Some(sparse_index),
+                            prefix_path.clone(),
+                        );
                         (Just(sparse_index_name), sparse_index)
                     },
                 ),
@@ -310,7 +334,7 @@ impl SegmentFilePaths {
 
         let new_sparse_indices_strategy = proptest::collection::hash_map(
             (0..10).prop_map(|i| format!("sparse_index_{}", i)),
-            new_or_forked_sparse_index_strategy(None),
+            new_or_forked_sparse_index_strategy(None, self.prefix_path.clone()),
             0..3,
         )
         .prop_map(|sparse_indices| {
@@ -336,12 +360,18 @@ impl SegmentFilePaths {
                 },
             );
 
+        let segment_id = self.segment_id;
+        let prefix_path = self.prefix_path.clone();
         (hnsw_references_strategy, sparse_indices_strategy)
-            .prop_map(|(hnsw_references, sparse_indices)| {
+            .prop_map(move |(hnsw_references, sparse_indices)| {
                 let mut references = hnsw_references;
                 references.extend(sparse_indices);
 
-                Self(references)
+                Self {
+                    paths: references,
+                    segment_id,
+                    prefix_path: prefix_path.clone(),
+                }
             })
             .boxed()
     }
@@ -350,8 +380,6 @@ impl SegmentFilePaths {
 /// A group of the three segment types. Note that the files generated for each segment type may not corelate with what the real system would create (e.g. the metadata segment may have HNSW files).
 ///
 /// This grouping is used instead of generating a variable number of segments as the latter is quite difficult to construct with proptest (there's no transform for `Vec<BoxedStrategy<T>> -> BoxedStrategy<Vec<T>>`).
-///
-/// We do not track segment IDs here as they are not known until after creation.
 #[derive(Clone, Debug)]
 pub struct SegmentGroup {
     pub vector: SegmentFilePaths,
@@ -368,10 +396,10 @@ impl SegmentGroup {
         all_file_paths
     }
 
-    pub fn into_segment_flushes(self, ids: &SegmentIds) -> Arc<[SegmentFlushInfo]> {
-        let vector_flush_info = self.vector.into_segment_flush_info(ids.vector);
-        let metadata_flush_info = self.metadata.into_segment_flush_info(ids.metadata);
-        let record_flush_info = self.record.into_segment_flush_info(ids.record);
+    pub fn into_segment_flushes(self) -> Arc<[SegmentFlushInfo]> {
+        let vector_flush_info = self.vector.into_segment_flush_info();
+        let metadata_flush_info = self.metadata.into_segment_flush_info();
+        let record_flush_info = self.record.into_segment_flush_info();
 
         Arc::from([vector_flush_info, metadata_flush_info, record_flush_info])
     }
@@ -387,7 +415,8 @@ impl SegmentGroup {
 }
 
 async fn write_files_for_segment(storage: &Storage, file_paths: &SegmentFilePaths) {
-    for refs in file_paths.0.values() {
+    let prefix_path = file_paths.prefix_path.clone();
+    for refs in file_paths.paths.values() {
         for file_ref in refs {
             match &file_ref.reference {
                 FileReference::SparseIndex { block_paths, .. } => {
@@ -397,9 +426,15 @@ async fn write_files_for_segment(storage: &Storage, file_paths: &SegmentFilePath
                             Uuid::parse_str(block_path.split('/').last().unwrap()).unwrap()
                         })
                         .collect::<Vec<_>>();
-                    create_test_sparse_index(storage, file_ref.reference_id, block_ids, None)
-                        .await
-                        .unwrap();
+                    create_test_sparse_index(
+                        storage,
+                        file_ref.reference_id,
+                        block_ids,
+                        None,
+                        prefix_path.clone(),
+                    )
+                    .await
+                    .unwrap();
 
                     // Write blocks
                     let contents = vec![0; 8];
@@ -441,14 +476,14 @@ async fn write_files_for_segment(storage: &Storage, file_paths: &SegmentFilePath
 }
 
 impl Arbitrary for SegmentGroup {
-    type Parameters = ();
+    type Parameters = (String, DatabaseUuid, CollectionUuid);
     type Strategy = BoxedStrategy<Self>;
 
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+    fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
         (
-            any::<SegmentFilePaths>(),
-            any::<SegmentFilePaths>(),
-            any::<SegmentFilePaths>(),
+            any_with::<SegmentFilePaths>(params.clone()),
+            any_with::<SegmentFilePaths>(params.clone()),
+            any_with::<SegmentFilePaths>(params.clone()),
         )
             .prop_map(
                 |(vector_segment_paths, metadata_segment_paths, record_segment_paths)| {

--- a/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/segment_file_strategies.rs
@@ -1,4 +1,5 @@
 use chroma_blockstore::test_utils::sparse_index_test_utils::create_test_sparse_index;
+use chroma_index::hnsw_provider::FILES;
 use chroma_storage::Storage;
 use chroma_types::{CollectionUuid, DatabaseUuid, SegmentFlushInfo, SegmentUuid};
 use futures::StreamExt;
@@ -78,12 +79,10 @@ struct SegmentFileReference {
 fn new_hnsw_index_strategy(prefix_path: String) -> BoxedStrategy<SegmentFileReference> {
     let hnsw_index_id = Uuid::new_v4();
     let hnsw_index = FileReference::Hnsw {
-        file_paths: vec![
-            format!("{}/hnsw/{}/header.bin", prefix_path, hnsw_index_id),
-            format!("{}/hnsw/{}/data_level0.bin", prefix_path, hnsw_index_id),
-            format!("{}/hnsw/{}/length.bin", prefix_path, hnsw_index_id),
-            format!("{}/hnsw/{}/link_lists.bin", prefix_path, hnsw_index_id),
-        ],
+        file_paths: FILES
+            .iter()
+            .map(|file_name| format!("{}/hnsw/{}/{}", prefix_path, hnsw_index_id, file_name))
+            .collect::<Vec<String>>(),
     };
     Just(SegmentFileReference {
         reference_id: hnsw_index_id,
@@ -251,18 +250,15 @@ impl SegmentFilePaths {
                             // Don't inherit, create new
                             let hnsw_index_id = Uuid::new_v4();
                             let hnsw_index = FileReference::Hnsw {
-                                file_paths: vec![
-                                    format!("{}/hnsw/{}/header.bin", prefix_path, hnsw_index_id),
-                                    format!(
-                                        "{}/hnsw/{}/data_level0.bin",
-                                        prefix_path, hnsw_index_id
-                                    ),
-                                    format!("{}/hnsw/{}/length.bin", prefix_path, hnsw_index_id),
-                                    format!(
-                                        "{}/hnsw/{}/link_lists.bin",
-                                        prefix_path, hnsw_index_id
-                                    ),
-                                ],
+                                file_paths: FILES
+                                    .iter()
+                                    .map(|file_name| {
+                                        format!(
+                                            "{}/hnsw/{}/{}",
+                                            prefix_path, hnsw_index_id, file_name
+                                        )
+                                    })
+                                    .collect::<Vec<String>>(),
                             };
 
                             refs.insert(

--- a/rust/index/benches/full_text.rs
+++ b/rust/index/benches/full_text.rs
@@ -3,6 +3,7 @@ use chroma_benchmark::datasets::types::Record;
 use chroma_benchmark::datasets::{
     ms_marco_queries::MicrosoftMarcoQueriesDataset, scidocs::SciDocsDataset, types::RecordDataset,
 };
+use chroma_blockstore::arrow::provider::BlockfileReaderOptions;
 use chroma_blockstore::BlockfileWriterOptions;
 use chroma_blockstore::{arrow::provider::ArrowBlockfileProvider, provider::BlockfileProvider};
 use chroma_cache::UnboundedCacheConfig;
@@ -46,7 +47,9 @@ async fn compact_log_and_get_reader<'a>(
 ) -> Result<FullTextIndexReader<'a>> {
     let prefix_path = String::from("");
     let postings_blockfile_writer = blockfile_provider
-        .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path).ordered_mutations())
+        .write::<u32, Vec<u32>>(
+            BlockfileWriterOptions::new(prefix_path.clone()).ordered_mutations(),
+        )
         .await
         .unwrap();
     let postings_blockfile_id = postings_blockfile_writer.id();
@@ -63,8 +66,9 @@ async fn compact_log_and_get_reader<'a>(
     let flusher = full_text_index_writer.commit().await.unwrap();
     flusher.flush().await.unwrap();
 
+    let read_options = BlockfileReaderOptions::new(postings_blockfile_id, prefix_path);
     let postings_blockfile_reader = blockfile_provider
-        .read::<u32, &[u32]>(&postings_blockfile_id)
+        .read::<u32, &[u32]>(read_options)
         .await
         .unwrap();
 

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -285,6 +285,10 @@ impl FullTextIndexFlusher {
     pub fn pls_id(&self) -> Uuid {
         self.posting_lists_blockfile_flusher.id()
     }
+
+    pub fn prefix_path(&self) -> String {
+        self.posting_lists_blockfile_flusher.prefix_path()
+    }
 }
 
 #[derive(Clone)]

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -462,7 +462,10 @@ impl<'reader> NgramLiteralProvider<FullTextIndexError> for FullTextIndexReader<'
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chroma_blockstore::{provider::BlockfileProvider, BlockfileWriterOptions};
+    use chroma_blockstore::{
+        arrow::provider::BlockfileReaderOptions, provider::BlockfileProvider,
+        BlockfileWriterOptions,
+    };
     use chroma_cache::new_cache_for_test;
     use chroma_storage::{local::LocalStorage, Storage};
     use tantivy::tokenizer::NgramTokenizer;
@@ -485,7 +488,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -496,10 +499,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let _ = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
     }
@@ -509,7 +510,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -526,10 +527,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -548,7 +547,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -565,10 +564,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -581,7 +578,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -604,10 +601,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -620,7 +615,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -637,10 +632,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -653,7 +646,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -670,10 +663,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -686,7 +677,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -709,10 +700,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let reader_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(reader_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -728,7 +717,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -751,10 +740,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -770,7 +757,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -801,10 +788,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -826,7 +811,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -861,10 +846,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -883,7 +866,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -910,10 +893,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -932,7 +913,7 @@ mod tests {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -961,10 +942,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -987,7 +966,9 @@ mod tests {
         let provider = BlockfileProvider::new_arrow(storage, 1024 * 1024, block_cache, root_cache);
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path).ordered_mutations())
+            .write::<u32, Vec<u32>>(
+                BlockfileWriterOptions::new(prefix_path.clone()).ordered_mutations(),
+            )
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -1006,10 +987,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(3, 3, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -1026,7 +1005,9 @@ mod tests {
         let provider = BlockfileProvider::new_arrow(storage, 1024 * 1024, block_cache, root_cache);
         let prefix_path = String::from("");
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path).ordered_mutations())
+            .write::<u32, Vec<u32>>(
+                BlockfileWriterOptions::new(prefix_path.clone()).ordered_mutations(),
+            )
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -1045,10 +1026,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(3, 3, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -1102,7 +1081,7 @@ mod tests {
         // Update document document 1 with same content, update document 3 with new content
         let pl_blockfile_writer = provider
             .write::<u32, Vec<u32>>(
-                BlockfileWriterOptions::new(prefix_path)
+                BlockfileWriterOptions::new(prefix_path.clone())
                     .ordered_mutations()
                     .fork(pl_blockfile_id),
             )
@@ -1129,10 +1108,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 
@@ -1269,7 +1246,9 @@ mod tests {
 
         // Delete document 3
         let pl_blockfile_writer = provider
-            .write::<u32, Vec<u32>>(BlockfileWriterOptions::new(prefix_path).fork(pl_blockfile_id))
+            .write::<u32, Vec<u32>>(
+                BlockfileWriterOptions::new(prefix_path.clone()).fork(pl_blockfile_id),
+            )
             .await
             .unwrap();
         let pl_blockfile_id = pl_blockfile_writer.id();
@@ -1285,10 +1264,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -1175,7 +1175,7 @@ mod tests {
         // Update document with same content, should be a noop
         let pl_blockfile_writer = provider
             .write::<u32, Vec<u32>>(
-                BlockfileWriterOptions::new(prefix_path)
+                BlockfileWriterOptions::new(prefix_path.clone())
                     .ordered_mutations()
                     .fork(pl_blockfile_id),
             )
@@ -1195,10 +1195,8 @@ mod tests {
         let flusher = index_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
-        let pl_blockfile_reader = provider
-            .read::<u32, &[u32]>(&pl_blockfile_id)
-            .await
-            .unwrap();
+        let read_options = BlockfileReaderOptions::new(pl_blockfile_id, prefix_path);
+        let pl_blockfile_reader = provider.read::<u32, &[u32]>(read_options).await.unwrap();
         let tokenizer = NgramTokenizer::new(1, 1, false).unwrap();
         let index_reader = FullTextIndexReader::new(pl_blockfile_reader, tokenizer);
 

--- a/rust/index/src/fulltext/types.rs
+++ b/rust/index/src/fulltext/types.rs
@@ -286,7 +286,7 @@ impl FullTextIndexFlusher {
         self.posting_lists_blockfile_flusher.id()
     }
 
-    pub fn prefix_path(&self) -> String {
+    pub fn prefix_path(&self) -> &str {
         self.posting_lists_blockfile_flusher.prefix_path()
     }
 }

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -57,16 +57,30 @@ pub struct HnswIndexProvider {
     pub write_mutex: AysncPartitionedMutex<IndexUuid>,
 }
 
+pub struct HnswIndexFlusher {
+    pub provider: HnswIndexProvider,
+    pub prefix_path: String,
+    pub index_id: IndexUuid,
+}
+
 #[derive(Clone)]
 pub struct HnswIndexRef {
-    pub inner: Arc<RwLock<HnswIndex>>,
+    pub inner: Arc<RwLock<DistributedHnswInner>>,
+}
+
+pub struct DistributedHnswInner {
+    pub hnsw_index: HnswIndex,
+    pub prefix_path: String,
 }
 
 impl Debug for HnswIndexRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HnswIndexRef")
-            .field("id", &self.inner.read().id)
-            .field("dimensionality", &self.inner.read().dimensionality())
+            .field("id", &self.inner.read().hnsw_index.id)
+            .field(
+                "dimensionality",
+                &self.inner.read().hnsw_index.dimensionality(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -99,10 +113,12 @@ impl Configurable<(HnswProviderConfig, Storage)> for HnswIndexProvider {
 impl chroma_cache::Weighted for HnswIndexRef {
     fn weight(&self) -> usize {
         let index = self.inner.read();
-        if index.len() == 0 {
+        if index.hnsw_index.is_empty() {
             return 1;
         }
-        let bytes = index.len() * std::mem::size_of::<f32>() * index.dimensionality() as usize;
+        let bytes = index.hnsw_index.len()
+            * std::mem::size_of::<f32>()
+            * index.hnsw_index.dimensionality() as usize;
         let as_mb = bytes / 1024 / 1024;
         if as_mb == 0 {
             1
@@ -135,7 +151,7 @@ impl HnswIndexProvider {
         match self.cache.get(cache_key).await.ok().flatten() {
             Some(index) => {
                 let index_with_lock = index.inner.read();
-                if index_with_lock.id == *index_id {
+                if index_with_lock.hnsw_index.id == *index_id {
                     // Clone is cheap because we are just cloning the Arc.
                     Some(index.clone())
                 } else {
@@ -146,9 +162,12 @@ impl HnswIndexProvider {
         }
     }
 
-    // TODO(rohitcp): Use HNSW_INDEX_S3_PREFIX.
-    fn format_key(&self, id: &IndexUuid, file: &str) -> String {
-        format!("hnsw/{}/{}", id, file)
+    fn format_key(&self, prefix_path: &str, id: &IndexUuid, file: &str) -> String {
+        // For legacy collections, prefix_path will be empty.
+        if prefix_path.is_empty() {
+            return format!("hnsw/{}/{}", id, file);
+        }
+        format!("{}/hnsw/{}/{}", prefix_path, id, file)
     }
 
     pub async fn fork(
@@ -158,6 +177,7 @@ impl HnswIndexProvider {
         dimensionality: i32,
         distance_function: DistanceFunction,
         ef_search: usize,
+        prefix_path: &str,
     ) -> Result<HnswIndexRef, Box<HnswIndexProviderForkError>> {
         // We take a lock here to synchronize concurrent forks of the same index.
         // Otherwise, we could end up with a corrupted index since the filesystem
@@ -176,7 +196,7 @@ impl HnswIndexProvider {
         }
 
         match self
-            .load_hnsw_segment_into_directory(source_id, &new_storage_path)
+            .load_hnsw_segment_into_directory(source_id, &new_storage_path, prefix_path)
             .await
         {
             Ok(_) => {}
@@ -203,7 +223,10 @@ impl HnswIndexProvider {
             None => match HnswIndex::load(storage_path_str, &index_config, ef_search, new_id) {
                 Ok(index) => {
                     let index = HnswIndexRef {
-                        inner: Arc::new(RwLock::new(index)),
+                        inner: Arc::new(RwLock::new(DistributedHnswInner {
+                            hnsw_index: index,
+                            prefix_path: prefix_path.to_string(),
+                        })),
                     };
                     self.cache.insert(*cache_key, index.clone()).await;
                     Ok(index)
@@ -251,6 +274,7 @@ impl HnswIndexProvider {
         &self,
         source_id: &IndexUuid,
         index_storage_path: &Path,
+        prefix_path: &str,
     ) -> Result<(), Box<HnswIndexProviderFileError>> {
         // Fetch the files from storage and put them in the index storage path.
         for file in FILES.iter() {
@@ -258,7 +282,7 @@ impl HnswIndexProvider {
                 tracing::trace_span!(parent: Span::current(), "Read bytes from s3", file = file);
             let buf = s3_fetch_span
                 .in_scope(|| async {
-                    let key = self.format_key(source_id, file);
+                    let key = self.format_key(prefix_path, source_id, file);
                     tracing::info!("Loading hnsw index file: {} into directory", key);
                     let bytes_res = self
                         .storage
@@ -296,6 +320,7 @@ impl HnswIndexProvider {
         dimensionality: i32,
         distance_function: DistanceFunction,
         ef_search: usize,
+        prefix_path: &str,
     ) -> Result<HnswIndexRef, Box<HnswIndexProviderOpenError>> {
         // This is the double checked locking pattern. This avoids taking the
         // async mutex in the common case where the index is already in the cache.
@@ -320,7 +345,7 @@ impl HnswIndexProvider {
         }
 
         match self
-            .load_hnsw_segment_into_directory(id, &index_storage_path)
+            .load_hnsw_segment_into_directory(id, &index_storage_path, prefix_path)
             .await
         {
             Ok(_) => {}
@@ -347,7 +372,10 @@ impl HnswIndexProvider {
             None => match HnswIndex::load(index_storage_path_str, &index_config, ef_search, *id) {
                 Ok(index) => {
                     let index = HnswIndexRef {
-                        inner: Arc::new(RwLock::new(index)),
+                        inner: Arc::new(RwLock::new(DistributedHnswInner {
+                            hnsw_index: index,
+                            prefix_path: prefix_path.to_string(),
+                        })),
                     };
                     self.cache.insert(*cache_key, index.clone()).await;
                     Ok(index)
@@ -379,6 +407,7 @@ impl HnswIndexProvider {
     // Cases
     // A query comes in and the index is in the cache -> we can query the index based on segment files id (Same as compactor case 3 where we have the index)
     // A query comes in and the index is not in the cache -> we need to load the index from s3 based on the segment files id
+    #[allow(clippy::too_many_arguments)]
     pub async fn create(
         &self,
         cache_key: &CacheKey,
@@ -387,6 +416,7 @@ impl HnswIndexProvider {
         ef_search: usize,
         dimensionality: i32,
         distance_function: DistanceFunction,
+        prefix_path: &str,
     ) -> Result<HnswIndexRef, Box<HnswIndexProviderCreateError>> {
         let id = IndexUuid(Uuid::new_v4());
         // We take a lock here to synchronize concurrent creates of the same index.
@@ -425,7 +455,10 @@ impl HnswIndexProvider {
             Some(index) => Ok(index.clone()),
             None => {
                 let index = HnswIndexRef {
-                    inner: Arc::new(RwLock::new(index)),
+                    inner: Arc::new(RwLock::new(DistributedHnswInner {
+                        hnsw_index: index,
+                        prefix_path: prefix_path.to_string(),
+                    })),
                 };
                 self.cache.insert(*cache_key, index.clone()).await;
                 Ok(index)
@@ -434,7 +467,7 @@ impl HnswIndexProvider {
     }
 
     pub fn commit(&self, index: HnswIndexRef) -> Result<(), Box<dyn ChromaError>> {
-        match index.inner.write().save() {
+        match index.inner.write().hnsw_index.save() {
             Ok(_) => {}
             Err(e) => {
                 return Err(Box::new(HnswIndexProviderCommitError::HnswSaveError(e)));
@@ -444,11 +477,15 @@ impl HnswIndexProvider {
         Ok(())
     }
 
-    pub async fn flush(&self, id: &IndexUuid) -> Result<(), Box<HnswIndexProviderFlushError>> {
+    pub async fn flush(
+        &self,
+        prefix_path: &str,
+        id: &IndexUuid,
+    ) -> Result<(), Box<HnswIndexProviderFlushError>> {
         let index_storage_path = self.temporary_storage_path.join(id.to_string());
         for file in FILES.iter() {
             let file_path = index_storage_path.join(file);
-            let key = self.format_key(id, file);
+            let key = self.format_key(prefix_path, id, file);
             let res = self
                 .storage
                 .put_file(
@@ -641,6 +678,7 @@ mod tests {
         let dimensionality = 128;
         let distance_function = DistanceFunction::Euclidean;
         let default_hnsw_params = InternalHnswConfiguration::default();
+        let prefix_path = "";
         let created_index = provider
             .create(
                 &collection_id,
@@ -649,10 +687,11 @@ mod tests {
                 default_hnsw_params.ef_search,
                 dimensionality,
                 distance_function.clone(),
+                prefix_path,
             )
             .await
             .unwrap();
-        let created_index_id = created_index.inner.read().id;
+        let created_index_id = created_index.inner.read().hnsw_index.id;
 
         let forked_index = provider
             .fork(
@@ -661,10 +700,11 @@ mod tests {
                 dimensionality,
                 distance_function,
                 default_hnsw_params.ef_search,
+                prefix_path,
             )
             .await
             .unwrap();
-        let forked_index_id = forked_index.inner.read().id;
+        let forked_index_id = forked_index.inner.read().hnsw_index.id;
 
         assert_ne!(created_index_id, forked_index_id);
     }
@@ -684,6 +724,7 @@ mod tests {
         let dimensionality = 2;
         let distance_function = DistanceFunction::Euclidean;
         let default_hnsw_params = InternalHnswConfiguration::default();
+        let prefix_path = "";
         let created_index = provider
             .create(
                 &collection_id,
@@ -692,18 +733,20 @@ mod tests {
                 default_hnsw_params.ef_search,
                 dimensionality,
                 distance_function.clone(),
+                prefix_path,
             )
             .await
             .unwrap();
         created_index
             .inner
             .write()
+            .hnsw_index
             .add(1, &[1.0, 3.0])
             .expect("Expected to add");
-        let created_index_id = created_index.inner.read().id;
+        let created_index_id = created_index.inner.read().hnsw_index.id;
         provider.commit(created_index).expect("Expected to commit");
         provider
-            .flush(&created_index_id)
+            .flush(prefix_path, &created_index_id)
             .await
             .expect("Expected to flush");
         // clear the cache.
@@ -719,10 +762,11 @@ mod tests {
                 dimensionality,
                 distance_function,
                 default_hnsw_params.ef_search,
+                prefix_path,
             )
             .await
             .expect("Expect open to succeed");
-        let opened_index_id = open_index.inner.read().id;
+        let opened_index_id = open_index.inner.read().hnsw_index.id;
 
         assert_eq!(opened_index_id, created_index_id);
         check_purge_successful(storage_dir.clone()).await;

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -783,9 +783,7 @@ mod tests {
 
             if metadata.is_dir() {
                 assert!(
-                    path.ends_with("hnsw")
-                        || path.ends_with("block")
-                        || path.ends_with("sparse_index")
+                    path.ends_with("hnsw") || path.ends_with("block") || path.ends_with("root")
                 );
             } else {
                 panic!("Expected hnsw purge to be successful")

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 // These are the files hnswlib writes to disk. This is strong coupling, but we need to know
 // what files to read from disk. We could in the future have the C++ code return the files
 // but ideally we have a rust implementation of hnswlib
-const FILES: [&str; 4] = [
+pub const FILES: [&str; 4] = [
     "header.bin",
     "data_level0.bin",
     "length.bin",

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -162,7 +162,7 @@ impl HnswIndexProvider {
         }
     }
 
-    fn format_key(&self, prefix_path: &str, id: &IndexUuid, file: &str) -> String {
+    pub fn format_key(prefix_path: &str, id: &IndexUuid, file: &str) -> String {
         // For legacy collections, prefix_path will be empty.
         if prefix_path.is_empty() {
             return format!("hnsw/{}/{}", id, file);
@@ -282,7 +282,7 @@ impl HnswIndexProvider {
                 tracing::trace_span!(parent: Span::current(), "Read bytes from s3", file = file);
             let buf = s3_fetch_span
                 .in_scope(|| async {
-                    let key = self.format_key(prefix_path, source_id, file);
+                    let key = Self::format_key(prefix_path, source_id, file);
                     tracing::info!("Loading hnsw index file: {} into directory", key);
                     let bytes_res = self
                         .storage
@@ -485,7 +485,7 @@ impl HnswIndexProvider {
         let index_storage_path = self.temporary_storage_path.join(id.to_string());
         for file in FILES.iter() {
             let file_path = index_storage_path.join(file);
-            let key = self.format_key(prefix_path, id, file);
+            let key = Self::format_key(prefix_path, id, file);
             let res = self
                 .storage
                 .put_file(

--- a/rust/index/src/metadata/types.rs
+++ b/rust/index/src/metadata/types.rs
@@ -702,7 +702,10 @@ impl<'me> MetadataIndexReader<'me> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use chroma_blockstore::{provider::BlockfileProvider, BlockfileWriterOptions};
+    use chroma_blockstore::{
+        arrow::provider::BlockfileReaderOptions, provider::BlockfileProvider,
+        BlockfileWriterOptions,
+    };
 
     #[tokio::test]
     async fn test_new_string_writer() {
@@ -753,7 +756,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -762,8 +765,9 @@ mod test {
         let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<&str, RoaringBitmap>(&writer_id)
+            .read::<&str, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_string(blockfile_reader);
@@ -774,7 +778,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -783,8 +787,9 @@ mod test {
         let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -795,7 +800,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -804,8 +809,9 @@ mod test {
         let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -816,7 +822,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -825,8 +831,9 @@ mod test {
         let flusher = md_writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<bool, RoaringBitmap>(&writer_id)
+            .read::<bool, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let _reader = MetadataIndexReader::new_bool(blockfile_reader);
@@ -837,7 +844,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -847,8 +854,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<&str, RoaringBitmap>(&writer_id)
+            .read::<&str, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_string(blockfile_reader);
@@ -862,7 +870,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -872,8 +880,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -887,7 +896,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -897,8 +906,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -912,7 +922,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -922,8 +932,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<bool, RoaringBitmap>(&writer_id)
+            .read::<bool, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_bool(blockfile_reader);
@@ -937,7 +948,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<&str, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -950,8 +961,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<&str, RoaringBitmap>(&writer_id)
+            .read::<&str, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_string(blockfile_reader);
@@ -970,7 +982,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -983,8 +995,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1003,7 +1016,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1016,8 +1029,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1036,7 +1050,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<bool, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1049,8 +1063,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<bool, RoaringBitmap>(&writer_id)
+            .read::<bool, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_bool(blockfile_reader);
@@ -1069,7 +1084,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1083,8 +1098,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1106,7 +1122,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1120,8 +1136,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1144,7 +1161,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1158,8 +1175,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1181,7 +1199,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<u32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1195,8 +1213,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<u32, RoaringBitmap>(&writer_id)
+            .read::<u32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_u32(blockfile_reader);
@@ -1219,7 +1238,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1233,8 +1252,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1257,7 +1277,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1271,8 +1291,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1296,7 +1317,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1310,8 +1331,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);
@@ -1333,7 +1355,7 @@ mod test {
         let provider = BlockfileProvider::new_memory();
         let prefix_path = String::from("");
         let blockfile_writer = provider
-            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path))
+            .write::<f32, RoaringBitmap>(BlockfileWriterOptions::new(prefix_path.clone()))
             .await
             .unwrap();
         let writer_id = blockfile_writer.id();
@@ -1347,8 +1369,9 @@ mod test {
         let flusher = writer.commit().await.unwrap();
         flusher.flush().await.unwrap();
 
+        let reader_options = BlockfileReaderOptions::new(writer_id, prefix_path);
         let blockfile_reader = provider
-            .read::<f32, RoaringBitmap>(&writer_id)
+            .read::<f32, RoaringBitmap>(reader_options)
             .await
             .unwrap();
         let reader = MetadataIndexReader::new_f32(blockfile_reader);

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2383,7 +2383,7 @@ impl SpannIndexFlusher {
             versions_map_id: self.versions_map_flusher.id(),
             max_head_id_id: self.max_head_id_flusher.id(),
             hnsw_id: self.hnsw_flusher.index_id,
-            prefix_path: self.max_head_id_flusher.prefix_path(),
+            prefix_path: self.max_head_id_flusher.prefix_path().to_string(),
         };
         let attribute = &[KeyValue::new(
             "collection_id",

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2371,6 +2371,7 @@ pub struct SpannIndexIds {
     pub versions_map_id: Uuid,
     pub max_head_id_id: Uuid,
     pub hnsw_id: IndexUuid,
+    pub prefix_path: String,
 }
 
 impl SpannIndexFlusher {
@@ -2380,6 +2381,7 @@ impl SpannIndexFlusher {
             versions_map_id: self.versions_map_flusher.id(),
             max_head_id_id: self.max_head_id_flusher.id(),
             hnsw_id: self.hnsw_flusher.index_id,
+            prefix_path: self.max_head_id_flusher.prefix_path(),
         };
         let attribute = &[KeyValue::new(
             "collection_id",

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -535,9 +535,8 @@ impl SpannIndexWriter {
     async fn fork_postings_list(
         blockfile_id: &Uuid,
         blockfile_provider: &BlockfileProvider,
+        prefix_path: String,
     ) -> Result<BlockfileWriter, SpannIndexWriterError> {
-        // TODO(Sanket-temp): Change this suitably
-        let prefix_path = String::from("");
         let mut bf_options = BlockfileWriterOptions::new(prefix_path);
         bf_options = bf_options.unordered_mutations();
         bf_options = bf_options.fork(*blockfile_id);
@@ -559,9 +558,8 @@ impl SpannIndexWriter {
 
     async fn create_posting_list(
         blockfile_provider: &BlockfileProvider,
+        prefix_path: String,
     ) -> Result<BlockfileWriter, SpannIndexWriterError> {
-        // TODO(Sanket-temp): Change this suitably
-        let prefix_path = String::from("");
         let mut bf_options = BlockfileWriterOptions::new(prefix_path);
         bf_options = bf_options.unordered_mutations();
         match blockfile_provider
@@ -584,6 +582,7 @@ impl SpannIndexWriter {
         posting_list_id: Option<&Uuid>,
         max_head_id_bf_id: Option<&Uuid>,
         collection_id: &CollectionUuid,
+        prefix_path: String,
         dimensionality: usize,
         blockfile_provider: &BlockfileProvider,
         params: InternalSpannConfiguration,
@@ -629,9 +628,10 @@ impl SpannIndexWriter {
         // Fork the posting list writer.
         let posting_list_writer = match posting_list_id {
             Some(posting_list_id) => {
-                Self::fork_postings_list(posting_list_id, blockfile_provider).await?
+                Self::fork_postings_list(posting_list_id, blockfile_provider, prefix_path.clone())
+                    .await?
             }
-            None => Self::create_posting_list(blockfile_provider).await?,
+            None => Self::create_posting_list(blockfile_provider, prefix_path).await?,
         };
 
         let max_head_id = match max_head_id_bf_id {
@@ -2753,6 +2753,7 @@ mod tests {
         )
         .await
         .expect("Error converting config to gc context");
+        let prefix_path = String::from("block/");
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -2760,6 +2761,7 @@ mod tests {
             None,
             None,
             &collection_id,
+            prefix_path,
             dimensionality,
             &blockfile_provider,
             params,
@@ -2965,6 +2967,7 @@ mod tests {
         )
         .await
         .expect("Error converting config to gc context");
+        let prefix_path = String::from("block/");
         let mut writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -2972,6 +2975,7 @@ mod tests {
             None,
             None,
             &collection_id,
+            prefix_path,
             dimensionality,
             &blockfile_provider,
             params,
@@ -3212,6 +3216,7 @@ mod tests {
         )
         .await
         .expect("Error converting config to gc context");
+        let prefix_path = String::from("block/");
         let mut writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -3219,6 +3224,7 @@ mod tests {
             None,
             None,
             &collection_id,
+            prefix_path,
             dimensionality,
             &blockfile_provider,
             params,
@@ -3427,6 +3433,7 @@ mod tests {
         )
         .await
         .expect("Error converting config to gc context");
+        let prefix_path = String::from("block/");
         let writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -3434,6 +3441,7 @@ mod tests {
             None,
             None,
             &collection_id,
+            prefix_path,
             dimensionality,
             &blockfile_provider,
             params,
@@ -3685,6 +3693,7 @@ mod tests {
         )
         .await
         .expect("Error converting config to gc context");
+        let prefix_path = String::from("block/");
         let mut writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -3692,6 +3701,7 @@ mod tests {
             None,
             None,
             &collection_id,
+            prefix_path,
             dimensionality,
             &blockfile_provider,
             params,
@@ -3980,6 +3990,7 @@ mod tests {
             )
             .await
             .expect("Error converting config to gc context");
+            let prefix_path = String::from("block/");
             let writer = SpannIndexWriter::from_id(
                 &hnsw_provider,
                 None,
@@ -3987,6 +3998,7 @@ mod tests {
                 None,
                 None,
                 &collection_id,
+                prefix_path,
                 dimensionality,
                 &blockfile_provider,
                 params,
@@ -4091,6 +4103,7 @@ mod tests {
             )
             .await
             .expect("Error converting config to gc context");
+            let prefix_path = String::from("block/");
             let writer = SpannIndexWriter::from_id(
                 &hnsw_provider,
                 None,
@@ -4098,6 +4111,7 @@ mod tests {
                 None,
                 None,
                 &collection_id,
+                prefix_path,
                 dimensionality,
                 &blockfile_provider,
                 params,
@@ -4226,6 +4240,7 @@ mod tests {
                 let blockfile_provider =
                     new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
                 let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
+                let prefix_path = String::from("block/");
                 let writer = SpannIndexWriter::from_id(
                     &hnsw_provider,
                     hnsw_path.as_ref(),
@@ -4233,6 +4248,7 @@ mod tests {
                     pl_path.as_ref(),
                     max_bf_id_path.as_ref(),
                     &collection_id,
+                    prefix_path,
                     dimensionality,
                     &blockfile_provider,
                     params.clone(),
@@ -4364,6 +4380,7 @@ mod tests {
                 let blockfile_provider =
                     new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
                 let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
+                let prefix_path = String::from("block/");
                 let writer = SpannIndexWriter::from_id(
                     &hnsw_provider,
                     hnsw_path.as_ref(),
@@ -4371,6 +4388,7 @@ mod tests {
                     pl_path.as_ref(),
                     max_bf_id_path.as_ref(),
                     &collection_id,
+                    prefix_path,
                     dimensionality,
                     &blockfile_provider,
                     params.clone(),
@@ -4523,6 +4541,7 @@ mod tests {
                 let blockfile_provider =
                     new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
                 let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
+                let prefix_path = String::from("block/");
                 let writer = SpannIndexWriter::from_id(
                     &hnsw_provider,
                     hnsw_path.as_ref(),
@@ -4530,6 +4549,7 @@ mod tests {
                     pl_path.as_ref(),
                     max_bf_id_path.as_ref(),
                     &collection_id,
+                    prefix_path,
                     dimensionality,
                     &blockfile_provider,
                     params.clone(),
@@ -4638,6 +4658,7 @@ mod tests {
             let blockfile_provider =
                 new_blockfile_provider_for_tests(max_block_size_bytes, storage.clone());
             let hnsw_provider = new_hnsw_provider_for_tests(storage.clone(), &tmp_dir);
+            let prefix_path = String::from("block/");
             let writer = SpannIndexWriter::from_id(
                 &hnsw_provider,
                 hnsw_path.as_ref(),
@@ -4645,6 +4666,7 @@ mod tests {
                 pl_path.as_ref(),
                 max_bf_id_path.as_ref(),
                 &collection_id,
+                prefix_path,
                 dimensionality,
                 &blockfile_provider,
                 params.clone(),
@@ -4756,6 +4778,7 @@ mod tests {
                 count += 1;
             }
             assert_eq!(results.len(), count);
+            let prefix_path = String::from("block/");
             // After GC, it should return the same result.
             let mut writer = SpannIndexWriter::from_id(
                 &hnsw_provider,
@@ -4764,6 +4787,7 @@ mod tests {
                 pl_path.as_ref(),
                 max_bf_id_path.as_ref(),
                 &collection_id,
+                prefix_path,
                 dimensionality,
                 &blockfile_provider,
                 params,

--- a/rust/index/src/spann/utils.rs
+++ b/rust/index/src/spann/utils.rs
@@ -538,6 +538,7 @@ pub async fn rng_query(
         let allowed_ids = vec![];
         let disallowed_ids = vec![];
         let (ids, distances) = read_guard
+            .hnsw_index
             .query(normalized_query, k, &allowed_ids, &disallowed_ids)
             .map_err(|_| RngQueryError::HnswSearchError)?;
         for (id, distance) in ids.iter().zip(distances.iter()) {
@@ -549,6 +550,7 @@ pub async fn rng_query(
         // Get the embeddings also for distance computation.
         for id in nearby_ids.iter() {
             let emb = read_guard
+                .hnsw_index
                 .get(*id)
                 .map_err(|_| RngQueryError::HnswSearchError)?
                 .ok_or(RngQueryError::HnswSearchError)?;

--- a/rust/index/src/types.rs
+++ b/rust/index/src/types.rs
@@ -2,8 +2,6 @@ use chroma_distance::DistanceFunction;
 use chroma_error::ChromaError;
 use uuid::Uuid;
 
-pub const HNSW_INDEX_S3_PREFIX: &str = "hnsw/";
-
 #[derive(Clone, Debug)]
 pub struct IndexConfig {
     pub dimensionality: i32,

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -1,3 +1,5 @@
+use crate::types::ChromaSegmentFlusher;
+
 use super::blockfile_record::ApplyMaterializedLogError;
 use super::blockfile_record::RecordSegmentReader;
 use super::types::MaterializeLogsResult;
@@ -814,10 +816,9 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             FULL_TEXT_PLS.to_string(),
-            vec![format!(
-                "{}/{}",
-                prefix_path.clone(),
-                full_text_pls_id.to_string()
+            vec![ChromaSegmentFlusher::flush_key(
+                &prefix_path,
+                &full_text_pls_id,
             )],
         );
 
@@ -827,10 +828,9 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             BOOL_METADATA.to_string(),
-            vec![format!(
-                "{}/{}",
-                prefix_path.clone(),
-                bool_metadata_id.to_string()
+            vec![ChromaSegmentFlusher::flush_key(
+                &prefix_path,
+                &bool_metadata_id,
             )],
         );
 
@@ -840,10 +840,9 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             F32_METADATA.to_string(),
-            vec![format!(
-                "{}/{}",
-                prefix_path.clone(),
-                f32_metadata_id.to_string()
+            vec![ChromaSegmentFlusher::flush_key(
+                &prefix_path,
+                &f32_metadata_id,
             )],
         );
 
@@ -853,10 +852,9 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             U32_METADATA.to_string(),
-            vec![format!(
-                "{}/{}",
-                prefix_path.clone(),
-                u32_metadata_id.to_string()
+            vec![ChromaSegmentFlusher::flush_key(
+                &prefix_path,
+                &u32_metadata_id,
             )],
         );
 
@@ -866,10 +864,9 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             STRING_METADATA.to_string(),
-            vec![format!(
-                "{}/{}",
-                prefix_path.clone(),
-                string_metadata_id.to_string()
+            vec![ChromaSegmentFlusher::flush_key(
+                &prefix_path,
+                &string_metadata_id,
             )],
         );
 

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -799,6 +799,7 @@ impl Debug for MetadataSegmentFlusher {
 
 impl MetadataSegmentFlusher {
     pub async fn flush(self) -> Result<HashMap<String, Vec<String>>, Box<dyn ChromaError>> {
+        let prefix_path = self.full_text_index_flusher.prefix_path();
         let full_text_pls_id = self.full_text_index_flusher.pls_id();
         let string_metadata_id = self.string_metadata_index_flusher.id();
         let bool_metadata_id = self.bool_metadata_index_flusher.id();
@@ -813,7 +814,11 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             FULL_TEXT_PLS.to_string(),
-            vec![full_text_pls_id.to_string()],
+            vec![format!(
+                "{}/{}",
+                prefix_path.clone(),
+                full_text_pls_id.to_string()
+            )],
         );
 
         match self.bool_metadata_index_flusher.flush().await {
@@ -822,20 +827,38 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             BOOL_METADATA.to_string(),
-            vec![bool_metadata_id.to_string()],
+            vec![format!(
+                "{}/{}",
+                prefix_path.clone(),
+                bool_metadata_id.to_string()
+            )],
         );
 
         match self.f32_metadata_index_flusher.flush().await {
             Ok(_) => {}
             Err(e) => return Err(Box::new(e)),
         }
-        flushed.insert(F32_METADATA.to_string(), vec![f32_metadata_id.to_string()]);
+        flushed.insert(
+            F32_METADATA.to_string(),
+            vec![format!(
+                "{}/{}",
+                prefix_path.clone(),
+                f32_metadata_id.to_string()
+            )],
+        );
 
         match self.u32_metadata_index_flusher.flush().await {
             Ok(_) => {}
             Err(e) => return Err(Box::new(e)),
         }
-        flushed.insert(U32_METADATA.to_string(), vec![u32_metadata_id.to_string()]);
+        flushed.insert(
+            U32_METADATA.to_string(),
+            vec![format!(
+                "{}/{}",
+                prefix_path.clone(),
+                u32_metadata_id.to_string()
+            )],
+        );
 
         match self.string_metadata_index_flusher.flush().await {
             Ok(_) => {}
@@ -843,7 +866,11 @@ impl MetadataSegmentFlusher {
         }
         flushed.insert(
             STRING_METADATA.to_string(),
-            vec![string_metadata_id.to_string()],
+            vec![format!(
+                "{}/{}",
+                prefix_path.clone(),
+                string_metadata_id.to_string()
+            )],
         );
 
         Ok(flushed)

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -773,7 +773,7 @@ impl Debug for MetadataSegmentFlusher {
 
 impl MetadataSegmentFlusher {
     pub async fn flush(self) -> Result<HashMap<String, Vec<String>>, Box<dyn ChromaError>> {
-        let prefix_path = self.full_text_index_flusher.prefix_path();
+        let prefix_path = self.full_text_index_flusher.prefix_path().to_string();
         let full_text_pls_id = self.full_text_index_flusher.pls_id();
         let string_metadata_id = self.string_metadata_index_flusher.id();
         let bool_metadata_id = self.bool_metadata_index_flusher.id();

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -584,7 +584,7 @@ impl Debug for RecordSegmentFlusher {
 
 impl RecordSegmentFlusher {
     pub async fn flush(self) -> Result<HashMap<String, Vec<String>>, Box<dyn ChromaError>> {
-        let prefix_path = self.user_id_to_id_flusher.prefix_path();
+        let prefix_path = self.user_id_to_id_flusher.prefix_path().to_string();
         let user_id_to_id_bf_id = self.user_id_to_id_flusher.id();
         let id_to_user_id_bf_id = self.id_to_user_id_flusher.id();
         let id_to_data_bf_id = self.id_to_data_flusher.id();

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -1,3 +1,5 @@
+use crate::types::ChromaSegmentFlusher;
+
 use super::distributed_spann::SpannSegmentWriterError;
 use super::types::{HydratedMaterializedLogRecord, LogMaterializerError, MaterializeLogsResult};
 use chroma_blockstore::arrow::provider::BlockfileReaderOptions;
@@ -615,10 +617,9 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     USER_ID_TO_OFFSET_ID.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        prefix_path.clone(),
-                        user_id_to_id_bf_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &prefix_path,
+                        &user_id_to_id_bf_id,
                     )],
                 );
             }
@@ -631,10 +632,9 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     OFFSET_ID_TO_USER_ID.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        prefix_path.clone(),
-                        id_to_user_id_bf_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &prefix_path,
+                        &id_to_user_id_bf_id,
                     )],
                 );
             }
@@ -647,10 +647,9 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     OFFSET_ID_TO_DATA.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        prefix_path.clone(),
-                        id_to_data_bf_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &prefix_path,
+                        &id_to_data_bf_id,
                     )],
                 );
             }
@@ -663,10 +662,9 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     MAX_OFFSET_ID.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        prefix_path.clone(),
-                        max_offset_id_bf_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &prefix_path,
+                        &max_offset_id_bf_id,
                     )],
                 );
             }

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -599,6 +599,7 @@ impl Debug for RecordSegmentFlusher {
 
 impl RecordSegmentFlusher {
     pub async fn flush(self) -> Result<HashMap<String, Vec<String>>, Box<dyn ChromaError>> {
+        let prefix_path = self.user_id_to_id_flusher.prefix_path();
         let user_id_to_id_bf_id = self.user_id_to_id_flusher.id();
         let id_to_user_id_bf_id = self.id_to_user_id_flusher.id();
         let id_to_data_bf_id = self.id_to_data_flusher.id();
@@ -614,7 +615,11 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     USER_ID_TO_OFFSET_ID.to_string(),
-                    vec![user_id_to_id_bf_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        prefix_path.clone(),
+                        user_id_to_id_bf_id.to_string()
+                    )],
                 );
             }
             Err(e) => {
@@ -626,7 +631,11 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     OFFSET_ID_TO_USER_ID.to_string(),
-                    vec![id_to_user_id_bf_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        prefix_path.clone(),
+                        id_to_user_id_bf_id.to_string()
+                    )],
                 );
             }
             Err(e) => {
@@ -638,7 +647,11 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     OFFSET_ID_TO_DATA.to_string(),
-                    vec![id_to_data_bf_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        prefix_path.clone(),
+                        id_to_data_bf_id.to_string()
+                    )],
                 );
             }
             Err(e) => {
@@ -650,7 +663,11 @@ impl RecordSegmentFlusher {
             Ok(_) => {
                 flushed_files.insert(
                     MAX_OFFSET_ID.to_string(),
-                    vec![max_offset_id_bf_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        prefix_path.clone(),
+                        max_offset_id_bf_id.to_string()
+                    )],
                 );
             }
             Err(e) => {

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -13,7 +13,6 @@ use chroma_types::{MaterializedLogOperation, Segment};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use thiserror::Error;
-use uuid::Uuid;
 
 const HNSW_INDEX: &str = "hnsw_index";
 
@@ -125,15 +124,8 @@ impl DistributedHNSWSegmentWriter {
                 }
             };
 
-            let (prefix_path, index_id) = Segment::extract_prefix_and_id(index_path);
-            let index_uuid = match Uuid::parse_str(index_id) {
-                Ok(uuid) => uuid,
-                Err(_) => {
-                    return Err(Box::new(
-                        DistributedHNSWSegmentFromSegmentError::InvalidUUID,
-                    ))
-                }
-            };
+            let (prefix_path, index_uuid) = Segment::extract_prefix_and_id(index_path)
+                .map_err(|_| Box::new(DistributedHNSWSegmentFromSegmentError::InvalidUUID))?;
             let index_uuid = IndexUuid(index_uuid);
 
             let index = match hnsw_index_provider
@@ -349,15 +341,8 @@ impl DistributedHNSWSegmentReader {
                 }
             };
 
-            let (prefix_path, index_id) = Segment::extract_prefix_and_id(index_path);
-            let index_uuid = match Uuid::parse_str(index_id) {
-                Ok(uuid) => uuid,
-                Err(_) => {
-                    return Err(Box::new(
-                        DistributedHNSWSegmentFromSegmentError::InvalidUUID,
-                    ))
-                }
-            };
+            let (prefix_path, index_uuid) = Segment::extract_prefix_and_id(index_path)
+                .map_err(|_| Box::new(DistributedHNSWSegmentFromSegmentError::InvalidUUID))?;
             let index_uuid = IndexUuid(index_uuid);
             let index = match hnsw_index_provider
                 .open(

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -277,10 +277,11 @@ impl DistributedHNSWSegmentWriter {
             Ok(_) => {}
             Err(e) => return Err(e),
         }
-        // TODO(Sanket-temp): Use path prefix here as well so that can register
-        // with sysdb correctly.
         let mut flushed_files = HashMap::new();
-        flushed_files.insert(HNSW_INDEX.to_string(), vec![hnsw_index_id.to_string()]);
+        flushed_files.insert(
+            HNSW_INDEX.to_string(),
+            vec![format!("{}/{}", prefix_path, hnsw_index_id.to_string())],
+        );
         Ok(flushed_files)
     }
 

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -1,3 +1,5 @@
+use crate::types::ChromaSegmentFlusher;
+
 use super::blockfile_record::{ApplyMaterializedLogError, RecordSegmentReader};
 use super::types::MaterializeLogsResult;
 use chroma_error::{ChromaError, ErrorCodes};
@@ -280,7 +282,10 @@ impl DistributedHNSWSegmentWriter {
         let mut flushed_files = HashMap::new();
         flushed_files.insert(
             HNSW_INDEX.to_string(),
-            vec![format!("{}/{}", prefix_path, hnsw_index_id.to_string())],
+            vec![ChromaSegmentFlusher::flush_key(
+                &prefix_path,
+                &hnsw_index_id.0,
+            )],
         );
         Ok(flushed_files)
     }

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -1,6 +1,3 @@
-use crate::types::construct_prefix_path;
-use crate::types::extract_prefix_and_id;
-
 use super::blockfile_record::ApplyMaterializedLogError;
 use super::blockfile_record::RecordSegmentReader;
 use super::types::{
@@ -116,7 +113,7 @@ impl SpannSegmentWriter {
         let (hnsw_id, segment_prefix_hnsw) = match segment.file_path.get(HNSW_PATH) {
             Some(hnsw_path) => match hnsw_path.first() {
                 Some(index_path) => {
-                    let (prefix, index_id) = extract_prefix_and_id(index_path);
+                    let (prefix, index_id) = Segment::extract_prefix_and_id(index_path);
                     let index_uuid = match Uuid::parse_str(index_id) {
                         Ok(uuid) => uuid,
                         Err(e) => {
@@ -134,7 +131,7 @@ impl SpannSegmentWriter {
         let (versions_map_id, segment_prefix_vf) = match segment.file_path.get(VERSION_MAP_PATH) {
             Some(version_map_paths) => match version_map_paths.first() {
                 Some(version_map_path) => {
-                    let (prefix, version_map_id) = extract_prefix_and_id(version_map_path);
+                    let (prefix, version_map_id) = Segment::extract_prefix_and_id(version_map_path);
                     let version_map_uuid = match Uuid::parse_str(version_map_id) {
                         Ok(uuid) => uuid,
                         Err(e) => {
@@ -155,7 +152,8 @@ impl SpannSegmentWriter {
         let (posting_list_id, segment_prefix_pl) = match segment.file_path.get(POSTING_LIST_PATH) {
             Some(posting_list_paths) => match posting_list_paths.first() {
                 Some(posting_list_path) => {
-                    let (prefix, posting_list_id) = extract_prefix_and_id(posting_list_path);
+                    let (prefix, posting_list_id) =
+                        Segment::extract_prefix_and_id(posting_list_path);
                     let posting_list_uuid = match Uuid::parse_str(posting_list_id) {
                         Ok(uuid) => uuid,
                         Err(e) => {
@@ -179,7 +177,7 @@ impl SpannSegmentWriter {
                 Some(max_head_id_bf_paths) => match max_head_id_bf_paths.first() {
                     Some(max_head_id_bf_path) => {
                         let (prefix, max_head_id_bf_id) =
-                            extract_prefix_and_id(max_head_id_bf_path);
+                            Segment::extract_prefix_and_id(max_head_id_bf_path);
                         let max_head_id_bf_uuid = match Uuid::parse_str(max_head_id_bf_id) {
                             Ok(uuid) => uuid,
                             Err(e) => {
@@ -200,12 +198,7 @@ impl SpannSegmentWriter {
 
         let prefix_path = match segment_prefix_hnsw {
             Some(prefix) => prefix,
-            None => construct_prefix_path(
-                &collection.tenant,
-                &collection.database_id,
-                &collection.collection_id,
-                &segment.id,
-            ),
+            None => segment.construct_prefix_path(&collection.tenant, &collection.database_id),
         };
         let index_writer = match SpannIndexWriter::from_id(
             hnsw_provider,
@@ -472,7 +465,7 @@ impl<'me> SpannSegmentReader<'me> {
         let (hnsw_id, segment_prefix_hnsw) = match segment.file_path.get(HNSW_PATH) {
             Some(hnsw_path) => match hnsw_path.first() {
                 Some(index_path) => {
-                    let (prefix, index_id) = extract_prefix_and_id(index_path);
+                    let (prefix, index_id) = Segment::extract_prefix_and_id(index_path);
                     let index_uuid = match Uuid::parse_str(index_id) {
                         Ok(uuid) => uuid,
                         Err(e) => {
@@ -490,7 +483,7 @@ impl<'me> SpannSegmentReader<'me> {
         let (versions_map_id, segment_prefix_vf) = match segment.file_path.get(VERSION_MAP_PATH) {
             Some(version_map_paths) => match version_map_paths.first() {
                 Some(version_map_path) => {
-                    let (prefix, version_map_id) = extract_prefix_and_id(version_map_path);
+                    let (prefix, version_map_id) = Segment::extract_prefix_and_id(version_map_path);
                     let version_map_uuid = match Uuid::parse_str(version_map_id) {
                         Ok(uuid) => uuid,
                         Err(e) => {
@@ -511,7 +504,8 @@ impl<'me> SpannSegmentReader<'me> {
         let (posting_list_id, segment_prefix_pl) = match segment.file_path.get(POSTING_LIST_PATH) {
             Some(posting_list_paths) => match posting_list_paths.first() {
                 Some(posting_list_path) => {
-                    let (prefix, posting_list_id) = extract_prefix_and_id(posting_list_path);
+                    let (prefix, posting_list_id) =
+                        Segment::extract_prefix_and_id(posting_list_path);
                     let posting_list_uuid = match Uuid::parse_str(posting_list_id) {
                         Ok(uuid) => uuid,
                         Err(e) => {
@@ -532,12 +526,7 @@ impl<'me> SpannSegmentReader<'me> {
 
         let prefix_path = match segment_prefix_hnsw {
             Some(prefix) => prefix,
-            None => construct_prefix_path(
-                &collection.tenant,
-                &collection.database_id,
-                &collection.collection_id,
-                &segment.id,
-            ),
+            None => segment.construct_prefix_path(&collection.tenant, &collection.database_id),
         };
 
         let index_reader = match SpannIndexReader::from_id(

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -1,3 +1,5 @@
+use crate::types::construct_prefix_path;
+
 use super::blockfile_record::ApplyMaterializedLogError;
 use super::blockfile_record::RecordSegmentReader;
 use super::types::{
@@ -102,6 +104,12 @@ impl SpannSegmentWriter {
         if segment.r#type != SegmentType::Spann || segment.scope != SegmentScope::VECTOR {
             return Err(SpannSegmentWriterError::InvalidArgument);
         }
+        let prefix_path = construct_prefix_path(
+            &collection.tenant,
+            &collection.database_id,
+            &collection.collection_id,
+            &segment.id,
+        );
         let params = collection
             .config
             .get_spann_config()
@@ -184,6 +192,7 @@ impl SpannSegmentWriter {
             posting_list_id.as_ref(),
             max_head_id_bf_id.as_ref(),
             &segment.collection,
+            prefix_path,
             dimensionality,
             blockfile_provider,
             params,

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -371,18 +371,37 @@ impl SpannSegmentFlusher {
             Err(e) => Err(Box::new(e)),
             Ok(index_ids) => {
                 let mut index_id_map = HashMap::new();
-                index_id_map.insert(HNSW_PATH.to_string(), vec![index_ids.hnsw_id.to_string()]);
+                index_id_map.insert(
+                    HNSW_PATH.to_string(),
+                    vec![format!(
+                        "{}/{}",
+                        index_ids.prefix_path.clone(),
+                        index_ids.hnsw_id.to_string()
+                    )],
+                );
                 index_id_map.insert(
                     VERSION_MAP_PATH.to_string(),
-                    vec![index_ids.versions_map_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        index_ids.prefix_path.clone(),
+                        index_ids.versions_map_id.to_string()
+                    )],
                 );
                 index_id_map.insert(
                     POSTING_LIST_PATH.to_string(),
-                    vec![index_ids.pl_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        index_ids.prefix_path.clone(),
+                        index_ids.pl_id.to_string()
+                    )],
                 );
                 index_id_map.insert(
                     MAX_HEAD_ID_BF_PATH.to_string(),
-                    vec![index_ids.max_head_id_id.to_string()],
+                    vec![format!(
+                        "{}/{}",
+                        index_ids.prefix_path.clone(),
+                        index_ids.max_head_id_id.to_string()
+                    )],
                 );
                 tracing::info!(
                     "Flushed file paths for spann segment flusher {:?}",

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -1,3 +1,5 @@
+use crate::types::ChromaSegmentFlusher;
+
 use super::blockfile_record::ApplyMaterializedLogError;
 use super::blockfile_record::RecordSegmentReader;
 use super::types::{
@@ -373,34 +375,30 @@ impl SpannSegmentFlusher {
                 let mut index_id_map = HashMap::new();
                 index_id_map.insert(
                     HNSW_PATH.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        index_ids.prefix_path.clone(),
-                        index_ids.hnsw_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &index_ids.prefix_path,
+                        &index_ids.hnsw_id.0,
                     )],
                 );
                 index_id_map.insert(
                     VERSION_MAP_PATH.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        index_ids.prefix_path.clone(),
-                        index_ids.versions_map_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &index_ids.prefix_path,
+                        &index_ids.versions_map_id,
                     )],
                 );
                 index_id_map.insert(
                     POSTING_LIST_PATH.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        index_ids.prefix_path.clone(),
-                        index_ids.pl_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &index_ids.prefix_path,
+                        &index_ids.pl_id,
                     )],
                 );
                 index_id_map.insert(
                     MAX_HEAD_ID_BF_PATH.to_string(),
-                    vec![format!(
-                        "{}/{}",
-                        index_ids.prefix_path.clone(),
-                        index_ids.max_head_id_id.to_string()
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &index_ids.prefix_path,
+                        &index_ids.max_head_id_id,
                     )],
                 );
                 tracing::info!(

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -28,7 +28,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use thiserror::Error;
-use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct SpannSegmentWriter {
@@ -115,13 +114,8 @@ impl SpannSegmentWriter {
         let (hnsw_id, segment_prefix_hnsw) = match segment.file_path.get(HNSW_PATH) {
             Some(hnsw_path) => match hnsw_path.first() {
                 Some(index_path) => {
-                    let (prefix, index_id) = Segment::extract_prefix_and_id(index_path);
-                    let index_uuid = match Uuid::parse_str(index_id) {
-                        Ok(uuid) => uuid,
-                        Err(e) => {
-                            return Err(SpannSegmentWriterError::IndexIdParsingError(e));
-                        }
-                    };
+                    let (prefix, index_uuid) = Segment::extract_prefix_and_id(index_path)
+                        .map_err(SpannSegmentWriterError::IndexIdParsingError)?;
                     (Some(IndexUuid(index_uuid)), Some(prefix.to_string()))
                 }
                 None => {
@@ -133,13 +127,9 @@ impl SpannSegmentWriter {
         let (versions_map_id, segment_prefix_vf) = match segment.file_path.get(VERSION_MAP_PATH) {
             Some(version_map_paths) => match version_map_paths.first() {
                 Some(version_map_path) => {
-                    let (prefix, version_map_id) = Segment::extract_prefix_and_id(version_map_path);
-                    let version_map_uuid = match Uuid::parse_str(version_map_id) {
-                        Ok(uuid) => uuid,
-                        Err(e) => {
-                            return Err(SpannSegmentWriterError::IndexIdParsingError(e));
-                        }
-                    };
+                    let (prefix, version_map_uuid) =
+                        Segment::extract_prefix_and_id(version_map_path)
+                            .map_err(SpannSegmentWriterError::IndexIdParsingError)?;
                     (Some(version_map_uuid), Some(prefix.to_string()))
                 }
                 None => {
@@ -154,14 +144,9 @@ impl SpannSegmentWriter {
         let (posting_list_id, segment_prefix_pl) = match segment.file_path.get(POSTING_LIST_PATH) {
             Some(posting_list_paths) => match posting_list_paths.first() {
                 Some(posting_list_path) => {
-                    let (prefix, posting_list_id) =
-                        Segment::extract_prefix_and_id(posting_list_path);
-                    let posting_list_uuid = match Uuid::parse_str(posting_list_id) {
-                        Ok(uuid) => uuid,
-                        Err(e) => {
-                            return Err(SpannSegmentWriterError::IndexIdParsingError(e));
-                        }
-                    };
+                    let (prefix, posting_list_uuid) =
+                        Segment::extract_prefix_and_id(posting_list_path)
+                            .map_err(SpannSegmentWriterError::IndexIdParsingError)?;
                     (Some(posting_list_uuid), Some(prefix.to_string()))
                 }
                 None => {
@@ -178,14 +163,9 @@ impl SpannSegmentWriter {
             match segment.file_path.get(MAX_HEAD_ID_BF_PATH) {
                 Some(max_head_id_bf_paths) => match max_head_id_bf_paths.first() {
                     Some(max_head_id_bf_path) => {
-                        let (prefix, max_head_id_bf_id) =
-                            Segment::extract_prefix_and_id(max_head_id_bf_path);
-                        let max_head_id_bf_uuid = match Uuid::parse_str(max_head_id_bf_id) {
-                            Ok(uuid) => uuid,
-                            Err(e) => {
-                                return Err(SpannSegmentWriterError::IndexIdParsingError(e));
-                            }
-                        };
+                        let (prefix, max_head_id_bf_uuid) =
+                            Segment::extract_prefix_and_id(max_head_id_bf_path)
+                                .map_err(SpannSegmentWriterError::IndexIdParsingError)?;
                         (Some(max_head_id_bf_uuid), Some(prefix.to_string()))
                     }
                     None => {
@@ -482,13 +462,8 @@ impl<'me> SpannSegmentReader<'me> {
         let (hnsw_id, segment_prefix_hnsw) = match segment.file_path.get(HNSW_PATH) {
             Some(hnsw_path) => match hnsw_path.first() {
                 Some(index_path) => {
-                    let (prefix, index_id) = Segment::extract_prefix_and_id(index_path);
-                    let index_uuid = match Uuid::parse_str(index_id) {
-                        Ok(uuid) => uuid,
-                        Err(e) => {
-                            return Err(SpannSegmentReaderError::IndexIdParsingError(e));
-                        }
-                    };
+                    let (prefix, index_uuid) = Segment::extract_prefix_and_id(index_path)
+                        .map_err(SpannSegmentReaderError::IndexIdParsingError)?;
                     (Some(IndexUuid(index_uuid)), Some(prefix.to_string()))
                 }
                 None => {
@@ -500,13 +475,9 @@ impl<'me> SpannSegmentReader<'me> {
         let (versions_map_id, segment_prefix_vf) = match segment.file_path.get(VERSION_MAP_PATH) {
             Some(version_map_paths) => match version_map_paths.first() {
                 Some(version_map_path) => {
-                    let (prefix, version_map_id) = Segment::extract_prefix_and_id(version_map_path);
-                    let version_map_uuid = match Uuid::parse_str(version_map_id) {
-                        Ok(uuid) => uuid,
-                        Err(e) => {
-                            return Err(SpannSegmentReaderError::IndexIdParsingError(e));
-                        }
-                    };
+                    let (prefix, version_map_uuid) =
+                        Segment::extract_prefix_and_id(version_map_path)
+                            .map_err(SpannSegmentReaderError::IndexIdParsingError)?;
                     (Some(version_map_uuid), Some(prefix.to_string()))
                 }
                 None => {
@@ -521,14 +492,9 @@ impl<'me> SpannSegmentReader<'me> {
         let (posting_list_id, segment_prefix_pl) = match segment.file_path.get(POSTING_LIST_PATH) {
             Some(posting_list_paths) => match posting_list_paths.first() {
                 Some(posting_list_path) => {
-                    let (prefix, posting_list_id) =
-                        Segment::extract_prefix_and_id(posting_list_path);
-                    let posting_list_uuid = match Uuid::parse_str(posting_list_id) {
-                        Ok(uuid) => uuid,
-                        Err(e) => {
-                            return Err(SpannSegmentReaderError::IndexIdParsingError(e));
-                        }
-                    };
+                    let (prefix, posting_list_uuid) =
+                        Segment::extract_prefix_and_id(posting_list_path)
+                            .map_err(SpannSegmentReaderError::IndexIdParsingError)?;
                     (Some(posting_list_uuid), Some(prefix.to_string()))
                 }
                 None => {

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{Instrument, Span};
+use uuid::Uuid;
 
 use crate::distributed_spann::{SpannSegmentFlusher, SpannSegmentWriter};
 
@@ -1039,6 +1040,13 @@ pub enum ChromaSegmentFlusher {
 }
 
 impl ChromaSegmentFlusher {
+    pub fn flush_key(prefix_path: &str, id: &Uuid) -> String {
+        // For legacy collections, prefix_path will be empty.
+        if prefix_path.is_empty() {
+            return id.to_string();
+        }
+        format!("{}/{}", prefix_path, id)
+    }
     pub fn get_id(&self) -> SegmentUuid {
         match self {
             ChromaSegmentFlusher::RecordSegment(flusher) => flusher.id,

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -31,6 +31,13 @@ pub(super) fn construct_prefix_path(
     )
 }
 
+pub(super) fn extract_prefix_and_id(path: &str) -> (&str, &str) {
+    match path.rfind('/') {
+        Some(pos) => (&path[..pos], &path[pos + 1..]),
+        None => ("", path),
+    }
+}
+
 // Materializes metadata from update metadata, populating the delete list
 // and upsert list.
 fn materialize_update_metadata(

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -1,8 +1,8 @@
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::{
-    logical_size_of_metadata, Chunk, CollectionUuid, DataRecord, DatabaseUuid, DeletedMetadata,
-    LogRecord, MaterializedLogOperation, Metadata, MetadataDelta, MetadataValue,
-    MetadataValueConversionError, Operation, SegmentUuid, UpdateMetadata, UpdateMetadataValue,
+    logical_size_of_metadata, Chunk, DataRecord, DeletedMetadata, LogRecord,
+    MaterializedLogOperation, Metadata, MetadataDelta, MetadataValue, MetadataValueConversionError,
+    Operation, SegmentUuid, UpdateMetadata, UpdateMetadataValue,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicU32;
@@ -18,25 +18,6 @@ use super::blockfile_record::{
     RecordSegmentReaderCreationError, RecordSegmentWriter,
 };
 use super::distributed_hnsw::DistributedHNSWSegmentWriter;
-
-pub(super) fn construct_prefix_path(
-    tenant: &str,
-    database_id: &DatabaseUuid,
-    collection_id: &CollectionUuid,
-    segment_id: &SegmentUuid,
-) -> String {
-    format!(
-        "{}/{}/{}/{}",
-        tenant, database_id, collection_id, segment_id
-    )
-}
-
-pub(super) fn extract_prefix_and_id(path: &str) -> (&str, &str) {
-    match path.rfind('/') {
-        Some(pos) => (&path[..pos], &path[pos + 1..]),
-        None => ("", path),
-    }
-}
 
 // Materializes metadata from update metadata, populating the delete list
 // and upsert list.
@@ -1201,6 +1182,9 @@ mod tests {
                             RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
                                 panic!("Error creating record segment reader");
                             }
+                            _ => {
+                                panic!("Unexpected error creating record segment reader: {:?}", e);
+                            }
                         }
                     }
                 };
@@ -1491,6 +1475,9 @@ mod tests {
                             RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
                                 panic!("Error creating record segment reader");
                             }
+                            _ => {
+                                panic!("Unexpected error creating record segment reader: {:?}", e);
+                            }
                         }
                     }
                 };
@@ -1772,6 +1759,9 @@ mod tests {
                             }
                             RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
                                 panic!("Error creating record segment reader");
+                            }
+                            _ => {
+                                panic!("Unexpected error creating record segment reader: {:?}", e);
                             }
                         }
                     }
@@ -2069,6 +2059,9 @@ mod tests {
                             }
                             RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
                                 panic!("Error creating record segment reader");
+                            }
+                            _ => {
+                                panic!("Unexpected error creating record segment reader: {:?}", e);
                             }
                         }
                     }

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -248,6 +248,8 @@ pub enum CollectionConversionError {
     InvalidUuid,
     #[error(transparent)]
     MetadataValueConversionError(#[from] MetadataValueConversionError),
+    #[error("Missing Database Id")]
+    MissingDatabaseId,
 }
 
 impl ChromaError for CollectionConversionError {
@@ -256,6 +258,7 @@ impl ChromaError for CollectionConversionError {
             CollectionConversionError::InvalidConfig(_) => ErrorCodes::InvalidArgument,
             CollectionConversionError::InvalidUuid => ErrorCodes::InvalidArgument,
             CollectionConversionError::MetadataValueConversionError(e) => e.code(),
+            CollectionConversionError::MissingDatabaseId => ErrorCodes::Internal,
         }
     }
 }
@@ -281,11 +284,12 @@ impl TryFrom<chroma_proto::Collection> for Collection {
             }
             None => SystemTime::now(),
         };
-        // TOOD(Sanket): this should be updated to error with "missing field" once all SysDb deployments are up-to-date
         let database_id = match proto_collection.database_id {
             Some(db_id) => DatabaseUuid::from_str(&db_id)
                 .map_err(|_| CollectionConversionError::InvalidUuid)?,
-            None => DatabaseUuid::new(),
+            None => {
+                return Err(CollectionConversionError::MissingDatabaseId);
+            }
         };
         Ok(Collection {
             collection_id,

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -2,7 +2,7 @@ use super::{
     CollectionUuid, Metadata, MetadataValueConversionError, SegmentScope,
     SegmentScopeConversionError,
 };
-use crate::chroma_proto;
+use crate::{chroma_proto, DatabaseUuid};
 use chroma_error::{ChromaError, ErrorCodes};
 use std::{collections::HashMap, str::FromStr};
 use thiserror::Error;
@@ -134,6 +134,17 @@ impl Segment {
             _ => {}
         }
         res
+    }
+
+    pub fn extract_prefix_and_id(path: &str) -> (&str, &str) {
+        match path.rfind('/') {
+            Some(pos) => (&path[..pos], &path[pos + 1..]),
+            None => ("", path),
+        }
+    }
+
+    pub fn construct_prefix_path(&self, tenant: &str, database_id: &DatabaseUuid) -> String {
+        format!("{}/{}/{}/{}", tenant, database_id, self.collection, self.id)
     }
 }
 

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -144,7 +144,10 @@ impl Segment {
     }
 
     pub fn construct_prefix_path(&self, tenant: &str, database_id: &DatabaseUuid) -> String {
-        format!("{}/{}/{}/{}", tenant, database_id, self.collection, self.id)
+        format!(
+            "tenant/{}/database/{}/collection/{}/segment/{}",
+            tenant, database_id, self.collection, self.id
+        )
     }
 }
 

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -136,10 +136,14 @@ impl Segment {
         res
     }
 
-    pub fn extract_prefix_and_id(path: &str) -> (&str, &str) {
-        match path.rfind('/') {
+    pub fn extract_prefix_and_id(path: &str) -> Result<(&str, uuid::Uuid), uuid::Error> {
+        let (prefix, id) = match path.rfind('/') {
             Some(pos) => (&path[..pos], &path[pos + 1..]),
             None => ("", path),
+        };
+        match Uuid::try_parse(id) {
+            Ok(uid) => Ok((prefix, uid)),
+            Err(e) => Err(e),
         }
     }
 
@@ -293,5 +297,51 @@ mod tests {
         let metadata = converted_segment.metadata.unwrap();
         assert_eq!(metadata.len(), 1);
         assert_eq!(metadata.get("foo").unwrap(), &MetadataValue::Int(42));
+    }
+
+    #[test]
+    fn test_segment_construct_prefix_path() {
+        let segment = Segment {
+            id: SegmentUuid(Uuid::nil()),
+            r#type: SegmentType::BlockfileMetadata,
+            scope: SegmentScope::METADATA,
+            collection: CollectionUuid(Uuid::nil()),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+        let tenant = "test_tenant";
+        let database_id = &DatabaseUuid(Uuid::nil());
+        let prefix_path = segment.construct_prefix_path(tenant, database_id);
+        assert_eq!(
+            prefix_path,
+            "tenant/test_tenant/database/00000000-0000-0000-0000-000000000000/collection/00000000-0000-0000-0000-000000000000/segment/00000000-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn test_segment_extract_prefix_and_id() {
+        let path = "tenant/test_tenant/database/00000000-0000-0000-0000-000000000000/collection/00000000-0000-0000-0000-000000000000/segment/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000001";
+        let (prefix, id) =
+            Segment::extract_prefix_and_id(path).expect("Failed to extract prefix and id");
+        assert_eq!(
+            prefix,
+            "tenant/test_tenant/database/00000000-0000-0000-0000-000000000000/collection/00000000-0000-0000-0000-000000000000/segment/00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            id,
+            Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("Cannot happen")
+        );
+    }
+
+    #[test]
+    fn test_segment_extract_prefix_and_id_legacy() {
+        let path = "00000000-0000-0000-0000-000000000001";
+        let (prefix, id) =
+            Segment::extract_prefix_and_id(path).expect("Failed to extract prefix and id");
+        assert_eq!(prefix, "");
+        assert_eq!(
+            id,
+            Uuid::from_str("00000000-0000-0000-0000-000000000001").expect("Cannot happen")
+        );
     }
 }

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -90,7 +90,7 @@ fn add_to_index_and_get_reader<'a>(
         )
         .await
         .expect("Error converting config to gc context");
-        let prefix_path = String::from("block/");
+        let prefix_path = "";
         let mut writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -146,6 +146,7 @@ fn add_to_index_and_get_reader<'a>(
                 Some(&paths.pl_id),
                 Some(&paths.versions_map_id),
                 &blockfile_provider,
+                prefix_path,
             )
             .await
             .expect("Error creating spann index reader"),

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -90,6 +90,7 @@ fn add_to_index_and_get_reader<'a>(
         )
         .await
         .expect("Error converting config to gc context");
+        let prefix_path = String::from("block/");
         let mut writer = SpannIndexWriter::from_id(
             &hnsw_provider,
             None,
@@ -97,6 +98,7 @@ fn add_to_index_and_get_reader<'a>(
             None,
             None,
             &collection_id,
+            prefix_path,
             dimensionality,
             &blockfile_provider,
             params.clone(),

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -709,11 +709,7 @@ mod tests {
             let metadata = entry.metadata().await.expect("Failed to read metadata");
 
             if metadata.is_dir() {
-                assert!(
-                    path.ends_with("hnsw")
-                        || path.ends_with("block")
-                        || path.ends_with("sparse_index")
-                );
+                assert!(path.ends_with("tenant"));
             } else {
                 panic!("Expected hnsw purge to be successful")
             }

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -113,6 +113,10 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
                     RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
                         return Err(CountRecordsError::RecordSegmentCreateError(*e));
                     }
+                    _ => {
+                        tracing::error!("Unexpected error creating record segment reader: {:?}", e);
+                        return Err(CountRecordsError::RecordSegmentCreateError(*e));
+                    }
                 }
             }
         };
@@ -292,6 +296,9 @@ mod tests {
                                 panic!("Error creating record segment reader");
                             }
                             RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
+                                panic!("Error creating record segment reader");
+                            }
+                            _ => {
                                 panic!("Error creating record segment reader");
                             }
                         }

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -1170,6 +1170,9 @@ mod tests {
                             RecordSegmentReaderCreationError::UserRecordNotFound(_) => {
                                 panic!("Error creating record segment reader");
                             }
+                            _ => {
+                                panic!("Unexpected error creating record segment reader: {:?}", e);
+                            }
                         }
                     }
                 };

--- a/rust/worker/src/execution/operators/prefetch_segment.rs
+++ b/rust/worker/src/execution/operators/prefetch_segment.rs
@@ -77,9 +77,13 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
             .segment
             .filepaths_to_prefetch()
             .into_iter()
-            .map(|blockfile_id| async move {
-                let blockfile_id = Uuid::parse_str(&blockfile_id)?;
-                let count = input.blockfile_provider.prefetch(&blockfile_id).await?;
+            .map(|blockfile_path| async move {
+                let (prefix, blockfile_id) = Segment::extract_prefix_and_id(&blockfile_path);
+                let blockfile_id = Uuid::parse_str(blockfile_id)?;
+                let count = input
+                    .blockfile_provider
+                    .prefetch(&blockfile_id, prefix)
+                    .await?;
                 Ok::<_, PrefetchSegmentError>(count)
             })
             .collect::<FuturesUnordered<_>>();

--- a/rust/worker/src/execution/operators/prefetch_segment.rs
+++ b/rust/worker/src/execution/operators/prefetch_segment.rs
@@ -5,7 +5,6 @@ use chroma_types::{Segment, SegmentType};
 use futures::{stream::FuturesUnordered, StreamExt};
 use thiserror::Error;
 use tonic::async_trait;
-use uuid::Uuid;
 
 #[derive(Debug, Default)]
 pub struct PrefetchSegmentOperator {}
@@ -78,8 +77,7 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
             .filepaths_to_prefetch()
             .into_iter()
             .map(|blockfile_path| async move {
-                let (prefix, blockfile_id) = Segment::extract_prefix_and_id(&blockfile_path);
-                let blockfile_id = Uuid::parse_str(blockfile_id)?;
+                let (prefix, blockfile_id) = Segment::extract_prefix_and_id(&blockfile_path)?;
                 let count = input
                     .blockfile_provider
                     .prefetch(&blockfile_id, prefix)


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - In case of existing collections created before this change is deployed, the existing prefix remains i.e. blockfile blocks are read/written to s3 prefix `block/<id>`, Sparse indexes to `sparse_index/<id>` and hnsw to `hnsw/<id>/<file>`
  - For new collections created after this change is deployed, the s3 full path with prefix changes to `tenant/<tenant>/database/<database_id>/collection/<collection_id>/segment/<segment_id>/block/<id>` for blocks, `tenant/<tenant>/database/<database_id>/collection/<collection_id>/segment/<segment_id>/root/<id>` for sparse indexes, `tenant/<tenant>/database/<database_id>/collection/<collection_id>/segment/<segment_id>/hnsw/<id>/<file>` for hnsw files

## Test plan

_How are these changes tested?_
Added new tests + got some existing tests that serve as validation for free. Will babysit staging
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
