### PR TITLE
[PERF]: Parallelize fetching blocks for brute force regex

### DIFF
--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -1598,16 +1598,16 @@ mod test {
             .await
             .expect("Record segment get all data failed");
         assert_eq!(res.len(), 2);
-        res.sort_by(|x, y| x.id.cmp(y.id));
+        res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         let mut id1_mt = HashMap::new();
         id1_mt.insert(
             String::from("hello"),
             MetadataValue::Str(String::from("new world")),
         );
-        assert_eq!(res.first().as_ref().unwrap().metadata, Some(id1_mt));
+        assert_eq!(res.first().as_ref().unwrap().1.metadata, Some(id1_mt));
         let mut id2_mt = HashMap::new();
         id2_mt.insert(String::from("hello"), MetadataValue::Float(1.0));
-        assert_eq!(res.get(1).as_ref().unwrap().metadata, Some(id2_mt));
+        assert_eq!(res.get(1).as_ref().unwrap().1.metadata, Some(id2_mt));
     }
 
     #[tokio::test]
@@ -1840,13 +1840,13 @@ mod test {
             .await
             .expect("Record segment get all data failed");
         assert_eq!(res.len(), 1);
-        res.sort_by(|x, y| x.id.cmp(y.id));
+        res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         let mut id1_mt = HashMap::new();
         id1_mt.insert(
             String::from("bye"),
             MetadataValue::Str(String::from("world")),
         );
-        assert_eq!(res.first().as_ref().unwrap().metadata, Some(id1_mt));
+        assert_eq!(res.first().as_ref().unwrap().1.metadata, Some(id1_mt));
     }
 
     #[tokio::test]
@@ -2069,9 +2069,9 @@ mod test {
             .await
             .expect("Record segment get all data failed");
         assert_eq!(res.len(), 1);
-        res.sort_by(|x, y| x.id.cmp(y.id));
+        res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         assert_eq!(
-            res.first().as_ref().unwrap().document,
+            res.first().as_ref().unwrap().1.document,
             Some(String::from("bye").as_str())
         );
     }
@@ -2269,13 +2269,13 @@ mod test {
             .await
             .expect("Record segment get all data failed");
         assert_eq!(res.len(), 2);
-        res.sort_by(|x, y| x.id.cmp(y.id));
+        res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         assert_eq!(
-            res.first().as_ref().unwrap().document,
+            res.first().as_ref().unwrap().1.document,
             Some(String::from("hello").as_str())
         );
         assert_eq!(
-            res.get(1).as_ref().unwrap().document,
+            res.get(1).as_ref().unwrap().1.document,
             Some(String::from("world").as_str())
         );
     }

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -951,12 +951,12 @@ impl RecordSegmentReader<'_> {
     }
 
     /// Returns all data in the record segment, sorted by their offset ids
