### PR TITLE
[ENH] Better JS client error messaging

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-fetch.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-fetch.ts
@@ -4,6 +4,7 @@ import {
   ChromaForbiddenError,
   ChromaNotFoundError,
   ChromaQuotaExceededError,
+  ChromaRateLimitError,
   ChromaUnauthorizedError,
   ChromaUniqueError,
 } from "./errors";
@@ -64,9 +65,11 @@ export const chromaFetch: typeof fetch = async (input, init) => {
         throw new ChromaQuotaExceededError(body?.message);
       }
       break;
+    case 429:
+      throw new ChromaRateLimitError("Rate limit exceeded");
   }
 
   throw new ChromaConnectionError(
-    `Unable to connect to the chromadb server. Please try again later.`,
+    `Unable to connect to the chromadb server (status: ${response.status}). Please try again later.`,
   );
 };

--- a/clients/new-js/packages/chromadb/src/errors.ts
+++ b/clients/new-js/packages/chromadb/src/errors.ts
@@ -92,6 +92,13 @@ export class ChromaQuotaExceededError extends Error {
   }
 }
 
+export class ChromaRateLimitError extends Error {
+  name = "ChromaRateLimitError";
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+  }
+}
+
 export function createErrorByType(type: string, message: string) {
   switch (type) {
     case "InvalidCollection":


### PR DESCRIPTION
This is a simple script that simulates a naive mass upload to Chroma that will trigger our rate limiter

```
import { CloudClient } from "chromadb";

const client = new CloudClient({
  apiKey: "...",
  tenant: "...",
  database: "test-db",
});

async function run() {
  const collection = await client.getOrCreateCollection({
    name: "ratelimit_test",
  })

  for (let i = 0; i < 100; i++) {
    collection.upsert({
      ids: [i.toString()],
      documents: [`Document ${i}`],
    });
  }
}

run();
```

Users will get a vague "unable to connect" error:

```
/Users/kylediaz/Repos/chroma-core/smokey/node_modules/.pnpm/chromadb@3.0.4/node_modules/chromadb/dist/cjs/chromadb.cjs:1749
  throw new ChromaConnectionError(
        ^


ChromaConnectionError: Unable to connect to the chromadb server. Please try again later.
    at chromaFetch (/Users/kylediaz/Repos/chroma-core/smokey/node_modules/.pnpm/chromadb@3.0.4/node_modules/chromadb/dist/cjs/chromadb.cjs:1749:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async o (/Users/kylediaz/Repos/chroma-core/smokey/node_modules/.pnpm/chromadb@3.0.4/node_modules/chromadb/dist/cjs/chromadb.cjs:397:26)
    at async _CollectionImpl.upsert (/Users/kylediaz/Repos/chroma-core/smokey/node_modules/.pnpm/chromadb@3.0.4/node_modules/chromadb/dist/cjs/chromadb.cjs:1644:5) {
  cause: undefined
}

Node.js v22.15.0
```

This PR adds a special error message when hitting a rate limit, and it shows the response status for all other cases to cover anything we may have missed