### PR TITLE
[BUG][wal3]  GC gets wedged

### DIFF
--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -328,7 +328,24 @@ impl ManifestManager {
             }
             staging.garbage = Some(garbage);
         }
-        self.do_work().await
+        loop {
+            {
+                let staging = self.staging.lock().unwrap();
+                if staging.garbage.is_none() {
+                    break;
+                }
+            }
+            match self.do_work().await {
+                Ok(_) => {}
+                Err(Error::LogContentionRetry)
+                | Err(Error::LogContentionFailure)
+                | Err(Error::LogContentionDurable) => {}
+                Err(err) => {
+                    return Err(err);
+                }
+            };
+        }
+        Ok(())
     }
 
     async fn do_work(&self) -> Result<(), Error> {


### PR DESCRIPTION
## Description of changes

When a log contention error is encountered in GC, it will proceeed to
delete without installing the manifest.  Further, if an existing GC file
is found after this case, the GC will be wedged trying to make garbage
from a snapshot that doesn't exist.

The fix is to retry applying the manifest until there is no garbage
work.  And then try loading garbage before generating garbage.

## Test plan

CI

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
