### PR TITLE
[ENH]: limit number of concurrent get_all_block_ids() when using buffer_unordered()

### DIFF
--- a/rust/garbage_collector/src/operators/list_files_at_version.rs
+++ b/rust/garbage_collector/src/operators/list_files_at_version.rs
@@ -144,7 +144,6 @@ impl Operator<ListFilesAtVersionInput, ListFilesAtVersionOutput> for ListFilesAt
         }
 
         if !sparse_index_ids.is_empty() {
-            let num = sparse_index_ids.len();
             let mut get_block_ids_stream = futures::stream::iter(sparse_index_ids)
                 .map(|(sparse_index_id, file_prefix)|
                     async move {
@@ -159,7 +158,7 @@ impl Operator<ListFilesAtVersionInput, ListFilesAtVersionOutput> for ListFilesAt
                             }
                             Err(e) => Err(e),
                         }
-                }).buffer_unordered(num);
+                }).buffer_unordered(100);
 
             while let Some(res) = get_block_ids_stream.next().await {
                 let block_ids = res.map_err(ListFilesAtVersionError::FetchBlockIdsError)?;


### PR DESCRIPTION
## Description of changes

One of our GC pods is currently OOMing and it seems like the majority of memory used is just to track all the futures for `get_all_block_ids()`:

<img width="1912" alt="Screenshot 2025-07-09 at 12 53 40" src="https://github.com/user-attachments/assets/17f940a4-8249-453c-95f1-e99e9214dd47" />

This should not be an issue for the vast majority of collections, but there are currently 0.02% of collections with > 1k active versions and a handful with > 20k active versions.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

n/a