### PR TITLE
[ENH]: Load HNSW index without disk intermediary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "hnswlib"
 version = "0.8.1"
-source = "git+https://github.com/chroma-core/hnswlib.git#581f689d0620fbc6601a9293142888c81b3751e1"
+source = "git+https://github.com/chroma-core/hnswlib.git?branch=master#7cb7befea40d8cf858580eb06f06cf76467755f9"
 dependencies = [
  "cc",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bytemuck = "1.21.0"
 rayon = "1.10.0"
 validator = { version = "0.19", features = ["derive"] }
 rust-embed = { version = "8.5.0", features = ["include-exclude", "debug-embed"] }
-hnswlib = { version = "0.8.1", git = "https://github.com/chroma-core/hnswlib.git" }
+hnswlib = { version = "0.8.1", git = "https://github.com/chroma-core/hnswlib.git", branch = "master" }
 reqwest = { version = "0.12.9", features = ["rustls-tls-native-roots", "http2"], default-features = false }
 random-port = "0.1.1"
 ndarray = { version = "0.16.1", features = ["approx"] }

--- a/rust/index/src/config.rs
+++ b/rust/index/src/config.rs
@@ -15,6 +15,10 @@ pub struct HnswProviderConfig {
     // inspired by the birthday paradox.
     #[serde(default = "HnswProviderConfig::default_permitted_parallelism")]
     pub permitted_parallelism: u32,
+    // Control whether HNSW indices are loaded from memory
+    // instead of disk. Defaults to false.
+    #[serde(default = "HnswProviderConfig::default_use_direct_hnsw")]
+    pub use_direct_hnsw: bool,
 }
 
 impl HnswProviderConfig {
@@ -24,6 +28,10 @@ impl HnswProviderConfig {
 
     const fn default_permitted_parallelism() -> u32 {
         180
+    }
+
+    const fn default_use_direct_hnsw() -> bool {
+        false
     }
 }
 

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -244,6 +244,29 @@ impl PersistentIndex<HnswIndexConfig> for HnswIndex {
             distance_function: index_config.distance_function.clone(),
         })
     }
+
+    fn load_from_hnsw_data(
+        hnsw_data: hnswlib::HnswData,
+        index_config: &IndexConfig,
+        ef_search: usize,
+        id: IndexUuid,
+    ) -> Result<Self, Box<dyn ChromaError>> {
+        let index = hnswlib::HnswIndex::load_from_hnsw_data(
+            hnswlib::HnswIndexMemoryLoadConfig {
+                distance_function: map_distance_function(index_config.distance_function.clone()),
+                dimensionality: index_config.dimensionality,
+                ef_search,
+            },
+            hnsw_data,
+        )
+        .map_err(|e| WrappedHnswInitError::Other(e).boxed())?;
+
+        Ok(HnswIndex {
+            index,
+            id,
+            distance_function: index_config.distance_function.clone(),
+        })
+    }
 }
 
 fn map_distance_function(distance_function: DistanceFunction) -> hnswlib::HnswDistanceFunction {

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -14,6 +14,7 @@ use chroma_error::ErrorCodes;
 use chroma_storage::admissioncontrolleds3::StorageRequestPriority;
 use chroma_storage::{GetOptions, PutOptions, Storage};
 use chroma_types::CollectionUuid;
+use futures::future::try_join_all;
 use parking_lot::RwLock;
 use std::fmt::Debug;
 use std::path::Path;
@@ -55,6 +56,10 @@ pub struct HnswIndexProvider {
     pub temporary_storage_path: PathBuf,
     storage: Storage,
     pub write_mutex: AysncPartitionedMutex<IndexUuid>,
+    // TODO(tanujnay112): This feature flag is a temporary measure to gate
+    // the hnsw loading from memory feature. Remove this after that feature
+    // stabilizes.
+    use_direct_hnsw: bool,
 }
 
 pub struct HnswIndexFlusher {
@@ -106,6 +111,7 @@ impl Configurable<(HnswProviderConfig, Storage)> for HnswIndexProvider {
             PathBuf::from(&hnsw_config.hnsw_temporary_path),
             cache,
             hnsw_config.permitted_parallelism,
+            hnsw_config.use_direct_hnsw,
         ))
     }
 }
