### PR TITLE
[BUG]  An transient error in scrubbing leads to scrub error.

### DIFF
--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -436,13 +436,15 @@ impl LogReader {
             short_read,
         };
         if !short_read && manifest_scrub_success != observed_scrub_success {
-            Err(vec![Error::ScrubError(
+            let mut ret = vec![Error::ScrubError(
                 ScrubError::OverallMismatch {
                     manifest: manifest_scrub_success,
                     observed: observed_scrub_success,
                 }
                 .into(),
-            )])
+            )];
+            ret.extend(errors);
+            Err(ret)
         } else if short_read {
             Err(vec![Error::Success])
         } else {


### PR DESCRIPTION
## Description of changes

If there is a transient error on scrub, the error will present as a bad
checksum, but the actual error gets dropped.

## Test plan

CI

## Documentation Changes

N/A
