### PR TITLE
[ENH]  And endpoint and tool to rollback collection log offset after DR.

### DIFF
--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -153,6 +153,10 @@ func (s *logServer) UpdateCollectionLogOffset(ctx context.Context, req *logservi
 	return
 }
 
+func (s *logServer) RollbackCollectionLogOffset(ctx context.Context, req *logservicepb.UpdateCollectionLogOffsetRequest) (res *logservicepb.UpdateCollectionLogOffsetResponse, err error) {
+	return
+}
+
 func (s *logServer) PurgeDirtyForCollection(ctx context.Context, req *logservicepb.PurgeDirtyForCollectionRequest) (res *logservicepb.PurgeDirtyForCollectionResponse, err error) {
 	return
 }

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -30,7 +30,7 @@ func (s *collectionDb) DeleteAll() error {
 func (s *collectionDb) GetCollectionWithoutMetadata(collectionID *string, databaseName *string, softDeletedFlag *bool) (*dbmodel.Collection, error) {
 	var collections []*dbmodel.Collection
 	query := s.db.Table("collections").
-		Select("collections.id, collections.name, collections.database_id, collections.is_deleted, collections.tenant, collections.version, collections.version_file_name, NULLIF(collections.root_collection_id, '') AS root_collection_id, NULLIF(collections.lineage_file_name, '') AS lineage_file_name").
+		Select("collections.id, collections.name, collections.database_id, collections.is_deleted, collections.tenant, collections.version, collections.version_file_name, collections.log_position, NULLIF(collections.root_collection_id, '') AS root_collection_id, NULLIF(collections.lineage_file_name, '') AS lineage_file_name").
 		Joins("INNER JOIN databases ON collections.database_id = databases.id").
 		Where("collections.id = ?", collectionID)
 

--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -193,4 +193,7 @@ service LogService {
   rpc GarbageCollectPhase2(GarbageCollectPhase2Request) returns (GarbageCollectPhase2Response) {}
   // This endpoint will purge from cache the specified items.
   rpc PurgeFromCache(PurgeFromCacheRequest) returns (PurgeFromCacheResponse) {}
+  // Similar to UpdateCollectionLogOffset, but allows the offset to go back in time.
+  // Uses the exact same request/response types as UpdateCollectionLogOffset by design.
+  rpc RollbackCollectionLogOffset(UpdateCollectionLogOffsetRequest) returns (UpdateCollectionLogOffsetResponse) {}
 }

--- a/rust/log-service/src/bin/chroma-rollback-collection-log-offset.rs
+++ b/rust/log-service/src/bin/chroma-rollback-collection-log-offset.rs
@@ -1,0 +1,54 @@
+use tonic::transport::Channel;
+use uuid::Uuid;
+
+use chroma_types::chroma_proto::log_service_client::LogServiceClient;
+use chroma_types::chroma_proto::sys_db_client::SysDbClient;
+use chroma_types::chroma_proto::{CheckCollectionsRequest, UpdateCollectionLogOffsetRequest};
+use chroma_types::CollectionUuid;
+
+#[tokio::main]
+async fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() != 3 {
+        eprintln!("USAGE: chroma-migrate-log [LOG-HOST] [SYSDB-HOST] [COLLECTION-UUID]");
+        std::process::exit(13);
+    }
+    let logservice = Channel::from_shared(args[0].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to log service");
+    let mut log_client = LogServiceClient::new(logservice);
+    let sysdbservice = Channel::from_shared(args[1].clone())
+        .expect("could not create channel")
+        .connect()
+        .await
+        .expect("could not connect to sysdb service");
+    let mut sysdb_client = SysDbClient::new(sysdbservice);
+    let collection_id = Uuid::parse_str(&args[2])
+        .map(CollectionUuid)
+        .expect("Failed to parse collection_id");
+    let collection_info = sysdb_client
+        .check_collections(CheckCollectionsRequest {
+            collection_ids: vec![args[2].clone()],
+        })
+        .await
+        .expect("could not fetch collection info")
+        .into_inner();
+    eprintln!("{collection_info:?}");
+    if collection_info.deleted.len() != 1 || collection_info.log_position.len() != 1 {
+        eprintln!("got abnormal/non-length-1 results");
+        std::process::exit(13);
+    }
+    if collection_info.deleted[0] {
+        eprintln!("cowardly refusing to do anything with a deleted collection");
+        std::process::exit(13);
+    }
+    let _resp = log_client
+        .rollback_collection_log_offset(UpdateCollectionLogOffsetRequest {
+            collection_id: collection_id.to_string(),
+            log_offset: collection_info.log_position[0],
+        })
+        .await
+        .expect("migrate log request should succeed");
+}

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -727,10 +727,13 @@ impl LogServer {
             )
         })?;
 
