### PR TITLE
[CHORE] Add pprof server to compaction service

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.50
+version: 0.1.51
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -59,6 +59,9 @@ spec:
             {{ end }}
           ports:
             - containerPort: 50051
+            - containerPort: 6060
+              protocol: TCP
+              name: pprof
           env:
             {{if .Values.compactionService.configuration}}
             - name: CONFIG_PATH
@@ -68,6 +71,10 @@ spec:
             - name: {{ .name }}
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
+            {{ end }}
+            {{ if .Values.compactionService.jemallocConfig }}
+            - name: _RJEM_MALLOC_CONF
+              value: {{ .Values.compactionService.jemallocConfig }}
             {{ end }}
             - name: CHROMA_COMPACTION_SERVICE__MY_MEMBER_ID
               valueFrom:

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -94,7 +94,7 @@ spec:
             {{ end }}
             {{ if .Values.queryService.jemallocConfig }}
             - name: _RJEM_MALLOC_CONF
-              value: {{ .Values.queryService.jemallocConfig}}
+              value: {{ .Values.queryService.jemallocConfig }}
             {{ end }}
             - name: CHROMA_QUERY_SERVICE__MY_MEMBER_ID
               valueFrom:

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -32,6 +32,7 @@ compactionService:
       value: 'value: "1"'
     - name: CONFIG_PATH
       value: 'value: "/tilt_config.yaml"'
+  jemallocConfig: "prof:true,prof_active:true,lg_prof_sample:19"
 
 rustLogService:
   replicaCount: 1

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -1,84 +1,82 @@
 # Default values for distributed-chroma.
 # Strongly prefer single quotes.
 
-namespace: 'chroma'
+namespace: "chroma"
 
 rustFrontendService:
   image:
-    repository: 'rust-frontend-service'
-    tag: 'latest'
+    repository: "rust-frontend-service"
+    tag: "latest"
   replicaCount: 1
   resources:
     limits:
-      cpu: '2000m'
-      memory: '1Gi'
+      cpu: "2000m"
+      memory: "1Gi"
     requests:
-      cpu: '1000m'
-      memory: '512Mi'
+      cpu: "1000m"
+      memory: "512Mi"
 
 sysdb:
   image:
-    repository: 'sysdb'
-    tag: 'latest'
+    repository: "sysdb"
+    tag: "latest"
   replicaCount: 1
   env:
-  - name: OPTL_TRACING_ENDPOINT
-    value: 'value: "jaeger:4317"'
+    - name: OPTL_TRACING_ENDPOINT
+      value: 'value: "jaeger:4317"'
   resources:
     limits:
-      cpu: '2000m'
-      memory: '1Gi'
+      cpu: "2000m"
+      memory: "1Gi"
     requests:
-      cpu: '1000m'
-      memory: '512Mi'
+      cpu: "1000m"
+      memory: "512Mi"
   flags:
-
 
 logService:
   image:
-    repository: 'logservice'
-    tag: 'latest'
+    repository: "logservice"
+    tag: "latest"
   env:
-  - name: OPTL_TRACING_ENDPOINT
-    value: 'value: "otel-collector:4317"'
-  - name: SYSDB_CONN
-    value: 'value: "sysdb.chroma:50051"'
+    - name: OPTL_TRACING_ENDPOINT
+      value: 'value: "otel-collector:4317"'
+    - name: SYSDB_CONN
+      value: 'value: "sysdb.chroma:50051"'
   flags:
   replicaCount: 1
 
-
 rustLogService:
   image:
-    repository: 'rust-log-service'
-    tag: 'latest'
+    repository: "rust-log-service"
+    tag: "latest"
   cache:
-    hostPath: '/local/cache/chroma-log-service'
-    mountPath: '/cache/'
+    hostPath: "/local/cache/chroma-log-service"
+    mountPath: "/cache/"
 
 queryService:
   image:
-    repository: 'query-service'
-    tag: 'latest'
+    repository: "query-service"
+    tag: "latest"
   env:
   cache:
-    hostPath: '/local/cache/chroma-query-service'
-    mountPath: '/cache/'
+    hostPath: "/local/cache/chroma-query-service"
+    mountPath: "/cache/"
   replicaCount: 2
 
 compactionService:
   image:
-    repository: 'compaction-service'
-    tag: 'latest'
+    repository: "compaction-service"
+    tag: "latest"
   env:
   cache:
-    hostPath: '/local/cache/chroma-compaction-service'
-    mountPath: '/cache/'
+    hostPath: "/local/cache/chroma-compaction-service"
+    mountPath: "/cache/"
   replicaCount: 1
 
 sysdbMigration:
   image:
-    repository: 'sysdb-migration'
-    tag: 'latest'
+    repository: "sysdb-migration"
+    tag: "latest"
   username: chroma
   password: chroma
   netloc: postgres
@@ -88,28 +86,28 @@ sysdbMigration:
 
 logServiceMigration:
   image:
-    repository: 'logservice-migration'
-    tag: 'latest'
+    repository: "logservice-migration"
+    tag: "latest"
   env:
-  - name: CHROMA_DB_LOG_URL
-    value: 'value: "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log?sslmode=disable"'
+    - name: CHROMA_DB_LOG_URL
+      value: 'value: "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log?sslmode=disable"'
 
 # Add the garbage collector configuration
 garbageCollector:
   image:
-    repository: 'garbage-collector'
-    tag: 'latest'
+    repository: "garbage-collector"
+    tag: "latest"
   replicaCount: 1
   resources:
     limits:
-      cpu: '200m'
-      memory: '256Mi'
+      cpu: "200m"
+      memory: "256Mi"
     requests:
-      cpu: '100m'
-      memory: '128Mi'
+      cpu: "100m"
+      memory: "128Mi"
   cache:
-    hostPath: '/local/cache/chroma-garbage-collector'
-    mountPath: '/cache/'
+    hostPath: "/local/cache/chroma-garbage-collector"
+    mountPath: "/cache/"
   configuration: |
     service_name: "garbage-collector"
     otel_endpoint: "http://otel-collector:4317"

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -1,82 +1,84 @@
 # Default values for distributed-chroma.
 # Strongly prefer single quotes.
 
-namespace: "chroma"
+namespace: 'chroma'
 
 rustFrontendService:
   image:
-    repository: "rust-frontend-service"
-    tag: "latest"
+    repository: 'rust-frontend-service'
+    tag: 'latest'
   replicaCount: 1
   resources:
     limits:
-      cpu: "2000m"
-      memory: "1Gi"
+      cpu: '2000m'
+      memory: '1Gi'
     requests:
-      cpu: "1000m"
-      memory: "512Mi"
+      cpu: '1000m'
+      memory: '512Mi'
 
 sysdb:
   image:
-    repository: "sysdb"
-    tag: "latest"
+    repository: 'sysdb'
+    tag: 'latest'
   replicaCount: 1
   env:
-    - name: OPTL_TRACING_ENDPOINT
-      value: 'value: "jaeger:4317"'
+  - name: OPTL_TRACING_ENDPOINT
+    value: 'value: "jaeger:4317"'
   resources:
     limits:
-      cpu: "2000m"
-      memory: "1Gi"
+      cpu: '2000m'
+      memory: '1Gi'
     requests:
-      cpu: "1000m"
-      memory: "512Mi"
+      cpu: '1000m'
+      memory: '512Mi'
   flags:
+
 
 logService:
   image:
-    repository: "logservice"
-    tag: "latest"
+    repository: 'logservice'
+    tag: 'latest'
   env:
-    - name: OPTL_TRACING_ENDPOINT
-      value: 'value: "otel-collector:4317"'
-    - name: SYSDB_CONN
-      value: 'value: "sysdb.chroma:50051"'
+  - name: OPTL_TRACING_ENDPOINT
+    value: 'value: "otel-collector:4317"'
+  - name: SYSDB_CONN
+    value: 'value: "sysdb.chroma:50051"'
   flags:
   replicaCount: 1
 
+
 rustLogService:
   image:
-    repository: "rust-log-service"
-    tag: "latest"
+    repository: 'rust-log-service'
+    tag: 'latest'
   cache:
-    hostPath: "/local/cache/chroma-log-service"
-    mountPath: "/cache/"
+    hostPath: '/local/cache/chroma-log-service'
+    mountPath: '/cache/'
 
 queryService:
   image:
-    repository: "query-service"
-    tag: "latest"
+    repository: 'query-service'
+    tag: 'latest'
   env:
   cache:
