### PR TITLE
[ENH]  Do not trace this error if not should_trace_error

### DIFF
--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -138,7 +138,9 @@ pub trait Orchestrator: Debug + Send + Sized + 'static {
     ) {
         self.cleanup().await;
         let cancel = if let Err(err) = &res {
-            tracing::error!("Error running {}: {}", Self::name(), err);
+            if err.should_trace_error() {
+                tracing::error!("Error running {}: {}", Self::name(), err);
+            }
             true
         } else {
             false


### PR DESCRIPTION
## Description of changes

I missed this one as it's buried within a different span.

## Test plan

CI for testing.

## Migration plan

N/A

## Observability plan

See the pages go away.

## Documentation Changes

N/A
