### PR TITLE
[ENH]  Warn, not error, if dirty log has no cursor.

### DIFF
--- a/rust/garbage_collector/src/operators/truncate_dirty_log.rs
+++ b/rust/garbage_collector/src/operators/truncate_dirty_log.rs
@@ -80,6 +80,12 @@ impl Operator<TruncateDirtyLogInput, TruncateDirtyLogOutput> for TruncateDirtyLo
                 .await
             {
                 Ok(()) => Ok(()),
+                Err(wal3::Error::NoSuchCursor(_)) => {
+                    tracing::warn!(
+                        "dirty log has no cursor; this should not happen in steady state"
+                    );
+                    Ok(())
+                }
                 Err(err) => {
                     tracing::error!("Unable to garbage collect dirty log: {err}");
                     Err(TruncateDirtyLogError::Wal3(err))


### PR DESCRIPTION
## Description of changes

This should only happen in tilt, but it shouldn't return an error.

## Test plan

Tested locally that tilt up doesn't error anymore.

## Documentation Changes

N/A
