### PR TITLE
[ENH]  "Failed to fetch: status: NotFound" be gone.

### DIFF
--- a/rust/error/src/lib.rs
+++ b/rust/error/src/lib.rs
@@ -129,6 +129,9 @@ pub trait ChromaError: Error + Send {
     {
         Box::new(self)
     }
+    fn should_trace_error(&self) -> bool {
+        true
+    }
 }
 
 impl Error for Box<dyn ChromaError> {}
@@ -136,5 +139,11 @@ impl Error for Box<dyn ChromaError> {}
 impl ChromaError for Box<dyn ChromaError> {
     fn code(&self) -> ErrorCodes {
         self.as_ref().code()
+    }
+}
+
+impl ChromaError for std::io::Error {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Unknown
     }
 }

--- a/rust/garbage_collector/src/operators/list_files_at_version.rs
+++ b/rust/garbage_collector/src/operators/list_files_at_version.rs
@@ -3,6 +3,7 @@ use chroma_blockstore::{
     arrow::provider::{BlockManager, RootManagerError},
     RootManager,
 };
+use chroma_error::{ChromaError, ErrorCodes};
 use chroma_index::{
     hnsw_provider::{HnswIndexProvider, FILES},
     IndexUuid,
@@ -58,6 +59,18 @@ pub enum ListFilesAtVersionError {
     FetchBlockIdsError(#[from] RootManagerError),
     #[error("Version file missing collection ID")]
     VersionFileMissingCollectionId,
+}
+
+impl ChromaError for ListFilesAtVersionError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            ListFilesAtVersionError::VersionHistoryMissing => ErrorCodes::NotFound,
+            ListFilesAtVersionError::VersionNotFound(_) => ErrorCodes::NotFound,
+            ListFilesAtVersionError::InvalidUuid(_) => ErrorCodes::InvalidArgument,
+            ListFilesAtVersionError::FetchBlockIdsError(e) => e.code(),
+            ListFilesAtVersionError::VersionFileMissingCollectionId => ErrorCodes::InvalidArgument,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -448,6 +448,8 @@ impl GrpcLog {
             Err(e) => {
                 if e.code() == chroma_error::ErrorCodes::Unavailable.into() {
                     Err(GrpcPullLogsError::Backoff)
+                } else if e.code() == chroma_error::ErrorCodes::NotFound.into() {
+                    Err(GrpcPullLogsError::FailedToPullLogs(e))
                 } else {
                     tracing::error!("Failed to pull logs: {}", e);
                     Err(GrpcPullLogsError::FailedToPullLogs(e))

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -45,7 +45,7 @@ pub enum Log {
 }
 
 impl Log {
-    #[tracing::instrument(skip(self), err(Display))]
+    #[tracing::instrument(skip(self))]
     pub async fn read(
         &mut self,
         tenant: &str,

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -318,7 +318,7 @@ mod tests {
     struct MockOperator {}
     #[async_trait]
     impl Operator<f32, String> for MockOperator {
-        type Error = ();
+        type Error = std::io::Error;
 
         fn get_name(&self) -> &'static str {
             "MockOperator"
@@ -338,7 +338,7 @@ mod tests {
     struct MockIoOperator {}
     #[async_trait]
     impl Operator<String, String> for MockIoOperator {
-        type Error = ();
+        type Error = std::io::Error;
 
         fn get_name(&self) -> &'static str {
             "MockIoOperator"
@@ -392,12 +392,12 @@ mod tests {
         }
     }
     #[async_trait]
-    impl Handler<TaskResult<String, ()>> for MockIoDispatchUser {
+    impl Handler<TaskResult<String, std::io::Error>> for MockIoDispatchUser {
         type Result = ();
 
         async fn handle(
             &mut self,
-            _message: TaskResult<String, ()>,
+            _message: TaskResult<String, std::io::Error>,
             ctx: &ComponentContext<MockIoDispatchUser>,
         ) {
             self.counter.fetch_add(1, Ordering::SeqCst);
@@ -455,12 +455,12 @@ mod tests {
         }
     }
     #[async_trait]
-    impl Handler<TaskResult<String, ()>> for MockDispatchUser {
+    impl Handler<TaskResult<String, std::io::Error>> for MockDispatchUser {
         type Result = ();
 
         async fn handle(
             &mut self,
-            _message: TaskResult<String, ()>,
+            _message: TaskResult<String, std::io::Error>,
             ctx: &ComponentContext<MockDispatchUser>,
         ) {
             self.counter.fetch_add(1, Ordering::SeqCst);

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -148,7 +148,10 @@ where
         match result {
             Ok(result) => {
                 if let Err(err) = result.as_ref() {
-                    tracing::error!("Task {} failed with error: {:?}", self.task_id, err);
+                    if format!("{err:?}").contains("FailedToPullLogs(Status { code: NotFound") {
+                    } else {
+                        tracing::error!("Task {} failed with error: {:?}", self.task_id, err);
+                    }
                 }
 
                 // If this (or similarly, the .send() below) errors, it means the receiver was dropped.

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -97,7 +97,10 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     ) {
         self.cleanup().await;
         let cancel = if let Err(err) = &res {
-            tracing::error!("Error running {}: {}", Self::name(), err);
+            if format!("{err:?}").contains("FailedToPullLogs(Status { code: NotFound") {
+            } else {
+                tracing::error!("Error running {}: {}", Self::name(), err);
+            }
             true
         } else {
             false

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -97,8 +97,7 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     ) {
         self.cleanup().await;
         let cancel = if let Err(err) = &res {
-            if format!("{err:?}").contains("FailedToPullLogs(Status { code: NotFound") {
-            } else {
+            if err.should_trace_error() {
                 tracing::error!("Error running {}: {}", Self::name(), err);
             }
             true

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -291,9 +291,7 @@ impl CompactionManagerContext {
                 return Ok(result);
             }
             Err(e) => {
-                if e.should_warn_instead_of_error() {
-                    tracing::warn!("Compaction Job failed: {:?}", e);
-                } else {
+                if e.should_trace_error() {
                     tracing::error!("Compaction Job failed: {:?}", e);
                 }
                 return Err(Box::new(e));

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -291,7 +291,11 @@ impl CompactionManagerContext {
                 return Ok(result);
             }
             Err(e) => {
-                tracing::error!("Compaction Job failed: {:?}", e);
+                if e.should_warn_instead_of_error() {
+                    tracing::warn!("Compaction Job failed: {:?}", e);
+                } else {
+                    tracing::error!("Compaction Job failed: {:?}", e);
+                }
                 return Err(Box::new(e));
             }
         }

--- a/rust/worker/src/execution/operators/knn_merge.rs
+++ b/rust/worker/src/execution/operators/knn_merge.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use chroma_error::{ChromaError, ErrorCodes};
 use chroma_system::Operator;
 use chroma_types::operator::{KnnMerge, RecordDistance};
 use thiserror::Error;
@@ -29,6 +30,12 @@ pub struct KnnMergeOutput {
 #[derive(Error, Debug)]
 #[error("Knn merge error (unreachable)")]
 pub struct KnnMergeError;
+
+impl ChromaError for KnnMergeError {
+    fn code(&self) -> ErrorCodes {
+        ErrorCodes::Internal
+    }
+}
 
 #[async_trait]
 impl Operator<KnnMergeInput, KnnMergeOutput> for KnnMerge {

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -181,6 +181,16 @@ pub enum CompactionError {
     SourceRecordSegment(#[from] SourceRecordSegmentError),
 }
 
+impl CompactionError {
+    pub fn should_warn_instead_of_error(&self) -> bool {
+        if let Self::FetchLog(FetchLogError::PullLog(status)) = self {
+            status.code() == ErrorCodes::NotFound
+        } else {
+            false
+        }
+    }
+}
+
 impl<E> From<TaskError<E>> for CompactionError
 where
     E: Into<CompactionError>,


### PR DESCRIPTION
## Description of changes

This is logged because of err(Display) and a trace error.  Make the
trace not apply to NotFound response codes.  Make the err(Display) go
away as it's going to be redundant with the tracing::error.

## Test plan

CI

## Documentation Changes

N/A
