### PR TITLE
[ENH]: Add more tracing in the filter path

### DIFF
--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -139,6 +139,10 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
                         if let Some(reader) = &record_segment_reader {
                             let record = reader
                                 .get_data_for_offset_id(*offset_id)
+                                .instrument(tracing::trace_span!(
+                                    parent: Span::current(), "Get DataRecord for offset",
+                                    offset_id = *offset_id
+                                ))
                                 .await?
                                 .ok_or(ProjectionError::RecordSegmentPhantomRecord(*offset_id))?;
                             ProjectionRecord {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Filter and Projection were missing tracing cold block gets because of join_all on futures. Will clean it up and revert it once we are done debugging
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
Tracing works on staging

## Documentation Changes
None
