### PR TITLE
[BUG] RLS should use 32MB GRPC payload size limit

### DIFF
--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -305,7 +305,7 @@ impl std::ops::AddAssign<usize> for LogPosition {
 /// for different prefixes.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct ThrottleOptions {
-    /// The maximum number of bytes to batch.  Defaults to 8MB.
+    /// The maximum number of bytes to batch.  Defaults to 64MB (2 * GRPC max payload size).
     #[serde(default = "ThrottleOptions::default_batch_size_bytes")]
     pub batch_size_bytes: usize,
     /// The maximum number of microseconds to batch.  Defaults to 100ms or 100_000us.
@@ -321,7 +321,7 @@ pub struct ThrottleOptions {
 
 impl ThrottleOptions {
     fn default_batch_size_bytes() -> usize {
-        8 * 1_000_000
+        64_000_000
     }
 
     fn default_batch_interval_us() -> usize {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Rust Log Service did not configure the max payload size, which defaults to 4MB. We would like to use 32MB payload size (which is the default for GRPC log client right now).
  - We would like to bump the max frag size from 8MB to 64MB (2*GRPC max payload size)
- New functionality
  - N/A

## Test plan
Planning to perform data ingestion after config change

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
