### PR TITLE
[ENH]  Wire up the should_trace_error for soft-deleted collections.

### DIFF
--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -1432,9 +1432,7 @@ impl ChromaError for FlushCompactionError {
     fn code(&self) -> ErrorCodes {
         match self {
             FlushCompactionError::FailedToFlushCompaction(status) => {
-                if std::convert::Into::<chroma_error::ErrorCodes>::into(status.code())
-                    == ErrorCodes::FailedPrecondition
-                {
+                if status.code() == Code::FailedPrecondition {
                     ErrorCodes::FailedPrecondition
                 } else {
                     ErrorCodes::Internal
@@ -1477,5 +1475,20 @@ impl ChromaError for DeleteCollectionVersionError {
         match self {
             DeleteCollectionVersionError::FailedToDeleteVersion(e) => e.code().into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Status;
+
+    use super::*;
+
+    #[test]
+    fn flush_compaction_error() {
+        let fce = FlushCompactionError::FailedToFlushCompaction(Status::failed_precondition(
+            "collection soft deleted",
+        ));
+        assert!(!fce.should_trace_error());
     }
 }

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -51,7 +51,7 @@ pub enum TaskError<Err> {
     Aborted,
 }
 
-impl<Err> ChromaError for TaskError<Err>
+impl<Err: ChromaError> ChromaError for TaskError<Err>
 where
     Err: Debug + ChromaError + 'static,
 {
@@ -60,6 +60,14 @@ where
             TaskError::Panic(_) => ErrorCodes::Internal,
             TaskError::TaskFailed(e) => e.code(),
             TaskError::Aborted => ErrorCodes::ResourceExhausted,
+        }
+    }
+
+    fn should_trace_error(&self) -> bool {
+        match self {
+            TaskError::Panic(_) => true,
+            TaskError::TaskFailed(e) => e.should_trace_error(),
+            TaskError::Aborted => true,
         }
     }
 }
@@ -409,5 +417,33 @@ mod tests {
         assert!(result.is_err());
         let err = result.as_ref().unwrap_err();
         assert!(err.to_string().contains("MockOperator panicking"));
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("should trace: {0}")]
+    struct MockError(bool);
+
+    impl ChromaError for MockError {
+        fn code(&self) -> chroma_error::ErrorCodes {
+            chroma_error::ErrorCodes::InvalidArgument
+        }
+
+        fn should_trace_error(&self) -> bool {
+            self.0
+        }
+    }
+
+    #[test]
+    fn should_trace_flush_compaction_error() {
+        let fce = MockError(true);
+        let te: TaskError<MockError> = fce.into();
+        assert!(te.should_trace_error());
+    }
+
+    #[test]
+    fn should_not_trace_flush_compaction_error() {
+        let fce = MockError(false);
+        let te: TaskError<MockError> = fce.into();
+        assert!(!te.should_trace_error());
     }
 }

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -99,6 +99,13 @@ impl ChromaError for RegisterError {
             RegisterError::UpdateLogOffsetError(e) => e.code(),
         }
     }
+
+    fn should_trace_error(&self) -> bool {
+        match self {
+            RegisterError::FlushCompactionError(e) => e.should_trace_error(),
+            RegisterError::UpdateLogOffsetError(e) => e.should_trace_error(),
+        }
+    }
 }
 
 #[async_trait]
@@ -308,5 +315,14 @@ mod tests {
         assert_eq!(segment_1.file_path, file_path_3);
         let segment_2 = segments.iter().find(|s| s.id == segment_id_2).unwrap();
         assert_eq!(segment_2.file_path, file_path_4);
+    }
+
+    #[test]
+    fn flush_compaction_error() {
+        let fce = FlushCompactionError::FailedToFlushCompaction(
+            tonic::Status::failed_precondition("collection soft deleted"),
+        );
+        let register: RegisterError = fce.into();
+        assert!(!register.should_trace_error());
     }
 }


### PR DESCRIPTION
## Description of changes

Turns out the previous attempt to fix this did not do so.  I needed to
propagate the should_trace_error call from containing type to contained
type.  This PR does that and adds some tests to assure it will be the
last word.  Let's hope it is.

## Test plan

Local + CI.

It adds tests, so short of wiring up tracing in CI and looking for an
error on a compaction of a soft-deleted collection, this is the best
we'll do.

## Migration plan

N/A

## Observability plan

It currently pages.  It shouldn't.

## Documentation Changes

N/A
