### PR TITLE
[ENH]  Thread collection ID through the GC::Wal3 error.

### DIFF
--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -33,8 +33,11 @@ pub type DeleteUnusedLogsOutput = ();
 
 #[derive(Debug, Error)]
 pub enum DeleteUnusedLogsError {
-    #[error(transparent)]
-    Wal3(#[from] wal3::Error),
+    #[error("failed to garbage collect in wal3 for {collection_id}: {err}")]
+    Wal3 {
+        collection_id: CollectionUuid,
+        err: wal3::Error,
+    },
     #[error(transparent)]
     Gc(#[from] chroma_log::GarbageCollectError),
 }
@@ -68,6 +71,7 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
             let mut log_gc_futures = Vec::with_capacity(input.collections_to_garbage_collect.len());
             for (collection_id, minimum_log_offset_to_keep) in &input.collections_to_garbage_collect
             {
+                let collection_id = *collection_id;
                 let storage_clone = storage_arc.clone();
                 let mut logs = self.logs.clone();
                 log_gc_futures.push(async move {
@@ -83,7 +87,7 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                         Err(wal3::Error::UninitializedLog) => return Ok(()),
                         Err(err) => {
                             tracing::error!("Unable to initialize log writer for collection [{collection_id}]: {err}");
-                            return Err(DeleteUnusedLogsError::Wal3(err))
+                            return Err(DeleteUnusedLogsError::Wal3{ collection_id, err})
                         }
                     };
                     // See README.md in wal3 for a description of why this happens in three phases.
@@ -92,10 +96,10 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                         Ok(false) => return Ok(()),
                         Err(err) => {
                             tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                            return Err(DeleteUnusedLogsError::Wal3(err));
+                            return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
                         }
                     };
-                    if let Err(err) = logs.garbage_collect_phase2(*collection_id).await {
+                    if let Err(err) = logs.garbage_collect_phase2(collection_id).await {
                         tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
                         return Err(DeleteUnusedLogsError::Gc(err));
                     };
@@ -103,7 +107,7 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                         CleanupMode::Delete | CleanupMode::DeleteV2 => {
                             if let Err(err) = writer.garbage_collect_phase3_delete_garbage(&GarbageCollectionOptions::default()).await {
                                 tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                                return Err(DeleteUnusedLogsError::Wal3(err));
+                                return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
                             };
                         }
                         mode => {
@@ -125,6 +129,7 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                     let mut log_destroy_futures =
                         Vec::with_capacity(input.collections_to_destroy.len());
                     for collection_id in &input.collections_to_destroy {
+                        let collection_id = *collection_id;
                         let storage_clone = storage_arc.clone();
                         log_destroy_futures.push(async move {
                             match wal3::destroy(storage_clone, &collection_id.storage_prefix_for_log())
@@ -135,7 +140,7 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                                     tracing::error!(
                                         "Unable to destroy log for collection [{collection_id}]: {err:?}"
                                     );
-                                    Err(DeleteUnusedLogsError::Wal3(err))
+                                    Err(DeleteUnusedLogsError::Wal3{ collection_id, err})
                                 }
                             }
                         })


### PR DESCRIPTION
## Description of changes

This change adds the collection ID as a property of the garbage
collection error, so we can trace which collection is responsible for a
particular error.

## Test plan

CI

## Migration plan

N/A

## Observability plan

This is an observability PR.

## Documentation Changes

N/A
