### PR TITLE
[ENH]: remove "Dispatcher" spans from tracing

### DIFF
--- a/rust/system/src/execution/worker_thread.rs
+++ b/rust/system/src/execution/worker_thread.rs
@@ -2,7 +2,6 @@ use super::{dispatcher::TaskRequestMessage, operator::TaskMessage};
 use crate::{Component, ComponentContext, ComponentRuntime, Handler, ReceiverForMessage};
 use async_trait::async_trait;
 use std::fmt::{Debug, Formatter, Result};
-use tracing::{trace_span, Instrument, Span};
 
 /// A worker thread is responsible for executing tasks
 /// It sends requests to the dispatcher for new tasks.
@@ -57,9 +56,7 @@ impl Handler<TaskMessage> for WorkerThread {
     type Result = ();
 
     async fn handle(&mut self, mut task: TaskMessage, ctx: &ComponentContext<WorkerThread>) {
-        let child_span =
-            trace_span!(parent: Span::current(), "Task execution", name = task.get_name());
-        task.run().instrument(child_span).await;
+        task.run().await;
         let req: TaskRequestMessage = TaskRequestMessage::new(ctx.receiver());
         let _res = self.dispatcher.send(req, None).await;
         // TODO: task run should be able to error and we should send it as part of the result


### PR DESCRIPTION
## Description of changes

Reduces span spam and necessary nesting in traces.

A consequence is that spans that run in worker threads are no longer tagged as such, but the task type is usually obvious when looking at the code. If this is undesired I can add a task type span.

Before:

<img width="1943" alt="Screenshot 2025-06-12 at 09 55 48" src="https://github.com/user-attachments/assets/e721968e-0742-4630-a342-b5e8fcad97da" />

After:

<img width="2221" alt="Screenshot 2025-06-12 at 09 57 46" src="https://github.com/user-attachments/assets/673a19aa-4987-4c08-89d8-934ae495e6b4" />


## Test plan

_How are these changes tested?_

Verified in Jaeger.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a