### PR TITLE
[TST] Add tests for CheckCollections, make test collection setup more flexible

### DIFF
--- a/go/pkg/sysdb/grpc/collection_service_test.go
+++ b/go/pkg/sysdb/grpc/collection_service_test.go
@@ -655,17 +655,12 @@ func (suite *CollectionServiceTestSuite) TestServer_CheckCollections() {
 }
 
 func (suite *CollectionServiceTestSuite) TestGetCollectionSize() {
-	collection := daotest.NewTestCollection(
-		daotest.TestTenantID,
-		suite.databaseId,
-		"collection_service_test_get_collection_size",
-		daotest.WithTotalRecordsPostCompaction(100),
-	)
-	collectionID, err := dao.CreateTestCollection(suite.db, collection)
+	collectionName := "collection_service_test_get_collection_size"
+	collectionID, err := dao.CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName, 128, suite.databaseId, nil))
 	suite.NoError(err)
 
 	req := coordinatorpb.GetCollectionSizeRequest{
-		Id: collection.ID,
+		Id: collectionID,
 	}
 	res, err := suite.s.GetCollectionSize(context.Background(), &req)
 	suite.NoError(err)

--- a/go/pkg/sysdb/metastore/db/dao/collection_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao/daotest"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/suite"
@@ -48,7 +49,7 @@ func (suite *CollectionDbTestSuite) TearDownSuite() {
 func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	collectionName := "test_collection_get_collections"
 	dim := int32(128)
-	collectionID, err := CreateTestCollection(suite.db, collectionName, dim, suite.databaseId, nil)
+	collectionID, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName, dim, suite.databaseId, nil))
 	suite.NoError(err)
 
 	testKey := "test"
@@ -103,7 +104,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	suite.Len(collections, 1)
 	suite.Equal(collectionID, collections[0].Collection.ID)
 
-	collectionID2, err := CreateTestCollection(suite.db, "test_collection_get_collections2", 128, suite.databaseId, nil)
+	collectionID2, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection("test_collection_get_collections2", 128, suite.databaseId, nil))
 	suite.NoError(err)
 
 	// Test order by. Collections are ordered by create time so collectionID2 should be second
@@ -137,10 +138,10 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 	suite.NoError(err)
 
 	// Create two collections in the new database.
-	collectionID3, err := CreateTestCollection(suite.db, "test_collection_get_collections3", 128, DbId, nil)
+	collectionID3, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection("test_collection_get_collections3", 128, DbId, nil))
 	suite.NoError(err)
 
-	collectionID4, err := CreateTestCollection(suite.db, "test_collection_get_collections4", 128, DbId, nil)
+	collectionID4, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection("test_collection_get_collections4", 128, DbId, nil))
 	suite.NoError(err)
 
 	// Test count collections
@@ -174,7 +175,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollections() {
 
 func (suite *CollectionDbTestSuite) TestCollectionDb_UpdateLogPositionVersionTotalRecordsAndLogicalSize() {
 	collectionName := "test_collection_get_collections"
-	collectionID, _ := CreateTestCollection(suite.db, collectionName, 128, suite.databaseId, nil)
+	collectionID, _ := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName, 128, suite.databaseId, nil))
 	ids := []string{collectionID}
 	// verify default values
 	collections, err := suite.collectionDb.GetCollections(ids, nil, "", "", nil, nil, false)
@@ -228,9 +229,9 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_SoftDelete() {
 	// Create 2 collections.
 	collectionName1 := "test_collection_soft_delete1"
 	collectionName2 := "test_collection_soft_delete2"
-	collectionID1, err := CreateTestCollection(suite.db, collectionName1, 128, suite.databaseId, nil)
+	collectionID1, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName1, 128, suite.databaseId, nil))
 	suite.NoError(err)
-	collectionID2, err := CreateTestCollection(suite.db, collectionName2, 128, suite.databaseId, nil)
+	collectionID2, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName2, 128, suite.databaseId, nil))
 	suite.NoError(err)
 
 	// Soft delete collection 1 by Updating the is_deleted column
@@ -265,7 +266,7 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_SoftDelete() {
 
 func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollectionSize() {
 	collectionName := "test_collection_get_collection_size"
-	collectionID, err := CreateTestCollection(suite.db, collectionName, 128, suite.databaseId, nil)
+	collectionID, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName, 128, suite.databaseId, nil))
 	suite.NoError(err)
 
 	total_records_post_compaction, err := suite.collectionDb.GetCollectionSize(collectionID)
