### PR TITLE
[ENH]: default to garbage collection delete v2 mode when running locally

### DIFF
--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -114,7 +114,7 @@ garbageCollector:
     max_collections_to_gc: 1000
     gc_interval_mins: 1
     disallow_collections: []
-    default_mode: "delete"
+    default_mode: "deletev2"
     sysdb_config:
       host: "sysdb.chroma"
       port: 50051


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
