### PR TITLE
[BLD] Optimize which tests we run on Windows

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -257,8 +257,10 @@ jobs:
         PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
   test-windows-smoke:
-    # only run windows smoke tests when the runner isn't already windows
-    if: ${{ !contains(inputs.runner, 'windows') }}
+    # only run windows smoke tests when the runner isn't already windows,
+    # also only run the smoke tests on PRs (ie not main and not tags) since
+    # we are already running the full suite on Windows in those cases
+    if: ${{ !contains(inputs.runner, 'windows') && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -53,7 +53,7 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
-      python_versions: '["3.9", "3.10", "3.11", "3.12"]'
+      python_versions: '["3.12"]'
       property_testing_preset: 'normal'
       runner: '16core-64gb-windows-latest'
 

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -53,6 +53,8 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
+      # we only run windows tests on 3.12 because windows runners are expensive
+      # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
       property_testing_preset: 'normal'
       runner: '16core-64gb-windows-latest'


### PR DESCRIPTION
## Description of changes

We want to optimize our usage of Windows runners since they cost so much. The cost is due in large part to the amount of time our individual jobs take to run against Windows, but also the sheer number of jobs we run on Windows when we merge to main or push a tag. Details are below:

- Improvements & Bug fixes
  - Only run the Windows tests against the latest version of Python -- this greatly reduces the number of jobs we run on Windows for a single merge to main (reduces the total number of jobs by ~3x). The logic being that when we see failures for Python tests, we see them across all versions of Python and not just a single version _AND_ we are running the tests against the full matrix on Linux anyways.
  - Optimizes the logic for when we run the smoke tests -- we were running them on merges to main and tags when we shouldn't have been (it's redundant).

## Test plan

This doesn't change the tests, it just changes how many tests we are running. I've also double/triple tested/checked the logic for the smoke tests and I am pretty sure I got it right this time. 


## Documentation Changes

N/A