### PR TITLE
[CHORE] Add pprof server to query service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9754,6 +9754,7 @@ dependencies = [
  "chroma-distance",
  "chroma-error",
  "chroma-index",
+ "chroma-jemalloc-pprof-server",
  "chroma-log",
  "chroma-memberlist",
  "chroma-segment",

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.49
+version: 0.1.50
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -89,6 +89,10 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
+            {{ if .Values.queryService.jemallocConfig }}
+            - name: _RJEM_MALLOC_CONF
+              value: {{ .Values.queryService.jemallocConfig}}
+            {{ end }}
             - name: CHROMA_QUERY_SERVICE__MY_MEMBER_ID
               valueFrom:
                 fieldRef:

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -79,6 +79,9 @@ spec:
             {{ end }}
           ports:
             - containerPort: 50051
+            - containerPort: 6060
+              protocol: TCP
+              name: pprof
           env:
             {{if .Values.queryService.configuration}}
             - name: CONFIG_PATH

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -24,6 +24,7 @@ queryService:
       value: 'value: "1"'
     - name: CONFIG_PATH
       value: 'value: "/tilt_config.yaml"'
+  jemallocConfig: "prof:true,prof_active:true,lg_prof_sample:19"
 
 compactionService:
   env:

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -61,7 +61,7 @@ pub async fn garbage_collector_service_entrypoint() -> Result<(), Box<dyn std::e
         info!("Starting jemalloc pprof server on port {}", port);
         let shutdown_channel = tokio::sync::oneshot::channel();
         pprof_shutdown_tx = Some(shutdown_channel.0);
-        spawn_pprof_server(6060, shutdown_channel.1).await;
+        spawn_pprof_server(port, shutdown_channel.1).await;
     }
 
     let tracing_layers = vec![

--- a/rust/worker/Cargo.toml
+++ b/rust/worker/Cargo.toml
@@ -57,6 +57,7 @@ chroma-storage = { workspace = true }
 chroma-system = { workspace = true }
 chroma-sysdb = { workspace = true }
 chroma-types = { workspace = true }
+chroma-jemalloc-pprof-server = { workspace = true }
 
 fastrace = "0.7"
 fastrace-opentelemetry = "0.8"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -82,6 +82,7 @@ query_service:
                 name: "hnsw_cache"
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
+    jemalloc_pprof_server_port: 6060
 
 compaction_service:
     service_name: "compaction-service"

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -82,7 +82,6 @@ query_service:
                 name: "hnsw_cache"
                 capacity: 8589934592 # 8GB
         permitted_parallelism: 180
-    jemalloc_pprof_server_port: 6060
 
 compaction_service:
     service_name: "compaction-service"

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -1,5 +1,12 @@
 use worker::query_service_entrypoint;
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[tokio::main]
 async fn main() {
     query_service_entrypoint().await;

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -135,6 +135,8 @@ pub struct QueryServiceConfig {
     pub hnsw_provider: chroma_index::config::HnswProviderConfig,
     #[serde(default = "QueryServiceConfig::default_fetch_log_batch_size")]
     pub fetch_log_batch_size: u32,
+    #[serde(default)]
+    pub jemalloc_pprof_server_port: Option<u16>,
 }
 
 impl QueryServiceConfig {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -3,6 +3,7 @@ use chroma_blockstore::provider::BlockfileProvider;
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
 use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::SpannMetrics};
+use chroma_jemalloc_pprof_server::spawn_pprof_server;
 use chroma_log::Log;
 use chroma_segment::spann_provider::SpannProvider;
 use chroma_storage::Storage;
@@ -45,6 +46,7 @@ pub struct WorkerServer {
     hnsw_index_provider: HnswIndexProvider,
     blockfile_provider: BlockfileProvider,
     port: u16,
+    jemalloc_pprof_server_port: Option<u16>,
     // config
     fetch_log_batch_size: u32,
 }
@@ -77,6 +79,7 @@ impl Configurable<(QueryServiceConfig, System)> for WorkerServer {
             hnsw_index_provider,
             blockfile_provider,
             port: config.my_port,
+            jemalloc_pprof_server_port: config.jemalloc_pprof_server_port,
             fetch_log_batch_size: config.fetch_log_batch_size,
         })
     }
@@ -92,6 +95,15 @@ impl WorkerServer {
         let server = Server::builder()
             .add_service(health_service)
             .add_service(QueryExecutorServer::new(worker.clone()));
+
+        // Start pprof server
+        let mut pprof_shutdown_tx = None;
+        if let Some(port) = worker.jemalloc_pprof_server_port {
+            tracing::info!("Starting jemalloc pprof server on port {}", port);
+            let shutdown_channel = tokio::sync::oneshot::channel();
+            pprof_shutdown_tx = Some(shutdown_channel.0);
+            spawn_pprof_server(port, shutdown_channel.1).await;
+        }
 
         #[cfg(debug_assertions)]
         let server = server.add_service(
@@ -127,6 +139,11 @@ impl WorkerServer {
         });
 
         server.await?;
+
+        // Shutdown pprof server after server is finished shutting down
+        if let Some(shutdown_tx) = pprof_shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
 
         Ok(())
     }
@@ -492,6 +509,7 @@ mod tests {
             hnsw_index_provider: segments.hnsw_provider,
             blockfile_provider: segments.blockfile_provider,
             port,
+            jemalloc_pprof_server_port: None,
             fetch_log_batch_size: 100,
         };
 


### PR DESCRIPTION
## Description of changes

Similar to what we did in #4845, this adds the jemalloc pprof server to the query-service server so that we can do memory profiling for the service using Polar Signals.

Note: I also updated a place in the garbage collector's implementation where the port was hard-coded to 6060. 

- New functionality
  - pprof server started when config given

## Test plan

Build should succeed and updating `chroma_config.yaml` with local tilt environment to test that pprof endpoint is up.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
