### PR TITLE
[BUG] Batch inserts on push_logs in sqlite

### DIFF
--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -21,6 +21,10 @@ fn default_migration_mode() -> MigrationMode {
     MigrationMode::Apply
 }
 
+fn default_push_logs_batch_size() -> usize {
+    999
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct SqliteDBConfig {
@@ -31,6 +35,8 @@ pub struct SqliteDBConfig {
     // The SQLite database URL
     // If unspecified, then the database is in memory only
     pub url: Option<String>,
+    #[serde(default = "default_push_logs_batch_size")]
+    pub push_logs_batch_size: usize,
 }
 
 impl Default for SqliteDBConfig {
@@ -39,6 +45,7 @@ impl Default for SqliteDBConfig {
             hash_type: default_hash_type(),
             migration_mode: default_migration_mode(),
             url: None,
+            push_logs_batch_size: default_push_logs_batch_size(),
         }
     }
 }
@@ -81,6 +88,7 @@ impl SqliteDBConfig {
             hash_type,
             migration_mode,
             url,
+            push_logs_batch_size: default_push_logs_batch_size(),
         }
     }
 }
@@ -123,7 +131,7 @@ impl Configurable<SqliteDBConfig, SqliteCreationError> for SqliteDb {
                 .await?
         };
 
-        let db = SqliteDb::new(conn, config.hash_type);
+        let db = SqliteDb::new(conn, config.hash_type, config.push_logs_batch_size);
 
         db.initialize_migrations_table().await?;
         match config.migration_mode {
@@ -151,6 +159,7 @@ mod tests {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::SHA256,
             migration_mode: MigrationMode::Apply,
+            push_logs_batch_size: default_push_logs_batch_size(),
         };
 
         let registry = Registry::new();

--- a/rust/sqlite/src/db.rs
+++ b/rust/sqlite/src/db.rs
@@ -19,13 +19,19 @@ use tokio::io;
 pub struct SqliteDb {
     conn: SqlitePool,
     migration_hash_type: MigrationHash,
+    pub push_logs_batch_size: usize,
 }
 
 impl SqliteDb {
-    pub(crate) fn new(conn: SqlitePool, migration_hash_type: MigrationHash) -> Self {
+    pub(crate) fn new(
+        conn: SqlitePool,
+        migration_hash_type: MigrationHash,
+        push_logs_batch_size: usize,
+    ) -> Self {
         Self {
             conn,
             migration_hash_type,
+            push_logs_batch_size,
         }
     }
 
@@ -334,6 +340,7 @@ pub mod test_utils {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let registry = Registry::new();
         SqliteDb::try_from_config(&config, &registry)
@@ -360,6 +367,7 @@ mod tests {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -384,6 +392,7 @@ mod tests {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -409,6 +418,7 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -431,6 +441,7 @@ mod tests {
             url: test_db_path,
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Validate,
+            ..Default::default()
         };
         let registry = Registry::new();
         let _ = SqliteDb::try_from_config(&config, &registry)
@@ -445,6 +456,7 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -475,6 +487,7 @@ mod tests {
             url: test_db_path,
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Validate,
+            ..Default::default()
         };
 
         let result = SqliteDb::try_from_config(&config, &registry).await;
@@ -493,6 +506,7 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let db = SqliteDb::try_from_config(&config, &Registry::new())
             .await
@@ -524,6 +538,7 @@ mod tests {
             url: test_db_path,
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Validate,
+            ..Default::default()
         };
 
         let result = SqliteDb::try_from_config(&config, &Registry::new()).await;
@@ -542,6 +557,7 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
+            ..Default::default()
         };
         let db = SqliteDb::try_from_config(&config, &Registry::new())
             .await


### PR DESCRIPTION
## Description of changes

Users were running into an issue where when trying to delete extremely large sets of records, they would hit a sql too many variables issue. This is because when pushing to logs, we would fetch all ids, and then add it into the embeddings_queue in a single transaction rather than batching. This PR updates it to batch in groups of 999 (max sql variables is 999).


Fixes: https://github.com/chroma-core/chroma/issues/4802

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
