### PR TITLE
[BLD] [REVERT]: avoid Rust cache thrashing

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -29,7 +29,5 @@ runs:
         repo-token: ${{ inputs.github-token }}
     - name: Set up cache
       uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: common-rust-cache
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest


### PR DESCRIPTION
Reverts chroma-core/chroma#4833.

This is not the correct solution to thrashing since jobs may compile Rust with different configs (e.g. dev vs release mode) but that config is not included in the cache key.

I'll ask Blacksmith to bump our cache limit instead.