### PR TITLE
[CHORE] enable base64_encoding by default on clients

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -144,7 +144,7 @@ class Settings(BaseSettings):  # type: ignore
     tenant_id: str = "default"
     topic_namespace: str = "default"
 
-    use_base64_encoding_for_embeddings: bool = False
+    use_base64_encoding_for_embeddings: bool = True
 
     chroma_server_host: Optional[str] = None
     chroma_server_headers: Optional[Dict[str, str]] = None

--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -52,7 +52,7 @@ export interface ChromaClientArgs {
 export class ChromaClient {
   private _tenant: string | undefined;
   private _database: string | undefined;
-  private _use_base64_encoding_for_embeddings: boolean = false;
+  private _use_base64_encoding_for_embeddings: boolean = true;
   private readonly apiClient: ReturnType<typeof createClient>;
 
   /**


### PR DESCRIPTION
## Description of changes

Enable base64 encoding by default on clients for improved performance


## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
