### PR TITLE
[BLD] build arm64 image on arm runner instead of in QEMU

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -29,6 +29,3 @@ runs:
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-password }}
-    - uses: useblacksmith/build-push-action@v1.1
-      with:
-        setup-only: true

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -17,11 +17,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # https://github.com/docker/setup-qemu-action - for multiplatform builds
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
     - name: Log in to the Github Container registry
       uses: docker/login-action@v2.1.0
       if: ${{ inputs.ghcr-username != '' }}

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -13,6 +13,10 @@ inputs:
   dockerhub-password:
     description: "DockerHub password"
     required: true
+  setup-blacksmith:
+    description: "Setup blacksmith"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -29,3 +33,8 @@ runs:
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-password }}
+    - name: Set up Blacksmith builder
+      if: ${{ inputs.setup-blacksmith == 'true' }}
+      uses: useblacksmith/build-push-action@v1.1
+      with:
+        setup-only: true

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -33,17 +33,27 @@ permissions:
 env:
   GHCR_IMAGE_NAME: "ghcr.io/chroma-core/chroma"
   DOCKERHUB_IMAGE_NAME: "chromadb/chroma"
-  PLATFORMS: linux/amd64,linux/arm64 #linux/riscv64, linux/arm/v7
 
 jobs:
   build:
-    name: Build and publish container image
+    name: Build image for ${{ matrix.platform }}
     runs-on: blacksmith-16vcpu-ubuntu-2204
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runner: blacksmith-16vcpu-ubuntu-2204
+            docker_platform: linux/amd64
+          - platform: arm64
+            runner: blacksmith-16vcpu-ubuntu-2204-arm
+            docker_platform: linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:
@@ -51,16 +61,22 @@ jobs:
           ghcr-password: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Compute tags
-        shell: bash
-        id: compute_tags
-        run: |
-          tags="${{ env.GHCR_IMAGE_NAME }}:${{ inputs.tag }},${{ env.DOCKERHUB_IMAGE_NAME }}:${{ inputs.tag }}"
-          if [ "${{ inputs.tag_as_latest }}" = "true" ]; then
-            tags="${tags},${{ env.GHCR_IMAGE_NAME }}:latest,${{ env.DOCKERHUB_IMAGE_NAME }}:latest"
-          fi
 
-          echo "tags=${tags}" >> $GITHUB_OUTPUT
+      - name: Compute arch-specific tags
+        id: tags
+        shell: bash
+        run: |
+          arch_tag="${{ inputs.tag }}-${{ matrix.platform }}"
+          ghcr="${{ env.GHCR_IMAGE_NAME }}:${arch_tag}"
+          dhub="${{ env.DOCKERHUB_IMAGE_NAME }}:${arch_tag}"
+          echo "arch_tag=$arch_tag"      >> $GITHUB_OUTPUT
+
+          # expose *matrix-unique* step outputs
+          echo "ghcr_tag_${{ matrix.platform }}=$ghcr"         >> $GITHUB_OUTPUT
+          echo "dockerhub_tag_${{ matrix.platform }}=$dhub"    >> $GITHUB_OUTPUT
+
+          # these two tags are what the build-push action will publish for *this* arch
+          echo "tags=$ghcr,$dhub" >> $GITHUB_OUTPUT
 
       - name: Build and push image
         uses: useblacksmith/build-push-action@v1.1
@@ -68,8 +84,55 @@ jobs:
           context: .
           file: rust/Dockerfile
           target: cli
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.docker_platform }}
           push: true
           build-args: |
             RELEASE_MODE=1
-          tags: ${{ steps.compute_tags.outputs.tags }}
+          tags: ${{ steps.tags.outputs.tags }}
+    outputs:
+      ghcr_tag_amd64:      ${{ steps.tags.outputs.ghcr_tag_amd64 }}
+      ghcr_tag_arm64:      ${{ steps.tags.outputs.ghcr_tag_arm64 }}
+      dockerhub_tag_amd64: ${{ steps.tags.outputs.dockerhub_tag_amd64 }}
+      dockerhub_tag_arm64: ${{ steps.tags.outputs.dockerhub_tag_arm64 }}
+
+  merge:
+    name: Merge platform manifests
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    needs:
+      - build
+    steps:
+      - name: Set up Docker
+        uses: ./.github/actions/docker
+        with:
+          ghcr-username: ${{ github.actor }}
+          ghcr-password: ${{ secrets.GITHUB_TOKEN }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Pull the per-arch tags from job-level outputs
+          ghcr_amd64='${{ needs.build.outputs.ghcr_tag_amd64 }}'
+          ghcr_arm64='${{ needs.build.outputs.ghcr_tag_arm64 }}'
+          dhub_amd64='${{ needs.build.outputs.dockerhub_tag_amd64 }}'
+          dhub_arm64='${{ needs.build.outputs.dockerhub_tag_arm64 }}'
+
+          base_tag='${{ inputs.tag }}'
+          ghcr_base="${{ env.GHCR_IMAGE_NAME }}:${base_tag}"
+          dhub_base="${{ env.DOCKERHUB_IMAGE_NAME }}:${base_tag}"
+
+          docker buildx imagetools create --tag "$ghcr_base" $ghcr_amd64 $ghcr_arm64
+          docker buildx imagetools create --tag "$dhub_base"  $dhub_amd64 $dhub_arm64
+
+          if [[ "${{ inputs.tag_as_latest }}" == "true" ]]; then
+            docker buildx imagetools create --tag "${{ env.GHCR_IMAGE_NAME }}:latest"  $ghcr_amd64 $ghcr_arm64
+            docker buildx imagetools create --tag "${{ env.DOCKERHUB_IMAGE_NAME }}:latest" $dhub_amd64 $dhub_arm64
+          fi
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE_NAME }}:${{ inputs.tag }}
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_IMAGE_NAME }}:${{ inputs.tag }}

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -49,6 +49,7 @@ jobs:
     name: Build image for ${{ matrix.platform }}
     runs-on: blacksmith-16vcpu-ubuntu-2204
     strategy:
