### PR TITLE
Fix Typo: Correct "enviroment" to "environment" in Documentation Comments

### DIFF
--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -100,7 +100,7 @@ impl Default for RootConfig {
 /// - my_ip: The IP address of the worker service. Used for memberlist assignment. Must be provided.
 /// - assignment_policy: The assignment policy to use. Must be provided.
 /// # Notes
-/// In order to set the enviroment variables, you must prefix them with CHROMA_WORKER__<FIELD_NAME>.
+/// In order to set the environment variables, you must prefix them with CHROMA_WORKER__<FIELD_NAME>.
 /// For example, to set my_ip, you would set CHROMA_WORKER__MY_IP.
 /// Each submodule that needs to be configured from the config object should implement the Configurable trait and
 /// have its own field in this struct for its Config struct.
@@ -166,7 +166,7 @@ impl QueryServiceConfig {
 /// - my_ip: The IP address of the worker service. Used for memberlist assignment. Must be provided.
 /// - assignment_policy: The assignment policy to use. Must be provided.
 /// # Notes
-/// In order to set the enviroment variables, you must prefix them with CHROMA_COMPACTOR__<FIELD_NAME>.
+/// In order to set the environment variables, you must prefix them with CHROMA_COMPACTOR__<FIELD_NAME>.
 /// For example, to set my_ip, you would set CHROMA_COMPACTOR__MY_IP.
 /// Each submodule that needs to be configured from the config object should implement the Configurable trait and
 /// have its own field in this struct for its Config struct.


### PR DESCRIPTION
## Description of changes

This pull request fixes a typo in the documentation comments within `rust/worker/src/config.rs`, changing "enviroment" to the correct spelling "environment". This improves the clarity and professionalism of the documentation for setting environment variables in both `RootConfig` and `QueryServiceConfig`. No functional code changes are included.