### PR TITLE
[BUG] Use InternalUpdateConfiguration in Rust, correctly update configuration in go

### DIFF
--- a/chromadb/test/configurations/test_collection_configuration.py
+++ b/chromadb/test/configurations/test_collection_configuration.py
@@ -281,6 +281,16 @@ def test_hnsw_configuration_updates(client: ClientAPI) -> None:
             assert hnsw_config.get("ef_construction") == 100
             assert hnsw_config.get("max_neighbors") == 16
 
+    coll = client.get_collection(name="test_updates")
+    loaded_config = coll.configuration_json
+    if loaded_config and isinstance(loaded_config, dict):
+        hnsw_config = loaded_config.get("hnsw", {})
+        if isinstance(hnsw_config, dict):
+            assert hnsw_config.get("ef_search") == 20
+            assert hnsw_config.get("space") == "cosine"
+            assert hnsw_config.get("ef_construction") == 100
+            assert hnsw_config.get("max_neighbors") == 16
+
 
 def test_configuration_persistence(client_factories: "ClientFactories") -> None:
     """Test configuration persistence across client restarts"""
@@ -712,6 +722,15 @@ def test_configuration_spann_updates(client: ClientAPI) -> None:
             # Original values should remain unchanged
             assert spann_config.get("space") == "cosine"
 
+    coll = client.get_collection("test_spann_updates")
+    loaded_config = coll.configuration_json
+    if loaded_config and isinstance(loaded_config, dict):
+        spann_config = loaded_config.get("spann", {})
+        if isinstance(spann_config, dict):
+            assert spann_config.get("ef_search") == 150
+            assert spann_config.get("search_nprobe") == 20
+            assert spann_config.get("space") == "cosine"
+
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
 def test_spann_update_from_json(client: ClientAPI) -> None:
@@ -743,6 +762,21 @@ def test_spann_update_from_json(client: ClientAPI) -> None:
     coll.modify(configuration=update_config)
 
     # Verify updates were applied
+    loaded_config = coll.configuration_json
+    if loaded_config and isinstance(loaded_config, dict):
+        spann_config = loaded_config.get("spann", {})
+        if isinstance(spann_config, dict):
+            # Updated values
+            assert spann_config.get("ef_search") == 200
+            assert spann_config.get("search_nprobe") == 15
+
+            # Unchanged values
+            assert spann_config.get("space") == "cosine"
+            assert spann_config.get("ef_construction") == 150
+            assert spann_config.get("max_neighbors") == 12
+            assert spann_config.get("write_nprobe") == 20
+
+    coll = client.get_collection("test_spann_json_update")
     loaded_config = coll.configuration_json
     if loaded_config and isinstance(loaded_config, dict):
         spann_config = loaded_config.get("spann", {})

--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -1,17 +1,12 @@
 package model
 
 type EmbeddingFunctionConfiguration struct {
-	Type   string                             `json:"type"`
-	Config *EmbeddingFunctionNewConfiguration `json:"config,omitempty"`
-}
-
-type EmbeddingFunctionNewConfiguration struct {
+	Type   string      `json:"type"`
 	Name   string      `json:"name"`
 	Config interface{} `json:"config"`
 }
 
 type VectorIndexConfiguration struct {
-	Type  string              `json:"type"`
 	Hnsw  *HnswConfiguration  `json:"hnsw,omitempty"`
 	Spann *SpannConfiguration `json:"spann,omitempty"`
 }
