### PR TITLE
[CHORE]: bump default regex quota to 256

### DIFF
--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -336,7 +336,7 @@ lazy_static::lazy_static! {
         m.insert(UsageType::NumCollections, 1_000_000);
         m.insert(UsageType::NumDatabases, 10);
         m.insert(UsageType::NumQueryIDs, 1000);
-        m.insert(UsageType::RegexPatternLength, 0);
+        m.insert(UsageType::RegexPatternLength, 256);
         m.insert(UsageType::NumForks, 256);
         m
     };


### PR DESCRIPTION
## Description of changes

Bumps the default regex to 256, which has already been done on the management plane.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A