### PR TITLE
[ENH]: Dedup inserts to the same key in foyer

### DIFF
--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -14,7 +14,7 @@ use crate::{
     Value,
 };
 use async_trait::async_trait;
-use chroma_cache::{CacheError, PersistentCache};
+use chroma_cache::{AysncPartitionedMutex, CacheError, PersistentCache};
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::{
@@ -355,6 +355,7 @@ pub struct BlockManager {
     storage: Storage,
     default_max_block_size_bytes: usize,
     block_metrics: BlockMetrics,
+    cache_mutex: AysncPartitionedMutex<Uuid>,
 }
 
 impl BlockManager {
@@ -369,6 +370,7 @@ impl BlockManager {
             storage,
             default_max_block_size_bytes,
             block_metrics: BlockMetrics::default(),
+            cache_mutex: AysncPartitionedMutex::new(()),
         }
     }
 
@@ -456,8 +458,20 @@ impl BlockManager {
                             deserialization_span.in_scope(|| Block::from_bytes(&bytes, *id));
                         match block {
                             Ok(block) => {
-                                self.block_cache.insert(*id, block.clone()).await;
-                                Ok(Some(block))
+                                let _guard = self.cache_mutex.lock(id).await;
+                                match self.block_cache.obtain(*id).await {
+                                    Ok(Some(b)) => {
+                                        Ok(Some(b))
+                                    }
+                                    Ok(None) => {
+                                        self.block_cache.insert(*id, block.clone()).await;
+                                        Ok(Some(block))
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("Error getting block from cache {:?}", e);
+                                        Err(GetError::BlockLoadError(e.into()))
+                                    }
+                                }
                             }
                             Err(e) => {
                                 tracing::error!(


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Dedups inserts to the same key in foyer. This should prevent buffer overflows
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes
None
