### PR TITLE
[PERF]: Skip creating readers if filter is null

### DIFF
--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -495,6 +495,12 @@ impl Operator<FilterInput, FilterOutput> for Filter {
     type Error = FilterError;
 
     async fn run(&self, input: &FilterInput) -> Result<FilterOutput, FilterError> {
+        if self.query_ids.is_none() && self.where_clause.is_none() {
+            return Ok(FilterOutput {
+                log_offset_ids: SignedRoaringBitmap::full(),
+                compact_offset_ids: SignedRoaringBitmap::full(),
+            });
+        }
         tracing::debug!(
             "[{}]: Num log entries {:?}, metadata segment {:?}, record segment {:?}",
             self.get_name(),


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - In query() if user did not supply any filters then no need to unnecessarily create the segment readers (thus reading roots from s3) and materialize the logs
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
