### PR TITLE
[ENH]  Cancellation safety for append_batch.

### DIFF
--- a/rust/wal3/src/batch_manager.rs
+++ b/rust/wal3/src/batch_manager.rs
@@ -166,7 +166,7 @@ impl BatchManager {
         let Some((fragment_seq_no, log_position)) =
             state.select_for_write(&self.options, manifest_manager, acc_count)?
         else {
-            // No fragment can be written at this time.
+            // Cannot yet select for write.  Notify will come from the timeout background is on.
             return Ok(None);
         };
         let mut work = std::mem::take(&mut state.enqueued);


### PR DESCRIPTION
## Description of changes

In a commit back in March I took out the cancellation safety from append batch.

This re-adds that so that the batch only waits for itself, not until all work is done.

## Test plan

CI

## Documentation Changes

N/A