@@ -299,17 +300,17 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_GetCollectionByResourceName
 
 	collectionName := "test_collection"
 	dim := int32(128)
-	collectionID, err := CreateTestCollection(suite.db, collectionName, dim, databaseID, nil)
+	collectionID, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName, dim, databaseID, nil))
 	suite.NoError(err)
 
-	collection, err := suite.collectionDb.GetCollectionByResourceName(tenantResourceName, databaseName, collectionName)
+	collectionResult, err := suite.collectionDb.GetCollectionByResourceName(tenantResourceName, databaseName, collectionName)
 	suite.NoError(err)
-	suite.NotNil(collection)
-	suite.Equal(collectionID, collection.Collection.ID)
-	suite.Equal(collectionName, *collection.Collection.Name)
-	suite.Equal(databaseID, collection.Collection.DatabaseID)
-	suite.Equal(tenantID, collection.TenantID)
-	suite.Equal(databaseName, collection.DatabaseName)
+	suite.NotNil(collectionResult)
+	suite.Equal(collectionID, collectionResult.Collection.ID)
+	suite.Equal(collectionName, *collectionResult.Collection.Name)
+	suite.Equal(databaseID, collectionResult.Collection.DatabaseID)
+	suite.Equal(tenantID, collectionResult.TenantID)
+	suite.Equal(databaseName, collectionResult.DatabaseName)
 
 	nonExistentCollection, err := suite.collectionDb.GetCollectionByResourceName(tenantResourceName, databaseName, "non_existent_collection")
 	suite.Error(err, "collection not found")

--- a/go/pkg/sysdb/metastore/db/dao/daotest/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/daotest/collection.go
@@ -1,0 +1,166 @@
+package daotest
+
+import (
+	"time"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
+	"github.com/chroma-core/chroma/go/pkg/types"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+)
+
+// defaults for a test collection
+var (
+	defaultConfigurationJsonStr       = "{\"a\": \"param\", \"b\": \"param2\", \"3\": true}"
+	defaultDimension                  = int32(128)
+	defaultTotalRecordsPostCompaction = uint64(100)
+	defaultSizeBytesPostCompaction    = uint64(500000)
+	defaultLastCompactionTimeSecs     = uint64(1741037006)
+)
+
+// TestDatabaseID is the default database ID for a test collection. It's exported because it's so frequently used
+// and can be the same across most tests.
+const TestDatabaseID = "test_database"
+
+// TestTenantID is the default tenant ID for a test collection. It's exported because it's so frequently used
+// and can be the same across most tests.
+const TestTenantID = "test_tenant"
+
+// NewDefaultTestCollection is a "shim" for callsites that existed before dao.CreateTestCollection was refactored to
+// take a dbmodel.Collection instead of a subset of its fields as arguments. It should not be used for new tests.
+func NewDefaultTestCollection(collectionName string, dimension int32, databaseID string, lineageFileName *string) *dbmodel.Collection {
+	log.Info("new default test collection", zap.String("collectionName", collectionName), zap.Int32("dimension", dimension), zap.String("databaseID", databaseID))
+	return NewTestCollection(
+		TestTenantID,
+		databaseID,
+		collectionName,
+		WithDimension(dimension),
+		WithTotalRecordsPostCompaction(defaultTotalRecordsPostCompaction),
+		WithSizeBytesPostCompaction(defaultSizeBytesPostCompaction),
+		WithLastCompactionTimeSecs(defaultLastCompactionTimeSecs),
+		WithLineageFileName(lineageFileName),
+	)
+}
+
+// NewTestCollection creates a new test collection with the given name, database ID, and tenant ID.
+// Name, databaseID, and tenantID are required, other fields have defaults but can be overridden with
+// option function of a similar name.
+// Note: collection.CreatedAt is set to the current time, but collection.UpdatedAt is not set.
+func NewTestCollection(tenantID, databaseID, collectionName string, options ...TestCollectionOption) *dbmodel.Collection {
+	log.Info("new test collection", zap.String("tenantID", tenantID), zap.String("databaseID", databaseID), zap.String("collectionName", collectionName))
+	collectionId := types.NewUniqueID().String()
+
+	collection := &dbmodel.Collection{
+		ID:                   collectionId,
+		Name:                 &collectionName,
+		ConfigurationJsonStr: &defaultConfigurationJsonStr,
+		Dimension:            &defaultDimension,
+		DatabaseID:           databaseID,
+		CreatedAt:            time.Now(),
+		Tenant:               tenantID,
+	}
+
+	for _, option := range options {
+		option(collection)
+	}
+
+	return collection
+}
+
+type TestCollectionOption func(*dbmodel.Collection)
+
+func WithConfigurationJsonStr(configurationJsonStr string) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.ConfigurationJsonStr = &configurationJsonStr
+	}
+}
+
+func WithDimension(dimension int32) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.Dimension = &dimension
+	}
+}
+
+func WithTs(ts int64) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.Ts = ts
+	}
+}
+
+func WithIsDeleted(isDeleted bool) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.IsDeleted = isDeleted
+	}
+}
+
+func WithCreatedAt(createdAt time.Time) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.CreatedAt = createdAt
+	}
+}
+
+func WithUpdatedAt(updatedAt time.Time) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.UpdatedAt = updatedAt
+	}
+}
+
+func WithLogPosition(logPosition int64) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.LogPosition = logPosition
+	}
+}
+
+func WithVersion(version int32) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.Version = version
+	}
+}
+
+func WithVersionFileName(versionFileName string) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.VersionFileName = versionFileName
+	}
+}
+
+func WithRootCollectionID(rootCollectionId string) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.RootCollectionId = &rootCollectionId
+	}
+}
+
+func WithLineageFileName(lineageFileName *string) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.LineageFileName = lineageFileName
+	}
+}
+
+func WithTotalRecordsPostCompaction(totalRecordsPostCompaction uint64) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.TotalRecordsPostCompaction = totalRecordsPostCompaction
+	}
+}
+
+func WithSizeBytesPostCompaction(sizeBytesPostCompaction uint64) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.SizeBytesPostCompaction = sizeBytesPostCompaction
+	}
+}
+
+func WithLastCompactionTimeSecs(lastCompactionTimeSecs uint64) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.LastCompactionTimeSecs = lastCompactionTimeSecs
+	}
+}
+
+func WithNumVersions(numVersions uint32) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.NumVersions = numVersions
+	}
+}
+
+func WithOldestVersionTs(oldestVersionTs time.Time) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.OldestVersionTs = oldestVersionTs
+	}
+}

