### PR TITLE
[BUG]  Track the threshold of garbage collected fragments

### DIFF
--- a/chromadb/test/distributed/test_log_failover.py
+++ b/chromadb/test/distributed/test_log_failover.py
@@ -285,3 +285,73 @@ def test_log_failover_with_query_operations(
         result = collection.get(ids=[str(i)], include=["embeddings"])
         assert len(result["embeddings"]) > 0, f"Missing result for ID {i} after failover with new data"
         assert all([math.fabs(x - y) < 0.001 for (x, y) in zip(result["embeddings"][0], embeddings[i])]), f"Embedding mismatch for ID {i}"
+
+@skip_if_not_cluster()
+def test_log_failover_with_compaction_and_gc_delay(
+    client: ClientAPI,
+) -> None:
+    seed = time.time()
+    random.seed(seed)
+    print("Generating data with seed ", seed)
+    reset(client)
+    collection = client.create_collection(
+        name="test",
+        metadata={"hnsw:construction_ef": 128, "hnsw:search_ef": 128, "hnsw:M": 128},
+    )
+
+    time.sleep(1)
+
+    print('failing over for', collection.id)
+    channel = grpc.insecure_channel('localhost:50052')
+    log_service_stub = LogServiceStub(channel)
+
+    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    ids = []
+    embeddings = []
+    for i in range(RECORDS):
+        ids.append(str(i))
+        embeddings.append(np.random.rand(1, 3)[0])
+        collection.add(
+            ids=[str(i)],
+            embeddings=[embeddings[-1]],
+        )
+        if i == RECORDS / 2:
+            # NOTE(rescrv):  This compaction tests a very particular race when migrating logs.
+            # Imagine this sequence:
+            # 1. Write 51 records to the go log.
+            # 2. Compact all 51 records.
+            # 3. Write 49 more records to the go log.
+            # 4. Seal the go log.
+            # 5. Log migration moves the remaining 49 records to the rust service.
+            # 6. Cached frontend tries to read from a timestamp that includes all 100 records, using
+            #    the initial compaction, but from a log that only has 49 records.
+            # The fix is to make sure the log returns not found when a prefix of the log is
+            # compacted.  This forces a fallback to repopulate the cache of the sysdb.
+            wait_for_version_increase(client, collection.name, 0)
+            # We sleep for 90 seconds to let GC bulldoze this collection with high probability.
+            time.sleep(90)
+
+    request = SealLogRequest(collection_id=str(collection.id))
+    response = log_service_stub.SealLog(request, timeout=60)
+
+    # Add another RECORDS records, where each embedding has 3 dimensions randomly generated between 0
+    # and 1
+    for i in range(RECORDS, RECORDS + RECORDS):
+        ids.append(str(i))
+        embeddings.append(np.random.rand(1, 3)[0])
+        collection.add(
+            ids=[str(i)],
+            embeddings=[embeddings[-1]],
+        )
+
+    results = []
+    for i in range(RECORDS + RECORDS):
+        result = collection.get(ids=[str(i)], include=["embeddings"])
+        if len(result["embeddings"]) == 0:
+            print("missing result", i)
+        results.append(result)
+    for (i, result) in enumerate(results):
+        if len(result["embeddings"]):
+            assert all([math.fabs(x - y) < 0.001 for (x, y) in zip(result["embeddings"][0], embeddings[i])])
+        else:
+            assert False, "missing a result"

--- a/chromadb/test/distributed/test_log_failover.py
+++ b/chromadb/test/distributed/test_log_failover.py
@@ -346,3 +346,64 @@ def test_log_failover_with_compaction_and_gc_delay(
             assert all([math.fabs(x - y) < 0.001 for (x, y) in zip(result["embeddings"][0], embeddings[i])])
         else:
             assert False, "missing a result"
+
+@skip_if_not_cluster()
+def test_log_failover_with_migration_and_gc_delay(
+    client: ClientAPI,
+) -> None:
+    seed = time.time()
+    random.seed(seed)
+    print("Generating data with seed ", seed)
+    reset(client)
+    collection = client.create_collection(
+        name="test",
+        metadata={"hnsw:construction_ef": 128, "hnsw:search_ef": 128, "hnsw:M": 128},
+    )
+
+    time.sleep(1)
+
+    print('failing over for', collection.id)
+    channel = grpc.insecure_channel('localhost:50052')
+    log_service_stub = LogServiceStub(channel)
+
+    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    ids = []
+    embeddings = []
+    for i in range(RECORDS):
+        ids.append(str(i))
+        embeddings.append(np.random.rand(1, 3)[0])
+        collection.add(
+            ids=[str(i)],
+            embeddings=[embeddings[-1]],
+        )
+
+    wait_for_version_increase(client, collection.name, 0)
+    request = SealLogRequest(collection_id=str(collection.id))
+    response = log_service_stub.SealLog(request, timeout=60)
+    request = MigrateLogRequest(collection_id=str(collection.id))
+    response = log_service_stub.MigrateLog(request, timeout=60)
+
+    # We sleep for 90 seconds to let GC bulldoze this collection with high probability.
+    time.sleep(90)
+
+    # Add another RECORDS records, where each embedding has 3 dimensions randomly generated between 0
+    # and 1
+    for i in range(RECORDS, RECORDS + RECORDS):
+        ids.append(str(i))
+        embeddings.append(np.random.rand(1, 3)[0])
+        collection.add(
+            ids=[str(i)],
+            embeddings=[embeddings[-1]],
+        )
+
+    results = []
+    for i in range(RECORDS + RECORDS):
+        result = collection.get(ids=[str(i)], include=["embeddings"])
+        if len(result["embeddings"]) == 0:
+            print("missing result", i)
+        results.append(result)
+    for (i, result) in enumerate(results):
+        if len(result["embeddings"]):
+            assert all([math.fabs(x - y) < 0.001 for (x, y) in zip(result["embeddings"][0], embeddings[i])])
+        else:
+            assert False, "missing a result"

--- a/chromadb/test/property/test_fork.py
+++ b/chromadb/test/property/test_fork.py
@@ -225,3 +225,13 @@ def test_fork_with_log_migration(
     fork_collection = collection.fork("fork-legacy-go-collection-1")
     wait_for_version_increase(client, fork_collection.name, 0)
     assert sorted(fork_collection.get()["ids"]) == ids
+
+    collection = client.create_collection("legacy-go-collection-2")
+    for i in range(NUMBER):
+        collection.add(ids=[f"id_{i}"], embeddings=[[i, i]])
+    wait_for_version_increase(client, collection.name, 0)
+    go_log_service.SealLog(SealLogRequest(collection_id=collection.id.hex))
+    collection.add(ids=[f"id_{NUMBER}"], embeddings=[[NUMBER, NUMBER]])
+    fork_collection = collection.fork("fork-legacy-go-collection-2")
+    ids = sorted([f"id_{i}" for i in range(NUMBER + 1)])
+    assert sorted(fork_collection.get()["ids"]) == ids

--- a/rust/wal3/src/copy.rs
+++ b/rust/wal3/src/copy.rs
@@ -4,7 +4,9 @@ use chroma_storage::Storage;
 use setsum::Setsum;
 
 use crate::reader::LogReader;
-use crate::{prefixed_fragment_path, Error, Limits, LogPosition, LogWriterOptions, Manifest};
+use crate::{
+    prefixed_fragment_path, Error, FragmentSeqNo, Limits, LogPosition, LogWriterOptions, Manifest,
+};
 
 pub async fn copy(
     storage: &Storage,
@@ -14,38 +16,50 @@ pub async fn copy(
     target: String,
 ) -> Result<(), Error> {
     let fragments = reader.scan(offset, Limits::UNLIMITED).await?;
-    let mut futures = vec![];
-    for fragment in fragments.into_iter() {
-        let target = &target;
-        futures.push(async move {
-            storage
-                .copy(
-                    &prefixed_fragment_path(&reader.prefix, fragment.seq_no),
-                    &prefixed_fragment_path(target, fragment.seq_no),
-                )
-                .await
-                .map(|_| fragment)
-        });
+    if !fragments.is_empty() {
+        let mut futures = vec![];
+        for fragment in fragments.into_iter() {
+            let target = &target;
+            futures.push(async move {
+                storage
+                    .copy(
+                        &prefixed_fragment_path(&reader.prefix, fragment.seq_no),
+                        &prefixed_fragment_path(target, fragment.seq_no),
+                    )
+                    .await
+                    .map(|_| fragment)
+            });
+        }
+        let fragments = futures::future::try_join_all(futures)
+            .await
+            .map_err(Arc::new)?;
+        let setsum = fragments
+            .iter()
+            .map(|x| x.setsum)
+            .fold(Setsum::default(), |x, y| x + y);
+        let collected = Setsum::default();
+        let acc_bytes = fragments.iter().map(|x| x.num_bytes).sum::<u64>();
+        let initial_offset = Some(fragments.iter().map(|f| f.start).min().unwrap_or(offset));
+        let initial_seq_no = Some(
+            fragments
+                .iter()
+                .map(|f| f.seq_no)
+                .min()
+                .unwrap_or(FragmentSeqNo::BEGIN),
+        );
+        let manifest = Manifest {
+            setsum,
+            collected,
+            acc_bytes,
+            writer: "copy task".to_string(),
+            snapshots: vec![],
+            fragments,
+            initial_offset,
+            initial_seq_no,
+        };
+        Manifest::initialize_from_manifest(options, storage, &target, manifest).await?;
+    } else {
+        Manifest::initialize(options, storage, &target, "empty copy task").await?;
     }
-    let fragments = futures::future::try_join_all(futures)
-        .await
-        .map_err(Arc::new)?;
-    let setsum = fragments
-        .iter()
-        .map(|x| x.setsum)
-        .fold(Setsum::default(), |x, y| x + y);
-    let collected = Setsum::default();
-    let acc_bytes = fragments.iter().map(|x| x.num_bytes).sum::<u64>();
-    let initial_offset = Some(fragments.iter().map(|f| f.start).min().unwrap_or(offset));
-    let manifest = Manifest {
-        setsum,
-        collected,
-        acc_bytes,
-        writer: "copy task".to_string(),
-        snapshots: vec![],
-        fragments,
-        initial_offset,
-    };
-    Manifest::initialize_from_manifest(options, storage, &target, manifest).await?;
     Ok(())
 }

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -250,8 +250,8 @@ impl Snapshot {
         }
     }
 
-    /// Return the lowest addressable offset in the log.
-    pub fn maximum_log_position(&self) -> LogPosition {
+    /// Return the the next address to insert into the log.
+    pub fn limiting_log_position(&self) -> LogPosition {
         let frags = self
             .fragments
             .iter()
@@ -300,7 +300,7 @@ impl Snapshot {
             path_to_snapshot: self.path.clone(),
             depth: self.depth,
             start: self.minimum_log_position(),
-            limit: self.maximum_log_position(),
+            limit: self.limiting_log_position(),
             num_bytes: self.num_bytes(),
         }
     }
@@ -327,6 +327,8 @@ pub struct Manifest {
     pub fragments: Vec<Fragment>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_offset: Option<LogPosition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_seq_no: Option<FragmentSeqNo>,
 }
 
 impl Manifest {
@@ -340,6 +342,7 @@ impl Manifest {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: None,
+            initial_seq_no: None,
         }
     }
 
@@ -462,7 +465,7 @@ impl Manifest {
             path_to_snapshot: snapshot.path.clone(),
             depth: snapshot.depth,
             start: snapshot.minimum_log_position(),
-            limit: snapshot.maximum_log_position(),
+            limit: snapshot.limiting_log_position(),
             num_bytes: snapshot.num_bytes(),
         });
         self.scrub()?;
@@ -474,14 +477,7 @@ impl Manifest {
     /// Once upon a time there was more parallelism in wal3 and this was a more interesting.  Now
     /// it mostly returns true unless internal invariants are violated.
     pub fn can_apply_fragment(&self, fragment: &Fragment) -> bool {
-        let max_seq_no = self
-            .fragments
-            .iter()
-            .map(|f| f.seq_no)
-            .max()
-            .unwrap_or(FragmentSeqNo(0));
-        max_seq_no < max_seq_no + 1
-            && max_seq_no + 1 == fragment.seq_no
+        Some(fragment.seq_no) == self.next_fragment_seq_no()
             && fragment.start.offset() < fragment.limit.offset()
     }
 
@@ -511,35 +507,47 @@ impl Manifest {
     }
 
     /// The oldest LogPosition in the manifest.
-    pub fn oldest_timestamp(&self) -> Option<LogPosition> {
-        if let Some(snap) = self
+    pub fn oldest_timestamp(&self) -> LogPosition {
+        let frags = self
+            .fragments
+            .iter()
+            .map(|f| f.start)
+            .min_by_key(|p| p.offset());
+        let snaps = self
             .snapshots
             .iter()
-            .map(|f| f.start)
-            .min_by_key(|p| p.offset())
-        {
-            return Some(snap);
+            .map(|s| s.start)
+            .min_by_key(|p| p.offset());
+        match (frags, snaps) {
+            (Some(f), Some(s)) => LogPosition {
+                offset: std::cmp::min(f.offset, s.offset),
+            },
+            (Some(f), None) => f,
+            (None, Some(s)) => s,
+            (None, None) => self.initial_offset.unwrap_or(LogPosition::from_offset(1)),
         }
-        self.fragments
-            .iter()
-            .map(|f| f.start)
-            .min_by_key(|p| p.offset())
     }
 
     /// The LogPosition of the next record to be written.
-    pub fn newest_timestamp(&self) -> Option<LogPosition> {
-        if let Some(frag) = self
+    pub fn next_write_timestamp(&self) -> LogPosition {
+        let frags = self
             .fragments
             .iter()
             .map(|f| f.limit)
-            .max_by_key(|p| p.offset())
-        {
-            return Some(frag);
-        }
-        self.snapshots
+            .max_by_key(|p| p.offset());
+        let snaps = self
+            .snapshots
             .iter()
-            .map(|f| f.start)
-            .max_by_key(|p| p.offset())
+            .map(|s| s.limit)
+            .max_by_key(|p| p.offset());
+        match (frags, snaps) {
+            (Some(f), Some(s)) => LogPosition {
+                offset: std::cmp::max(f.offset, s.offset),
+            },
+            (Some(f), None) => f,
+            (None, Some(s)) => s,
+            (None, None) => self.initial_offset.unwrap_or(LogPosition::from_offset(1)),
+        }
     }
 
     /// Given a position, get the fragment to be written.
@@ -613,18 +621,25 @@ impl Manifest {
         })
     }
 
-    /// The next sequence number to generate, or None if the log has exhausted them.
-    pub fn next_fragment_seq_no(&self) -> Option<FragmentSeqNo> {
-        let max_seq_no = self
-            .fragments
+    /// Return the lowest addressable fragment sequence number.
+    pub fn oldest_fragment_seq_no(&self) -> FragmentSeqNo {
+        self.fragments
             .iter()
             .map(|f| f.seq_no)
-            .max()
-            .unwrap_or(FragmentSeqNo(0));
-        if max_seq_no + 1 > max_seq_no {
-            Some(max_seq_no + 1)
+            .min()
+            .unwrap_or(self.initial_seq_no.unwrap_or(FragmentSeqNo::BEGIN))
+    }
+
+    /// The next sequence number to generate, or None if the log has exhausted them.
+    pub fn next_fragment_seq_no(&self) -> Option<FragmentSeqNo> {
+        if let Some(max_seq_no) = self.fragments.iter().map(|f| f.seq_no).max() {
+            if max_seq_no + 1 > max_seq_no {
+                Some(max_seq_no + 1)
+            } else {
+                None
+            }
         } else {
-            None
+            Some(self.initial_seq_no.unwrap_or(FragmentSeqNo::BEGIN))
         }
     }
 
@@ -645,6 +660,7 @@ impl Manifest {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: None,
+            initial_seq_no: None,
         };
         Self::initialize_from_manifest(options, storage, prefix, initial).await
     }
@@ -737,7 +753,7 @@ impl Manifest {
         tracing::info!(
             "installing manifest at {} {:?} {:?}",
             prefix,
-            new.maximum_log_position(),
+            new.next_write_timestamp(),
             current,
         );
         loop {
@@ -782,59 +798,6 @@ impl Manifest {
         }
     }
 
-    /// Return the lowest addressable offset in the log.
-    pub fn maximum_log_position(&self) -> LogPosition {
-        let frags = self
-            .fragments
-            .iter()
-            .map(|f| f.limit)
-            .max_by_key(|p| p.offset());
-        let snaps = self
-            .snapshots
-            .iter()
-            .map(|s| s.limit)
-            .max_by_key(|p| p.offset());
-        match (frags, snaps) {
-            (Some(f), Some(s)) => LogPosition {
-                offset: std::cmp::max(f.offset, s.offset),
-            },
-            (Some(f), None) => f,
-            (None, Some(s)) => s,
-            (None, None) => self.initial_offset.unwrap_or(LogPosition::from_offset(1)),
-        }
-    }
-
-    /// Return the lowest addressable offset in the log.
-    pub fn minimum_log_position(&self) -> LogPosition {
-        let frags = self
-            .fragments
-            .iter()
-            .map(|f| f.start)
-            .min_by_key(|p| p.offset());
-        let snaps = self
-            .snapshots
-            .iter()
-            .map(|s| s.start)
-            .min_by_key(|p| p.offset());
-        match (frags, snaps) {
-            (Some(f), Some(s)) => LogPosition {
-                offset: std::cmp::min(f.offset, s.offset),
-            },
-            (Some(f), None) => f,
-            (None, Some(s)) => s,
-            (None, None) => self.initial_offset.unwrap_or(LogPosition::from_offset(1)),
-        }
-    }
-
-    /// Return the lowest addressable offset in the log.
-    pub fn minimum_fragment_seq_no(&self) -> FragmentSeqNo {
-        self.fragments
-            .iter()
-            .map(|f| f.seq_no)
-            .min()
-            .unwrap_or(FragmentSeqNo::BEGIN)
-    }
-
     /// Apply the destructive operation specified by the Garbage struct.
     #[allow(clippy::result_large_err)]
     pub fn apply_garbage(&self, mut garbage: Garbage) -> Result<Self, Error> {
@@ -861,6 +824,7 @@ impl Manifest {
         }
         new.collected += garbage.setsum_to_discard;
         new.initial_offset = Some(garbage.first_to_keep);
+        new.initial_seq_no = Some(garbage.fragments_to_drop_limit);
         new.scrub()?;
         Ok(new)
     }
@@ -925,6 +889,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment1, fragment2],
             initial_offset: None,
+            initial_seq_no: None,
         };
         assert!(!manifest.contains_position(LogPosition::from_offset(0)));
         assert!(manifest.contains_position(LogPosition::from_offset(1)));
@@ -969,6 +934,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment1.clone(), fragment2.clone()],
             initial_offset: None,
+            initial_seq_no: None,
         };
         assert!(manifest.scrub().is_ok());
         let manifest = Manifest {
@@ -982,6 +948,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment1, fragment2],
             initial_offset: None,
+            initial_seq_no: None,
         };
         assert!(manifest.scrub().is_err());
     }
@@ -1018,6 +985,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: None,
+            initial_seq_no: None,
         };
         assert!(!manifest.can_apply_fragment(&fragment2));
         assert!(manifest.can_apply_fragment(&fragment1));
@@ -1059,6 +1027,7 @@ mod tests {
                     }
                 ],
                 initial_offset: None,
