### PR TITLE
[ENH] Read args from env variables for Python CloudClient

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -329,7 +329,10 @@ def CloudClient(
 
     missing_args = [arg for arg in required_args if arg.value is None]
     if missing_args:
-        raise ValueError(f"Missing required arguments: {", ".join([arg.name for arg in missing_args])}. Please provide them or set the environment variables: {", ".join([arg.env_var for arg in missing_args])}")
+        raise ValueError(
+            f"Missing required arguments: {', '.join([arg.name for arg in missing_args])}. "
+            f"Please provide them or set the environment variables: {', '.join([arg.env_var for arg in missing_args])}"
+        )
 
     if settings is None:
         settings = Settings()

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -296,8 +296,8 @@ async def AsyncHttpClient(
 
 
 def CloudClient(
-    tenant: str,
-    database: str,
+    tenant: Optional[str] = None,
+    database: Optional[str] = None,
     api_key: Optional[str] = None,
     settings: Optional[Settings] = None,
     *,  # Following arguments are keyword-only, intended for testing only.
@@ -314,18 +314,12 @@ def CloudClient(
         api_key: The api key to use for this client.
     """
 
-    # If no API key is provided, try to load it from the environment variable
-    if api_key is None:
+    # If any of tenant, database, or api_key is not provided, try to load it from the environment variable
+    if not all([tenant, database, api_key]):
         import os
-
-        api_key = os.environ.get("CHROMA_API_KEY")
-
-    # If the API key is still not provided, prompt the user
-    if api_key is None:
-        print(
-            "\033[93mDon't have an API key?\033[0m Get one at https://app.trychroma.com"
-        )
-        api_key = input("Please enter your Chroma API key: ")
+        tenant = tenant or os.environ.get("CHROMA_TENANT")
+        database = database or os.environ.get("CHROMA_DATABASE")
+        api_key = api_key or os.environ.get("CHROMA_API_KEY")
 
     if settings is None:
         settings = Settings()

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Optional, Union, Sequence, Dict, Mapping, Generic
 
 from typing_extensions import Self
@@ -297,6 +298,12 @@ class Unspecified:
 T = TypeVar("T")
 OptionalArgument = Union[T, Unspecified]
 
+
+@dataclass
+class CloudClientArg:
+    name: str
+    env_var: str
+    value: Optional[str] = None
 
 __all__ = [
     "Metadata",


### PR DESCRIPTION
## Description of changes

Make `CloudClient` arguments optional, and read them from the environment variables `CHROMA_TENANT`, `CHROMA_DATABASE`, and `CHROMA_API_KEY`

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

In a separate PR
