### PR TITLE
[ENH]  Do not do any mutations of the manifest from within GC.

### DIFF
--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -11,7 +11,7 @@ use chroma_system::{Operator, OperatorType};
 use chroma_types::CollectionUuid;
 use futures::future::try_join_all;
 use thiserror::Error;
-use wal3::{GarbageCollectionOptions, LogPosition, LogWriter, LogWriterOptions};
+use wal3::{GarbageCollectionOptions, GarbageCollector, LogPosition, LogWriterOptions};
 
 #[derive(Clone, Debug)]
 pub struct DeleteUnusedLogsOperator {
@@ -67,12 +67,11 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                 let storage_clone = storage_arc.clone();
                 let mut logs = self.logs.clone();
                 log_gc_futures.push(async move {
-                    let writer = match LogWriter::open(
+                    let writer = match GarbageCollector::open(
                         LogWriterOptions::default(),
                         storage_clone,
                         &collection_id.storage_prefix_for_log(),
                         "garbage collection service",
-                        (),
                     )
                     .await
                     {

--- a/rust/garbage_collector/src/operators/truncate_dirty_log.rs
+++ b/rust/garbage_collector/src/operators/truncate_dirty_log.rs
@@ -7,7 +7,7 @@ use chroma_storage::Storage;
 use chroma_system::{Operator, OperatorType};
 use futures::future::try_join_all;
 use thiserror::Error;
-use wal3::{GarbageCollectionOptions, LogWriter, LogWriterOptions};
+use wal3::{GarbageCollectionOptions, GarbageCollector, LogWriterOptions};
 
 #[derive(Clone, Debug)]
 pub struct TruncateDirtyLogOperator {
@@ -56,12 +56,11 @@ impl Operator<TruncateDirtyLogInput, TruncateDirtyLogOutput> for TruncateDirtyLo
         let mut replica_id = 0u64;
         loop {
             let dirty_log_prefix = format!("dirty-rust-log-service-{replica_id}");
-            match LogWriter::open(
+            match GarbageCollector::open(
                 LogWriterOptions::default(),
                 storage_arc.clone(),
                 &dirty_log_prefix,
                 "garbage collection service",
-                (),
             )
             .await
             {

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -22,7 +22,7 @@ pub use batch_manager::BatchManager;
 pub use copy::copy;
 pub use cursors::{Cursor, CursorName, CursorStore, Witness};
 pub use destroy::destroy;
-pub use gc::Garbage;
+pub use gc::{Garbage, GarbageCollector};
 pub use manifest::{unprefixed_snapshot_path, Manifest, Snapshot, SnapshotPointer};
 pub use manifest_manager::ManifestManager;
 pub use reader::{Limits, LogReader};


### PR DESCRIPTION
## Description of changes

3-phase gc still used the open and recover path.  This causes contention
between GC and the writer, especially for hotly written logs.

## Test plan

CI

## Documentation Changes

N/A
