### PR TITLE
[BLD] Add a concurrency group to our PR checks workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
       - main
       - '**'
 
+# Cancel any in-progress workflows when a new commit is pushed to the PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,10 @@ on:
       - main
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # This job detects what changed and determines which tests to run
   change-detection:


### PR DESCRIPTION
## Preview Note

This is to create a discussion. I'd like to hear from others as to whether this is a desired property of our GitHub Actions configuration.

## Description of changes

This adds a concurrency group for our PR checks. This solves for the case where a developer pushes a commit to a PR, the build is triggered, then shortly thereafter (any time before the triggered build completes) another build is triggered but the previous is not cancelled. This change will cancel any inflight builds when a new commit for a PR is pushed. We are only doing this for PR checks as we don't necessarily want this behavior for our merges to main. 

- Improvements & Bug fixes
  - Cancels in-flight builds when new commits are pushed

## Test plan

Should have no effect on existing functionality.