### PR TITLE
Improve data chunk

### DIFF
--- a/rust/types/src/data_chunk.rs
+++ b/rust/types/src/data_chunk.rs
@@ -82,20 +82,20 @@ impl<T> Chunk<T> {
     /// The iterator returns a tuple of the element and its index
     /// # Returns
     /// An iterator over the visible elements in the data chunk
-    pub fn iter(&self) -> DataChunkIteraror<'_, T> {
-        DataChunkIteraror {
+    pub fn iter(&self) -> DataChunkIterator<'_, T> {
+        DataChunkIterator {
             chunk: self,
             index: 0,
         }
     }
 }
 
-pub struct DataChunkIteraror<'a, T> {
+pub struct DataChunkIterator<'a, T> {
     chunk: &'a Chunk<T>,
     index: usize,
 }
 
-impl<'a, T> Iterator for DataChunkIteraror<'a, T> {
+impl<'a, T> Iterator for DataChunkIterator<'a, T> {
     type Item = (&'a T, usize);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rust/types/src/data_chunk.rs
+++ b/rust/types/src/data_chunk.rs
@@ -1,18 +1,9 @@
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chunk<T> {
     data: Arc<[T]>,
     visibility: Arc<[bool]>,
-}
-
-impl<T> Clone for Chunk<T> {
-    fn clone(&self) -> Self {
-        Chunk {
-            data: self.data.clone(),
-            visibility: self.visibility.clone(),
-        }
-    }
 }
 
 impl<T> Chunk<T> {


### PR DESCRIPTION
* Replaced the manual implementation of `Clone` for `Chunk<T>` with `#[derive(Clone)]` so the struct relies on the automatic, efficient clone implementation provided for `Arc` types
* Fixed a typo in `DataChunkIterator`