### PR TITLE
[ENH]: make S3 tracing spans less verbose by default

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -144,7 +144,7 @@ impl AdmissionControlledS3Storage {
         }
 
         let part_size = storage.download_part_size_bytes;
-        tracing::info!(
+        tracing::debug!(
             "[AdmissionControlledS3][Parallel fetch] Content length: {}, key ranges: {:?}",
             content_length,
             ranges

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -665,12 +665,11 @@ impl S3Storage {
 
     #[tracing::instrument(skip(self), level = "trace")]
     pub async fn rename(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
-        tracing::info!(src = %src_key, dst = %dst_key, "Renaming object in S3");
         // S3 doesn't have a native rename operation, so we need to copy and delete
         self.copy(src_key, dst_key).await?;
         match self.delete(src_key, DeleteOptions::default()).await {
             Ok(_) => {
-                tracing::info!(src = %src_key, dst = %dst_key, "Successfully renamed object");
+                tracing::debug!(src = %src_key, dst = %dst_key, "Successfully renamed object");
                 Ok(())
             }
             Err(e) => {
@@ -682,7 +681,6 @@ impl S3Storage {
 
     #[tracing::instrument(skip(self), level = "trace")]
     pub async fn copy(&self, src_key: &str, dst_key: &str) -> Result<(), StorageError> {
-        tracing::info!(src = %src_key, dst = %dst_key, "Copying object in S3");
         match self
             .client
             .copy_object()

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
 pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
     EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| {
-        "error,opentelemetry_sdk=info,garbage_collector=debug,".to_string()
+        "error,opentelemetry_sdk=info,garbage_collector=debug,chroma_storage=debug,".to_string()
             + &vec![
                 "chroma",
                 "chroma-blockstore",
@@ -26,7 +26,6 @@ pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                 "chroma-log-service",
                 "chroma-frontend",
                 "chroma-index",
-                "chroma-storage",
                 "chroma-test",
                 "chroma-types",
                 "compaction_service",


### PR DESCRIPTION
## Description of changes

Bumps the tracing level of `chroma-storage` to debug from trace.

I audited all spans in `rust/storage` to ensure all high-frequency code paths only have trace-level events and that any errors are correctly logged with the error level.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

Confirmed that S3 spans no longer show up in Jaeger.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a