### PR TITLE
[ENH] Remove CoreML as a provider for default ef

### DIFF
--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -241,6 +241,13 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
         so.log_severity_level = 3
         so.graph_optimization_level = self.ort.GraphOptimizationLevel.ORT_ENABLE_ALL
 
+        if (
+            self._preferred_providers
+            and "CoreMLExecutionProvider" in self._preferred_providers
+        ):
+            # remove CoreMLExecutionProvider from the list, it is not as well optimized as CPU.
+            self._preferred_providers.remove("CoreMLExecutionProvider")
+
         return self.ort.InferenceSession(
             os.path.join(self.DOWNLOAD_PATH, self.EXTRACTED_FOLDER_NAME, "model.onnx"),
             # Since 1.9 onnyx runtime requires providers to be specified when there are multiple available


### PR DESCRIPTION
## Description of changes

Remove CoreMLExecutionProvider from providers if available, it performs worse than CPU in all scenarios, as it is not optimized for BERT transformers.
## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
