### PR TITLE
[BLD] Update deploy automation to deploy control and data planes separately

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,0 +1,39 @@
+name: Trigger deploy
+
+on:
+  workflow_call:
+    inputs:
+      plane:
+        description: 'Plane to deploy (control or data)'
+        required: true
+        type: string
+      ignore-lock:
+        description: 'Ignore lock file'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  deploy:
+    name: Dispatch deploy ${{ inputs.plane }} plane workflow
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Dispatch deploy ${{ inputs.plane }} plane
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN}}
+          # we don't expose environment here because we only want to automate deploys to staging
+          # we also don't expose the ref here because we want to use the defaults on the other side (latest, main)
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'chroma-core',
+              repo: 'hosted-chroma',
+              workflow_id: 'deploy.yaml',
+              ref: 'main',
+              inputs: {
+                'planes': '${{ inputs.plane }}',
+                 environment: 'staging',
+                'ignore-lock': ${{ inputs.ignore-lock }},
+              }
+            })
+            console.log(result)

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -205,36 +205,25 @@ jobs:
           removeArtifacts: true
           prerelease: true
 
-  release-hosted:
-    name: Release to Chroma Cloud
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+  release-hosted-control-plane:
+    name: Release to Chroma Cloud control plane
+    # depends on release-github because it updates the tag to latest, which is what will get deployed
     needs:
       - release-github
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Dispatch deploy
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN }}
-          script: |
-            const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'chroma-core',
-              repo: 'hosted-chroma',
-              workflow_id: 'deploy.yaml',
-              ref: 'main',
-              inputs: {
-                // We intentionally *do not* provide the current commit SHA of chroma-core/chroma here. The workflow we dispatch defaults to the commit tagged with "latest" (which we update above).
-                // If we provided the current commit here, there's a potential race condition:
-                // - Commit history is A -> B
-                // - This CI workflow runs on both commits, but the second commit finishes first
-                // - B is deployed to Chroma Cloud
-                // - This workflow finishes for A and deploys A to Chroma Cloud
-                // Chroma Cloud is now running A, but the last commit was B.
-                "environment": "staging",
-                "planes": "control,data"
-              }
-            })
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      plane: control
+    secrets: inherit
+
+  release-hosted-data-plane:
+    name: Release to Chroma Cloud data plane
+    # depends on release-github because it updates the tag to latest, which is what will get deployed
+    needs:
+      - release-github
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      plane: data
+    secrets: inherit
 
   release-docs:
     name: Deploy docs to Vercel

--- a/.github/workflows/trigger-deploy.yaml
+++ b/.github/workflows/trigger-deploy.yaml
@@ -10,26 +10,18 @@ on:
       - rc/**-**-**
 
 jobs:
-  deploy:
-    name: Dispatch deploy workflow
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-      - name: Dispatch deploy
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.HOSTED_CHROMA_WORKFLOW_DISPATCH_TOKEN}}
-          script: |
-            const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'chroma-core',
-              repo: 'hosted-chroma',
-              workflow_id: 'deploy.yaml',
-              ref: 'main',
-              inputs: {
-                'planes': 'control,data',
-                 environment: 'staging',
-                'ignore-lock': true,
-                'oss-ref': '${{ github.ref_name }}',
-                'hosted-ref': '${{ github.ref_name }}'
-              }
-            })
-            console.log(result)
+  deploy-control-plane:
+    name: Dispatch deploy control plane workflow
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      plane: control
+      ignore-lock: true
+    secrets: inherit
+
+  deploy-data-plane:
+    name: Dispatch deploy data plane workflow
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      plane: data
+      ignore-lock: true
+    secrets: inherit


### PR DESCRIPTION
## Description of changes

Updates the places in our GitHub Actions where we dispatch the `deploy.yaml` workflow in our internal repository to match the updates to its inputs. The deploy workflow was updated to take a single `plane` string value instead of a comma-separated `planes` input. The update on the other side is intended to affect the deployments to production to further reduce the likelihood that one of the planes is inadvertently deployed.

Note: Rather than write the throw-away code on the other side to support both `plane` and `planes` inputs, I'm going to land this change shortly after landing the change in hosted, but there may be older versions of the `trigger-deploy.yaml` workflow that fail if they dispatch with the old `planes` input.

## Test plan

Once this change lands, it will trigger a deploy and we will see if it works.