-    hostPath: "/local/cache/chroma-query-service"
-    mountPath: "/cache/"
+    hostPath: '/local/cache/chroma-query-service'
+    mountPath: '/cache/'
   replicaCount: 2
 
 compactionService:
   image:
-    repository: "compaction-service"
-    tag: "latest"
+    repository: 'compaction-service'
+    tag: 'latest'
   env:
   cache:
-    hostPath: "/local/cache/chroma-compaction-service"
-    mountPath: "/cache/"
+    hostPath: '/local/cache/chroma-compaction-service'
+    mountPath: '/cache/'
   replicaCount: 1
 
 sysdbMigration:
   image:
-    repository: "sysdb-migration"
-    tag: "latest"
+    repository: 'sysdb-migration'
+    tag: 'latest'
   username: chroma
   password: chroma
   netloc: postgres
@@ -86,28 +88,28 @@ sysdbMigration:
 
 logServiceMigration:
   image:
-    repository: "logservice-migration"
-    tag: "latest"
+    repository: 'logservice-migration'
+    tag: 'latest'
   env:
-    - name: CHROMA_DB_LOG_URL
-      value: 'value: "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log?sslmode=disable"'
+  - name: CHROMA_DB_LOG_URL
+    value: 'value: "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log?sslmode=disable"'
 
 # Add the garbage collector configuration
 garbageCollector:
   image:
-    repository: "garbage-collector"
-    tag: "latest"
+    repository: 'garbage-collector'
+    tag: 'latest'
   replicaCount: 1
   resources:
     limits:
-      cpu: "200m"
-      memory: "256Mi"
+      cpu: '200m'
+      memory: '256Mi'
     requests:
-      cpu: "100m"
-      memory: "128Mi"
+      cpu: '100m'
+      memory: '128Mi'
   cache:
