### PR TITLE
[ENH]: temporary patch to enable tracing for Chroma's billing service

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -39,6 +39,7 @@ pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                 "worker",
                 "garbage_collector",
                 "continuous_verification",
+                "billing-service",
             ]
             .into_iter()
             .map(|s| s.to_string() + "=trace")

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -153,6 +153,7 @@ pub fn init_stdout_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                     .module_path()
                     .unwrap_or("")
                     .starts_with("continuous_verification")
+                || metadata.module_path().unwrap_or("").starts_with("billing")
         }))
         .with_filter(tracing_subscriber::filter::LevelFilter::INFO)
         .boxed()


### PR DESCRIPTION
## Description of changes

This is stacked PR with [#789](https://github.com/chroma-core/k8s/pull/789). It is a temporary patch that will hold us over until we can implement a more structured and extensible approach to tracing between our open-source and hosted codebases.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
