### PR TITLE
[ENH] Auto-set tenant, scoped database in python CloudClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-cli"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "arboard",
  "axum 0.8.1",

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -311,10 +311,11 @@ def CloudClient(
     enable_ssl: bool = True,
 ) -> ClientAPI:
     """
-    Creates a client to connect to a tennant and database on the Chroma cloud.
+    Creates a client to connect to a tenant and database on Chroma cloud.
 
     Args:
-        database: The database to use for this client.
+        tenant: The tenant to use for this client. Optional. If not provided, it will be inferred from the API key if the key is scoped to a single tenant. If provided, it will be validated against the API key's scope.
+        database: The database to use for this client. Optional. If not provided, it will be inferred from the API key if the key is scoped to a single database. If provided, it will be validated against the API key's scope.
         api_key: The api key to use for this client.
     """
 

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -1,7 +1,9 @@
 from typing import Dict, Optional, Union
 import logging
 from chromadb.api.client import Client as ClientCreator
-from chromadb.api.client import AdminClient as AdminClientCreator
+from chromadb.api.client import (
+    AdminClient as AdminClientCreator,
+)
 from chromadb.api.async_client import AsyncClient as AsyncClientCreator
 from chromadb.auth.token_authn import TokenTransportHeader
 import chromadb.config
@@ -27,6 +29,7 @@ from chromadb.api.types import (
     UpdateCollectionMetadata,
 )
 from pathlib import Path
