### PR TITLE
[ENH]: Leader election for SysDB

### DIFF
--- a/go/cmd/logservice/main.go
+++ b/go/cmd/logservice/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net"
 
+	"github.com/chroma-core/chroma/go/pkg/leader"
 	"github.com/chroma-core/chroma/go/pkg/log/configuration"
-	"github.com/chroma-core/chroma/go/pkg/log/leader"
 	"github.com/chroma-core/chroma/go/pkg/log/metrics"
 	"github.com/chroma-core/chroma/go/pkg/log/purging"
 	"github.com/chroma-core/chroma/go/pkg/log/repository"

--- a/go/pkg/memberlist_manager/memberlist_manager.go
+++ b/go/pkg/memberlist_manager/memberlist_manager.go
@@ -2,8 +2,8 @@ package memberlist_manager
 
 import (
 	"context"
-	"time"
 	"sort"
+	"time"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
 	"github.com/pingcap/log"

--- a/k8s/distributed-chroma/templates/lease-watcher-role.yaml
+++ b/k8s/distributed-chroma/templates/lease-watcher-role.yaml
@@ -1,0 +1,13 @@
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Values.namespace }}
+  name: lease-watcher
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "create", "watch", "update", "delete"]
+
+---

--- a/k8s/distributed-chroma/templates/logservice.yaml
+++ b/k8s/distributed-chroma/templates/logservice.yaml
@@ -88,14 +88,3 @@ subjects:
 - kind: ServiceAccount
   name: logservice-serviceaccount
   namespace: {{ .Values.namespace }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: {{ .Values.namespace }}
-  name: lease-watcher
-rules:
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "create", "watch", "update", "delete"]

--- a/k8s/distributed-chroma/templates/sysdb-service.yaml
+++ b/k8s/distributed-chroma/templates/sysdb-service.yaml
@@ -26,6 +26,14 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           image: "{{ .Values.sysdb.image.repository }}:{{ .Values.sysdb.image.tag }}"
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -84,3 +92,16 @@ subjects:
   namespace: {{ .Values.namespace }}
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sysdb-serviceaccount-lease-watcher-binding
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lease-watcher
+subjects:
+- kind: ServiceAccount
+  name: sysdb-serviceaccount
+  namespace: {{ .Values.namespace }}


### PR DESCRIPTION
## Description of changes

This change introduces leader election in the SysDB service in preparation to scale out this layer. After this change, only the leader monitors and updates the member list. Not that the leader election in question just reuses the Kubernetes leader election API so it is not strongly consistent and can lead to split-brain scenarios. These split-brain scenarios are not harmful here.

Since this change reuses the leader election code that's already in the log service, that code has been moved out of the log service directory.

- Improvements & Bug fixes
  - Gated member list service operations by a leader election.
- New functionality
  - Described above. This should enable the SysDB service to scale out.

## Test plan

Observing log statements on local tilt.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A. Before scaling out the SysDB layer, make sure this change is in the SysDB binary.

## Observability plan

N/A

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
