### PR TITLE
[CHORE]: enable change notifier otel/tracing

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -38,6 +38,7 @@ pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
                 "wal3",
                 "worker",
                 "continuous_verification",
+                "change_notifier",
             ]
             .into_iter()
             .map(|s| s.to_string() + "=trace")


### PR DESCRIPTION
## Description of changes

Enables otel/tracing for the change notifier service.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
