### PR TITLE
[BUG]: Spann indexing bug

### DIFF
--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -865,7 +865,7 @@ impl SpannIndexWriter {
                 .versions_map
                 .get(&doc_offset_id)
                 .ok_or(SpannIndexWriterError::VersionNotFound)?;
-            if doc_version < *current_version {
+            if *current_version == 0 || doc_version < *current_version {
                 tracing::debug!(
                     "Outdated point {} for reassignment version {} current head id {}",
                     doc_offset_id,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - If we delete a point concurrently to a reassign of the same point then it can happen that reassign resurrects the deleted point. This is because the code misses a check in one place to ignore reassigning a deleted point.
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None