### PR TITLE
[ENH]  The rust log service uses connect_lazy; change to connect strict

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -1594,6 +1594,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
 #[cfg(test)]
 mod tests {
     use chroma_config::registry::Registry;
+    use chroma_log::config::{GrpcLogConfig, LogConfig};
     use chroma_sysdb::GrpcSysDbConfig;
     use chroma_types::Collection;
     use uuid::Uuid;
@@ -1659,7 +1660,12 @@ mod tests {
             segment_manager: None,
             sysdb: Default::default(),
             collections_with_segments_provider: Default::default(),
-            log: Default::default(),
+            log: LogConfig::Grpc(GrpcLogConfig {
+                host: "localhost".to_string(),
+                port: 50054,
+                alt_host: Some("localhost".to_string()),
+                ..Default::default()
+            }),
             executor: ExecutorConfig::Distributed(DistributedExecutorConfig {
                 connections_per_node: 128,
                 replication_factor: 2,

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -888,7 +888,12 @@ mod tests {
             jemalloc_pprof_server_port: None,
             enable_log_gc_for_tenant: Vec::new(),
             enable_log_gc_for_tenant_threshold: "tenant-threshold".to_string(),
-            log: LogConfig::default(),
+            log: LogConfig::Grpc(GrpcLogConfig {
+                host: "localhost".to_string(),
+                port: 50054,
+                alt_host: Some("localhost".to_string()),
+                ..Default::default()
+            }),
             enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
         };
         let registry = Registry::new();
@@ -1092,7 +1097,12 @@ mod tests {
             enable_log_gc_for_tenant: Vec::new(),
             enable_log_gc_for_tenant_threshold:
                 "tenant-delete-mode-ffffffff-ffff-ffff-ffff-ffffffffffff".to_string(),
-            log: LogConfig::default(),
+            log: LogConfig::Grpc(GrpcLogConfig {
+                host: "localhost".to_string(),
+                port: 50054,
+                alt_host: Some("localhost".to_string()),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let registry = Registry::new();

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -547,7 +547,7 @@ mod tests {
 
     use super::*;
     use crate::helper::ChromaGrpcClients;
-    use chroma_log::config::LogConfig;
+    use chroma_log::config::{GrpcLogConfig, LogConfig};
     use chroma_memberlist::memberlist_provider::Member;
     use chroma_storage::s3_config_for_localhost_with_bucket_name;
     use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig};
@@ -749,7 +749,12 @@ mod tests {
             port: 50055,
             root_cache_config: Default::default(),
             jemalloc_pprof_server_port: None,
-            log: LogConfig::default(),
+            log: LogConfig::Grpc(GrpcLogConfig {
+                host: "localhost".to_string(),
+                port: 50054,
+                alt_host: Some("localhost".to_string()),
+                ..Default::default()
+            }),
             enable_log_gc_for_tenant: Vec::new(),
             enable_log_gc_for_tenant_threshold: "tenant-ffffffff-ffff-ffff-ffff-ffffffffffff"
                 .to_string(),

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -6,7 +6,7 @@ use chroma_blockstore::RootManager;
 use chroma_cache::nop::NopCache;
 use chroma_config::registry::Registry;
 use chroma_config::Configurable;
-use chroma_log::config::LogConfig;
+use chroma_log::config::{GrpcLogConfig, LogConfig};
 use chroma_log::Log;
 use chroma_storage::s3::s3_client_for_test_with_bucket_name;
 use chroma_storage::{DeleteOptions, GetOptions, Storage};
@@ -117,7 +117,13 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                 .await
                 .unwrap();
             let system = System::new();
-            let logs = Log::try_from_config(&(LogConfig::default(), system), &registry)
+            let log_config = LogConfig::Grpc(GrpcLogConfig {
+                host: "localhost".to_string(),
+                port: 50054,
+                alt_host: Some("localhost".to_string()),
+                ..Default::default()
+            });
+            let logs = Log::try_from_config(&(log_config, system), &registry)
                 .await
                 .unwrap();
 


### PR DESCRIPTION
## Description of changes

I hypothesize that the connect_lazy code path (only take for log service
clients) is to blame for our hangs when there's churn in the rust log
service on staging.  Change to connect() rather than connect_lazy() so
the whole grpc handshake gets done before trying to use the connection.

## Test plan

CI

## Migration plan

N/A

## Observability plan

I plan to deploy to staging and then beat it up until the problem occurs
or the problem is doesn't manifest and is therefore likely to be gone.

## Documentation Changes

N/A
