### PR TITLE
[ENH]: return error on /add if embeddings are not provided

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1310,6 +1310,10 @@ async fn collection_add(
     let mut quota_payload = QuotaPayload::new(Action::Add, tenant.clone(), api_token);
     quota_payload = quota_payload.with_ids(&payload.ids);
 
+    if payload.embeddings.is_none() {
+        return Err(ValidationError::MissingEmbeddings.into());
+    }
+
     let payload_embeddings: Option<Vec<Vec<f32>>> = maybe_decode_embeddings(payload.embeddings)?;
     if let Some(embeddings) = payload_embeddings.as_ref() {
         quota_payload = quota_payload.with_add_embeddings(embeddings);

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -30,6 +30,8 @@ pub enum ValidationError {
     UpdateCollection(#[from] UpdateCollectionError),
     #[error("Error parsing collection configuration: {0}")]
     ParseCollectionConfiguration(#[from] CollectionConfigurationToInternalConfigurationError),
+    #[error("Embeddings not provided")]
+    MissingEmbeddings,
 }
 
 impl ChromaError for ValidationError {
@@ -42,6 +44,7 @@ impl ChromaError for ValidationError {
             ValidationError::GetCollection(err) => err.code(),
             ValidationError::UpdateCollection(err) => err.code(),
             ValidationError::ParseCollectionConfiguration(_) => ErrorCodes::InvalidArgument,
+            ValidationError::MissingEmbeddings => ErrorCodes::InvalidArgument,
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Our official clients prevent this but the server does not have a check. A better solution is making `AddCollectionRecordsPayload.embddings` non-optional, but this works as a minimal patch for now.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a