### PR TITLE
[BUG]: Bump helm chart version

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.52
+version: 0.1.53
 appVersion: "0.4.24"
 keywords:
   - chroma


### PR DESCRIPTION
## Description of changes

Bump helm chart. This should have been done as a part [of](https://github.com/chroma-core/chroma/pull/5104).

## Test plan

N/A

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
N/A

## Observability plan

N/A

## Documentation Changes

N/A