### PR TITLE
[ENH]: require embeddings & require min embedding dimension on /add

### DIFF
--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -15,7 +15,7 @@
 export namespace Api {
   export interface AddCollectionRecordsPayload {
     documents?: (string | null)[] | null;
-    embeddings?: Api.EmbeddingsPayload | null;
+    embeddings: Api.EmbeddingsPayload;
     ids: string[];
     metadatas?:
       | ({ [name: string]: boolean | number | number | string } | null)[]

--- a/rust/cli/src/client/collection.rs
+++ b/rust/cli/src/client/collection.rs
@@ -120,7 +120,7 @@ impl Collection {
     pub async fn add(
         &self,
         ids: Vec<String>,
-        embeddings: Option<Vec<Vec<f32>>>,
+        embeddings: Vec<Vec<f32>>,
         documents: Option<Vec<Option<String>>>,
         uris: Option<Vec<Option<String>>>,
         metadatas: Option<Vec<Option<Metadata>>>,

--- a/rust/cli/src/commands/copy.rs
+++ b/rust/cli/src/commands/copy.rs
@@ -248,7 +248,9 @@ async fn copy_collections(
             target_collection
                 .add(
                     records.ids,
-                    records.embeddings,
+                    records
+                        .embeddings
+                        .ok_or_else(|| CollectionAPIError::Add(collection.name.clone()))?,
                     records.documents,
                     records.uris,
                     records.metadatas,

--- a/rust/frontend/src/base64_decode.rs
+++ b/rust/frontend/src/base64_decode.rs
@@ -28,15 +28,14 @@ pub enum UpdateEmbeddingsPayload {
     Base64Binary(Vec<Option<String>>),
 }
 
-pub(crate) fn maybe_decode_embeddings(
-    embeddings: Option<EmbeddingsPayload>,
-) -> Result<Option<Vec<Vec<f32>>>, ValidationError> {
+pub(crate) fn decode_embeddings(
+    embeddings: EmbeddingsPayload,
+) -> Result<Vec<Vec<f32>>, ValidationError> {
     match embeddings {
-        Some(EmbeddingsPayload::Base64Binary(base64_strings)) => {
-            Ok(Some(decode_base64_embeddings(&base64_strings)?))
+        EmbeddingsPayload::Base64Binary(base64_strings) => {
+            Ok(decode_base64_embeddings(&base64_strings)?)
         }
-        Some(EmbeddingsPayload::JsonArrays(arrays)) => Ok(Some(arrays)),
-        None => Ok(None),
+        EmbeddingsPayload::JsonArrays(arrays) => Ok(arrays),
     }
 }
 
@@ -132,7 +131,7 @@ mod tests {
     #[test]
     fn test_get_embeddings_propagates_error() {
         let invalid_embeddings = EmbeddingsPayload::Base64Binary(vec!["invalid!@#$".to_string()]);
-        let result = maybe_decode_embeddings(Some(invalid_embeddings));
+        let result = decode_embeddings(invalid_embeddings);
 
         assert!(matches!(
             result,
@@ -163,7 +162,7 @@ mod tests {
         let embeddings =
             EmbeddingsPayload::Base64Binary(vec![valid_base64, "invalid!@#$".to_string()]);
 
-        let result = maybe_decode_embeddings(Some(embeddings));
+        let result = decode_embeddings(embeddings);
         assert!(matches!(
             result,
             Err(ValidationError::Base64Decode(

--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -373,7 +373,7 @@ mod tests {
                     "default_database".to_string(),
                     collection.collection_id,
                     vec!["id1".to_string(), "id2".to_string()],
-                    Some(vec![vec![-1.0, -1.0], vec![1.0, 1.0]]),
+                    vec![vec![-1.0, -1.0], vec![1.0, 1.0]],
                     None,
                     None,
                     None,

--- a/rust/frontend/src/impls/in_memory_frontend.rs
+++ b/rust/frontend/src/impls/in_memory_frontend.rs
@@ -315,7 +315,7 @@ impl InMemoryFrontend {
             ..
         } = request;
 
-        let embeddings = embeddings.map(|embeddings| embeddings.into_iter().map(Some).collect());
+        let embeddings = Some(embeddings.into_iter().map(Some).collect());
 
         let (records, _) = to_records(
             ids,
@@ -730,7 +730,7 @@ mod tests {
             collection.database.clone(),
             collection.collection_id,
             ids,
-            Some(embeddings),
+            embeddings,
             Some(documents),
             None,
             Some(metadatas),

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -718,13 +718,16 @@ impl ServiceBasedFrontend {
             ..
         }: AddCollectionRecordsRequest,
     ) -> Result<AddCollectionRecordsResponse, AddCollectionRecordsError> {
-        self.validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
-            Some(embedding.len())
-        })
+        self.validate_embedding(
+            collection_id,
+            Some(&embeddings),
+            true,
+            |embedding: &Vec<f32>| Some(embedding.len()),
+        )
         .await
         .map_err(|err| err.boxed())?;
 
-        let embeddings = embeddings.map(|embeddings| embeddings.into_iter().map(Some).collect());
+        let embeddings = Some(embeddings.into_iter().map(Some).collect());
 
         let (records, log_size_bytes) =
             to_records(ids, embeddings, documents, uris, metadatas, Operation::Add)

--- a/rust/frontend/src/types/errors.rs
+++ b/rust/frontend/src/types/errors.rs
@@ -30,8 +30,6 @@ pub enum ValidationError {
     UpdateCollection(#[from] UpdateCollectionError),
     #[error("Error parsing collection configuration: {0}")]
     ParseCollectionConfiguration(#[from] CollectionConfigurationToInternalConfigurationError),
-    #[error("Embeddings not provided")]
-    MissingEmbeddings,
 }
 
 impl ChromaError for ValidationError {
@@ -44,7 +42,6 @@ impl ChromaError for ValidationError {
             ValidationError::GetCollection(err) => err.code(),
             ValidationError::UpdateCollection(err) => err.code(),
             ValidationError::ParseCollectionConfiguration(_) => ErrorCodes::InvalidArgument,
-            ValidationError::MissingEmbeddings => ErrorCodes::InvalidArgument,
         }
     }
 }

--- a/rust/frontend/tests/proptest_helpers/arbitrary.rs
+++ b/rust/frontend/tests/proptest_helpers/arbitrary.rs
@@ -89,7 +89,7 @@ impl Arbitrary for CollectionRequest {
                             database.clone(),
                             collection_id,
                             ids,
-                            Some(embeddings),
+                            embeddings,
                             documents,
                             None,
                             metadatas,

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -406,7 +406,7 @@ impl Bindings {
             database,
             collection_id,
             ids,
-            Some(embeddings),
+            embeddings,
             documents,
             uris,
             metadatas,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -970,7 +970,8 @@ pub struct AddCollectionRecordsRequest {
     pub database_name: String,
     pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
-    pub embeddings: Option<Vec<Vec<f32>>>,
+    #[validate(custom(function = "Self::validate_embeddings"))]
+    pub embeddings: Vec<Vec<f32>>,
     pub documents: Option<Vec<Option<String>>>,
     pub uris: Option<Vec<Option<String>>>,
     pub metadatas: Option<Vec<Option<Metadata>>>,
@@ -983,7 +984,7 @@ impl AddCollectionRecordsRequest {
         database_name: String,
         collection_id: CollectionUuid,
         ids: Vec<String>,
-        embeddings: Option<Vec<Vec<f32>>>,
+        embeddings: Vec<Vec<f32>>,
         documents: Option<Vec<Option<String>>>,
         uris: Option<Vec<Option<String>>>,
         metadatas: Option<Vec<Option<Metadata>>>,
@@ -1000,6 +1001,14 @@ impl AddCollectionRecordsRequest {
         };
         request.validate().map_err(ChromaValidationError::from)?;
         Ok(request)
+    }
+
+    fn validate_embeddings(embeddings: &[Vec<f32>]) -> Result<(), ValidationError> {
+        if embeddings.iter().any(|e| e.is_empty()) {
+            return Err(ValidationError::new("embedding_minimum_dimensions")
+                .with_message("Each embedding must have at least 1 dimension".into()));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description of changes

Replaces https://github.com/chroma-core/chroma/pull/5033. The rest of our system assumes that adds have non-empty embeddings.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a