### PR TITLE
[CLN] Clean up configuration docs for spann, add max on search_nprobe

### DIFF
--- a/rust/types/src/spann_configuration.rs
+++ b/rust/types/src/spann_configuration.rs
@@ -93,6 +93,7 @@ impl ChromaError for DistributedSpannParametersFromSegmentError {
 #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq, ToSchema)]
 pub struct InternalSpannConfiguration {
     #[serde(default = "default_search_nprobe")]
+    #[validate(range(max = 128))]
     pub search_nprobe: u32,
     #[serde(default = "default_search_rng_factor")]
     pub search_rng_factor: f32,


### PR DESCRIPTION
## Description of changes

This PR updates the docs for spann configuration to reflect the default values, and ranges supported by the system. It also adds a max value on search_nprobe that was not previously defined.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
