### PR TITLE
[ENH] Allow users to define null EFs on create collection

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -265,7 +265,7 @@ export class ChromaClient {
     name: string;
     configuration?: CreateCollectionConfiguration;
     metadata?: CollectionMetadata;
-    embeddingFunction?: EmbeddingFunction;
+    embeddingFunction?: EmbeddingFunction | null;
   }): Promise<Collection> {
     const collectionConfig = await processCreateCollectionConfig({
       configuration,
@@ -382,7 +382,7 @@ export class ChromaClient {
     name: string;
     configuration?: CreateCollectionConfiguration;
     metadata?: CollectionMetadata;
-    embeddingFunction?: EmbeddingFunction;
+    embeddingFunction?: EmbeddingFunction | null;
   }): Promise<Collection> {
     const collectionConfig = await processCreateCollectionConfig({
       configuration,

--- a/clients/new-js/packages/chromadb/src/collection-configuration.ts
+++ b/clients/new-js/packages/chromadb/src/collection-configuration.ts
@@ -56,7 +56,7 @@ export const processCreateCollectionConfig = async ({
   embeddingFunction,
 }: {
   configuration?: CreateCollectionConfiguration;
-  embeddingFunction?: EmbeddingFunction;
+  embeddingFunction?: EmbeddingFunction | null;
 }) => {
   if (configuration?.hnsw && configuration?.spann) {
     throw new ChromaValueError(
@@ -64,11 +64,14 @@ export const processCreateCollectionConfig = async ({
     );
   }
 
-  const embeddingFunctionConfiguration =
-    serializeEmbeddingFunction({
-      embeddingFunction,
-      configEmbeddingFunction: configuration?.embeddingFunction,
-    }) || (await getDefaultEFConfig());
+  let embeddingFunctionConfiguration = serializeEmbeddingFunction({
+    embeddingFunction: embeddingFunction ?? undefined,
+    configEmbeddingFunction: configuration?.embeddingFunction,
+  });
+
+  if (!embeddingFunctionConfiguration && embeddingFunction !== null) {
+    embeddingFunctionConfiguration = await getDefaultEFConfig();
+  }
 
   return {
     ...(configuration || {}),

--- a/docs/docs.trychroma.com/markdoc/content/docs/collections/manage-collections.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/collections/manage-collections.md
@@ -80,6 +80,15 @@ collection = client.create_collection(
 )
 ```
 
+Instead of having Chroma embed documents, you can also provide embeddings directly when [adding data](./add-data) to a collection. In this case, your collection will not have an embedding function set, and you will be responsible for providing embeddings directly when adding data and querying.
+
+```python
+collection = client.create_collection(
+    name="my_collection",
+    embedding_function=None
+)
+```
+
 {% /Tab %}
 
 {% Tab label="typescript" %}
@@ -128,11 +137,44 @@ const collection = await client.createCollection({
 });
 ```
 
+Instead of having Chroma embed documents, you can also provide embeddings directly when [adding data](./add-data) to a collection. In this case, your collection will not have an embedding function set, and you will be responsible for providing embeddings directly when adding data and querying.
+
+```typescript
+const collection = await client.createCollection({
+    name: "my_collection",
+    embeddingFunction: null
+})
+```
+
 {% /Tab %}
 
 {% /Tabs %}
 
-Instead of having Chroma embed documents, you can also provide embeddings directly when [adding data](./add-data) to a collection. In this case, your collection will not have an embedding function set, and you will be responsible for providing embeddings directly when adding data and querying.
+{% TabbedCodeBlock %}
+
+{% Tab label="python" %}
+```python
+collection = client.create_collection(
+    name="my_collection",
+    embedding_function=None
+)
+```
+{% /Tab %}
+
+{% Tab label="typescript" %}
+```typescript
+let collection = await client.createCollection({
+    name: "my_collection",
+    embeddingFunction: emb_fn,
+    metadata: {
+        description: "my first Chroma collection",
+        created: (new Date()).toString()
+    }
+});
+```
+{% /Tab %}
+
+{% /TabbedCodeBlock %}
 
 ### Collection Metadata
 


### PR DESCRIPTION
## Description of changes

Allow users to explicitly define `null` EF when creating collections. This is intended for users who want to provide embeddings directly to a collection and don't want to install the default embed package. 

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Documentation Changes

In this PR