### PR TITLE
[CLN] Add max_batch_size to sqlite_log, use in push_logs

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -1477,6 +1477,9 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             sqlite_log
                 .init_compactor_handle(handle.clone())
                 .map_err(|e| e.boxed())?;
+            sqlite_log
+                .init_max_batch_size(max_batch_size)
+                .map_err(|e| e.boxed())?;
             registry.register(handle);
         }
 

--- a/rust/sqlite/src/config.rs
+++ b/rust/sqlite/src/config.rs
@@ -21,10 +21,6 @@ fn default_migration_mode() -> MigrationMode {
     MigrationMode::Apply
 }
 
-fn default_push_logs_batch_size() -> usize {
-    999
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct SqliteDBConfig {
@@ -35,8 +31,6 @@ pub struct SqliteDBConfig {
     // The SQLite database URL
     // If unspecified, then the database is in memory only
     pub url: Option<String>,
-    #[serde(default = "default_push_logs_batch_size")]
-    pub push_logs_batch_size: usize,
 }
 
 impl Default for SqliteDBConfig {
@@ -45,7 +39,6 @@ impl Default for SqliteDBConfig {
             hash_type: default_hash_type(),
             migration_mode: default_migration_mode(),
             url: None,
-            push_logs_batch_size: default_push_logs_batch_size(),
         }
     }
 }
@@ -88,7 +81,6 @@ impl SqliteDBConfig {
             hash_type,
             migration_mode,
             url,
-            push_logs_batch_size: default_push_logs_batch_size(),
         }
     }
 }
@@ -131,7 +123,7 @@ impl Configurable<SqliteDBConfig, SqliteCreationError> for SqliteDb {
                 .await?
         };
 
-        let db = SqliteDb::new(conn, config.hash_type, config.push_logs_batch_size);
+        let db = SqliteDb::new(conn, config.hash_type);
 
         db.initialize_migrations_table().await?;
         match config.migration_mode {
@@ -159,7 +151,6 @@ mod tests {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::SHA256,
             migration_mode: MigrationMode::Apply,
-            push_logs_batch_size: default_push_logs_batch_size(),
         };
 
         let registry = Registry::new();

--- a/rust/sqlite/src/db.rs
+++ b/rust/sqlite/src/db.rs
@@ -19,19 +19,13 @@ use tokio::io;
 pub struct SqliteDb {
     conn: SqlitePool,
     migration_hash_type: MigrationHash,
-    pub push_logs_batch_size: usize,
 }
 
 impl SqliteDb {
-    pub(crate) fn new(
-        conn: SqlitePool,
-        migration_hash_type: MigrationHash,
-        push_logs_batch_size: usize,
-    ) -> Self {
+    pub(crate) fn new(conn: SqlitePool, migration_hash_type: MigrationHash) -> Self {
         Self {
             conn,
             migration_hash_type,
-            push_logs_batch_size,
         }
     }
 
@@ -340,7 +334,6 @@ pub mod test_utils {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let registry = Registry::new();
         SqliteDb::try_from_config(&config, &registry)
@@ -367,7 +360,6 @@ mod tests {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -392,7 +384,6 @@ mod tests {
             url: new_test_db_persist_path(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -418,7 +409,6 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -441,7 +431,6 @@ mod tests {
             url: test_db_path,
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Validate,
-            ..Default::default()
         };
         let registry = Registry::new();
         let _ = SqliteDb::try_from_config(&config, &registry)
@@ -456,7 +445,6 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let registry = Registry::new();
         let db = SqliteDb::try_from_config(&config, &registry)
@@ -487,7 +475,6 @@ mod tests {
             url: test_db_path,
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Validate,
-            ..Default::default()
         };
 
         let result = SqliteDb::try_from_config(&config, &registry).await;
@@ -506,7 +493,6 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let db = SqliteDb::try_from_config(&config, &Registry::new())
             .await
@@ -538,7 +524,6 @@ mod tests {
             url: test_db_path,
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Validate,
-            ..Default::default()
         };
 
         let result = SqliteDb::try_from_config(&config, &Registry::new()).await;
@@ -557,7 +542,6 @@ mod tests {
             url: test_db_path.clone(),
             hash_type: MigrationHash::MD5,
             migration_mode: MigrationMode::Apply,
-            ..Default::default()
         };
         let db = SqliteDb::try_from_config(&config, &Registry::new())
             .await

--- a/rust/types/src/scalar_encoding.rs
+++ b/rust/types/src/scalar_encoding.rs
@@ -70,6 +70,15 @@ impl From<ScalarEncoding> for String {
     }
 }
 
+impl From<&ScalarEncoding> for String {
+    fn from(encoding: &ScalarEncoding) -> String {
+        match encoding {
+            ScalarEncoding::FLOAT32 => "FLOAT32".to_string(),
+            ScalarEncoding::INT32 => "INT32".to_string(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Description of changes

This PR removes the push_logs_batch_size from sqlite config, and replaces it with max_batch_size. It sets up with OnceLock for thread safe lazy initialization with the existing get_max_batch_sizes() on frontend creation. 

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
