### PR TITLE
[CHORE] Fix pr title workflow to allow edits

### DIFF
--- a/.github/workflows/pr-check-title.yml
+++ b/.github/workflows/pr-check-title.yml
@@ -1,0 +1,36 @@
+name: Check PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+    branches:
+      - main
+      - '**'
+
+jobs:
+  check-title:
+    name: Check PR Title
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Check PR Title
+        uses: Slashgear/action-check-pr-title@v4.3.0
+        with:
+          regexp: '\[(ENH|BUG|DOC|TST|BLD|PERF|TYP|CLN|CHORE|RELEASE|HOTFIX)\].*'
+          helpMessage: "Please tag your PR title. See https://docs.trychroma.com/contributing#contributing-code-and-ideas."
+      - name: Comment explaining failure
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-info
+          message: |
+            Please tag your PR title with one of: `[ENH | BUG | DOC | TST | BLD | PERF | TYP | CLN | CHORE]`. See https://docs.trychroma.com/contributing#contributing-code-and-ideas
+      - name: Delete comment on success
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-info
+          delete: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,27 +194,6 @@ jobs:
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
 
-  check-title:
-    name: Check PR Title
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-        - name: Check PR Title
-          uses: Slashgear/action-check-pr-title@v4.3.0
-          with:
-            regexp: '\[(ENH|BUG|DOC|TST|BLD|PERF|TYP|CLN|CHORE|RELEASE|HOTFIX)\].*'
-            helpMessage: "Please tag your PR title. See https://docs.trychroma.com/contributing#contributing-code-and-ideas. You must push new code to this PR for this check to run again."
-        - name: Comment explaining failure
-          if: failure()
-          uses: actions/github-script@v6
-          with:
-            script: |
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: 'Please tag your PR title with one of: \\[ENH | BUG | DOC | TST | BLD | PERF | TYP | CLN | CHORE\\]. See https://docs.trychroma.com/contributing#contributing-code-and-ideas'
-              })
-
   lint:
     name: Lint
     runs-on: blacksmith-4vcpu-ubuntu-2204
@@ -264,7 +243,6 @@ jobs:
     - javascript-client-tests
     - rust-tests
     - go-tests
-    - check-title
     - lint
     - check-helm-version-bump
     - delete-helm-comment


### PR DESCRIPTION
## Description of changes

This PR fixes a bug in CI where on PR title modifications, the workflow was not rerun, and instead required a code push to fix.

Fixes https://github.com/chroma-core/chroma/issues/3520

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
