### PR TITLE
[BUG] Fix test parallelization

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -144,7 +144,7 @@ jobs:
           - "chromadb/test/distributed/test_log_backpressure.py"
           - "chromadb/test/distributed/test_log_failover.py"
         include:
-          - test-glob: "chromadb/test/distributed/test_add.py"
+          - test-glob: "chromadb/test/property/test_add.py"
             parallelized: true
     runs-on: blacksmith-8vcpu-ubuntu-2204
     # OIDC token auth for AWS


### PR DESCRIPTION
## Description of changes

I had a bad merge when I was resolving conflicts for #4787 at which time, I accidentally disabled the parallelization of one of our tests. This reapplies the parallelization to the right test module.
