### PR TITLE
[TST]: fix `test_rebuild` flake

### DIFF
--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1054,6 +1054,7 @@ mod tests {
         operator::{Filter, Limit, Projection},
         DocumentExpression, DocumentOperator, MetadataExpression, PrimitiveOperator, Where,
     };
+    use regex::Regex;
 
     use crate::{
         config::RootConfig,
@@ -1205,13 +1206,13 @@ mod tests {
 
         let mut expected_new_collection = old_cas.collection.clone();
         expected_new_collection.version += 1;
+
+        let version_suffix_re = Regex::new(r"/\d+$").unwrap();
+
         expected_new_collection.version_file_path = Some(
-            old_cas
-                .collection
-                .version_file_path
-                .clone()
-                .unwrap()
-                .replace("/1", "/2"),
+            version_suffix_re
+                .replace(&old_cas.collection.version_file_path.clone().unwrap(), "/2")
+                .to_string(),
         );
         assert_eq!(new_cas.collection, expected_new_collection);
         assert_eq!(new_cas.metadata_segment.id, old_cas.metadata_segment.id);


### PR DESCRIPTION
## Description of changes

Fixes a test flake for `test_rebuild`. The issue was that `/1` was replaced with `/2` to construct the expected final version file path, but there may be other `/1` occurrences in the file path besides the version number suffix. E.g. a collection ID may start with `1`.