### PR TITLE
[ENH] add query config on collection configuration, splade, and bm25 efs

### DIFF
--- a/chromadb/api/collection_configuration.py
+++ b/chromadb/api/collection_configuration.py
@@ -99,7 +99,6 @@ def load_collection_configuration_from_json(
                 raise ValueError(
                     f"Could not build embedding function {ef_config['name']} from config {ef_config['config']}: {e}"
                 )
-
     else:
         ef = None
 
@@ -148,11 +147,6 @@ def collection_configuration_to_json(config: CollectionConfiguration) -> Dict[st
     if ef is None:
         ef = None
         ef_config = {"type": "legacy"}
-        return {
-            "hnsw": hnsw_config,
-            "spann": spann_config,
-            "embedding_function": ef_config,
-        }
 
     if ef is not None:
         try:
@@ -260,16 +254,6 @@ class CreateCollectionConfiguration(TypedDict, total=False):
     embedding_function: Optional[EmbeddingFunction]  # type: ignore
 
 
-def load_collection_configuration_from_create_collection_configuration(
-    config: CreateCollectionConfiguration,
-) -> CollectionConfiguration:
-    return CollectionConfiguration(
-        hnsw=config.get("hnsw"),
-        spann=config.get("spann"),
-        embedding_function=config.get("embedding_function"),
-    )
-
-
 def create_collection_configuration_from_legacy_collection_metadata(
     metadata: CollectionMetadata,
 ) -> CreateCollectionConfiguration:
@@ -299,13 +283,6 @@ def create_collection_configuration_from_legacy_metadata_dict(
     hnsw_config = populate_create_hnsw_defaults(hnsw_config)
 
     return CreateCollectionConfiguration(hnsw=hnsw_config)
-
-
-def load_create_collection_configuration_from_json_str(
-    json_str: str,
-) -> CreateCollectionConfiguration:
-    json_map = json.loads(json_str)
-    return load_create_collection_configuration_from_json(json_map)
 
 
 # TODO: make warnings prettier and add link to migration docs

--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -9,6 +9,7 @@ from chromadb.api.types import (
     Embeddings,
     Space,
     Embeddable,
+    SparseEmbeddingFunction,
 )
 from chromadb.api.models.CollectionCommon import validation_context
 
@@ -48,6 +49,8 @@ def test_get_builtins_holds() -> None:
         "ChromaLangchainEmbeddingFunction",
         "TogetherAIEmbeddingFunction",
         "DefaultEmbeddingFunction",
+        "HuggingFaceSparseEmbeddingFunction",
+        "FastembedSparseEmbeddingFunction",
     }
 
     assert expected_builtins == embedding_functions.get_builtins()
@@ -58,7 +61,9 @@ def test_default_ef_exists() -> None:
     default_ef = embedding_functions.DefaultEmbeddingFunction()
 
     assert default_ef is not None
-    assert isinstance(default_ef, EmbeddingFunction)
+    assert isinstance(default_ef, EmbeddingFunction) or isinstance(
+        default_ef, SparseEmbeddingFunction
+    )
 
 
 def test_ef_imports() -> None:
@@ -68,7 +73,9 @@ def test_ef_imports() -> None:
             continue
         assert hasattr(embedding_functions, ef)
         assert isinstance(getattr(embedding_functions, ef), type)
-        assert issubclass(getattr(embedding_functions, ef), EmbeddingFunction)
+        assert issubclass(
+            getattr(embedding_functions, ef), EmbeddingFunction
+        ) or issubclass(getattr(embedding_functions, ef), SparseEmbeddingFunction)
 
 
 @register_embedding_function

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -32,6 +32,7 @@ from chromadb.utils.embedding_functions.instructor_embedding_function import (
 )
 from chromadb.utils.embedding_functions.jina_embedding_function import (
     JinaEmbeddingFunction,
+    JinaQueryConfig,
 )
 from chromadb.utils.embedding_functions.voyageai_embedding_function import (
     VoyageAIEmbeddingFunction,
@@ -67,6 +68,12 @@ from chromadb.utils.embedding_functions.mistral_embedding_function import (
 from chromadb.utils.embedding_functions.morph_embedding_function import (
     MorphEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.huggingface_sparse_embedding_function import (
+    HuggingFaceSparseEmbeddingFunction,
+)
+from chromadb.utils.embedding_functions.fastembed_sparse_embedding_function import (
+    FastembedSparseEmbeddingFunction,
+)
 
 try:
     from chromadb.is_thin_client import is_thin_client
@@ -99,6 +106,8 @@ _all_classes: Set[str] = {
     "CloudflareWorkersAIEmbeddingFunction",
     "TogetherAIEmbeddingFunction",
     "DefaultEmbeddingFunction",
+    "HuggingFaceSparseEmbeddingFunction",
+    "FastembedSparseEmbeddingFunction",
 }
 
 
@@ -237,6 +246,7 @@ __all__ = [
     "OllamaEmbeddingFunction",
     "InstructorEmbeddingFunction",
     "JinaEmbeddingFunction",
+    "JinaQueryConfig",
     "MistralEmbeddingFunction",
     "MorphEmbeddingFunction",
     "VoyageAIEmbeddingFunction",
@@ -247,6 +257,8 @@ __all__ = [
     "AmazonBedrockEmbeddingFunction",
     "ChromaLangchainEmbeddingFunction",
     "TogetherAIEmbeddingFunction",
+    "HuggingFaceSparseEmbeddingFunction",
+    "FastembedSparseEmbeddingFunction",
     "register_embedding_function",
     "config_to_embedding_function",
     "known_embedding_functions",

--- a/chromadb/utils/embedding_functions/fastembed_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/fastembed_sparse_embedding_function.py
@@ -1,0 +1,159 @@
+from chromadb.api.types import (
+    SparseEmbeddingFunction,
+    SparseEmbeddings,
+    Documents,
+)
+from typing import Dict, Any, TypedDict, Optional
+from typing import cast, Literal
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+
+TaskType = Literal["document", "query"]
+
+
+class FastembedSparseEmbeddingFunctionQueryConfig(TypedDict):
+    task: TaskType
+
+
+class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
+    def __init__(
+        self,
+        model_name: str,
+        task: Optional[TaskType] = "document",
+        query_config: Optional[FastembedSparseEmbeddingFunctionQueryConfig] = None,
+    ):
+        """Initialize SparseEncoderEmbeddingFunction.
+
+        Args:
+            model_name (str, optional): Identifier of the Splade model
+            List of commonly used models: Qdrant/bm25, prithivida/Splade_PP_en_v1, Qdrant/minicoil-v1
+            task (str, optional): Task to perform, can be "document" or "query"
+            query_config (dict, optional): Configuration for the query, can be "task"
+        """
+        try:
+            from fastembed import SparseTextEmbedding
+        except ImportError:
+            raise ValueError(
+                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+            )
+
+        self.task = task
+        self.query_config = query_config
+        self.model_name = model_name
+        self._model = SparseTextEmbedding(model_name)
+
+    def __call__(self, input: Documents) -> SparseEmbeddings:
+        """Generate embeddings for the given documents.
+
+        Args:
+            input: Documents to generate embeddings for.
+
+        Returns:
+            Embeddings for the documents.
+        """
+        try:
+            from fastembed import SparseTextEmbedding
+        except ImportError:
+            raise ValueError(
+                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+            )
+        model = cast(SparseTextEmbedding, self._model)
+        if self.task == "document":
+            embeddings = model.embed(
+                list(input),
+            )
+        elif self.task == "query":
+            embeddings = model.query_embed(
+                list(input),
+            )
+        else:
+            raise ValueError(f"Invalid task: {self.task}")
+
+        sparse_embeddings: SparseEmbeddings = []
+
+        for vec in embeddings:
+            sparse_embeddings.append(
+                {"indices": vec.indices.tolist(), "values": vec.values.tolist()}
+            )
+
+        return sparse_embeddings
+
+    def embed_query(self, input: Documents) -> SparseEmbeddings:
+        try:
+            from fastembed import SparseTextEmbedding
+        except ImportError:
+            raise ValueError(
+                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+            )
+        model = cast(SparseTextEmbedding, self._model)
+        if self.query_config is not None:
+            task = self.query_config.get("task")
+            if task == "document":
+                embeddings = model.embed(
+                    list(input),
+                )
+            elif task == "query":
+                embeddings = model.query_embed(
+                    list(input),
+                )
+            else:
+                raise ValueError(f"Invalid task: {task}")
+
+            sparse_embeddings: SparseEmbeddings = []
+
+            for vec in embeddings:
+                sparse_embeddings.append(
+                    {"indices": vec.indices.tolist(), "values": vec.values.tolist()}
+                )
+
+            return sparse_embeddings
+
+        else:
+            return self.__call__(input)
+
+    @staticmethod
+    def name() -> str:
+        return "fastembed_sparse"
+
+    @staticmethod
+    def build_from_config(
+        config: Dict[str, Any]
+    ) -> "SparseEmbeddingFunction[Documents]":
+        model_name = config.get("model_name")
+        task = config.get("task")
+        query_config = config.get("query_config")
+        if model_name is None:
+            assert False, "This code should not be reached"
+
+        return FastembedSparseEmbeddingFunction(
+            model_name=model_name,
+            task=task,
+            query_config=query_config,
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "task": self.task,
+            "query_config": self.query_config,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        # model_name is also used as the identifier for model path if stored locally.
+        # Users should be able to change the path if needed, so we should not validate that.
+        # e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
+        return
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+
+        Raises:
+            ValidationError: If the configuration does not match the schema
+        """
+        validate_config_schema(config, "fastembed_sparse")

--- a/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
@@ -1,0 +1,195 @@
+from chromadb.api.types import (
+    SparseEmbeddingFunction,
+    SparseEmbeddings,
+    Documents,
+)
+from typing import Dict, Any, TypedDict, Optional
+import numpy as np
+from typing import cast, Literal
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+
+TaskType = Literal["document", "query"]
+
+
+class HuggingFaceSparseEmbeddingFunctionQueryConfig(TypedDict):
+    task: TaskType
+
+
+class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
+    # Since we do dynamic imports we have to type this as Any
+    models: Dict[str, Any] = {}
+
+    def __init__(
+        self,
+        model_name: str,
+        device: str,
+        task: Optional[TaskType] = "document",
+        query_config: Optional[HuggingFaceSparseEmbeddingFunctionQueryConfig] = None,
+        **kwargs: Any,
+    ):
+        """Initialize SparseEncoderEmbeddingFunction.
+
+        Args:
+            model_name (str, optional): Identifier of the Splade model
+            Some common models: prithivida/Splade_PP_en_v1, naver/splade-cocondenser-ensembledistil, naver/splade-v3
+            device (str, optional): Device used for computation
+            **kwargs: Additional arguments to pass to the Splade model.
+        """
+        try:
+            from sentence_transformers import SparseEncoder
+        except ImportError:
+            raise ValueError(
+                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+            )
+
+        self.model_name = model_name
+        self.device = device
+        self.task = task
+        self.query_config = query_config
+        for key, value in kwargs.items():
+            if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
+                raise ValueError(f"Keyword argument {key} is not a primitive type")
+        self.kwargs = kwargs
+
+        if model_name not in self.models:
+            self.models[model_name] = SparseEncoder(
+                model_name_or_path=model_name, device=device, **kwargs
+            )
+        self._model = self.models[model_name]
+
+    def __call__(self, input: Documents) -> SparseEmbeddings:
+        """Generate embeddings for the given documents.
+
+        Args:
+            input: Documents to generate embeddings for.
+
+        Returns:
+            Embeddings for the documents.
+        """
+        try:
+            from sentence_transformers import SparseEncoder
+        except ImportError:
+            raise ValueError(
+                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+            )
+        model = cast(SparseEncoder, self._model)
+        if self.task == "document":
+            embeddings = model.encode_document(
+                list(input),
+            )
+        elif self.task == "query":
+            embeddings = model.encode_query(
+                list(input),
+            )
+        else:
+            raise ValueError(f"Invalid task: {self.task}")
+
+        sparse_embeddings: SparseEmbeddings = []
+
+        for vec in embeddings:
+            # Convert sparse tensor to dense array if needed
+            if hasattr(vec, "to_dense"):
+                vec_dense = vec.to_dense().numpy()
+            else:
+                vec_dense = vec.numpy() if hasattr(vec, "numpy") else np.array(vec)
+
+            nz = np.where(vec_dense != 0)[0]
+            sparse_embeddings.append(
+                {"indices": nz.tolist(), "values": vec_dense[nz].tolist()}
+            )
+
+        return sparse_embeddings
+
+    def embed_query(self, input: Documents) -> SparseEmbeddings:
+        try:
+            from sentence_transformers import SparseEncoder
+        except ImportError:
+            raise ValueError(
+                "The sentence_transformers python package is not installed. Please install it with `pip install sentence_transformers`"
+            )
+        model = cast(SparseEncoder, self._model)
+        if self.query_config is not None:
+            if self.query_config.get("task") == "document":
+                embeddings = model.encode_document(
+                    list(input),
+                )
+            elif self.query_config.get("task") == "query":
+                embeddings = model.encode_query(
+                    list(input),
+                )
+            else:
+                raise ValueError(f"Invalid task: {self.query_config.get('task')}")
+
+            sparse_embeddings: SparseEmbeddings = []
+
+            for vec in embeddings:
+                # Convert sparse tensor to dense array if needed
+                if hasattr(vec, "to_dense"):
+                    vec_dense = vec.to_dense().numpy()
+                else:
+                    vec_dense = vec.numpy() if hasattr(vec, "numpy") else np.array(vec)
+
+                nz = np.where(vec_dense != 0)[0]
+                sparse_embeddings.append(
+                    {"indices": nz.tolist(), "values": vec_dense[nz].tolist()}
+                )
+
+            return sparse_embeddings
+
+        else:
+            return self.__call__(input)
+
+    @staticmethod
+    def name() -> str:
+        return "huggingface_sparse"
+
+    @staticmethod
+    def build_from_config(
+        config: Dict[str, Any]
+    ) -> "SparseEmbeddingFunction[Documents]":
+        model_name = config.get("model_name")
+        device = config.get("device")
+        task = config.get("task")
+        query_config = config.get("query_config")
+        kwargs = config.get("kwargs", {})
+
+        if model_name is None or device is None:
+            assert False, "This code should not be reached"
+
+        return HuggingFaceSparseEmbeddingFunction(
+            model_name=model_name,
+            device=device,
+            task=task,
+            query_config=query_config,
+            **kwargs,
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "device": self.device,
+            "task": self.task,
+            "query_config": self.query_config,
+            "kwargs": self.kwargs,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        # model_name is also used as the identifier for model path if stored locally.
+        # Users should be able to change the path if needed, so we should not validate that.
+        # e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
+        return
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+
+        Raises:
+            ValidationError: If the configuration does not match the schema
+        """
+        validate_config_schema(config, "huggingface_sparse")


### PR DESCRIPTION
## Description of changes

This PR adds a new function embed_query on the base embeddingfunction type to allow embedding functions to define a secondary path to embed documents for query path. by default this will invoke the __call__ method.

this also adds a new protocol for SparseEmbeddingFunctions, and 2 new embedding functions: huggingface_sparse_embedding_function and fastembed_sparse_embedding_function

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
