### PR TITLE
[DOCS]: Persistent client example fix for typescript

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/run-chroma/persistent-client.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/run-chroma/persistent-client.md
@@ -4,6 +4,12 @@
 
 {% Tab label="python" %}
 
+To run a Chroma server locally that will persist your data, install Chroma via `pip`:
+
+```terminal
+pip install chromadb
+```
+
 You can configure Chroma to save and load the database from your local machine, using the `PersistentClient`. 
 
 Data will be persisted automatically and loaded on start (if it exists).
@@ -22,11 +28,35 @@ The `path` is where Chroma will store its database files on disk, and load them 
 
 To connect with the JS/TS client, you must connect to a Chroma server. 
 
-To run a Chroma server locally that will persist your data, install Chroma via `pip`:
+To run a Chroma server locally that will persist your data, install Chroma:
 
+{% TabbedUseCaseCodeBlock language="Terminal" %}
+
+{% Tab label="npm" %}
 ```terminal
-pip install chromadb
+npm install chromadb
 ```
+{% /Tab %}
+
+{% Tab label="pnpm" %}
+```terminal
+pnpm add chromadb
+```
+{% /Tab %}
+
+{% Tab label="yarn" %}
+```terminal
+yarn add chromadb
+```
+{% /Tab %}
+
+{% Tab label="bun" %}
+```terminal
+bun add chromadb
+```
+{% /Tab %}
+
+{% /TabbedUseCaseCodeBlock %}
 
 And run the server using our CLI:
 


### PR DESCRIPTION
## Description of changes

**Persistent Client:** Fixed install chroma instructions for typescript.

Before:
<img width="1124" height="286" alt="Screenshot 2025-08-02 at 8 17 52 PM" src="https://github.com/user-attachments/assets/3a11f1c2-202e-49b5-bc31-8f3cf10a8e3a" />


After:
<img width="1073" height="280" alt="Screenshot 2025-08-02 at 8 17 22 PM" src="https://github.com/user-attachments/assets/cd71474b-7dde-4474-9dc2-9827a2d8688c" />



