### PR TITLE
[ENH]  Switch garbage collector off object-store-based backend

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -525,9 +525,7 @@ mod tests {
     use super::*;
     use crate::helper::ChromaGrpcClients;
     use chroma_memberlist::memberlist_provider::Member;
-    use chroma_storage::config::{
-        ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
-    };
+    use chroma_storage::s3_config_for_test_with_bucket_name;
     use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig};
     use chroma_system::{DispatcherConfig, System};
     use tracing_test::traced_test;
@@ -709,15 +707,7 @@ mod tests {
                 num_channels: 1,
             },
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: StorageConfig::ObjectStore(ObjectStoreConfig {
-                bucket: ObjectStoreBucketConfig {
-                    name: "chroma-storage".to_string(),
-                    r#type: ObjectStoreType::Minio,
-                },
-                upload_part_size_bytes: 1024 * 1024,   // 1MB
-                download_part_size_bytes: 1024 * 1024, // 1MB
-                max_concurrent_requests: 10,
-            }),
+            storage_config: s3_config_for_test_with_bucket_name("chroma-storage").await,
             default_mode: CleanupMode::DryRun,
             tenant_mode_overrides: Some(tenant_mode_overrides),
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),
@@ -836,15 +826,7 @@ mod tests {
                 num_channels: 1,
             },
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: StorageConfig::ObjectStore(ObjectStoreConfig {
-                bucket: ObjectStoreBucketConfig {
-                    name: "chroma-storage".to_string(),
-                    r#type: ObjectStoreType::Minio,
-                },
-                upload_part_size_bytes: 1024 * 1024,   // 1MB
-                download_part_size_bytes: 1024 * 1024, // 1MB
-                max_concurrent_requests: 10,
-            }),
+            storage_config: s3_config_for_test_with_bucket_name("chroma-storage").await,
             default_mode: CleanupMode::DryRun,
             tenant_mode_overrides: Some(tenant_mode_overrides),
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),
@@ -1037,15 +1019,7 @@ mod tests {
                 num_channels: 1,
             },
             dispatcher_config: DispatcherConfig::default(),
