### PR TITLE
[CHORE]: allow authz resources and actions to be serializable

### DIFF
--- a/rust/frontend/src/auth/mod.rs
+++ b/rust/frontend/src/auth/mod.rs
@@ -6,8 +6,9 @@ use axum::http::HeaderMap;
 use axum::http::StatusCode;
 
 use chroma_types::{Collection, GetUserIdentityResponse};
+use serde::Serialize;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub enum AuthzAction {
     Reset,
     CreateTenant,
@@ -62,7 +63,7 @@ impl Display for AuthzAction {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct AuthzResource {
     pub tenant: Option<String>,
     pub database: Option<String>,


### PR DESCRIPTION
Allows Authz actions and resources to be serialized into JSON via serde. Needed for the auth update in 

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
