### PR TITLE
added s3 get metrics and verified on prometheus

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -666,7 +666,11 @@ mod tests {
 
     use rand::{distributions::Alphanumeric, Rng};
 
-    use crate::{admissioncontrolleds3::AdmissionControlledS3Storage, s3::S3Storage, GetOptions};
+    use crate::{
+        admissioncontrolleds3::AdmissionControlledS3Storage,
+        s3::{S3Storage, S3StorageMetrics},
+        GetOptions,
+    };
 
     fn get_s3_client() -> aws_sdk_s3::Client {
         // Set up credentials assuming minio is running locally
@@ -698,6 +702,7 @@ mod tests {
             client,
             upload_part_size_bytes: 1024 * 1024 * 8,
             download_part_size_bytes: 1024 * 1024 * 8,
+            metrics: S3StorageMetrics::new(opentelemetry::global::meter("chroma")),
         };
         storage.create_bucket().await.unwrap();
         let admission_controlled_storage =
@@ -749,6 +754,7 @@ mod tests {
             client,
             upload_part_size_bytes: 1024 * 1024 * 8,
             download_part_size_bytes: 1024 * 1024 * 8,
+            metrics: S3StorageMetrics::new(opentelemetry::global::meter("chroma")),
         };
         storage.create_bucket().await.unwrap();
         let admission_controlled_storage =

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -34,6 +34,7 @@ use futures::stream;
 use futures::FutureExt;
 use futures::Stream;
 use futures::StreamExt;
+use opentelemetry::metrics::Meter;
 use rand::Rng;
 use std::clone::Clone;
 use std::ops::Range;
@@ -42,12 +43,30 @@ use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tracing::Instrument;
 
+#[derive(Clone, Debug)]
+pub struct S3StorageMetrics {
+    total_num_get_requests: opentelemetry::metrics::Counter<u64>,
+}
+
+impl S3StorageMetrics {
+    pub fn new(meter: Meter) -> Self {
+        Self {
+            total_num_get_requests: meter
+                .u64_counter("s3_storage_total_num_get_requests")
+                .with_description("The number of GET requests to S3. This does not include metadata HEAD requests or failed requests.")
+                .with_unit("requests")
+                .build(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct S3Storage {
     pub(super) bucket: String,
     pub(super) client: aws_sdk_s3::Client,
     pub(super) upload_part_size_bytes: usize,
     pub(super) download_part_size_bytes: usize,
+    pub(super) metrics: S3StorageMetrics,
 }
 
 impl S3Storage {
@@ -62,6 +81,7 @@ impl S3Storage {
             client,
             upload_part_size_bytes,
             download_part_size_bytes,
+            metrics: S3StorageMetrics::new(opentelemetry::global::meter("chroma")),
         }
     }
 
@@ -125,6 +145,7 @@ impl S3Storage {
         match res {
             Ok(res) => {
                 let byte_stream = res.body;
+                self.metrics.total_num_get_requests.add(1, &[]);
                 Ok((
                     Box::new(S3ByteStream::new(byte_stream)),
                     res.e_tag.map(ETag),
@@ -222,7 +243,10 @@ impl S3Storage {
             .send()
             .await;
         match res {
-            Ok(output) => Ok(output),
+            Ok(output) => {
+                self.metrics.total_num_get_requests.add(1, &[]);
+                Ok(output)
+            }
             Err(e) => {
                 tracing::error!("Error fetching range: {:?}", e);
                 match e {
@@ -829,6 +853,7 @@ mod tests {
             client,
             upload_part_size_bytes: 1024 * 1024 * 8,
             download_part_size_bytes: 1024 * 1024 * 8,
+            metrics: S3StorageMetrics::new(opentelemetry::global::meter("chroma")),
         };
         storage.create_bucket().await.unwrap();
 
@@ -854,6 +879,7 @@ mod tests {
             client,
             upload_part_size_bytes,
             download_part_size_bytes,
+            metrics: S3StorageMetrics::new(opentelemetry::global::meter("chroma")),
         };
         storage.create_bucket().await.unwrap();
         storage
@@ -901,6 +927,7 @@ mod tests {
             client,
             upload_part_size_bytes: 1024 * 1024 * 8,
             download_part_size_bytes: 1024 * 1024 * 8,
+            metrics: S3StorageMetrics::new(opentelemetry::global::meter("chroma")),
         };
         storage.create_bucket().await.unwrap();
 


### PR DESCRIPTION
## Description of changes

Added object store-level metrics. In the current version of this PR, it just tracks the number of successful gets done in the `default_s3_storage_num_get_requests_total` that one can view from Prometheus.

- Improvements & Bug fixes
  - n/a
- New functionality
  - New metric `default_s3_storage_num_get_requests_total`

## Test plan

_How are these changes tested?_

- [v] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- Manually verified the metric changes on local Prometheus after disabling caching.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