-            storage_config: StorageConfig::ObjectStore(ObjectStoreConfig {
-                bucket: ObjectStoreBucketConfig {
-                    name: "chroma-storage".to_string(),
-                    r#type: ObjectStoreType::Minio,
-                },
-                upload_part_size_bytes: 1024 * 1024,   // 1MB
-                download_part_size_bytes: 1024 * 1024, // 1MB
-                max_concurrent_requests: 10,
-            }),
+            storage_config: s3_config_for_test_with_bucket_name("chroma-storage").await,
             default_mode: CleanupMode::DeleteV2,
             tenant_mode_overrides: None,
             assignment_policy: chroma_config::assignment::config::AssignmentPolicyConfig::default(),

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -524,9 +524,7 @@ mod tests {
     use crate::helper::ChromaGrpcClients;
     use chroma_config::registry::Registry;
     use chroma_config::Configurable;
-    use chroma_storage::config::{
-        ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
-    };
+    use chroma_storage::s3_config_for_test_with_bucket_name;
     use chroma_storage::GetOptions;
     use chroma_sysdb::{GrpcSysDbConfig, SysDbConfig};
     use chroma_system::System;
@@ -772,15 +770,7 @@ mod tests {
 
     async fn test_k8s_integration_check_end_to_end(use_spann: bool) {
         // Create storage config and storage client
-        let storage_config = StorageConfig::ObjectStore(ObjectStoreConfig {
-            bucket: ObjectStoreBucketConfig {
-                name: "chroma-storage".to_string(),
-                r#type: ObjectStoreType::Minio,
-            },
-            upload_part_size_bytes: 1024 * 1024,   // 1MB
-            download_part_size_bytes: 1024 * 1024, // 1MB
-            max_concurrent_requests: 10,
-        });
+        let storage_config = s3_config_for_test_with_bucket_name("chroma-storage").await;
 
         let registry = Registry::new();
         let storage = Storage::try_from_config(&storage_config, &registry)
@@ -920,15 +910,7 @@ mod tests {
     #[traced_test]
     async fn test_k8s_integration_soft_delete() {
         // Create storage config and storage client
-        let storage_config = StorageConfig::ObjectStore(ObjectStoreConfig {
-            bucket: ObjectStoreBucketConfig {
-                name: "chroma-storage".to_string(),
-                r#type: ObjectStoreType::Minio,
-            },
-            upload_part_size_bytes: 1024 * 1024,   // 1MB
-            download_part_size_bytes: 1024 * 1024, // 1MB
-            max_concurrent_requests: 10,
-        });
+        let storage_config = s3_config_for_test_with_bucket_name("chroma-storage").await;
 
         let registry = Registry::new();
         let storage = Storage::try_from_config(&storage_config, &registry)
@@ -1086,15 +1068,7 @@ mod tests {
     #[traced_test]
     async fn test_k8s_integration_dry_run() {
         // Create storage config and storage client
-        let storage_config = StorageConfig::ObjectStore(ObjectStoreConfig {
-            bucket: ObjectStoreBucketConfig {
-                name: "chroma-storage".to_string(),
-                r#type: ObjectStoreType::Minio,
-            },
-            upload_part_size_bytes: 1024 * 1024,   // 1MB
-            download_part_size_bytes: 1024 * 1024, // 1MB
-            max_concurrent_requests: 10,
-        });
+        let storage_config = s3_config_for_test_with_bucket_name("chroma-storage").await;
 
         let registry = Registry::new();
         let storage = Storage::try_from_config(&storage_config, &registry)

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -139,9 +139,7 @@ mod tests {
     use super::*;
     use chroma_config::registry;
     use chroma_config::Configurable;
-    use chroma_storage::config::{
-        ObjectStoreBucketConfig, ObjectStoreConfig, ObjectStoreType, StorageConfig,
-    };
+    use chroma_storage::s3_config_for_test_with_bucket_name;
     use chroma_storage::PutOptions;
     use chroma_types::chroma_proto::CollectionInfoImmutable;
     use chroma_types::chroma_proto::CollectionVersionHistory;
@@ -150,15 +148,7 @@ mod tests {
 
     async fn setup_test_storage() -> Storage {
         // Create storage config for Minio
-        let storage_config = StorageConfig::ObjectStore(ObjectStoreConfig {
-            bucket: ObjectStoreBucketConfig {
-                name: "chroma-storage".to_string(),
-                r#type: ObjectStoreType::Minio,
-            },
-            upload_part_size_bytes: 1024 * 1024,
-            download_part_size_bytes: 1024 * 1024,
-            max_concurrent_requests: 10,
-        });
+        let storage_config = s3_config_for_test_with_bucket_name("chroma-storage").await;
 
         // Add more detailed logging
         tracing::info!("Setting up test storage with config: {:?}", storage_config);

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -16,7 +16,7 @@ use local::LocalStorage;
 use tempfile::TempDir;
 use thiserror::Error;
 
-pub use s3::s3_client_for_test_with_new_bucket;
+pub use s3::{s3_client_for_test_with_new_bucket, s3_config_for_test_with_bucket_name};
 
 /// A StorageError captures all kinds of errors that can come from storage.
 //

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -8,7 +8,7 @@
 // Once we move to our own implementation of hnswlib we can support
 // streaming from s3.
 
-use super::config::StorageConfig;
+use super::config::{S3CredentialsConfig, StorageConfig};
 use super::stream::ByteStreamItem;
 use super::stream::S3ByteStream;
 use super::StorageConfigError;
@@ -787,6 +787,14 @@ impl Configurable<StorageConfig> for S3Storage {
             _ => Err(Box::new(StorageConfigError::InvalidStorageConfig)),
         }
     }
+}
+
+pub async fn s3_config_for_test_with_bucket_name(name: impl Into<String>) -> crate::StorageConfig {
+    StorageConfig::S3(crate::config::S3StorageConfig {
+        bucket: name.into(),
+        credentials: S3CredentialsConfig::Minio,
+        ..Default::default()
+    })
 }
 
 pub async fn s3_client_for_test_with_bucket_name(name: &str) -> crate::Storage {


### PR DESCRIPTION
## Description of changes

The best intentions of mice and men or something led us to have an ObjectStore backend, and the path
of least resistance led to us using it in tests.

Change all instances of that backend to use S3 storage with a Minio credential.

## Test plan

CI
    
- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
