### PR TITLE
[BLD]: move GC proptest into separate job

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,14 +15,14 @@ test-group = "against-tilt"
 path = "junit.xml"
 
 [profile.ci_k8s_integration]
-default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_integration_garbage_collection) and not test(test_k8s_integration_rust_log_service_dirty_logs)"
+default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_integration_garbage_collection)"
 
 [[profile.ci_k8s_integration.overrides]]
 filter = "all()"
 test-group = "against-tilt"
 
 [profile.ci_k8s_integration_slow]
-default-filter = "test(test_k8s_integration_garbage_collection) or test(test_k8s_integration_rust_log_service_dirty_logs)"
+default-filter = "test(test_k8s_integration_garbage_collection)"
 
 [[profile.ci_k8s_integration_slow.overrides]]
 filter = "all()"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,6 +21,8 @@ default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_integratio
 filter = "all()"
 test-group = "against-tilt"
 
+# This one test is extremely slow in CI and difficult to speed up.
+# TODO(@codetheweb): after all collection files are stored under a prefix, test_k8s_integration_* tests can be run in parallel and we can remove this profile.
 [profile.ci_k8s_integration_slow]
 default-filter = "test(test_k8s_integration_garbage_collection)"
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,14 +15,14 @@ test-group = "against-tilt"
 path = "junit.xml"
 
 [profile.ci_k8s_integration]
-default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_integration_garbage_collection)"
+default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_integration_garbage_collection) and not test(test_k8s_integration_rust_log_service_dirty_logs)"
 
 [[profile.ci_k8s_integration.overrides]]
 filter = "all()"
 test-group = "against-tilt"
 
 [profile.ci_k8s_integration_slow]
-default-filter = "test(test_k8s_integration_garbage_collection)"
+default-filter = "test(test_k8s_integration_garbage_collection) or test(test_k8s_integration_rust_log_service_dirty_logs)"
 
 [[profile.ci_k8s_integration_slow.overrides]]
 filter = "all()"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,9 +15,16 @@ test-group = "against-tilt"
 path = "junit.xml"
 
 [profile.ci_k8s_integration]
-default-filter = "test(/test_k8s_integration_/)"
+default-filter = "test(/test_k8s_integration_/) and not test(test_k8s_integration_garbage_collection)"
 
 [[profile.ci_k8s_integration.overrides]]
+filter = "all()"
+test-group = "against-tilt"
+
+[profile.ci_k8s_integration_slow]
+default-filter = "test(test_k8s_integration_garbage_collection)"
+
+[[profile.ci_k8s_integration_slow.overrides]]
 filter = "all()"
 test-group = "against-tilt"
 

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build CLI
         run: cargo build --bin chroma
       - name: Run tests
-        run: cargo nextest run --profile ${{ matrix.nextest_profile }} --partition ${{ matrix.partition_method }}:${{ matrix.partition }}/2
+        run: cargo nextest run --profile ${{ matrix.nextest_profile }} --partition ${{ matrix.partition_method }}:${{ matrix.partition }}/2 --no-tests warn
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -42,9 +42,15 @@ jobs:
     strategy:
       matrix:
         platform: [blacksmith-16vcpu-ubuntu-2204]
+        nextest_profile: [ci_k8s_integration, ci_k8s_integration_slow]
         partition: [1, 2]
+        include:
+          - nextest_profile: ci_k8s_integration
+            partition_method: hash
+          - nextest_profile: ci_k8s_integration_slow
+            partition_method: count
     runs-on: ${{ matrix.platform }}
-    name: Integration test ${{ matrix.partition }}/2
+    name: Integration test ${{ matrix.nextest_profile }} ${{ matrix.partition }}
     # OIDC token auth for AWS
     permissions:
       contents: read
@@ -68,12 +74,12 @@ jobs:
       - name: Build CLI
         run: cargo build --bin chroma
       - name: Run tests
-        run: cargo nextest run --profile ci_k8s_integration --partition hash:${{ matrix.partition }}/2
+        run: cargo nextest run --profile ${{ matrix.nextest_profile }} --partition ${{ matrix.partition_method }}:${{ matrix.partition }}/2
       - name: Save service logs to artifact
         if: always()
         uses: ./.github/actions/export-tilt-logs
         with:
-          artifact-name: "rust-integration-test-${{ matrix.partition }}"
+          artifact-name: "rust-integration-test-${{ matrix.nextest_profile }}-${{ matrix.partition }}"
   test-benches:
     strategy:
       matrix:


### PR DESCRIPTION
## Description of changes

The wall time of Rust integration tests is now ~18m, down from ~22m.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
