### PR TITLE
[ENH] Query node log memberlist readiness

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.44
+version: 0.1.45
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -67,6 +67,7 @@ spec:
           readinessProbe:
             grpc:
               port: 50051
+              service: chroma.QueryExecutor
           volumeMounts:
             {{if .Values.queryService.configuration}}
             - name: query-service-config

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -88,6 +88,9 @@ impl WorkerServer {
         println!("Worker listening on {}", addr);
 
         let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
+        health_reporter
+            .set_not_serving::<QueryExecutorServer<WorkerServer>>()
+            .await;
 
         let server = Server::builder()
             .add_service(health_service)

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -88,9 +88,6 @@ impl WorkerServer {
         println!("Worker listening on {}", addr);
 
         let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
-        health_reporter
-            .set_not_serving::<QueryExecutorServer<WorkerServer>>()
-            .await;
 
         let server = Server::builder()
             .add_service(health_service)

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -121,7 +121,6 @@ impl WorkerServer {
                     break;
                 }
             }
-            // Wait for the server to start
             health_reporter
                 .set_serving::<QueryExecutorServer<WorkerServer>>()
                 .await;

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -111,10 +111,10 @@ impl WorkerServer {
         });
 
         tokio::spawn(async move {
-            // Poll is-ready every 50ms until the server is ready
+            // Poll is-ready every ms until the server is ready
             // We don't timeout here because we assume some upstream daemon like
             // system will kill/restart us if we don't become ready in a reasonable time
-            let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(1));
             loop {
                 interval.tick().await;
                 if worker.is_ready() {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._
- Improvements & Bug fixes
  - Query nodes now wait on the log memberlist in order to pass readiness checks
- New functionality
  - None

## Test plan
_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None