### PR TITLE
[BLD]: speed up test_add.py against cluster

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -139,6 +139,9 @@ jobs:
                     "chromadb/test/property/test_collections_with_database_tenant_overwrite.py",
                     "chromadb/test/distributed/test_sanity.py",
                     "chromadb/test/distributed/test_log_failover.py"]
+        include:
+          - test-globs: "chromadb/test/property/test_add.py"
+            parallelized: true
     runs-on: ${{ matrix.platform }}
     # OIDC token auth for AWS
     permissions:
@@ -157,7 +160,7 @@ jobs:
       - name: Start Tilt services
         uses: ./.github/actions/tilt
       - name: Test
-        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}" --durations 10'
+        run: bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-globs }}" ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} --durations 10'
         shell: bash
         env:
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}

--- a/chromadb/test/api/test_collection.py
+++ b/chromadb/test/api/test_collection.py
@@ -7,6 +7,8 @@ from chromadb.errors import ChromaError, UniqueConstraintError
 def test_duplicate_collection_create(
     client: ClientAPI,
 ) -> None:
+    client.reset()
+
     client.create_collection(
         name="test",
         metadata={"hnsw:construction_ef": 128, "hnsw:search_ef": 128, "hnsw:M": 128},

--- a/chromadb/test/api/test_invalid_update.py
+++ b/chromadb/test/api/test_invalid_update.py
@@ -3,6 +3,8 @@ from chromadb.api import ClientAPI
 
 
 def test_invalid_update(client: ClientAPI) -> None:
+    client.reset()
+
     collection = client.create_collection("test")
 
     # Update is invalid because ID does not exist

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -62,7 +62,7 @@ hypothesis.settings.register_profile(
         hypothesis.HealthCheck.large_base_example,
         hypothesis.HealthCheck.function_scoped_fixture,
     ],
-    verbosity=hypothesis.Verbosity.verbose
+    verbosity=hypothesis.Verbosity.verbose,
 )
 
 hypothesis.settings.register_profile(
@@ -882,12 +882,10 @@ def client(system: System) -> Generator[ClientAPI, None, None]:
 
     if system.settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
         client = cast(Any, AsyncClientCreatorSync.from_system_async(system))
-        client.reset()
         yield client
         client.clear_system_cache()
     else:
         client = ClientCreator.from_system(system)
-        client.reset()
         yield client
         client.clear_system_cache()
 

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -7,9 +7,9 @@ import pytest
 import hypothesis.strategies as st
 from hypothesis import given, settings
 from chromadb.api import ClientAPI
+from chromadb.api.client import AdminClient
 from chromadb.api.types import Embeddings, Metadatas
 from chromadb.test.conftest import (
-    reset,
     NOT_CLUSTER_ONLY,
     override_hypothesis_profile,
 )
@@ -17,6 +17,18 @@ import chromadb.test.property.strategies as strategies
 import chromadb.test.property.invariants as invariants
 from chromadb.test.utils.wait_for_version_increase import wait_for_version_increase
 from chromadb.utils.batch_utils import create_batches
+
+
+def create_isolated_database(client: ClientAPI) -> None:
+    """Create an isolated database for the test."""
+    admin_settings = client.get_settings()
+    if admin_settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
+        admin_settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
+
+    admin = AdminClient(admin_settings)
+    database = "test_add_" + str(uuid.uuid4())
+    admin.create_database(database)
+    client.set_database(database)
 
 
 collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="coll")
@@ -105,7 +117,7 @@ def _test_add(
     should_compact: bool,
     batch_ann_accuracy: bool = False,
 ) -> None:
-    reset(client)
+    create_isolated_database(client)
 
     # TODO: Generative embedding functions
     coll = client.create_collection(
@@ -187,6 +199,8 @@ def create_large_recordset(
 def test_add_large(
     client: ClientAPI, collection: strategies.Collection, should_compact: bool
 ) -> None:
+    create_isolated_database(client)
+
     if (
         client.get_settings().chroma_api_impl
         == "chromadb.api.async_fastapi.AsyncFastAPI"
@@ -194,7 +208,6 @@ def test_add_large(
         pytest.skip(
             "TODO @jai, come back and debug why CI runners fail with async + sync"
         )
-    reset(client)
 
     record_set = create_large_recordset(
         min_size=10000,
@@ -235,6 +248,8 @@ def test_add_large(
 def test_add_large_exceeding(
     client: ClientAPI, collection: strategies.Collection
 ) -> None:
+    create_isolated_database(client)
+
     if (
         client.get_settings().chroma_api_impl
         == "chromadb.api.async_fastapi.AsyncFastAPI"
@@ -242,7 +257,6 @@ def test_add_large_exceeding(
         pytest.skip(
             "TODO @jai, come back and debug why CI runners fail with async + sync"
         )
-    reset(client)
 
     record_set = create_large_recordset(
         min_size=client.get_max_batch_size(),
@@ -273,7 +287,6 @@ def test_out_of_order_ids(client: ClientAPI) -> None:
         pytest.skip(
             "TODO @jai, come back and debug why CI runners fail with async + sync"
         )
-    reset(client)
     ooo_ids = [
         "40",
         "05",
@@ -313,6 +326,9 @@ def test_out_of_order_ids(client: ClientAPI) -> None:
 
 def test_add_partial(client: ClientAPI) -> None:
     """Tests adding a record set with some of the fields set to None."""
+
+    create_isolated_database(client)
+
     if (
         client.get_settings().chroma_api_impl
         == "chromadb.api.async_fastapi.AsyncFastAPI"
@@ -320,7 +336,6 @@ def test_add_partial(client: ClientAPI) -> None:
         pytest.skip(
             "TODO @jai, come back and debug why CI runners fail with async + sync"
         )
-    reset(client)
 
     coll = client.create_collection("test")
     # TODO: We need to clean up the api types to support this typing


### PR DESCRIPTION
## Description of changes

`test_add.py` against the cluster is now parallelized. This speeds up the test by ~6m and brings it under the 15m threshold.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
