### PR TITLE
[ENH] add chroma cloud embedding function to python client

### DIFF
--- a/chromadb/test/ef/test_chroma_cloud_ef.py
+++ b/chromadb/test/ef/test_chroma_cloud_ef.py
@@ -1,0 +1,154 @@
+import os
+import pytest
+import numpy as np
+from unittest.mock import patch, MagicMock
+from chromadb.utils.embedding_functions.chroma_cloud_embedding_function import (
+    ChromaCloudEmbeddingFunction,
+    ChromaCloudEmbeddingModel,
+)
+
+TEST_API_KEY = "test-chroma-api-key"
+TEST_TENANT_UUID = "a1b2c3d4-e5f6-7890-1234-56789abcdef0"
+API_KEY_ENV_VAR = "CHROMA_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def set_env_var():
+    """Fixture to set and unset the environment variable for tests."""
+    original_value = os.environ.get(API_KEY_ENV_VAR)
+    os.environ[API_KEY_ENV_VAR] = TEST_API_KEY
+    yield
+    if original_value is None:
+        del os.environ[API_KEY_ENV_VAR]
+    else:
+        os.environ[API_KEY_ENV_VAR] = original_value
+
+
+def test_chroma_cloud_embedding_function_init() -> None:
+    """Test the initialization of the ChromaCloudEmbeddingFunction."""
+    # Test initialization with api_key parameter (should raise a warning)
+    with pytest.warns(DeprecationWarning):
+        ef = ChromaCloudEmbeddingFunction(
+            model="baai/bge-m3",
+            tenant_uuid=TEST_TENANT_UUID,
+            api_key=TEST_API_KEY,
+        )
+    assert ef.api_key == TEST_API_KEY
+
+    # Test initialization with environment variable
+    ef = ChromaCloudEmbeddingFunction(
+        model="baai/bge-m3",
+        tenant_uuid=TEST_TENANT_UUID,
+        api_key_env_var=API_KEY_ENV_VAR,
+    )
+    assert ef.api_key == TEST_API_KEY
+
+    # Test initialization failure when no API key is found
+    os.environ.pop(API_KEY_ENV_VAR, None)
+    with pytest.raises(ValueError, match=f"The {API_KEY_ENV_VAR} environment variable is not set."):
+        ChromaCloudEmbeddingFunction(
+            model="baai/bge-m3",
+            tenant_uuid=TEST_TENANT_UUID,
+            api_key_env_var=API_KEY_ENV_VAR,
+        )
+
+
+@patch("httpx.Client")
+def test_chroma_cloud_embedding_function_call(mock_httpx_client: MagicMock) -> None:
+    """Test the __call__ method of the ChromaCloudEmbeddingFunction."""
+    # Mock the response from the Chroma API
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {"embedding": [0.1, 0.2, 0.3]},
+            {"embedding": [0.4, 0.5, 0.6]},
+        ]
+    }
+    mock_httpx_client.return_value.post.return_value = mock_response
+
+    ef = ChromaCloudEmbeddingFunction(
+        model="baai/bge-m3",
+        tenant_uuid=TEST_TENANT_UUID,
+        api_key_env_var=API_KEY_ENV_VAR,
+    )
+
+    documents = ["This is a test document.", "This is another test document."]
+    embeddings = ef(documents)
+
+    assert embeddings is not None
+    assert len(embeddings) == 2
+    assert all(isinstance(emb, np.ndarray) for emb in embeddings)
+    assert embeddings[0].shape == (3,)
+    np.testing.assert_array_equal(embeddings[0], np.array([0.1, 0.2, 0.3], dtype=np.float32))
+
+    # Test with empty input
+    assert ef([]) == []
+
+
+def test_chroma_cloud_embedding_function_config_roundtrip() -> None:
+    """Test that the configuration can be saved and restored."""
+    ef = ChromaCloudEmbeddingFunction(
+        model="baai/bge-m3",
+        tenant_uuid=TEST_TENANT_UUID,
+        api_key_env_var=API_KEY_ENV_VAR,
+    )
+
+    # Get the config (only api_key_env_var should be returned)
+    config = ef.get_config()
+    assert config == {"api_key_env_var": API_KEY_ENV_VAR}
+
+    # The build_from_config method needs more than get_config provides,
+    # as model and tenant_uuid are required for instantiation.
+    full_config = {
+        "model": "baai/bge-m3",
+        "tenant_uuid": TEST_TENANT_UUID,
+        "api_key_env_var": API_KEY_ENV_VAR,
+    }
+
+    # Test building from a full config
+    new_ef = ChromaCloudEmbeddingFunction.build_from_config(full_config)
+    assert isinstance(new_ef, ChromaCloudEmbeddingFunction)
+    assert new_ef.model == "baai/bge-m3"
+    assert new_ef.tenant_uuid == TEST_TENANT_UUID
+    assert new_ef.api_key_env_var == API_KEY_ENV_VAR
+
+
+def test_chroma_cloud_embedding_function_name_and_spaces() -> None:
+    """Test the name, default_space, and supported_spaces methods."""
+    ef = ChromaCloudEmbeddingFunction(
+        model="baai/bge-m3",
+        tenant_uuid=TEST_TENANT_UUID,
+        api_key_env_var=API_KEY_ENV_VAR,
+    )
+
+    assert ef.name() == "chroma_hosted"
+    assert ef.default_space() == "cosine"
+    supported_spaces = ef.supported_spaces()
+    assert "cosine" in supported_spaces
+    assert "l2" in supported_spaces
+    assert "ip" in supported_spaces
+
+
+def test_chroma_cloud_embedding_function_validate_update() -> None:
+    """Test that updating the model is not allowed."""
+    ef = ChromaCloudEmbeddingFunction(
+        model="baai/bge-m3",
+        tenant_uuid=TEST_TENANT_UUID,
+        api_key_env_var=API_KEY_ENV_VAR,
+    )
+    with pytest.raises(ValueError, match="The model name cannot be changed"):
+        ef.validate_config_update(
+            old_config={}, new_config={"model": "new/model"}
+        )
+
+
+@patch("chromadb.utils.embedding_functions.chroma_cloud_embedding_function.validate_config_schema")
+def test_chroma_cloud_embedding_function_validate_config(mock_validate: MagicMock) -> None:
+    """Test that the static validate_config method calls the schema validator."""
+    valid_config = {
+        "model": "baai/bge-m3",
+        "tenant_uuid": TEST_TENANT_UUID,
+        "api_key_env_var": API_KEY_ENV_VAR,
+    }
+    ChromaCloudEmbeddingFunction.validate_config(valid_config)
+    mock_validate.assert_called_once_with(valid_config, "chroma_hosted")

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -67,6 +67,9 @@ from chromadb.utils.embedding_functions.mistral_embedding_function import (
 from chromadb.utils.embedding_functions.morph_embedding_function import (
     MorphEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.chroma_cloud_embedding_function import (
+    ChromaCloudEmbeddingFunction,
+)
 
 try:
     from chromadb.is_thin_client import is_thin_client
@@ -99,6 +102,7 @@ _all_classes: Set[str] = {
     "CloudflareWorkersAIEmbeddingFunction",
     "TogetherAIEmbeddingFunction",
     "DefaultEmbeddingFunction",
+    "ChromaCloudEmbeddingFunction",
 }
 
 
@@ -161,6 +165,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "default": DefaultEmbeddingFunction,
     "cloudflare_workers_ai": CloudflareWorkersAIEmbeddingFunction,
     "together_ai": TogetherAIEmbeddingFunction,
+    "chroma_cloud": ChromaCloudEmbeddingFunction
 }
 
 
@@ -240,6 +245,7 @@ __all__ = [
     "MistralEmbeddingFunction",
     "MorphEmbeddingFunction",
     "VoyageAIEmbeddingFunction",
+    "ChromaCloudEmbeddingFunction",
     "ONNXMiniLM_L6_V2",
     "OpenCLIPEmbeddingFunction",
     "RoboflowEmbeddingFunction",

--- a/chromadb/utils/embedding_functions/chroma_cloud_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_embedding_function.py
@@ -37,7 +37,7 @@ class ChromaCloudEmbeddingFunction(EmbeddingFunction[Documents]):
             )
         
         try:
-            model = ChromaCloudEmbeddingModel(model)
+            validated_model = ChromaCloudEmbeddingModel(model)
         except:
             raise ValueError("The valid ")
 
@@ -48,14 +48,14 @@ class ChromaCloudEmbeddingFunction(EmbeddingFunction[Documents]):
                 DeprecationWarning,
             )
 
