### PR TITLE
[CLN] Remove err(Display) from wal3.

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -134,7 +134,6 @@ impl S3Storage {
             Err(e) => {
                 match e {
                     SdkError::ServiceError(err) => {
-                        tracing::error!("error: {:?}", err);
                         let inner = err.into_err();
                         match &inner {
                             aws_sdk_s3::operation::get_object::GetObjectError::NoSuchKey(_) => {

--- a/rust/wal3/src/gc.rs
+++ b/rust/wal3/src/gc.rs
@@ -126,7 +126,7 @@ impl Garbage {
         }
     }
 
-    #[tracing::instrument(skip(storage), err(Display))]
+    #[tracing::instrument(skip(storage))]
     pub async fn load(
         options: &ThrottleOptions,
         storage: &Storage,
@@ -165,7 +165,7 @@ impl Garbage {
         }
     }
 
-    #[tracing::instrument(skip(self, storage), err(Display))]
+    #[tracing::instrument(skip(self, storage))]
     pub async fn install(
         &self,
         options: &ThrottleOptions,
@@ -177,7 +177,7 @@ impl Garbage {
         Self::transition(options, storage, prefix, existing, self).await
     }
 
-    #[tracing::instrument(skip(self, storage), err(Display))]
+    #[tracing::instrument(skip(self, storage))]
     pub async fn reset(
         &self,
         options: &ThrottleOptions,

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -168,7 +168,7 @@ impl Snapshot {
         })
     }
 
-    #[tracing::instrument(skip(storage), err(Display))]
+    #[tracing::instrument(skip(storage))]
     pub async fn load(
         options: &ThrottleOptions,
         storage: &Storage,
@@ -639,7 +639,7 @@ impl Manifest {
     }
 
     /// Initialize the log with an empty manifest.
-    #[tracing::instrument(skip(storage), err(Display))]
+    #[tracing::instrument(skip(storage))]
     pub async fn initialize(
         options: &LogWriterOptions,
         storage: &Storage,
@@ -661,7 +661,7 @@ impl Manifest {
     }
 
     /// Initialize the log with an empty manifest.
-    #[tracing::instrument(skip(storage), err(Display))]
+    #[tracing::instrument(skip(storage))]
     pub async fn initialize_from_manifest(
         _: &LogWriterOptions,
         storage: &Storage,
@@ -683,7 +683,7 @@ impl Manifest {
     }
 
     /// Load the latest manifest from object storage.
-    #[tracing::instrument(skip(storage), err(Display))]
+    #[tracing::instrument(skip(storage))]
     pub async fn load(
         options: &ThrottleOptions,
         storage: &Storage,
@@ -732,7 +732,7 @@ impl Manifest {
     }
 
     /// Install a manifest to object storage.
-    #[tracing::instrument(skip(self, storage, new), err(Display))]
+    #[tracing::instrument(skip(self, storage, new))]
     pub async fn install(
         &self,
         options: &ThrottleOptions,


### PR DESCRIPTION
## Description of changes

It gives the false impression that non-success cases---even those
handled internally---are errors.  Further it forces traces to be
sampled.  Therefore, remove the err(Display) annotation.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