@@ -62,7 +57,6 @@ type InternalCollectionConfiguration struct {
 func DefaultHnswCollectionConfiguration() *InternalCollectionConfiguration {
 	return &InternalCollectionConfiguration{
 		VectorIndex: &VectorIndexConfiguration{
-			Type: "hnsw",
 			Hnsw: DefaultHnswConfiguration(),
 		},
 	}
@@ -119,7 +113,6 @@ type UpdateSpannConfiguration struct {
 }
 
 type UpdateVectorIndexConfiguration struct {
-	Type  string                    `json:"type"`
 	Hnsw  *UpdateHnswConfiguration  `json:"hnsw,omitempty"`
 	Spann *UpdateSpannConfiguration `json:"spann,omitempty"`
 }

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -815,8 +815,8 @@ func (tc *Catalog) updateCollectionConfiguration(
 
 	// Update existing configuration with new values
 	if updateConfig.VectorIndex != nil {
-		if updateConfig.VectorIndex.Type == "hnsw" && updateConfig.VectorIndex.Hnsw != nil {
-			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Type != "hnsw" {
+		if updateConfig.VectorIndex.Hnsw != nil {
+			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Hnsw == nil {
 				return existingConfigJsonStr, nil
 			}
 			if updateConfig.VectorIndex.Hnsw.EfSearch != nil {
@@ -837,8 +837,8 @@ func (tc *Catalog) updateCollectionConfiguration(
 			if updateConfig.VectorIndex.Hnsw.BatchSize != nil {
 				existingConfig.VectorIndex.Hnsw.BatchSize = *updateConfig.VectorIndex.Hnsw.BatchSize
 			}
-		} else if updateConfig.VectorIndex.Type == "spann" && updateConfig.VectorIndex.Spann != nil {
-			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Type != "spann" {
+		} else if updateConfig.VectorIndex.Spann != nil {
+			if existingConfig.VectorIndex == nil || existingConfig.VectorIndex.Spann == nil {
 				return existingConfigJsonStr, nil
 			}
 			if updateConfig.VectorIndex.Spann.EfSearch != nil {

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -428,6 +428,9 @@ func generateCollectionUpdatesWithoutID(in *dbmodel.Collection) map[string]inter
 	if in.Name != nil {
 		ret["name"] = *in.Name
 	}
+	if in.ConfigurationJsonStr != nil {
+		ret["configuration_json_str"] = *in.ConfigurationJsonStr
+	}
 	if in.Dimension != nil {
 		ret["dimension"] = *in.Dimension
 	}

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -18,10 +18,10 @@ use chroma_types::{
     DeleteCollectionRecordsResponse, DeleteDatabaseRequest, DeleteDatabaseResponse,
     GetCollectionRequest, GetDatabaseRequest, GetDatabaseResponse, GetRequest, GetResponse,
     GetTenantRequest, GetTenantResponse, GetUserIdentityResponse, HeartbeatResponse, IncludeList,
-    InternalCollectionConfiguration, ListCollectionsRequest, ListCollectionsResponse,
-    ListDatabasesRequest, ListDatabasesResponse, Metadata, QueryRequest, QueryResponse,
-    UpdateCollectionConfiguration, UpdateCollectionRecordsResponse, UpdateCollectionResponse,
-    UpdateMetadata, UpsertCollectionRecordsResponse,
+    InternalCollectionConfiguration, InternalUpdateCollectionConfiguration, ListCollectionsRequest,
+    ListCollectionsResponse, ListDatabasesRequest, ListDatabasesResponse, Metadata, QueryRequest,
+    QueryResponse, UpdateCollectionConfiguration, UpdateCollectionRecordsResponse,
+    UpdateCollectionResponse, UpdateMetadata, UpsertCollectionRecordsResponse,
 };
 use chroma_types::{ForkCollectionResponse, RawWhereFields};
 use mdac::{Rule, Scorecard, ScorecardTicket};
@@ -1101,13 +1101,18 @@ async fn update_collection(
     let collection_id =
         CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?;
 
+    let configuration = match payload.new_configuration {
+        Some(c) => Some(InternalUpdateCollectionConfiguration::try_from(c)?),
+        None => None,
+    };
+
     let request = chroma_types::UpdateCollectionRequest::try_new(
         collection_id,
         payload.new_name,
         payload
             .new_metadata
             .map(CollectionMetadataUpdate::UpdateMetadata),
-        payload.new_configuration,
+        configuration,
     )?;
 
     server.frontend.update_collection(request).await?;

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -19,9 +19,9 @@ use chroma_types::{
     CountResponse, CreateCollectionRequest, CreateDatabaseRequest, CreateTenantRequest, Database,
     DeleteCollectionRequest, DeleteDatabaseRequest, GetCollectionRequest, GetDatabaseRequest,
     GetResponse, GetTenantRequest, GetTenantResponse, HeartbeatError, IncludeList,
-    InternalCollectionConfiguration, KnnIndex, ListCollectionsRequest, ListDatabasesRequest,
-    Metadata, QueryResponse, UpdateCollectionConfiguration, UpdateCollectionRequest,
-    UpdateMetadata, WrappedSerdeJsonError,
+    InternalCollectionConfiguration, InternalUpdateCollectionConfiguration, KnnIndex,
+    ListCollectionsRequest, ListDatabasesRequest, Metadata, QueryResponse,
+    UpdateCollectionConfiguration, UpdateCollectionRequest, UpdateMetadata, WrappedSerdeJsonError,
 };
 use pyo3::{exceptions::PyValueError, pyclass, pyfunction, pymethods, types::PyAnyMethods, Python};
 use std::time::SystemTime;
@@ -344,11 +344,16 @@ impl Bindings {
             None => None,
         };
 
+        let configuration = match configuration_json {
+            Some(c) => Some(InternalUpdateCollectionConfiguration::try_from(c)?),
+            None => None,
+        };
+
         let request = UpdateCollectionRequest::try_new(
             collection_id,
             new_name,
             new_metadata.map(CollectionMetadataUpdate::UpdateMetadata),
-            configuration_json,
+            configuration,
         )?;
 
         let mut frontend = self.frontend.clone();

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -14,9 +14,9 @@ use chroma_types::{
     DeleteCollectionError, DeleteDatabaseError, DeleteDatabaseResponse, GetCollectionSizeError,
     GetCollectionWithSegmentsError, GetCollectionsError, GetDatabaseError, GetDatabaseResponse,
     GetSegmentsError, GetTenantError, GetTenantResponse, InternalCollectionConfiguration,
-    ListCollectionVersionsError, ListDatabasesError, ListDatabasesResponse, Metadata, ResetError,
-    ResetResponse, SegmentFlushInfo, SegmentFlushInfoConversionError, SegmentUuid,
-    UpdateCollectionConfiguration, UpdateCollectionError, VectorIndexConfiguration,
+    InternalUpdateCollectionConfiguration, ListCollectionVersionsError, ListDatabasesError,
+    ListDatabasesResponse, Metadata, ResetError, ResetResponse, SegmentFlushInfo,
+    SegmentFlushInfoConversionError, SegmentUuid, UpdateCollectionError, VectorIndexConfiguration,
 };
 use chroma_types::{
     BatchGetCollectionSoftDeleteStatusError, BatchGetCollectionVersionFilePathsError, Collection,
@@ -284,7 +284,7 @@ impl SysDb {
         name: Option<String>,
         metadata: Option<CollectionMetadataUpdate>,
         dimension: Option<u32>,
-        configuration: Option<UpdateCollectionConfiguration>,
+        configuration: Option<InternalUpdateCollectionConfiguration>,
     ) -> Result<(), UpdateCollectionError> {
         match self {
             SysDb::Grpc(grpc) => {
@@ -969,7 +969,7 @@ impl GrpcSysDb {
         name: Option<String>,
         metadata: Option<CollectionMetadataUpdate>,
         dimension: Option<u32>,
-        configuration: Option<UpdateCollectionConfiguration>,
+        configuration: Option<InternalUpdateCollectionConfiguration>,
     ) -> Result<(), UpdateCollectionError> {
         let mut configuration_json_str = None;
         if let Some(configuration) = configuration {

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1,5 +1,5 @@
 use crate::collection_configuration::InternalCollectionConfiguration;
-use crate::collection_configuration::UpdateCollectionConfiguration;
+use crate::collection_configuration::InternalUpdateCollectionConfiguration;
 use crate::error::QueryConversionError;
 use crate::operator::GetResult;
 use crate::operator::KnnBatchResult;
@@ -721,7 +721,7 @@ pub struct UpdateCollectionRequest {
     pub new_name: Option<String>,
     #[validate(custom(function = "validate_non_empty_collection_update_metadata"))]
     pub new_metadata: Option<CollectionMetadataUpdate>,
-    pub new_configuration: Option<UpdateCollectionConfiguration>,
+    pub new_configuration: Option<InternalUpdateCollectionConfiguration>,
 }
 
 impl UpdateCollectionRequest {
@@ -729,7 +729,7 @@ impl UpdateCollectionRequest {
         collection_id: CollectionUuid,
         new_name: Option<String>,
         new_metadata: Option<CollectionMetadataUpdate>,
-        new_configuration: Option<UpdateCollectionConfiguration>,
+        new_configuration: Option<InternalUpdateCollectionConfiguration>,
     ) -> Result<Self, ChromaValidationError> {
         let request = Self {
             collection_id,

--- a/rust/types/src/spann_configuration.rs
+++ b/rust/types/src/spann_configuration.rs
@@ -197,7 +197,7 @@ impl Default for SpannConfiguration {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq, ToSchema)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, Validate, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct UpdateSpannConfiguration {


### PR DESCRIPTION
## Description of changes

Previously, the go code did not update the configuration str for collections because it was not passed as part of `generateCollectionUpdatesWithoutID`

This was fixed, and tests were added. It also cleans up the existing go types, and updates the rust types to use a similar InternalCollectionConfiguration for updates.



## Test plan

_How are these changes tested?_

Tests were added to validate that both the modify worked, and on future fetches maintains the values. Db tests were also added to the dao

- [x ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
