### PR TITLE
[ENH]: change default trace level of garbage collector from trace -> debug

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
 pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
     EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| {
-        "error,opentelemetry_sdk=info,".to_string()
+        "error,opentelemetry_sdk=info,garbage_collector=debug,".to_string()
             + &vec![
                 "chroma",
                 "chroma-blockstore",
@@ -38,7 +38,6 @@ pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                 "query_service",
                 "wal3",
                 "worker",
-                "garbage_collector",
                 "continuous_verification",
             ]
             .into_iter()


### PR DESCRIPTION
## Description of changes

`trace` spans can log an unbounded amount of data, so this should help us avoid running into exporter payload size limits.

## Test plan

_How are these changes tested?_

Looks good in Jaeger.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a