+                initial_seq_no: None,
             },
             manifest
         );
@@ -1114,6 +1083,7 @@ mod tests {
             }],
             fragments: vec![fragment2.clone()],
             initial_offset: None,
+            initial_seq_no: None,
         };
         assert!(manifest.can_apply_fragment(&fragment3));
         manifest.apply_fragment(fragment3.clone());
@@ -1136,13 +1106,14 @@ mod tests {
                 }],
                 fragments: vec![fragment2.clone(), fragment3.clone()],
                 initial_offset: None,
+                initial_seq_no: None,
             },
             manifest
         );
     }
 
     #[test]
-    fn manifest_maximum_log_position_with_initial_offset() {
+    fn manifest_limiting_log_position_with_initial_offset() {
         let manifest = Manifest {
             writer: "bootstrap".to_string(),
             setsum: Setsum::default(),
@@ -1151,15 +1122,20 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(10)),
         };
         assert_eq!(
-            manifest.maximum_log_position(),
+            manifest.next_write_timestamp(),
             LogPosition::from_offset(100)
         );
+        assert_eq!(manifest.oldest_timestamp(), LogPosition::from_offset(100));
+        assert_eq!(manifest.next_fragment_seq_no(), Some(FragmentSeqNo(10)));
+        assert_eq!(manifest.oldest_fragment_seq_no(), FragmentSeqNo(10));
+        assert_eq!(manifest.next_fragment_seq_no(), Some(FragmentSeqNo(10)));
 
         let fragment = Fragment {
             path: "path1".to_string(),
-            seq_no: FragmentSeqNo(1),
+            seq_no: FragmentSeqNo(10),
             start: LogPosition::from_offset(100),
             limit: LogPosition::from_offset(200),
             num_bytes: 100,
@@ -1173,10 +1149,23 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(10)),
         };
         assert_eq!(
-            manifest_with_fragment.maximum_log_position(),
+            manifest_with_fragment.next_write_timestamp(),
             LogPosition::from_offset(200)
+        );
+        assert_eq!(
+            manifest_with_fragment.oldest_timestamp(),
+            LogPosition::from_offset(100)
+        );
+        assert_eq!(
+            manifest_with_fragment.next_fragment_seq_no(),
+            Some(FragmentSeqNo(11)),
+        );
+        assert_eq!(
+            manifest_with_fragment.oldest_fragment_seq_no(),
+            FragmentSeqNo(10)
         );
     }
 
