### PR TITLE
[ENH]  Make the Failed to Fetch log error verbose

### DIFF
--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -31,7 +31,7 @@ use uuid::Uuid;
 pub enum GrpcPullLogsError {
     #[error("Please backoff exponentially and retry")]
     Backoff,
-    #[error("Failed to fetch")]
+    #[error("Failed to fetch: {0}")]
     FailedToPullLogs(#[from] tonic::Status),
     #[error("Failed to scout logs: {0}")]
     FailedToScoutLogs(tonic::Status),
@@ -101,7 +101,7 @@ impl ChromaError for GrpcForkLogsError {
 
 #[derive(Error, Debug)]
 pub enum GrpcGetCollectionsWithNewDataError {
-    #[error("Failed to fetch")]
+    #[error("Failed to fetch: {0}")]
     FailedGetCollectionsWithNewData(#[from] tonic::Status),
 }
 

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -117,7 +117,7 @@ impl ChromaError for GrpcGetCollectionsWithNewDataError {
 
 #[derive(Error, Debug)]
 pub enum GrpcUpdateCollectionLogOffsetError {
-    #[error("Failed to update collection log offset")]
+    #[error("Failed to update collection log offset: {0}")]
     FailedToUpdateCollectionLogOffset(#[from] tonic::Status),
     #[error(transparent)]
     ClientAssignerError(#[from] ClientAssignmentError),


### PR DESCRIPTION
## Description of changes

The Failed to Fetch error masks the true underlying cause.

## Test plan

cargo clippy locally; CI for the rest.

## Documentation Changes

N/A