+import os
 
 # Re-export types from chromadb.types
 __all__ = [
@@ -304,26 +307,23 @@ def CloudClient(
     settings: Optional[Settings] = None,
     *,  # Following arguments are keyword-only, intended for testing only.
     cloud_host: str = "api.trychroma.com",
-    cloud_port: int = 8000,
+    cloud_port: int = 443,
     enable_ssl: bool = True,
 ) -> ClientAPI:
     """
     Creates a client to connect to a tennant and database on the Chroma cloud.
 
     Args:
-        tenant: The tenant to use for this client.
         database: The database to use for this client.
         api_key: The api key to use for this client.
     """
+
     required_args = [
-        CloudClientArg(name="tenant", env_var="CHROMA_TENANT", value=tenant),
-        CloudClientArg(name="database", env_var="CHROMA_DATABASE", value=database),
         CloudClientArg(name="api_key", env_var="CHROMA_API_KEY", value=api_key),
     ]
 
-    # If any of tenant, database, or api_key is not provided, try to load it from the environment variable
+    # If api_key is not provided, try to load it from the environment variable
     if not all([arg.value for arg in required_args]):
-        import os
         for arg in required_args:
             arg.value = arg.value or os.environ.get(arg.env_var)
 
@@ -338,8 +338,12 @@ def CloudClient(
         settings = Settings()
 
     # Make sure paramaters are the correct types -- users can pass anything.
-    tenant = str(tenant)
-    database = str(database)
+    tenant = tenant or os.environ.get("CHROMA_TENANT")
+    if tenant is not None:
+        tenant = str(tenant)
+    database = database or os.environ.get("CHROMA_DATABASE")
+    if database is not None:
+        database = str(database)
     api_key = str(api_key)
     cloud_host = str(cloud_host)
     cloud_port = int(cloud_port)
@@ -348,7 +352,6 @@ def CloudClient(
     settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
     settings.chroma_server_host = cloud_host
     settings.chroma_server_http_port = cloud_port
-    # Always use SSL for cloud
     settings.chroma_server_ssl_enabled = enable_ssl
 
     settings.chroma_client_auth_provider = (
@@ -356,6 +359,7 @@ def CloudClient(
     )
     settings.chroma_client_auth_credentials = api_key
     settings.chroma_auth_token_transport_header = TokenTransportHeader.X_CHROMA_TOKEN
+    settings.chroma_overwrite_singleton_tenant_database_access_from_auth = True
 
     return ClientCreator(tenant=tenant, database=database, settings=settings)
 

--- a/chromadb/auth/utils/__init__.py
+++ b/chromadb/auth/utils/__init__.py
@@ -32,8 +32,10 @@ def _singleton_tenant_database_if_applicable(
     user_databases = user_identity.databases
     if user_tenant and user_tenant != "*":
         tenant = user_tenant
-    if user_databases and len(user_databases) == 1 and user_databases[0] != "*":
-        database = user_databases[0]
+    if user_databases:
+        user_databases_set = set(user_databases)
+        if len(user_databases_set) == 1 and "*" not in user_databases_set:
+            database = list(user_databases_set)[0]
     return tenant, database
 
 
@@ -63,14 +65,14 @@ def maybe_set_tenant_and_database(
         and new_tenant
         and new_tenant != user_provided_tenant
     ):
-        raise ChromaAuthError
+        raise ChromaAuthError(f"Tenant {user_provided_tenant} does not match {new_tenant} from the server. Are you sure the tenant is correct?")
     if (
         user_provided_database
         and user_provided_database != DEFAULT_DATABASE
         and new_database
         and new_database != user_provided_database
     ):
-        raise ChromaAuthError
+        raise ChromaAuthError(f"Database {user_provided_database} does not match {new_database} from the server. Are you sure the database is correct?")
 
     if (
         not user_provided_tenant or user_provided_tenant == DEFAULT_TENANT

--- a/chromadb/test/client/test_cloud_client.py
+++ b/chromadb/test/client/test_cloud_client.py
@@ -1,101 +1,52 @@
-import multiprocessing
-from typing import Any, Dict, Generator, Optional, Tuple
 import pytest
+from unittest.mock import patch
 from chromadb import CloudClient
-from chromadb.api import ServerAPI
-from chromadb.auth.token_authn import TokenTransportHeader
-from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Settings, System
 from chromadb.errors import ChromaAuthError
-
-from chromadb.test.conftest import _await_server, _run_server, find_free_port
-
-TOKEN_TRANSPORT_HEADER = TokenTransportHeader.X_CHROMA_TOKEN
-TEST_CLOUD_HOST = "localhost"
+from chromadb.auth import UserIdentity
+from chromadb.types import Tenant, Database
+from uuid import uuid4
 
 
-@pytest.fixture(scope="module")
-def valid_token() -> str:
-    return "valid_token"
-
-
-@pytest.fixture(scope="module")
-def mock_cloud_server(valid_token: str) -> Generator[System, None, None]:
-    chroma_server_authn_provider: str = (
-        "chromadb.auth.token_authn.TokenAuthenticationServerProvider"
-    )
-    chroma_server_authn_credentials: str = valid_token
-    chroma_auth_token_transport_header: str = TOKEN_TRANSPORT_HEADER
-
-    port = find_free_port()
-
-    args: Tuple[
-        int,
-        bool,
-        Optional[str],
-        Optional[str],
-        Optional[str],
-        Optional[str],
-        Optional[str],
-        Optional[str],
-        Optional[str],
-        Optional[Dict[str, Any]],
-    ] = (
-        port,
-        False,
-        None,
-        chroma_server_authn_provider,
-        None,
-        chroma_server_authn_credentials,
-        chroma_auth_token_transport_header,
-        None,
-        None,
-        None,
-    )
-    ctx = multiprocessing.get_context("spawn")
-    proc = ctx.Process(target=_run_server, args=args, daemon=True)
-    proc.start()
-
-    settings = Settings(
-        chroma_api_impl="chromadb.api.fastapi.FastAPI",
-        chroma_server_host=TEST_CLOUD_HOST,
-        chroma_server_http_port=port,
-        chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider",
-        chroma_client_auth_credentials=valid_token,
-        chroma_auth_token_transport_header=TOKEN_TRANSPORT_HEADER,
-    )
-
-    system = System(settings)
-    api = system.instance(ServerAPI)
-    system.start()
-    _await_server(api)
-    yield system
-    system.stop()
-    proc.kill()
-
-
-def test_valid_key(mock_cloud_server: System, valid_token: str) -> None:
-    valid_client = CloudClient(
-        tenant=DEFAULT_TENANT,
-        database=DEFAULT_DATABASE,
-        api_key=valid_token,
-        cloud_host=TEST_CLOUD_HOST,
-        cloud_port=mock_cloud_server.settings.chroma_server_http_port or 8000,
-        enable_ssl=False,
-    )
-
-    assert valid_client.heartbeat()
-
-
-def test_invalid_key(mock_cloud_server: System, valid_token: str) -> None:
-    # Try to connect to the default tenant and database with an invalid token
-    invalid_token = valid_token + "_invalid"
-    with pytest.raises(ChromaAuthError):
-        client = CloudClient(
-            tenant=DEFAULT_TENANT,
-            database=DEFAULT_DATABASE,
-            api_key=invalid_token,
-            cloud_host=TEST_CLOUD_HOST,
-            cloud_port=mock_cloud_server.settings.chroma_server_http_port or 8000,
-            enable_ssl=False,
+def test_valid_key() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database, patch(
+        "chromadb.api.fastapi.FastAPI.heartbeat"
+    ) as mock_heartbeat:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="default_tenant", databases=["testdb"]
         )
-        client.heartbeat()
+        mock_get_tenant.return_value = Tenant(name="default_tenant")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="testdb", tenant="default_tenant"
+        )
+        mock_heartbeat.return_value = 1234567890
+
+        client = CloudClient(database="testdb", api_key="valid_token")
+
+        assert client.get_user_identity().user_id == "test_user"
+        assert client.get_user_identity().tenant == "default_tenant"
+        assert client.get_user_identity().databases == ["testdb"]
+
+        settings = client.get_settings()
+        assert settings.chroma_client_auth_credentials == "valid_token"
+        assert (
+            settings.chroma_client_auth_provider
+            == "chromadb.auth.token_authn.TokenAuthClientProvider"
+        )
+
+        assert client.heartbeat() == 1234567890
+
+
+def test_invalid_key() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.side_effect = ChromaAuthError("Authentication failed")
+
+        with pytest.raises(ChromaAuthError):
+            CloudClient(database="testdb", api_key="invalid_token")

--- a/chromadb/test/client/test_cloud_client.py
+++ b/chromadb/test/client/test_cloud_client.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 from chromadb import CloudClient
-from chromadb.errors import ChromaAuthError
+from chromadb.errors import ChromaAuthError, NotFoundError
 from chromadb.auth import UserIdentity
 from chromadb.types import Tenant, Database
 from uuid import uuid4
@@ -50,3 +50,285 @@ def test_invalid_key() -> None:
 
         with pytest.raises(ChromaAuthError):
             CloudClient(database="testdb", api_key="invalid_token")
+
+
+# Scoped API key to 1 database tests
+def test_scoped_api_key_to_single_db_with_api_key_only() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database:
+        # mock single db scoped api key
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["right-db"]
+        )
+        mock_get_tenant.return_value = Tenant(name="123-456-789")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="right-db", tenant="123-456-789"
+        )
+
+        client = CloudClient(api_key="valid_token")
+
+        # should resolve to single db
+        assert client.database == "right-db"
+        assert client.tenant == "123-456-789"
+
+
+def test_scoped_api_key_to_single_db_with_correct_tenant() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["right-db"]
+        )
+        mock_get_tenant.return_value = Tenant(name="123-456-789")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="right-db", tenant="123-456-789"
+        )
+
+        client = CloudClient(tenant="123-456-789", api_key="valid_token")
+
+        assert client.tenant == "123-456-789"
+        assert client.database == "right-db"
+
+
+def test_scoped_api_key_to_single_db_with_correct_db() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["right-db"]
+        )
+        mock_get_tenant.return_value = Tenant(name="123-456-789")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="right-db", tenant="123-456-789"
+        )
+
+        client = CloudClient(database="right-db", api_key="valid_token")
+
+        assert client.tenant == "123-456-789"
+        assert client.database == "right-db"
+
+
+def test_scoped_api_key_to_single_db_with_correct_tenant_and_db() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["right-db"]
+        )
+        mock_get_tenant.return_value = Tenant(name="123-456-789")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="right-db", tenant="123-456-789"
+        )
+
+        client = CloudClient(
+            tenant="123-456-789", database="right-db", api_key="valid_token"
+        )
+
+        assert client.tenant == "123-456-789"
+        assert client.database == "right-db"
+
+
+def test_scoped_api_key_to_single_db_with_wrong_tenant() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["right-db"]
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Tenant wrong-tenant does not match 123-456-789 from the server. Are you sure the tenant is correct?",
+        ):
+            CloudClient(tenant="wrong-tenant", api_key="valid_token")
+
+
+def test_scoped_api_key_to_single_db_with_wrong_database() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["right-db"]
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Database wrong-db does not match right-db from the server. Are you sure the database is correct?",
+        ):
+            CloudClient(database="wrong-db", api_key="valid_token")
+
+
+def test_scoped_api_key_to_single_db_with_wrong_api_key() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.side_effect = ChromaAuthError("Permission denied.")
+
+        with pytest.raises(ChromaAuthError, match="Permission denied."):
+            CloudClient(database="right-db", api_key="wrong-api-key")
+
+
+# Scoped API key to multiple databases tests
+def test_scoped_api_key_to_multiple_dbs_with_wrong_tenant() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user",
+            tenant="123-456-789",
+            databases=["right-db", "another-db"],
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Tenant wrong-tenant does not match 123-456-789 from the server. Are you sure the tenant is correct?",
+        ):
+            CloudClient(
+                tenant="wrong-tenant", database="right-db", api_key="valid_token"
+            )
+
+
+def test_scoped_api_key_to_multiple_dbs_with_correct_tenant_and_db() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user",
+            tenant="123-456-789",
+            databases=["right-db", "another-db"],
+        )
+        mock_get_tenant.return_value = Tenant(name="123-456-789")
+        mock_get_database.return_value = Database(
+            id=uuid4(), name="right-db", tenant="123-456-789"
+        )
+
+        client = CloudClient(
+            tenant="123-456-789", database="right-db", api_key="valid_token"
+        )
+
+        assert client.tenant == "123-456-789"
+        assert client.database == "right-db"
+
+
+def test_scoped_api_key_to_multiple_dbs_with_nonexistent_database() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity, patch(
+        "chromadb.api.client.AdminClient.get_tenant"
+    ) as mock_get_tenant, patch(
+        "chromadb.api.client.AdminClient.get_database"
+    ) as mock_get_database:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user",
+            tenant="123-456-789",
+            databases=["right-db", "another-db"],
+        )
+        mock_get_tenant.return_value = Tenant(name="123-456-789")
+        mock_get_database.side_effect = NotFoundError(
+            "Database [wrong-db] not found. Are you sure it exists?"
+        )
+
+        with pytest.raises(
+            NotFoundError,
+            match="Database \\[wrong-db\\] not found. Are you sure it exists?",
+        ):
+            CloudClient(database="wrong-db", api_key="valid_token")
+
+
+def test_scoped_api_key_to_multiple_dbs_with_api_key_only() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user",
+            tenant="123-456-789",
+            databases=["right-db", "another-db"],
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Could not determine a database name from the current authentication method. Please provide a database name.",
+        ):
+            CloudClient(api_key="valid_token")
+
+
+# Unscoped API key tests
+def test_api_key_with_unscoped_tenant() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="*", databases=["right-db"]
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Could not determine a tenant from the current authentication method. Please provide a tenant.",
+        ):
+            CloudClient(api_key="valid_token")
+
+
+def test_api_key_with_unscoped_db() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=["*"]
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Could not determine a database name from the current authentication method. Please provide a database name.",
+        ):
+            CloudClient(api_key="valid_token")
+
+
+def test_api_key_with_no_db_access() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant="123-456-789", databases=[]
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Could not determine a database name from the current authentication method. Please provide a database name.",
+        ):
+            CloudClient(api_key="valid_token")
+
+
+def test_api_key_with_no_tenant_access() -> None:
+    with patch(
+        "chromadb.api.fastapi.FastAPI.get_user_identity"
+    ) as mock_get_user_identity:
+        mock_get_user_identity.return_value = UserIdentity(
+            user_id="test_user", tenant=None, databases=["right-db"]
+        )
+
+        with pytest.raises(
+            ChromaAuthError,
+            match="Could not determine a tenant from the current authentication method. Please provide a tenant.",
+        ):
+            CloudClient(api_key="valid_token")