@@ -134,6 +140,7 @@ impl HnswIndexProvider {
         storage_path: PathBuf,
         cache: Box<dyn Cache<CollectionUuid, HnswIndexRef>>,
         permitted_parallelism: u32,
+        use_direct_hnsw: bool,
     ) -> Self {
         let cache: Arc<dyn Cache<CollectionUuid, HnswIndexRef>> = cache.into();
         Self {
@@ -144,6 +151,7 @@ impl HnswIndexProvider {
                 permitted_parallelism as usize,
                 (),
             ),
+            use_direct_hnsw,
         }
     }
 
@@ -185,54 +193,44 @@ impl HnswIndexProvider {
         // The lock is a partitioned mutex to allow for higher concurrency across collections.
         let _guard = self.write_mutex.lock(source_id).await;
         let new_id = IndexUuid(Uuid::new_v4());
-        let new_storage_path = self.temporary_storage_path.join(new_id.to_string());
-        // This is ok to be called from multiple threads concurrently. See
-        // the documentation of tokio::fs::create_dir_all to see why.
-        match self.create_dir_all(&new_storage_path).await {
-            Ok(_) => {}
-            Err(e) => {
-                return Err(Box::new(HnswIndexProviderForkError::FileError(*e)));
-            }
-        }
-
-        match self
-            .load_hnsw_segment_into_directory(source_id, &new_storage_path, prefix_path)
-            .await
-        {
-            Ok(_) => {}
-            Err(e) => {
-                return Err(Box::new(HnswIndexProviderForkError::FileError(*e)));
-            }
-        }
 
         let index_config = IndexConfig::new(dimensionality, distance_function);
-
-        let storage_path_str = match new_storage_path.to_str() {
-            Some(storage_path_str) => storage_path_str,
-            None => {
-                return Err(Box::new(HnswIndexProviderForkError::PathToStringError(
-                    new_storage_path,
-                )));
-            }
-        };
 
         // Check if the entry is in the cache, if it is, we assume
         // another thread has loaded the index and we return it.
         match self.get(&new_id, cache_key).await {
             Some(index) => Ok(index.clone()),
-            None => match HnswIndex::load(storage_path_str, &index_config, ef_search, new_id) {
-                Ok(index) => {
-                    let index = HnswIndexRef {
-                        inner: Arc::new(RwLock::new(DistributedHnswInner {
-                            hnsw_index: index,
-                            prefix_path: prefix_path.to_string(),
-                        })),
-                    };
-                    self.cache.insert(*cache_key, index.clone()).await;
-                    Ok(index)
-                }
-                Err(e) => Err(Box::new(HnswIndexProviderForkError::IndexLoadError(e))),
-            },
+            None => {
+                let index_raw = if self.use_direct_hnsw {
+                    HnswIndex::load_from_hnsw_data(
+                        self.fetch_hnsw_segment(source_id, prefix_path)
+                            .await
+                            .map_err(|e| Box::new(HnswIndexProviderForkError::FileError(*e)))?,
+                        &index_config,
+                        ef_search,
+                        new_id,
+                    )
+                    .map_err(|e| Box::new(HnswIndexProviderForkError::IndexLoadError(e)))?
+                } else {
+                    self.open_and_persist_hnsw_on_disk(
+                        source_id,
+                        new_id,
+                        prefix_path,
+                        &index_config,
+                        ef_search,
+                    )
+                    .await
+                    .map_err(|e| Box::new(HnswIndexProviderForkError::IndexLoadError(e)))?
+                };
+                let index = HnswIndexRef {
+                    inner: Arc::new(RwLock::new(DistributedHnswInner {
+                        hnsw_index: index_raw,
+                        prefix_path: prefix_path.to_string(),
+                    })),
+                };
+                self.cache.insert(*cache_key, index.clone()).await;
+                Ok(index)
+            }
         }
     }
 
