### PR TITLE
[BLD]: avoid Rust cache thrashing

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -29,5 +29,7 @@ runs:
         repo-token: ${{ inputs.github-token }}
     - name: Set up cache
       uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: common-rust-cache
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest


### PR DESCRIPTION
## Description of changes

I'm seeing a lot of thrashing on our actions cache (at 99% usage with no old entries) because each job saves a Rust cache under a separate key, and each one is quite large (1GB+). This updates the Rust cache config to use the same cache key across all jobs.

## Test plan

_How are these changes tested?_

Observed updated cache key construction in workflow.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a