@@ -1190,15 +1179,19 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(10)),
         };
+        assert_eq!(manifest.oldest_timestamp(), LogPosition::from_offset(100));
         assert_eq!(
-            manifest.minimum_log_position(),
+            manifest.next_write_timestamp(),
             LogPosition::from_offset(100)
         );
+        assert_eq!(manifest.oldest_fragment_seq_no(), FragmentSeqNo(10));
+        assert_eq!(manifest.next_fragment_seq_no(), Some(FragmentSeqNo(10)));
 
         let fragment = Fragment {
             path: "path1".to_string(),
-            seq_no: FragmentSeqNo(1),
+            seq_no: FragmentSeqNo(10),
             start: LogPosition::from_offset(100),
             limit: LogPosition::from_offset(200),
             num_bytes: 100,
@@ -1212,10 +1205,19 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(10)),
         };
         assert_eq!(
-            manifest_with_fragment.minimum_log_position(),
+            manifest_with_fragment.oldest_timestamp(),
             LogPosition::from_offset(100)
+        );
+        assert_eq!(
+            manifest_with_fragment.oldest_fragment_seq_no(),
+            FragmentSeqNo(10)
+        );
+        assert_eq!(
+            manifest_with_fragment.next_fragment_seq_no(),
+            Some(FragmentSeqNo(11))
         );
     }
 
