### PR TITLE
[BLD]: add workspaces option to reusable Rust action

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -4,6 +4,9 @@ inputs:
   github-token:
     description: "GitHub token"
     required: false
+  workspaces:
+    description: "Workspace paths to cache (see documentation on Swatinem/rust-cache for details)"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -29,5 +32,7 @@ runs:
         repo-token: ${{ inputs.github-token }}
     - name: Set up cache
       uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: ${{ inputs.workspaces }}
     - name: Setup Nextest
       uses: taiki-e/install-action@nextest


### PR DESCRIPTION
## Description of changes

We use this Rust setup action in private repos with multiple Cargo workspaces. The cache is currently not utalized in these cases because the workspace paths need to be specified to the cache action. This allows callers to provide a list of workspaces that is forwarded to the cache action.

## Test plan

_How are these changes tested?_

I observed that the Rust cache is still used in this repo for the checks that ran on this PR.