### PR TITLE
[CHORE]  Bump Compaction Sleep to 3 minutes.

### DIFF
--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -131,7 +131,7 @@ def override_hypothesis_profile(
 
 
 NOT_CLUSTER_ONLY = os.getenv("CHROMA_CLUSTER_TEST_ONLY") != "1"
-COMPACTION_SLEEP = 120
+COMPACTION_SLEEP = 240
 
 
 def skip_if_not_cluster() -> pytest.MarkDecorator:


### PR DESCRIPTION
## Description of changes

We see during the course of test add that it will create up to 2.5
minutes backlog of collections and then flake the test.  Better to make
it wait and always pass.

## Test plan

CI

## Documentation Changes

N/A
