### PR TITLE
[ENH]  Tool to purge a collection from the dirty log.

### DIFF
--- a/rust/log-service/src/bin/chroma-purge-dirty-log.rs
+++ b/rust/log-service/src/bin/chroma-purge-dirty-log.rs
@@ -1,0 +1,30 @@
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::PurgeDirtyForCollectionRequest;
+use chroma_types::CollectionUuid;
+
+#[tokio::main]
+async fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 2 {
+        eprintln!("USAGE: chroma-purge-dirty-log [HOST] [COLLECTION-UUID]");
+        std::process::exit(13);
+    }
+    let logservice = Channel::from_shared(args[0].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to log service");
+    let collection_id = Uuid::parse_str(&args[1])
+        .map(CollectionUuid)
+        .expect("Failed to parse collection_id");
+    let mut client = LogServiceClient::new(logservice);
+    let _resp = client
+        .purge_dirty_for_collection(PurgeDirtyForCollectionRequest {
+            collection_id: collection_id.to_string(),
+        })
+        .await
+        .expect("purge-dirty-log request should succeed");
+}


### PR DESCRIPTION
## Description of changes

This affects wal3/rust-log-service.  When a collection is on the dirty
log it can be scheduled for compaction.  This tool forcibly inserts a
"purge" marker to the dirty log that effectively drops the marked
collection from the dirty log until it gets written to again.

Use with care.

## Test plan

I'm relying upon the compiler and visual inspection of the code.

## Documentation Changes

N/A
