### PR TITLE
[ENH]: Reduce recall threshold in test_add to 95

### DIFF
--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -275,7 +275,7 @@ def ann_accuracy(
     collection: Collection,
     record_set: RecordSet,
     n_results: int = 1,
-    min_recall: float = 0.99,
+    min_recall: float = 0.95,
     embedding_function: Optional[types.EmbeddingFunction] = None,  # type: ignore[type-arg]
     query_indices: Optional[List[int]] = None,
     query_embeddings: Optional[types.Embeddings] = None,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - We reduced the PL size from 200 to 50 so now we are brute forcing 1/4th of what we used to do before. We also modified the rng_query() to correctly handle negative distances. Previously for IP, rng pruning would filter out everything so the code ended up creating a new center everytime a point was added. Now, it appends to existing centers and also duplicates the same point to different centers.
   - Because of these, test_add is flakey sometimes with recall of < 99 for high k. One instance was obtained_recall=98% and k=50.
   - This PR changes the recall threshold to 95% for test_add which is a more realistic threshold.
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
CI flakes are gone

## Documentation Changes
None
