### PR TITLE
[ENH]  Add Copy API to chroma storage.

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -477,6 +477,11 @@ impl AdmissionControlledS3Storage {
         )
         .await
     }
+
+    pub async fn copy(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
+        // Akin to a HEAD request; no AC.
+        self.storage.copy(src_key, dst_key).await
+    }
 }
 
 #[async_trait]

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -311,6 +311,15 @@ impl Storage {
         }
     }
 
+    pub async fn copy(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
+        match self {
+            Storage::ObjectStore(_) => Err(StorageError::NotImplemented),
+            Storage::S3(s3) => s3.copy(src_key, dst_key).await,
+            Storage::Local(local) => local.copy(src_key, dst_key).await,
+            Storage::AdmissionControlledS3(_) => Err(StorageError::NotImplemented),
+        }
+    }
+
     pub async fn list_prefix(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
         match self {
             Storage::Local(local) => local.list_prefix(prefix).await,

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -316,7 +316,7 @@ impl Storage {
             Storage::ObjectStore(_) => Err(StorageError::NotImplemented),
             Storage::S3(s3) => s3.copy(src_key, dst_key).await,
             Storage::Local(local) => local.copy(src_key, dst_key).await,
-            Storage::AdmissionControlledS3(_) => Err(StorageError::NotImplemented),
+            Storage::AdmissionControlledS3(ac) => ac.copy(src_key, dst_key).await,
         }
     }
 


### PR DESCRIPTION
## Description of changes

This API will use the serverside option to upload a file, meaning that
copying a file becomes a cheap operation, relatively speaking.  No
longer will it have to stream to the rust-log-service and back to S3.

## Test plan

I added a unit test.  CI for the rest.

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
