### PR TITLE
[BLD]: disable sccache during maturin build

### DIFF
--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -108,7 +108,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: ${{ matrix.platform.os == 'linux' && '--zig' || '' }} --release --out dist
           container: "off"
-          sccache: true
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description of changes

This was added in https://github.com/chroma-core/chroma/pull/4806, but it seems like the default sccache config doesn't work with Blacksmith. Disabling while we debug.