### PR TITLE
[CHORE]: update tracing filters to use underscores instead of hyphens

### DIFF
--- a/bin/rust_single_node_integration_test_config.yaml
+++ b/bin/rust_single_node_integration_test_config.yaml
@@ -13,5 +13,5 @@ open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"
   filters:
-    - crate_name: "chroma-frontend"
+    - crate_name: "chroma_frontend"
       filter_level: "trace"

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -4,7 +4,7 @@ open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"
   filters:
-    - crate_name: "chroma-frontend"
+    - crate_name: "chroma_frontend"
       filter_level: "trace"  
 sysdb:
   grpc:

--- a/rust/frontend/sample_configs/single_node_full.yaml
+++ b/rust/frontend/sample_configs/single_node_full.yaml
@@ -5,7 +5,7 @@ open_telemetry:
   service_name: "chroma"
   endpoint: "http://otel-collector:4317"
   filters:
-    - crate_name: "chroma-frontend"
+    - crate_name: "chroma_frontend"
       filter_level: "trace"  
 port: 8000
 listen_address: "0.0.0.0"

--- a/rust/frontend/sample_configs/tilt_config.yaml
+++ b/rust/frontend/sample_configs/tilt_config.yaml
@@ -4,7 +4,7 @@ open_telemetry:
   service_name: "rust-frontend-service"
   endpoint: "http://otel-collector:4317"
   filters:
-    - crate_name: "chroma-frontend"
+    - crate_name: "chroma_frontend"
       filter_level: "trace"  
 sysdb:
   grpc:

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -97,7 +97,7 @@ fn default_otel_service_name() -> String {
 
 fn default_otel_filters() -> Vec<OtelFilter> {
     vec![OtelFilter {
-        crate_name: "chroma-frontend".to_string(),
+        crate_name: "chroma_frontend".to_string(),
         filter_level: OtelFilterLevel::Trace,
     }]
 }

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2293,7 +2293,7 @@ fn default_otel_service_name() -> String {
 
 fn default_otel_filters() -> Vec<OtelFilter> {
     vec![OtelFilter {
-        crate_name: "chroma-log-service".to_string(),
+        crate_name: "chroma_log_service".to_string(),
         filter_level: OtelFilterLevel::Trace,
     }]
 }

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -43,18 +43,21 @@ pub struct OtelFilter {
 pub fn init_global_filter_layer(
     custom_filters: &[OtelFilter],
 ) -> Box<dyn Layer<Registry> + Send + Sync> {
+    // These need to have underscores because the Rust compiler automatically
+    // converts all hyphens in crate names to underscores to make them valid
+    // Rust identifiers
     let default_crate_names = vec![
         "chroma",
-        "chroma-blockstore",
-        "chroma-config",
-        "chroma-cache",
-        "chroma-distance",
-        "chroma-error",
-        "chroma-log",
-        "chroma-log-service",
-        "chroma-index",
-        "chroma-test",
-        "chroma-types",
+        "chroma_blockstore",
+        "chroma_config",
+        "chroma_cache",
+        "chroma_distance",
+        "chroma_error",
+        "chroma_log",
+        "chroma_log-service",
+        "chroma_index",
+        "chroma_test",
+        "chroma_types",
         "compaction_service",
         "distance_metrics",
         "full_text",

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -176,7 +176,7 @@ log_service:
         service_name: "rust-log-service"
         endpoint: "http://otel-collector:4317"
         filters:
-            - crate_name: "chroma-log"
+            - crate_name: "chroma_log"
               filter_level: "trace" 
             - crate_name: "wal3"
               filter_level: "trace"                  

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -182,7 +182,7 @@ log_service:
         service_name: "rust-log-service"
         endpoint: "http://otel-collector:4317"
         filters:
-            - crate_name: "chroma-log"
+            - crate_name: "chroma_log"
               filter_level: "trace" 
             - crate_name: "wal3"
               filter_level: "trace"        


### PR DESCRIPTION
## Description of changes

The tracing issues we've been chasing boil down to a _fun_ little quirk of Rust compiler, in which hyphens in crate names are converted to underscores automatically to make the crate names valid Rust identifiers.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

Monitor staging to make sure missing traces start to reappear.

## Documentation Changes

N/A
