### PR TITLE
[BUG]  Fix for empty manifests.

### DIFF
--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -188,9 +188,11 @@ impl ManifestManager {
             return Err(Error::UninitializedLog);
         };
         let latest_fragment = manifest.fragments.iter().max_by_key(|f| f.limit.offset());
-        let next_log_position = latest_fragment
-            .map(|f| f.limit)
-            .unwrap_or(LogPosition::from_offset(1));
+        let next_log_position = latest_fragment.map(|f| f.limit).unwrap_or(
+            manifest
+                .initial_offset
+                .unwrap_or(LogPosition::from_offset(1)),
+        );
         let next_seq_no_to_assign = latest_fragment
             .map(|f| f.seq_no + 1)
             .unwrap_or(FragmentSeqNo(1));


### PR DESCRIPTION
## Description of changes

If the manifest contains no fragments, the proper thing to do to get the log position is to consult
the initial offset and only then fall back to LogPosition::INITIAL.

## Test plan

Land this so staging can go green overnight.  Merge tests tomorrow.

## Documentation Changes

n/a
