### PR TITLE
[CHORE] Fix type error in batch_utils

### DIFF
--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -14,23 +14,23 @@ def create_batches(
     embeddings: Optional[Embeddings] = None,
     metadatas: Optional[Metadatas] = None,
     documents: Optional[Documents] = None,
-) -> List[Tuple[IDs, Embeddings, Optional[Metadatas], Optional[Documents]]]:
+) -> List[Tuple[IDs, Optional[Embeddings], Optional[Metadatas], Optional[Documents]]]:
     _batches: List[
-        Tuple[IDs, Embeddings, Optional[Metadatas], Optional[Documents]]
+        Tuple[IDs, Optional[Embeddings], Optional[Metadatas], Optional[Documents]]
     ] = []
     if len(ids) > api.get_max_batch_size():
         # create split batches
         for i in range(0, len(ids), api.get_max_batch_size()):
             _batches.append(
-                (  # type: ignore
+                (
                     ids[i : i + api.get_max_batch_size()],
                     embeddings[i : i + api.get_max_batch_size()]
-                    if embeddings
+                    if embeddings is not None
                     else None,
                     metadatas[i : i + api.get_max_batch_size()] if metadatas else None,
                     documents[i : i + api.get_max_batch_size()] if documents else None,
                 )
             )
     else:
-        _batches.append((ids, embeddings, metadatas, documents))  # type: ignore
+        _batches.append((ids, embeddings, metadatas, documents))
     return _batches


### PR DESCRIPTION
## Description of changes

This script failed batch_utils. This PR fixes it with the correct type checks


```
import chromadb
from chromadb.utils.batch_utils import create_batches
import numpy as np

client = chromadb.EphemeralClient()

collection = client.create_collection("foo")

ids = [str(i) for i in range(100_000)]
embeddings = np.random.rand(100_000, 128)

# Add 100,000 records
for (ids, embeddings, _, _) in create_batches(client, ids=ids, embeddings=embeddings):
   collection.add(ids=ids, embeddings=embeddings)

# Delete added records
for (ids, _, _, _) in create_batches(client, ids=ids):
   collection.delete(ids=ids)
```

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
