### PR TITLE
[HOTFIX] Applying PR 5149 to release/2025-07-25

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -263,7 +263,6 @@ jobs:
     - javascript-client-tests
     - rust-tests
     - go-tests
-    - check-title
     - lint
     - check-helm-version-bump
     - delete-helm-comment

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -257,7 +257,8 @@ jobs:
       - release-pypi
       - release-thin-pypi
       - release-github
-      - release-hosted
+      - release-hosted-control-plane
+      - release-hosted-data-plane
       - release-docs
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
This PR cherry-picks the commit https://github.com/chroma-core/chroma/commit/cf1a0134525207e1e98a97a07be23ad01c088a19 onto release/2025-07-25.