### PR TITLE
[DOC]: update list_collections docs to indicate new max limit of 100

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
@@ -266,7 +266,7 @@ List all collections.
 
 **Arguments**:
 
-- `limit` - The maximum number of entries to return. Defaults to None.
+- `limit` - The maximum number of entries to return. The maximum value is 100. If no value is provided, the maximum will be used as the default. If a value is provided that exceeds the maximum, an error will be thrown.
 - `offset` - The number of entries to skip before returning. Defaults to None.
 
 


### PR DESCRIPTION
## Description of changes

Updates docs to explain #4929 

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

See above