### PR TITLE
[BUG]  Contention in S3 gets assumed to be retryable, leading the manifest to fail.

### DIFF
--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -780,7 +780,7 @@ pub async fn upload_parquet(
                 return Ok((unprefixed_path, setsum, buffer.len()));
             }
             Err(StorageError::Precondition { path: _, source: _ }) => {
-                return Err(Error::LogContentionRetry);
+                return Err(Error::LogContentionFailure);
             }
             Err(err) => {
                 if start.elapsed() > Duration::from_secs(60) {


### PR DESCRIPTION
## Description of changes

We identified this last night and I dropped it accidentally.

Basically, contention at the storage layer in upload_parquet needs to
fail out directly; there is no way to retry safely.

## Test plan

CI

## Documentation Changes

N/A
