### PR TITLE
[BUG]  Be more resilient to failure.

### DIFF
--- a/rust/wal3/src/batch_manager.rs
+++ b/rust/wal3/src/batch_manager.rs
@@ -189,6 +189,13 @@ impl BatchManager {
         self.state.lock().unwrap().finish_write();
         self.write_finished.notify_one();
     }
+
+    pub fn shutdown(&self) {
+        let mut state = self.state.lock().unwrap();
+        for (_, tx) in std::mem::take(&mut state.enqueued) {
+            let _ = tx.send(Err(Error::LogContentionRetry));
+        }
+    }
 }
 
 /////////////////////////////////////////////// tests //////////////////////////////////////////////

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -215,6 +215,14 @@ impl ManifestManager {
         })
     }
 
+    /// Signal log contention to anyone writing on the manifest.
+    pub fn shutdown(&self) {
+        let mut staging = self.staging.lock().unwrap();
+        for (_, tx) in std::mem::take(&mut staging.fragments) {
+            let _ = tx.send(Some(Error::LogContentionDurable));
+        }
+    }
+
     /// Return the latest stable manifest
     pub fn latest(&self) -> Manifest {
         let staging = self.staging.lock().unwrap();


### PR DESCRIPTION
## Description of changes

On error, reset the writer.  On log contention, only reset if the epoch
matches the one we took the writer from.  On shutdown of the writer,
notify anyone with waiting batches that they encountered log contention.

## Test plan

CI

## Documentation Changes

N/A
