### PR TITLE
[CHORE]  Cut the two most spammy spans from RLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-cli"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "arboard",
  "axum 0.8.1",


### PR DESCRIPTION
## Description of changes

Looking at the logs, these two spans can be dropped/coalesced to emit fewer events from the RLS.

## Test plan

cargo clippy --all-targets -- -D clippy::all

## Migration plan

N/A

## Observability plan

Less noise in observability.

## Documentation Changes

N/A
