### PR TITLE
[ENH]  Allow scorecarding of fork collection by collection or tenant.

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1283,8 +1283,11 @@ async fn fork_collection(
             collection_id.0.to_string(),
         ));
 
-    let _guard =
-        server.scorecard_request(&["op:fork_collection", format!("tenant:{}", tenant).as_str()])?;
+    let _guard = server.scorecard_request(&[
+        "op:fork_collection",
+        format!("tenant:{}", tenant).as_str(),
+        format!("collection:{}", collection_id).as_str(),
+    ])?;
 
     let request = chroma_types::ForkCollectionRequest::try_new(
         tenant,


### PR DESCRIPTION
## Description of changes

This adds the collection ID to the tags available for scorecarding
requests for the `fork_collection` call.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