+      fail-fast: false
       matrix:
         platform: [amd64, arm64]
         include:

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -88,6 +88,15 @@ jobs:
           # these two tags are what the build-push action will publish for *this* arch
           echo "tags=$ghcr,$dhub" >> $GITHUB_OUTPUT
 
+      - name: Pre-pull base images
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Pre-pull base images to speed up the build
+          docker pull --platform ${{ matrix.docker_platform }} rust:1.81.0
+          docker pull --platform ${{ matrix.docker_platform }} debian:stable-slim
+
       - name: Build and push image
         uses: useblacksmith/build-push-action@v1.1
         with:

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   build:
     name: Build image for ${{ matrix.platform }}
-    runs-on: blacksmith-16vcpu-ubuntu-2204
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -72,6 +72,8 @@ jobs:
           ghcr-password: ${{ secrets.GITHUB_TOKEN }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          # Calling useblacksmith/build-push-action twice in the same job leads to strange errors
+          setup-blacksmith: false
 
       - name: Compute arch-specific tags
         id: tags

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -3,6 +3,11 @@ name: Build and publish container image to Docker and GitHub Container Registry
 on:
   workflow_dispatch:
     inputs:
+      push:
+        description: 'Push the built image to registries'
+        required: true
+        default: false
+        type: boolean
       tag:
         description: 'Tag to publish'
         required: true
@@ -15,6 +20,11 @@ on:
 
   workflow_call:
     inputs:
+      push:
+        description: 'Push the built image to registries'
+        required: true
+        default: false
+        type: boolean
       tag:
         description: 'Tag to publish'
         required: true
@@ -85,7 +95,7 @@ jobs:
           file: rust/Dockerfile
           target: cli
           platforms: ${{ matrix.docker_platform }}
-          push: true
+          push: ${{ inputs.push }}
           build-args: |
             RELEASE_MODE=1
           tags: ${{ steps.tags.outputs.tags }}
@@ -98,6 +108,7 @@ jobs:
   merge:
     name: Merge platform manifests
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    if: ${{ inputs.push == 'true' }}
     needs:
       - build
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,15 +186,6 @@ jobs:
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
 
-  images-build:
-    name: Build images
-    needs: change-detection
-    uses: ./.github/workflows/_build_release_container.yml
-    secrets: inherit
-    with:
-      push: false
-      tag: ${{ github.sha }}
-
   go-tests:
     name: Go tests
     needs: change-detection

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,6 +186,15 @@ jobs:
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
 
+  images-build:
+    name: Build images
+    needs: change-detection
+    uses: ./.github/workflows/_build_release_container.yml
+    secrets: inherit
+    with:
+      push: false
+      tag: ${{ github.sha }}
+
   go-tests:
     name: Go tests
     needs: change-detection

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,14 +1,22 @@
 FROM rust:1.81.0 AS builder
 
 ARG RELEASE_MODE=
+ARG PROTOC_VERSION=25.1
 
 WORKDIR /chroma
 
-ENV PROTOC_ZIP=protoc-25.1-linux-x86_64.zip
-RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.1/$PROTOC_ZIP \
-  && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
-  && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
-  && rm -f $PROTOC_ZIP
+RUN ARCH=$(uname -m) && \
+  if [ "$ARCH" = "x86_64" ]; then \
+    PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
+  elif [ "$ARCH" = "aarch64" ]; then \
+    PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-aarch_64.zip; \
+  else \
+    echo "Unsupported architecture: $ARCH" && exit 1; \
+  fi && \
+  curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/$PROTOC_ZIP && \
+  unzip -o $PROTOC_ZIP -d /usr/local bin/protoc && \
+  unzip -o $PROTOC_ZIP -d /usr/local 'include/*' && \
+  rm -f $PROTOC_ZIP
 
 COPY idl/ idl/
 COPY Cargo.toml Cargo.toml


### PR DESCRIPTION
This PR re-adds split builders for image releases so that ARM images can be built on native platforms. The issue before was that we ran `useblacksmith/build-push-action@v1.1` twice in the same workflow, which led to undefined behavior.

Validated that the new image build workflow succeeds by running in this PR (although I can't test the manifest merging until a run on main).