### PR TITLE
[CHORE]: hide private service names in otel/tracing init

### DIFF
--- a/rust/cli/src/commands/run.rs
+++ b/rust/cli/src/commands/run.rs
@@ -118,7 +118,14 @@ pub fn run(args: RunArgs) -> Result<(), CliError> {
 
     let runtime = tokio::runtime::Runtime::new().map_err(|_| RunError::ServerStartFailed)?;
     runtime.block_on(async {
-        frontend_service_entrypoint_with_config(Arc::new(()), Arc::new(()), &config, true).await;
+        frontend_service_entrypoint_with_config(
+            "chroma-frontend=trace",
+            Arc::new(()),
+            Arc::new(()),
+            &config,
+            true,
+        )
+        .await;
     });
     Ok(())
 }

--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -359,7 +359,14 @@ pub async fn standup_local_chroma(
 ) -> Result<(AdminClient, JoinHandle<()>), CliError> {
     let host = format!("http://localhost:{}", config.port);
     let handle = spawn(async move {
-        frontend_service_entrypoint_with_config(Arc::new(()), Arc::new(()), &config, true).await;
+        frontend_service_entrypoint_with_config(
+            "chroma-frontend=trace",
+            Arc::new(()),
+            Arc::new(()),
+            &config,
+            true,
+        )
+        .await;
     });
     let admin_client = AdminClient::local(host);
     admin_client

--- a/rust/frontend/src/bin/frontend_service.rs
+++ b/rust/frontend/src/bin/frontend_service.rs
@@ -3,5 +3,11 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    frontend_service_entrypoint(Arc::new(()) as _, Arc::new(()) as _, true).await;
+    frontend_service_entrypoint(
+        "chroma-frontend=trace",
+        Arc::new(()) as _,
+        Arc::new(()) as _,
+        true,
+    )
+    .await;
 }

--- a/rust/garbage_collector/src/lib.rs
+++ b/rust/garbage_collector/src/lib.rs
@@ -65,7 +65,7 @@ pub async fn garbage_collector_service_entrypoint() -> Result<(), Box<dyn std::e
     }
 
     let tracing_layers = vec![
-        init_global_filter_layer(),
+        init_global_filter_layer("garbage_collector=debug"),
         init_otel_layer(&config.service_name, &config.otel_endpoint),
         init_stdout_layer(),
     ];

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2496,7 +2496,11 @@ pub async fn log_entrypoint() {
     let registry = chroma_config::registry::Registry::new();
     if let Some(otel_config) = &config.opentelemetry {
         eprintln!("enabling tracing");
-        chroma_tracing::init_otel_tracing(&otel_config.service_name, &otel_config.endpoint);
+        chroma_tracing::init_otel_tracing(
+            &otel_config.service_name,
+            "chroma-log-service=trace",
+            &otel_config.endpoint,
+        );
     } else {
         eprintln!("tracing disabled");
     }

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -12,40 +12,37 @@ use tracing_subscriber::fmt;
 use tracing_subscriber::Registry;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
-pub fn init_global_filter_layer() -> Box<dyn Layer<Registry> + Send + Sync> {
-    EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| {
-        "error,opentelemetry_sdk=info,garbage_collector=debug,chroma_storage=debug,".to_string()
-            + &vec![
-                "chroma",
-                "chroma-blockstore",
-                "chroma-config",
-                "chroma-cache",
-                "chroma-distance",
-                "chroma-error",
-                "chroma-log",
-                "chroma-log-service",
-                "chroma-frontend",
-                "chroma-index",
-                "chroma-test",
-                "chroma-types",
-                "compaction_service",
-                "distance_metrics",
-                "full_text",
-                "hosted_frontend",
-                "billing",
-                "metadata_filtering",
-                "query_service",
-                "wal3",
-                "worker",
-                "continuous_verification",
-                "change_notifier",
-            ]
-            .into_iter()
-            .map(|s| s.to_string() + "=trace")
-            .collect::<Vec<String>>()
-            .join(",")
-    }))
-    .boxed()
+pub fn init_global_filter_layer(crate_filters: &str) -> Box<dyn Layer<Registry> + Send + Sync> {
+    let default_crate_names = vec![
+        "chroma",
+        "chroma-blockstore",
+        "chroma-config",
+        "chroma-cache",
+        "chroma-distance",
+        "chroma-error",
+        "chroma-log",
+        "chroma-index",
+        "chroma-test",
+        "chroma-types",
+        "compaction_service",
+        "distance_metrics",
+        "full_text",
+        "metadata_filtering",
+        "query_service",
+        "wal3",
+    ];
+
+    let global_filter = format!(
+        "error,opentelemetry_sdk=info,chroma_storage=debug,{default_crate_filters},{additional_crate_filters}",
+        default_crate_filters = default_crate_names
+            .iter()
+            .map(|s| format!("{s}=trace"))
+            .collect::<Vec<_>>()
+            .join(","),
+            additional_crate_filters = crate_filters,
+    );
+
+    EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(|_| global_filter)).boxed()
 }
 
 pub fn init_otel_layer(
@@ -165,9 +162,9 @@ pub fn init_panic_tracing_hook() {
     }));
 }
 
-pub fn init_otel_tracing(service_name: &String, otel_endpoint: &String) {
+pub fn init_otel_tracing(service_name: &String, crate_filters: &str, otel_endpoint: &String) {
     let layers = vec![
-        init_global_filter_layer(),
+        init_global_filter_layer(crate_filters),
         init_otel_layer(service_name, otel_endpoint),
         init_stdout_layer(),
     ];

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -35,7 +35,7 @@ pub async fn query_service_entrypoint() {
     let config = config.query_service;
     let registry = Registry::new();
 
-    chroma_tracing::init_otel_tracing(&config.service_name, &config.otel_endpoint);
+    chroma_tracing::init_otel_tracing(&config.service_name, "worker=trace", &config.otel_endpoint);
 
     let system = chroma_system::System::new();
     let dispatcher =
@@ -100,7 +100,7 @@ pub async fn compaction_service_entrypoint() {
     let config = config.compaction_service;
     let registry = Registry::new();
 
-    chroma_tracing::init_otel_tracing(&config.service_name, &config.otel_endpoint);
+    chroma_tracing::init_otel_tracing(&config.service_name, "worker=trace", &config.otel_endpoint);
 
     let system = chroma_system::System::new();
 


### PR DESCRIPTION
## Description of changes

Currently, the OSS code is responsible for initializing tracing/otel for all crates. A global filter is applied in which for all crates that initialize tracing, every filter is applied for that crate. This PR slightly refactors this pattern to define a set of "global default crate filters" and allow initializers to pass in additional crate filters (and even overrides) at their call sites.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

N/A
