### PR TITLE
[BUG] remove a left-in assert for RLS

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -354,6 +354,13 @@ impl RollupPerCollection {
         self.start_log_position = witness
             .map(|x| x.1.position)
             .unwrap_or(LogPosition::from_offset(1));
+        if self.start_log_position > self.limit_log_position {
+            tracing::error!(
+                "invariant violation; will patch: {:?} > {:?}",
+                self.start_log_position,
+                self.limit_log_position
+            );
+        }
         self.limit_log_position = self.limit_log_position.max(self.start_log_position);
     }
 

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -354,7 +354,6 @@ impl RollupPerCollection {
         self.start_log_position = witness
             .map(|x| x.1.position)
             .unwrap_or(LogPosition::from_offset(1));
-        assert!(self.start_log_position <= self.limit_log_position);
         self.limit_log_position = self.limit_log_position.max(self.start_log_position);
     }
 


### PR DESCRIPTION
## Description of changes

We put in an assert for testing and left it in.  It's triggering, indicating we got the bug.

## Test plan

CI

## Documentation Changes

N/A
