### PR TITLE
[BLD]: use sccache during PyPi build

### DIFF
--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -109,6 +109,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: ${{ matrix.platform.os == 'linux' && '--zig' || '' }} --release --out dist
           container: "off"
+          sccache: true
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description of changes

The PyPi build stopped being cached when the common Rust action switched to caching the target directory rather than going through sccache. This updates the maturin build step during PyPi release to use sccache for faster builds.
