### PR TITLE
[ENH]: wrap CollectionVersionFile in Arc

### DIFF
--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -30,6 +30,7 @@ use petgraph::{dot::Dot, graph::DiGraph};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
+    sync::Arc,
 };
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
@@ -55,7 +56,7 @@ pub struct ConstructVersionGraphOrchestrator {
     lineage_file_path: Option<String>,
 
     version_dependencies: Vec<VersionDependency>,
-    version_files: HashMap<CollectionUuid, CollectionVersionFile>,
+    version_files: HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
     num_pending_tasks: usize,
 }
 
@@ -88,7 +89,7 @@ impl ConstructVersionGraphOrchestrator {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct ConstructVersionGraphResponse {
-    pub version_files: HashMap<CollectionUuid, CollectionVersionFile>,
+    pub version_files: HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
     pub graph: VersionGraph,
 }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -37,8 +37,6 @@
 //!    - Input: Version file, versions to delete, unused S3 files
 //!    - Output: Deletion confirmation
 
-use std::fmt::{Debug, Formatter};
-
 use crate::types::{CleanupMode, GarbageCollectorResponse};
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
@@ -51,6 +49,8 @@ use chroma_system::{
 use chroma_types::chroma_proto::CollectionVersionFile;
 use chroma_types::CollectionUuid;
 use chrono::{DateTime, Utc};
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
@@ -87,7 +87,7 @@ pub struct GarbageCollectorOrchestrator {
     dispatcher: ComponentHandle<Dispatcher>,
     storage: Storage,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
-    pending_version_file: Option<CollectionVersionFile>,
+    pending_version_file: Option<Arc<CollectionVersionFile>>,
     pending_versions_to_delete: Option<chroma_types::chroma_proto::VersionListForCollection>,
     pending_epoch_id: Option<i64>,
     num_versions_deleted: u32,

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -62,7 +62,7 @@ pub struct GarbageCollectorOrchestrator {
     root_manager: RootManager,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
     cleanup_mode: CleanupMode,
-    version_files: HashMap<CollectionUuid, CollectionVersionFile>,
+    version_files: HashMap<CollectionUuid, Arc<CollectionVersionFile>>,
     versions_to_delete_output: Option<ComputeVersionsToDeleteOutput>,
     pending_mark_versions_at_sysdb_tasks: HashSet<CollectionUuid>,
     pending_list_files_at_version_tasks: HashSet<(CollectionUuid, i64)>,

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -5,7 +5,7 @@ use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
 use futures::stream::StreamExt;
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -22,7 +22,7 @@ impl std::fmt::Debug for DeleteVersionsAtSysDbOperator {
 
 #[derive(Debug)]
 pub struct DeleteVersionsAtSysDbInput {
-    pub version_file: CollectionVersionFile,
+    pub version_file: Arc<CollectionVersionFile>,
     pub epoch_id: i64,
     pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
@@ -31,7 +31,7 @@ pub struct DeleteVersionsAtSysDbInput {
 
 #[derive(Debug)]
 pub struct DeleteVersionsAtSysDbOutput {
-    pub version_file: CollectionVersionFile,
+    pub version_file: Arc<CollectionVersionFile>,
     pub versions_to_delete: VersionListForCollection,
     pub unused_s3_files: HashSet<String>,
 }
@@ -209,10 +209,10 @@ mod tests {
         let sysdb = SysDb::Test(TestSysDb::new());
 
         // Create a version file with actual version history
-        let version_file = CollectionVersionFile {
+        let version_file = Arc::new(CollectionVersionFile {
             version_history: Some(chroma_proto::CollectionVersionHistory { versions: vec![] }),
             ..Default::default()
-        };
+        });
 
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
@@ -245,7 +245,7 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
         let sysdb = SysDb::Test(TestSysDb::new());
-        let version_file = CollectionVersionFile::default();
+        let version_file = Arc::new(CollectionVersionFile::default());
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
             database_id: "default".to_string(),
@@ -368,7 +368,7 @@ mod tests {
         }
 
         // Create version file with history
-        let version_file = CollectionVersionFile {
+        let version_file = Arc::new(CollectionVersionFile {
             version_history: Some(chroma_proto::CollectionVersionHistory {
                 versions: vec![
                     chroma_proto::CollectionVersionInfo {
@@ -386,7 +386,7 @@ mod tests {
                 ],
             }),
             ..Default::default()
-        };
+        });
 
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
@@ -439,7 +439,7 @@ mod tests {
         }
 
         // Create version file with history
-        let version_file = CollectionVersionFile {
+        let version_file = Arc::new(CollectionVersionFile {
             version_history: Some(chroma_proto::CollectionVersionHistory {
                 versions: vec![
                     chroma_proto::CollectionVersionInfo {
@@ -457,7 +457,7 @@ mod tests {
                 ],
             }),
             ..Default::default()
-        };
+        });
 
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),

--- a/rust/garbage_collector/src/operators/fetch_version_file.rs
+++ b/rust/garbage_collector/src/operators/fetch_version_file.rs
@@ -17,6 +17,7 @@ use chroma_types::CollectionUuid;
 use prost::Message;
 use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
+use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Clone, Debug, Default)]
@@ -53,7 +54,7 @@ impl Debug for FetchVersionFileInput {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct FetchVersionFileOutput {
-    pub file: CollectionVersionFile,
+    pub file: Arc<CollectionVersionFile>,
     pub collection_id: CollectionUuid,
 }
 
@@ -128,7 +129,7 @@ impl Operator<FetchVersionFileInput, FetchVersionFileOutput> for FetchVersionFil
         .map_err(FetchVersionFileError::InvalidUuid)?;
 
         Ok(FetchVersionFileOutput {
-            file: version_file,
+            file: Arc::new(version_file),
             collection_id,
         })
     }
@@ -202,7 +203,7 @@ mod tests {
         let result = operator.run(&input).await.expect("Failed to run operator");
 
         // Verify the content
-        assert_eq!(result.file, test_file);
+        assert_eq!(result.file, test_file.into());
 
         // Cleanup - Note: object_store doesn't have a delete method,
         // but the test bucket should be cleaned up between test runs

--- a/rust/garbage_collector/src/operators/list_files_at_version.rs
+++ b/rust/garbage_collector/src/operators/list_files_at_version.rs
@@ -4,21 +4,21 @@ use chroma_storage::StorageError;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::{chroma_proto::CollectionVersionFile, CollectionUuid, HNSW_PATH};
 use futures::stream::StreamExt;
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, str::FromStr, sync::Arc};
 use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct ListFilesAtVersionInput {
     root_manager: RootManager,
-    version_file: CollectionVersionFile,
+    version_file: Arc<CollectionVersionFile>,
     version: i64,
 }
 
 impl ListFilesAtVersionInput {
     pub fn new(
         root_manager: RootManager,
-        version_file: CollectionVersionFile,
+        version_file: Arc<CollectionVersionFile>,
         version: i64,
     ) -> Self {
         Self {

--- a/rust/garbage_collector/src/operators/mark_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/mark_versions_at_sysdb.rs
@@ -3,6 +3,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
+use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Clone, Debug)]
@@ -10,7 +11,7 @@ pub struct MarkVersionsAtSysDbOperator {}
 
 #[derive(Debug)]
 pub struct MarkVersionsAtSysDbInput {
-    pub version_file: CollectionVersionFile,
+    pub version_file: Arc<CollectionVersionFile>,
     pub versions_to_delete: VersionListForCollection,
     pub sysdb_client: SysDb,
     pub epoch_id: i64,
@@ -19,7 +20,7 @@ pub struct MarkVersionsAtSysDbInput {
 
 #[derive(Debug)]
 pub struct MarkVersionsAtSysDbOutput {
-    pub version_file: CollectionVersionFile,
+    pub version_file: Arc<CollectionVersionFile>,
     pub epoch_id: i64,
     pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
@@ -78,7 +79,7 @@ mod tests {
     #[tokio::test]
     async fn test_mark_versions_success() {
         let sysdb = SysDb::Test(TestSysDb::new());
-        let version_file = CollectionVersionFile::default();
+        let version_file = Arc::new(CollectionVersionFile::default());
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
             database_id: "default".to_string(),
@@ -105,7 +106,7 @@ mod tests {
     #[tokio::test]
     async fn test_mark_versions_empty_list() {
         let sysdb = SysDb::Test(TestSysDb::new());
-        let version_file = CollectionVersionFile::default();
+        let version_file = Arc::new(CollectionVersionFile::default());
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
             database_id: "default".to_string(),
@@ -132,7 +133,7 @@ mod tests {
     #[tokio::test]
     async fn test_mark_versions_error() {
         let sysdb = SysDb::Test(TestSysDb::new());
-        let version_file = CollectionVersionFile::default();
+        let version_file = Arc::new(CollectionVersionFile::default());
         let versions_to_delete = VersionListForCollection {
             collection_id: "test_collection".to_string(),
             database_id: "default".to_string(),


### PR DESCRIPTION
## Description of changes

These files can be quite large, especially when garbage collection hasn't yet been run/hasn't been run in a while on a collection.

Wrapping this type in an Arc should significantly reduce peak memory usage.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a