@@ -1246,14 +1248,12 @@ mod tests {
             snapshots: vec![snapshot],
             fragments: vec![fragment],
             initial_offset: Some(LogPosition::from_offset(25)),
+            initial_seq_no: Some(FragmentSeqNo(1)),
         };
 
+        assert_eq!(manifest.oldest_timestamp(), LogPosition::from_offset(50));
         assert_eq!(
-            manifest.minimum_log_position(),
-            LogPosition::from_offset(50)
-        );
-        assert_eq!(
-            manifest.maximum_log_position(),
+            manifest.next_write_timestamp(),
             LogPosition::from_offset(200)
         );
     }
@@ -1268,6 +1268,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: Some(LogPosition::from_offset(1000)),
+            initial_seq_no: Some(FragmentSeqNo(100)),
         };
 
         let serialized = serde_json::to_string(&manifest).unwrap();
@@ -1277,6 +1278,7 @@ mod tests {
             deserialized.initial_offset,
             Some(LogPosition::from_offset(1000))
         );
+        assert_eq!(deserialized.initial_seq_no, Some(FragmentSeqNo(100)));
 
         let manifest_none = Manifest {
             writer: "bootstrap".to_string(),
@@ -1286,6 +1288,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: None,
+            initial_seq_no: None,
         };
 
         let serialized_none = serde_json::to_string(&manifest_none).unwrap();
