### PR TITLE
Fix typo AysncPartitionedMutex -> AsyncPartitionedMutex

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -11,7 +11,7 @@ use crate::arrow::root::CURRENT_VERSION;
 use crate::arrow::sparse_index::SparseIndexWriter;
 use crate::key::CompositeKey;
 use crate::key::KeyWrapper;
-use chroma_cache::AysncPartitionedMutex;
+use chroma_cache::AsyncPartitionedMutex;
 use chroma_error::ChromaError;
 use chroma_error::ErrorCodes;
 use chroma_storage::admissioncontrolleds3::StorageRequestPriority;
@@ -32,7 +32,7 @@ pub struct ArrowUnorderedBlockfileWriter {
     block_deltas: Arc<Mutex<HashMap<Uuid, UnorderedBlockDelta>>>,
     root: RootWriter,
     id: Uuid,
-    deltas_mutex: Arc<AysncPartitionedMutex<Uuid>>,
+    deltas_mutex: Arc<AsyncPartitionedMutex<Uuid>>,
 }
 // TODO: method visibility should not be pub(crate)
 
@@ -86,7 +86,7 @@ impl ArrowUnorderedBlockfileWriter {
             block_deltas,
             root: root_writer,
             id,
-            deltas_mutex: Arc::new(AysncPartitionedMutex::new(())),
+            deltas_mutex: Arc::new(AsyncPartitionedMutex::new(())),
         }
     }
 
@@ -105,7 +105,7 @@ impl ArrowUnorderedBlockfileWriter {
             block_deltas,
             root: new_root,
             id,
-            deltas_mutex: Arc::new(AysncPartitionedMutex::new(())),
+            deltas_mutex: Arc::new(AsyncPartitionedMutex::new(())),
         }
     }
 
@@ -809,7 +809,7 @@ mod tests {
         arrow::config::TEST_MAX_BLOCK_SIZE_BYTES, arrow::provider::ArrowBlockfileProvider,
     };
     use crate::{BlockfileReader, BlockfileWriter, BlockfileWriterOptions};
-    use chroma_cache::{new_cache_for_test, AysncPartitionedMutex};
+    use chroma_cache::{new_cache_for_test, AsyncPartitionedMutex};
     use chroma_storage::{local::LocalStorage, Storage};
     use chroma_types::{CollectionUuid, DataRecord, DatabaseUuid, MetadataValue, SegmentUuid};
     use futures::{StreamExt, TryStreamExt};
@@ -2236,7 +2236,7 @@ mod tests {
             block_deltas,
             root: root_writer,
             id: Uuid::new_v4(),
-            deltas_mutex: Arc::new(AysncPartitionedMutex::new(())),
+            deltas_mutex: Arc::new(AsyncPartitionedMutex::new(())),
         };
 
         let n = 2000;

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -14,7 +14,7 @@ use crate::{
     Value,
 };
 use async_trait::async_trait;