-    hostPath: "/local/cache/chroma-garbage-collector"
-    mountPath: "/cache/"
+    hostPath: '/local/cache/chroma-garbage-collector'
+    mountPath: '/cache/'
   configuration: |
     service_name: "garbage-collector"
     otel_endpoint: "http://otel-collector:4317"

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chroma_jemalloc_pprof_server::spawn_pprof_server;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     compactor_server::{Compactor, CompactorServer},
@@ -18,6 +19,7 @@ use super::{CompactionManager, RebuildMessage};
 pub struct CompactionServer {
     pub manager: ComponentHandle<CompactionManager>,
     pub port: u16,
+    pub jemalloc_pprof_server_port: Option<u16>,
 }
 
 impl CompactionServer {
@@ -42,9 +44,19 @@ impl CompactionServer {
             .send(RegisterOnReadySignal { on_ready_tx }, None)
             .await?;
 
+        // Start pprof server
+        let mut pprof_shutdown_tx = None;
+        if let Some(port) = self.jemalloc_pprof_server_port.clone() {
+            tracing::info!("Starting jemalloc pprof server on port {}", port);
+            let shutdown_channel = tokio::sync::oneshot::channel();
+            pprof_shutdown_tx = Some(shutdown_channel.0);
+            spawn_pprof_server(port, shutdown_channel.1).await;
+        }
+
         let server = Server::builder()
             .add_service(health_service)
             .add_service(CompactorServer::new(self));
+
         server
             .serve_with_shutdown(addr, async {
                 match signal(SignalKind::terminate()) {
@@ -58,6 +70,12 @@ impl CompactionServer {
                 }
             })
             .await?;
+
+        // Shutdown pprof server after server is finished shutting down
+        if let Some(shutdown_tx) = pprof_shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
+
         Ok(())
     }
 }

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -202,6 +202,8 @@ pub struct CompactionServiceConfig {
     pub hnsw_provider: chroma_index::config::HnswProviderConfig,
     #[serde(default)]
     pub spann_provider: chroma_index::config::SpannProviderConfig,
+    #[serde(default)]
+    pub jemalloc_pprof_server_port: Option<u16>,
 }
 
 impl CompactionServiceConfig {

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -148,6 +148,7 @@ pub async fn compaction_service_entrypoint() {
     let compaction_server = CompactionServer {
         manager: compaction_manager_handle.clone(),
         port: config.my_port,
+        jemalloc_pprof_server_port: config.jemalloc_pprof_server_port,
     };
 
     let server_join_handle = tokio::spawn(async move {

--- a/rust/worker/tests/config_from_default_path.rs
+++ b/rust/worker/tests/config_from_default_path.rs
@@ -78,6 +78,7 @@ fn test_config_from_default_path() {
                 otel_endpoint: "http://jaeger:4317"
                 my_member_id: "compaction-service-0"
                 my_port: 50051
+                jemalloc_pprof_server_port: 6060
                 assignment_policy:
                     rendezvous_hashing:
                         hasher: Murmur3
@@ -161,6 +162,10 @@ fn test_config_from_default_path() {
             "compaction-service-0"
         );
         assert_eq!(config.compaction_service.my_port, 50051);
+        assert_eq!(
+            config.compaction_service.jemalloc_pprof_server_port,
+            Some(6060)
+        );
         assert_eq!(
             config
                 .compaction_service

--- a/rust/worker/tests/config_from_specific_path.rs
+++ b/rust/worker/tests/config_from_specific_path.rs
@@ -76,6 +76,7 @@ fn test_config_from_specific_path() {
                 otel_endpoint: "http://jaeger:4317"
                 my_member_id: "compaction-service-0"
                 my_port: 50051
+                jemalloc_pprof_server_port: 6060
                 assignment_policy:
                     rendezvous_hashing:
                         hasher: Murmur3
@@ -161,6 +162,10 @@ fn test_config_from_specific_path() {
             "compaction-service-0"
         );
         assert_eq!(config.compaction_service.my_port, 50051);
+        assert_eq!(
+            config.compaction_service.jemalloc_pprof_server_port,
+            Some(6060)
+        );
         assert!(
             config
                 .compaction_service

--- a/rust/worker/tests/config_with_env_override.rs
+++ b/rust/worker/tests/config_with_env_override.rs
@@ -14,6 +14,10 @@ fn test_config_with_env_override() {
             "compaction-service-0",
         );
         jail.set_env("CHROMA_COMPACTION_SERVICE__MY_PORT", 50051);
+        jail.set_env(
+            "CHROMA_COMPACTION_SERVICE__JEMALLOC_PPROF_SERVER_PORT",
+            6060,
+        );
         jail.set_env("CHROMA_COMPACTION_SERVICE__STORAGE__S3__BUCKET", "buckets!");
         jail.set_env("CHROMA_COMPACTION_SERVICE__STORAGE__S3__CREDENTIALS", "AWS");
         jail.set_env(
@@ -156,6 +160,7 @@ fn test_config_with_env_override() {
         let config = RootConfig::load();
         assert_eq!(config.query_service.my_member_id, "query-service-0");
         assert_eq!(config.query_service.my_port, 50051);
+        assert_eq!(config.query_service.jemalloc_pprof_server_port, Some(6060));
         assert_eq!(
             config.compaction_service.my_member_id,
             "compaction-service-0"

--- a/rust/worker/tests/config_without_cache_directive.rs
+++ b/rust/worker/tests/config_without_cache_directive.rs
@@ -71,6 +71,7 @@ fn test_config_without_cache_directive() {
                 otel_endpoint: "http://jaeger:4317"
                 my_member_id: "compaction-service-0"
                 my_port: 50051
+                jemalloc_pprof_server_port: 6060
                 assignment_policy:
                     rendezvous_hashing:
                         hasher: Murmur3
@@ -135,6 +136,7 @@ fn test_config_without_cache_directive() {
         let config = RootConfig::load_from_path("random_path.yaml");
         assert_eq!(config.query_service.my_member_id, "query-service-0");
         assert_eq!(config.query_service.my_port, 50051);
+        assert_eq!(config.query_service.jemalloc_pprof_server_port, Some(6060));
 
         assert_eq!(
             config.compaction_service.my_member_id,


### PR DESCRIPTION
## Description of changes

Similar to what we did in https://github.com/chroma-core/chroma/pull/4845 and #5072, this adds the jemalloc pprof server to the compaction-service server so that we can do memory profiling for the service using Polar Signals.

- New functionality
  - pprof server started when config given

## Test plan

Build should succeed and updating chroma_config.yaml with local tilt environment to test that pprof endpoint is up.
