### PR TITLE
[CHORE]: use a match for defining default quotas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,6 +1540,8 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -47,6 +47,8 @@ utoipa = { workspace = true }
 utoipa-axum = { version = "0.2.0", features = ["debug"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 base64 = { workspace = true }
+strum = "0.27.1"
+strum_macros = "0.27.1"
 
 [dev-dependencies]
 reqwest = { workspace = true }

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -220,8 +220,6 @@ impl<'other> QuotaPayload<'other> {
     }
 }
 
-use std::collections::HashMap;
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum UsageType {
     MetadataKeySizeBytes,       // Max metadata key size in bytes
@@ -313,33 +311,37 @@ impl TryFrom<&str> for UsageType {
     }
 }
 
-lazy_static::lazy_static! {
-    pub static ref DEFAULT_QUOTAS: HashMap<UsageType, usize> = {
-        let mut m = HashMap::new();
-        m.insert(UsageType::MetadataKeySizeBytes, 36);
-        m.insert(UsageType::MetadataValueSizeBytes, 36);
-        m.insert(UsageType::NumMetadataKeys, 16);
-        m.insert(UsageType::NumWherePredicates, 8);
-        m.insert(UsageType::WhereValueSizeBytes, 36); // Same as METADATA_VALUE_SIZE
-        m.insert(UsageType::NumWhereDocumentPredicates, 8);
-        m.insert(UsageType::WhereDocumentValueLength, 130);
-        m.insert(UsageType::NumRecords, 100);
-        m.insert(UsageType::EmbeddingDimensions, 3072);
-        m.insert(UsageType::DocumentSizeBytes, 5000);
-        m.insert(UsageType::UriSizeBytes, 32);
-        m.insert(UsageType::IdSizeBytes, 128);
-        m.insert(UsageType::NameSizeBytes, 128);
-        m.insert(UsageType::LimitValue, 1000);
-        m.insert(UsageType::NumResults, 100);
-        m.insert(UsageType::NumQueryEmbeddings, 100);
-        m.insert(UsageType::CollectionSizeRecords, 1_000_000);
-        m.insert(UsageType::NumCollections, 1_000_000);
-        m.insert(UsageType::NumDatabases, 10);
-        m.insert(UsageType::NumQueryIDs, 1000);
-        m.insert(UsageType::RegexPatternLength, 0);
-        m.insert(UsageType::NumForks, 256);
-        m
-    };
+pub trait DefaultQuota {
+    fn default_quota(&self) -> usize;
+}
+
+impl DefaultQuota for UsageType {
+    fn default_quota(&self) -> usize {
+        match self {
+            UsageType::MetadataKeySizeBytes => 36,
+            UsageType::MetadataValueSizeBytes => 36,
+            UsageType::NumMetadataKeys => 16,
+            UsageType::NumWherePredicates => 8,
+            UsageType::WhereValueSizeBytes => 36, // Same as METADATA_VALUE_SIZE
+            UsageType::NumWhereDocumentPredicates => 8,
+            UsageType::WhereDocumentValueLength => 130,
+            UsageType::NumRecords => 100,
+            UsageType::EmbeddingDimensions => 3072,
+            UsageType::DocumentSizeBytes => 5000,
+            UsageType::UriSizeBytes => 32,
+            UsageType::IdSizeBytes => 128,
+            UsageType::NameSizeBytes => 128,
+            UsageType::LimitValue => 1000,
+            UsageType::NumResults => 100,
+            UsageType::NumQueryEmbeddings => 100,
+            UsageType::CollectionSizeRecords => 1_000_000,
+            UsageType::NumCollections => 1_000_000,
+            UsageType::NumDatabases => 10,
+            UsageType::NumQueryIDs => 1000,
+            UsageType::RegexPatternLength => 0,
+            UsageType::NumForks => 256,
+        }
+    }
 }
 
 #[derive(Debug, Validate)]


### PR DESCRIPTION
## Description of changes

This PR introduces a trait `DefaultQuota` that is implemented for `UsageType` as a way to unfailingly get a default quota. Since default quotas are known at compilation, we should have an unfailing way to get them for the UsageType enum. We still need the `DEFAULT_QUOTAS` hashmap because this mimics the data structure in which tenant overrides are stored.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
