### PR TITLE
[BUG] ci: Use correct step dependencies for Slack notifications

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -263,7 +263,6 @@ jobs:
     - javascript-client-tests
     - rust-tests
     - go-tests
-    - check-title
     - lint
     - check-helm-version-bump
     - delete-helm-comment

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -257,7 +257,8 @@ jobs:
       - release-pypi
       - release-thin-pypi
       - release-github
-      - release-hosted
+      - release-hosted-control-plane
+      - release-hosted-data-plane
       - release-docs
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
## Description of changes

Between the time I originally created this PR and when I revisited it and eventually merged it, the steps upon which the `notify-slack-on-failure` step depends on needed to be updated, which I didn't do, so the workflow is technically invalid. This fixes it by using the correct step dependencies.

- Improvements & Bug fixes
  - Uses the correct step dependencies in the `notify-slack-on-failure` step

## Test plan

I validated against the GitHub Action schema linter. It was showing the bug right away.

## Observability plan

We should see this run after the change merges.

## Documentation Changes

N/A