### PR TITLE
[DOC] Add API route for llm text files

### DIFF
--- a/docs/docs.trychroma.com/app/api/llms/[...path]/route.ts
+++ b/docs/docs.trychroma.com/app/api/llms/[...path]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
+  try {
+    const filePath = join(process.cwd(), 'public', 'llms', ...params.path);
+    const content = await readFile(filePath, 'utf-8');
+    
+    return new NextResponse(content, {
+      headers: {
+        'Content-Type': 'text/plain',
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+  } catch (error) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+}


### PR DESCRIPTION
## Description of changes

Adding an API route to serve text files for LLMs to consume the docs.

Context: We want to enable 
