### PR TITLE
[CHORE] Set limit default on list_collections

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -343,7 +343,7 @@ class ClientAPI(BaseAPI, ABC):
     @abstractmethod
     def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
     ) -> Sequence[Collection]:
         """List all collections.
@@ -576,7 +576,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
     @abstractmethod
     def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -336,7 +336,7 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
     @abstractmethod
     async def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
     ) -> Sequence[AsyncCollection]:
         """List all collections.
@@ -562,7 +562,7 @@ class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
     @abstractmethod
     async def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -159,7 +159,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
 
     @override
     async def list_collections(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
+        self, limit: Optional[int] = 100, offset: Optional[int] = None
     ) -> Sequence[AsyncCollection]:
         models = await self._server.list_collections(
             limit, offset, tenant=self.tenant, database=self.database

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -251,7 +251,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @override
     async def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -124,7 +124,7 @@ class Client(SharedSystemClient, ClientAPI):
 
     @override
     def list_collections(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
+        self, limit: Optional[int] = 100, offset: Optional[int] = None
     ) -> Sequence[Collection]:
         return [
             Collection(client=self._server, model=model)

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -205,7 +205,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
     @override
     def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -180,7 +180,7 @@ class RustBindingsAPI(ServerAPI):
     @override
     def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -325,7 +325,7 @@ class SegmentAPI(ServerAPI):
     @rate_limit
     def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -86,7 +86,7 @@ class Bindings:
     ) -> int: ...
     def list_collections(
         self,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -29,7 +29,7 @@ class DB(Component):
 
     @abstractmethod
     def list_collections(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
+        self, limit: Optional[int] = 100, offset: Optional[int] = None
     ) -> Sequence:  # type: ignore
         pass
 

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -711,7 +711,7 @@ class FastAPI(Server):
         request: Request,
         tenant: str,
         database_name: str,
-        limit: Optional[int] = None,
+        limit: Optional[int] = 100,
         offset: Optional[int] = None,
     ) -> Sequence[CollectionModel]:
         def process_list_collections(

--- a/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/python/client.md
@@ -258,7 +258,7 @@ class ClientAPI(BaseAPI, ABC)
 ## list\_collections
 
 ```python
-def list_collections(limit: Optional[int] = None,
+def list_collections(limit: Optional[int] = 100,
                      offset: Optional[int] = None) -> Sequence[Collection]
 ```
 
@@ -266,7 +266,7 @@ List all collections.
 
 **Arguments**:
 
-- `limit` - The maximum number of entries to return. Defaults to None.
+- `limit` - The maximum number of entries to return. Defaults to 100.
 - `offset` - The number of entries to skip before returning. Defaults to None.
 
 

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -331,11 +331,12 @@ impl ServiceBasedFrontend {
             ..
         }: ListCollectionsRequest,
     ) -> Result<ListCollectionsResponse, GetCollectionsError> {
+        let limit = limit.unwrap_or(100);
         self.sysdb_client
             .get_collections(GetCollectionsOptions {
                 tenant: Some(tenant_id.clone()),
                 database: Some(database_name.clone()),
-                limit,
+                limit: Some(limit),
                 offset,
                 ..Default::default()
             })

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -139,25 +139,10 @@ impl SysDb {
 
     pub async fn get_collections(
         &mut self,
-        mut options: GetCollectionsOptions,
+        options: GetCollectionsOptions,
     ) -> Result<Vec<Collection>, GetCollectionsError> {
         match self {
-            SysDb::Grpc(grpc) => {
-                // TODO(c-gamble): Move this to config
-                let max_get_collections_limit = 100u32;
-                match options.limit {
-                    Some(limit) => {
-                        if limit > max_get_collections_limit {
-                            return Err(GetCollectionsError::MaximumLimitExceeded(
-                                limit,
-                                max_get_collections_limit,
-                            ));
-                        }
-                    }
-                    None => options.limit = Some(max_get_collections_limit),
-                }
-                grpc.get_collections(options).await
-            }
+            SysDb::Grpc(grpc) => grpc.get_collections(options).await,
             SysDb::Sqlite(sqlite) => sqlite.get_collections(options).await,
             SysDb::Test(test) => test.get_collections(options).await,
         }


### PR DESCRIPTION
## Description of changes

This PR sets a default of 100 for limit on list_collections, and removes the global maximum set in sysdb. If there is no limit provided, the server also automatically sets it to 100

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
