### PR TITLE
[CLN] fix minor typos

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -69,7 +69,7 @@ pub enum GetCollectionWithSegmentsError {
     GetSegmentsError(#[from] GetSegmentsError),
     #[error("Grpc error: {0}")]
     Grpc(#[from] Status),
-    #[error("Collection [{0}] does not exists.")]
+    #[error("Collection [{0}] does not exist.")]
     NotFound(String),
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
@@ -572,7 +572,7 @@ pub type GetCollectionResponse = Collection;
 pub enum GetCollectionError {
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
-    #[error("Collection [{0}] does not exists")]
+    #[error("Collection [{0}] does not exist")]
     NotFound(String),
 }
 
@@ -740,7 +740,7 @@ pub struct UpdateCollectionResponse {}
 
 #[derive(Error, Debug)]
 pub enum UpdateCollectionError {
-    #[error("Collection [{0}] does not exists")]
+    #[error("Collection [{0}] does not exist")]
     NotFound(String),
     #[error("Metadata reset unsupported")]
     MetadataResetUnsupported,
@@ -796,7 +796,7 @@ pub struct DeleteCollectionResponse {}
 
 #[derive(Error, Debug)]
 pub enum DeleteCollectionError {
-    #[error("Collection [{0}] does not exists")]
+    #[error("Collection [{0}] does not exist")]
     NotFound(String),
     #[error(transparent)]
     Validation(#[from] ChromaValidationError),
@@ -866,7 +866,7 @@ pub enum ForkCollectionError {
     Local,
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
-    #[error("Collection [{0}] does not exists")]
+    #[error("Collection [{0}] does not exist")]
     NotFound(String),
     #[error("Failed to convert proto segment")]
     SegmentConversionError(#[from] SegmentConversionError),
@@ -915,7 +915,7 @@ impl ChromaError for CountForksError {
 pub enum GetCollectionSizeError {
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
-    #[error("Collection [{0}] does not exists")]
+    #[error("Collection [{0}] does not exist")]
     NotFound(String),
 }
 
@@ -932,7 +932,7 @@ impl ChromaError for GetCollectionSizeError {
 pub enum ListCollectionVersionsError {
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
-    #[error("Collection [{0}] does not exists")]
+    #[error("Collection [{0}] does not exist")]
     NotFound(String),
 }
 


### PR DESCRIPTION
## Description of changes

Fixed some minuscule typos in rust/types/src/api_types.rs.

## Test plan

No tests needed.

## Documentation Changes

No documentation changes needed.
