### PR TITLE
[ENH] Add dedupe closure to storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ regex-syntax = "0.8.5"
 roaring = "0.10.6"
 sea-query = "0.32"
 sea-query-binder = "0.7"
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.215", features = ["derive", "rc"] }
 serde_json = "1.0.133"
 setsum = "0.7"
 tantivy = "0.22.0"

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -14,7 +14,7 @@ use crate::{
     Value,
 };
 use async_trait::async_trait;
-use chroma_cache::{AysncPartitionedMutex, CacheError, PersistentCache};
+use chroma_cache::{CacheError, PersistentCache};
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::{

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -441,11 +441,13 @@ impl BlockManager {
             return Ok(Some(block));
         }
 
+        // Closure cloning
         let key = Self::format_key(prefix_path, id);
         let id_clone = *id;
         let block_cache_clone = self.block_cache.clone();
         let key_clone = key.clone();
-        // If the block is not in the cache, we fetch it from storage.
+        let num_get_requests_metric_clone = self.block_metrics.num_get_requests.clone();
+
         let res = self.storage
             .fetch(&key, GetOptions::new(priority), |bytes| async move {
                 let bytes = match bytes {
@@ -457,7 +459,7 @@ impl BlockManager {
                         });
                     }
                 };
-
+                num_get_requests_metric_clone.record(1, &[]);
                 let deserialization_span = tracing::trace_span!(
                     parent: Span::current(),
                     "BlockManager deserialize block",

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -18,7 +18,7 @@ use chroma_cache::{AysncPartitionedMutex, CacheError, PersistentCache};
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::{
-    admissioncontrolleds3::StorageRequestPriority, GetOptions, PutOptions, Storage,
+    admissioncontrolleds3::StorageRequestPriority, GetOptions, PutOptions, Storage, StorageError,
 };
 use chroma_tracing::util::Stopwatch;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -355,7 +355,6 @@ pub struct BlockManager {
     storage: Storage,
     default_max_block_size_bytes: usize,
     block_metrics: BlockMetrics,
-    cache_mutex: AysncPartitionedMutex<Uuid>,
 }
 
 impl BlockManager {
@@ -370,7 +369,6 @@ impl BlockManager {
             storage,
             default_max_block_size_bytes,
             block_metrics: BlockMetrics::default(),
-            cache_mutex: AysncPartitionedMutex::new(()),
         }
     }
 
@@ -448,72 +446,51 @@ impl BlockManager {
         if let Some(block) = block {
             return Ok(Some(block));
         }
+
         let key = Self::format_key(prefix_path, id);
         let id_clone = *id;
+        let block_cache_clone = self.block_cache.clone();
+        let key_clone = key.clone();
         // If the block is not in the cache, we fetch it from storage.
         let res = ac_storage
-            .fetch(&key, GetOptions::new(priority), move |bytes| {
+            .fetch(&key, GetOptions::new(priority), |bytes| async move {
+                let bytes = match bytes {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        tracing::error!("Error loading block from storage: {:?}", e);
+                        return Err(StorageError::Message {
+                            message: "Error loading block".to_string(),
+                        });
+                    }
+                };
+
                 let deserialization_span = tracing::trace_span!(
                     parent: Span::current(),
                     "BlockManager deserialize block",
                     id = id_clone.to_string()
                 );
-                deserialization_span.in_scope(|| Block::from_bytes(&bytes, id_clone).unwrap())
-            })
+                let block = deserialization_span.in_scope(|| Block::from_bytes(&bytes, id_clone));
+                match block {
+                    Ok(block) => {
+                        block_cache_clone.insert(id_clone, block.clone()).await;
+                        Ok(block)
+                    }
+                    Err(e) => {
+                        tracing::error!("Error converting bytes to Block {:?}/{:?}", key_clone, e);
+                        Err(StorageError::Message {
+                            message: "Error converting bytes to Block".to_string(),
+                        })
+                    }
+                }
+            }).instrument(tracing::trace_span!(parent: Span::current(), "BlockManager get cold", block_id = id.to_string()))
             .await;
-        let res = res.unwrap().0;
-        Ok(Some(res))
-
-        // match block {
-        //     Some(block) => Ok(Some(block)),
-        //     None => async {
-        //         let key = Self::format_key(prefix_path, id);
-        //         let bytes_res = self
-        //             .storage
-        //             .get(&key, GetOptions::new(priority))
-        //             .instrument(
-        //                 tracing::trace_span!(parent: Span::current(), "BlockManager storage get", id = id.to_string()),
-        //             )
-        //             .await;
-        //         match bytes_res {
-        //             Ok(bytes) => {
-        //                 self.block_metrics.num_get_requests.record(1, &[]);
-        //                 let deserialization_span = tracing::trace_span!(parent: Span::current(), "BlockManager deserialize block");
-        //                 let block =
-        //                     deserialization_span.in_scope(|| Block::from_bytes(&bytes, *id));
-        //                 match block {
-        //                     Ok(block) => {
-        //                         let _guard = self.cache_mutex.lock(id).await;
-        //                         match self.block_cache.obtain(*id).await {
-        //                             Ok(Some(b)) => {
-        //                                 Ok(Some(b))
-        //                             }
-        //                             Ok(None) => {
-        //                                 self.block_cache.insert(*id, block.clone()).await;
-        //                                 Ok(Some(block))
-        //                             }
-        //                             Err(e) => {
-        //                                 tracing::error!("Error getting block from cache {:?}", e);
-        //                                 Err(GetError::BlockLoadError(e.into()))
-        //                             }
-        //                         }
-        //                     }
-        //                     Err(e) => {
-        //                         tracing::error!(
-        //                             "Error converting bytes to Block {:?}/{:?}",
-        //                             key,
-        //                             e
-        //                         );
-        //                         Err(GetError::BlockLoadError(e))
-        //                     }
-        //                 }
-        //             }
-        //             Err(e) => {
-        //                 tracing::error!("Error converting bytes to Block {:?}", e);
-        //                 Err(GetError::StorageGetError(e))
-        //             }
-        //         }
-        //     }.instrument(tracing::trace_span!(parent: Span::current(), "BlockManager get cold", block_id = id.to_string())).await
+        match res {
+            Ok(block) => Ok(Some(block.0)),
+            Err(e) => {
+                tracing::error!("Error fetching block from storage: {:?}", e);
+                Err(GetError::StorageGetError(e))
+            }
+        }
     }
 
     pub(super) async fn flush(

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -437,12 +437,6 @@ impl BlockManager {
         priority: StorageRequestPriority,
     ) -> Result<Option<Block>, GetError> {
         let block = self.block_cache.obtain(*id).await.ok().flatten();
-        let ac_storage = match &self.storage {
-            Storage::AdmissionControlledS3(s3) => s3,
-            _ => {
-                panic!("tst");
-            }
-        };
         if let Some(block) = block {
             return Ok(Some(block));
         }
@@ -452,7 +446,7 @@ impl BlockManager {
         let block_cache_clone = self.block_cache.clone();
         let key_clone = key.clone();
         // If the block is not in the cache, we fetch it from storage.
-        let res = ac_storage
+        let res = self.storage
             .fetch(&key, GetOptions::new(priority), |bytes| async move {
                 let bytes = match bytes {
                     Ok(bytes) => bytes,

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -477,6 +477,9 @@ impl BlockManager {
                     }
                     Err(e) => {
                         tracing::error!("Error converting bytes to Block {:?}/{:?}", key_clone, e);
+                        // TODO(hammadb): We should ideally use BlockLoadError here since that is what this level of the code expects,
+                        // however that type is not trivially Clone. Since for all practical purposes this error results in the same upstream handling
+                        // and observability properties we use a generic StorageError here.
                         Err(StorageError::Message {
                             message: "Error converting bytes to Block".to_string(),
                         })

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -1021,7 +1021,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_k8s_dedupe_requests() {
+    async fn test_k8s_integration_dedupe_requests() {
         let client = get_s3_client();
 
         let storage = S3Storage {

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{any::Any, future::Future, sync::Arc};
 
 use self::config::StorageConfig;
 use admissioncontrolleds3::StorageRequestPriority;
@@ -227,6 +227,41 @@ impl Storage {
             Storage::Local(local) => local.get(key).await,
             Storage::AdmissionControlledS3(admission_controlled_storage) => {
                 admission_controlled_storage.get(key, options).await
+            }
+        }
+    }
+
+    pub async fn fetch<FetchReturn, FetchFn, FetchFut>(
+        &self,
+        key: &str,
+        options: GetOptions,
+        fetch_fn: FetchFn,
+    ) -> Result<(FetchReturn, Option<ETag>), StorageError>
+    where
+        FetchFn: FnOnce(Result<Arc<Vec<u8>>, StorageError>) -> FetchFut,
+        FetchFut: Future<Output = Result<FetchReturn, StorageError>> + Send + 'static,
+        FetchReturn: Clone + Any + Sync + Send,
+    {
+        match self {
+            Storage::ObjectStore(object_store) => {
+                let res = object_store.get_with_e_tag(key).await?;
+                let fetch_result = fetch_fn(Ok(res.0)).await?;
+                Ok((fetch_result, res.1))
+            }
+            Storage::S3(s3) => {
+                let res = s3.get_with_e_tag(key).await?;
+                let fetch_result = fetch_fn(Ok(res.0)).await?;
+                Ok((fetch_result, res.1))
+            }
+            Storage::Local(local) => {
+                let res = local.get_with_e_tag(key).await?;
+                let fetch_result = fetch_fn(Ok(res.0)).await?;
+                Ok((fetch_result, res.1))
+            }
+            Storage::AdmissionControlledS3(admission_controlled_storage) => {
+                admission_controlled_storage
+                    .fetch(key, options, fetch_fn)
+                    .await
             }
         }
     }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._
  - Adds a dedupe closure API to the storage interface under `fetch`
  - Fetch allows providing an async closure to be deduplicated 
  - This changes off of a Shared future for deduplication, since the dispatcher runtimes and main runtime may share that future, leading to undefined behavior.

## Test plan

_How are these changes tested?_
Existing tests cover this
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan
_What is the plan to instrument and monitor this change?_
Existing telemetry monitors this change

## Documentation Changes
None