@@ -240,7 +238,7 @@ impl HnswIndexProvider {
     async fn copy_bytes_to_local_file(
         &self,
         file_path: &Path,
-        buf: Arc<Vec<u8>>,
+        buf: &[u8],
     ) -> Result<(), Box<HnswIndexProviderFileError>> {
         let file_handle = tokio::fs::File::create(&file_path).await;
 
@@ -252,7 +250,7 @@ impl HnswIndexProvider {
             }
         };
 
-        let res = file_handle.write_all(&buf).await;
+        let res = file_handle.write_all(buf).await;
         match res {
             Ok(_) => {}
             Err(e) => {
@@ -277,43 +275,137 @@ impl HnswIndexProvider {
         prefix_path: &str,
     ) -> Result<(), Box<HnswIndexProviderFileError>> {
         // Fetch the files from storage and put them in the index storage path.
-        for file in FILES.iter() {
-            let s3_fetch_span =
-                tracing::trace_span!(parent: Span::current(), "Read bytes from s3", file = file);
-            let buf = s3_fetch_span
-                .in_scope(|| async {
-                    let key = Self::format_key(prefix_path, source_id, file);
-                    tracing::info!("Loading hnsw index file: {} into directory", key);
-                    let bytes_res = self
-                        .storage
-                        .get(
-                            &key,
-                            GetOptions::new(StorageRequestPriority::P0).with_parallelism(),
-                        )
-                        .await;
-                    let bytes_read;
-                    let buf = match bytes_res {
-                        Ok(buf) => {
-                            bytes_read = buf.len();
-                            buf
-                        }
-                        Err(e) => {
-                            tracing::error!("Failed to load hnsw index file from storage: {}", e);
-                            return Err(Box::new(HnswIndexProviderFileError::StorageError(e)));
-                        }
-                    };
-                    tracing::info!(
-                        "Fetched {} bytes from s3 for storage key {:?}",
-                        bytes_read,
-                        key,
-                    );
-                    Ok(buf)
-                })
-                .await?;
+        let hnsw_data = self.fetch_hnsw_segment(source_id, prefix_path).await?;
+        let buffers = [
+            hnsw_data.header_buffer(),
+            hnsw_data.data_level0_buffer(),
+            hnsw_data.length_buffer(),
+            hnsw_data.link_list_buffer(),
+        ];
+        for (file, buffer) in FILES.iter().zip(buffers) {
             let file_path = index_storage_path.join(file);
-            self.copy_bytes_to_local_file(&file_path, buf).await?;
+            self.copy_bytes_to_local_file(&file_path, buffer).await?;
         }
         Ok(())
+    }
+
+    async fn fetch_hnsw_segment(
+        &self,
+        source_id: &IndexUuid,
+        prefix_path: &str,
+    ) -> Result<hnswlib::HnswData, Box<HnswIndexProviderFileError>> {
+        // Fetch all files in parallel
+        let futures = FILES.iter().map(|file| {
+            let prefix_path = prefix_path.to_string();
+            async move {
+                let s3_fetch_span =
+                    tracing::trace_span!(parent: Span::current(), "Read bytes from s3", file = file);
+                s3_fetch_span
+                    .in_scope(|| async {
+                        let key = Self::format_key(&prefix_path, source_id, file);
+                        tracing::info!("Loading hnsw index file: {} into directory", key);
+                        let bytes_res = self
+                            .storage
+                            .get(
+                                &key,
+                                GetOptions::new(StorageRequestPriority::P0).with_parallelism(),
+                            )
+                            .await;
+                        let bytes_read;
+                        let buf = match bytes_res {
+                            Ok(buf) => {
+                                bytes_read = buf.len();
+                                buf
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to load hnsw index file from storage: {}", e);
+                                return Err(Box::new(HnswIndexProviderFileError::StorageError(e)));
+                            }
+                        };
+                        tracing::info!(
+                            "Fetched {} bytes from s3 for storage key {:?}",
+                            bytes_read,
+                            key,
+                        );
+                        Ok(buf)
+                    }).await
+                }
+            });
+        let buffers = try_join_all(futures).await?;
+        match hnswlib::HnswDataBuilder::new()
+            .header_buffer(buffers[0].clone())
+            .data_level0_buffer(buffers[1].clone())
+            .length_buffer(buffers[2].clone())
+            .link_list_buffer(buffers[3].clone())
+            .build()
+        {
+            Ok(hnsw_data) => Ok(hnsw_data),
+            Err(e) => Err(Box::new(HnswIndexProviderFileError::BuildError(e))),
+        }
+    }
+
+    // Loads the given hnsw index by using a disk intermediary. This function
+    // makes sure to purge the disk intermediary once the index is loaded.
+    // TODO(tanujnay112): Remove this once we stabilze loading HNSW via memory.
+    async fn load_hnsw_with_disk_and_purge(
+        &self,
+        source_id: &IndexUuid,
+        new_id: IndexUuid,
+        prefix_path: &str,
+        index_config: &IndexConfig,
+        ef_search: usize,
+    ) -> Result<HnswIndex, Box<HnswIndexProviderOpenError>> {
+        let index = self
+            .open_and_persist_hnsw_on_disk(source_id, new_id, prefix_path, index_config, ef_search)
+            .await;
+        // Cleanup directory.
+        // Readers don't modify the index, so we can delete the files on disk
+        // once the index is fully loaded in memory.
+        Self::purge_one_id(&self.temporary_storage_path, new_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to cleanup files: {}", e);
+                Box::new(HnswIndexProviderOpenError::CleanupError(e))
+            })?;
+        index
+    }
+
+    // Opens the given hnsw index by using a disk intermediary. This function
+    // does not purge the disk intermediary once the index is loaded.
+    // TODO(tanujnay112): Remove this once we stabilze loading HNSW via memory.
+    async fn open_and_persist_hnsw_on_disk(
+        &self,
+        source_id: &IndexUuid,
+        new_id: IndexUuid,
+        prefix_path: &str,
+        index_config: &IndexConfig,
+        ef_search: usize,
+    ) -> Result<HnswIndex, Box<HnswIndexProviderOpenError>> {
+        let index_storage_path = self.temporary_storage_path.join(new_id.to_string());
+
+        // This is ok to be called from multiple threads concurrently. See
+        // the documentation of tokio::fs::create_dir_all to see why.
+        self.create_dir_all(&index_storage_path)
+            .await
+            .map_err(|e| Box::new(HnswIndexProviderOpenError::FileError(*e)))?;
+
+        self.load_hnsw_segment_into_directory(source_id, &index_storage_path, prefix_path)
+            .await
+            .map_err(|e| Box::new(HnswIndexProviderOpenError::FileError(*e)))?;
+
+        let index_storage_path_str = match index_storage_path.to_str() {
+            Some(index_storage_path_str) => index_storage_path_str,
+            None => {
+                return Err(Box::new(HnswIndexProviderOpenError::PathToStringError(
+                    index_storage_path,
+                )));
+            }
+        };
+
+        let index = HnswIndex::load(index_storage_path_str, index_config, ef_search, new_id)
+            .map_err(|e| Box::new(HnswIndexProviderOpenError::IndexLoadError(e)))?;
+
+        Ok(index)
     }
 
     pub async fn open(
@@ -330,6 +422,9 @@ impl HnswIndexProvider {
         if let Some(index) = self.get(id, cache_key).await {
             return Ok(index);
         }
+
+        let index_config = IndexConfig::new(dimensionality, distance_function);
+
         // We take a lock here to synchronize concurrent forks of the same index.
         // Otherwise, we could end up with a corrupted index since the filesystem
         // operations are not guaranteed to be atomic.
@@ -357,47 +452,42 @@ impl HnswIndexProvider {
             }
         }
 
-        let index_config = IndexConfig::new(dimensionality, distance_function);
-
-        let index_storage_path_str = match index_storage_path.to_str() {
-            Some(index_storage_path_str) => index_storage_path_str,
-            None => {
-                return Err(Box::new(HnswIndexProviderOpenError::PathToStringError(
-                    index_storage_path,
-                )));
-            }
-        };
-
         // Check if the entry is in the cache, if it is, we assume
         // another thread has loaded the index and we return it.
-        let index = match self.get(id, cache_key).await {
+        match self.get(id, cache_key).await {
             Some(index) => Ok(index.clone()),
-            None => match HnswIndex::load(index_storage_path_str, &index_config, ef_search, *id) {
-                Ok(index) => {
-                    let index = HnswIndexRef {
-                        inner: Arc::new(RwLock::new(DistributedHnswInner {
-                            hnsw_index: index,
-                            prefix_path: prefix_path.to_string(),
-                        })),
-                    };
-                    self.cache.insert(*cache_key, index.clone()).await;
-                    Ok(index)
-                }
-                Err(e) => Err(Box::new(HnswIndexProviderOpenError::IndexLoadError(e))),
-            },
-        };
-
-        // Cleanup directory.
-        // Readers don't modify the index, so we can delete the files on disk
-        // once the index is fully loaded in memory.
-        Self::purge_one_id(&self.temporary_storage_path, *id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to cleanup files: {}", e);
-                Box::new(HnswIndexProviderOpenError::CleanupError(e))
-            })?;
-
-        index
+            None => {
+                let index_raw = if self.use_direct_hnsw {
+                    HnswIndex::load_from_hnsw_data(
+                        self.fetch_hnsw_segment(id, prefix_path)
+                            .await
+                            .map_err(|e| Box::new(HnswIndexProviderOpenError::FileError(*e)))?,
+                        &index_config,
+                        ef_search,
+                        *id,
+                    )
+                    .map_err(|e| Box::new(HnswIndexProviderOpenError::IndexLoadError(e)))?
+                } else {
+                    self.load_hnsw_with_disk_and_purge(
+                        id,
+                        *id,
+                        prefix_path,
+                        &index_config,
+                        ef_search,
+                    )
+                    .await
+                    .map_err(|e| Box::new(HnswIndexProviderOpenError::IndexLoadError(e)))?
+                };
+                let index = HnswIndexRef {
+                    inner: Arc::new(RwLock::new(DistributedHnswInner {
+                        hnsw_index: index_raw,
+                        prefix_path: prefix_path.to_string(),
+                    })),
+                };
+                self.cache.insert(*cache_key, index.clone()).await;
+                Ok(index)
+            }
+        }
     }
 
     // Compactor
@@ -666,6 +756,8 @@ pub enum HnswIndexProviderFileError {
     IOError(#[from] std::io::Error),
     #[error("Storage Error: {0}")]
     StorageError(#[from] chroma_storage::StorageError),
+    #[error("HNSW Build Error: {0}")]
+    BuildError(#[from] hnswlib::HnswError),
     #[error("Must provide full path to file")]
     InvalidFilePath,
 }
@@ -687,7 +779,7 @@ mod tests {
 
         let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
         let cache = new_non_persistent_cache_for_test();
-        let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache, 16);
+        let provider = HnswIndexProvider::new(storage, hnsw_tmp_path, cache, 16, false);
         let collection_id = CollectionUuid(Uuid::new_v4());
 
         let dimensionality = 128;
@@ -733,7 +825,7 @@ mod tests {
 
         let storage = Storage::Local(LocalStorage::new(storage_dir.to_str().unwrap()));
         let cache = new_non_persistent_cache_for_test();
-        let provider = HnswIndexProvider::new(storage, storage_dir.clone(), cache, 16);
+        let provider = HnswIndexProvider::new(storage, storage_dir.clone(), cache, 16, false);
         let collection_id = CollectionUuid(Uuid::new_v4());
 
         let dimensionality = 2;

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -26,6 +26,7 @@ pub fn test_hnsw_index_provider() -> (TempDir, HnswIndexProvider) {
         temp_dir.path().to_path_buf(),
         new_non_persistent_cache_for_test(),
         16,
+        false,
     );
     (temp_dir, provider)
 }

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2899,6 +2899,7 @@ mod tests {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -3112,6 +3113,7 @@ mod tests {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -3376,6 +3378,7 @@ mod tests {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -3612,6 +3615,7 @@ mod tests {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -3875,6 +3879,7 @@ mod tests {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 2;
@@ -4174,6 +4179,7 @@ mod tests {
             PathBuf::from(temp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         )
     }
 

--- a/rust/index/src/types.rs
+++ b/rust/index/src/types.rs
@@ -67,6 +67,18 @@ pub trait PersistentIndex<C>: Index<C> {
     ) -> Result<Self, Box<dyn ChromaError>>
     where
         Self: Sized;
+
+    // This function is used to load the index from memory without using disk.
+    // TODO(tanujnay112): Replace `load` from above with this once we stablize
+    // loading HNSW via memory.
+    fn load_from_hnsw_data(
+        hnsw_data: hnswlib::HnswData,
+        index_config: &IndexConfig,
+        ef_search: usize,
+        id: IndexUuid,
+    ) -> Result<Self, Box<dyn ChromaError>>
+    where
+        Self: Sized;
 }
 
 /// IndexUuid is a wrapper around Uuid to provide a type for the index id.

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -630,6 +630,7 @@ mod test {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
@@ -754,6 +755,7 @@ mod test {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let gc_context = GarbageCollectionContext::try_from_config(
             &(
@@ -868,6 +870,7 @@ mod test {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();
@@ -974,6 +977,7 @@ mod test {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let spann_reader = SpannSegmentReader::from_segment(
             &collection,
@@ -1046,6 +1050,7 @@ mod test {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
 
@@ -1156,6 +1161,7 @@ mod test {
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let gc_context = GarbageCollectionContext::try_from_config(
             &(

--- a/rust/worker/benches/spann.rs
+++ b/rust/worker/benches/spann.rs
@@ -80,6 +80,7 @@ fn add_to_index_and_get_reader<'a>(
             PathBuf::from(tmp_dir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let collection_id = CollectionUuid::new();
         let dimensionality = 128;

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -447,11 +447,12 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
         )
         .await?;
 
-        let hnsw_index_provider = HnswIndexProvider::try_from_config(
-            &(config.hnsw_provider.clone(), storage.clone()),
-            registry,
-        )
-        .await?;
+        // TODO(tanujnay112): Remove this after we support loading hnsw from memory
+        // on the write path.
+        let mut hnsw_config = config.hnsw_provider.clone();
+        hnsw_config.use_direct_hnsw = false;
+        let hnsw_index_provider =
+            HnswIndexProvider::try_from_config(&(hnsw_config, storage.clone()), registry).await?;
 
         let spann_provider = SpannProvider::try_from_config(
             &(
@@ -920,6 +921,7 @@ mod tests {
             PathBuf::from(tmpdir.path().to_str().unwrap()),
             hnsw_cache,
             16,
+            false,
         );
         let spann_provider = SpannProvider {
             hnsw_provider: hnsw_provider.clone(),


### PR DESCRIPTION
## Description of changes
Added logic to load the HNSW sparse index without a disk intermediary by taking advantage of chroma/hnswlib's [corresponding change](https://github.com/chroma-core/hnswlib/commit/20f8c6123d744379e437161ed9071eb697c01f6f). This is gated by the `hnsw_provider` config feature flag `load_hnsw_from_memory` which is false by default.

- Improvements & Bug fixes
    - Loads the HNSW index from S3 without a disk intermediary by directly passing in the memory buffer given by S3.
- New functionality

## Test plan
This feature is false by default, but the tests in `hnsw_provider.rs` pass with it set to true and false.

- [ ] Tests pass locally with `pytest`for python, `yarn test`for js, `cargo test`for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_