### PR TITLE
[ENH]: migrate current metering functionality to new metering lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,12 +1518,14 @@ dependencies = [
  "chroma-error",
  "chroma-log",
  "chroma-memberlist",
+ "chroma-metering",
  "chroma-segment",
  "chroma-sqlite",
  "chroma-sysdb",
  "chroma-system",
  "chroma-tracing",
  "chroma-types",
+ "chrono",
  "criterion",
  "figment",
  "futures",
@@ -1714,6 +1716,22 @@ dependencies = [
  "tokio",
  "tonic",
  "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "chroma-metering"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chroma-metering-macros",
+ "chroma-system",
+ "chrono",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "rust/log-service",
     "rust/memberlist",
     "rust/metering-macros",
+    "rust/metering",
     "rust/storage",
     "rust/system",
     "rust/sysdb",
@@ -56,6 +57,7 @@ opentelemetry-http = { version = "0.27", features = ["reqwest"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 parking_lot = { version = "0.12.3", features = ["serde"] }
 parquet = "52"
+pin-project = "1.1.10"
 prost = "0.13"
 prost-types = "0.13.5"
 regex = "1.11.1"
@@ -110,6 +112,7 @@ chroma-index = { path = "rust/index" }
 chroma-log = { path = "rust/log" }
 chroma-memberlist = { path = "rust/memberlist" }
 chroma-metering-macros = { path = "rust/metering-macros" }
+chroma-metering = { path = "rust/metering" }
 chroma-segment = { path = "rust/segment" }
 chroma-storage = { path = "rust/storage" }
 chroma-system = { path = "rust/system" }

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -8,6 +8,7 @@ name = "frontend_service"
 path = "src/bin/frontend_service.rs"
 
 [dependencies]
+chrono = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
 serde = { workspace = true }
@@ -37,6 +38,7 @@ chroma-distance = { workspace = true }
 chroma-error = { workspace = true, features = ["validator", "http"] }
 chroma-log = { workspace = true }
 chroma-memberlist = { workspace = true }
+chroma-metering = { workspace = true }
 chroma-segment = { workspace = true }
 chroma-sysdb = { workspace = true }
 chroma-system = { workspace = true }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -6,11 +6,15 @@ use backon::{ExponentialBuilder, Retryable};
 use chroma_config::{registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::{LocalCompactionManager, LocalCompactionManagerConfig, Log};
+use chroma_metering::{
+    CollectionForkContext, CollectionReadContext, CollectionWriteContext, Enterable,
+    FtsQueryLength, LatestCollectionLogicalSizeBytes, LogSizeBytes, MetadataPredicateCount,
+    MeterEvent, PulledLogSizeBytes, QueryEmbeddingCount, ReturnBytes, WriteAction,
+};
 use chroma_segment::local_segment_manager::LocalSegmentManager;
 use chroma_sqlite::db::SqliteDb;
 use chroma_sysdb::{GetCollectionsOptions, SysDb};
 use chroma_system::System;
-use chroma_tracing::meter_event::{MeterEvent, ReadAction, WriteAction};
 use chroma_types::{
     operator::{Filter, KnnBatch, KnnProjection, Limit, Projection, Scan},
     plan::{Count, Get, Knn},
@@ -34,6 +38,7 @@ use chroma_types::{
     UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, VectorIndexConfiguration,
     Where,
 };
+use chrono::Utc;
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -603,7 +608,6 @@ impl ServiceBasedFrontend {
         &mut self,
         ForkCollectionRequest {
             tenant_id,
-            database_name,
             source_collection_id,
             target_collection_name,
             ..
@@ -634,15 +638,17 @@ impl ServiceBasedFrontend {
             .set_collection_with_segments(collection_and_segments)
             .await;
 
+        // Attach the collection's latest logical size to the metering context
+        chroma_metering::with_current(|context| {
+            context.latest_collection_logical_size_bytes(latest_collection_logical_size_bytes)
+        });
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionFork {
-            tenant: tenant_id,
-            database: database_name,
-            collection_id: source_collection_id.0,
-            latest_collection_logical_size_bytes,
+        if let Ok(collection_fork_context) = chroma_metering::close::<CollectionForkContext>() {
+            MeterEvent::CollectionFork(collection_fork_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
 
         Ok(collection)
     }
@@ -698,7 +704,6 @@ impl ServiceBasedFrontend {
         &mut self,
         AddCollectionRecordsRequest {
             tenant_id,
-            database_name,
             collection_id,
             ids,
             embeddings,
@@ -745,16 +750,15 @@ impl ServiceBasedFrontend {
             .add_retries_counter
             .add(retries.load(Ordering::Relaxed) as u64, &[]);
 
+        // Attach the log size in bytes to the metering context
+        chroma_metering::with_current(|context| context.log_size_bytes(log_size_bytes));
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionWrite {
-            tenant: tenant_id,
-            database: database_name,
-            collection_id: collection_id.0,
-            action: WriteAction::Add,
-            log_size_bytes,
+        if let Ok(collection_write_context) = chroma_metering::close::<CollectionWriteContext>() {
+            MeterEvent::CollectionWrite(collection_write_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
 
         match res {
             Ok(()) => Ok(AddCollectionRecordsResponse {}),
@@ -772,7 +776,6 @@ impl ServiceBasedFrontend {
         &mut self,
         UpdateCollectionRecordsRequest {
             tenant_id,
-            database_name,
             collection_id,
             ids,
             embeddings,
@@ -823,16 +826,15 @@ impl ServiceBasedFrontend {
             .update_retries_counter
             .add(retries.load(Ordering::Relaxed) as u64, &[]);
 
+        // Attach the log size in bytes to the metering context
+        chroma_metering::with_current(|context| context.log_size_bytes(log_size_bytes));
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionWrite {
-            tenant: tenant_id,
-            database: database_name,
-            collection_id: collection_id.0,
-            action: WriteAction::Update,
-            log_size_bytes,
+        if let Ok(collection_write_context) = chroma_metering::close::<CollectionWriteContext>() {
+            MeterEvent::CollectionWrite(collection_write_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
 
         match res {
             Ok(()) => Ok(UpdateCollectionRecordsResponse {}),
@@ -850,7 +852,6 @@ impl ServiceBasedFrontend {
         &mut self,
         UpsertCollectionRecordsRequest {
             tenant_id,
-            database_name,
             collection_id,
             ids,
             embeddings,
@@ -903,16 +904,15 @@ impl ServiceBasedFrontend {
             .upsert_retries_counter
             .add(retries.load(Ordering::Relaxed) as u64, &[]);
 
+        // Attach the log size in bytes to the metering context
+        chroma_metering::with_current(|context| context.log_size_bytes(log_size_bytes));
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionWrite {
-            tenant: tenant_id,
-            database: database_name,
-            collection_id: collection_id.0,
-            action: WriteAction::Upsert,
-            log_size_bytes,
+        if let Ok(collection_write_context) = chroma_metering::close::<CollectionWriteContext>() {
+            MeterEvent::CollectionWrite(collection_write_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
 
         match res {
             Ok(()) => Ok(UpsertCollectionRecordsResponse {}),
@@ -938,6 +938,12 @@ impl ServiceBasedFrontend {
         }: DeleteCollectionRecordsRequest,
     ) -> Result<DeleteCollectionRecordsResponse, DeleteCollectionRecordsError> {
         let mut records = Vec::new();
+
+        // NOTE(c-gamble): We are using a non-standard metering pattern in which we create a metering context within a
+        // nested call because we have to emit both a read and write event for delete requests. We need to extract the
+        // request start time from the current context here because our metering library only allows one active metering
+        // context per thread at a time. Eventually, this should be replaced by a single `CollectionDeleteRecordsContext`.
+        let mut maybe_request_received_at = None;
 
         let read_event = if let Some(where_clause) = r#where {
             let collection_and_segments = self
@@ -987,19 +993,26 @@ impl ServiceBasedFrontend {
                     metadata: None,
                 });
             }
-            // TODO: Submit event after the response is sent
-            Some(MeterEvent::CollectionRead {
-                tenant: tenant_id.clone(),
-                database: database_name.clone(),
-                collection_id: collection_id.0,
-                action: ReadAction::GetForDelete,
-                fts_query_length,
-                metadata_predicate_count,
-                query_embedding_count: 0,
-                pulled_log_size_bytes: get_result.pulled_log_bytes,
-                latest_collection_logical_size_bytes,
-                return_bytes,
-            })
+
+            // Attach metadata to the read context
+            chroma_metering::with_current(|context| {
+                context.fts_query_length(fts_query_length);
+                context.metadata_predicate_count(metadata_predicate_count);
+                context.query_embedding_count(0);
+                context.pulled_log_size_bytes(get_result.pulled_log_bytes);
+                context.latest_collection_logical_size_bytes(latest_collection_logical_size_bytes);
+                context.return_bytes(return_bytes);
+            });
+
+            if let Ok(collection_read_context) = chroma_metering::close::<CollectionReadContext>() {
+                // Store the request start time for the subsequent write event
+                maybe_request_received_at = Some(collection_read_context.get_request_received_at());
+
+                // Return the read event
+                Some(MeterEvent::CollectionRead(collection_read_context))
+            } else {
+                None
+            }
         } else if let Some(user_ids) = ids {
             records.extend(user_ids.into_iter().map(|id| OperationRecord {
                 id,
@@ -1035,16 +1048,37 @@ impl ServiceBasedFrontend {
         if let Some(event) = read_event {
             event.submit().await;
         }
+
+        // NOTE(c-gamble): See note above for additional context, but this is a non-standard pattern
+        // and we are only implementing metering for delete in this manner because delete currently
+        // produces two metering events.
+        let collection_write_context_container =
+            chroma_metering::create::<CollectionWriteContext>(CollectionWriteContext::new(
+                tenant_id.clone(),
+                database_name.clone(),
+                collection_id.0.to_string(),
+                WriteAction::Delete,
+                if let Some(request_received_at) = maybe_request_received_at {
+                    request_received_at
+                } else {
+                    Utc::now()
+                },
+            ));
+        collection_write_context_container.enter();
+
+        // Attach the log size bytes to the write context
+        chroma_metering::with_current(|context| context.log_size_bytes(log_size_bytes));
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionWrite {
-            tenant: tenant_id,
-            database: database_name,
-            collection_id: collection_id.0,
-            action: WriteAction::Delete,
-            log_size_bytes,
+        if let Ok(collection_write_context) = chroma_metering::close::<CollectionWriteContext>() {
+            MeterEvent::CollectionWrite(collection_write_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
+
+        // NOTE(c-gamble): This is not strictly necessary but good for hygiene. We can remove it once we consolidate
+        // delete into a single event.
+        collection_write_context_container.exit();
 
         Ok(DeleteCollectionRecordsResponse {})
     }
@@ -1100,12 +1134,7 @@ impl ServiceBasedFrontend {
 
     pub async fn retryable_count(
         &mut self,
-        CountRequest {
-            tenant_id,
-            database_name,
-            collection_id,
-            ..
-        }: CountRequest,
+        CountRequest { collection_id, .. }: CountRequest,
     ) -> Result<CountResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
@@ -1124,21 +1153,24 @@ impl ServiceBasedFrontend {
             })
             .await?;
         let return_bytes = count_result.size_bytes();
+
+        // Attach metadata to the metering context
+        chroma_metering::with_current(|context| {
+            context.fts_query_length(0);
+            context.metadata_predicate_count(0);
+            context.query_embedding_count(0);
+            context.pulled_log_size_bytes(count_result.pulled_log_bytes);
+            context.latest_collection_logical_size_bytes(latest_collection_logical_size_bytes);
+            context.return_bytes(return_bytes);
+        });
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionRead {
-            tenant: tenant_id.clone(),
-            database: database_name.clone(),
-            collection_id: collection_id.0,
-            action: ReadAction::Count,
-            fts_query_length: 0,
-            metadata_predicate_count: 0,
-            query_embedding_count: 0,
-            pulled_log_size_bytes: count_result.pulled_log_bytes,
-            latest_collection_logical_size_bytes,
-            return_bytes,
+        if let Ok(collection_read_context) = chroma_metering::close::<CollectionReadContext>() {
+            MeterEvent::CollectionRead(collection_read_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
+
         Ok(count_result.count)
     }
 
@@ -1191,8 +1223,6 @@ impl ServiceBasedFrontend {
     async fn retryable_get(
         &mut self,
         GetRequest {
-            tenant_id,
-            database_name,
             collection_id,
             ids,
             r#where,
@@ -1242,21 +1272,24 @@ impl ServiceBasedFrontend {
             })
             .await?;
         let return_bytes = get_result.size_bytes();
+
+        // Attach metadata to the metering context
+        chroma_metering::with_current(|context| {
+            context.fts_query_length(fts_query_length);
+            context.metadata_predicate_count(metadata_predicate_count);
+            context.query_embedding_count(0);
+            context.pulled_log_size_bytes(get_result.pulled_log_bytes);
+            context.latest_collection_logical_size_bytes(latest_collection_logical_size_bytes);
+            context.return_bytes(return_bytes);
+        });
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionRead {
-            tenant: tenant_id.clone(),
-            database: database_name.clone(),
-            collection_id: collection_id.0,
-            action: ReadAction::Get,
-            metadata_predicate_count,
-            fts_query_length,
-            query_embedding_count: 0,
-            pulled_log_size_bytes: get_result.pulled_log_bytes,
-            latest_collection_logical_size_bytes,
-            return_bytes,
+        if let Ok(collection_read_context) = chroma_metering::close::<CollectionReadContext>() {
+            MeterEvent::CollectionRead(collection_read_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
+
         Ok((get_result, include).into())
     }
 
@@ -1309,8 +1342,6 @@ impl ServiceBasedFrontend {
     async fn retryable_query(
         &mut self,
         QueryRequest {
-            tenant_id,
-            database_name,
             collection_id,
             ids,
             r#where,
@@ -1364,21 +1395,24 @@ impl ServiceBasedFrontend {
             })
             .await?;
         let return_bytes = query_result.size_bytes();
+
+        // Attach metadata to the metering context
+        chroma_metering::with_current(|context| {
+            context.fts_query_length(fts_query_length);
+            context.metadata_predicate_count(metadata_predicate_count);
+            context.query_embedding_count(query_embedding_count);
+            context.pulled_log_size_bytes(query_result.pulled_log_bytes);
+            context.latest_collection_logical_size_bytes(latest_collection_logical_size_bytes);
+            context.return_bytes(return_bytes);
+        });
+
         // TODO: Submit event after the response is sent
-        MeterEvent::CollectionRead {
-            tenant: tenant_id.clone(),
-            database: database_name.clone(),
-            collection_id: collection_id.0,
-            action: ReadAction::Query,
-            metadata_predicate_count,
-            fts_query_length,
-            query_embedding_count,
-            pulled_log_size_bytes: query_result.pulled_log_bytes,
-            latest_collection_logical_size_bytes,
-            return_bytes,
+        if let Ok(collection_read_context) = chroma_metering::close::<CollectionReadContext>() {
+            MeterEvent::CollectionRead(collection_read_context)
+                .submit()
+                .await;
         }
-        .submit()
-        .await;
+
         Ok((query_result, include).into())
     }
 

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -5,6 +5,10 @@ use axum::{
     routing::{get, post},
     Json, Router, ServiceExt,
 };
+use chroma_metering::{
+    CollectionForkContext, CollectionReadContext, CollectionWriteContext, MeteredFutureExt,
+    ReadAction, WriteAction,
+};
 use chroma_system::System;
 use chroma_types::{
     AddCollectionRecordsResponse, ChecklistResponse, Collection, CollectionConfiguration,
@@ -20,6 +24,7 @@ use chroma_types::{
     UpdateMetadata, UpsertCollectionRecordsResponse,
 };
 use chroma_types::{ForkCollectionResponse, RawWhereFields};
+use chrono::Utc;
 use mdac::{Rule, Scorecard, ScorecardTicket};
 use opentelemetry::global;
 use opentelemetry::metrics::{Counter, Meter};
@@ -1206,6 +1211,14 @@ async fn fork_collection(
     quota_payload = quota_payload.with_collection_name(&payload.new_name);
     server.quota_enforcer.enforce(&quota_payload).await?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionForkContext>(CollectionForkContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+        ));
+
     let _guard =
         server.scorecard_request(&["op:fork_collection", format!("tenant:{}", tenant).as_str()])?;
 
@@ -1216,7 +1229,13 @@ async fn fork_collection(
         payload.new_name,
     )?;
 
-    Ok(Json(server.frontend.fork_collection(request).await?))
+    Ok(Json(
+        server
+            .frontend
+            .fork_collection(request)
+            .meter(metering_context_container)
+            .await?,
+    ))
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]
@@ -1311,6 +1330,16 @@ async fn collection_add(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionWriteContext>(CollectionWriteContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+            WriteAction::Add,
+            Utc::now(),
+        ));
+
     tracing::info!(name: "collection_add", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.len());
     let request = chroma_types::AddCollectionRecordsRequest::try_new(
         tenant,
@@ -1323,7 +1352,11 @@ async fn collection_add(
         payload.metadatas,
     )?;
 
-    let res = server.frontend.add(request).await?;
+    let res = server
+        .frontend
+        .add(request)
+        .meter(metering_context_container)
+        .await?;
 
     Ok((StatusCode::CREATED, Json(res)))
 }
@@ -1401,6 +1434,16 @@ async fn collection_update(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionWriteContext>(CollectionWriteContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+            WriteAction::Update,
+            Utc::now(),
+        ));
+
     tracing::info!(name: "collection_update", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.len());
     let request = chroma_types::UpdateCollectionRecordsRequest::try_new(
         tenant,
@@ -1413,7 +1456,13 @@ async fn collection_update(
         payload.metadatas,
     )?;
 
-    Ok(Json(server.frontend.update(request).await?))
+    Ok(Json(
+        server
+            .frontend
+            .update(request)
+            .meter(metering_context_container)
+            .await?,
+    ))
 }
 
 #[derive(Deserialize, Debug, Clone, ToSchema, Serialize)]
@@ -1496,6 +1545,16 @@ async fn collection_upsert(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionWriteContext>(CollectionWriteContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+            WriteAction::Upsert,
+            Utc::now(),
+        ));
+
     tracing::info!(name: "collection_upsert", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.len());
     let request = chroma_types::UpsertCollectionRecordsRequest::try_new(
         tenant,
@@ -1508,7 +1567,13 @@ async fn collection_upsert(
         payload.metadatas,
     )?;
 
-    Ok(Json(server.frontend.upsert(request).await?))
+    Ok(Json(
+        server
+            .frontend
+            .upsert(request)
+            .meter(metering_context_container)
+            .await?,
+    ))
 }
 
 #[derive(Deserialize, Debug, Clone, ToSchema, Serialize)]
@@ -1580,6 +1645,18 @@ async fn collection_delete(
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
     ])?;
+
+    // Create a metering context
+    // NOTE(c-gamble): This is a read context because read happens first on delete, then write.
+    let metering_context_container =
+        chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+            ReadAction::GetForDelete,
+            Utc::now(),
+        ));
+
     tracing::info!(name: "collection_delete", tenant_name = %tenant, database_name = %database, collection_id = %collection_id, num_ids = %payload.ids.as_ref().map_or(0, |ids| ids.len()), has_where = r#where.is_some());
     let request = chroma_types::DeleteCollectionRecordsRequest::try_new(
         tenant,
@@ -1589,7 +1666,11 @@ async fn collection_delete(
         r#where,
     )?;
 
-    server.frontend.delete(request).await?;
+    server
+        .frontend
+        .delete(request)
+        .meter(metering_context_container)
+        .await?;
 
     Ok(Json(DeleteCollectionRecordsResponse {}))
 }
@@ -1646,13 +1727,29 @@ async fn collection_count(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.clone(),
+            ReadAction::Count,
+            Utc::now(),
+        ));
+
     let request = CountRequest::try_new(
         tenant,
         database,
         CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?,
     )?;
 
-    Ok(Json(server.frontend.count(request).await?))
+    Ok(Json(
+        server
+            .frontend
+            .count(request)
+            .meter(metering_context_container)
+            .await?,
+    ))
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -1732,6 +1829,16 @@ async fn collection_get(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+            ReadAction::Get,
+            Utc::now(),
+        ));
+
     tracing::info!(
         name: "collection_get",
         num_ids = payload.ids.as_ref().map_or(0, |ids| ids.len()),
@@ -1748,7 +1855,11 @@ async fn collection_get(
         payload.offset.unwrap_or(0),
         payload.include,
     )?;
-    let res = server.frontend.get(request).await?;
+    let res = server
+        .frontend
+        .get(request)
+        .meter(metering_context_container)
+        .await?;
     Ok(Json(res))
 }
 
@@ -1835,6 +1946,16 @@ async fn collection_query(
         format!("collection:{}", collection_id).as_str(),
     ])?;
 
+    // Create a metering context
+    let metering_context_container =
+        chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            tenant.clone(),
+            database.clone(),
+            collection_id.0.to_string(),
+            ReadAction::Query,
+            Utc::now(),
+        ));
+
     tracing::info!(
         name: "collection_query",
         num_ids = payload.ids.as_ref().map_or(0, |ids| ids.len()),
@@ -1853,7 +1974,11 @@ async fn collection_query(
         payload.include,
     )?;
 
-    let res = server.frontend.query(request).await?;
+    let res = server
+        .frontend
+        .query(request)
+        .meter(metering_context_container)
+        .await?;
 
     Ok(Json(res))
 }

--- a/rust/metering/Cargo.toml
+++ b/rust/metering/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "chroma-metering"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = { workspace = true }
+chroma-metering-macros = { workspace = true }
+chroma-system = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+pin-project = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -1,0 +1,346 @@
+use chroma_metering_macros::initialize_metering;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use crate::types::MeteringAtomicU64;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "read_action")]
+pub enum ReadAction {
+    Count,
+    Get,
+    GetForDelete,
+    Query,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "write_action")]
+pub enum WriteAction {
+    Add,
+    Delete,
+    Update,
+    Upsert,
+}
+
+initialize_metering! {
+    #[capability]
+    pub trait LatestCollectionLogicalSizeBytes {
+        fn latest_collection_logical_size_bytes(&self, latest_collection_logical_size_bytes: u64);
+    }
+
+    #[capability]
+    pub trait LogSizeBytes {
+        fn log_size_bytes(&self, log_size_bytes: u64);
+    }
+
+    #[capability]
+    pub trait RequestHandlingDuration {
+        fn request_handling_duration(&self, completed_at: DateTime<Utc>);
+    }
+
+    #[capability]
+    pub trait FtsQueryLength {
+        fn fts_query_length(&self, fts_query_length: u64);
+    }
+
+    #[capability]
+    pub trait MetadataPredicateCount {
+        fn metadata_predicate_count(&self, metadata_predicate_count: u64);
+    }
+
+    #[capability]
+    pub trait QueryEmbeddingCount {
+        fn query_embedding_count(&self, query_embedding_count: u64);
+    }
+
+    #[capability]
+    pub trait PulledLogSizeBytes {
+        fn pulled_log_size_bytes(&self, pulled_log_size_bytes: u64);
+    }
+
+    #[capability]
+    pub trait ReturnBytes {
+        fn return_bytes(&self, return_bytes: u64);
+    }
+
+    ////////////////////////////////// collection_fork //////////////////////////////////
+    #[context(
+        capabilities = [
+            LatestCollectionLogicalSizeBytes
+        ],
+        handlers = [
+            __handler_collection_fork_latest_collection_logical_size_bytes
+        ]
+    )]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct CollectionForkContext {
+        pub tenant: String,
+        pub database: String,
+        pub collection_id: String,
+        pub latest_collection_logical_size_bytes: MeteringAtomicU64,
+    }
+
+    impl CollectionForkContext {
+        pub fn new(tenant: String, database: String, collection_id: String) -> Self {
+            CollectionForkContext {
+                tenant,
+                database,
+                collection_id,
+                latest_collection_logical_size_bytes: MeteringAtomicU64(Arc::new(AtomicU64::new(0)))
+            }
+        }
+    }
+
+    /// Handler for [`crate::core::LatestCollectionLogicalSizeBytes`] capability for collection fork contexts
+    fn __handler_collection_fork_latest_collection_logical_size_bytes(
+        context: &CollectionForkContext,
+        latest_collection_logical_size_bytes: u64,
+    ) {
+        context
+            .latest_collection_logical_size_bytes
+            .store(latest_collection_logical_size_bytes, Ordering::SeqCst);
+    }
+
+    ////////////////////////////////// collection_read //////////////////////////////////
+    #[context(
+        capabilities = [
+            RequestHandlingDuration,
+            FtsQueryLength,
+            MetadataPredicateCount,
+            QueryEmbeddingCount,
+            PulledLogSizeBytes,
+            LatestCollectionLogicalSizeBytes,
+            ReturnBytes,
+            ],
+        handlers = [
+            __handler_collection_read_request_handling_duration,
+            __handler_collection_read_fts_query_length,
+            __handler_collection_read_metadata_predicate_count,
+            __handler_collection_read_query_embedding_count,
+            __handler_collection_read_pulled_log_size_bytes,
+            __handler_collection_read_latest_collection_logical_size_bytes,
+            __handler_collection_read_return_bytes,
+        ]
+    )]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct CollectionReadContext {
+        tenant: String,
+        database: String,
+        collection_id: String,
+        #[serde(flatten)]
+        action: ReadAction,
+        fts_query_length: MeteringAtomicU64,
+        metadata_predicate_count: MeteringAtomicU64,
+        query_embedding_count: MeteringAtomicU64,
+        pulled_log_size_bytes: MeteringAtomicU64,
+        latest_collection_logical_size_bytes: MeteringAtomicU64,
+        return_bytes: MeteringAtomicU64,
+        // NOTE(c-gamble): We use chrono's `DateTime` object here because `std::time::Instant`
+        // is not compatible with serde.
+        request_received_at: DateTime<Utc>,
+        request_handling_duration_ms: MeteringAtomicU64,
+    }
+
+    impl CollectionReadContext {
+        pub fn new(tenant: String, database: String, collection_id: String, action: ReadAction, request_received_at: DateTime<Utc>,) -> Self {
+            CollectionReadContext {
+                tenant,
+                database,
+                collection_id,
+                action,
+                fts_query_length: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                metadata_predicate_count: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                query_embedding_count: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                pulled_log_size_bytes: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                latest_collection_logical_size_bytes: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                return_bytes: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                request_received_at,
+                request_handling_duration_ms: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+            }
+        }
+
+        // NOTE(c-gamble): This is a special method to support the current multi-event nature of delete requests. It
+        // should be deleted in the future once we have a single delete event.
+        pub fn get_request_received_at(&self) -> DateTime<Utc> {
+            self.request_received_at
+        }
+    }
+
+    /// Handler for [`crate::core::FtsQueryLength`] capability for collection read contexts
+    fn __handler_collection_read_fts_query_length(
+        context: &CollectionReadContext,
+        fts_query_length: u64,
+    ) {
+        context
+            .fts_query_length
+            .store(fts_query_length, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::MetadataPredicateCount`] capability for collection read contexts
+    fn __handler_collection_read_metadata_predicate_count(
+        context: &CollectionReadContext,
+        metadata_predicate_count: u64,
+    ) {
+        context
+            .metadata_predicate_count
+            .store(metadata_predicate_count, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::QueryEmbeddingCount`] capability for collection read contexts
+    fn __handler_collection_read_query_embedding_count(
+        context: &CollectionReadContext,
+        query_embedding_count: u64,
+    ) {
+        context
+            .query_embedding_count
+            .store(query_embedding_count, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::PulledLogSizeBytes`] capability for collection read contexts
+    fn __handler_collection_read_pulled_log_size_bytes(
+        context: &CollectionReadContext,
+        pulled_log_size_bytes: u64,
+    ) {
+        context
+            .pulled_log_size_bytes
+            .store(pulled_log_size_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::LatestCollectionLogicalSizeBytes`] capability for collection read contexts
+    fn __handler_collection_read_latest_collection_logical_size_bytes(
+        context: &CollectionReadContext,
+        latest_collection_logical_size_bytes: u64,
+    ) {
+        context
+            .latest_collection_logical_size_bytes
+            .store(latest_collection_logical_size_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::ReturnBytes`] capability for collection read contexts
+    fn __handler_collection_read_return_bytes(
+        context: &CollectionReadContext,
+        return_bytes: u64,
+    ) {
+        context
+            .return_bytes
+            .store(return_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::RequestHandlingDuration`] capability for collection read contexts
+    fn __handler_collection_read_request_handling_duration(
+        context: &CollectionReadContext,
+        completed_at: DateTime<Utc>,
+    ) {
+        let duration_ms = completed_at
+            .signed_duration_since(context.request_received_at) // NOTE(c-gamble): We use signed to suppress "time went backward" errors.
+            .num_milliseconds()
+            .max(0) as u64;
+
+        context
+            .request_handling_duration_ms
+            .store(duration_ms, Ordering::SeqCst);
+    }
+
+    ////////////////////////////////// collection_write //////////////////////////////////
+    #[context(
+        capabilities = [
+            RequestHandlingDuration,
+            LogSizeBytes
+            ],
+        handlers = [
+            __handler_collection_write_request_handling_duration,
+            __handler_collection_write_log_size_bytes
+        ]
+    )]
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct CollectionWriteContext {
+        tenant: String,
+        database: String,
+        collection_id: String,
+        #[serde(flatten)]
+        action: WriteAction,
+        log_size_bytes: MeteringAtomicU64,
+        request_received_at: DateTime<Utc>,
+        request_handling_duration_ms: MeteringAtomicU64,
+    }
+
+    impl CollectionWriteContext {
+        pub fn new(tenant: String, database: String, collection_id: String, action: WriteAction, request_received_at: DateTime<Utc>) -> Self {
+            CollectionWriteContext {
+                tenant,
+                database,
+                collection_id,
+                action,
+                log_size_bytes: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+                request_received_at,
+                request_handling_duration_ms: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+            }
+        }
+    }
+
+    /// Handler for [`crate::core::LogSizeBytes`] capability for collection write contexts
+    fn __handler_collection_write_log_size_bytes(
+        context: &CollectionWriteContext,
+        log_size_bytes: u64,
+    ) {
+        context
+            .log_size_bytes
+            .store(log_size_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::RequestHandlingDuration`] capability for collection write contexts
+    fn __handler_collection_write_request_handling_duration(
+        context: &CollectionWriteContext,
+        completed_at: DateTime<Utc>,
+    ) {
+        let duration_ms = completed_at
+            .signed_duration_since(context.request_received_at) // NOTE(c-gamble): We use signed to suppress "time went backward" errors.
+            .num_milliseconds()
+            .max(0) as u64;
+
+        context
+            .request_handling_duration_ms
+            .store(duration_ms, Ordering::SeqCst);
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "event_name")]
+pub enum MeterEvent {
+    CollectionFork(CollectionForkContext),
+    CollectionRead(CollectionReadContext),
+    CollectionWrite(CollectionWriteContext),
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use std::sync::{atomic::AtomicU64, Arc};
+
+    use super::{CollectionWriteContext, MeterEvent, WriteAction};
+    use crate::types::MeteringAtomicU64;
+
+    #[test]
+    fn test_event_serialization() {
+        let event = MeterEvent::CollectionWrite(CollectionWriteContext {
+            tenant: "test_tenant".to_string(),
+            database: "test_database".to_string(),
+            collection_id: "test_collection".to_string(),
+            action: WriteAction::Add,
+            log_size_bytes: MeteringAtomicU64(Arc::new(AtomicU64::new(1000))),
+            request_received_at: Utc::now(),
+            request_handling_duration_ms: MeteringAtomicU64(Arc::new(AtomicU64::new(0))),
+        });
+        let json_str = serde_json::to_string(&event).expect("The event should be serializable");
+        let json_event =
+            serde_json::from_str::<MeterEvent>(&json_str).expect("Json should be deserializable");
+        assert_eq!(json_event, event);
+    }
+}

--- a/rust/metering/src/lib.rs
+++ b/rust/metering/src/lib.rs
@@ -1,0 +1,10 @@
+mod core;
+mod receiver;
+mod types;
+
+pub use core::{
+    close, create, get_current, with_current, CollectionForkContext, CollectionReadContext,
+    CollectionWriteContext, Enterable, FtsQueryLength, LatestCollectionLogicalSizeBytes,
+    LogSizeBytes, MetadataPredicateCount, MeterEvent, MeteredFutureExt, PulledLogSizeBytes,
+    QueryEmbeddingCount, ReadAction, RequestHandlingDuration, ReturnBytes, WriteAction,
+};

--- a/rust/metering/src/receiver.rs
+++ b/rust/metering/src/receiver.rs
@@ -1,0 +1,109 @@
+use chroma_system::ReceiverForMessage;
+use std::sync::OnceLock;
+use tracing::Span;
+
+use crate::core::MeterEvent;
+
+pub static METER_EVENT_RECEIVER: OnceLock<Box<dyn ReceiverForMessage<MeterEvent>>> =
+    OnceLock::new();
+
+impl MeterEvent {
+    pub fn init_receiver(receiver: Box<dyn ReceiverForMessage<MeterEvent>>) {
+        if METER_EVENT_RECEIVER.set(receiver).is_err() {
+            tracing::error!("Meter event handler is already initialized")
+        }
+    }
+
+    pub async fn submit(self) {
+        if let Some(handler) = METER_EVENT_RECEIVER.get() {
+            if let Err(err) = handler.send(self, Some(Span::current())).await {
+                tracing::error!("Unable to send meter event: {err}")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use crate::{core::MeterEvent, CollectionForkContext, MeteredFutureExt};
+    use chroma_system::{Component, ComponentContext, Handler, ReceiverForMessage, System};
+    #[derive(Clone)]
+    struct MeteringTestComponent {
+        messages: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl std::fmt::Debug for MeteringTestComponent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MeteringTestComponent").finish()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Component for MeteringTestComponent {
+        fn get_name() -> &'static str {
+            "MeteringTestComponent"
+        }
+        fn queue_size(&self) -> usize {
+            100
+        }
+        async fn on_start(&mut self, _: &ComponentContext<Self>) {}
+        fn on_stop_timeout(&self) -> std::time::Duration {
+            std::time::Duration::from_secs(1)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Handler<MeterEvent> for MeteringTestComponent {
+        type Result = Option<()>;
+        async fn handle(
+            &mut self,
+            message: MeterEvent,
+            _ctx: &ComponentContext<Self>,
+        ) -> Self::Result {
+            self.messages.lock().unwrap().push(format!("{:?}", message));
+            None
+        }
+    }
+    static TEST_ENV: OnceLock<(System, Arc<Mutex<Vec<String>>>)> = OnceLock::new();
+    fn test_env() -> Arc<Mutex<Vec<String>>> {
+        TEST_ENV
+            .get_or_init(|| {
+                let system = System::new();
+                let messages = Arc::new(Mutex::new(Vec::new()));
+                let component = MeteringTestComponent {
+                    messages: messages.clone(),
+                };
+                let handle = system.start_component(component);
+                let rx: Box<dyn ReceiverForMessage<MeterEvent>> = handle.receiver();
+                MeterEvent::init_receiver(rx);
+                (system, messages.clone())
+            })
+            .1
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn test_init_custom_receiver() {
+        let messages = test_env();
+        messages.lock().unwrap().clear();
+
+        async fn helper() {
+            if let Ok(metering_context) = crate::core::close::<CollectionForkContext>() {
+                MeterEvent::CollectionFork(metering_context).submit().await;
+            }
+        }
+
+        let metering_context_container =
+            crate::create::<CollectionForkContext>(CollectionForkContext::new(
+                "tenant".to_string(),
+                "database".to_string(),
+                "collection".to_string(),
+            ));
+        helper().meter(metering_context_container).await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(messages.lock().unwrap().len(), 1);
+    }
+}

--- a/rust/metering/src/types.rs
+++ b/rust/metering/src/types.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
+
+/// A wrapper around `Mutex<T>` that implements `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`,
+/// assuming `T` implements those traits.
+pub struct MeteringMutex<T>(pub Mutex<T>);
+
+impl<T: Clone> Clone for MeteringMutex<T> {
+    fn clone(&self) -> Self {
+        MeteringMutex(Mutex::new(self.0.lock().unwrap().clone()))
+    }
+}
+
+impl<T: PartialEq> PartialEq for MeteringMutex<T> {
+    fn eq(&self, other: &Self) -> bool {
+        *self.0.lock().unwrap() == *other.0.lock().unwrap()
+    }
+}
+
+impl<T: Eq> Eq for MeteringMutex<T> {}
+
+impl<T> Deref for MeteringMutex<T> {
+    type Target = Mutex<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for MeteringMutex<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for MeteringMutex<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.lock().unwrap().fmt(formatter)
+    }
+}
+impl<T: Serialize> Serialize for MeteringMutex<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serde_mutex::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for MeteringMutex<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        serde_mutex::deserialize(deserializer).map(MeteringMutex)
+    }
+}
+
+/// Internal module to support serde for `Mutex<T>`
+mod serde_mutex {
+    use super::*;
+    pub fn serialize<T: Serialize, S: Serializer>(
+        mutex: &Mutex<T>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        mutex.lock().unwrap().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, T: Deserialize<'de>, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Mutex<T>, D::Error> {
+        let inner = T::deserialize(deserializer)?;
+        Ok(Mutex::new(inner))
+    }
+}
+
+/// A wrapper around `Arc<AtomicU64>` that implements `Clone`, `Debug`, `PartialEq`, `Eq`, `Serialize`, and `Deserialize`.
+#[derive(Clone)]
+pub struct MeteringAtomicU64(pub Arc<AtomicU64>);
+
+impl PartialEq for MeteringAtomicU64 {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.load(Ordering::SeqCst) == other.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Eq for MeteringAtomicU64 {}
+
+impl Deref for MeteringAtomicU64 {
+    type Target = AtomicU64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for MeteringAtomicU64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("MeteringAtomicU64")
+            .field(&self.0.load(Ordering::SeqCst))
+            .finish()
+    }
+}
+
+impl Serialize for MeteringAtomicU64 {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u64(self.0.load(Ordering::SeqCst))
+    }
+}
+
+impl<'de> Deserialize<'de> for MeteringAtomicU64 {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = u64::deserialize(deserializer)?;
+        Ok(MeteringAtomicU64(Arc::new(AtomicU64::new(value))))
+    }
+}


### PR DESCRIPTION
## Description of changes

This PR migrates all of the existing metering functionality of Chroma to use the metering library created in #4746. It does not introduce any new metering functionality on top of what was present before.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