-use chroma_cache::{AysncPartitionedMutex, CacheError, PersistentCache};
+use chroma_cache::{AsyncPartitionedMutex, CacheError, PersistentCache};
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::{
@@ -355,7 +355,7 @@ pub struct BlockManager {
     storage: Storage,
     default_max_block_size_bytes: usize,
     block_metrics: BlockMetrics,
-    cache_mutex: AysncPartitionedMutex<Uuid>,
+    cache_mutex: AsyncPartitionedMutex<Uuid>,
 }
 
 impl BlockManager {
@@ -370,7 +370,7 @@ impl BlockManager {
             storage,
             default_max_block_size_bytes,
             block_metrics: BlockMetrics::default(),
-            cache_mutex: AysncPartitionedMutex::new(()),
+            cache_mutex: AsyncPartitionedMutex::new(()),
         }
     }
 

--- a/rust/cache/src/async_partitioned_mutex.rs
+++ b/rust/cache/src/async_partitioned_mutex.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[derive(Clone, Debug)]
-pub struct AysncPartitionedMutex<K, V = (), H = DefaultHasher>
+pub struct AsyncPartitionedMutex<K, V = (), H = DefaultHasher>
 where
     K: Hash + Eq,
     H: Hasher + Default,
@@ -21,7 +21,7 @@ where
 // TODO: A sensible value for this.
 const DEFAULT_NUM_PARTITIONS: usize = 32768;
 
-impl<K, V, H> AysncPartitionedMutex<K, V, H>
+impl<K, V, H> AsyncPartitionedMutex<K, V, H>
 where
     K: Hash + Eq,
     H: Hasher + Default,

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -1,5 +1,5 @@
 use backon::ConstantBuilder;
-use chroma_cache::{AysncPartitionedMutex, Cache, CacheError, Weighted};
+use chroma_cache::{AsyncPartitionedMutex, Cache, CacheError, Weighted};
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
@@ -67,7 +67,7 @@ impl Configurable<CollectionsWithSegmentsProviderConfig> for CollectionsWithSegm
         >(&config.cache)
         .await?;
         let sysdb_rpc_lock =
-            AysncPartitionedMutex::with_parallelism(config.permitted_parallelism as usize, ());
+            AsyncPartitionedMutex::with_parallelism(config.permitted_parallelism as usize, ());
 
         let retry_backoff = ConstantBuilder::default()
             .with_delay(Duration::from_millis(
@@ -108,7 +108,7 @@ pub struct CollectionsWithSegmentsProvider {
     pub(crate) collections_with_segments_cache:
         Arc<dyn Cache<CollectionUuid, CollectionAndSegmentsWithTtl>>,
     pub(crate) cache_ttl_secs: u32,
-    pub(crate) sysdb_rpc_lock: chroma_cache::AysncPartitionedMutex<CollectionUuid>,
+    pub(crate) sysdb_rpc_lock: chroma_cache::AsyncPartitionedMutex<CollectionUuid>,
     pub(crate) retry_backoff: ConstantBuilder,
 }
 

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -4,7 +4,7 @@ use super::config::HnswProviderConfig;
 use super::{HnswIndex, HnswIndexConfig, Index, IndexConfig, IndexUuid};
 
 use async_trait::async_trait;
-use chroma_cache::AysncPartitionedMutex;
+use chroma_cache::AsyncPartitionedMutex;
 use chroma_cache::Cache;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
@@ -54,7 +54,7 @@ pub struct HnswIndexProvider {
     cache: Arc<dyn Cache<CollectionUuid, HnswIndexRef>>,
     pub temporary_storage_path: PathBuf,
     storage: Storage,
-    pub write_mutex: AysncPartitionedMutex<IndexUuid>,
+    pub write_mutex: AsyncPartitionedMutex<IndexUuid>,
 }
 
 pub struct HnswIndexFlusher {
@@ -140,7 +140,7 @@ impl HnswIndexProvider {
             cache,
             storage,
             temporary_storage_path: storage_path,
-            write_mutex: AysncPartitionedMutex::with_parallelism(
+            write_mutex: AsyncPartitionedMutex::with_parallelism(
                 permitted_parallelism as usize,
                 (),
             ),

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -11,7 +11,7 @@ use chroma_blockstore::{
     provider::{BlockfileProvider, CreateError, OpenError},
     BlockfileFlusher, BlockfileReader, BlockfileWriter, BlockfileWriterOptions,
 };
-use chroma_cache::AysncPartitionedMutex;
+use chroma_cache::AsyncPartitionedMutex;
 use chroma_config::{registry::Registry, Configurable};
 use chroma_distance::{normalize, DistanceFunction};
 use chroma_error::{ChromaError, ErrorCodes};
@@ -288,7 +288,7 @@ pub struct SpannIndexWriter {
     blockfile_provider: BlockfileProvider,
     // Posting list of the centroids.
     pub posting_list_writer: BlockfileWriter,
-    pub posting_list_partitioned_mutex: Arc<AysncPartitionedMutex<u32>>,
+    pub posting_list_partitioned_mutex: Arc<AsyncPartitionedMutex<u32>>,
     pub next_head_id: Arc<AtomicU32>,
     // Version number of each point.
     // TODO(Sanket): Finer grained locking for this map in future if perf is not satisfactory.
@@ -431,7 +431,7 @@ impl SpannIndexWriter {
             hnsw_provider,
             blockfile_provider,
             posting_list_writer,
-            posting_list_partitioned_mutex: Arc::new(AysncPartitionedMutex::new(())),
+            posting_list_partitioned_mutex: Arc::new(AsyncPartitionedMutex::new(())),
             next_head_id: Arc::new(AtomicU32::new(next_head_id)),
             versions_map: Arc::new(tokio::sync::RwLock::new(versions_map)),
             dimensionality,


### PR DESCRIPTION
I found another typo in the Rust codebase. Fixed across six files.