### PR TITLE
[ENH]  Log the first_to_keep value that triggers an error.

### DIFF
--- a/rust/wal3/src/gc.rs
+++ b/rust/wal3/src/gc.rs
@@ -65,9 +65,9 @@ impl Garbage {
         first_to_keep: LogPosition,
     ) -> Result<Option<Self>, Error> {
         let Some(first_to_keep) = manifest.round_to_boundary(first_to_keep) else {
-            return Err(Error::CorruptGarbage(
-                "First to keep does not overlap manifest.".to_string(),
-            ));
+            return Err(Error::CorruptGarbage(format!(
+                "First to keep does not overlap manifest (first_to_keep={first_to_keep:?})"
+            )));
         };
         let dropped_snapshots = manifest
             .snapshots

--- a/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
+++ b/rust/wal3/tests/test_k8s_integration_98_garbage_alternate.rs
@@ -93,7 +93,7 @@ async fn garbage_collector_thread(
             {
                 Ok(()) => break,
                 Err(Error::CorruptGarbage(m))
-                    if m == "First to keep does not overlap manifest." =>
+                    if m.starts_with("First to keep does not overlap manifest") =>
                 {
                     println!("gc sees cursor ahead of manifest; only a problem if looping");
                     tokio::time::sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
## Description of changes

If the rust log service tries to GC something that's not within range,
it will throw this error, but without knowing the offset it's hard to
say how things have gone wrong.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Improved.

## Documentation Changes

N/A