-    #[allow(dead_code)]
-    pub async fn get_all_data(&self) -> Result<Vec<DataRecord>, Box<dyn ChromaError>> {
-        self.id_to_data
-            .get_range(""..="", ..)
-            .await
-            .map(|vec| vec.into_iter().map(|(_, _, data)| data).collect())
+    pub async fn get_all_data(&self) -> Result<Vec<(u32, DataRecord)>, Box<dyn ChromaError>> {
+        self.id_to_data.get_range(""..="", ..).await.map(|vec| {
+            vec.into_iter()
+                .map(|(_, offset, data)| (offset, data))
+                .collect()
+        })
     }
 
     pub async fn get_data_stream<'me>(

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -1337,10 +1337,10 @@ mod tests {
             .expect("Get all data failed");
         assert_eq!(all_data.len(), 1);
         let record = &all_data[0];
-        assert_eq!(record.id, "embedding_id_1");
-        assert_eq!(record.document, Some("number"));
-        assert_eq!(record.embedding, &[7.0, 8.0, 9.0]);
-        assert_eq!(record.metadata, Some(res_metadata));
+        assert_eq!(record.1.id, "embedding_id_1");
+        assert_eq!(record.1.document, Some("number"));
+        assert_eq!(record.1.embedding, &[7.0, 8.0, 9.0]);
+        assert_eq!(record.1.metadata, Some(res_metadata));
         // Search by metadata filter.
         let metadata_segment_reader =
             MetadataSegmentReader::from_segment(&metadata_segment, &blockfile_provider)
@@ -1621,10 +1621,10 @@ mod tests {
             .expect("Get all data failed");
         assert_eq!(all_data.len(), 1);
         let record = &all_data[0];
-        assert_eq!(record.id, "embedding_id_1");
-        assert_eq!(record.document, Some("doc1"));
-        assert_eq!(record.embedding, &[7.0, 8.0, 9.0]);
-        assert_eq!(record.metadata, Some(res_metadata));
+        assert_eq!(record.1.id, "embedding_id_1");
+        assert_eq!(record.1.document, Some("doc1"));
+        assert_eq!(record.1.embedding, &[7.0, 8.0, 9.0]);
+        assert_eq!(record.1.metadata, Some(res_metadata));
         // Search by metadata filter.
         let metadata_segment_reader =
             MetadataSegmentReader::from_segment(&metadata_segment, &blockfile_provider)
@@ -1926,10 +1926,10 @@ mod tests {
             .expect("Get all data failed");
         assert_eq!(all_data.len(), 1);
         let record = &all_data[0];
-        assert_eq!(record.id, "embedding_id_1");
-        assert_eq!(record.document, Some("number"));
-        assert_eq!(record.embedding, &[7.0, 8.0, 9.0]);
-        assert_eq!(record.metadata, Some(res_metadata));
+        assert_eq!(record.1.id, "embedding_id_1");
+        assert_eq!(record.1.document, Some("number"));
+        assert_eq!(record.1.embedding, &[7.0, 8.0, 9.0]);
+        assert_eq!(record.1.metadata, Some(res_metadata));
         // Search by metadata filter.
         let metadata_segment_reader =
             MetadataSegmentReader::from_segment(&metadata_segment, &blockfile_provider)
@@ -2271,70 +2271,83 @@ mod tests {
             .await
             .expect("Get all data failed");
         for data in all_data {
-            assert_ne!(data.id, "embedding_id_2");
-            if data.id == "embedding_id_1" {
+            assert_ne!(data.1.id, "embedding_id_2");
+            if data.1.id == "embedding_id_1" {
                 assert!(data
+                    .1
                     .metadata
                     .clone()
                     .expect("Metadata is empty")
                     .contains_key("hello"),);
                 assert_eq!(
-                    data.metadata
+                    data.1
+                        .metadata
                         .clone()
                         .expect("Metadata is empty")
                         .get("hello"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
                 assert!(data
+                    .1
                     .metadata
                     .clone()
                     .expect("Metadata is empty")
                     .contains_key("bye"),);
                 assert_eq!(
-                    data.metadata.clone().expect("Metadata is empty").get("bye"),
+                    data.1
+                        .metadata
+                        .clone()
+                        .expect("Metadata is empty")
+                        .get("bye"),
                     Some(&MetadataValue::Str(String::from("world")))
                 );
                 assert!(data
+                    .1
                     .metadata
                     .clone()
                     .expect("Metadata is empty")
                     .contains_key("hello_again"),);
                 assert_eq!(
-                    data.metadata
+                    data.1
+                        .metadata
                         .clone()
                         .expect("Metadata is empty")
                         .get("hello_again"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
-                assert_eq!(data.document.expect("Non empty document"), "doc1");
-                assert_eq!(data.embedding, vec![1.0, 2.0, 3.0]);
-            } else if data.id == "embedding_id_3" {
+                assert_eq!(data.1.document.expect("Non empty document"), "doc1");
+                assert_eq!(data.1.embedding, vec![1.0, 2.0, 3.0]);
+            } else if data.1.id == "embedding_id_3" {
                 assert!(data
+                    .1
                     .metadata
                     .clone()
                     .expect("Metadata is empty")
                     .contains_key("hello"),);
                 assert_eq!(
-                    data.metadata
+                    data.1
+                        .metadata
                         .clone()
                         .expect("Metadata is empty")
                         .get("hello"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
                 assert!(data
+                    .1
                     .metadata
                     .clone()
                     .expect("Metadata is empty")
                     .contains_key("hello_again"),);
                 assert_eq!(
-                    data.metadata
+                    data.1
+                        .metadata
                         .clone()
                         .expect("Metadata is empty")
                         .get("hello_again"),
                     Some(&MetadataValue::Str(String::from("new_world")))
                 );
-                assert_eq!(data.document.expect("Non empty document"), "doc3");
-                assert_eq!(data.embedding, vec![7.0, 8.0, 9.0]);
+                assert_eq!(data.1.document.expect("Non empty document"), "doc3");
+                assert_eq!(data.1.embedding, vec![7.0, 8.0, 9.0]);
             }
         }
     }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Brute forcing list of ids or all the ids was sequential. We now parallelize all the block gets and then perform regex
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
