### PR TITLE
[BLD] Use 8core runners for all our windows jobs

### DIFF
--- a/.github/workflows/_build_js_bindings.yml
+++ b/.github/workflows/_build_js_bindings.yml
@@ -75,7 +75,7 @@ jobs:
 
   build-windows:
     name: Build Windows bindings
-    runs-on: windows-latest
+    runs-on: 8core-32gb-windows-latest
     defaults:
       run:
         working-directory: rust/js_bindings

--- a/.github/workflows/_build_release_pypi.yml
+++ b/.github/workflows/_build_release_pypi.yml
@@ -67,7 +67,7 @@ jobs:
         platform:
           - { os: linux, runner: blacksmith-4vcpu-ubuntu-2204, target: x86_64 }
           - { os: linux, runner: blacksmith-4vcpu-ubuntu-2204-arm, target: aarch64 }
-          - { os: windows, runner: windows-latest, target: x64 }
+          - { os: windows, runner: 8core-32gb-windows-latest, target: x64 }
           - { os: macos, runner: macos-14, target: x86_64 }
           - { os: macos, runner: macos-14, target: aarch64 }
 

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -265,7 +265,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-    runs-on: 16core-64gb-windows-latest
+    runs-on: 8core-32gb-windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -57,7 +57,7 @@ jobs:
       # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
       property_testing_preset: 'normal'
-      runner: '16core-64gb-windows-latest'
+      runner: '8core-64gb-windows-latest'
 
   javascript-client-tests:
     name: JavaScript client tests

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-windows:
     name: Build Windows binary
-    runs-on: windows-latest
+    runs-on: 8core-32gb-windows-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description of changes

Switch the runner for our Windows-based jobs to that of the 8core-32gb-x86 variety.

- Improvements & Bug fixes
  - Optimizes our Windows workflows/jobs to use the most "optimal" Windows based on cost/performance trade-offs

## Details

After a ton of experimentation across all of the workflows and jobs that run on Widows, I have concluded that the 8-core runners are the best "bang for the buck" when it comes to Windows.

I have to mention one big caveat though (which was pretty disappointing tbh): I could not test the ARM64 runners because our protobuf dependencies require Python 3.9 for which there are not builds for ARM64 (see [the complete manifest of options](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)). This is disappointing because on a core-to-core basis, ARM-based runners are cheaper than their x86_64 equivalents (see [billing info](https://docs.github.com/en/billing/managing-billing-for-your-products/about-billing-for-github-actions?search-overlay-input=which+windows+runners+are+the+4-core+windows+runners#per-minute-rates-for-arm64-powered-larger-runners)) and I suspect that we could potentially go _down_ in terms of core count to get equivalent performance with ARM-based runners based on prior experimentation of ARM and x86_64 runners.

Alas, we are stuck with x86_64 until we want to open the can of worms that is managing our proto builds. With that said, based on my experimentation, there seemed to be a very clear difference between 4-core and 8-core Windows runners. See these jobs for reference:
- `Release CLI` run comparing all Windows runner types: [link](https://github.com/chroma-core/chroma/actions/runs/15985617867/job/45089382786).
- `PR Checks` run comparing all Windows runner types for Python builds: [link](https://github.com/chroma-core/chroma/actions/runs/15985618486).

When I ran these tests multiple times, there was consistently a very clear jump, almost always about 2x in terms of time, between 4-core and 8-core runners. Then comparing the 8/16/32 -core runners, there wasn't a meaningful difference. Perhaps that is because we aren't properly parallelizing past a factor of 8, but I didn't want to get into the weeds of individual job configurations to confound the immediate experimentation results. Also worth notable observations:
- most of the time, jobs running on 32-core machines would fail. I'm not entirely sure why.
- about ~50% of the time (every other run) the 8-core runner would perform better than the 16-core machine. 

All of this led me to conclude that we should use the 8-core machines versus the others. We were using 16-core machines in some cases which means we should see a 50% reduction in cost while not losing any performance for these jobs. 

I also updated the runner type for a few of the lower frequency workflows to use 8-core machines because they were using the 4-core machines which would often be > 2x slower. As you go up in core count, the cost doubles, so this doesn't make any sense to not get the time improvement while it is also cheaper, because it finishes in < half the time.

## Test plan

CI should be unaffected (except in terms of cost and performance which should be strictly better)