### PR TITLE
[BLD]: add actions/checkout step to image publish workflow

### DIFF
--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -124,6 +124,8 @@ jobs:
     needs:
       - build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Docker
         uses: ./.github/actions/docker
         with:


### PR DESCRIPTION
## Description of changes

The [last run](https://github.com/chroma-core/chroma/actions/runs/15687261091/job/44197731471) of this workflow failed because the custom action used in the merge job was never checked out.
