### PR TITLE
[ENH]  Allow garbage collection to provide a phantom cursor to retain more of the log.

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -296,8 +296,10 @@ impl GarbageCollectorOrchestrator {
             .await
             {
                 Ok(log) => {
+                    // TODO(rescrv,codetheweb):  Thread through the minimum compaction offset to
+                    // keep_at_least.
                     if let Err(err) = log
-                        .garbage_collect(&GarbageCollectionOptions::default())
+                        .garbage_collect(&GarbageCollectionOptions::default(), None)
                         .await
                     {
                         tracing::error!("could not garbage collect log: {err:?}");

--- a/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
+++ b/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
@@ -47,7 +47,7 @@ async fn test_k8s_integration_82_copy_empty_log_initializes() {
         )
         .await
         .unwrap();
-    log.garbage_collect(&GarbageCollectionOptions::default())
+    log.garbage_collect(&GarbageCollectionOptions::default(), None)
         .await
         .unwrap();
 

--- a/rust/wal3/tests/test_k8s_integration_90_garbage_collect.rs
+++ b/rust/wal3/tests/test_k8s_integration_90_garbage_collect.rs
@@ -42,7 +42,7 @@ async fn test_k8s_integration_90_garbage_collect() {
     }
 
     let res = log
-        .garbage_collect(&GarbageCollectionOptions::default())
+        .garbage_collect(&GarbageCollectionOptions::default(), None)
         .await;
     assert!(matches!(res, Err(Error::NoSuchCursor(_))));
 
@@ -64,7 +64,7 @@ async fn test_k8s_integration_90_garbage_collect() {
         .await
         .unwrap();
 
-    log.garbage_collect(&GarbageCollectionOptions::default())
+    log.garbage_collect(&GarbageCollectionOptions::default(), None)
         .await
         .unwrap();
 
@@ -81,7 +81,7 @@ async fn test_k8s_integration_90_garbage_collect() {
         .await
         .unwrap();
 
-    log.garbage_collect(&GarbageCollectionOptions::default())
+    log.garbage_collect(&GarbageCollectionOptions::default(), None)
         .await
         .unwrap();
 }

--- a/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
+++ b/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
@@ -87,7 +87,7 @@ async fn garbage_collector_thread(
         println!("gc grabs lock in iteration {i}");
         loop {
             match writer
-                .garbage_collect(&GarbageCollectionOptions::default())
+                .garbage_collect(&GarbageCollectionOptions::default(), None)
                 .await
             {
                 Ok(()) => break,


### PR DESCRIPTION
## Description of changes

Add a new argument to the garbage collect path that acts like an
additional cursor was temporarily placed on the log for the interval of
garbage collection.  The practical upshot of this is that garbage
collection can keep arbitrary amounts of data, but wal3 will guard
against garbage collection ever collecting past any cursor.

There's a TODO in the garbage collector to thread the appropriate offset
to the garbage collector.

## Test plan

CI

## Documentation Changes

N/A
