### PR TITLE
[ENH]: Propagate cancellation to all spawned Tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ serde_json = "1.0.133"
 setsum = "0.7"
 tantivy = "0.22.0"
 thiserror = "1.0.69"
-tokio = { version = "1.41", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.41", features = ["fs", "macros", "rt-multi-thread", "time", "io-util"] }
 tokio-util = "0.7.12"
 tonic = "0.12"
 tonic-health = "0.12.3"

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -222,7 +222,9 @@ impl GarbageCollector {
             }),
             (),
             ctx.receiver(),
+            ctx.cancellation_token.clone(),
         );
+
         if let Err(err) = dispatcher
             .send(truncate_dirty_log_task, Some(Span::current()))
             .await

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -38,7 +38,7 @@ use chroma_storage::Storage;
 use chroma_sysdb::{GetCollectionsOptions, SysDb};
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    PanicError, System, TaskError, TaskResult,
+    OrchestratorContext, PanicError, System, TaskError, TaskResult,
 };
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
 use chroma_types::{CollectionUuid, DeleteCollectionError};
@@ -60,7 +60,7 @@ pub struct GarbageCollectorOrchestrator {
     version_absolute_cutoff_time: DateTime<Utc>,
     collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
     sysdb_client: SysDb,
-    dispatcher: ComponentHandle<Dispatcher>,
+    context: OrchestratorContext,
     system: System,
     storage: Storage,
     logs: Log,
@@ -111,7 +111,7 @@ impl GarbageCollectorOrchestrator {
             version_absolute_cutoff_time,
             collection_soft_delete_absolute_cutoff_time,
             sysdb_client,
-            dispatcher,
+            context: OrchestratorContext::new(dispatcher),
             system,
             storage,
             logs,
@@ -209,7 +209,11 @@ impl Orchestrator for GarbageCollectorOrchestrator {
     type Error = GarbageCollectorError;
 
     fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
-        self.dispatcher.clone()
+        self.context.dispatcher.clone()
+    }
+
+    fn context(&self) -> &OrchestratorContext {
+        &self.context
     }
 
     async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
@@ -322,6 +326,7 @@ impl GarbageCollectorOrchestrator {
                 min_versions_to_keep: self.min_versions_to_keep,
             },
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
 
         self.dispatcher()
@@ -400,6 +405,7 @@ impl GarbageCollectorOrchestrator {
                     oldest_version_to_keep: 0,
                 },
                 ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
             );
             self.dispatcher()
                 .send(mark_deleted_versions_task, Some(Span::current()))
@@ -415,6 +421,7 @@ impl GarbageCollectorOrchestrator {
                         *version,
                     ),
                     ctx.receiver(),
+                    self.context.task_cancellation_token.clone(),
                 );
 
                 self.dispatcher()
@@ -526,6 +533,7 @@ impl GarbageCollectorOrchestrator {
                 collections_to_garbage_collect,
             },
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         self.dispatcher()
             .send(task, Some(Span::current()))
@@ -736,6 +744,7 @@ impl GarbageCollectorOrchestrator {
                 hnsw_prefixes_for_deletion: vec![],
             },
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         self.dispatcher()
             .send(task, Some(Span::current()))
