### PR TITLE
[ENH]  Do not crash loop on hard deleted collections.

### DIFF
--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -138,7 +138,16 @@ impl Scheduler {
                     let tenant = self.sysdb.get_last_compaction_time(tenant_ids).await;
 
                     let last_compaction_time = match tenant {
-                        Ok(tenant) => tenant[0].last_compaction_time,
+                        Ok(tenant) => {
+                            if tenant.is_empty() {
+                                tracing::info!(
+                                    "Ignoring collection: {:?}",
+                                    collection_info.collection_id
+                                );
+                                continue;
+                            }
+                            tenant[0].last_compaction_time
+                        }
                         Err(e) => {
                             tracing::error!("Error: {:?}", e);
                             // Ignore this collection id for this compaction iteration


### PR DESCRIPTION
## Description of changes

When a collection gets cleaned up for good, the compactor will crash.
Instead, let's trace an info.

## Test plan

CI

## Documentation Changes

N/A
