### PR TITLE
[ENH] Add flag on Dockerfile to use AVX512 instructions

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,6 +2,7 @@ FROM rust:1.81.0 AS builder
 
 ARG RELEASE_MODE=
 ARG PROTOC_VERSION=31.1
+ARG ENABLE_AVX512=
 
 WORKDIR /chroma
 
@@ -30,6 +31,13 @@ ENV EXCLUDED_PACKAGES="chromadb_rust_bindings chromadb-js-bindings chroma-benchm
 
 RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
   --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+  if [ "$ENABLE_AVX512" = "1" ]; then \
+    export CXXFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
+    export CFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
+    echo "Building with AVX512 optimizations for hnswlib"; \
+  else \
+    echo "Building without AVX512 optimizations"; \
+  fi && \
   if [ "$RELEASE_MODE" = "1" ]; then cargo build --workspace $(printf -- '--exclude %s ' $EXCLUDED_PACKAGES) --release; else cargo build --workspace $(printf -- '--exclude %s ' $EXCLUDED_PACKAGES); fi && \
   # Move CLI binary
   if [ "$RELEASE_MODE" = "1" ]; then mv target/release/chroma ./chroma; else mv target/debug/chroma ./chroma; fi && \


### PR DESCRIPTION
## Description of changes

This PR adds an `ENABLE_AVX512` flag to the rust Dockerfile to enable building the binary to force it to use AVX512 instructions, improving performance on devices that support AVX512 instructions

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
