### PR TITLE
[BLD]: pin Python version for wheel build workflow

### DIFF
--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
           architecture: ${{ matrix.platform.target }}
 
       - name: Set version in pyproject.toml


### PR DESCRIPTION
## Description of changes

The release workflow [recently started failing](https://github.com/chroma-core/chroma/actions/runs/15547454682/job/43808309595) with errors like 

```
  Version 3.x was not found in the local cache
  Error: The version '3.x' with architecture 'x86_64' was not found for Ubuntu 22.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

I wasn't able to find any relevant issues for the `actions/setup-python` action. Maybe something on Blacksmith's side changed?

In any case, hopeful that pinning the major/minor version will fix it since this action completes successfully in other workflows with a pinned version.
