### PR TITLE
[BUG] js client: handle 422 billing errors as QuotaExceeded instead of ChromaConnectionError

### DIFF
--- a/clients/js/packages/chromadb-core/src/ChromaFetch.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaFetch.ts
@@ -16,9 +16,9 @@ import { FetchAPI } from "./generated";
 function isOfflineError(error: any): boolean {
   return Boolean(
     (error?.name === "TypeError" || error?.name === "FetchError") &&
-      (error.message?.includes("fetch failed") ||
-        error.message?.includes("Failed to fetch") ||
-        error.message?.includes("ENOTFOUND")),
+    (error.message?.includes("fetch failed") ||
+      error.message?.includes("Failed to fetch") ||
+      error.message?.includes("ENOTFOUND")),
   );
 }
 
@@ -78,7 +78,10 @@ export const chromaFetch: FetchAPI = async (
         case 422:
           if (
             respBody?.message &&
-            respBody?.message.startsWith("Quota exceeded")
+            (
+              respBody?.message.startsWith("Quota exceeded") ||
+              respBody?.message.startsWith("Billing limit exceeded")
+            )
           ) {
             throw new ChromaQuotaExceededError(respBody?.message);
           }


### PR DESCRIPTION
When no payment method is present, data plane error message will be: 

`{"error":"ChromaError","message":"Billing limit exceeded. Log into trychroma.com or contact hello@trychroma.com to raise it."}`

This PR adds support for this type of error message to the JS client, so it is recognized as a quota error instead of a connection error. 