@@ -1304,11 +1307,12 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: Some(LogPosition::from_offset(500)),
+            initial_seq_no: Some(FragmentSeqNo(50)),
         };
 
         let fragment = Fragment {
             path: "path1".to_string(),
-            seq_no: FragmentSeqNo(1),
+            seq_no: FragmentSeqNo(50),
             start: LogPosition::from_offset(500),
             limit: LogPosition::from_offset(600),
             num_bytes: 100,
@@ -1329,10 +1333,11 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment],
             initial_offset: Some(LogPosition::from_offset(500)),
+            initial_seq_no: Some(FragmentSeqNo(50)),
         };
 
         assert_eq!(manifest, expected_manifest);
-        assert_eq!(manifest.next_fragment_seq_no(), Some(FragmentSeqNo(2)));
+        assert_eq!(manifest.next_fragment_seq_no(), Some(FragmentSeqNo(51)));
     }
 
     #[test]
@@ -1362,6 +1367,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment1.clone(), fragment2.clone()],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(1)),
         };
 
         assert_eq!(
@@ -1401,6 +1407,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(1)),
         };
 
         assert!(!manifest.contains_position(LogPosition::from_offset(50)));
@@ -1435,15 +1442,13 @@ mod tests {
             snapshots: vec![],
             fragments: vec![fragment1, fragment2],
             initial_offset: Some(LogPosition::from_offset(100)),
+            initial_seq_no: Some(FragmentSeqNo(42)),
         };
 
