### PR TITLE
[BUG]  Two racing garbage collectors could leave garbage uncollected.

### DIFF
--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::HNSW_INDEX_S3_PREFIX;
 use chroma_storage::Storage;
-use chroma_storage::StorageError;
+use chroma_storage::{DeleteOptions, StorageError};
 use chroma_system::{Operator, OperatorType};
 use futures::stream::StreamExt;
 use std::collections::HashSet;
@@ -31,7 +31,9 @@ impl DeleteUnusedFilesOperator {
     }
 
     async fn delete_with_path(&self, file_path: String) -> Result<(), StorageError> {
-        self.storage.delete(&file_path).await
+        self.storage
+            .delete(&file_path, DeleteOptions::default())
+            .await
     }
 
     async fn rename_with_path(

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
-use chroma_storage::Storage;
+use chroma_storage::{DeleteOptions, Storage};
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
@@ -89,7 +89,7 @@ impl DeleteVersionsAtSysDbOperator {
             let path = file_path.clone();
             futures.push(async move {
                 storage
-                    .delete(&path)
+                    .delete(&path, DeleteOptions::default())
                     .await
                     .map_err(|e| (path, e.to_string()))
             });

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -8,7 +8,7 @@ use chroma_config::Configurable;
 use chroma_storage::config::{
     ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
 };
-use chroma_storage::{GetOptions, Storage};
+use chroma_storage::{DeleteOptions, GetOptions, Storage};
 use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig, SysDb};
 use chroma_system::Orchestrator;
 use chroma_system::{Dispatcher, DispatcherConfig, System};
@@ -60,7 +60,10 @@ impl Drop for GarbageCollectorUnderTest {
                 .map(|file| {
                     let storage = self.storage.clone();
                     async move {
-                        storage.delete(&file).await.unwrap();
+                        storage
+                            .delete(&file, DeleteOptions::default())
+                            .await
+                            .unwrap();
                     }
                 })
                 .buffer_unordered(32)

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -3,7 +3,7 @@ use crate::{
     s3::S3Storage,
     GetOptions,
 };
-use crate::{ETag, PutOptions, StorageConfigError};
+use crate::{DeleteOptions, ETag, PutOptions, StorageConfigError};
 use async_trait::async_trait;
 use aws_sdk_s3::primitives::{ByteStream, Length};
 use bytes::Bytes;
@@ -491,6 +491,10 @@ impl AdmissionControlledS3Storage {
         let atomic_priority = Arc::new(AtomicUsize::new(options.priority.as_usize()));
         let _permit = self.rate_limiter.enter(atomic_priority, None).await;
         self.storage.list_prefix(prefix).await
+    }
+
+    pub async fn delete(&self, prefix: &str, options: DeleteOptions) -> Result<(), StorageError> {
+        self.storage.delete(prefix, options).await
     }
 }
 

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -34,6 +34,10 @@ impl CollectionUuid {
     pub fn new() -> Self {
         CollectionUuid(Uuid::new_v4())
     }
+
+    pub fn storage_prefix_for_log(&self) -> String {
+        format!("logs/{}", self)
+    }
 }
 
 impl std::str::FromStr for CollectionUuid {
@@ -374,5 +378,14 @@ mod test {
             converted_collection.updated_at,
             SystemTime::UNIX_EPOCH + Duration::new(1, 1)
         );
+    }
+
+    #[test]
+    fn storage_prefix_for_log_format() {
+        let collection_id = Uuid::parse_str("34e72052-5e60-47cb-be88-19a9715b7026")
+            .map(CollectionUuid)
+            .unwrap();
+        let prefix = collection_id.storage_prefix_for_log();
+        assert_eq!("logs/34e72052-5e60-47cb-be88-19a9715b7026", prefix);
     }
 }

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -362,7 +362,6 @@ impl Manifest {
                         && self.snapshots[0].depth < snapshot_depth
                     {
                         let to_insert = &self.snapshots[0];
-                        eprintln!("INSERT {to_insert:#?}");
                         setsum += to_insert.setsum;
                         snapshots.insert(0, to_insert.clone());
                     }


### PR DESCRIPTION
## Description of changes

Race:
- First thread installs a garbage file.
- First thread deletes garabage, but not GARBAGE file.
- Second thread "resumes" garbage deletion, deletes garbage.
- Second thread deletes GARBAGE file.
- Second thread installs GARBAGE file pointing to garbage.
- First thread deletes the wrong garbage file.

Use delete-if-match for S3 to protect against this.

## Test plan

CI

## Documentation Changes

N/A
