### PR TITLE
[ENH]: make take_result_channel() return an option

### DIFF
--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -205,10 +205,8 @@ impl Orchestrator for ConstructVersionGraphOrchestrator {
         self.result_channel = Some(sender);
     }
 
-    fn take_result_channel(&mut self) -> Sender<Result<Self::Output, Self::Error>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(&mut self) -> Option<Sender<Result<Self::Output, Self::Error>>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -217,10 +217,8 @@ impl Orchestrator for GarbageCollectorOrchestrator {
 
     fn take_result_channel(
         &mut self,
-    ) -> Sender<Result<GarbageCollectorResponse, GarbageCollectorError>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    ) -> Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -237,10 +237,8 @@ impl Orchestrator for GarbageCollectorOrchestrator {
 
     fn take_result_channel(
         &mut self,
-    ) -> Sender<Result<GarbageCollectorResponse, GarbageCollectorError>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    ) -> Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -607,10 +607,10 @@ impl Orchestrator for CompactOrchestrator {
         self.result_channel = Some(sender)
     }
 
-    fn take_result_channel(&mut self) -> Sender<Result<CompactionResponse, CompactionError>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(
+        &mut self,
+    ) -> Option<Sender<Result<CompactionResponse, CompactionError>>> {
+        self.result_channel.take()
     }
 
     async fn cleanup(&mut self) {

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -138,10 +138,8 @@ impl Orchestrator for CountOrchestrator {
         self.result_channel = Some(sender)
     }
 
-    fn take_result_channel(&mut self) -> Sender<CountResult> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(&mut self) -> Option<Sender<CountResult>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/worker/src/execution/orchestration/get.rs
+++ b/rust/worker/src/execution/orchestration/get.rs
@@ -236,10 +236,8 @@ impl Orchestrator for GetOrchestrator {
         self.result_channel = Some(sender)
     }
 
-    fn take_result_channel(&mut self) -> Sender<Result<GetResult, GetError>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(&mut self) -> Option<Sender<Result<GetResult, GetError>>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/worker/src/execution/orchestration/knn.rs
+++ b/rust/worker/src/execution/orchestration/knn.rs
@@ -235,10 +235,8 @@ impl Orchestrator for KnnOrchestrator {
         self.result_channel = Some(sender)
     }
 
-    fn take_result_channel(&mut self) -> Sender<Result<KnnProjectionOutput, KnnError>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(&mut self) -> Option<Sender<Result<KnnProjectionOutput, KnnError>>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/worker/src/execution/orchestration/knn_filter.rs
+++ b/rust/worker/src/execution/orchestration/knn_filter.rs
@@ -285,10 +285,8 @@ impl Orchestrator for KnnFilterOrchestrator {
         self.result_channel = Some(sender)
     }
 
-    fn take_result_channel(&mut self) -> Sender<KnnFilterResult> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(&mut self) -> Option<Sender<KnnFilterResult>> {
+        self.result_channel.take()
     }
 }
 

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -229,10 +229,8 @@ impl Orchestrator for SpannKnnOrchestrator {
         self.result_channel = Some(sender)
     }
 
-    fn take_result_channel(&mut self) -> Sender<Result<KnnProjectionOutput, KnnError>> {
-        self.result_channel
-            .take()
-            .expect("The result channel should be set before take")
+    fn take_result_channel(&mut self) -> Option<Sender<Result<KnnProjectionOutput, KnnError>>> {
+        self.result_channel.take()
     }
 }
 


### PR DESCRIPTION
## Description of changes

The garbage collector in production logs "The result channel should be set before take" before stalling. It is unclear if this panic is causing the stalling as I can't reproduce the stall locally, but the currently the `Orchestrator` trait makes a faulty assumption which should be fixed regardless. It assumes that `take_result_channel()` is called at most once. But this is impossible to guarentee under current semantics as it doesn't take ownership of `self`. For example, this triggers a panic:

```rust
#[async_trait]
impl Handler<TaskResult<ListFilesAtVersionOutput, ListFilesAtVersionError>>
    for GarbageCollectorOrchestrator
{
    type Result = ();

    async fn handle(
        &mut self,
        message: TaskResult<ListFilesAtVersionOutput, ListFilesAtVersionError>,
        ctx: &ComponentContext<GarbageCollectorOrchestrator>,
    ) {
       // imagine this resolves to ListFilesAtVersionError, which takes the result channel and sends the error
        let output = match self.ok_or_terminate(message.into_inner(), ctx).await {
            Some(output) => output,
            None => {}, // note no return here
        };
        // at this point, the result channel has been taken but this handler is still executing
        let res = self.handle_list_files_at_version_output(output, ctx).await;
        // we take the result channel a second time but panic because it was already taken
        self.ok_or_terminate(res, ctx).await;
    }
}
```

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
