### PR TITLE
[CLN]  Remove the the top most spammy log lines from rls/wal3.

### DIFF
--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -381,7 +381,6 @@ impl GrpcLog {
     }
 
     // ScoutLogs returns the offset of the next record to be inserted into the log.
-    #[tracing::instrument(skip(self))]
     pub(super) async fn scout_logs(
         &mut self,
         tenant: &str,
@@ -406,7 +405,6 @@ impl GrpcLog {
         Ok(scout.first_uninserted_record_offset as u64)
     }
 
-    #[tracing::instrument(skip(self))]
     pub(super) async fn read(
         &mut self,
         tenant: &str,

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -385,7 +385,7 @@ impl GrpcLog {
         &mut self,
         tenant: &str,
         collection_id: CollectionUuid,
-        start_from: u64,
+        _start_from: u64,
     ) -> Result<u64, Box<dyn ChromaError>> {
         let mut client = self
             .client_for(tenant, collection_id)

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -683,7 +683,6 @@ impl Manifest {
     }
 
     /// Load the latest manifest from object storage.
-    #[tracing::instrument(skip(storage))]
     pub async fn load(
         options: &ThrottleOptions,
         storage: &Storage,


### PR DESCRIPTION
## Description of changes

This change solely removes log lines that generate the most spans
without adding sufficient information.

## Test plan

CI

## Documentation Changes

N/A
