### PR TITLE
correction on package name in openai.md

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/openai.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/openai.md
@@ -54,7 +54,7 @@ You can pass in an optional `model` argument, which lets you choose which OpenAI
 ```typescript
 // npm install @chroma-core/openai
 
-import { OpenAIEmbeddingFunction } from '@chroma-core/ollama';
+import { OpenAIEmbeddingFunction } from '@chroma-core/openai';
 
 const embeddingFunction = new OpenAIEmbeddingFunction({
     openai_api_key: "apiKey",


### PR DESCRIPTION
Correcting the package name @chroma-core/ollama to @chroma-core/openai 

A small correction for new learners not to get confused

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
