### PR TITLE
[CHORE]: Added short descriptions to CLI commands

### DIFF
--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -37,7 +37,7 @@ enum Command {
     Profile(ProfileCommand),
     #[command(about = "Start a local Chroma server", long_about = None)]
     Run(RunArgs),
-    #[command(about = "Open Chroma Discord support", long_about = None)]
+    #[command(about = "Open the Chroma Discord", long_about = None)]
     Support,
     #[command(about = "Check for Chroma CLI updates", long_about = None)]
     Update,

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -19,18 +19,29 @@ use colored::Colorize;
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    #[command(about = "Browse Chroma collections", long_about = None)]
     Browse(BrowseArgs),
+    #[command(about = "Copy collection between local and Chroma Cloud", long_about = None)]
     Copy(CopyArgs),
+    #[command(about = "Manage Chroma Cloud databases", long_about = None)]
     #[command(subcommand)]
     Db(DbCommand),
+    #[command(about = "Open Chroma online documentation", long_about = None)]
     Docs,
+    #[command(about = "Install sample applications", long_about = None)]
     Install(InstallArgs),
+    #[command(about = "Log in to Chroma Cloud", long_about = None)]
     Login(LoginArgs),
+    #[command(about = "Manage Chroma Cloud profiles", long_about = None)]
     #[command(subcommand)]
     Profile(ProfileCommand),
+    #[command(about = "Start a local Chroma server", long_about = None)]
     Run(RunArgs),
+    #[command(about = "Open Chroma Discord support", long_about = None)]
     Support,
+    #[command(about = "Check for Chroma CLI updates", long_about = None)]
     Update,
+    #[command(about = "Vacuum a local Chroma persistent directory", long_about = None)]
     Vacuum(VacuumArgs),
 }
 


### PR DESCRIPTION
Closes #5216

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Short descriptive names of each CLI command

## Test plan

_How are these changes tested?_

```bash
./target/debug/chroma --help                                                                                                                                                                                                                                                                                                                                                                                      21:44:01 
A CLI for Chroma

Usage: chroma <COMMAND>

Commands:
  browse   Browse chroma collections
  copy     Copy collection between local and Cloud chroma
  db       Manage Chroma Cloud databases
  docs     Navigate to Chroma online docs
  install  Install sample apps
  login    Login to Chroma Cloud
  profile  Manage Chroma Cloud profiles
  run      Start a local Chroma server
  support  Navigate to Chroma Discord
  update   Check for Chroma CLI updates
  vacuum   Vacuum local Chroma persistent directory
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
