### PR TITLE
[CHORE] Remove a spammy log line in RLS.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1367,13 +1367,6 @@ impl LogServer {
                     ));
                 }
             };
-
-            // NOTE(sicheng): This is temporary trace added for analyzing number of frags between the offsets
-            match log_reader.scan(start_position, Default::default()).await {
-                Ok(frags) => tracing::info!(name: "Counting live fragments", frag_count = frags.len()),
-                Err(e) => tracing::error!(name: "Unable to scout number of live fragments", error = e.to_string()),
-            }
-
             let start_offset = start_position.offset() as i64;
             let limit_offset = limit_position.offset() as i64;
             Ok(Response::new(ScoutLogsResponse {


### PR DESCRIPTION
## Description of changes

This log line is about 12x more spammy than the next-most spammy log
line, where spammy is determined by a histogram of log lines.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Negative space isn't observable.

## Documentation Changes

N/A
