### PR TITLE
[BUG] Read from legacy metadata config when no collection config set

### DIFF
--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -228,7 +228,7 @@ export namespace Api {
      * @memberof HnswConfiguration
      */
     resize_factor?: number | null;
-    space?: Api.HnswSpace;
+    space?: Api.HnswSpace | null;
     /**
      * @type {number | null}
      * @memberof HnswConfiguration
@@ -317,7 +317,7 @@ export namespace Api {
      * minimum: 0
      */
     search_nprobe?: number | null;
-    space?: Api.HnswSpace;
+    space?: Api.HnswSpace | null;
     /**
      * @type {number | null}
      * @memberof SpannConfiguration
@@ -335,7 +335,7 @@ export namespace Api {
   export interface UpdateCollectionConfiguration {
     embedding_function?: Api.EmbeddingFunctionConfiguration | null;
     hnsw?: Api.UpdateHnswConfiguration | null;
-    spann?: Api.SpannConfiguration | null;
+    spann?: Api.UpdateSpannConfiguration | null;
   }
 
   export interface UpdateCollectionPayload {
@@ -398,6 +398,21 @@ export namespace Api {
      * minimum: 0
      */
     sync_threshold?: number | null;
+  }
+
+  export interface UpdateSpannConfiguration {
+    /**
+     * @type {number | null}
+     * @memberof UpdateSpannConfiguration
+     * minimum: 0
+     */
+    ef_search?: number | null;
+    /**
+     * @type {number | null}
+     * @memberof UpdateSpannConfiguration
+     * minimum: 0
+     */
+    search_nprobe?: number | null;
   }
 
   export interface UpsertCollectionRecordsPayload {

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -144,7 +144,7 @@ export type HnswConfiguration = {
   ef_search?: number | null;
   max_neighbors?: number | null;
   resize_factor?: number | null;
-  space?: HnswSpace;
+  space?: null | HnswSpace;
   sync_threshold?: number | null;
 };
 
@@ -188,7 +188,7 @@ export type SpannConfiguration = {
   merge_threshold?: number | null;
   reassign_neighbor_count?: number | null;
   search_nprobe?: number | null;
-  space?: HnswSpace;
+  space?: null | HnswSpace;
   split_threshold?: number | null;
   write_nprobe?: number | null;
 };
@@ -196,7 +196,7 @@ export type SpannConfiguration = {
 export type UpdateCollectionConfiguration = {
   embedding_function?: null | EmbeddingFunctionConfiguration;
   hnsw?: null | UpdateHnswConfiguration;
-  spann?: null | SpannConfiguration;
+  spann?: null | UpdateSpannConfiguration;
 };
 
 export type UpdateCollectionPayload = {
@@ -232,6 +232,11 @@ export type UpdateHnswConfiguration = {
   num_threads?: number | null;
   resize_factor?: number | null;
   sync_threshold?: number | null;
+};
+
+export type UpdateSpannConfiguration = {
+  ef_search?: number | null;
+  search_nprobe?: number | null;
 };
 
 export type UpsertCollectionRecordsPayload = {

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -952,10 +952,12 @@ async fn create_collection(
         Some(c) => Some(InternalCollectionConfiguration::try_from_config(
             c,
             server.config.frontend.default_knn_index,
+            payload_clone.metadata,
         )?),
         None => Some(InternalCollectionConfiguration::try_from_config(
             CollectionConfiguration::default(),
             server.config.frontend.default_knn_index,
+            payload_clone.metadata,
         )?),
     };
 

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -274,6 +274,7 @@ impl Bindings {
             Some(c) => Some(InternalCollectionConfiguration::try_from_config(
                 c,
                 self.frontend.get_default_knn_index(),
+                metadata.clone(),
             )?),
             None => Some(InternalCollectionConfiguration::try_from_config(
                 CollectionConfiguration {
@@ -282,6 +283,7 @@ impl Bindings {
                     embedding_function: None,
                 },
                 self.frontend.get_default_knn_index(),
+                metadata.clone(),
             )?),
         };
 

--- a/rust/types/src/hnsw_configuration.rs
+++ b/rust/types/src/hnsw_configuration.rs
@@ -69,10 +69,14 @@ fn default_batch_size() -> usize {
     100
 }
 
+fn default_space() -> HnswSpace {
+    HnswSpace::L2
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct InternalHnswConfiguration {
-    #[serde(default)]
+    #[serde(default = "default_space")]
     pub space: HnswSpace,
     #[serde(default = "default_construction_ef")]
     pub ef_construction: usize,
@@ -104,8 +108,7 @@ impl Default for InternalHnswConfiguration {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct HnswConfiguration {
-    #[serde(default)]
-    pub space: HnswSpace,
+    pub space: Option<HnswSpace>,
     pub ef_construction: Option<usize>,
     pub ef_search: Option<usize>,
     pub max_neighbors: Option<usize>,
@@ -122,7 +125,7 @@ pub struct HnswConfiguration {
 impl From<InternalHnswConfiguration> for HnswConfiguration {
     fn from(config: InternalHnswConfiguration) -> Self {
         Self {
-            space: config.space,
+            space: Some(config.space),
             ef_construction: Some(config.ef_construction),
             ef_search: Some(config.ef_search),
             max_neighbors: Some(config.max_neighbors),
@@ -137,7 +140,7 @@ impl From<InternalHnswConfiguration> for HnswConfiguration {
 impl From<HnswConfiguration> for InternalHnswConfiguration {
     fn from(config: HnswConfiguration) -> Self {
         Self {
-            space: config.space,
+            space: config.space.unwrap_or(default_space()),
             ef_construction: config.ef_construction.unwrap_or(default_construction_ef()),
             ef_search: config.ef_search.unwrap_or(default_search_ef()),
             max_neighbors: config.max_neighbors.unwrap_or(default_m()),


### PR DESCRIPTION
## Description of changes

This PR fixes a bug where SPANN space was not read from the legacy metadata configuration if provided. The hnsw would read from the legacy config at sysdb, but SPANN was not configured to create the configuration using the legacy metadata configurations. This PR ensures that when neither hnsw nor spann configurations are specified in collection configuration, it will then read from legacy metadata

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
