### PR TITLE
[ENH]: speed up filter benchmark

### DIFF
--- a/rust/log/src/test.rs
+++ b/rust/log/src/test.rs
@@ -124,7 +124,7 @@ pub trait LoadFromGenerator<L: LogGenerator> {
 impl<L: LogGenerator + Send + 'static> LoadFromGenerator<L> for TestDistributedSegment {
     async fn populate_with_generator(&mut self, log_count: usize, generator: L) {
         let ids: Vec<_> = (1..=log_count).collect();
-        for chunk in ids.chunks(100) {
+        for chunk in ids.chunks(10_000) {
             self.compact_log(
                 generator.generate_chunk(chunk.iter().copied()),
                 chunk


### PR DESCRIPTION
## Description of changes

This speeds up the filter benchmark by 2.3x (tested locally, 7m12s -> 3m9s).

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
