### PR TITLE
[ENH]: Turn off adaptive nsearch

### DIFF
--- a/rust/worker/tilt_config.yaml
+++ b/rust/worker/tilt_config.yaml
@@ -84,7 +84,7 @@ query_service:
         capacity: 8589934592 # 8GB
     permitted_parallelism: 180
   spann_provider:
-    adaptive_search_nprobe: true
+    adaptive_search_nprobe: false
   fetch_log_batch_size: 1000
 compaction_service:
   service_name: "compaction-service"


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - test_add.py is flakey. Turning it off until it is root caused
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
CI becomes green again

## Documentation Changes
None
