### PR TITLE
[CHORE]: Fix s3 get metric name

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -57,7 +57,7 @@ pub struct StorageMetrics {
 impl Default for StorageMetrics {
     fn default() -> Self {
         Self {
-            s3_get_count: opentelemetry::global::meter("chroma.storage.s3")
+            s3_get_count: opentelemetry::global::meter("chroma.storage")
                 .u64_counter("s3_get_count")
                 .with_description("Number of S3 get operations")
                 .build(),


### PR DESCRIPTION
## Description of changes

Changing the name of the s3 get metric from `chroma.storage.s3.s3_get_foo` to be. a nicer `chroma.storage.s3_get_foo`.

- Improvements & Bug fixes
  - N/A
- New functionality
  - N/A

## Test plan
N/A

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
