### PR TITLE
[BUG]  Panic on sysdb when calling CheckCollection

### DIFF
--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -263,6 +263,7 @@ func (s *Server) GetCollectionSize(ctx context.Context, req *coordinatorpb.GetCo
 func (s *Server) CheckCollections(ctx context.Context, req *coordinatorpb.CheckCollectionsRequest) (*coordinatorpb.CheckCollectionsResponse, error) {
 	res := &coordinatorpb.CheckCollectionsResponse{}
 	res.Deleted = make([]bool, len(req.CollectionIds))
+	res.LogPosition = make([]int64, len(req.CollectionIds))
 
 	for i, collectionID := range req.CollectionIds {
 		parsedId, err := types.ToUniqueID(&collectionID)


### PR DESCRIPTION
## Description of changes

PR #4722 introduced a new field to the CheckCollectionsResponse, but
does not populate the slice/array necessary to return the result, ending
up in a null-ptr deref.  This PR populates the array at top of the loop.

## Test plan

CI + review

## Documentation Changes

N/A
