### PR TITLE
[BUG]  Fix offset calculation in the dirty log.

### DIFF
--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -518,9 +518,7 @@ impl OnceLogWriter {
             log_position,
             messages,
         );
-        let fut2 = self
-            .mark_dirty
-            .mark_dirty(log_position + messages_len, messages_len);
+        let fut2 = self.mark_dirty.mark_dirty(log_position, messages_len);
         let (res1, res2) = futures::future::join(fut1, fut2).await;
         res2?;
         let (path, setsum, num_bytes) = res1?;


### PR DESCRIPTION
## Description of changes

Should mark [x, x+i) as dirty, but marks [x+i, x+2i), so the dirty log
always sticks around, causing compactors to try and compact nothing.

## Test plan

CI

## Documentation Changes

N/A
