### PR TITLE
[DOC] Fix link in embedding docs

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
@@ -13,9 +13,9 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Instructor](../../integrations/embedding-models/instructor)                             | ✓      | -          |
 | [Hugging Face Embedding Server](../../integrations/embedding-models/hugging-face-server) | ✓      | ✓          |
 | [Jina AI](../../integrations/embedding-models/jina-ai)                                   | ✓      | ✓          |
-| [Cloudflare Workers AI](../../integrations/embedding-models/cloudflare-workers-ai.md)    | ✓      | ✓          |
-| [Together AI](../../integrations/embedding-models/together-ai.md)                        | ✓      | ✓          |
-| [Mistral](../../integrations/embedding-models/mistral.md)                                | ✓      | -          |
+| [Cloudflare Workers AI](../../integrations/embedding-models/cloudflare-workers-ai)    | ✓      | ✓          |
+| [Together AI](../../integrations/embedding-models/together-ai)                        | ✓      | ✓          |
+| [Mistral](../../integrations/embedding-models/mistral)                                | ✓      | -          |
 
 We welcome pull requests to add new Embedding Functions to the community.
 


### PR DESCRIPTION
These hyperlinks in the docs led to a 404 because they incorrectly had their file extension