### PR TITLE
[TST]: fix flakes in Rust tests caused by port conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,6 @@ dependencies = [
  "proptest",
  "proptest-state-machine",
  "rand 0.8.5",
- "random-port",
  "regex",
  "reqwest 0.12.9",
  "rust-embed",

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -52,7 +52,6 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 
 [dev-dependencies]
 reqwest = { workspace = true }
-random-port = { workspace = true }
 proptest = { workspace = true }
 proptest-state-machine = { workspace = true }
 chroma-types = { workspace = true, features = ["testing"] }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -124,7 +124,7 @@ pub async fn frontend_service_entrypoint_with_config_system_registry(
         quota_enforcer,
         system,
     )
-    .run()
+    .run(None)
     .await;
 }
 


### PR DESCRIPTION
## Description of changes

https://github.com/chroma-core/chroma/pull/4780 started running the Rust tests in parallel in CI, which resulted in a new type of flake. The `random-port` crate is not safe to use across processes without additional locking/retry logic as it does not actually bind to and lock the port. Because of this, tests occasionally flake with port conflict errors when run in parallel.

This change fixes the issue by acquiring a random port at bind time.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
