### PR TITLE
[BUG]  Enrich from the manifest if a cursor doesn't exist.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -369,7 +369,9 @@ impl RollupPerCollection {
         self.start_log_position = manifest
             .map(|m| m.oldest_timestamp())
             .unwrap_or(LogPosition::from_offset(1));
-        self.limit_log_position = self.limit_log_position.max(self.start_log_position);
+        self.limit_log_position = manifest
+            .map(|m| m.next_write_timestamp())
+            .unwrap_or(LogPosition::from_offset(1));
     }
 
     fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Description of changes

If the cursor doesn't exist, enrich from the manifest.

This makes sure that the dirty log entries eventually reflect the
complete content of everything between the oldest uncompacted record and
the newest record.

## Test plan

CI

## Documentation Changes

N/A
