### PR TITLE
[ENH] Lower default posting list sizes for spann

### DIFF
--- a/rust/types/src/spann_configuration.rs
+++ b/rust/types/src/spann_configuration.rs
@@ -18,7 +18,7 @@ fn default_search_rng_epsilon() -> f32 {
 }
 
 fn default_write_nprobe() -> u32 {
-    64
+    32
 }
 
 fn default_write_rng_factor() -> f32 {
@@ -26,11 +26,11 @@ fn default_write_rng_factor() -> f32 {
 }
 
 fn default_write_rng_epsilon() -> f32 {
-    10.0
+    5.0
 }
 
 fn default_split_threshold() -> u32 {
-    200
+    50
 }
 
 fn default_num_samples_kmeans() -> usize {
@@ -46,7 +46,7 @@ fn default_reassign_neighbor_count() -> u32 {
 }
 
 fn default_merge_threshold() -> u32 {
-    100
+    25
 }
 
 fn default_num_centers_to_merge_to() -> u32 {


### PR DESCRIPTION
## Description of changes

This PR lowers the default posting list sizes for spann from 200 to 50, as per testing. This is done by changing the default split threshold for clusters, and correspondingly changing the merge threshold

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
