### PR TITLE
[ENH] Get max_batch_size from quota for preflight checks

### DIFF
--- a/chromadb/utils/batch_utils.py
+++ b/chromadb/utils/batch_utils.py
@@ -14,21 +14,29 @@ def create_batches(
     embeddings: Optional[Embeddings] = None,
     metadatas: Optional[Metadatas] = None,
     documents: Optional[Documents] = None,
+    max_batch_size: Optional[int] = None,
 ) -> List[Tuple[IDs, Optional[Embeddings], Optional[Metadatas], Optional[Documents]]]:
     _batches: List[
         Tuple[IDs, Optional[Embeddings], Optional[Metadatas], Optional[Documents]]
     ] = []
-    if len(ids) > api.get_max_batch_size():
+    server_max_batch_size = api.get_max_batch_size()
+    if max_batch_size is None:
+        max_batch_size = server_max_batch_size
+    else:
+        if max_batch_size > server_max_batch_size:
+            max_batch_size = server_max_batch_size
+
+    if len(ids) > max_batch_size:
         # create split batches
-        for i in range(0, len(ids), api.get_max_batch_size()):
+        for i in range(0, len(ids), max_batch_size):
             _batches.append(
                 (
-                    ids[i : i + api.get_max_batch_size()],
-                    embeddings[i : i + api.get_max_batch_size()]
+                    ids[i : i + max_batch_size],
+                    embeddings[i : i + max_batch_size]
                     if embeddings is not None
                     else None,
-                    metadatas[i : i + api.get_max_batch_size()] if metadatas else None,
-                    documents[i : i + api.get_max_batch_size()] if documents else None,
+                    metadatas[i : i + max_batch_size] if metadatas else None,
+                    documents[i : i + max_batch_size] if documents else None,
                 )
             )
     else:


### PR DESCRIPTION
## Description of changes
This PR updates the preflight checks to read the max batch size from the quota system.
It also adds batch size as an argument to the batch utils so that users can pass it in to customize the batching if necessary.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
