### PR TITLE
[BUG] Fixes an issue with markdown syntax

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/overview/introduction.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/overview/introduction.md
@@ -6,7 +6,7 @@
 New to Chroma? Check out the [getting started guide](./getting-started)
 {% /Banner %}
 
-{% MarkdocImage lightSrc="/computer-light.png" darkSrc="/computer-dark.png" alt="Chroma Computer" %}
+{% MarkdocImage lightSrc="/computer-light.png" darkSrc="/computer-dark.png" alt="Chroma Computer" /%}
 
 Chroma gives you everything you need for retrieval:
 


### PR DESCRIPTION
The markdoc renderer doesn't throw when there is a syntax error

Given that, the missing closing tag in this change prevented the rest of the page from rendering.

Separately, we should throw if the markdown renderer catches a syntax error like this.