-        self.model = model
+        self.model = validated_model
         self.tenant_uuid = tenant_uuid
         self.api_key_env_var = api_key_env_var
         self.api_key = api_key or os.getenv(api_key_env_var)
         if not self.api_key:
             raise ValueError(f"The {api_key_env_var} environment variable is not set.")
 
-        self._api_url = "https://api.trychroma.com/api/v2/embed"
+        self._api_url = "https://chroma-core-staging--chroma-trieve-ingest-immediateembed-10d1fc.modal.run"
         self._session = httpx.Client(timeout=timeout_seconds)
         self._session.headers.update(
             {"x-chroma-token": self.api_key}
@@ -124,7 +124,7 @@ class ChromaCloudEmbeddingFunction(EmbeddingFunction[Documents]):
 
         # Create and return the embedding function
         return ChromaCloudEmbeddingFunction(
-            model=ChromaCloudEmbeddingModel(model),
+            model=model,
             tenant_uuid=tenant_uuid,
             api_key_env_var=api_key_env_var,
         )

--- a/chromadb/utils/embedding_functions/chroma_cloud_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_embedding_function.py
@@ -1,0 +1,130 @@
+from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from typing import List, Dict, Any, Optional
+import os
+import numpy as np
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+import warnings
+from enum import Enum
+
+class ChromaCloudEmbeddingModel(Enum):
+    BGE_M3 = "baai/bge-m3"
+
+class ChromaCloudEmbeddingFunction(EmbeddingFunction[Documents]):
+    def __init__(
+        self,
+        model: ChromaCloudEmbeddingModel,
+        tenant_uuid: str,
+        api_key: Optional[str] = None,
+        api_key_env_var: str = "CHROMA_API_KEY",
+    ):
+        """
+        Initialize the ChromaCloudEmbeddingFunction.
+
+        Args:
+            api_key (str, optional): The API key for the Chroma API. If not provided,
+                it will be read from the environment variable specified by api_key_env_var.
+            api_key_env_var (str, optional): Environment variable name that contains your API key.
+                Defaults to "CHROMA_API_KEY".
+        """
+        try:
+            import httpx
+        except ImportError:
+            raise ValueError(
+                "The httpx python package is not installed. Please install it with `pip install httpx`."
+            )
+
+        if api_key is not None:
+            warnings.warn(
+                "Direct api_key configuration will not be persisted. "
+                "Please use environment variables via api_key_env_var for persistent storage.",
+                DeprecationWarning,
+            )
+
+        self.model = model
+        self.tenant_uuid = tenant_uuid
+        self.api_key_env_var = api_key_env_var
+        self.api_key = api_key or os.getenv(api_key_env_var)
+        if not self.api_key:
+            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+
+        self._api_url = "https://api.trychroma.com/api/v2/embed"
+        self._session = httpx.Client()
+        self._session.headers.update(
+            {"x-chroma-token": self.api_key}
+        )
+
+    def __call__(self, input: Documents) -> Embeddings:
+        """
+        Generate embeddings for the given documents.
+
+        Args:
+            input: Documents to generate embeddings for.
+
+        Returns:
+            Embeddings for the documents.
+        """
+        # Handle empty input
+        if not input:
+            return []
+
+        # Get embeddings from /embed endpoint
+        response = self._session.post(
+            self._api_url,
+            json={"model": str(self.model.value), "texts": input, "tenant_uuid": self.tenant_uuid},
+        ).json()
+
+        # Extract embeddings from response
+        return [np.array(data.embedding, dtype=np.float32) for data in response.data]
+
+    @staticmethod
+    def name() -> str:
+        return "chroma_hosted"
+
+    def default_space(self) -> Space:
+        return "cosine"
+
+    def supported_spaces(self) -> List[Space]:
+        return ["cosine", "l2", "ip"]
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+        # Extract parameters from config
+        model = config.get("model")
+        tenant_uuid = config.get("tenant_uuid")
+        api_key_env_var = config.get("api_key_env_var")
+
+        if model is None or tenant_uuid is None or api_key_env_var is None:
+            assert False, "This code should not be reached"
+
+        # Create and return the embedding function
+        return ChromaCloudEmbeddingFunction(
+            model=ChromaCloudEmbeddingModel(model),
+            tenant_uuid=tenant_uuid,
+            api_key_env_var=api_key_env_var,
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "api_key_env_var": self.api_key_env_var,
+        }
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        if "model" in new_config:
+            raise ValueError(
+                "The model name cannot be changed after the embedding function has been initialized."
+            )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        """
+        Validate the configuration using the JSON schema.
+
+        Args:
+            config: Configuration to validate
+
+        Raises:
+            ValidationError: If the configuration does not match the schema
+        """
+        validate_config_schema(config, "chroma_hosted")


### PR DESCRIPTION
## Description of changes

Adds the Chroma Cloud embedding function to the Python client. Currently only supports BAAI/bge-m3 as the embedding model.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

We should add docs when this is GA but since this is just for a demo, no new docs changes
