### PR TITLE
[PERF]: Modify get_range to return an iterator

### DIFF
--- a/rust/blockstore/tests/blockfile_writer_test.rs
+++ b/rust/blockstore/tests/blockfile_writer_test.rs
@@ -281,7 +281,9 @@ mod tests {
 
             // Check that entries are ordered and match expected
             if !ref_last_commit.is_empty() {
-                let all_entries = block_on(reader.get_range(.., ..)).unwrap();
+                let all_entries = block_on(reader.get_range(.., ..))
+                    .unwrap()
+                    .collect::<Vec<_>>();
 
                 assert_eq!(all_entries.len(), ref_last_commit.len());
 

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -559,8 +559,8 @@ impl SpannIndexWriter {
             );
             SpannIndexWriterError::VersionsMapDataLoadError(e)
         })?;
-        versions_data.iter().for_each(|(_, key, value)| {
-            versions_map.insert(*key, *value);
+        versions_data.for_each(|(_, key, value)| {
+            versions_map.insert(key, value);
         });
         Ok(VersionsMapInner { versions_map })
     }

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -1225,7 +1225,8 @@ mod test {
         let res = record_segment_reader
             .get_all_data()
             .await
-            .expect("Error getting all data from record segment");
+            .expect("Error getting all data from record segment")
+            .collect::<Vec<_>>();
         assert_eq!(res.len(), 0);
         // Add a few records and they should exist.
         let data = vec![
@@ -1316,7 +1317,8 @@ mod test {
         let res = record_segment_reader
             .get_all_data()
             .await
-            .expect("Error getting all data from record segment");
+            .expect("Error getting all data from record segment")
+            .collect::<Vec<_>>();
         assert_eq!(res.len(), 2);
     }
 
@@ -1577,7 +1579,8 @@ mod test {
         let mut res = record_segment_reader
             .get_all_data()
             .await
-            .expect("Record segment get all data failed");
+            .expect("Record segment get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(res.len(), 2);
         res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         let mut id1_mt = HashMap::new();
@@ -1820,7 +1823,8 @@ mod test {
         let mut res = record_segment_reader
             .get_all_data()
             .await
-            .expect("Record segment get all data failed");
+            .expect("Record segment get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(res.len(), 1);
         res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         let mut id1_mt = HashMap::new();
@@ -2050,7 +2054,8 @@ mod test {
         let mut res = record_segment_reader
             .get_all_data()
             .await
-            .expect("Record segment get all data failed");
+            .expect("Record segment get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(res.len(), 1);
         res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         assert_eq!(
@@ -2251,7 +2256,8 @@ mod test {
         let mut res = record_segment_reader
             .get_all_data()
             .await
-            .expect("Record segment get all data failed");
+            .expect("Record segment get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(res.len(), 2);
         res.sort_by(|x, y| x.1.id.cmp(y.1.id));
         assert_eq!(

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -850,12 +850,13 @@ impl RecordSegmentReader<'_> {
     }
 
     /// Returns all data in the record segment, sorted by their offset ids
-    pub async fn get_all_data(&self) -> Result<Vec<(u32, DataRecord)>, Box<dyn ChromaError>> {
-        self.id_to_data.get_range(""..="", ..).await.map(|vec| {
-            vec.into_iter()
-                .map(|(_, offset, data)| (offset, data))
-                .collect()
-        })
+    pub async fn get_all_data(
+        &self,
+    ) -> Result<impl Iterator<Item = (u32, DataRecord)> + '_, Box<dyn ChromaError>> {
+        self.id_to_data
+            .get_range(""..="", ..)
+            .await
+            .map(|iter| iter.map(|(_, offset, data)| (offset, data)))
     }
 
     pub async fn get_data_stream<'me>(

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -1001,7 +1001,8 @@ mod test {
             .posting_lists
             .get_range(.., ..)
             .await
-            .expect("Error getting all data from reader");
+            .expect("Error getting all data from reader")
+            .collect::<Vec<_>>();
         pl.sort_by(|a, b| a.0.cmp(b.0));
         assert_eq!(pl.len(), 1);
         assert_eq!(pl[0].2.doc_offset_ids, &[1, 2]);
@@ -1012,7 +1013,8 @@ mod test {
             .versions_map
             .get_range(.., ..)
             .await
-            .expect("Error gettting all data from reader");
+            .expect("Error gettting all data from reader")
+            .collect::<Vec<_>>();
         versions_map.sort_by(|a, b| a.1.cmp(&b.1));
         assert_eq!(
             versions_map

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -1338,7 +1338,8 @@ mod tests {
         let all_data = segment_reader
             .get_all_data()
             .await
-            .expect("Get all data failed");
+            .expect("Get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(all_data.len(), 1);
         let record = &all_data[0];
         assert_eq!(record.1.id, "embedding_id_1");
@@ -1623,7 +1624,8 @@ mod tests {
         let all_data = segment_reader
             .get_all_data()
             .await
-            .expect("Get all data failed");
+            .expect("Get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(all_data.len(), 1);
         let record = &all_data[0];
         assert_eq!(record.1.id, "embedding_id_1");
@@ -1929,7 +1931,8 @@ mod tests {
         let all_data = segment_reader
             .get_all_data()
             .await
-            .expect("Get all data failed");
+            .expect("Get all data failed")
+            .collect::<Vec<_>>();
         assert_eq!(all_data.len(), 1);
         let record = &all_data[0];
         assert_eq!(record.1.id, "embedding_id_1");
@@ -2276,7 +2279,8 @@ mod tests {
         let all_data = segment_reader
             .get_all_data()
             .await
-            .expect("Get all data failed");
+            .expect("Get all data failed")
+            .collect::<Vec<_>>();
         for data in all_data {
             assert_ne!(data.1.id, "embedding_id_2");
             if data.1.id == "embedding_id_1" {

--- a/rust/types/src/regex/literal_expr.rs
+++ b/rust/types/src/regex/literal_expr.rs
@@ -94,7 +94,7 @@ pub trait NgramLiteralProvider<E, const N: usize = 3> {
         ngram_range: NgramRange,
     ) -> Result<Vec<(&'me str, u32, &'me [u32])>, E>
     where
-        NgramRange: Clone + RangeBounds<&'me str> + Send + Sync;
+        NgramRange: Clone + RangeBounds<&'me str> + Send + Sync + 'me;
 
     // Return the documents containing the literals. The search space is restricted to the documents in the mask if specified
     //


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - BlockfileReader's get_range() method used to return a Vec<Items>. The overhead of vector allocation and extend is non-trivial especially if the range is large. Regex brute force for e.g. has this overhead.
  - This PR modifies the interface to return an iterator instead of a vector so that the overhead of materialization can be cut down
  - get_all_data() is also updated to return an iterator and all callsites updated
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
Perf testing on staging

## Documentation Changes
None
