### PR TITLE
[ENH]: bump GC delete batch size from 100 -> 1,000

### DIFF
--- a/rust/garbage_collector/src/operators/delete_unused_files.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_files.rs
@@ -124,7 +124,8 @@ impl Operator<DeleteUnusedFilesInput, DeleteUnusedFilesOutput> for DeleteUnusedF
             CleanupMode::Delete | CleanupMode::DeleteV2 => {
                 // Hard delete - remove the file
                 if !all_files.is_empty() {
-                    for chunk in all_files.chunks(100) {
+                    // The S3 DeleteObjects API allows up to 1000 objects per request
+                    for chunk in all_files.chunks(1000) {
                         let result = self.storage.delete_many(chunk).await?;
                         if !result.errors.is_empty() {
                             // Log the errors but don't fail the operation


### PR DESCRIPTION
## Description of changes

Cumulatively, this operation is very slow in production. Hoping that increasing the batch size to the maximum will speed it up.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
