### PR TITLE
[BLD]: fix input type of `push` for build images workflow (string -> bool)

### DIFF
--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -120,7 +120,7 @@ jobs:
   merge:
     name: Merge platform manifests
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    if: ${{ inputs.push == 'true' }}
+    if: ${{ inputs.push == true }}
     needs:
       - build
     steps:


### PR DESCRIPTION
## Description of changes

The `merge` job is currently skipped on main because the types don't match.