### PR TITLE
[BLD] Fix windows runner label

### DIFF
--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -57,7 +57,7 @@ jobs:
       # and we usually don't see failures that are isolated to a specific version
       python_versions: '["3.12"]'
       property_testing_preset: 'normal'
-      runner: '8core-64gb-windows-latest'
+      runner: '8core-32gb-windows-latest'
 
   javascript-client-tests:
     name: JavaScript client tests


### PR DESCRIPTION
## Description of changes

In #5027 I accidentally wrote the Windows runner label as "8core-64gb-windows-latest" when it should be "8core-32gb-windows-latest" (32gb vs 64gb). I have since created a runner that matches the wrong label, but this was causing our windows builds to back up. 

## Test plan

We will see the release job run when this is merged. 