### PR TITLE
[ENH] Move Log GC to operator

### DIFF
--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1292,12 +1292,7 @@ func (tc *Catalog) createFirstVersionFile(ctx context.Context, databaseID string
 		VersionHistory: &coordinatorpb.CollectionVersionHistory{
 			Versions: []*coordinatorpb.CollectionVersionInfo{
 				{
-					Version: 0,
-					CollectionInfoMutable: &coordinatorpb.CollectionInfoMutable{
-						CurrentLogPosition:       0,
-						CurrentCollectionVersion: 0,
-						UpdatedAtSecs:            int64(ts),
-					},
+					Version:       0,
 					CreatedAtSecs: int64(ts),
 					SegmentInfo: &coordinatorpb.CollectionSegmentInfo{
 						SegmentCompactionInfo: segmentCompactionInfos,

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -1292,7 +1292,12 @@ func (tc *Catalog) createFirstVersionFile(ctx context.Context, databaseID string
 		VersionHistory: &coordinatorpb.CollectionVersionHistory{
 			Versions: []*coordinatorpb.CollectionVersionInfo{
 				{
-					Version:       0,
+					Version: 0,
+					CollectionInfoMutable: &coordinatorpb.CollectionInfoMutable{
+						CurrentLogPosition:       0,
+						CurrentCollectionVersion: 0,
+						UpdatedAtSecs:            int64(ts),
+					},
 					CreatedAtSecs: int64(ts),
 					SegmentInfo: &coordinatorpb.CollectionSegmentInfo{
 						SegmentCompactionInfo: segmentCompactionInfos,

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -11,7 +11,9 @@ use crate::operators::delete_unused_files::{
     DeleteUnusedFilesError, DeleteUnusedFilesInput, DeleteUnusedFilesOperator,
     DeleteUnusedFilesOutput,
 };
-use crate::operators::delete_unused_logs::{DeleteUnusedLogsError, DeleteUnusedLogsOutput};
+use crate::operators::delete_unused_logs::{
+    DeleteUnusedLogsError, DeleteUnusedLogsInput, DeleteUnusedLogsOperator, DeleteUnusedLogsOutput,
+};
 use crate::operators::delete_versions_at_sysdb::{
     DeleteVersionsAtSysDbError, DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOperator,
     DeleteVersionsAtSysDbOutput,
@@ -47,6 +49,7 @@ use std::time::SystemTime;
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
+use wal3::LogPosition;
 
 #[derive(Debug)]
 pub struct GarbageCollectorOrchestrator {
@@ -66,6 +69,8 @@ pub struct GarbageCollectorOrchestrator {
     versions_to_delete_output: Option<ComputeVersionsToDeleteOutput>,
     pending_mark_versions_at_sysdb_tasks: HashSet<CollectionUuid>,
     pending_list_files_at_version_tasks: HashSet<(CollectionUuid, i64)>,
+    delete_unused_file_output: Option<DeleteUnusedFilesOutput>,
+    delete_unused_log_output: Option<DeleteUnusedLogsOutput>,
     file_ref_counts: HashMap<String, u32>,
     num_pending_tasks: usize,
     min_versions_to_keep: u32,
@@ -112,6 +117,8 @@ impl GarbageCollectorOrchestrator {
             versions_to_delete_output: None,
             pending_mark_versions_at_sysdb_tasks: HashSet::new(),
             pending_list_files_at_version_tasks: HashSet::new(),
+            delete_unused_file_output: None,
+            delete_unused_log_output: None,
             num_pending_tasks: 0,
             min_versions_to_keep,
             graph: None,
@@ -426,9 +433,84 @@ impl GarbageCollectorOrchestrator {
         self.pending_mark_versions_at_sysdb_tasks
             .remove(&collection_id);
 
-        self.advance_after_list_files_and_mark_version_tasks_complete(ctx)
-            .await?;
+        self.start_delete_unused_log_operator(ctx).await?;
 
+        self.try_start_delete_unused_files_operator(ctx).await?;
+
+        Ok(())
+    }
+
+    async fn start_delete_unused_log_operator(
+        &mut self,
+        ctx: &ComponentContext<Self>,
+    ) -> Result<(), GarbageCollectorError> {
+        let collections_to_destroy = self.soft_deleted_collections_to_gc.clone();
+        let mut collections_to_garbage_collect = HashMap::new();
+        let versions_to_delete = self.versions_to_delete_output.as_ref().ok_or(
+            GarbageCollectorError::InvariantViolation(
+                "Expected versions_to_delete_output to be set".to_string(),
+            ),
+        )?;
+
+        for (collection_id, versions) in &versions_to_delete.versions {
+            let Some(&min_version_to_keep) = versions
+                .iter()
+                .filter_map(|(version, action)| {
+                    matches!(action, CollectionVersionAction::Keep).then_some(version)
+                })
+                .min()
+            else {
+                continue;
+            };
+            let version_file = self.version_files.get(collection_id).ok_or(
+                GarbageCollectorError::InvariantViolation(
+                    "Expected version file to be present".to_string(),
+                ),
+            )?;
+            let version_history = &version_file
+                .as_ref()
+                .version_history
+                .as_ref()
+                .ok_or(GarbageCollectorError::InvariantViolation(
+                    "Expected version file to contain version history".to_string(),
+                ))?
+                .versions;
+            let min_log_offset = version_history
+                .iter()
+                .find(|version_info| version_info.version == min_version_to_keep)
+                .ok_or(GarbageCollectorError::InvariantViolation(
+                    "Expected min kept version to be present in version history".to_string(),
+                ))?
+                .collection_info_mutable
+                .as_ref()
+                .ok_or(GarbageCollectorError::InvariantViolation(
+                    "Expected collection info to be present in version history".to_string(),
+                ))?
+                .current_log_position
+                .try_into()
+                .map_err(|_| {
+                    GarbageCollectorError::InvariantViolation(
+                        "Expected log offset to be unsigned".to_string(),
+                    )
+                })?;
+            collections_to_garbage_collect
+                .insert(*collection_id, LogPosition::from_offset(min_log_offset));
+        }
+
+        let task = wrap(
+            Box::new(DeleteUnusedLogsOperator {
+                storage: self.storage.clone(),
+            }),
+            DeleteUnusedLogsInput {
+                collections_to_destroy,
+                collections_to_garbage_collect,
+            },
+            ctx.receiver(),
+        );
+        self.dispatcher()
+            .send(task, Some(Span::current()))
+            .await
+            .map_err(GarbageCollectorError::Channel)?;
         Ok(())
     }
 
@@ -561,13 +643,12 @@ impl GarbageCollectorOrchestrator {
         self.pending_list_files_at_version_tasks
             .remove(&(output.collection_id, output.version));
 
-        self.advance_after_list_files_and_mark_version_tasks_complete(ctx)
-            .await?;
+        self.try_start_delete_unused_files_operator(ctx).await?;
 
         Ok(())
     }
 
-    async fn advance_after_list_files_and_mark_version_tasks_complete(
+    async fn try_start_delete_unused_files_operator(
         &mut self,
         ctx: &ComponentContext<Self>,
     ) -> Result<(), GarbageCollectorError> {
@@ -644,11 +725,18 @@ impl GarbageCollectorOrchestrator {
         Ok(())
     }
 
-    async fn handle_delete_unused_files_output(
+    async fn try_start_delete_versions_at_sysdb_operator(
         &mut self,
-        output: DeleteUnusedFilesOutput,
         ctx: &ComponentContext<Self>,
     ) -> Result<(), GarbageCollectorError> {
+        let Some(output) = self.delete_unused_file_output.as_ref() else {
+            return Ok(());
+        };
+
+        if self.delete_unused_log_output.is_none() {
+            return Ok(());
+        }
+
         if self.cleanup_mode == CleanupMode::DryRun {
             tracing::info!("Dry run mode, skipping actual deletion");
             let response = GarbageCollectorResponse {
@@ -938,7 +1026,8 @@ impl Handler<TaskResult<DeleteUnusedFilesOutput, DeleteUnusedFilesError>>
             None => return,
         };
 
-        let res = self.handle_delete_unused_files_output(output, ctx).await;
+        self.delete_unused_file_output = Some(output);
+        let res = self.try_start_delete_versions_at_sysdb_operator(ctx).await;
         self.ok_or_terminate(res, ctx).await;
     }
 }
@@ -954,7 +1043,14 @@ impl Handler<TaskResult<DeleteUnusedLogsOutput, DeleteUnusedLogsError>>
         message: TaskResult<DeleteUnusedLogsOutput, DeleteUnusedLogsError>,
         ctx: &ComponentContext<GarbageCollectorOrchestrator>,
     ) {
-        self.ok_or_terminate(message.into_inner(), ctx).await;
+        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
+            Some(output) => output,
+            None => return,
+        };
+
+        self.delete_unused_log_output = Some(output);
+        let res = self.try_start_delete_versions_at_sysdb_operator(ctx).await;
+        self.ok_or_terminate(res, ctx).await;
     }
 }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -456,7 +456,8 @@ impl GarbageCollectorOrchestrator {
             let Some(&min_version_to_keep) = versions
                 .iter()
                 .filter_map(|(version, action)| {
-                    matches!(action, CollectionVersionAction::Keep).then_some(version)
+                    (matches!(action, CollectionVersionAction::Keep) && *version > 0)
+                        .then_some(version)
                 })
                 .min()
             else {

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -70,7 +70,6 @@ pub struct GarbageCollectorOrchestrator {
     num_pending_tasks: usize,
     min_versions_to_keep: u32,
     graph: Option<VersionGraph>,
-    collections_to_gc: HashSet<CollectionUuid>,
     soft_deleted_collections_to_gc: HashSet<CollectionUuid>,
     tenant: Option<String>,
     database_name: Option<String>,
@@ -116,7 +115,6 @@ impl GarbageCollectorOrchestrator {
             num_pending_tasks: 0,
             min_versions_to_keep,
             graph: None,
-            collections_to_gc: HashSet::new(),
             soft_deleted_collections_to_gc: HashSet::new(),
             tenant: None,
             database_name: None,
@@ -152,6 +150,8 @@ pub enum GarbageCollectorError {
     ListFilesAtVersion(#[from] ListFilesAtVersionError),
     #[error("Failed to delete unused files: {0}")]
     DeleteUnusedFiles(#[from] DeleteUnusedFilesError),
+    #[error("Failed to delete unused logs: {0}")]
+    DeleteUnusedLogs(#[from] DeleteUnusedLogsError),
     #[error("Failed to delete versions at sysdb: {0}")]
     DeleteVersionsAtSysDb(#[from] DeleteVersionsAtSysDbError),
 
@@ -287,7 +287,6 @@ impl GarbageCollectorOrchestrator {
 
         let collection_ids = output.version_files.keys().cloned().collect::<Vec<_>>();
 
-        self.collections_to_gc = HashSet::from_iter(collection_ids.iter().cloned());
         self.soft_deleted_collections_to_gc = self
             .get_eligible_soft_deleted_collections_to_gc(collection_ids)
             .await?;

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -82,7 +82,9 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     if let Err(err) =
                         wal3::destroy(storage_clone, &collection_id.storage_prefix_for_log()).await
                     {
-                        tracing::error!("could not destroy/hard delete wal3 instance: {err:?}");
+                        tracing::error!(
+                            "Unable to destroy log for collection [{collection_id}]: {err:?}"
+                        );
                     }
                 })
             }

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -8,7 +8,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::CollectionUuid;
-use futures::future::join_all;
+use futures::future::try_join_all;
 use thiserror::Error;
 use wal3::{GarbageCollectionOptions, LogPosition, LogWriter, LogWriterOptions};
 
@@ -27,8 +27,8 @@ pub type DeleteUnusedLogsOutput = ();
 
 #[derive(Debug, Error)]
 pub enum DeleteUnusedLogsError {
-    #[error("No log service found")]
-    NoLogServiceFound,
+    #[error(transparent)]
+    Wal3(#[from] wal3::Error),
 }
 
 impl ChromaError for DeleteUnusedLogsError {
@@ -66,74 +66,47 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     .await
                     {
                         Ok(log_writer) => log_writer,
-                        Err(wal3::Error::UninitializedLog) => return,
+                        Err(wal3::Error::UninitializedLog) => return Ok(()),
                         Err(err) => {
                             tracing::error!("Unable to initialize log writer for collection [{collection_id}]: {err}");
-                            return
+                            return Err(DeleteUnusedLogsError::Wal3(err))
                         }
                     };
-                    if let Err(err) = writer.garbage_collect(&GarbageCollectionOptions::default(), Some(*minimum_log_offset_to_keep)).await {
-                        tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
+                    return match writer.garbage_collect(&GarbageCollectionOptions::default(), Some(*minimum_log_offset_to_keep)).await {
+                        Ok(()) => Ok(()),
+                        Err(err) => {
+                            tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
+                            Err(DeleteUnusedLogsError::Wal3(err))
+                        },
                     }
                 });
             }
-            join_all(log_gc_futures).await;
+            try_join_all(log_gc_futures).await?;
         }
         if !input.collections_to_destroy.is_empty() {
             let mut log_destroy_futures = Vec::with_capacity(input.collections_to_destroy.len());
             for collection_id in &input.collections_to_destroy {
                 let storage_clone = storage_arc.clone();
                 log_destroy_futures.push(async move {
-                    if let Err(err) =
-                        wal3::destroy(storage_clone, &collection_id.storage_prefix_for_log()).await
+                    return match wal3::destroy(
+                        storage_clone,
+                        &collection_id.storage_prefix_for_log(),
+                    )
+                    .await
                     {
-                        tracing::error!(
-                            "Unable to destroy log for collection [{collection_id}]: {err:?}"
-                        );
-                    }
+                        Ok(()) => Ok(()),
+                        Err(err) => {
+                            tracing::error!(
+                                "Unable to destroy log for collection [{collection_id}]: {err:?}"
+                            );
+                            Err(DeleteUnusedLogsError::Wal3(err))
+                        }
+                    };
                 })
             }
-            join_all(log_destroy_futures).await;
+            try_join_all(log_destroy_futures).await?;
         }
 
-        // NOTE: This is a hack to get the dirty log writers for all available log services
-        // It tries to open the dirty log manifest sequentially until the manifest is not found
-        // It assumes that all dirty log paths looks like `dirty-rust-log-service-<replica_id>`
-        let mut dirty_log_writers = Vec::new();
-        let mut replica_id = 0;
-        loop {
-            let dirty_log_prefix = format!("dirty-rust-log-service-{replica_id}");
-            match LogWriter::open(
-                LogWriterOptions::default(),
-                storage_arc.clone(),
-                &dirty_log_prefix,
-                "garbage collection service",
-                (),
-            )
-            .await
-            {
-                Ok(log_writer) => dirty_log_writers.push(log_writer),
-                Err(wal3::Error::UninitializedLog) => break,
-                Err(err) => {
-                    tracing::error!("Unable to open dirty log [{dirty_log_prefix}]: {err}");
-                    break;
-                }
-            };
-            replica_id += 1;
-        }
-        if dirty_log_writers.is_empty() {
-            tracing::error!("Unable to find any dirty log manifest. Skipping dirty log GC");
-            return Err(DeleteUnusedLogsError::NoLogServiceFound);
-        }
-        join_all(dirty_log_writers.into_iter().map(|writer| async move {
-            if let Err(err) = writer
-                .garbage_collect(&GarbageCollectionOptions::default(), None)
-                .await
-            {
-                tracing::error!("Unable to garbage collect dirty log: {err}");
-            }
-        }))
-        .await;
         Ok(())
     }
 }

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::Storage;
+use chroma_system::{Operator, OperatorType};
+use chroma_types::CollectionUuid;
+use futures::future::join_all;
+use thiserror::Error;
+use wal3::{GarbageCollectionOptions, LogWriter, LogWriterOptions};
+
+#[derive(Clone, Debug)]
+pub struct DeleteUnusedLogsOperator {
+    storage: Arc<Storage>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DeleteUnusedLogsInput {
+    collections_to_destroy: Vec<CollectionUuid>,
+    collections_to_garbage_collect: Vec<CollectionUuid>,
+}
+
+pub type DeleteUnusedLogsOutput = ();
+
+#[derive(Debug, Error)]
+pub enum DeleteUnusedLogsError {
+    #[error("No log service found")]
+    NoLogServiceFound,
+}
+
+impl ChromaError for DeleteUnusedLogsError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+#[async_trait]
+impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLogsOperator {
+    type Error = DeleteUnusedLogsError;
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
+    }
+
+    async fn run(
+        &self,
+        input: &DeleteUnusedLogsInput,
+    ) -> Result<DeleteUnusedLogsOutput, DeleteUnusedLogsError> {
+        if !input.collections_to_garbage_collect.is_empty() {
+            let mut log_gc_futures = Vec::with_capacity(input.collections_to_garbage_collect.len());
+            for collection_id in &input.collections_to_garbage_collect {
+                let storage_clone = self.storage.clone();
+                log_gc_futures.push(async move {
+                    let writer = match LogWriter::open(
+                        LogWriterOptions::default(),
+                        storage_clone,
+                        &collection_id.storage_prefix_for_log(),
+                        "garbage collection service",
+                        (),
+                    )
+                    .await
+                    {
+                        Ok(log_writer) => log_writer,
+                        Err(wal3::Error::UninitializedLog) => return,
+                        Err(err) => {
+                            tracing::error!("Unable to initialize log writer for collection [{collection_id}]: {err}");
+                            return
+                        }
+                    };
+                    if let Err(err) = writer.garbage_collect(&GarbageCollectionOptions::default()).await {
+                        tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
+                    }
+                });
+            }
+            join_all(log_gc_futures).await;
+        }
+        if !input.collections_to_destroy.is_empty() {
+            let mut log_destroy_futures = Vec::with_capacity(input.collections_to_destroy.len());
+            for collection_id in &input.collections_to_destroy {
+                let storage_clone = self.storage.clone();
+                log_destroy_futures.push(async move {
+                    if let Err(err) =
+                        wal3::destroy(storage_clone, &collection_id.storage_prefix_for_log()).await
+                    {
+                        tracing::error!("could not destroy/hard delete wal3 instance: {err:?}");
+                    }
+                })
+            }
+            join_all(log_destroy_futures).await;
+        }
+
+        // NOTE: This is a hack to get the dirty log writers for all available log services
+        // It tries to open the dirty log manifest sequentially until the manifest is not found
+        // It assumes that all dirty log paths looks like `dirty-rust-log-service-<replica_id>`
+        let mut dirty_log_writers = Vec::new();
+        let mut replica_id = 0;
+        loop {
+            let log_service_name = format!("rust-log-service-{replica_id}");
+            match LogWriter::open(
+                LogWriterOptions::default(),
+                self.storage.clone(),
+                &log_service_name,
+                "garbage collection service",
+                (),
+            )
+            .await
+            {
+                Ok(log_writer) => dirty_log_writers.push(log_writer),
+                Err(wal3::Error::UninitializedLog) => break,
+                Err(err) => {
+                    tracing::error!("Unable to open dirty log [{log_service_name}]: {err}");
+                    break;
+                }
+            };
+            replica_id += 1;
+        }
+        if dirty_log_writers.is_empty() {
+            tracing::error!("Unable to find any dirty log manifest. Skipping dirty log GC");
+            return Err(DeleteUnusedLogsError::NoLogServiceFound);
+        }
+        join_all(dirty_log_writers.into_iter().map(|writer| async move {
+            if let Err(err) = writer
+                .garbage_collect(&GarbageCollectionOptions::default())
+                .await
+            {
+                tracing::error!("Unable to garbage collect dirty log: {err}");
+            }
+        }))
+        .await;
+        Ok(())
+    }
+}

--- a/rust/garbage_collector/src/operators/mod.rs
+++ b/rust/garbage_collector/src/operators/mod.rs
@@ -3,6 +3,7 @@ pub mod compute_unused_files;
 pub mod compute_versions_to_delete;
 pub mod compute_versions_to_delete_from_graph;
 pub mod delete_unused_files;
+pub mod delete_unused_logs;
 pub mod delete_versions_at_sysdb;
 pub mod fetch_lineage_file;
 pub mod fetch_sparse_index_files;

--- a/rust/garbage_collector/src/operators/mod.rs
+++ b/rust/garbage_collector/src/operators/mod.rs
@@ -11,3 +11,4 @@ pub mod fetch_version_file;
 pub mod get_version_file_paths;
 pub mod list_files_at_version;
 pub mod mark_versions_at_sysdb;
+pub mod truncate_dirty_log;

--- a/rust/garbage_collector/src/operators/truncate_dirty_log.rs
+++ b/rust/garbage_collector/src/operators/truncate_dirty_log.rs
@@ -75,7 +75,7 @@ impl Operator<TruncateDirtyLogInput, TruncateDirtyLogOutput> for TruncateDirtyLo
             return Err(TruncateDirtyLogError::NoLogServiceFound);
         }
         try_join_all(dirty_log_writers.into_iter().map(|writer| async move {
-            return match writer
+            match writer
                 .garbage_collect(&GarbageCollectionOptions::default(), None)
                 .await
             {
@@ -84,7 +84,7 @@ impl Operator<TruncateDirtyLogInput, TruncateDirtyLogOutput> for TruncateDirtyLo
                     tracing::error!("Unable to garbage collect dirty log: {err}");
                     Err(TruncateDirtyLogError::Wal3(err))
                 }
-            };
+            }
         }))
         .await?;
         Ok(())

--- a/rust/garbage_collector/src/operators/truncate_dirty_log.rs
+++ b/rust/garbage_collector/src/operators/truncate_dirty_log.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chroma_error::{ChromaError, ErrorCodes};
+use chroma_storage::Storage;
+use chroma_system::{Operator, OperatorType};
+use futures::future::try_join_all;
+use thiserror::Error;
+use wal3::{GarbageCollectionOptions, LogWriter, LogWriterOptions};
+
+#[derive(Clone, Debug)]
+pub struct TruncateDirtyLogOperator {
+    pub storage: Storage,
+}
+
+pub type TruncateDirtyLogInput = ();
+
+pub type TruncateDirtyLogOutput = ();
+
+#[derive(Debug, Error)]
+pub enum TruncateDirtyLogError {
+    #[error("No log service found")]
+    NoLogServiceFound,
+    #[error(transparent)]
+    Wal3(#[from] wal3::Error),
+}
+
+impl ChromaError for TruncateDirtyLogError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
+
+#[async_trait]
+impl Operator<TruncateDirtyLogInput, TruncateDirtyLogOutput> for TruncateDirtyLogOperator {
+    type Error = TruncateDirtyLogError;
+
+    fn get_type(&self) -> OperatorType {
+        OperatorType::IO
+    }
+
+    async fn run(
+        &self,
+        _input: &TruncateDirtyLogInput,
+    ) -> Result<TruncateDirtyLogOutput, TruncateDirtyLogError> {
+        let storage_arc = Arc::new(self.storage.clone());
+
+        // NOTE: This is a hack to get the dirty log writers for all available log services
+        // It tries to open the dirty log manifest sequentially until the manifest is not found
+        // It assumes that all dirty log paths looks like `dirty-rust-log-service-<replica_id>`
+        let mut dirty_log_writers = Vec::new();
+        let mut replica_id = 0;
+        loop {
+            let dirty_log_prefix = format!("dirty-rust-log-service-{replica_id}");
+            match LogWriter::open(
+                LogWriterOptions::default(),
+                storage_arc.clone(),
+                &dirty_log_prefix,
+                "garbage collection service",
+                (),
+            )
+            .await
+            {
+                Ok(log_writer) => dirty_log_writers.push(log_writer),
+                Err(wal3::Error::UninitializedLog) => break,
+                Err(err) => {
+                    tracing::error!("Unable to open dirty log [{dirty_log_prefix}]: {err}");
+                    break;
+                }
+            };
+            replica_id += 1;
+        }
+        if dirty_log_writers.is_empty() {
+            tracing::error!("Unable to find any dirty log manifest. Skipping dirty log GC");
+            return Err(TruncateDirtyLogError::NoLogServiceFound);
+        }
+        try_join_all(dirty_log_writers.into_iter().map(|writer| async move {
+            return match writer
+                .garbage_collect(&GarbageCollectionOptions::default(), None)
+                .await
+            {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    tracing::error!("Unable to garbage collect dirty log: {err}");
+                    Err(TruncateDirtyLogError::Wal3(err))
+                }
+            };
+        }))
+        .await?;
+        Ok(())
+    }
+}

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -487,7 +487,7 @@ pub struct MarkDirty {
 }
 
 impl MarkDirty {
-    fn path_for_hostname(hostname: &str) -> String {
+    pub fn path_for_hostname(hostname: &str) -> String {
         format!("dirty-{}", hostname)
     }
 }

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -256,6 +256,7 @@ impl TestSysDb {
         &mut self,
         collection_id: CollectionUuid,
         segment_flush_info: Arc<[SegmentFlushInfo]>,
+        log_position: i64,
     ) -> Result<(), String> {
         // Check if version file already exists for the collection.
         // If it does not, then create a new one with version 0.
@@ -285,6 +286,7 @@ impl TestSysDb {
                         chrono::Utc::now().timestamp()
                     },
                     version_change_reason: VersionChangeReason::DataCompaction as i32,
+                    collection_info_mutable: Some(Default::default()),
                     ..Default::default()
                 };
                 version_history.versions = vec![version_info];
@@ -293,23 +295,35 @@ impl TestSysDb {
             }
         };
 
+        let time_secs = if inner.mock_time > 0 {
+            inner.mock_time as i64
+        } else {
+            chrono::Utc::now().timestamp()
+        };
+
         // Get current version history
         let mut version_history = version_file.version_history.unwrap_or_default();
-        let next_version = version_history
+        let last_version_info = version_history
             .versions
             .last()
-            .map(|v| v.version + 1)
-            .unwrap_or(0);
+            .cloned()
+            .unwrap_or_default()
+            .clone();
+        let mut collection_info = last_version_info
+            .collection_info_mutable
+            .unwrap_or_default();
+        collection_info.current_collection_version = last_version_info.version + 1;
+        collection_info.current_log_position = log_position;
+        collection_info.updated_at_secs = time_secs;
+        collection_info.last_compaction_time_secs = time_secs;
 
         // Create new version info with segment file paths
+        let next_version = last_version_info.version + 1;
         let mut version_info = CollectionVersionInfo {
             version: next_version,
-            created_at_secs: if inner.mock_time > 0 {
-                inner.mock_time as i64
-            } else {
-                chrono::Utc::now().timestamp()
-            },
+            created_at_secs: time_secs,
             version_change_reason: VersionChangeReason::DataCompaction as i32,
+            collection_info_mutable: Some(collection_info),
             ..Default::default()
         };
 
@@ -455,7 +469,8 @@ impl TestSysDb {
         }
 
         // Update the in-memory version file
-        let result = self.update_collection_version_file(collection_id, segment_flush_info);
+        let result =
+            self.update_collection_version_file(collection_id, segment_flush_info, log_position);
         if result.is_err() {
             return Err(FlushCompactionError::FailedToFlushCompaction(
                 tonic::Status::internal("Failed to update version file"),

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -279,11 +279,15 @@ impl LogWriter {
             .map(|writer| writer.manifest_manager.latest())
     }
 
-    pub async fn garbage_collect(&self, options: &GarbageCollectionOptions) -> Result<(), Error> {
+    pub async fn garbage_collect(
+        &self,
+        options: &GarbageCollectionOptions,
+        keep_at_least: Option<LogPosition>,
+    ) -> Result<(), Error> {
         let once_log_garbage_collect = move |log: &Arc<OnceLogWriter>| {
             let options = options.clone();
             let log = Arc::clone(log);
-            async move { log.garbage_collect(&options).await }
+            async move { log.garbage_collect(&options, keep_at_least).await }
         };
         self.handle_log_contention(once_log_garbage_collect).await
     }
@@ -581,8 +585,13 @@ impl OnceLogWriter {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn garbage_collect(&self, options: &GarbageCollectionOptions) -> Result<(), Error> {
-        self.garbage_collect_recursive(options, false, None).await
+    async fn garbage_collect(
+        &self,
+        options: &GarbageCollectionOptions,
+        keep_at_least: Option<LogPosition>,
+    ) -> Result<(), Error> {
+        self.garbage_collect_recursive(options, false, None, keep_at_least)
+            .await
     }
 
     async fn garbage_collect_recursive(
@@ -590,8 +599,14 @@ impl OnceLogWriter {
         options: &GarbageCollectionOptions,
         base: bool,
         existing: Option<&ETag>,
+        keep_at_least: Option<LogPosition>,
     ) -> Result<(), Error> {
         let cutoff = self.garbage_collection_cutoff().await?;
+        let cutoff = if let Some(keep_at_least) = keep_at_least {
+            keep_at_least.min(cutoff)
+        } else {
+            cutoff
+        };
         self.manifest_manager.heartbeat().await?;
         let garbage = self
             .manifest_manager
@@ -626,6 +641,7 @@ impl OnceLogWriter {
                                     options,
                                     true,
                                     e_tag.as_ref(),
+                                    keep_at_least,
                                 ))
                                 .await;
                             }

--- a/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
+++ b/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
@@ -47,7 +47,7 @@ async fn test_k8s_integration_82_copy_empty_log_initializes() {
         )
         .await
         .unwrap();
-    log.garbage_collect(&GarbageCollectionOptions::default())
+    log.garbage_collect(&GarbageCollectionOptions::default(), None)
         .await
         .unwrap();
 

--- a/rust/wal3/tests/test_k8s_integration_90_garbage_collect.rs
+++ b/rust/wal3/tests/test_k8s_integration_90_garbage_collect.rs
@@ -42,7 +42,7 @@ async fn test_k8s_integration_90_garbage_collect() {
     }
 
     let res = log
-        .garbage_collect(&GarbageCollectionOptions::default())
+        .garbage_collect(&GarbageCollectionOptions::default(), None)
         .await;
     assert!(matches!(res, Err(Error::NoSuchCursor(_))));
 
@@ -64,7 +64,7 @@ async fn test_k8s_integration_90_garbage_collect() {
         .await
         .unwrap();
 
-    log.garbage_collect(&GarbageCollectionOptions::default())
+    log.garbage_collect(&GarbageCollectionOptions::default(), None)
         .await
         .unwrap();
 
@@ -81,7 +81,7 @@ async fn test_k8s_integration_90_garbage_collect() {
         .await
         .unwrap();
 
-    log.garbage_collect(&GarbageCollectionOptions::default())
+    log.garbage_collect(&GarbageCollectionOptions::default(), None)
         .await
         .unwrap();
 }

--- a/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
+++ b/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
@@ -87,7 +87,7 @@ async fn garbage_collector_thread(
         println!("gc grabs lock in iteration {i}");
         loop {
             match writer
-                .garbage_collect(&GarbageCollectionOptions::default())
+                .garbage_collect(&GarbageCollectionOptions::default(), None)
                 .await
             {
                 Ok(()) => break,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Extract log GC logic into its own operator
  - Runs the GC operator at the end of GC orchestration
  - Delete versions at sysdb operator waits until both file GC and log GC completes
  - Updates the test sysdb impl so that the version history contains log offsets
- New functionality
  - New log GC operator, including the logic to GC dirty log
  - Log GC will only GC upto the minimum kept version of the collection
  - Add an initial version history entry in version file

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
