### PR TITLE
[ENH]  Do not materialize all fragments to delete.

### DIFF
--- a/rust/wal3/src/gc.rs
+++ b/rust/wal3/src/gc.rs
@@ -242,15 +242,10 @@ impl Garbage {
         for snap in self.snapshots_to_drop.iter() {
             paths.push(format!("{}/{}", prefix, snap.path_to_snapshot));
         }
-        // TODO(rescrv):  When Step stabilizes, revisit this ugliness.
-        for seq_no in self.fragments_to_drop_start.0..self.fragments_to_drop_limit.0 {
-            paths.push(format!(
-                "{}/{}",
-                prefix,
-                unprefixed_fragment_path(FragmentSeqNo(seq_no))
-            ));
-        }
-        paths.into_iter()
+        paths.into_iter().chain(
+            (self.fragments_to_drop_start.0..self.fragments_to_drop_limit.0)
+                .map(|seq_no| unprefixed_fragment_path(FragmentSeqNo(seq_no))),
+        )
     }
 
     pub async fn install_new_snapshots(

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -790,10 +790,7 @@ impl OnceLogWriter {
                 "loaded garbage without e_tag".to_string(),
             ));
         };
-        let paths = garbage
-            .prefixed_paths_to_delete(&self.prefix)
-            .collect::<Vec<_>>();
-        for path in paths {
+        for path in garbage.prefixed_paths_to_delete(&self.prefix) {
             loop {
                 match self.storage.delete(&path, DeleteOptions::default()).await {
                     Ok(()) => break,


### PR DESCRIPTION
## Description of changes

~1e6 fragments on staging.  Materializing them all might be pushing the
service over the top.  Materialize the fragments lazily.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
