### PR TITLE
[ENH] Add where filtering support on list collections for local chroma

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -343,11 +343,13 @@ class ClientAPI(BaseAPI, ABC):
     @abstractmethod
     def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
     ) -> Sequence[Collection]:
         """List all collections.
         Args:
+            where: Conditional filtering on collection metadata. Defaults to None.
             limit: The maximum number of entries to return. Defaults to None.
             offset: The number of entries to skip before returning. Defaults to None.
 
@@ -576,6 +578,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
     @abstractmethod
     def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -336,11 +336,13 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
     @abstractmethod
     async def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
     ) -> Sequence[AsyncCollection]:
         """List all collections.
         Args:
+            where: Conditional filtering on collection metadata. Defaults to None.
             limit: The maximum number of entries to return. Defaults to None.
             offset: The number of entries to skip before returning. Defaults to None.
 
@@ -562,6 +564,7 @@ class AsyncServerAPI(AsyncBaseAPI, AsyncAdminAPI, Component):
     @abstractmethod
     async def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -159,10 +159,13 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
 
     @override
     async def list_collections(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
+        self,
+        where: Optional[Where] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> Sequence[AsyncCollection]:
         models = await self._server.list_collections(
-            limit, offset, tenant=self.tenant, database=self.database
+            where, limit, offset, tenant=self.tenant, database=self.database
         )
         return [AsyncCollection(client=self._server, model=model) for model in models]
 

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -2,6 +2,7 @@ import asyncio
 from uuid import UUID
 import urllib.parse
 import orjson
+import json
 from typing import Any, Optional, cast, Tuple, Sequence, Dict
 import logging
 import httpx
@@ -251,11 +252,13 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @override
     async def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
+        where_str = json.dumps(where) if where else None
         resp_json = await self._make_request(
             "get",
             f"/tenants/{tenant}/databases/{database}/collections",
@@ -263,6 +266,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 {
                     "limit": limit,
                     "offset": offset,
+                    "where": where_str,
                 }
             ),
         )

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -124,12 +124,15 @@ class Client(SharedSystemClient, ClientAPI):
 
     @override
     def list_collections(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
+        self,
+        where: Optional[Where] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> Sequence[Collection]:
         return [
             Collection(client=self._server, model=model)
             for model in self._server.list_collections(
-                limit, offset, tenant=self.tenant, database=self.database
+                where, limit, offset, tenant=self.tenant, database=self.database
             )
         ]
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -17,6 +17,7 @@ from chromadb import __version__
 from chromadb.api.base_http_client import BaseHTTPClient
 from chromadb.types import Database, Tenant, Collection as CollectionModel
 from chromadb.api import ServerAPI
+import json
 
 from chromadb.api.types import (
     Documents,
@@ -205,12 +206,14 @@ class FastAPI(BaseHTTPClient, ServerAPI):
     @override
     def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
         """Returns a list of all collections"""
+        where_str = json.dumps(where) if where else None
         json_collections = self._make_request(
             "get",
             f"/tenants/{tenant}/databases/{database}/collections",
@@ -218,6 +221,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
                 {
                     "limit": limit,
                     "offset": offset,
+                    "where": where_str,
                 }
             ),
         )

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -180,12 +180,15 @@ class RustBindingsAPI(ServerAPI):
     @override
     def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> Sequence[CollectionModel]:
-        collections = self.bindings.list_collections(limit, offset, tenant, database)
+        collections = self.bindings.list_collections(
+            limit, offset, tenant, database, json.dumps(where) if where else None
+        )
         return [
             CollectionModel(
                 id=collection.id,

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -325,6 +325,7 @@ class SegmentAPI(ServerAPI):
     @rate_limit
     def list_collections(
         self,
+        where: Optional[Where] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,

--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -86,6 +86,7 @@ class Bindings:
     ) -> int: ...
     def list_collections(
         self,
+        where: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         tenant: str = DEFAULT_TENANT,

--- a/chromadb/db/__init__.py
+++ b/chromadb/db/__init__.py
@@ -29,7 +29,10 @@ class DB(Component):
 
     @abstractmethod
     def list_collections(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
+        self,
+        where: Optional[Where] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> Sequence:  # type: ignore
         pass
 

--- a/chromadb/test/property/test_collections.py
+++ b/chromadb/test/property/test_collections.py
@@ -117,6 +117,35 @@ class CollectionStateMachine(RuleBasedStateMachine):
         else:
             assert len(colls) == limit
 
+    # @rule()
+    # def list_collections_with_where_filter(self) -> None:
+    #     if not self.model:
+    #         return
+    #     key_values = []
+    #     for name, metadata in self.model.items():
+    #         if metadata is not None:
+    #             for k, v in metadata.items():
+    #                 key_values.append((k, v))
+    #     if not key_values:
+    #         return
+    #     key, value = key_values[0]
+    #     expected = [
+    #         name
+    #         for name, metadata in self.model.items()
+    #         if metadata is not None and key in metadata and metadata[key] == value
+    #     ]
+    #     filtered = self.client.list_collections(
+    #         where={key: {"$eq": value}}  # type:ignore
+    #     )
+    #     filtered_names = [c.name for c in filtered]
+    #     for c in filtered:
+    #         assert (
+    #             c.metadata is not None
+    #             and key in c.metadata
+    #             and c.metadata[key] == value
+    #         )
+    #     assert sorted(filtered_names) == sorted(expected)
+
     @rule(
         target=collections,
         new_metadata=st.one_of(st.none(), strategies.collection_metadata),

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -164,6 +164,7 @@ func (s *Server) GetCollections(ctx context.Context, req *coordinatorpb.GetColle
 	databaseName := req.Database
 	limit := req.Limit
 	offset := req.Offset
+	// where := req.Where
 
 	res := &coordinatorpb.GetCollectionsResponse{}
 

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -188,6 +188,7 @@ message GetCollectionsRequest {
   optional int32 offset = 7;
   optional CollectionIdsFilter ids_filter = 8;
   optional bool include_soft_deleted = 9;
+  optional Where where = 10;
 }
 
 message GetCollectionsResponse {

--- a/rust/cli/src/commands/vacuum.rs
+++ b/rust/cli/src/commands/vacuum.rs
@@ -152,7 +152,8 @@ pub async fn vacuum_chroma(config: FrontendConfig) -> Result<(), Box<dyn Error>>
     let tenant = String::from("default_tenant");
     let database = String::from("default_database");
 
-    let list_collections_request = ListCollectionsRequest::try_new(tenant, database, None, 0)?;
+    let list_collections_request =
+        ListCollectionsRequest::try_new(tenant, database, None, 0, None)?;
     let collections = frontend.list_collections(list_collections_request).await?;
 
     let pb = ProgressBar::new(collections.len() as u64);

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -335,6 +335,7 @@ impl ServiceBasedFrontend {
             database_name,
             limit,
             offset,
+            r#where,
             ..
         }: ListCollectionsRequest,
     ) -> Result<ListCollectionsResponse, GetCollectionsError> {
@@ -344,6 +345,7 @@ impl ServiceBasedFrontend {
                 database: Some(database_name.clone()),
                 limit,
                 offset,
+                r#where,
                 ..Default::default()
             })
             .await

--- a/rust/sqlite/migrations/sysdb/00010-collection-metadata-indices.sqlite.sql
+++ b/rust/sqlite/migrations/sysdb/00010-collection-metadata-indices.sqlite.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS collection_metadata_int_value ON collection_metadata (key, int_value) WHERE int_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS collection_metadata_float_value ON collection_metadata (key, float_value) WHERE float_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS collection_metadata_string_value ON collection_metadata (key, str_value) WHERE str_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS collection_metadata_bool_value ON collection_metadata (key, bool_value) WHERE bool_value IS NOT NULL;

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -860,6 +860,7 @@ impl GrpcSysDb {
             database,
             limit,
             offset,
+            r#where,
         } = options;
 
         // TODO: move off of status into our own error type
@@ -878,6 +879,14 @@ impl GrpcSysDb {
                 offset: Some(offset as i32),
                 tenant: tenant.unwrap_or("".to_string()),
                 database: database.unwrap_or("".to_string()),
+                r#where: match r#where {
+                    Some(where_clause) => Some(
+                        where_clause
+                            .try_into()
+                            .map_err(|e| GetCollectionsError::Internal(Box::new(e)))?,
+                    ),
+                    None => None,
+                },
             })
             .await;
 

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -162,6 +162,7 @@ impl TestSysDb {
             database,
             limit: _,
             offset: _,
+            r#where: _,
         } = options;
 
         let inner = self.inner.lock();

--- a/rust/sysdb/src/types.rs
+++ b/rust/sysdb/src/types.rs
@@ -1,4 +1,4 @@
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionUuid, Where};
 
 #[derive(Default, Debug)]
 pub struct GetCollectionsOptions {
@@ -10,4 +10,5 @@ pub struct GetCollectionsOptions {
     pub database: Option<String>,
     pub limit: Option<u32>,
     pub offset: u32,
+    pub r#where: Option<Where>,
 }

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -498,6 +498,7 @@ pub struct ListCollectionsRequest {
     pub database_name: String,
     pub limit: Option<u32>,
     pub offset: u32,
+    pub r#where: Option<Where>,
 }
 
 impl ListCollectionsRequest {
@@ -506,12 +507,14 @@ impl ListCollectionsRequest {
         database_name: String,
         limit: Option<u32>,
         offset: u32,
+        r#where: Option<Where>,
     ) -> Result<Self, ChromaValidationError> {
         let request = Self {
             tenant_id,
             database_name,
             limit,
             offset,
+            r#where,
         };
         request.validate().map_err(ChromaValidationError::from)?;
         Ok(request)

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -479,6 +479,12 @@ pub enum WhereConversionError {
     Trace(String, Box<Self>),
 }
 
+impl ChromaError for WhereConversionError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::InvalidArgument
+    }
+}
+
 impl WhereConversionError {
     pub fn cause(msg: impl ToString) -> Self {
         Self::Cause(msg.to_string())


### PR DESCRIPTION
## Description of changes

This PR adds where filtering to collection metadata on list_collections on the client APIs and local chroma

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