+        assert_eq!(manifest.oldest_timestamp(), LogPosition::from_offset(100));
         assert_eq!(
-            manifest.oldest_timestamp(),
-            Some(LogPosition::from_offset(100))
-        );
-        assert_eq!(
-            manifest.newest_timestamp(),
-            Some(LogPosition::from_offset(200))
+            manifest.next_write_timestamp(),
+            LogPosition::from_offset(200)
         );
 
         let empty_manifest = Manifest {
@@ -1454,9 +1459,16 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: Some(LogPosition::from_offset(500)),
+            initial_seq_no: Some(FragmentSeqNo(50)),
         };
 
-        assert_eq!(empty_manifest.oldest_timestamp(), None);
-        assert_eq!(empty_manifest.newest_timestamp(), None);
+        assert_eq!(
+            empty_manifest.oldest_timestamp(),
+            LogPosition::from_offset(500)
+        );
+        assert_eq!(
+            empty_manifest.next_write_timestamp(),
+            LogPosition::from_offset(500)
+        );
     }
 }

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -824,7 +824,9 @@ impl Manifest {
         }
         new.collected += garbage.setsum_to_discard;
         new.initial_offset = Some(garbage.first_to_keep);
-        new.initial_seq_no = Some(garbage.fragments_to_drop_limit);
+        if garbage.fragments_to_drop_start < garbage.fragments_to_drop_limit {
+            new.initial_seq_no = Some(garbage.fragments_to_drop_limit);
+        }
         new.scrub()?;
         Ok(new)
     }

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -187,15 +187,10 @@ impl ManifestManager {
         let Some((manifest, e_tag)) = Manifest::load(&throttle, &storage, &prefix).await? else {
             return Err(Error::UninitializedLog);
         };
-        let latest_fragment = manifest.fragments.iter().max_by_key(|f| f.limit.offset());
-        let next_log_position = latest_fragment.map(|f| f.limit).unwrap_or(
-            manifest
-                .initial_offset
-                .unwrap_or(LogPosition::from_offset(1)),
-        );
-        let next_seq_no_to_assign = latest_fragment
-            .map(|f| f.seq_no + 1)
-            .unwrap_or(FragmentSeqNo(1));
+        let next_log_position = manifest.next_write_timestamp();
+        let Some(next_seq_no_to_assign) = manifest.next_fragment_seq_no() else {
+            return Err(Error::LogFull);
+        };
         let next_seq_no_to_apply = next_seq_no_to_assign;
         let stable = ManifestAndETag { manifest, e_tag };
         let staging = Arc::new(Mutex::new(Staging {

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -487,6 +487,7 @@ mod tests {
                 snapshots: vec![],
                 fragments: vec![],
                 initial_offset: None,
+                initial_seq_no: None,
             },
             work.0
         );
@@ -516,6 +517,7 @@ mod tests {
                     }
                 ],
                 initial_offset: None,
+                initial_seq_no: None,
             },
             work.2
         );

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -82,22 +82,22 @@ impl LogReader {
         )
     }
 
