### PR TITLE
[ENH]  Change ResourcesExhaused into Backoff/429 for log client.

### DIFF
--- a/chromadb/test/distributed/test_log_backpressure.py
+++ b/chromadb/test/distributed/test_log_backpressure.py
@@ -38,16 +38,17 @@ def test_log_backpressure(
     print('backpressuring for', collection.id)
 
     excepted = False
-    try:
-        # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
-        for i in range(0, RECORDS, BATCH_SIZE):
-            ids = []
-            embeddings = []
-            ids.extend([str(x) for x in range(i, i + BATCH_SIZE)])
-            embeddings.extend([np.random.rand(1, 3)[0] for x in range(i, i + BATCH_SIZE)])
+    # Add RECORDS records, where each embedding has 3 dimensions randomly generated between 0 and 1
+    for i in range(0, RECORDS, BATCH_SIZE):
+        ids = []
+        embeddings = []
+        ids.extend([str(x) for x in range(i, i + BATCH_SIZE)])
+        embeddings.extend([np.random.rand(1, 3)[0] for x in range(i, i + BATCH_SIZE)])
+        try:
             collection.add(ids=ids, embeddings=embeddings)
-    except Exception as x:
-        print(f"Caught exception:\n{x}")
-        if 'log needs compaction' in str(x):
-            excepted = True
+        except Exception as x:
+            print(f"Caught exception:\n{x}")
+            if 'Backoff and retry' in str(x):
+                excepted = True
+                break
     assert excepted, "Expected an exception to be thrown."

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tonic::transport::Endpoint;
 use tower::ServiceBuilder;
+use tracing::Level;
 use uuid::Uuid;
 
 use crate::GarbageCollectError;
@@ -479,7 +480,9 @@ impl GrpcLog {
             .map_err(|err| {
                 if err.code() == ErrorCodes::Unavailable.into()
                     || err.code() == ErrorCodes::AlreadyExists.into()
+                    || err.code() == ErrorCodes::ResourceExhausted.into()
                 {
+                    tracing::event!(Level::INFO, name = "backoff reason", error =? err);
                     GrpcPushLogsError::Backoff
                 } else {
                     err.into()


### PR DESCRIPTION
## Description of changes

This PR makes it so that a resources exhausted error from the grpc log
client gets translated into a Backoff error from the typed log client.

## Test plan

CI

## Migration plan

N/A

## Observability plan

We should be able to hit the backpressure limit and see it as a 429
instead of 500.

## Documentation Changes

N/A
