### PR TITLE
[CHORE] Add base64 encoding on preflight checks

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -516,10 +516,11 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         """
         Submits a batch of embeddings to the database
         """
+        supports_base64_encoding = await self.supports_base64_encoding()
         data = {
             "ids": batch[0],
             "embeddings": optional_embeddings_to_base64_strings(batch[1])
-            if self.get_settings().use_base64_encoding_for_embeddings
+            if supports_base64_encoding
             else batch[1],
             "metadatas": batch[2],
             "documents": batch[3],
@@ -676,10 +677,28 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     def get_settings(self) -> Settings:
         return self._settings
 
+    @trace_method(
+        "AsyncFastAPI.get_pre_flight_checks", OpenTelemetryGranularity.OPERATION
+    )
+    async def get_pre_flight_checks(self) -> Any:
+        if self.pre_flight_checks is None:
+            resp_json = await self._make_request("get", "/pre-flight-checks")
+            self.pre_flight_checks = resp_json
+        return self.pre_flight_checks
+
+    @trace_method(
+        "AsyncFastAPI.supports_base64_encoding", OpenTelemetryGranularity.OPERATION
+    )
+    async def supports_base64_encoding(self) -> bool:
+        pre_flight_checks = await self.get_pre_flight_checks()
+        b64_encoding_enabled = cast(
+            bool, pre_flight_checks.get("supports_base64_encoding", False)
+        )
+        return b64_encoding_enabled
+
     @trace_method("AsyncFastAPI.get_max_batch_size", OpenTelemetryGranularity.OPERATION)
     @override
     async def get_max_batch_size(self) -> int:
-        if self._max_batch_size == -1:
-            resp_json = await self._make_request("get", "/pre-flight-checks")
-            self._max_batch_size = cast(int, resp_json["max_batch_size"])
-        return self._max_batch_size
+        pre_flight_checks = await self.get_pre_flight_checks()
+        max_batch_size = cast(int, pre_flight_checks.get("max_batch_size", -1))
+        return max_batch_size

--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class BaseHTTPClient:
     _settings: Settings
-    _max_batch_size: int = -1
+    pre_flight_checks: Any = None
     keepalive_secs: int = 40
 
     @staticmethod

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -144,8 +144,6 @@ class Settings(BaseSettings):  # type: ignore
     tenant_id: str = "default"
     topic_namespace: str = "default"
 
-    use_base64_encoding_for_embeddings: bool = False
-
     chroma_server_host: Optional[str] = None
     chroma_server_headers: Optional[Dict[str, str]] = None
     chroma_server_http_port: Optional[int] = None

--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -32,6 +32,7 @@ export namespace Api {
      * minimum: 0
      */
     max_batch_size: number;
+    supports_base64_encoding: boolean;
   }
 
   export interface Collection {

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -14,6 +14,7 @@ export type AddCollectionRecordsResponse = {
 
 export type ChecklistResponse = {
     max_batch_size: number;
+    supports_base64_encoding: boolean;
 };
 
 export type Collection = {

--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -312,6 +312,12 @@ export const validateBaseRecordSet = ({
   }
 };
 
+export const validateMaxBatchSize = (recordSetLength: number, maxBatchSize: number) => {
+  if (recordSetLength > maxBatchSize) {
+    throw new ChromaValueError(`Record set length ${recordSetLength} exceeds max batch size ${maxBatchSize}`);
+  }
+};
+
 /**
  * Validates a where clause for metadata filtering.
  * @param where - Where clause object to validate

--- a/clients/new-js/packages/chromadb/test/preflight.test.ts
+++ b/clients/new-js/packages/chromadb/test/preflight.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, jest } from "@jest/globals";
+import { ChromaClient } from "../src";
+import { DefaultService as Api } from "../src/api";
+
+test("preflight", async () => {
+    const client = new ChromaClient();
+    const preflight = await client.getPreflightChecks();
+    expect(preflight).toBeDefined();
+    expect(preflight.supports_base64_encoding).toBe(true);
+    expect(preflight.max_batch_size).not.toBeUndefined();
+});
+
+test("legacy preflight", async () => {
+    jest.spyOn(Api, "preFlightChecks").mockResolvedValue({
+        data: {
+            max_batch_size: 100
+        }
+    } as any);
+
+    const client = new ChromaClient();
+    const preflight = await client.getPreflightChecks();
+    expect(preflight).toBeDefined();
+    expect(preflight.supports_base64_encoding).toBeUndefined();
+    expect(preflight.max_batch_size).not.toBeUndefined();
+
+    expect(await client.supportsBase64Encoding()).toBe(false);
+});
+
+test("preflight with no values", async () => {
+    jest.spyOn(Api, "preFlightChecks").mockResolvedValue({
+        data: {
+        }
+    } as any);
+
+    const client = new ChromaClient();
+    const preflight = await client.getPreflightChecks();
+    expect(preflight).toBeDefined();
+    expect(preflight.supports_base64_encoding).toBeUndefined();
+    expect(preflight.max_batch_size).toBeUndefined();
+
+    expect(await client.supportsBase64Encoding()).toBe(false);
+    expect(await client.getMaxBatchSize()).toBe(-1);
+});

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -446,6 +446,7 @@ async fn pre_flight_checks(
     server.metrics.pre_flight_checks.add(1, &[]);
     Ok(Json(ChecklistResponse {
         max_batch_size: server.frontend.clone().get_max_batch_size(),
+        supports_base64_encoding: true,
     }))
 }
 

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -156,6 +156,7 @@ impl ChromaError for ResetError {
 #[derive(Serialize, ToSchema)]
 pub struct ChecklistResponse {
     pub max_batch_size: u32,
+    pub supports_base64_encoding: bool,
 }
 
 #[derive(Serialize, ToSchema)]


### PR DESCRIPTION
## Description of changes

This PR removes the base64 setting, and replaces it with a preflight check that the server has base64 enabled, and if it does will use it. The preflight check is cached on the client for reuse.

It also adds preflight checks to the js client, caching it on the client for reuse.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