--- a/go/pkg/sysdb/metastore/db/dao/segment_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/segment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao/daotest"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/suite"
@@ -84,7 +85,7 @@ func (suite *SegmentDbTestSuite) TestSegmentDb_RegisterFilePath() {
 	// create a collection for testing
 	databaseId := types.NewUniqueID().String()
 	collectionName := "test_segment_register_file_paths"
-	collectionID, err := CreateTestCollection(suite.db, collectionName, 128, databaseId, nil)
+	collectionID, err := CreateTestCollection(suite.db, daotest.NewDefaultTestCollection(collectionName, 128, databaseId, nil))
 	suite.NoError(err)
 
 	segments, err := suite.segmentDb.GetSegments(types.NilUniqueID(), nil, nil, types.MustParse(collectionID))


### PR DESCRIPTION
## Note for reviewers
Sorry in advance for extra diff noise. I realized that the tests here are harder to work with than they should be (which is probably why we have so many gaps in the tests) so I refactored some things to move the needle in the right direction. I will follow up with more testing changes. 

## Summary
This adds a test for the `CheckCollections` method. This would have caught the issue fixed in #4899. 

Along the way, I discovered how these tests need some love, so I started down this path by introducing a new `daotest` package that provides testing helpers for creating `Collection` values that are easier to configure. Instead of having to potentially debug all the tests that use `dao.CreateTestCollection`, I defined a "shim" that can be used as a stop-gap so that I can change the signature of this `dao.CreateTestCollection` without potentially derailing the original goal which was just to add some missing test coverage.

- Improvements & Bug fixes
  - Added test coverage for `CheckCollections` service endpoint
- New functionality
  - Added `daotest` package and `NewTestCollection` helper with builder/options methods for more configurability

## Test plan

All the tests are passing.

## Documentation Changes

N/A
