### PR TITLE
[CLN] Remove get_parallel, replace with options for parallel

### DIFF
--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -286,7 +286,10 @@ impl HnswIndexProvider {
                     tracing::info!("Loading hnsw index file: {} into directory", key);
                     let bytes_res = self
                         .storage
-                        .get_parallel(&key, GetOptions::new(StorageRequestPriority::P0))
+                        .get(
+                            &key,
+                            GetOptions::new(StorageRequestPriority::P0).with_parallelism(),
+                        )
                         .await;
                     let bytes_read;
                     let buf = match bytes_res {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Minor cleanup that  removes get_parallel and replaces it with an option
- New functionality
  - None

## Test plan

_How are these changes tested?_
Existing tests for parallel reads were ported to the new path
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None required

## Observability plan
None required

## Documentation Changes
None required