### PR DESCRIPTION
## Description of changes

This PR updates the python CloudClient to auto-set tenant based on the API key.

to use the cloud client now with an api key scoped to a single db
```
client = chromadb.CloudClient(
    api_key="ck-xxxxxxxxx"
)
```

and with an api key scoped to multiple dbs
```
client = chromadb.CloudClient(
    database="right-db",
    api_key="ck-xxxxxxxxx"
)
```

edge cases:
scoped api key to 1 db:

```
# this works
client = chromadb.CloudClient(
    api_key="xxxxx"
)

# this works
client = chromadb.CloudClient(
    tenant="right-tenant",
    api_key="xxxxx"
)

# error returns: chromadb.errors.ChromaAuthError: Tenant wrong-tenant does not match e9de4745-55e2-4281-ac7c-5672498abff6 from the server. Are you sure the tenant is correct?
client = chromadb.CloudClient(
    tenant="wrong-tenant",
    api_key="xxxxx"
)


# error returns: chromadb.errors.ChromaAuthError: Database wrong-db does not match right-db from the server. Are you sure the database is correct?
client = chromadb.CloudClient(
    database="wrong-db",
    api_key="xxxxx"
)

# error returns: chromadb.errors.ChromaError: Permission denied.
client = chromadb.CloudClient(
    database="right-db",
    api_key="wrong-api-key"
)

```

scoped api key to multiple dbs
```
# error returns: chromadb.errors.ChromaAuthError: Tenant wrong-tenant does not match e9de4745-55e2-4281-ac7c-5672498abff6 from the server. Are you sure the tenant is correct?
client = chromadb.CloudClient(
    tenant="wrong-tenant",
    database="right-db",
    api_key="xxxxx"
)

# this works
client = chromadb.CloudClient(
    tenant="right-tenant",
    database="right-db",
    api_key="xxxxx"
)

# error returns: chromadb.errors.NotFoundError: Database [wrong-db] not found. Are you sure it exists?
client = chromadb.CloudClient(
    database="wrong-db",
    api_key="xxxxx"
)

# error returns: chromadb.errors.ChromaAuthError: Could not determine a database name from the current authentication method. Please provide a database name.
client = chromadb.CloudClient(
    api_key="xxxxx"
)
```

## Test plan

_How are these changes tested?_

Manually tested both clients, and all corresponding APIs for both CloudClient (collection apis, add/delete records), and AdminClient (get_tenant & list/get_database, confirm create_tenant and create_database are disabled)

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
