### PR TITLE
[ENH]  Add a hack to allow us to move past some broken collections on staging.

### DIFF
--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -67,6 +67,8 @@ pub(super) struct GarbageCollectorConfig {
     #[serde(default = "GarbageCollectorConfig::enable_log_gc_for_tenant_threshold")]
     pub enable_log_gc_for_tenant_threshold: String,
     pub log: LogConfig,
+    #[serde(default)]
+    pub enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
 impl GarbageCollectorConfig {

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -116,6 +116,7 @@ impl GarbageCollector {
         collection_soft_delete_absolute_cutoff_time: DateTime<Utc>,
         collection: CollectionToGcInfo,
         cleanup_mode: CleanupMode,
+        enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
     ) -> Result<GarbageCollectorResponse, GarbageCollectCollectionError> {
         let dispatcher = self
             .dispatcher
@@ -149,6 +150,7 @@ impl GarbageCollector {
                     cleanup_mode,
                     self.config.min_versions_to_keep,
                     enable_log_gc,
+                    enable_dangerous_option_to_ignore_min_versions_for_wal3,
                 );
 
             let started_at = SystemTime::now();
@@ -419,6 +421,7 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
                 collection_soft_delete_absolute_cutoff_time,
                 collection,
                 cleanup_mode,
+                self.config.enable_dangerous_option_to_ignore_min_versions_for_wal3,
             )
             .instrument(instrumented_span)
         })
@@ -750,6 +753,7 @@ mod tests {
             enable_log_gc_for_tenant: Vec::new(),
             enable_log_gc_for_tenant_threshold: "tenant-ffffffff-ffff-ffff-ffff-ffffffffffff"
                 .to_string(),
+            enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
         };
         let registry = Registry::new();
 
@@ -880,6 +884,7 @@ mod tests {
             enable_log_gc_for_tenant: Vec::new(),
             enable_log_gc_for_tenant_threshold: "tenant-threshold".to_string(),
             log: LogConfig::default(),
+            enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
         };
         let registry = Registry::new();
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -84,6 +84,8 @@ pub struct GarbageCollectorOrchestrator {
 
     num_files_deleted: u32,
     num_versions_deleted: u32,
+
+    enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -103,6 +105,7 @@ impl GarbageCollectorOrchestrator {
         cleanup_mode: CleanupMode,
         min_versions_to_keep: u32,
         enable_log_gc: bool,
+        enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
     ) -> Self {
         Self {
             collection_id,
@@ -135,6 +138,8 @@ impl GarbageCollectorOrchestrator {
 
             num_files_deleted: 0,
             num_versions_deleted: 0,
+
+            enable_dangerous_option_to_ignore_min_versions_for_wal3,
         }
     }
 }
@@ -524,6 +529,8 @@ impl GarbageCollectorOrchestrator {
                 mode: self.cleanup_mode,
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),
+                enable_dangerous_option_to_ignore_min_versions_for_wal3: self
+                    .enable_dangerous_option_to_ignore_min_versions_for_wal3,
             }),
             DeleteUnusedLogsInput {
                 collections_to_destroy,
@@ -1209,6 +1216,7 @@ mod tests {
             crate::types::CleanupMode::Delete,
             1,
             true,
+            false,
         );
         let result = orchestrator.run(system).await;
         assert!(result.is_err());

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -21,6 +21,7 @@ pub struct DeleteUnusedLogsOperator {
     pub mode: CleanupMode,
     pub storage: Storage,
     pub logs: Log,
+    pub enable_dangerous_option_to_ignore_min_versions_for_wal3: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -90,15 +91,34 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                             return Err(DeleteUnusedLogsError::Wal3{ collection_id, err})
                         }
                     };
-                    // See README.md in wal3 for a description of why this happens in three phases.
-                    match writer.garbage_collect_phase1_compute_garbage(&GarbageCollectionOptions::default(), Some(*minimum_log_offset_to_keep)).await {
-                        Ok(true) => {},
-                        Ok(false) => return Ok(()),
-                        Err(err) => {
-                            tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
-                            return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
-                        }
-                    };
+                    // NOTE(rescrv):  Once upon a time, we had a bug where we would not pass the
+                    // min log offset into the wal3 garbage collect process.  For disaster
+                    // recovery, we need to keep N versions per the config, but the collections
+                    // (staging only) were collected up to the most recent version.  The fix is
+                    // this hack to allow a corrupt garbage error to be masked iff the appropriate
+                    // configuration value is set.
+                    //
+                    // The configuration is
+                    // enable_dangerous_option_to_ignore_min_versions_for_wal3.  Its default is
+                    // false.  Setting it to true enables this loop to skip the min_log_offset.
+                    let mut min_log_offset = Some(*minimum_log_offset_to_keep);
+                    for _ in 0..if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 { 2 } else { 1 } {
+                        // See README.md in wal3 for a description of why this happens in three phases.
+                        match writer.garbage_collect_phase1_compute_garbage(&GarbageCollectionOptions::default(), min_log_offset).await {
+                            Ok(true) => {},
+                            Ok(false) => return Ok(()),
+                            Err(wal3::Error::CorruptGarbage(c)) if c.starts_with("First to keep does not overlap manifest") => {
+                                if self.enable_dangerous_option_to_ignore_min_versions_for_wal3 {
+                                    tracing::warn!("encountered enable_dangerous_option_to_ignore_min_versions_for_wal3 path");
+                                    min_log_offset.take();
+                                }
+                            }
+                            Err(err) => {
+                                tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
+                                return Err(DeleteUnusedLogsError::Wal3{ collection_id, err});
+                            }
+                        };
+                    }
                     if let Err(err) = logs.garbage_collect_phase2(collection_id).await {
                         tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
                         return Err(DeleteUnusedLogsError::Gc(err));

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -321,7 +321,8 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                                 state.root_manager.clone(),
                                 CleanupMode::Delete,
                                 min_versions_to_keep as u32,
-                                true
+                                true,
+                                false,
                             );
                             let result = orchestrator.run(system.clone()).await;
 


### PR DESCRIPTION
## Description of changes

This introduces a new configuration for the purposes of skipping the
num-versions-to-keep rule in GC for the wal3 log only.  When the new
enable_dangerous_option_to_ignore_min_versions_for_wal3 is set, it will
try to do the right thing, and if it fails with the symptoms of the bug,
it will then try again using just the compaction offset.

## Test plan

Send through CI, enable on staging, then stop.

## Migration plan

This is a migration of sorts.

## Observability plan

I will watch staging where we currently see errors and will not see them
in the future.

## Documentation Changes

N/A
