### PR TITLE
[BUG][wal3][gc]  Install snapshots before installing the manifest.

### DIFF
--- a/rust/wal3/src/gc.rs
+++ b/rust/wal3/src/gc.rs
@@ -185,7 +185,6 @@ impl Garbage {
         prefix: &str,
         existing: &ETag,
     ) -> Result<Option<ETag>, Error> {
-        self.install_new_snapshots(storage, prefix, options).await?;
         match Self::transition(options, storage, prefix, Some(existing), &Self::empty()).await {
             Ok(e_tag) => Ok(e_tag),
             Err(Error::LogContentionFailure) => Ok(None),

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -718,6 +718,9 @@ impl OnceLogWriter {
         let paths = garbage
             .prefixed_paths_to_delete(&self.prefix)
             .collect::<Vec<_>>();
+        garbage
+            .install_new_snapshots(&self.storage, &self.prefix, &self.options.throttle_manifest)
+            .await?;
         self.manifest_manager.apply_garbage(garbage.clone()).await?;
         let exp_backoff: ExponentialBackoff = options.throttle.into();
         let start = Instant::now();


### PR DESCRIPTION
## Description of changes

The wal3 garbage collection path installs the manifest before the
snapshots it references.  Fix that.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
