### PR TITLE
[BLD] Make Slack notifications consistent

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -278,6 +278,6 @@ jobs:
             text: |
               :x: *Test failure on main branch after PR merge!*
               *Workflow:* ${{ github.workflow }}
-              *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
               *Author:* ${{ github.actor }}

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -273,5 +273,5 @@ jobs:
               :x: *ChromaDB release failure!*
               *Workflow:* ${{ github.workflow }}
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
               *Author:* ${{ github.actor }}
-              *Ref:* ${{ github.ref_name }}

--- a/.github/workflows/release-dev-javascript-client.yml
+++ b/.github/workflows/release-dev-javascript-client.yml
@@ -121,5 +121,5 @@ jobs:
               :x: *JavaScript client (dev) release failure!*
               *Workflow:* ${{ github.workflow }}
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
               *Author:* ${{ github.actor }}
-              *Ref:* ${{ github.ref_name }}

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -82,5 +82,5 @@ jobs:
               :x: *Helm chart release failure!*
               *Workflow:* ${{ github.workflow }}
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
               *Author:* ${{ github.actor }}
-              *Ref:* ${{ github.ref_name }}

--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -114,8 +114,8 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
             text: |
-              :x: *Release failure!*
+              :x: *JavaScript client release failure!*
               *Workflow:* ${{ github.workflow }}
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/releases/tag/${{ steps.tag.outputs.tag }}|${{ steps.tag.outputs.tag }}>
               *Author:* ${{ github.actor }}
-              *Tag:* ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/trigger-deploy.yaml
+++ b/.github/workflows/trigger-deploy.yaml
@@ -43,5 +43,6 @@ jobs:
               :x: *Deploy failure!*
               *Workflow:* ${{ github.workflow }}
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+              *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
               *Author:* ${{ github.actor }}
-              *Ref:* ${{ github.ref_name }}
+              *Plane:* control, data

--- a/.github/workflows/trigger-deploy.yaml
+++ b/.github/workflows/trigger-deploy.yaml
@@ -40,9 +40,8 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
             text: |
-              :x: *Deploy failure!*
+              :x: *Trigger deploy failure!*
               *Workflow:* ${{ github.workflow }}
               *Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
               *Ref:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>
               *Author:* ${{ github.actor }}
-              *Plane:* control, data


### PR DESCRIPTION
## Description of changes

I noticed that our Slack notifications for workflow failures are slightly inconsistent. This makes them all have the same payload structure which is:
```
Title (aka what failed)
Workflow: <name of the workflow>
Run: <link to run>
Ref: <link to ref>
Author: <if possible>
[Args like "Plane"]: 
...
```

## Test plan

This only changes the payload for the existing functionality, so is pretty safe.