### PR TITLE
[BUG] Populate client args from deprecated args

### DIFF
--- a/clients/new-js/packages/chromadb/package.json
+++ b/clients/new-js/packages/chromadb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromadb",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A JavaScript interface for chroma",
   "keywords": [
     "chroma",

--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -88,10 +88,10 @@ export class ChromaClient {
       }
       if (
         !headers["x-chroma-token"] &&
-        headers["X_CHROMA_TOKEN"] &&
-        headers.credentials
+        args.auth.tokenHeaderType === "X_CHROMA_TOKEN" &&
+        args.auth.credentials
       ) {
-        headers["x-chroma-token"] = headers.credentials;
+        headers["x-chroma-token"] = args.auth.credentials;
       }
     }
 


### PR DESCRIPTION
## Description of changes

Fix condition for populating auth params for `ChromaClient`

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