-    pub async fn maximum_log_position(&self) -> Result<LogPosition, Error> {
+    pub async fn oldest_timestamp(&self) -> Result<LogPosition, Error> {
         let Some((manifest, _)) =
             Manifest::load(&self.options.throttle, &self.storage, &self.prefix).await?
         else {
             return Err(Error::UninitializedLog);
         };
-        Ok(manifest.maximum_log_position())
+        Ok(manifest.oldest_timestamp())
     }
 
-    pub async fn minimum_log_position(&self) -> Result<LogPosition, Error> {
+    pub async fn next_write_timestamp(&self) -> Result<LogPosition, Error> {
         let Some((manifest, _)) =
             Manifest::load(&self.options.throttle, &self.storage, &self.prefix).await?
         else {
             return Err(Error::UninitializedLog);
         };
-        Ok(manifest.minimum_log_position())
+        Ok(manifest.next_write_timestamp())
     }
 
     /// Scan up to:
@@ -781,6 +781,7 @@ mod tests {
             snapshots: vec![],
             fragments: fragments.clone(),
             initial_offset: Some(LogPosition::from_offset(1)),
+            initial_seq_no: Some(FragmentSeqNo(1)),
         };
 
         // Boundary case 1: Request exactly at the manifest limit
@@ -869,6 +870,7 @@ mod tests {
             snapshots: vec![],
             fragments: vec![],
             initial_offset: None,
+            initial_seq_no: None,
         };
         let result_empty =
             LogReader::scan_from_manifest(&empty_manifest, LogPosition::from_offset(0), limits);
@@ -3360,6 +3362,7 @@ mod tests {
                 },
             ],
             initial_offset: Some(LogPosition { offset: 1 }),
+            initial_seq_no: Some(FragmentSeqNo(1)),
         };
         let Some(fragments) = LogReader::scan_from_manifest(
             &manifest,

--- a/rust/wal3/tests/test_k8s_integration_0_properties.rs
+++ b/rust/wal3/tests/test_k8s_integration_0_properties.rs
@@ -130,8 +130,8 @@ proptest::proptest! {
             manifest.apply_fragment(fragment);
         }
         eprintln!("starting manifest = {manifest:#?}");
-        let start = manifest.oldest_timestamp().unwrap();
-        let limit = manifest.newest_timestamp().unwrap();
+        let start = manifest.oldest_timestamp();
+        let limit = manifest.next_write_timestamp();
         let cache = TestingSnapshotCache::default();
         for offset in start.offset()..limit.offset() {
             let position = LogPosition::from_offset(offset);
@@ -182,8 +182,8 @@ proptest::proptest! {
             }
         }
         eprintln!("starting manifest = {manifest:#?}");
-        let start = manifest.oldest_timestamp().unwrap();
-        let limit = manifest.newest_timestamp().unwrap();
+        let start = manifest.oldest_timestamp();
+        let limit = manifest.next_write_timestamp();
         let mut cache = TestingSnapshotCache {
             snapshots: snapshots.clone(),
         };

--- a/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
+++ b/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use chroma_storage::s3_client_for_test_with_new_bucket;
+
+use wal3::{
+    Cursor, CursorName, CursorStoreOptions, GarbageCollectionOptions, LogPosition, LogReader,
+    LogReaderOptions, LogWriter, LogWriterOptions, SnapshotOptions,
+};
+
+#[tokio::test]
+async fn test_k8s_integration_82_copy_empty_log_initializes() {
+    // Appending to a log that has failed to write its manifest fails with log contention.
+    // Subsequent writes will repair the log and continue to make progress.
+    let storage = Arc::new(s3_client_for_test_with_new_bucket().await);
+    let log = LogWriter::open_or_initialize(
+        LogWriterOptions {
+            snapshot_manifest: SnapshotOptions {
+                snapshot_rollover_threshold: 2,
+                fragment_rollover_threshold: 2,
+            },
+            ..LogWriterOptions::default()
+        },
+        Arc::clone(&storage),
+        "test_k8s_integration_82_copy_empty_log_initializes_source",
+        "load and scrub writer",
+        (),
+    )
+    .await
+    .unwrap();
+    let mut position: LogPosition = LogPosition::default();
+    for i in 0..100 {
+        let mut batch = Vec::with_capacity(100);
+        for j in 0..10 {
+            batch.push(Vec::from(format!("key:i={},j={}", i, j)));
+        }
+        position = log.append_many(batch).await.unwrap() + 10u64;
+    }
+    let cursors = log.cursors(CursorStoreOptions::default()).unwrap();
+    cursors
+        .init(
+            &CursorName::new("writer").unwrap(),
+            Cursor {
+                position,
+                epoch_us: 42,
+                writer: "unit tests".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    log.garbage_collect(&GarbageCollectionOptions::default())
+        .await
+        .unwrap();
+
+    let reader = LogReader::open(
+        LogReaderOptions::default(),
+        Arc::clone(&storage),
+        "test_k8s_integration_82_copy_empty_log_initializes_source".to_string(),
+    )
+    .await
+    .unwrap();
+    let scrubbed_source = reader.scrub().await.unwrap();
+    wal3::copy(
+        &storage,
+        &LogWriterOptions::default(),
+        &reader,
+        LogPosition::default(),
+        "test_k8s_integration_82_copy_empty_log_initializes_target".to_string(),
+    )
+    .await
+    .unwrap();
+    // Scrub the copy.
+    let copied = LogReader::open(
+        LogReaderOptions::default(),
+        Arc::clone(&storage),
+        "test_k8s_integration_82_copy_empty_log_initializes_target".to_string(),
+    )
+    .await
+    .unwrap();
+    let scrubbed_target = copied.scrub().await.unwrap();
+    assert_eq!(
+        scrubbed_source.calculated_setsum,
+        scrubbed_target.calculated_setsum,
+    );
+    let before_mani = reader.manifest().await.unwrap().unwrap();
+    let after_mani = copied.manifest().await.unwrap().unwrap();
+    assert_eq!(
+        before_mani.oldest_timestamp(),
+        before_mani.next_write_timestamp()
+    );
+    assert_eq!(
+        before_mani.oldest_timestamp(),
+        after_mani.oldest_timestamp()
+    );
+    assert_eq!(
+        before_mani.next_write_timestamp(),
+        after_mani.next_write_timestamp()
+    );
+    assert_eq!(
+        before_mani.oldest_fragment_seq_no(),
+        after_mani.oldest_fragment_seq_no()
+    );
+    assert_eq!(
+        before_mani.next_fragment_seq_no(),
+        after_mani.next_fragment_seq_no()
+    );
+}

--- a/rust/wal3/tests/test_k8s_integration_84_bootstrap_empty.rs
+++ b/rust/wal3/tests/test_k8s_integration_84_bootstrap_empty.rs
@@ -46,4 +46,21 @@ async fn test_k8s_integration_84_bootstrap_empty() {
         .await
         .unwrap();
     assert_eq!(0, scan.len());
+    reader.scrub().await.unwrap();
+
+    let writer = LogWriter::open(options, Arc::clone(&storage), PREFIX, WRITER, mark_dirty)
+        .await
+        .unwrap();
+    writer.manifest().unwrap().scrub().unwrap();
+    writer
+        .append_many(vec![Vec::from("fresh-write".to_string())])
+        .await
+        .unwrap();
+
+    let scan = reader
+        .scan(LogPosition::from_offset(42), Limits::default())
+        .await
+        .unwrap();
+    assert_eq!(1, scan.len());
+    reader.scrub().await.unwrap();
 }

--- a/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
+++ b/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
@@ -6,8 +6,8 @@ use tokio::sync::Mutex;
 use chroma_storage::s3_client_for_test_with_new_bucket;
 
 use wal3::{
-    Cursor, CursorName, CursorStoreOptions, Error, GarbageCollectionOptions, LogWriter,
-    LogWriterOptions, Manifest,
+    Cursor, CursorName, CursorStoreOptions, Error, GarbageCollectionOptions, LogReaderOptions,
+    LogWriter, LogWriterOptions, Manifest,
 };
 
 pub mod common;
@@ -46,6 +46,12 @@ async fn writer_thread(
                             },
                             &witness,
                         )
+                        .await
+                        .unwrap();
+                    writer
+                        .reader(LogReaderOptions::default())
+                        .unwrap()
+                        .scrub()
                         .await
                         .unwrap();
                     break;

--- a/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
+++ b/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
@@ -34,6 +34,7 @@ async fn writer_thread(
         loop {
             match writer.append(message.clone()).await {
                 Ok(position) => {
+                    let position = position + 1u64;
                     println!("writer succeeds in iteration {i}");
                     successful_writes += 1;
                     witness = cursors


### PR DESCRIPTION
## Description of changes

If all fragments are garbage collected, the manifest would revert to
FragmentSeqNo::BEGIN.  Track an initial sequence number and honor it.

## Test plan

CI

## Documentation Changes

N/A
