### PR TITLE
[ENH] A tool to inspect the number of records on the log.

### DIFF
--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -127,6 +127,8 @@ message InspectLogStateRequest {
 
 message InspectLogStateResponse {
   string debug = 1;
+  uint64 start = 2;
+  uint64 limit = 3;
 }
 
 message ScrubLogRequest {

--- a/rust/log-service/src/bin/chroma-inspect-log-state.rs
+++ b/rust/log-service/src/bin/chroma-inspect-log-state.rs
@@ -24,4 +24,7 @@ async fn main() {
         .expect("could not inspect log state");
     let state = state.into_inner();
     println!("{}", state.debug);
+    println!("start: {}", state.start);
+    println!("limit: {}", state.limit);
+    println!("records: {}", state.limit.wrapping_sub(state.start));
 }

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -64,6 +64,8 @@ pub struct Metrics {
     log_total_uncompacted_records_count: opentelemetry::metrics::Gauge<f64>,
     /// The rate at which records are read from the dirty log.
     dirty_log_records_read: opentelemetry::metrics::Counter<u64>,
+    /// A gauge for the number of dirty log collections as of the last rollup.
+    dirty_log_collections: opentelemetry::metrics::Gauge<u64>,
 }
 
 impl Metrics {
@@ -73,6 +75,7 @@ impl Metrics {
                 .f64_gauge("log_total_uncompacted_records_count")
                 .build(),
             dirty_log_records_read: meter.u64_counter("dirty_log_records_read").build(),
+            dirty_log_collections: meter.u64_gauge("dirty_log_collections").build(),
         }
     }
 }
@@ -969,6 +972,9 @@ impl LogServer {
             tracing::Level::INFO,
             collections = ?collections,
         );
+        self.metrics
+            .dirty_log_collections
+            .record(collections as u64, &[]);
         self.enrich_dirty_log(&mut rollup.rollups).await?;
         self.save_dirty_log(rollup).await
     }
@@ -1838,6 +1844,8 @@ impl LogServer {
         if let Err(wal3::Error::UninitializedLog) = mani {
             return Ok(Response::new(InspectLogStateResponse {
                 debug: "log uninitialized\n".to_string(),
+                start: 0,
+                limit: 0,
             }));
         }
         let mani = mani.map_err(|err| Status::unknown(err.to_string()))?;
@@ -1852,9 +1860,20 @@ impl LogServer {
         let witness = cursor_store.load(cursor_name).await.map_err(|err| {
             Status::new(err.code().into(), format!("Failed to load cursor: {}", err))
         })?;
-
+        let (start, limit) = if let Some(mani) = mani.as_ref() {
+            let start = witness
+                .as_ref()
+                .map(|w| w.cursor.position)
+                .unwrap_or(mani.oldest_timestamp());
+            let limit = mani.next_write_timestamp();
+            (start.offset(), limit.offset())
+        } else {
+            (0, 0)
+        };
         Ok(Response::new(InspectLogStateResponse {
             debug: format!("manifest: {mani:#?}\ncompaction cursor: {witness:?}"),
+            start,
+            limit,
         }))
     }
 


### PR DESCRIPTION
## Description of changes

I added a gauge that floats the number of collections uncompacted and
extended the inspect-log-state route to have return the start/limit and
number of records on the log.

## Test plan

CI

## Documentation Changes

Will update runbooks.