-        self._update_collection_log_offset(Request::new(UpdateCollectionLogOffsetRequest {
-            collection_id: collection_id.to_string(),
-            log_offset: start as i64 - 1,
-        }))
+        self._update_collection_log_offset(
+            Request::new(UpdateCollectionLogOffsetRequest {
+                collection_id: collection_id.to_string(),
+                log_offset: start as i64 - 1,
+            }),
+            false,
+        )
         .await?;
         // Set it up so that once we release the mutex, the next person won't do I/O and will
         // immediately be able to push logs.
@@ -829,6 +832,7 @@ impl LogServer {
     async fn _update_collection_log_offset(
         &self,
         request: Request<UpdateCollectionLogOffsetRequest>,
+        allow_rollback: bool,
     ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
         let request = request.into_inner();
         let adjusted_log_offset = request.log_offset + 1;
@@ -867,7 +871,7 @@ impl LogServer {
         })?;
         let default = Cursor::default();
         let cursor = witness.as_ref().map(|w| w.cursor()).unwrap_or(&default);
-        if cursor.position.offset() > adjusted_log_offset as u64 {
+        if !allow_rollback && cursor.position.offset() > adjusted_log_offset as u64 {
             return Ok(Response::new(UpdateCollectionLogOffsetResponse {}));
         }
         let cursor = Cursor {
@@ -1666,7 +1670,33 @@ impl LogServer {
             let key = LogKey { collection_id };
             let handle = self.open_logs.get_or_create_state(key);
             let mut _active = handle.active.lock().await;
-            self._update_collection_log_offset(Request::new(request))
+            self._update_collection_log_offset(Request::new(request), false)
+                .await
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn rollback_collection_log_offset(
+        &self,
+        request: Request<UpdateCollectionLogOffsetRequest>,
+    ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
+        let span = wrap_span_with_parent_context(
+            tracing::trace_span!("UpdateCollectionLogOffset",),
+            request.metadata(),
+        );
+
+        async move {
+            let request = request.into_inner();
+            let collection_id = Uuid::parse_str(&request.collection_id)
+                .map(CollectionUuid)
+                .map_err(|_| Status::invalid_argument("Failed to parse collection id"))?;
+
+            // Grab a lock on the state for this key, so that a racing initialize won't do anything.
+            let key = LogKey { collection_id };
+            let handle = self.open_logs.get_or_create_state(key);
+            let mut _active = handle.active.lock().await;
+            self._update_collection_log_offset(Request::new(request), true)
                 .await
         }
         .instrument(span)
@@ -2115,6 +2145,15 @@ impl LogService for LogServerWrapper {
         request: Request<UpdateCollectionLogOffsetRequest>,
     ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
         self.log_server.update_collection_log_offset(request).await
+    }
+
+    async fn rollback_collection_log_offset(
+        &self,
+        request: Request<UpdateCollectionLogOffsetRequest>,
+    ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
+        self.log_server
+            .rollback_collection_log_offset(request)
+            .await
     }
 
     async fn purge_dirty_for_collection(


### PR DESCRIPTION
## Description of changes

After Disaster Recovery (DR) we may be in an inconsistent state where
the log is ahead of the sysdb.  This is not a problem for safety as the
log will remain durable; the compaction will fail with the log being
behind.

This PR mitigates the problem by introducing an endpoint that can roll
back the cursor.  The current endpoint will silently succeed if the
endpoint is rolled back.  The new endpoint will rollback unconditionally
to match the sysdb offset.

## Test plan

Tested locally.

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