@@ -853,6 +862,7 @@ impl GarbageCollectorOrchestrator {
                     unused_s3_files: output.deleted_files.clone(),
                 },
                 ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
             );
 
             self.dispatcher()

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -423,7 +423,12 @@ mod tests {
                 .map(char::from)
                 .collect();
             println!("Scheduling mock io operator with filename {}", filename);
-            let task = wrap(Box::new(MockIoOperator {}), filename, ctx.receiver());
+            let task = wrap(
+                Box::new(MockIoOperator {}),
+                filename,
+                ctx.receiver(),
+                ctx.cancellation_token.clone(),
+            );
             let task_id = task.id();
             self.sent_tasks.lock().insert(task_id);
             let _res = self.dispatcher.send(task, None).await;
@@ -479,7 +484,12 @@ mod tests {
 
         async fn handle(&mut self, _message: (), ctx: &ComponentContext<MockDispatchUser>) {
             println!("Scheduling mock cpu operator with input {}", 42.0);
-            let task = wrap(Box::new(MockOperator {}), 42.0, ctx.receiver());
+            let task = wrap(
+                Box::new(MockOperator {}),
+                42.0,
+                ctx.receiver(),
+                ctx.cancellation_token.clone(),
+            );
             let task_id = task.id();
             self.sent_tasks.lock().insert(task_id);
             let _res = self.dispatcher.send(task, None).await;

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -4,6 +4,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 use futures::FutureExt;
 use std::{any::type_name, fmt::Debug, panic::AssertUnwindSafe};
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 pub enum OperatorType {
@@ -32,6 +33,10 @@ where
     /// By default operators will log an error event if their sender is dropped when sending the result.
     /// This is not always desired, e.g. when creating a "fire-and-forget" operator (data prefetching); so this method can be overridden to return false.
     fn errors_when_sender_dropped(&self) -> bool {
+        true
+    }
+
+    fn can_cancel(&self) -> bool {
         true
     }
 }
@@ -101,38 +106,16 @@ where
     reply_channel: Box<dyn ReceiverForMessage<TaskResult<Output, Error>>>,
     task_id: Uuid,
     task_state: TaskState,
+    cancellation_token: Option<CancellationToken>,
 }
 
-/// A message type used by the dispatcher to send tasks to worker threads.
-pub type TaskMessage = Box<dyn TaskWrapper>;
-
-/// A task wrapper is a trait that can be used to run a task. We use it to
-/// erase the I, O types from the Task struct so that tasks.
-#[async_trait]
-pub trait TaskWrapper: Send + Debug {
-    fn get_name(&self) -> &'static str;
-    async fn run(&mut self);
-    #[allow(dead_code)]
-    fn id(&self) -> Uuid;
-    fn get_type(&self) -> OperatorType;
-    async fn abort(&mut self);
-}
-
-/// Implement the TaskWrapper trait for every Task. This allows us to
-/// erase the I, O types from the Task struct so that tasks can be
-/// stored in a homogenous queue regardless of their input and output types.
-#[async_trait]
-impl<Input, Output, Error> TaskWrapper for Task<Input, Output, Error>
+impl<Input, Output, Error> Task<Input, Output, Error>
 where
-    Error: Debug + Send + ChromaError,
     Input: Send + Sync + Debug,
     Output: Send + Sync + Debug,
+    Error: Debug + Send + ChromaError,
 {
-    fn get_name(&self) -> &'static str {
-        self.operator.get_name()
-    }
-
-    async fn run(&mut self) {
+    async fn main_run(&mut self) {
         if self.task_state != TaskState::NotStarted {
             tracing::error!(
                 "Task {} is already running or has already finished",
@@ -214,6 +197,49 @@ where
             }
         };
     }
+}
+
+/// A message type used by the dispatcher to send tasks to worker threads.
+pub type TaskMessage = Box<dyn TaskWrapper>;
+
+/// A task wrapper is a trait that can be used to run a task. We use it to
+/// erase the I, O types from the Task struct so that tasks.
+#[async_trait]
+pub trait TaskWrapper: Send + Debug {
+    fn get_name(&self) -> &'static str;
+    async fn run(&mut self);
+    #[allow(dead_code)]
+    fn id(&self) -> Uuid;
+    fn get_type(&self) -> OperatorType;
+    async fn abort(&mut self);
+}
+
+/// Implement the TaskWrapper trait for every Task. This allows us to
+/// erase the I, O types from the Task struct so that tasks can be
+/// stored in a homogenous queue regardless of their input and output types.
+#[async_trait]
+impl<Input, Output, Error> TaskWrapper for Task<Input, Output, Error>
+where
+    Error: Debug + Send + ChromaError,
+    Input: Send + Sync + Debug,
+    Output: Send + Sync + Debug,
+{
+    fn get_name(&self) -> &'static str {
+        self.operator.get_name()
+    }
+
+    async fn run(&mut self) {
+        let cancellation_token = self.cancellation_token.clone();
+        match cancellation_token {
+            Some(token) => {
+                tokio::select! {
+                    _ = token.cancelled() => { self.abort().await; }
+                    _ = self.main_run() => {}
+                }
+            }
+            None => self.main_run().await,
+        }
+    }
 
     fn id(&self) -> Uuid {
         self.task_id
@@ -224,13 +250,6 @@ where
     }
 
     async fn abort(&mut self) {
-        if self.task_state != TaskState::NotStarted {
-            tracing::error!(
-                "Task {} is already running or has already finished",
-                self.task_id
-            );
-            return;
-        }
         self.task_state = TaskState::Aborted;
         match self
             .reply_channel
@@ -268,6 +287,7 @@ pub fn wrap<Input, Output, Error>(
     operator: Box<dyn Operator<Input, Output, Error = Error>>,
     input: Input,
     reply_channel: Box<dyn ReceiverForMessage<TaskResult<Output, Error>>>,
+    cancellation_token: CancellationToken,
 ) -> TaskMessage
 where
     Error: ChromaError + Debug + Send + 'static,
@@ -275,12 +295,18 @@ where
     Output: Send + Sync + Debug + 'static,
 {
     let id = Uuid::new_v4();
+    let mut token = Some(cancellation_token);
+
+    if !operator.can_cancel() {
+        token = None;
+    }
     Box::new(Task {
         operator,
         input,
         reply_channel,
         task_id: id,
         task_state: TaskState::NotStarted,
+        cancellation_token: token,
     })
 }
 
@@ -330,7 +356,12 @@ mod tests {
         }
 
         async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
-            let task = wrap(Box::new(MockOperator {}), (), ctx.receiver());
+            let task = wrap(
+                Box::new(MockOperator {}),
+                (),
+                ctx.receiver(),
+                ctx.cancellation_token.clone(),
+            );
             self.dispatcher.send(task, None).await.unwrap();
         }
     }

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -1,12 +1,38 @@
-use crate::{ChannelError, Component, ComponentContext, ComponentHandle, PanicError, System};
+use crate::{
+    ChannelError, CleanupGuard, Component, ComponentContext, ComponentHandle, PanicError, System,
+};
 use async_trait::async_trait;
 use chroma_error::ChromaError;
 use core::fmt::Debug;
 use std::any::type_name;
 use tokio::sync::oneshot::{self, error::RecvError, Sender};
+use tokio_util::sync::CancellationToken;
 use tracing::Span;
 
 use crate::{Dispatcher, TaskMessage};
+
+#[derive(Debug)]
+pub struct OrchestratorContext {
+    pub dispatcher: ComponentHandle<Dispatcher>,
+
+    // Used to cancel all spawned tasks.
+    pub task_cancellation_token: CancellationToken,
+}
+
+impl OrchestratorContext {
+    pub fn new(dispatcher: ComponentHandle<Dispatcher>) -> Self {
+        Self {
+            dispatcher,
+            task_cancellation_token: CancellationToken::new(),
+        }
+    }
+}
+
+impl Drop for OrchestratorContext {
+    fn drop(&mut self) {
+        self.task_cancellation_token.cancel();
+    }
+}
 
 #[async_trait]
 pub trait Orchestrator: Debug + Send + Sized + 'static {
@@ -15,6 +41,8 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
 
     /// Returns the handle of the dispatcher
     fn dispatcher(&self) -> ComponentHandle<Dispatcher>;
+
+    fn context(&self) -> &OrchestratorContext;
 
     /// Returns a vector of starting tasks that should be run in sequence
     async fn initial_tasks(
@@ -39,8 +67,11 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
         let (tx, rx) = oneshot::channel();
         self.set_result_channel(tx);
         let mut handle = system.start_component(self);
+
+        // We want to let the orchestrator clean up even if this future is dropped before
+        // the orchestrator is finished.
+        let _cleanup_guard = CleanupGuard::new(move || handle.stop());
         let res = rx.await;
-        handle.stop();
         res?
     }
 
@@ -97,9 +128,7 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     ) {
         self.cleanup().await;
         let cancel = if let Err(err) = &res {
-            if err.should_trace_error() {
-                tracing::error!("Error running {}: {}", Self::name(), err);
-            }
+            tracing::error!("Error running {}: {}", Self::name(), err);
             true
         } else {
             false
@@ -158,5 +187,214 @@ impl<O: Orchestrator> Component for O {
         if channel.send(Err(O::Error::from(error))).is_err() {
             tracing::error!("Error reporting panic to {}", Self::name());
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        execution::operator::{wrap, Operator, TaskResult},
+        types::Handler,
+        DispatcherConfig, ReceiverForMessage,
+    };
+    use async_trait::async_trait;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    #[derive(Debug)]
+    struct SleepingOperator {}
+
+    #[async_trait]
+    impl Operator<(), ()> for SleepingOperator {
+        type Error = TestError;
+
+        async fn run(&self, _: &()) -> Result<(), Self::Error> {
+            // Sleep forever (or until cancelled)
+            sleep(Duration::MAX).await;
+            unreachable!("Should've been sleeping!")
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestOrchestrator {
+        context: OrchestratorContext,
+        result_channel: Option<Sender<Result<(), TestError>>>,
+        num_tasks: usize,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    enum TestError {
+        #[error("Channel error: {0}")]
+        Channel(#[from] ChannelError),
+        #[error("Panic: {0}")]
+        Panic(#[from] PanicError),
+        #[error("Recv error: {0}")]
+        Recv(#[from] RecvError),
+        #[error("IO error: {0}")]
+        Io(#[from] std::io::Error),
+    }
+
+    impl ChromaError for TestError {
+        fn code(&self) -> chroma_error::ErrorCodes {
+            chroma_error::ErrorCodes::Internal
+        }
+    }
+
+    impl TestOrchestrator {
+        fn new(dispatcher: ComponentHandle<Dispatcher>, num_tasks: usize) -> Self {
+            Self {
+                context: OrchestratorContext::new(dispatcher),
+                result_channel: None,
+                num_tasks,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Handler<TaskResult<(), TestError>> for TestOrchestrator {
+        type Result = ();
+
+        async fn handle(
+            &mut self,
+            message: TaskResult<(), TestError>,
+            _ctx: &ComponentContext<Self>,
+        ) -> Self::Result {
+            // We expect these to be cancelled, so we ignore the results
+            let _ = message;
+        }
+    }
+
+    #[async_trait]
+    impl Orchestrator for TestOrchestrator {
+        type Output = ();
+        type Error = TestError;
+
+        fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
+            self.context.dispatcher.clone()
+        }
+
+        fn context(&self) -> &OrchestratorContext {
+            &self.context
+        }
+
+        async fn initial_tasks(
+            &mut self,
+            ctx: &ComponentContext<Self>,
+        ) -> Vec<(TaskMessage, Option<Span>)> {
+            let mut tasks = Vec::new();
+            for _ in 0..self.num_tasks {
+                let operator = SleepingOperator {};
+                let task = wrap(
+                    Box::new(operator),
+                    (),
+                    ctx.receiver(),
+                    self.context.task_cancellation_token.clone(),
+                );
+                tasks.push((task, None));
+            }
+            tasks
+        }
+
+        fn set_result_channel(&mut self, sender: Sender<Result<Self::Output, Self::Error>>) {
+            self.result_channel = Some(sender);
+        }
+
+        fn take_result_channel(&mut self) -> Sender<Result<Self::Output, Self::Error>> {
+            self.result_channel
+                .take()
+                .expect("Result channel should be set")
+        }
+    }
+
+    #[derive(Debug)]
+    struct SimpleOperator {}
+
+    #[async_trait]
+    impl Operator<(), ()> for SimpleOperator {
+        type Error = TestError;
+
+        async fn run(&self, _: &()) -> Result<(), Self::Error> {
+            // Sleep forever (or until cancelled)
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestReceiver<M> {
+        sender: tokio::sync::mpsc::Sender<M>,
+    }
+
+    // Cannot automatically derive, see https://github.com/rust-lang/rust/issues/26925
+    impl<M> Clone for TestReceiver<M> {
+        fn clone(&self) -> Self {
+            TestReceiver {
+                sender: self.sender.clone(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl<M: Debug + Send + 'static> ReceiverForMessage<M> for TestReceiver<M> {
+        async fn send(
+            &self,
+            message: M,
+            _: Option<tracing::Span>,
+        ) -> Result<(), crate::ChannelError> {
+            self.sender
+                .send(message)
+                .await
+                .map_err(|_| crate::ChannelError::SendError)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_operator_cancellation() {
+        let system = System::new();
+        let num_workers = 2;
+
+        // Create a dispatcher with a small number of worker threads
+        let dispatcher = Dispatcher::new(DispatcherConfig {
+            num_worker_threads: num_workers,
+            task_queue_limit: 1,
+            dispatcher_queue_size: 1,
+            worker_queue_size: 1,
+            active_io_tasks: 10,
+        });
+        let dispatcher_handle = system.start_component(dispatcher);
+
+        let orchestrator = TestOrchestrator::new(dispatcher_handle.clone(), 2);
+
+        // Run the orchestrator with a timeout - this should cancel all tasks
+        let res = timeout(Duration::from_secs(1), orchestrator.run(system.clone())).await;
+        match res {
+            Err(_) => {}
+            _ => panic!("Orchestrator should have timed out"),
+        }
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<TaskResult<(), TestError>>(2);
+        let test_receiver: Box<dyn ReceiverForMessage<TaskResult<(), TestError>>> =
+            Box::new(TestReceiver { sender: tx });
+        let task = wrap(
+            Box::new(SimpleOperator {}),
+            (),
+            test_receiver,
+            CancellationToken::new(),
+        );
+
+        // Check dispatcher state through a request
+        println!("Checking dispatcher state");
+        let _ = dispatcher_handle.request(task, None).await;
+        match rx.recv().await.unwrap().into_inner() {
+            Ok(_) => {}
+            Err(err) => panic!(
+                "Task should have finished - workers should be cancelled {:?}",
+                err
+            ),
+        }
+
+        // Stop the system and verify cleanup
+        system.stop().await;
+        system.join().await;
     }
 }

--- a/rust/system/src/utils/guard.rs
+++ b/rust/system/src/utils/guard.rs
@@ -1,0 +1,24 @@
+pub struct CleanupGuard<F>
+where
+    F: FnMut(),
+{
+    cleanup_fn: F,
+}
+
+impl<F> CleanupGuard<F>
+where
+    F: FnMut(),
+{
+    pub fn new(cleanup_fn: F) -> Self {
+        Self { cleanup_fn }
+    }
+}
+
+impl<F> Drop for CleanupGuard<F>
+where
+    F: FnMut(),
+{
+    fn drop(&mut self) {
+        (self.cleanup_fn)();
+    }
+}

--- a/rust/system/src/utils/mod.rs
+++ b/rust/system/src/utils/mod.rs
@@ -1,3 +1,7 @@
 pub mod panic;
 
 pub use panic::*;
+
+pub mod guard;
+
+pub use guard::*;

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -216,6 +216,7 @@ impl CompactionManager {
             Box::new(purge_dirty_log),
             purge_dirty_log_input,
             ctx.receiver(),
+            ctx.cancellation_token.clone(),
         );
         let Some(mut dispatcher) = self.context.dispatcher.clone() else {
             tracing::error!("Unable to create background task to purge dirty log: Dispatcher is not set for compaction manager");

--- a/rust/worker/src/execution/operators/prefetch_record.rs
+++ b/rust/worker/src/execution/operators/prefetch_record.rs
@@ -95,6 +95,10 @@ impl Operator<PrefetchRecordInput, PrefetchRecordOutput> for PrefetchRecordOpera
         false
     }
 
+    fn can_cancel(&self) -> bool {
+        false
+    }
+
     fn get_type(&self) -> OperatorType {
         OperatorType::IO
     }

--- a/rust/worker/src/execution/operators/prefetch_segment.rs
+++ b/rust/worker/src/execution/operators/prefetch_segment.rs
@@ -104,6 +104,10 @@ impl Operator<PrefetchSegmentInput, PrefetchSegmentOutput> for PrefetchSegmentOp
     fn errors_when_sender_dropped(&self) -> bool {
         false
     }
+
+    fn can_cancel(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -26,7 +26,7 @@ use chroma_segment::{
 use chroma_sysdb::SysDb;
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    PanicError, TaskError, TaskMessage, TaskResult,
+    OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
     Chunk, Collection, CollectionUuid, LogRecord, SegmentFlushInfo, SegmentType, SegmentUuid,
@@ -112,10 +112,10 @@ pub struct CompactOrchestrator {
     max_partition_size: usize,
 
     // Dependencies
-    dispatcher: ComponentHandle<Dispatcher>,
+    context: OrchestratorContext,
+    blockfile_provider: BlockfileProvider,
     log: Log,
     sysdb: SysDb,
-    blockfile_provider: BlockfileProvider,
     hnsw_provider: HnswIndexProvider,
     spann_provider: SpannProvider,
 
@@ -232,6 +232,7 @@ impl CompactOrchestrator {
         dispatcher: ComponentHandle<Dispatcher>,
         result_channel: Option<Sender<Result<CompactionResponse, CompactionError>>>,
     ) -> Self {
+        let context = OrchestratorContext::new(dispatcher);
         CompactOrchestrator {
             collection_id,
             hnsw_index_uuid: None,
@@ -239,10 +240,10 @@ impl CompactOrchestrator {
             fetch_log_batch_size,
             max_compaction_size,
             max_partition_size,
-            dispatcher,
+            context,
+            blockfile_provider,
             log,
             sysdb,
-            blockfile_provider,
             hnsw_provider,
             spann_provider,
             collection: OnceCell::new(),
@@ -274,7 +275,12 @@ impl CompactOrchestrator {
         let operator = PartitionOperator::new();
         tracing::info!("Sending N Records: {:?}", records.len());
         let input = PartitionInput::new(records, self.max_partition_size);
-        let task = wrap(operator, input, ctx.receiver());
+        let task = wrap(
+            operator,
+            input,
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         self.send(task, ctx, Some(Span::current())).await;
     }
 
@@ -306,7 +312,12 @@ impl CompactOrchestrator {
                 record_reader.clone(),
                 next_max_offset_id.clone(),
             );
-            let task = wrap(operator, input, ctx.receiver());
+            let task = wrap(
+                operator,
+                input,
+                ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
+            );
             self.send(task, ctx, Some(Span::current())).await;
         }
     }
@@ -337,7 +348,12 @@ impl CompactOrchestrator {
                 materialized_logs.clone(),
                 writers.record_reader.clone(),
             );
-            let task = wrap(operator, input, ctx.receiver());
+            let task = wrap(
+                operator,
+                input,
+                ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
+            );
             let res = self.dispatcher().send(task, Some(span)).await;
             if self.ok_or_terminate(res, ctx).await.is_none() {
                 return;
@@ -360,7 +376,12 @@ impl CompactOrchestrator {
                 materialized_logs.clone(),
                 writers.record_reader.clone(),
             );
-            let task = wrap(operator, input, ctx.receiver());
+            let task = wrap(
+                operator,
+                input,
+                ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
+            );
             let res = self.dispatcher().send(task, Some(span)).await;
             if self.ok_or_terminate(res, ctx).await.is_none() {
                 return;
@@ -380,7 +401,12 @@ impl CompactOrchestrator {
             let operator = ApplyLogToSegmentWriterOperator::new();
             let input =
                 ApplyLogToSegmentWriterInput::new(writer, materialized_logs, writers.record_reader);
-            let task = wrap(operator, input, ctx.receiver());
+            let task = wrap(
+                operator,
+                input,
+                ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
+            );
             let res = self.dispatcher().send(task, Some(span)).await;
             self.ok_or_terminate(res, ctx).await;
         }
@@ -394,7 +420,12 @@ impl CompactOrchestrator {
         let span = self.get_segment_writer_span(&segment_writer);
         let operator = CommitSegmentWriterOperator::new();
         let input = CommitSegmentWriterInput::new(segment_writer);
-        let task = wrap(operator, input, ctx.receiver());
+        let task = wrap(
+            operator,
+            input,
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         let res = self.dispatcher().send(task, Some(span)).await;
         self.ok_or_terminate(res, ctx).await;
     }
@@ -407,7 +438,12 @@ impl CompactOrchestrator {
         let span = self.get_segment_flusher_span(&segment_flusher);
         let operator = FlushSegmentWriterOperator::new();
         let input = FlushSegmentWriterInput::new(segment_flusher);
-        let task = wrap(operator, input, ctx.receiver());
+        let task = wrap(
+            operator,
+            input,
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         let res = self.dispatcher().send(task, Some(span)).await;
         self.ok_or_terminate(res, ctx).await;
     }
@@ -457,7 +493,12 @@ impl CompactOrchestrator {
             self.log.clone(),
         );
 
-        let task = wrap(operator, input, ctx.receiver());
+        let task = wrap(
+            operator,
+            input,
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         self.send(task, ctx, Some(Span::current())).await;
     }
 
@@ -531,7 +572,11 @@ impl Orchestrator for CompactOrchestrator {
     type Error = CompactionError;
 
     fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
-        self.dispatcher.clone()
+        self.context.dispatcher.clone()
+    }
+
+    fn context(&self) -> &OrchestratorContext {
+        &self.context
     }
 
     async fn initial_tasks(
@@ -546,6 +591,7 @@ impl Orchestrator for CompactOrchestrator {
                 }),
                 (),
                 ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
             ),
             Some(Span::current()),
         )]
@@ -630,6 +676,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     record_segment_reader: record_reader.clone(),
                 },
                 ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
             ),
             false => wrap(
                 Box::new(FetchLogOperator {
@@ -644,6 +691,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                 }),
                 (),
                 ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
             ),
         };
 
@@ -777,6 +825,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                 Box::new(PrefetchSegmentOperator::new()),
                 PrefetchSegmentInput::new(segment, self.blockfile_provider.clone()),
                 ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
             );
             // Prefetch task is detached from the orchestrator
             let prefetch_span =

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -3,7 +3,7 @@ use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    PanicError, TaskError, TaskMessage, TaskResult,
+    OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::CollectionAndSegments;
 use thiserror::Error;
@@ -65,10 +65,9 @@ type CountResult = Result<CountOutput, CountError>;
 #[derive(Debug)]
 pub struct CountOrchestrator {
     // Orchestrator parameters
+    context: OrchestratorContext,
     blockfile_provider: BlockfileProvider,
-    dispatcher: ComponentHandle<Dispatcher>,
     queue: usize,
-
     // Collection and segments
     collection_and_segments: CollectionAndSegments,
 
@@ -85,14 +84,15 @@ pub struct CountOrchestrator {
 impl CountOrchestrator {
     pub(crate) fn new(
         blockfile_provider: BlockfileProvider,
-        dispatcher: ComponentHandle<Dispatcher>,
+        dispatcher: chroma_system::ComponentHandle<Dispatcher>,
         queue: usize,
         collection_and_segments: CollectionAndSegments,
         fetch_log: FetchLogOperator,
     ) -> Self {
+        let context = OrchestratorContext::new(dispatcher);
         Self {
+            context,
             blockfile_provider,
-            dispatcher,
             collection_and_segments,
             queue,
             fetch_log,
@@ -108,7 +108,11 @@ impl Orchestrator for CountOrchestrator {
     type Error = CountError;
 
     fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
-        self.dispatcher.clone()
+        self.context.dispatcher.clone()
+    }
+
+    fn context(&self) -> &OrchestratorContext {
+        &self.context
     }
 
     async fn initial_tasks(
@@ -116,7 +120,12 @@ impl Orchestrator for CountOrchestrator {
         ctx: &ComponentContext<Self>,
     ) -> Vec<(TaskMessage, Option<Span>)> {
         vec![(
-            wrap(Box::new(self.fetch_log.clone()), (), ctx.receiver()),
+            wrap(
+                Box::new(self.fetch_log.clone()),
+                (),
+                ctx.receiver(),
+                self.context.task_cancellation_token.clone(),
+            ),
             Some(Span::current()),
         )]
     }
@@ -159,6 +168,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CountOrchestrator {
                 output,
             ),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         self.send(task, ctx, Some(Span::current())).await;
     }

--- a/rust/worker/src/execution/orchestration/get.rs
+++ b/rust/worker/src/execution/orchestration/get.rs
@@ -3,7 +3,7 @@ use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    PanicError, TaskError, TaskMessage, TaskResult,
+    OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
     operator::{Filter, GetResult, Limit, Projection, ProjectionOutput},
@@ -121,9 +121,9 @@ where
 #[derive(Debug)]
 pub struct GetOrchestrator {
     // Orchestrator parameters
-    blockfile_provider: BlockfileProvider,
-    dispatcher: ComponentHandle<Dispatcher>,
+    context: OrchestratorContext,
     queue: usize,
+    blockfile_provider: BlockfileProvider,
 
     // Collection segments
     collection_and_segments: CollectionAndSegments,
@@ -155,10 +155,11 @@ impl GetOrchestrator {
         limit: Limit,
         projection: Projection,
     ) -> Self {
+        let context = OrchestratorContext::new(dispatcher);
         Self {
-            blockfile_provider,
-            dispatcher,
+            context,
             queue,
+            blockfile_provider,
             collection_and_segments,
             fetch_log,
             fetched_logs: None,
@@ -176,7 +177,11 @@ impl Orchestrator for GetOrchestrator {
     type Error = GetError;
 
     fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
-        self.dispatcher.clone()
+        self.context.dispatcher.clone()
+    }
+
+    fn context(&self) -> &OrchestratorContext {
+        &self.context
     }
 
     async fn initial_tasks(
@@ -192,6 +197,7 @@ impl Orchestrator for GetOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         // Prefetch task is detached from the orchestrator
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch record segment", segment_id = %self.collection_and_segments.record_segment.id);
@@ -205,12 +211,18 @@ impl Orchestrator for GetOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch metadata segment", segment_id = %self.collection_and_segments.metadata_segment.id);
         tasks.push((prefetch_metadata_task, Some(prefetch_span)));
 
         // Fetch log task.
-        let fetch_log_task = wrap(Box::new(self.fetch_log.clone()), (), ctx.receiver());
+        let fetch_log_task = wrap(
+            Box::new(self.fetch_log.clone()),
+            (),
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         tasks.push((fetch_log_task, Some(Span::current())));
 
         tasks
@@ -269,6 +281,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for GetOrchestrator {
                 record_segment: self.collection_and_segments.record_segment.clone(),
             },
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         self.send(task, ctx, Some(Span::current())).await;
     }
@@ -301,6 +314,7 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for GetOrchestrator {
                 compact_offset_ids: output.compact_offset_ids,
             },
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         self.send(task, ctx, Some(Span::current())).await;
     }
@@ -336,13 +350,19 @@ impl Handler<TaskResult<LimitOutput, LimitError>> for GetOrchestrator {
             Box::new(PrefetchRecordOperator {}),
             input.clone(),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
 
         if !self.send(prefetch_task, ctx, Some(Span::current())).await {
             return;
         }
 
-        let task = wrap(Box::new(self.projection.clone()), input, ctx.receiver());
+        let task = wrap(
+            Box::new(self.projection.clone()),
+            input,
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         self.send(task, ctx, Some(Span::current())).await;
     }
 }

--- a/rust/worker/src/execution/orchestration/knn_filter.rs
+++ b/rust/worker/src/execution/orchestration/knn_filter.rs
@@ -9,7 +9,7 @@ use chroma_segment::{
 };
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    PanicError, TaskError, TaskMessage, TaskResult,
+    OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
     operator::Filter, CollectionAndSegments, HnswParametersFromSegmentError, Segment, SegmentType,
@@ -160,8 +160,8 @@ type KnnFilterResult = Result<KnnFilterOutput, KnnError>;
 #[derive(Debug)]
 pub struct KnnFilterOrchestrator {
     // Orchestrator parameters
+    context: OrchestratorContext,
     blockfile_provider: BlockfileProvider,
-    dispatcher: ComponentHandle<Dispatcher>,
     hnsw_provider: HnswIndexProvider,
     queue: usize,
 
@@ -191,9 +191,10 @@ impl KnnFilterOrchestrator {
         fetch_log: FetchLogOperator,
         filter: Filter,
     ) -> Self {
+        let context = OrchestratorContext::new(dispatcher);
         Self {
+            context,
             blockfile_provider,
-            dispatcher,
             hnsw_provider,
             queue,
             collection_and_segments,
@@ -211,7 +212,11 @@ impl Orchestrator for KnnFilterOrchestrator {
     type Error = KnnError;
 
     fn dispatcher(&self) -> ComponentHandle<Dispatcher> {
-        self.dispatcher.clone()
+        self.context.dispatcher.clone()
+    }
+
+    fn context(&self) -> &OrchestratorContext {
+        &self.context
     }
 
     async fn initial_tasks(
@@ -227,6 +232,7 @@ impl Orchestrator for KnnFilterOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         // Prefetch task is detached from the orchestrator
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch spann segment", segment_id = %self.collection_and_segments.vector_segment.id);
@@ -240,6 +246,7 @@ impl Orchestrator for KnnFilterOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         // Prefetch task is detached from the orchestrator
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch record segment", segment_id = %self.collection_and_segments.record_segment.id);
@@ -253,12 +260,18 @@ impl Orchestrator for KnnFilterOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch metadata segment", segment_id = %self.collection_and_segments.metadata_segment.id);
         tasks.push((prefetch_metadata_task, Some(prefetch_span)));
 
         // Fetch log task.
-        let fetch_log_task = wrap(Box::new(self.fetch_log.clone()), (), ctx.receiver());
+        let fetch_log_task = wrap(
+            Box::new(self.fetch_log.clone()),
+            (),
+            ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
+        );
         tasks.push((fetch_log_task, Some(Span::current())));
 
         tasks
@@ -317,6 +330,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for KnnFilterOrchestrato
                 record_segment: self.collection_and_segments.record_segment.clone(),
             },
             ctx.receiver(),
+            self.context.task_cancellation_token.clone(),
         );
         self.send(task, ctx, Some(Span::current())).await;
     }


### PR DESCRIPTION
## Description of changes

This change implements cancellation for all tasks spawned by an Orchestrator when it is dropped or stopped. Any of these actions would trigger a cancellation token that is passed on to every task this Orchestrator spawns. All Tasks now are initialized with a CancellationToken that is passed from the Orchestrator that constructs them. The runtime of these Tasks have been modified to poll on these tokens. Some operators like Prefetch operators don't use this token as it is preferable for those to run to completion even if their overlying Orchestrators get killed.

Because of these changes, a timeout would end up dropping or stopping any running Orchestrators and cancel their in-flight tasks. Any tasks that remain in the dispatcher but are not started will remain in the dispatcher queue as an eventual no-op procedure.

- Improvements & Bug fixes
  - Query timeouts on a request will now free up resources taken up by requests quickly.
- New functionality
  - No new user-facing functionality.

## Test plan
An automated test has been added in orchestrator.rs that creates a mock Orchestrator that spawns infinitely sleeping tasks. The test case validates cancellation of these tasks.

Manually tested locally on tilt. Injected a sleep into one of the KNN operators to trigger the query node grpc request timeout and observed the corresponding task cancellation log messages.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

We can make a metric to track the number of cancelled tasks.

## Documentation Changes

N/A
