### PR TITLE
[BUG]  Do not leak tokio tasks in the log service.

### DIFF
--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -381,6 +381,15 @@ impl std::fmt::Debug for LogWriter {
     }
 }
 
+impl Drop for LogWriter {
+    fn drop(&mut self) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(writer) = inner.writer.as_mut() {
+            writer.shutdown();
+        }
+    }
+}
+
 /////////////////////////////////////////// OnceLogWriter //////////////////////////////////////////
 
 /// OnceLogWriter writes to a log once until contention is discovered.  It must then be thrown away


### PR DESCRIPTION
## Description of changes

The background tasks of wal3 were leaked because the log service was not
calling shutdown when dropping a log.  This PR corrects that.

## Test plan

Local benchmark.  Will upload graph to GitHub PR.

## Documentation Changes

N/A
