### PR TITLE
[ENH]: Parallelize fetching sparse indexes of a segment

### DIFF
--- a/rust/blockstore/src/provider.rs
+++ b/rust/blockstore/src/provider.rs
@@ -42,6 +42,29 @@ impl Debug for BlockfileProvider {
         }
     }
 }
+pub trait ReadKey<'a>:
+    Key
+    + Into<KeyWrapper>
+    + TryFrom<&'a KeyWrapper, Error = InvalidKeyConversion>
+    + ArrowReadableKey<'a>
+    + Sync
+    + 'a
+{
+}
+
+pub trait ReadValue<'a>: Value + Readable<'a> + ArrowReadableValue<'a> + Sync + 'a {}
+
+impl<'a, T> ReadKey<'a> for T where
+    T: Key
+        + Into<KeyWrapper>
+        + TryFrom<&'a KeyWrapper, Error = InvalidKeyConversion>
+        + ArrowReadableKey<'a>
+        + Sync
+        + 'a
+{
+}
+
+impl<'a, T> ReadValue<'a> for T where T: Value + Readable<'a> + ArrowReadableValue<'a> + Sync + 'a {}
 
 impl BlockfileProvider {
     pub fn new_memory() -> Self {
@@ -62,16 +85,7 @@ impl BlockfileProvider {
         ))
     }
 
-    pub async fn read<
-        'new,
-        K: Key
-            + Into<KeyWrapper>
-            + TryFrom<&'new KeyWrapper, Error = InvalidKeyConversion>
-            + ArrowReadableKey<'new>
-            + Sync
-            + 'new,
-        V: Value + Readable<'new> + ArrowReadableValue<'new> + Sync + 'new,
-    >(
+    pub async fn read<'new, K: ReadKey<'new>, V: ReadValue<'new>>(
         &self,
         options: BlockfileReaderOptions,
     ) -> Result<BlockfileReader<'new, K, V>, Box<OpenError>> {


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Parallelize sparse index fetches within a segment.
- New functionality
  - N/A

## Test plan
TBD

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
