### PR TITLE
[ENH]  If the dirty log fails with LogContentionDurable, do not fail the operation.

### DIFF
--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -208,7 +208,7 @@ impl Snapshot {
         }
     }
 
-    #[tracing::instrument(skip(self, storage), err(Display))]
+    #[tracing::instrument(skip(self, storage))]
     pub async fn install(
         &self,
         options: &ThrottleOptions,


### PR DESCRIPTION
## Description of changes

Both roll_dirty_log and mark_dirty append to the dirty log.  At high gc
rates, this can fail, and the operation will fail.  We can simply return
Ok(()) for any case where the log is durable.

## Test plan

CI

## Documentation Changes

N/A
