### PR TITLE
[DOC] Add overview to intro and tweak one sentence

### DIFF
--- a/rust/wal3/README.md
+++ b/rust/wal3/README.md
@@ -13,7 +13,7 @@ This log is designed to provide high throughput with a single writer and multipl
 wal3 is designed to work on object storage.  It is intended to to be lightweight, to allow a single
 machine to multiplex many logs simultaneously over a variety of paths.
 
-At a high level wal3's logged records are in a large number of immutable files on object storage ("fragments"), and wal3 maintains multiple files that track which files compose the log and in which order. Those files are organized in a tree for performance. The root is the "manifest" (mutable) and the interior nodes are the "snapshots" (imutable).
+At a high level wal3's logged records are in a large number of immutable files on object storage ("fragments"), and wal3 maintains multiple files that track which files compose the log and in which order. Those files are organized in a tree for performance. The root is the "manifest" (mutable) and the interior nodes are the "snapshots" (immutable).
 
 ## Interface
 


### PR DESCRIPTION
## Description of changes

This PR adds a bit of text to the intro and design sections to help the reader who is coming in without any context to understand what wal3 can do and how it's designed at a high level.

It also rephrases one sentence to avoid the word "comprise" because that word is in the middle of linguistic drift, meaning both "the list of parts of a whole" and it's opposite, "the whole that these parts compose together." As a result this word is confusing to many, and rephrasing without it generally improves both readability and clarity.

It includes no new code and no code change. Therefore, it also includes no tests.

## Documentation Changes

The changes are only in the README, so no docstrings were changed.

The changes should correspond to the way the software already works (but please double-check).