### PR TITLE
[ENH] testing lower spann posting list configuration recall

### DIFF
--- a/rust/types/src/spann_configuration.rs
+++ b/rust/types/src/spann_configuration.rs
@@ -106,7 +106,7 @@ pub struct InternalSpannConfiguration {
     #[serde(default = "default_write_rng_epsilon")]
     pub write_rng_epsilon: f32,
     #[serde(default = "default_split_threshold")]
-    #[validate(range(min = 100, max = 200))]
+    #[validate(range(min = 25, max = 200))]
     pub split_threshold: u32,
     #[serde(default = "default_num_samples_kmeans")]
     pub num_samples_kmeans: usize,
@@ -116,7 +116,7 @@ pub struct InternalSpannConfiguration {
     #[validate(range(max = 64))]
     pub reassign_neighbor_count: u32,
     #[serde(default = "default_merge_threshold")]
-    #[validate(range(min = 50, max = 100))]
+    #[validate(range(min = 12, max = 100))]
     pub merge_threshold: u32,
     #[serde(default = "default_num_centers_to_merge_to")]
     #[validate(range(max = 8))]


### PR DESCRIPTION
## Description of changes

This PR lowers the split and merge threshold minimums to 25 and 12 respectively for recall measurements on staging.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
