### PR TITLE
[BUG]: Make embeddings mandatory in /upsert

### DIFF
--- a/chromadb/chromadb_rust_bindings.pyi
+++ b/chromadb/chromadb_rust_bindings.pyi
@@ -145,7 +145,7 @@ class Bindings:
         self,
         collection_id: str,
         ids: IDs,
-        embeddings: Optional[Embeddings] = None,
+        embeddings: Embeddings,
         metadatas: Optional[Metadatas] = None,
         documents: Optional[Documents] = None,
         uris: Optional[URIs] = None,

--- a/clients/js/packages/chromadb-core/src/ChromaFetch.ts
+++ b/clients/js/packages/chromadb-core/src/ChromaFetch.ts
@@ -16,9 +16,9 @@ import { FetchAPI } from "./generated";
 function isOfflineError(error: any): boolean {
   return Boolean(
     (error?.name === "TypeError" || error?.name === "FetchError") &&
-    (error.message?.includes("fetch failed") ||
-      error.message?.includes("Failed to fetch") ||
-      error.message?.includes("ENOTFOUND")),
+      (error.message?.includes("fetch failed") ||
+        error.message?.includes("Failed to fetch") ||
+        error.message?.includes("ENOTFOUND")),
   );
 }
 
@@ -78,10 +78,8 @@ export const chromaFetch: FetchAPI = async (
         case 422:
           if (
             respBody?.message &&
-            (
-              respBody?.message.startsWith("Quota exceeded") ||
-              respBody?.message.startsWith("Billing limit exceeded")
-            )
+            (respBody?.message.startsWith("Quota exceeded") ||
+              respBody?.message.startsWith("Billing limit exceeded"))
           ) {
             throw new ChromaQuotaExceededError(respBody?.message);
           }

--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -18,12 +18,12 @@ export namespace Api {
     embeddings: Api.EmbeddingsPayload;
     ids: string[];
     metadatas?:
-    | ({ [name: string]: boolean | number | number | string } | null)[]
-    | null;
+      | ({ [name: string]: boolean | number | number | string } | null)[]
+      | null;
     uris?: (string | null)[] | null;
   }
 
-  export interface AddCollectionRecordsResponse { }
+  export interface AddCollectionRecordsResponse {}
 
   export interface ChecklistResponse {
     /**
@@ -81,13 +81,13 @@ export namespace Api {
     name: string;
   }
 
-  export interface CreateDatabaseResponse { }
+  export interface CreateDatabaseResponse {}
 
   export interface CreateTenantPayload {
     name: string;
   }
 
-  export interface CreateTenantResponse { }
+  export interface CreateTenantResponse {}
 
   export interface Database {
     id: string;
@@ -99,9 +99,9 @@ export namespace Api {
     ids?: string[] | null;
   }
 
-  export interface DeleteCollectionRecordsResponse { }
+  export interface DeleteCollectionRecordsResponse {}
 
-  export interface DeleteDatabaseResponse { }
+  export interface DeleteDatabaseResponse {}
 
   export type EmbeddingFunctionConfiguration =
     | Api.EmbeddingFunctionConfiguration.ObjectValue
@@ -180,8 +180,8 @@ export namespace Api {
     ids: string[];
     include: Api.Include[];
     metadatas?:
-    | ({ [name: string]: boolean | number | number | string } | null)[]
-    | null;
+      | ({ [name: string]: boolean | number | number | string } | null)[]
+      | null;
     uris?: (string | null)[] | null;
   }
 
@@ -270,8 +270,8 @@ export namespace Api {
     ids: string[][];
     include: Api.Include[];
     metadatas?:
-    | ({ [name: string]: boolean | number | number | string } | null)[][]
-    | null;
+      | ({ [name: string]: boolean | number | number | string } | null)[][]
+      | null;
     uris?: (string | null)[][] | null;
   }
 
@@ -351,14 +351,14 @@ export namespace Api {
     embeddings?: Api.UpdateEmbeddingsPayload | null;
     ids: string[];
     metadatas?:
-    | ({ [name: string]: boolean | number | number | string } | null)[]
-    | null;
+      | ({ [name: string]: boolean | number | number | string } | null)[]
+      | null;
     uris?: (string | null)[] | null;
   }
 
-  export interface UpdateCollectionRecordsResponse { }
+  export interface UpdateCollectionRecordsResponse {}
 
-  export interface UpdateCollectionResponse { }
+  export interface UpdateCollectionResponse {}
 
   export type UpdateEmbeddingsPayload = (number[] | null)[] | (string | null)[];
 
@@ -420,12 +420,12 @@ export namespace Api {
     embeddings: Api.EmbeddingsPayload;
     ids: string[];
     metadatas?:
-    | ({ [name: string]: boolean | number | number | string } | null)[]
-    | null;
+      | ({ [name: string]: boolean | number | number | string } | null)[]
+      | null;
     uris?: (string | null)[] | null;
   }
 
-  export interface UpsertCollectionRecordsResponse { }
+  export interface UpsertCollectionRecordsResponse {}
 
   export interface Vec2 {
     configuration_json: Api.CollectionConfiguration;

--- a/clients/js/packages/chromadb-core/src/generated/models.ts
+++ b/clients/js/packages/chromadb-core/src/generated/models.ts
@@ -18,12 +18,12 @@ export namespace Api {
     embeddings: Api.EmbeddingsPayload;
     ids: string[];
     metadatas?:
-      | ({ [name: string]: boolean | number | number | string } | null)[]
-      | null;
+    | ({ [name: string]: boolean | number | number | string } | null)[]
+    | null;
     uris?: (string | null)[] | null;
   }
 
-  export interface AddCollectionRecordsResponse {}
+  export interface AddCollectionRecordsResponse { }
 
   export interface ChecklistResponse {
     /**
@@ -81,13 +81,13 @@ export namespace Api {
     name: string;
   }
 
-  export interface CreateDatabaseResponse {}
+  export interface CreateDatabaseResponse { }
 
   export interface CreateTenantPayload {
     name: string;
   }
 
-  export interface CreateTenantResponse {}
+  export interface CreateTenantResponse { }
 
   export interface Database {
     id: string;
@@ -99,9 +99,9 @@ export namespace Api {
     ids?: string[] | null;
   }
 
-  export interface DeleteCollectionRecordsResponse {}
+  export interface DeleteCollectionRecordsResponse { }
 
-  export interface DeleteDatabaseResponse {}
+  export interface DeleteDatabaseResponse { }
 
   export type EmbeddingFunctionConfiguration =
     | Api.EmbeddingFunctionConfiguration.ObjectValue
@@ -180,8 +180,8 @@ export namespace Api {
     ids: string[];
     include: Api.Include[];
     metadatas?:
-      | ({ [name: string]: boolean | number | number | string } | null)[]
-      | null;
+    | ({ [name: string]: boolean | number | number | string } | null)[]
+    | null;
     uris?: (string | null)[] | null;
   }
 
@@ -270,8 +270,8 @@ export namespace Api {
     ids: string[][];
     include: Api.Include[];
     metadatas?:
-      | ({ [name: string]: boolean | number | number | string } | null)[][]
-      | null;
+    | ({ [name: string]: boolean | number | number | string } | null)[][]
+    | null;
     uris?: (string | null)[][] | null;
   }
 
@@ -351,14 +351,14 @@ export namespace Api {
     embeddings?: Api.UpdateEmbeddingsPayload | null;
     ids: string[];
     metadatas?:
-      | ({ [name: string]: boolean | number | number | string } | null)[]
-      | null;
+    | ({ [name: string]: boolean | number | number | string } | null)[]
+    | null;
     uris?: (string | null)[] | null;
   }
 
-  export interface UpdateCollectionRecordsResponse {}
+  export interface UpdateCollectionRecordsResponse { }
 
-  export interface UpdateCollectionResponse {}
+  export interface UpdateCollectionResponse { }
 
   export type UpdateEmbeddingsPayload = (number[] | null)[] | (string | null)[];
 
@@ -417,15 +417,15 @@ export namespace Api {
 
   export interface UpsertCollectionRecordsPayload {
     documents?: (string | null)[] | null;
-    embeddings?: Api.EmbeddingsPayload | null;
+    embeddings: Api.EmbeddingsPayload;
     ids: string[];
     metadatas?:
-      | ({ [name: string]: boolean | number | number | string } | null)[]
-      | null;
+    | ({ [name: string]: boolean | number | number | string } | null)[]
+    | null;
     uris?: (string | null)[] | null;
   }
 
-  export interface UpsertCollectionRecordsResponse {}
+  export interface UpsertCollectionRecordsResponse { }
 
   export interface Vec2 {
     configuration_json: Api.CollectionConfiguration;

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -2,7 +2,7 @@
 
 export type AddCollectionRecordsPayload = {
   documents?: Array<string | null> | null;
-  embeddings?: null | EmbeddingsPayload;
+  embeddings: EmbeddingsPayload;
   ids: Array<string>;
   metadatas?: Array<null | HashMap> | null;
   uris?: Array<string | null> | null;
@@ -241,7 +241,7 @@ export type UpdateSpannConfiguration = {
 
 export type UpsertCollectionRecordsPayload = {
   documents?: Array<string | null> | null;
-  embeddings?: null | EmbeddingsPayload;
+  embeddings: EmbeddingsPayload;
   ids: Array<string>;
   metadatas?: Array<null | HashMap> | null;
   uris?: Array<string | null> | null;

--- a/rust/frontend/src/impls/in_memory_frontend.rs
+++ b/rust/frontend/src/impls/in_memory_frontend.rs
@@ -411,7 +411,7 @@ impl InMemoryFrontend {
             ..
         } = request;
 
-        let embeddings = embeddings.map(|embeddings| embeddings.into_iter().map(Some).collect());
+        let embeddings = Some(embeddings.into_iter().map(Some).collect());
 
         let (records, _) = to_records(
             ids,

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -887,13 +887,16 @@ impl ServiceBasedFrontend {
             ..
         }: UpsertCollectionRecordsRequest,
     ) -> Result<UpsertCollectionRecordsResponse, UpsertCollectionRecordsError> {
-        self.validate_embedding(collection_id, embeddings.as_ref(), true, |embedding| {
-            Some(embedding.len())
-        })
+        self.validate_embedding(
+            collection_id,
+            Some(&embeddings),
+            true,
+            |embedding: &Vec<f32>| Some(embedding.len()),
+        )
         .await
         .map_err(|err| err.boxed())?;
 
-        let embeddings = embeddings.map(|embeddings| embeddings.into_iter().map(Some).collect());
+        let embeddings = Some(embeddings.into_iter().map(Some).collect());
 
         let (records, log_size_bytes) = to_records(
             ids,

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1487,7 +1487,7 @@ async fn collection_update(
 #[derive(Deserialize, Debug, Clone, ToSchema, Serialize)]
 pub struct UpsertCollectionRecordsPayload {
     ids: Vec<String>,
-    embeddings: Option<EmbeddingsPayload>,
+    embeddings: EmbeddingsPayload,
     documents: Option<Vec<Option<String>>>,
     uris: Option<Vec<Option<String>>>,
     metadatas: Option<Vec<Option<UpdateMetadata>>>,
@@ -1543,13 +1543,8 @@ async fn collection_upsert(
         .map(|val| val.to_string());
     let mut quota_payload = QuotaPayload::new(Action::Upsert, tenant.clone(), api_token);
     quota_payload = quota_payload.with_ids(&payload.ids);
-    let payload_embeddings: Option<Vec<Vec<f32>>> = match payload.embeddings {
-        Some(embeddings) => Some(decode_embeddings(embeddings)?),
-        None => None,
-    };
-    if let Some(embeddings) = payload_embeddings.as_ref() {
-        quota_payload = quota_payload.with_add_embeddings(embeddings);
-    }
+    let payload_embeddings: Vec<Vec<f32>> = decode_embeddings(payload.embeddings)?;
+    quota_payload = quota_payload.with_add_embeddings(&payload_embeddings);
     if let Some(metadatas) = &payload.metadatas {
         quota_payload = quota_payload.with_update_metadatas(metadatas);
     }

--- a/rust/frontend/tests/proptest_helpers/arbitrary.rs
+++ b/rust/frontend/tests/proptest_helpers/arbitrary.rs
@@ -180,7 +180,7 @@ impl Arbitrary for CollectionRequest {
                             database.clone(),
                             collection_id,
                             ids,
-                            Some(embeddings),
+                            embeddings,
                             documents,
                             None,
                             metadatas,

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -466,14 +466,14 @@ impl Bindings {
     }
 
     #[pyo3(
-        signature = (collection_id, ids, embeddings = None, metadatas = None, documents = None, uris = None, tenant = DEFAULT_TENANT.to_string(), database = DEFAULT_DATABASE.to_string())
+        signature = (collection_id, ids, embeddings, metadatas = None, documents = None, uris = None, tenant = DEFAULT_TENANT.to_string(), database = DEFAULT_DATABASE.to_string())
     )]
     #[allow(clippy::too_many_arguments)]
     fn upsert(
         &self,
         collection_id: String,
         ids: Vec<String>,
-        embeddings: Option<Vec<Vec<f32>>>,
+        embeddings: Vec<Vec<f32>>,
         metadatas: Option<Vec<Option<UpdateMetadata>>>,
         documents: Option<Vec<Option<String>>>,
         uris: Option<Vec<Option<String>>>,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -967,7 +967,7 @@ pub struct AddCollectionRecordsRequest {
     pub database_name: String,
     pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
-    #[validate(custom(function = "Self::validate_embeddings"))]
+    #[validate(custom(function = "validate_embeddings"))]
     pub embeddings: Vec<Vec<f32>>,
     pub documents: Option<Vec<Option<String>>>,
     pub uris: Option<Vec<Option<String>>>,
@@ -999,14 +999,14 @@ impl AddCollectionRecordsRequest {
         request.validate().map_err(ChromaValidationError::from)?;
         Ok(request)
     }
+}
 
-    fn validate_embeddings(embeddings: &[Vec<f32>]) -> Result<(), ValidationError> {
-        if embeddings.iter().any(|e| e.is_empty()) {
-            return Err(ValidationError::new("embedding_minimum_dimensions")
-                .with_message("Each embedding must have at least 1 dimension".into()));
-        }
-        Ok(())
+fn validate_embeddings(embeddings: &[Vec<f32>]) -> Result<(), ValidationError> {
+    if embeddings.iter().any(|e| e.is_empty()) {
+        return Err(ValidationError::new("embedding_minimum_dimensions")
+            .with_message("Each embedding must have at least 1 dimension".into()));
     }
+    Ok(())
 }
 
 #[derive(Serialize, ToSchema, Default, Deserialize)]
@@ -1103,7 +1103,8 @@ pub struct UpsertCollectionRecordsRequest {
     pub database_name: String,
     pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
-    pub embeddings: Option<Vec<Vec<f32>>>,
+    #[validate(custom(function = "validate_embeddings"))]
+    pub embeddings: Vec<Vec<f32>>,
     pub documents: Option<Vec<Option<String>>>,
     pub uris: Option<Vec<Option<String>>>,
     pub metadatas: Option<Vec<Option<UpdateMetadata>>>,
@@ -1116,7 +1117,7 @@ impl UpsertCollectionRecordsRequest {
         database_name: String,
         collection_id: CollectionUuid,
         ids: Vec<String>,
-        embeddings: Option<Vec<Vec<f32>>>,
+        embeddings: Vec<Vec<f32>>,
         documents: Option<Vec<Option<String>>>,
         uris: Option<Vec<Option<String>>>,
         metadatas: Option<Vec<Option<UpdateMetadata>>>,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - embeddings is mandatory in /upsert now. Previously it was optional, and led to users pushing records without embeddings thereby failing compaction subsequently.
- New functionality
  - ...

## Test plan

_How are these changes tested?_
Locally tested on tilt
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
Will babysit staging to see that nothing breaks

## Documentation Changes
None
