### PR TITLE
[BUG]: Disable aws stalled stream protection

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use aws_config::retry::RetryConfig;
 use aws_config::timeout::TimeoutConfigBuilder;
 use aws_sdk_s3;
+use aws_sdk_s3::config::StalledStreamProtectionConfig;
 use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::create_bucket::CreateBucketError;
@@ -783,6 +784,7 @@ impl Configurable<StorageConfig> for S3Storage {
                             .to_builder()
                             .timeout_config(timeout_config_builder.build())
                             .retry_config(retry_config)
+                            .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
                             .build();
                         aws_sdk_s3::Client::new(&config)
                     }


### PR DESCRIPTION
## Description of changes

This change disables AWS [stalled stream protection](https://github.com/awslabs/aws-sdk-rust/discussions/956). It is causing issues such as [this](https://github.com/awslabs/aws-sdk-rust/issues/1146) for downloads. We already have various timeouts in place to perform the intended functionality of stalled stream protection.

- Improvements & Bug fixes
  - Disabled AWS stalled stream protection
- New functionality
  - N/A

## Test plan

N/A

- [v ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
