### PR TITLE
[ENH] Extract gc config under specific key if present

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -187,7 +187,7 @@ k8s_yaml(
 # We manually call helm template so we can call set-file
 k8s_yaml(
   local(
-    'helm template --set-file rustFrontendService.configuration=rust/frontend/sample_configs/tilt_config.yaml,rustLogService.configuration=rust/worker/tilt_config.yaml,compaction_service.configuration=rust/worker/tilt_config.yaml,query_service.configuration=rust/worker/tilt_config.yaml --values k8s/distributed-chroma/values.yaml,k8s/distributed-chroma/values.dev.yaml k8s/distributed-chroma'
+    'helm template --set-file rustFrontendService.configuration=rust/frontend/sample_configs/tilt_config.yaml,rustLogService.configuration=rust/worker/tilt_config.yaml,compactionService.configuration=rust/worker/tilt_config.yaml,queryService.configuration=rust/worker/tilt_config.yaml,garbageCollector.configuration=rust/worker/tilt_config.yaml --values k8s/distributed-chroma/values.yaml,k8s/distributed-chroma/values.dev.yaml k8s/distributed-chroma'
   ),
 )
 watch_file('rust/frontend/sample_configs/distributed.yaml')

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.53
+version: 0.1.54
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -1,8 +1,6 @@
 # Default values for distributed-chroma.
 # Strongly prefer single quotes.
-
 namespace: 'chroma'
-
 rustFrontendService:
   image:
     repository: 'rust-frontend-service'
@@ -15,15 +13,14 @@ rustFrontendService:
     requests:
       cpu: '1000m'
       memory: '512Mi'
-
 sysdb:
   image:
     repository: 'sysdb'
     tag: 'latest'
   replicaCount: 1
   env:
-  - name: OPTL_TRACING_ENDPOINT
-    value: 'value: "jaeger:4317"'
+    - name: OPTL_TRACING_ENDPOINT
+      value: 'value: "jaeger:4317"'
   resources:
     limits:
       cpu: '2000m'
@@ -32,21 +29,17 @@ sysdb:
       cpu: '1000m'
       memory: '512Mi'
   flags:
-
-
 logService:
   image:
     repository: 'logservice'
     tag: 'latest'
   env:
-  - name: OPTL_TRACING_ENDPOINT
-    value: 'value: "otel-collector:4317"'
-  - name: SYSDB_CONN
-    value: 'value: "sysdb.chroma:50051"'
+    - name: OPTL_TRACING_ENDPOINT
+      value: 'value: "otel-collector:4317"'
+    - name: SYSDB_CONN
+      value: 'value: "sysdb.chroma:50051"'
   flags:
   replicaCount: 1
-
-
 rustLogService:
   image:
     repository: 'rust-log-service'
@@ -54,7 +47,6 @@ rustLogService:
   cache:
     hostPath: '/local/cache/chroma-log-service'
     mountPath: '/cache/'
-
 queryService:
   image:
     repository: 'query-service'
@@ -64,7 +56,6 @@ queryService:
     hostPath: '/local/cache/chroma-query-service'
     mountPath: '/cache/'
   replicaCount: 2
-
 compactionService:
   image:
     repository: 'compaction-service'
@@ -74,7 +65,6 @@ compactionService:
     hostPath: '/local/cache/chroma-compaction-service'
     mountPath: '/cache/'
   replicaCount: 1
-
 sysdbMigration:
   image:
     repository: 'sysdb-migration'
@@ -85,15 +75,13 @@ sysdbMigration:
   port: 5432
   dbName: sysdb
   sslmode: disable
-
 logServiceMigration:
   image:
     repository: 'logservice-migration'
     tag: 'latest'
   env:
-  - name: CHROMA_DB_LOG_URL
-    value: 'value: "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log?sslmode=disable"'
-
+    - name: CHROMA_DB_LOG_URL
+      value: 'value: "postgresql://chroma:chroma@postgres.chroma.svc.cluster.local:5432/log?sslmode=disable"'
 # Add the garbage collector configuration
 garbageCollector:
   image:
@@ -110,41 +98,3 @@ garbageCollector:
   cache:
     hostPath: '/local/cache/chroma-garbage-collector'
     mountPath: '/cache/'
-  configuration: |
-    service_name: "garbage-collector"
-    otel_endpoint: "http://otel-collector:4317"
-    otel_filters:
-      - crate_name: "garbage_collector"
-        filter_level: "debug"
-    relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-    max_collections_to_gc: 1000
-    gc_interval_mins: 1
-    disallow_collections: []
-    default_mode: "deletev2"
-    sysdb_config:
-      host: "sysdb.chroma"
-      port: 50051
-      connect_timeout_ms: 60000
-      request_timeout_ms: 60000
-    dispatcher_config:
-      num_worker_threads: 4
-      dispatcher_queue_size: 100
-      worker_queue_size: 100
-    storage_config:
-      s3:
-        bucket: "chroma-storage"
-    assignment_policy:
-      rendezvous_hashing:
-        hasher: Murmur3
-    memberlist_provider:
-      custom_resource:
-        kube_namespace: "chroma"
-        memberlist_name: "garbage-collection-service-memberlist"
-        queue_size: 100
-    log:
-      grpc:
-        host: "logservice.chroma"
-        port: 50051
-        connect_timeout_ms: 5000
-        request_timeout_ms: 5000
-        alt_host: "rust-log-service.chroma"

--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -90,10 +90,8 @@ impl GarbageCollectorConfig {
             k => k.as_str().replace("__", ".").into(),
         }));
         if std::path::Path::new(path).exists() {
-            f = figment::Figment::from(Yaml::file(path)).merge(f);
-        }
-        if let Ok(config) = f.focus("garbage_collector").extract() {
-            return config;
+            let yaml = figment::Figment::from(Yaml::file(path));
+            f = yaml.clone().merge(yaml.focus("garbage_collector")).merge(f);
         }
         let res = f.extract();
         match res {

--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -92,6 +92,9 @@ impl GarbageCollectorConfig {
         if std::path::Path::new(path).exists() {
             f = figment::Figment::from(Yaml::file(path)).merge(f);
         }
+        if let Ok(config) = f.focus("garbage_collector").extract() {
+            return config;
+        }
         let res = f.extract();
         match res {
             Ok(config) => config,

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -5,191 +5,226 @@
 #
 # NOTE:  This file is NOT currently used by tilt, but instead shipped as the defaults.
 # See the adjacent tilt_config.yaml for tilt.
-
 query_service:
-    service_name: "query-service"
-    otel_endpoint: "http://otel-collector:4317"
-    otel_filters:
-        - crate_name: "worker"
-          filter_level: "trace"    
-    my_member_id: "query-service-0"
-    my_port: 50051
-    assignment_policy:
-        rendezvous_hashing:
-            hasher: Murmur3
-    memberlist_provider:
-        custom_resource:
-            kube_namespace: "chroma"
-            memberlist_name: "query-service-memberlist"
-            queue_size: 100
-    sysdb:
-        grpc:
-            host: "sysdb.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 5000
-    storage:
-        admission_controlled_s3:
-            s3_config:
-                bucket: "chroma-storage"
-                credentials: "Minio"
-                connect_timeout_ms: 5000
-                request_timeout_ms: 30000 # 1 minute
-                upload_part_size_bytes: 536870912 # 512MiB
-                download_part_size_bytes: 8388608 # 8MiB
-            rate_limiting_policy:
-                count_based_policy:
-                    max_concurrent_requests: 30
-                    bandwidth_allocation: [0.7, 0.3]
-    log:
-        grpc:
-            host: "logservice.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 5000
-    dispatcher:
-        num_worker_threads: 4
-        dispatcher_queue_size: 100
-        worker_queue_size: 100
-        task_queue_limit: 1000
-        active_io_tasks: 100
-    blockfile_provider:
-        arrow:
-            block_manager_config:
-                max_block_size_bytes: 8388608 # 8MB
-                block_cache_config:
-                    disk:
-                        name: "block_cache"
-                        dir: "/cache/chroma/query-service/block-cache"
-                        # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
-                        capacity: 1000
-                        mem: 8000 # 8GiB
-                        disk: 12884 # 12GiB
-                        file_size: 256 #  256 MiB
-                        flushers: 4
-                        flush: false
-                        reclaimers: 2
-                        recover_concurrency: 16
-                        admission_rate_limit: 256 # 256MiB/s
-                        shards: 64
-                        eviction: lru
-            sparse_index_manager_config:
-                sparse_index_cache_config:
-                    lru:
-                        name: "sparse_index_cache"
-                        capacity: 1000
-    hnsw_provider:
-        hnsw_temporary_path: "~/tmp"
-        hnsw_cache_config:
-            weighted_lru:
-                name: "hnsw_cache"
-                capacity: 8589934592 # 8GB
-        permitted_parallelism: 180
-
+  service_name: "query-service"
+  otel_endpoint: "http://otel-collector:4317"
+  otel_filters:
+    - crate_name: "worker"
+      filter_level: "trace"
+  my_member_id: "query-service-0"
+  my_port: 50051
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "query-service-memberlist"
+      queue_size: 100
+  sysdb:
+    grpc:
+      host: "sysdb.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 30000 # 1 minute
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 30
+          bandwidth_allocation: [0.7, 0.3]
+  log:
+    grpc:
+      host: "logservice.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+  dispatcher:
+    num_worker_threads: 4
+    dispatcher_queue_size: 100
+    worker_queue_size: 100
+    task_queue_limit: 1000
+    active_io_tasks: 100
+  blockfile_provider:
+    arrow:
+      block_manager_config:
+        max_block_size_bytes: 8388608 # 8MB
+        block_cache_config:
+          disk:
+            name: "block_cache"
+            dir: "/cache/chroma/query-service/block-cache"
+            # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
+            capacity: 1000
+            mem: 8000 # 8GiB
+            disk: 12884 # 12GiB
+            file_size: 256 #  256 MiB
+            flushers: 4
+            flush: false
+            reclaimers: 2
+            recover_concurrency: 16
+            admission_rate_limit: 256 # 256MiB/s
+            shards: 64
+            eviction: lru
+      sparse_index_manager_config:
+        sparse_index_cache_config:
+          lru:
+            name: "sparse_index_cache"
+            capacity: 1000
+  hnsw_provider:
+    hnsw_temporary_path: "~/tmp"
+    hnsw_cache_config:
+      weighted_lru:
+        name: "hnsw_cache"
+        capacity: 8589934592 # 8GB
+    permitted_parallelism: 180
 compaction_service:
-    service_name: "compaction-service"
-    otel_endpoint: "http://otel-collector:4317"
-    otel_filters:
-        - crate_name: "worker"
-          filter_level: "trace"    
-    my_member_id: "compaction-service-0"
-    my_port: 50051
-    assignment_policy:
-        rendezvous_hashing:
-            hasher: Murmur3
-    memberlist_provider:
-        custom_resource:
-            kube_namespace: "chroma"
-            memberlist_name: "compaction-service-memberlist"
-            queue_size: 100
-    sysdb:
-        grpc:
-            host: "sysdb.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 5000
-    storage:
-        admission_controlled_s3:
-            s3_config:
-                bucket: "chroma-storage"
-                credentials: "Minio"
-                connect_timeout_ms: 5000
-                request_timeout_ms: 60000 # 1 minute
-                upload_part_size_bytes: 536870912 # 512MiB
-                download_part_size_bytes: 8388608 # 8MiB
-            rate_limiting_policy:
-                count_based_policy:
-                    max_concurrent_requests: 30
-                    bandwidth_allocation: [0.7, 0.3]
-    log:
-        grpc:
-            host: "logservice.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 5000
-    dispatcher:
-        num_worker_threads: 4
-        dispatcher_queue_size: 100
-        worker_queue_size: 100
-        task_queue_limit: 1000
-        active_io_tasks: 100
-    compactor:
-        compaction_manager_queue_size: 1000
-        max_concurrent_jobs: 100
-        compaction_interval_sec: 10
-        min_compaction_size: 10
-        max_compaction_size: 10000
-        max_partition_size: 5000
-        disabled_collections: [] # uuids to disable compaction for
-    blockfile_provider:
-        arrow:
-            block_manager_config:
-                max_block_size_bytes: 8388608 # 8MB
-                block_cache_config:
-                    lru:
-                        name: "block_cache"
-                        capacity: 1000
-            sparse_index_manager_config:
-                sparse_index_cache_config:
-                    lru:
-                        name: "sparse_index_cache"
-                        capacity: 1000
-    hnsw_provider:
-        hnsw_temporary_path: "~/tmp"
-        hnsw_cache_config:
-            weighted_lru:
-                name: "hnsw_cache"
-                capacity: 8192 # 8192 MiB = 8GB
-        permitted_parallelism: 180
-    spann_provider:
-        pl_garbage_collection:
-            enabled: true
-            policy:
-                random_sample:
-                    sample_size: 0.1
-        hnsw_garbage_collection:
-            enabled: true
-            policy: "full_rebuild"
-
+  service_name: "compaction-service"
+  otel_endpoint: "http://otel-collector:4317"
+  otel_filters:
+    - crate_name: "worker"
+      filter_level: "trace"
+  my_member_id: "compaction-service-0"
+  my_port: 50051
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "compaction-service-memberlist"
+      queue_size: 100
+  sysdb:
+    grpc:
+      host: "sysdb.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 60000 # 1 minute
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 30
+          bandwidth_allocation: [0.7, 0.3]
+  log:
+    grpc:
+      host: "logservice.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+  dispatcher:
+    num_worker_threads: 4
+    dispatcher_queue_size: 100
+    worker_queue_size: 100
+    task_queue_limit: 1000
+    active_io_tasks: 100
+  compactor:
+    compaction_manager_queue_size: 1000
+    max_concurrent_jobs: 100
+    compaction_interval_sec: 10
+    min_compaction_size: 10
+    max_compaction_size: 10000
+    max_partition_size: 5000
+    disabled_collections: [] # uuids to disable compaction for
+  blockfile_provider:
+    arrow:
+      block_manager_config:
+        max_block_size_bytes: 8388608 # 8MB
+        block_cache_config:
+          lru:
+            name: "block_cache"
+            capacity: 1000
+      sparse_index_manager_config:
+        sparse_index_cache_config:
+          lru:
+            name: "sparse_index_cache"
+            capacity: 1000
+  hnsw_provider:
+    hnsw_temporary_path: "~/tmp"
+    hnsw_cache_config:
+      weighted_lru:
+        name: "hnsw_cache"
+        capacity: 8192 # 8192 MiB = 8GB
+    permitted_parallelism: 180
+  spann_provider:
+    pl_garbage_collection:
+      enabled: true
+      policy:
+        random_sample:
+          sample_size: 0.1
+    hnsw_garbage_collection:
+      enabled: true
+      policy: "full_rebuild"
 log_service:
-    opentelemetry:
-        service_name: "rust-log-service"
-        endpoint: "http://otel-collector:4317"
-        filters:
-            - crate_name: "chroma_log"
-              filter_level: "trace" 
-            - crate_name: "wal3"
-              filter_level: "trace"                  
-    storage:
-        admission_controlled_s3:
-            s3_config:
-                bucket: "chroma-storage"
-                credentials: "Minio"
-                connect_timeout_ms: 5000
-                request_timeout_ms: 60000 # 1 minute
-                upload_part_size_bytes: 536870912 # 512MiB
-                download_part_size_bytes: 8388608 # 8MiB
-            rate_limiting_policy:
-                count_based_policy:
-                    max_concurrent_requests: 500
-                    bandwidth_allocation: [1.0]
+  opentelemetry:
+    service_name: "rust-log-service"
+    endpoint: "http://otel-collector:4317"
+    filters:
+      - crate_name: "chroma_log"
+        filter_level: "trace"
+      - crate_name: "wal3"
+        filter_level: "trace"
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 60000 # 1 minute
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 500
+          bandwidth_allocation: [1.0]
+garbage_collector:
+  service_name: "garbage-collector"
+  otel_endpoint: "http://otel-collector:4317"
+  otel_filters:
+    - crate_name: "garbage_collector"
+      filter_level: "debug"
+  relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
+  max_collections_to_gc: 1000
+  gc_interval_mins: 1
+  disallow_collections: []
+  default_mode: "deletev2"
+  sysdb_config:
+    host: "sysdb.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
+  dispatcher_config:
+    num_worker_threads: 4
+    dispatcher_queue_size: 100
+    worker_queue_size: 100
+  storage_config:
+    s3:
+      bucket: "chroma-storage"
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "garbage-collection-service-memberlist"
+      queue_size: 100
+  log:
+    grpc:
+      host: "logservice.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+      alt_host: "rust-log-service.chroma"

--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -2,216 +2,251 @@
 # In the long term, every service should have an entry in this file
 # and this can become the global configuration file for Chroma
 # for now we nest it in the worker directory
-
 query_service:
-    service_name: "query-service"
-    otel_endpoint: "http://otel-collector:4317"
-    otel_filters:
-        - crate_name: "worker"
-          filter_level: "trace"    
-    my_member_id: "query-service-0"
-    my_port: 50051
-    assignment_policy:
-        rendezvous_hashing:
-            hasher: Murmur3
-    memberlist_provider:
-        custom_resource:
-            kube_namespace: "chroma"
-            memberlist_name: "query-service-memberlist"
-            queue_size: 100
-    sysdb:
-        grpc:
-            host: "sysdb.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 5000
-    storage:
-        admission_controlled_s3:
-            s3_config:
-                bucket: "chroma-storage"
-                credentials: "Minio"
-                connect_timeout_ms: 5000
-                request_timeout_ms: 30000 # 1 minute
-                upload_part_size_bytes: 536870912 # 512MiB
-                download_part_size_bytes: 8388608 # 8MiB
-            rate_limiting_policy:
-                count_based_policy:
-                    max_concurrent_requests: 30
-                    bandwidth_allocation: [0.7, 0.3]
-    log:
-        grpc:
-            host: "logservice.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 60000 # 1 minute
-            alt_host: "rust-log-service.chroma"
-            alt_host_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
-    dispatcher:
-        num_worker_threads: 4
-        dispatcher_queue_size: 1000
-        worker_queue_size: 100
-        task_queue_limit: 10000
-        active_io_tasks: 10000
-    blockfile_provider:
-        arrow:
-            block_manager_config:
-                max_block_size_bytes: 8388608 # 8MB
-                block_cache_config:
-                    disk:
-                        dir: "/cache/chroma/query-service/block-cache"
-                        name: "block_cache"
-                        # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
-                        capacity: 1000
-                        mem: 8000 # 8GiB
-                        disk: 12884 # 12GiB
-                        file_size: 256 #  256 MiB
-                        flushers: 4
-                        flush: false
-                        reclaimers: 2
-                        recover_concurrency: 16
-                        admission_rate_limit: 256 # 256MiB/s
-                        shards: 64
-                        eviction: lru
-            sparse_index_manager_config:
-                sparse_index_cache_config:
-                    lru:
-                        name: "sparse_index_cache"
-                        capacity: 1000
-    hnsw_provider:
-        hnsw_temporary_path: "~/tmp"
-        hnsw_cache_config:
-            weighted_lru:
-                name: "hnsw_cache"
-                capacity: 8589934592 # 8GB
-        permitted_parallelism: 180
-    fetch_log_batch_size: 1000
-
+  service_name: "query-service"
+  otel_endpoint: "http://otel-collector:4317"
+  otel_filters:
+    - crate_name: "worker"
+      filter_level: "trace"
+  my_member_id: "query-service-0"
+  my_port: 50051
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "query-service-memberlist"
+      queue_size: 100
+  sysdb:
+    grpc:
+      host: "sysdb.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 30000 # 1 minute
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 30
+          bandwidth_allocation: [0.7, 0.3]
+  log:
+    grpc:
+      host: "logservice.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 60000 # 1 minute
+      alt_host: "rust-log-service.chroma"
+      alt_host_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  dispatcher:
+    num_worker_threads: 4
+    dispatcher_queue_size: 1000
+    worker_queue_size: 100
+    task_queue_limit: 10000
+    active_io_tasks: 10000
+  blockfile_provider:
+    arrow:
+      block_manager_config:
+        max_block_size_bytes: 8388608 # 8MB
+        block_cache_config:
+          disk:
+            dir: "/cache/chroma/query-service/block-cache"
+            name: "block_cache"
+            # 1k blocks * 8MiB = 8GiB, this is actually ignored in the disk cache config. Leaving it set to 1k for consistency.
+            capacity: 1000
+            mem: 8000 # 8GiB
+            disk: 12884 # 12GiB
+            file_size: 256 #  256 MiB
+            flushers: 4
+            flush: false
+            reclaimers: 2
+            recover_concurrency: 16
+            admission_rate_limit: 256 # 256MiB/s
+            shards: 64
+            eviction: lru
+      sparse_index_manager_config:
+        sparse_index_cache_config:
+          lru:
+            name: "sparse_index_cache"
+            capacity: 1000
+  hnsw_provider:
+    hnsw_temporary_path: "~/tmp"
+    hnsw_cache_config:
+      weighted_lru:
+        name: "hnsw_cache"
+        capacity: 8589934592 # 8GB
+    permitted_parallelism: 180
+  fetch_log_batch_size: 1000
 compaction_service:
-    service_name: "compaction-service"
-    otel_endpoint: "http://otel-collector:4317"
-    otel_filters:
-        - crate_name: "worker"
-          filter_level: "trace"    
-    my_member_id: "compaction-service-0"
-    my_port: 50051
-    assignment_policy:
-        rendezvous_hashing:
-            hasher: Murmur3
-    memberlist_provider:
-        custom_resource:
-            kube_namespace: "chroma"
-            memberlist_name: "compaction-service-memberlist"
-            queue_size: 100
-    sysdb:
-        grpc:
-            host: "sysdb.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 5000
-    storage:
-        admission_controlled_s3:
-            s3_config:
-                bucket: "chroma-storage"
-                credentials: "Minio"
-                connect_timeout_ms: 5000
-                request_timeout_ms: 60000 # 1 minute
-                upload_part_size_bytes: 536870912 # 512MiB
-                download_part_size_bytes: 8388608 # 8MiB
-            rate_limiting_policy:
-                count_based_policy:
-                    max_concurrent_requests: 30
-                    bandwidth_allocation: [0.7, 0.3]
-    log:
-        grpc:
-            host: "logservice.chroma"
-            port: 50051
-            connect_timeout_ms: 5000
-            request_timeout_ms: 60000 # 1 minute
-            alt_host: "rust-log-service.chroma"
-            alt_host_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
-    dispatcher:
-        num_worker_threads: 4
-        dispatcher_queue_size: 1000
-        worker_queue_size: 100
-        task_queue_limit: 10000
-        active_io_tasks: 10000
-    compactor:
-        compaction_manager_queue_size: 1000
-        max_concurrent_jobs: 50
-        compaction_interval_sec: 10
-        min_compaction_size: 10
-        max_compaction_size: 10000
-        max_partition_size: 5000
-        disabled_collections: [] # uuids to disable compaction for
-        fetch_log_batch_size: 1000
-    blockfile_provider:
-        arrow:
-            block_manager_config:
-                max_block_size_bytes: 8388608 # 8MB
-                block_cache_config:
-                    lru:
-                        name: "block_cache"
-                        capacity: 1000
-            sparse_index_manager_config:
-                sparse_index_cache_config:
-                    lru:
-                        name: "sparse_index_cache"
-                        capacity: 1000
-    hnsw_provider:
-        hnsw_temporary_path: "~/tmp"
-        hnsw_cache_config:
-            weighted_lru:
-                name: "hnsw_cache"
-                capacity: 8192 # 8192 MiB = 8GB
-        permitted_parallelism: 180
-    spann_provider:
-        pl_block_size: 5242880 # 5MiB
-        pl_garbage_collection:
-            enabled: true
-            policy:
-                random_sample:
-                    sample_size: 0.1
-        hnsw_garbage_collection:
-            enabled: true
-            policy: "full_rebuild"
-
-log_service:
-    num_records_before_backpressure: 100000
-    reinsert_threshold: 0
-    opentelemetry:
-        service_name: "rust-log-service"
-        endpoint: "http://otel-collector:4317"
-        filters:
-            - crate_name: "chroma_log"
-              filter_level: "trace" 
-            - crate_name: "wal3"
-              filter_level: "trace"        
-    storage:
-        admission_controlled_s3:
-            s3_config:
-                bucket: "chroma-storage"
-                credentials: "Minio"
-                connect_timeout_ms: 5000
-                request_timeout_ms: 60000 # 1 minute
-                upload_part_size_bytes: 536870912 # 512MiB
-                download_part_size_bytes: 8388608 # 8MiB
-            rate_limiting_policy:
-                count_based_policy:
-                    max_concurrent_requests: 500
-                    bandwidth_allocation: [1.0]
-    cache:
-        memory:
-          capacity: 100000000 # 100 MB
-    writer:
-        throttle_fragment:
-            batch_interval_us: 100000
-            batch_size_bytes: 8388608 # 8MiB
-            throughput: 3300
-            headroom: 200
-    proxy_to:
-        host: "logservice.chroma"
-        port: 50051
+  service_name: "compaction-service"
+  otel_endpoint: "http://otel-collector:4317"
+  otel_filters:
+    - crate_name: "worker"
+      filter_level: "trace"
+  my_member_id: "compaction-service-0"
+  my_port: 50051
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "compaction-service-memberlist"
+      queue_size: 100
+  sysdb:
+    grpc:
+      host: "sysdb.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
         connect_timeout_ms: 5000
         request_timeout_ms: 60000 # 1 minute
-        alt_host: "rust-log-service.chroma"
-        alt_host_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 30
+          bandwidth_allocation: [0.7, 0.3]
+  log:
+    grpc:
+      host: "logservice.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 60000 # 1 minute
+      alt_host: "rust-log-service.chroma"
+      alt_host_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+  dispatcher:
+    num_worker_threads: 4
+    dispatcher_queue_size: 1000
+    worker_queue_size: 100
+    task_queue_limit: 10000
+    active_io_tasks: 10000
+  compactor:
+    compaction_manager_queue_size: 1000
+    max_concurrent_jobs: 50
+    compaction_interval_sec: 10
+    min_compaction_size: 10
+    max_compaction_size: 10000
+    max_partition_size: 5000
+    disabled_collections: [] # uuids to disable compaction for
+    fetch_log_batch_size: 1000
+  blockfile_provider:
+    arrow:
+      block_manager_config:
+        max_block_size_bytes: 8388608 # 8MB
+        block_cache_config:
+          lru:
+            name: "block_cache"
+            capacity: 1000
+      sparse_index_manager_config:
+        sparse_index_cache_config:
+          lru:
+            name: "sparse_index_cache"
+            capacity: 1000
+  hnsw_provider:
+    hnsw_temporary_path: "~/tmp"
+    hnsw_cache_config:
+      weighted_lru:
+        name: "hnsw_cache"
+        capacity: 8192 # 8192 MiB = 8GB
+    permitted_parallelism: 180
+  spann_provider:
+    pl_block_size: 5242880 # 5MiB
+    pl_garbage_collection:
+      enabled: true
+      policy:
+        random_sample:
+          sample_size: 0.1
+    hnsw_garbage_collection:
+      enabled: true
+      policy: "full_rebuild"
+log_service:
+  num_records_before_backpressure: 100000
+  reinsert_threshold: 0
+  opentelemetry:
+    service_name: "rust-log-service"
+    endpoint: "http://otel-collector:4317"
+    filters:
+      - crate_name: "chroma_log"
+        filter_level: "trace"
+      - crate_name: "wal3"
+        filter_level: "trace"
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 60000 # 1 minute
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 500
+          bandwidth_allocation: [1.0]
+  cache:
+    memory:
+      capacity: 100000000 # 100 MB
+  writer:
+    throttle_fragment:
+      batch_interval_us: 100000
+      batch_size_bytes: 8388608 # 8MiB
+      throughput: 3300
+      headroom: 200
+  proxy_to:
+    host: "logservice.chroma"
+    port: 50051
+    connect_timeout_ms: 5000
+    request_timeout_ms: 60000 # 1 minute
+    alt_host: "rust-log-service.chroma"
+    alt_host_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+garbage_collector:
+  service_name: "garbage-collector"
+  otel_endpoint: "http://otel-collector:4317"
+  otel_filters:
+    - crate_name: "garbage_collector"
+      filter_level: "debug"
+  relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
+  max_collections_to_gc: 1000
+  gc_interval_mins: 1
+  disallow_collections: []
+  default_mode: "deletev2"
+  sysdb_config:
+    host: "sysdb.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
+  dispatcher_config:
+    num_worker_threads: 4
+    dispatcher_queue_size: 100
+    worker_queue_size: 100
+  storage_config:
+    s3:
+      bucket: "chroma-storage"
+  assignment_policy:
+    rendezvous_hashing:
+      hasher: Murmur3
+  memberlist_provider:
+    custom_resource:
+      kube_namespace: "chroma"
+      memberlist_name: "garbage-collection-service-memberlist"
+      queue_size: 100
+  log:
+    grpc:
+      host: "logservice.chroma"
+      port: 50051
+      connect_timeout_ms: 5000
+      request_timeout_ms: 5000
+      alt_host: "rust-log-service.chroma"


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Load GC config under `garbage_collector` key if present. This is consistent to the behavior of other services
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
