### PR TITLE
[BUG]  The condition for setting the manifest initial_seq_no was broken.

### DIFF
--- a/rust/wal3/src/gc.rs
+++ b/rust/wal3/src/gc.rs
@@ -61,7 +61,7 @@ impl Garbage {
         throttle: &ThrottleOptions,
         snapshots: &dyn SnapshotCache,
         first_to_keep: LogPosition,
-    ) -> Result<Self, Error> {
+    ) -> Result<Option<Self>, Error> {
         let dropped_snapshots = manifest
             .snapshots
             .iter()
@@ -119,7 +119,11 @@ impl Garbage {
                 "setsums don't balance".to_string(),
             ))));
         }
-        Ok(ret)
+        if !first {
+            Ok(Some(ret))
+        } else {
+            Ok(None)
+        }
     }
 
     #[tracing::instrument(skip(storage), err(Display))]

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -834,11 +834,7 @@ impl Manifest {
         }
         new.collected += garbage.setsum_to_discard;
         new.initial_offset = Some(garbage.first_to_keep);
-        if garbage.fragments_to_drop_limit != FragmentSeqNo(0) {
-            new.initial_seq_no = Some(garbage.fragments_to_drop_limit);
-        } else {
-            new.initial_seq_no = Some(FragmentSeqNo(1));
-        }
+        new.initial_seq_no = Some(garbage.fragments_to_drop_limit);
         new.scrub()?;
         Ok(Some(new))
     }

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -383,7 +383,7 @@ impl ManifestManager {
         options: &GarbageCollectionOptions,
         first_to_keep: LogPosition,
         cache: &dyn SnapshotCache,
-    ) -> Result<Garbage, Error> {
+    ) -> Result<Option<Garbage>, Error> {
         // SAFETY(rescrv):  Mutex poisoning.
         let stable = {
             let staging = self.staging.lock().unwrap();

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -598,6 +598,9 @@ impl OnceLogWriter {
             // TODO(rescrv):  Evaluate putting a cache in here.
             .compute_garbage(options, cutoff, &())
             .await?;
+        let Some(garbage) = garbage else {
+            return Ok(());
+        };
         let (garbage, e_tag) = match garbage
             .install(
                 &self.options.throttle_manifest,

--- a/rust/wal3/tests/test_k8s_integration_0_properties.rs
+++ b/rust/wal3/tests/test_k8s_integration_0_properties.rs
@@ -139,7 +139,10 @@ proptest::proptest! {
             let garbage = rt.block_on(Garbage::new(&storage, "manifests_gargage", &manifest, &throttle, &cache, position)).unwrap();
             eprintln!("garbage = {garbage:#?}");
             let dropped = garbage.setsum_to_discard;
-            let new_manifest = manifest.apply_garbage(garbage.clone()).unwrap();
+            if garbage.is_empty() {
+                continue;
+            }
+            let new_manifest = manifest.apply_garbage(garbage.clone()).unwrap().unwrap();
             eprintln!("manifest.setsum = {}", manifest.setsum.hexdigest());
             eprintln!("new_manifest.setsum = {}", new_manifest.setsum.hexdigest());
             eprintln!("dropped = {}", dropped.hexdigest());
@@ -196,7 +199,10 @@ proptest::proptest! {
             eprintln!("garbage = {garbage:#?}");
             let dropped = garbage.setsum_to_discard;
             cache.snapshots.extend(garbage.snapshots_to_make.clone());
-            let new_manifest = manifest.apply_garbage(garbage.clone()).unwrap();
+            if garbage.is_empty() {
+                continue;
+            }
+            let new_manifest = manifest.apply_garbage(garbage.clone()).unwrap().unwrap();
             eprintln!("manifest.setsum = {}", manifest.setsum.hexdigest());
             eprintln!("new_manifest.setsum = {}", new_manifest.setsum.hexdigest());
             eprintln!("dropped = {}", dropped.hexdigest());

--- a/rust/wal3/tests/test_k8s_integration_0_properties.rs
+++ b/rust/wal3/tests/test_k8s_integration_0_properties.rs
@@ -133,16 +133,21 @@ proptest::proptest! {
         let start = manifest.oldest_timestamp();
         let limit = manifest.next_write_timestamp();
         let cache = TestingSnapshotCache::default();
+        let mut count = 0;
         for offset in start.offset()..limit.offset() {
             let position = LogPosition::from_offset(offset);
             eprintln!("position = {position:?}");
-            let garbage = rt.block_on(Garbage::new(&storage, "manifests_gargage", &manifest, &throttle, &cache, position)).unwrap();
+            let Some(garbage) = rt.block_on(Garbage::new(&storage, "manifests_gargage", &manifest, &throttle, &cache, position)).unwrap() else {
+                continue;
+            };
             eprintln!("garbage = {garbage:#?}");
             let dropped = garbage.setsum_to_discard;
             if garbage.is_empty() {
                 continue;
             }
-            let new_manifest = manifest.apply_garbage(garbage.clone()).unwrap().unwrap();
+            let Some(new_manifest) = manifest.apply_garbage(garbage.clone()).unwrap() else {
+                panic!("garbage fail {garbage:#?}");
+            };
             eprintln!("manifest.setsum = {}", manifest.setsum.hexdigest());
             eprintln!("new_manifest.setsum = {}", new_manifest.setsum.hexdigest());
             eprintln!("dropped = {}", dropped.hexdigest());
@@ -154,7 +159,9 @@ proptest::proptest! {
             assert_eq!(manifest.setsum, new_manifest.setsum, "manifest.setsum mismatch");
             assert_eq!(manifest.collected + dropped, new_manifest.collected, "manifest.collected mismatch");
             assert!(new_manifest.scrub().is_ok(), "scrub error");
+            count += 1;
         }
+        assert!(count > 1);
     }
 }
 
@@ -196,6 +203,9 @@ proptest::proptest! {
             let position = LogPosition::from_offset(offset);
             eprintln!("position = {position:?}");
             let garbage = rt.block_on(Garbage::new(&storage, "manifests_with_snapshots_gargage", &manifest, &throttle, &cache, position)).unwrap();
+            let Some(garbage) = garbage else {
+                continue;
+            };
             eprintln!("garbage = {garbage:#?}");
             let dropped = garbage.setsum_to_discard;
             cache.snapshots.extend(garbage.snapshots_to_make.clone());
@@ -216,6 +226,7 @@ proptest::proptest! {
                 last_initial_seq_no = new_manifest.initial_seq_no.unwrap();
             }
         }
+        assert!(last_initial_seq_no > FragmentSeqNo(0))
     }
 }
 

--- a/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
+++ b/rust/wal3/tests/test_k8s_integration_82_copy_empty_log_initializes.rs
@@ -96,10 +96,6 @@ async fn test_k8s_integration_82_copy_empty_log_initializes() {
         after_mani.next_write_timestamp()
     );
     assert_eq!(
-        before_mani.oldest_fragment_seq_no(),
-        after_mani.oldest_fragment_seq_no()
-    );
-    assert_eq!(
         before_mani.next_fragment_seq_no(),
         after_mani.next_fragment_seq_no()
     );


### PR DESCRIPTION
## Description of changes

The condition within wal3 for setting the initial_seq_no was broken.

The simpler condition is to set it to limit whenever limit is non-zero.
The start will always be <= limit by the guard at the top of the
function.  Therefore the only case this doesn't set the limit is when
limit is FragmentSeqNo(0), in which case we want an initial offset of 1.

## Test plan

CI

## Documentation Changes

N/A
