### PR TITLE
[ENH] Implement sparse vector support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alga"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
+dependencies = [
+ "approx 0.3.2",
+ "num-complex 0.2.4",
+ "num-traits",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +164,15 @@ name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "approx"
@@ -1644,6 +1664,7 @@ dependencies = [
  "rayon",
  "roaring",
  "serde",
+ "sprs",
  "tantivy",
  "tempfile",
  "thiserror 1.0.69",
@@ -5234,9 +5255,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "matrixmultiply",
- "num-complex",
+ "num-complex 0.4.6",
  "num-integer",
  "num-traits",
  "portable-atomic",
@@ -5289,7 +5310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
  "num-bigint",
- "num-complex",
+ "num-complex 0.4.6",
  "num-integer",
  "num-iter",
  "num-rational",
@@ -5321,6 +5342,16 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -7674,6 +7705,21 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.9",
+]
+
+[[package]]
+name = "sprs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bff8419009a08f6cb7519a602c5590241fbff1446bcc823c07af15386eb801b"
+dependencies = [
+ "alga",
+ "ndarray",
+ "num-complex 0.4.6",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "chroma-storage",
  "chroma-tracing",
  "chroma-types",
+ "clap",
  "criterion",
  "futures",
  "hnswlib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "async-trait",
+ "base64 0.22.1",
  "chroma-benchmark",
  "chroma-blockstore",
  "chroma-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/frontend", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server"]
 
 [workspace.dependencies]
+anyhow = "1.0"
 arrow = "55.1"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["macros"] }
@@ -37,6 +38,7 @@ sea-query-binder = "0.7"
 serde = { version = "1.0.215", features = ["derive", "rc"] }
 serde_json = "1.0.133"
 setsum = "0.7"
+sprs = "0.11"
 tantivy = "0.22.0"
 thiserror = "1.0.69"
 tokio = { version = "1.41", features = ["fs", "macros", "rt-multi-thread", "time", "io-util"] }

--- a/rust/blockstore/src/arrow/block/value/f32_value.rs
+++ b/rust/blockstore/src/arrow/block/value/f32_value.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::{Array, Float32Array, Float32Builder},
+    datatypes::{DataType, Field},
+};
+
+use crate::{
+    arrow::{
+        block::delta::{
+            single_column_size_tracker::SingleColumnSizeTracker,
+            single_column_storage::SingleColumnStorage, BlockStorage, UnorderedBlockDelta,
+        },
+        types::{ArrowReadableValue, ArrowWriteableKey, ArrowWriteableValue},
+    },
+    key::KeyWrapper,
+    BlockfileWriterMutationOrdering,
+};
+
+impl ArrowWriteableValue for f32 {
+    type ReadableValue<'referred_data> = f32;
+    type ArrowBuilder = Float32Builder;
+    type SizeTracker = SingleColumnSizeTracker;
+    type PreparedValue = f32;
+
+    fn offset_size(_item_count: usize) -> usize {
+        0
+    }
+
+    fn validity_size(_item_count: usize) -> usize {
+        0 // We don't support None values for Fload32Array
+    }
+
+    fn add(prefix: &str, key: KeyWrapper, value: Self, delta: &BlockStorage) {
+        match &delta {
+            BlockStorage::Float32(builder) => builder.add(prefix, key, value),
+            _ => panic!("Invalid builder type: {:?}", &delta),
+        }
+    }
+
+    fn delete(prefix: &str, key: KeyWrapper, delta: &UnorderedBlockDelta) {
+        match &delta.builder {
+            BlockStorage::Float32(builder) => builder.delete(prefix, key),
+            _ => panic!("Invalid builder type: {:?}", &delta.builder),
+        }
+    }
+
+    fn get_delta_builder(mutation_ordering_hint: BlockfileWriterMutationOrdering) -> BlockStorage {
+        BlockStorage::Float32(SingleColumnStorage::new(mutation_ordering_hint))
+    }
+
+    fn get_arrow_builder(size_tracker: Self::SizeTracker) -> Self::ArrowBuilder {
+        Float32Builder::with_capacity(size_tracker.get_num_items())
+    }
+
+    fn prepare(value: Self) -> Self::PreparedValue {
+        value
+    }
+
+    fn append(value: Self::PreparedValue, builder: &mut Self::ArrowBuilder) {
+        builder.append_value(value);
+    }
+
+    fn finish(mut builder: Self::ArrowBuilder, _: &Self::SizeTracker) -> (Field, Arc<dyn Array>) {
+        let value_field = Field::new("value", DataType::Float32, false);
+        let value_arr = builder.finish();
+        let value_arr = (&value_arr as &dyn Array).slice(0, value_arr.len());
+        (value_field, value_arr)
+    }
+
+    fn get_owned_value_from_delta(
+        prefix: &str,
+        key: KeyWrapper,
+        delta: &UnorderedBlockDelta,
+    ) -> Option<Self::PreparedValue> {
+        match &delta.builder {
+            BlockStorage::Float32(builder) => builder.get_owned_value(prefix, key),
+            _ => panic!("Invalid builder type: {:?}", &delta.builder),
+        }
+    }
+}
+
+impl ArrowReadableValue<'_> for f32 {
+    fn get(array: &Arc<dyn Array>, index: usize) -> f32 {
+        let array = array.as_any().downcast_ref::<Float32Array>().unwrap();
+        array.value(index)
+    }
+    fn add_to_delta<K: ArrowWriteableKey>(
+        prefix: &str,
+        key: K,
+        value: Self,
+        storage: &mut BlockStorage,
+    ) {
+        f32::add(prefix, key.into(), value, storage);
+    }
+}

--- a/rust/blockstore/src/arrow/block/value/f32_value.rs
+++ b/rust/blockstore/src/arrow/block/value/f32_value.rs
@@ -28,7 +28,7 @@ impl ArrowWriteableValue for f32 {
     }
 
     fn validity_size(_item_count: usize) -> usize {
-        0 // We don't support None values for Fload32Array
+        0 // We don't support None values for Float32Array
     }
 
     fn add(prefix: &str, key: KeyWrapper, value: Self, delta: &BlockStorage) {

--- a/rust/blockstore/src/arrow/block/value/mod.rs
+++ b/rust/blockstore/src/arrow/block/value/mod.rs
@@ -1,4 +1,5 @@
 pub(super) mod data_record_value;
+pub(super) mod f32_value;
 pub(super) mod roaring_bitmap_value;
 pub(super) mod spann_posting_list_value;
 pub(super) mod str_value;

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -19,7 +19,6 @@ use futures::future::{join_all, try_join_all};
 use futures::{Stream, StreamExt, TryStreamExt};
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashSet;
-use std::iter::once_with;
 use std::mem::transmute;
 use std::ops::RangeBounds;
 use std::{collections::HashMap, sync::Arc};
@@ -645,12 +644,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         let blocks = try_join_all(block_futures).await?;
         Ok(blocks
             .into_iter()
-            .flat_map(move |block| {
-                let prefix_range_clone = prefix_range.clone();
-                let key_range_clone = key_range.clone();
-                once_with(|| block.get_range(prefix_range_clone, key_range_clone))
-            })
-            .flatten())
+            .flat_map(move |block| block.get_range(prefix_range.clone(), key_range.clone())))
     }
 
     pub(crate) async fn contains(

--- a/rust/blockstore/src/memory/reader_writer.rs
+++ b/rust/blockstore/src/memory/reader_writer.rs
@@ -105,7 +105,7 @@ impl<
         &'storage self,
         prefix_range: PrefixRange,
         key_range: KeyRange,
-    ) -> Result<impl Iterator<Item = (&'storage str, K, V)> + 'storage, Box<dyn ChromaError>>
+    ) -> Result<impl Iterator<Item = (&'storage str, K, V)> + Send + 'storage, Box<dyn ChromaError>>
     where
         PrefixRange: RangeBounds<&'prefix str>,
         KeyRange: RangeBounds<K>,

--- a/rust/blockstore/src/types/key.rs
+++ b/rust/blockstore/src/types/key.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 use crate::key::KeyWrapper;
 
-pub trait Key: PartialEq + Debug + Display + Into<KeyWrapper> + Clone {
+pub trait Key: Clone + Debug + Display + Into<KeyWrapper> + PartialEq + Send + Sync {
     fn get_size(&self) -> usize;
 }
 

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -95,21 +95,21 @@ impl<
         prefix_range: PrefixRange,
         key_range: KeyRange,
     ) -> Result<
-        Box<dyn Iterator<Item = (&'referred_data str, K, V)> + 'referred_data>,
+        Box<dyn Iterator<Item = (&'referred_data str, K, V)> + Send + 'referred_data>,
         Box<dyn ChromaError>,
     >
     where
-        PrefixRange: RangeBounds<&'prefix str> + Clone + 'referred_data,
-        KeyRange: RangeBounds<K> + Clone + 'referred_data,
+        PrefixRange: RangeBounds<&'prefix str> + Clone + Send + 'referred_data,
+        KeyRange: RangeBounds<K> + Clone + Send + 'referred_data,
     {
         match self {
             BlockfileReader::MemoryBlockfileReader(reader) => reader
                 .get_range_iter(prefix_range, key_range)
-                .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = _> + 'referred_data>),
+                .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = _> + Send + 'referred_data>),
             BlockfileReader::ArrowBlockfileReader(reader) => reader
                 .get_range(prefix_range, key_range)
                 .await
-                .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = _> + 'referred_data>),
+                .map(|iter| Box::new(iter) as Box<dyn Iterator<Item = _> + Send + 'referred_data>),
         }
     }
 

--- a/rust/blockstore/src/types/value.rs
+++ b/rust/blockstore/src/types/value.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use chroma_types::{DataRecord, SpannPostingList};
 use roaring::RoaringBitmap;
 
-pub trait Value: Clone {
+pub trait Value: Clone + Send + Sync {
     fn get_size(&self) -> usize;
 }
 

--- a/rust/blockstore/src/types/value.rs
+++ b/rust/blockstore/src/types/value.rs
@@ -31,6 +31,12 @@ impl Value for String {
     }
 }
 
+impl Value for f32 {
+    fn get_size(&self) -> usize {
+        4
+    }
+}
+
 impl Value for u32 {
     fn get_size(&self) -> usize {
         4

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -43,6 +43,7 @@ opentelemetry = { version = "0.27.0", default-features = false, features = ["tra
 indicatif = { workspace = true }
 clap = { workspace = true }
 anyhow = "1.0"
+sprs = "0.11"
 
 [dev-dependencies]
 rayon = { workspace = true }

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -21,6 +21,7 @@ roaring = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
 tempfile = { workspace = true }
+base64 = { workspace = true }
 
 chroma-error = { workspace = true }
 chroma-types = { workspace = true }

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 path = "src/lib.rs"
 
+[[example]]
+name = "sparse_wand_benchmark"
+path = "examples/sparse_wand_benchmark.rs"
+
 [dependencies]
 rand = { workspace = true }
 thiserror = { workspace = true }
@@ -35,13 +39,17 @@ itertools = { workspace = true }
 hnswlib = { workspace = true }
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 
+# Dependencies for examples
+indicatif = { workspace = true }
+clap = { workspace = true }
+anyhow = "1.0"
+
 [dev-dependencies]
 rayon = { workspace = true }
 criterion = { workspace = true }
 chroma-benchmark = { workspace = true }
 proptest = { workspace = true }
 indicatif = { workspace = true }
-anyhow = "1.0.93"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }
 

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -42,8 +42,8 @@ opentelemetry = { version = "0.27.0", default-features = false, features = ["tra
 # Dependencies for examples
 indicatif = { workspace = true }
 clap = { workspace = true }
-anyhow = "1.0"
-sprs = "0.11"
+anyhow = { workspace = true }
+sprs = { workspace = true }
 
 [dev-dependencies]
 rayon = { workspace = true }

--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -50,7 +50,6 @@ rayon = { workspace = true }
 criterion = { workspace = true }
 chroma-benchmark = { workspace = true }
 proptest = { workspace = true }
-indicatif = { workspace = true }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }
 

--- a/rust/index/examples/sparse_wand_benchmark.rs
+++ b/rust/index/examples/sparse_wand_benchmark.rs
@@ -1,0 +1,687 @@
+use anyhow::Result;
+use arrow::array::{Array, Float32Array, Int32Array, ListArray, StringArray};
+use arrow::record_batch::RecordBatch;
+use chroma_blockstore::test_arrow_blockfile_provider;
+use chroma_blockstore::{provider::BlockfileProvider, BlockfileWriterOptions};
+use chroma_index::sparse::{
+    reader::SparseReader,
+    writer::{SparseDelta, SparseWriter},
+};
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::time::Instant;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+// Blockfile prefix constants
+const SPARSE_MAX_PREFIX: &str = "sparse_max";
+const SPARSE_OFFSET_VALUE_PREFIX: &str = "sparse_offset_value";
+
+// Sparse document and query structures using HashMap instead of sprs
+#[derive(Debug, Clone)]
+pub struct SparseDocument {
+    pub doc_id: String,
+    pub url: String,
+    pub title: String,
+    pub body: String,
+    pub sparse_vector: HashMap<usize, f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SparseQuery {
+    pub query_id: String,
+    pub text: String,
+    pub sparse_vector: HashMap<usize, f32>,
+}
+
+/// Load documents with sparse vectors from parquet file
+pub fn load_sparse_documents(
+    path: String,
+    offset: usize,
+    limit: usize,
+) -> Result<Vec<SparseDocument>> {
+    let file = File::open(&path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let reader = builder.build()?;
+
+    let mut documents = Vec::new();
+    let mut current_offset = 0;
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let batch_size = batch.num_rows();
+
+        // Skip if we haven't reached the offset yet
+        if current_offset + batch_size <= offset {
+            current_offset += batch_size;
+            continue;
+        }
+
+        // Process the batch
+        let start = offset.saturating_sub(current_offset);
+        let end = std::cmp::min(batch_size, start + (limit - documents.len()));
+
+        if start < end {
+            let sliced_batch = batch.slice(start, end - start);
+            documents.extend(process_sparse_document_batch(sliced_batch)?);
+        }
+
+        current_offset += batch_size;
+
+        // Stop if we've collected enough documents
+        if documents.len() >= limit {
+            break;
+        }
+    }
+
+    Ok(documents)
+}
+
+/// Load queries with sparse vectors from parquet file
+pub fn load_sparse_queries(path: String, offset: usize, limit: usize) -> Result<Vec<SparseQuery>> {
+    let file = File::open(&path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let reader = builder.build()?;
+
+    let mut queries = Vec::new();
+    let mut current_offset = 0;
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let batch_size = batch.num_rows();
+
+        // Skip if we haven't reached the offset yet
+        if current_offset + batch_size <= offset {
+            current_offset += batch_size;
+            continue;
+        }
+
+        // Process the batch
+        let start = offset.saturating_sub(current_offset);
+        let end = std::cmp::min(batch_size, start + (limit - queries.len()));
+
+        if start < end {
+            let sliced_batch = batch.slice(start, end - start);
+            queries.extend(process_sparse_query_batch(sliced_batch)?);
+        }
+
+        current_offset += batch_size;
+
+        // Stop if we've collected enough queries
+        if queries.len() >= limit {
+            break;
+        }
+    }
+
+    Ok(queries)
+}
+
+/// Process a document batch and extract sparse vectors
+fn process_sparse_document_batch(batch: RecordBatch) -> Result<Vec<SparseDocument>> {
+    let doc_ids = batch
+        .column_by_name("doc_id")
+        .ok_or_else(|| anyhow::anyhow!("doc_id column not found"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow::anyhow!("doc_id is not a string array"))?;
+
+    let urls = batch
+        .column_by_name("url")
+        .ok_or_else(|| anyhow::anyhow!("url column not found"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow::anyhow!("url is not a string array"))?;
+
+    let titles = batch
+        .column_by_name("title")
+        .ok_or_else(|| anyhow::anyhow!("title column not found"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow::anyhow!("title is not a string array"))?;
+
+    let bodies = batch
+        .column_by_name("body")
+        .ok_or_else(|| anyhow::anyhow!("body column not found"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow::anyhow!("body is not a string array"))?;
+
+    let sparse_indices = batch
+        .column_by_name("sparse_indices")
+        .ok_or_else(|| anyhow::anyhow!("sparse_indices column not found"))?
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .ok_or_else(|| anyhow::anyhow!("sparse_indices is not a list array"))?;
+
+    let sparse_values = batch
+        .column_by_name("sparse_values")
+        .ok_or_else(|| anyhow::anyhow!("sparse_values column not found"))?
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .ok_or_else(|| anyhow::anyhow!("sparse_values is not a list array"))?;
+
+    let mut documents = Vec::with_capacity(batch.num_rows());
+
+    for i in 0..batch.num_rows() {
+        let doc_id = doc_ids.value(i).to_string();
+        let url = urls.value(i).to_string();
+        let title = titles.value(i).to_string();
+        let body = bodies.value(i).to_string();
+
+        // Get indices and values for this document
+        let indices_array = sparse_indices.value(i);
+        let values_array = sparse_values.value(i);
+
+        let indices = indices_array
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or_else(|| anyhow::anyhow!("indices is not Int32Array"))?;
+
+        let values = values_array
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .ok_or_else(|| anyhow::anyhow!("values is not Float32Array"))?;
+
+        // Create sparse vector as HashMap
+        let mut sparse_vector = HashMap::new();
+        for j in 0..indices.len() {
+            sparse_vector.insert(indices.value(j) as usize, values.value(j));
+        }
+
+        documents.push(SparseDocument {
+            doc_id,
+            url,
+            title,
+            body,
+            sparse_vector,
+        });
+    }
+
+    Ok(documents)
+}
+
+/// Process a query batch and extract sparse vectors
+fn process_sparse_query_batch(batch: RecordBatch) -> Result<Vec<SparseQuery>> {
+    let query_ids = batch
+        .column_by_name("query_id")
+        .ok_or_else(|| anyhow::anyhow!("query_id column not found"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow::anyhow!("query_id is not a string array"))?;
+
+    let texts = batch
+        .column_by_name("text")
+        .ok_or_else(|| anyhow::anyhow!("text column not found"))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| anyhow::anyhow!("text is not a string array"))?;
+
+    let sparse_indices = batch
+        .column_by_name("sparse_indices")
+        .ok_or_else(|| anyhow::anyhow!("sparse_indices column not found"))?
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .ok_or_else(|| anyhow::anyhow!("sparse_indices is not a list array"))?;
+
+    let sparse_values = batch
+        .column_by_name("sparse_values")
+        .ok_or_else(|| anyhow::anyhow!("sparse_values column not found"))?
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .ok_or_else(|| anyhow::anyhow!("sparse_values is not a list array"))?;
+
+    let mut queries = Vec::with_capacity(batch.num_rows());
+
+    for i in 0..batch.num_rows() {
+        let query_id = query_ids.value(i).to_string();
+        let text = texts.value(i).to_string();
+
+        // Get indices and values for this query
+        let indices_array = sparse_indices.value(i);
+        let values_array = sparse_values.value(i);
+
+        let indices = indices_array
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or_else(|| anyhow::anyhow!("indices is not Int32Array"))?;
+
+        let values = values_array
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .ok_or_else(|| anyhow::anyhow!("values is not Float32Array"))?;
+
+        // Create sparse vector as HashMap
+        let mut sparse_vector = HashMap::new();
+        for j in 0..indices.len() {
+            sparse_vector.insert(indices.value(j) as usize, values.value(j));
+        }
+
+        queries.push(SparseQuery {
+            query_id,
+            text,
+            sparse_vector,
+        });
+    }
+
+    Ok(queries)
+}
+
+/// Command line arguments for the benchmark
+#[derive(Parser, Debug)]
+#[command(name = "sparse_wand_benchmark")]
+#[command(about = "Benchmark sparse index with Block-Max WAND algorithm")]
+struct Args {
+    /// Path to the dataset directory containing documents.parquet and queries.parquet
+    #[arg(short = 'd', long)]
+    dataset_path: String,
+
+    /// Number of documents to load
+    #[arg(short = 'n', long, default_value_t = 65536)]
+    num_documents: usize,
+
+    /// Number of queries to run
+    #[arg(short = 'm', long, default_value_t = 16)]
+    num_queries: usize,
+
+    /// Top-k results to retrieve
+    #[arg(short = 'k', long, default_value_t = 16)]
+    top_k: usize,
+
+    /// Block size for the sparse index
+    #[arg(short = 'b', long, default_value_t = 128)]
+    block_size: u32,
+}
+
+#[derive(Debug, Clone)]
+struct SearchResult {
+    query_id: String,
+    top_k_offsets: Vec<u32>,
+    scores: Vec<f32>,
+    search_time_ms: f64,
+}
+
+fn compute_sparse_dot_product(vec1: &[(u32, f32)], vec2: &[(u32, f32)]) -> f32 {
+    let mut score = 0.0;
+    let mut i = 0;
+    let mut j = 0;
+
+    while i < vec1.len() && j < vec2.len() {
+        match vec1[i].0.cmp(&vec2[j].0) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                score += vec1[i].1 * vec2[j].1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+
+    score
+}
+
+fn brute_force_search(
+    documents: &[SparseDocument],
+    query: &SparseQuery,
+    top_k: usize,
+) -> SearchResult {
+    let start = Instant::now();
+
+    // Convert query sparse vector to sorted list of (dimension_id, value)
+    let mut query_vec: Vec<(u32, f32)> = Vec::new();
+    for (idx, val) in query.sparse_vector.iter() {
+        query_vec.push((*idx as u32, *val));
+    }
+    query_vec.sort_by_key(|&(dim, _)| dim);
+
+    // Compute scores for all documents
+    let mut scores: Vec<(u32, f32)> = Vec::new();
+
+    for (offset, doc) in documents.iter().enumerate() {
+        // Convert document sparse vector to sorted list
+        let mut doc_vec: Vec<(u32, f32)> = Vec::new();
+        for (idx, val) in doc.sparse_vector.iter() {
+            doc_vec.push((*idx as u32, *val));
+        }
+        doc_vec.sort_by_key(|&(dim, _)| dim);
+
+        let score = compute_sparse_dot_product(&query_vec, &doc_vec);
+        if score > 0.0 {
+            scores.push((offset as u32, score));
+        }
+    }
+
+    // Sort by score descending and take top-k
+    scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    scores.truncate(top_k);
+
+    let elapsed = start.elapsed();
+
+    SearchResult {
+        query_id: query.query_id.clone(),
+        top_k_offsets: scores.iter().map(|&(offset, _)| offset).collect(),
+        scores: scores.iter().map(|&(_, score)| score).collect(),
+        search_time_ms: elapsed.as_secs_f64() * 1000.0,
+    }
+}
+
+async fn build_sparse_index(
+    documents: &[SparseDocument],
+    block_size: u32,
+) -> anyhow::Result<(TempDir, BlockfileProvider, Uuid, Uuid)> {
+    println!("Building sparse index...");
+    let start = Instant::now();
+
+    let (temp_dir, provider) = test_arrow_blockfile_provider(8 * 1024 * 1024);
+
+    // Create writers for the sparse index
+    let max_writer = provider
+        .write::<u32, f32>(BlockfileWriterOptions::new(SPARSE_MAX_PREFIX.to_string()))
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create max writer: {:?}", e))?;
+
+    let offset_value_writer = provider
+        .write::<u32, f32>(BlockfileWriterOptions::new(
+            SPARSE_OFFSET_VALUE_PREFIX.to_string(),
+        ))
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create offset value writer: {:?}", e))?;
+
+    // Store the writer IDs for later use when creating readers
+    let max_writer_id = max_writer.id();
+    let offset_value_writer_id = offset_value_writer.id();
+
+    // Create sparse writer (without reader since we're building from scratch)
+    let sparse_writer = SparseWriter::new(block_size, max_writer, offset_value_writer, None);
+
+    // Build the index
+    let pb = ProgressBar::new(documents.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    // Process documents in batches for efficiency
+    let batch_size = 4096;
+    for (chunk_idx, chunk) in documents.chunks(batch_size).enumerate() {
+        let mut delta = SparseDelta::default();
+
+        for (idx, doc) in chunk.iter().enumerate() {
+            let offset = (chunk_idx * batch_size + idx) as u32;
+
+            // Convert sparse vector to iterator of (dimension_id, value)
+            let sparse_iter = doc
+                .sparse_vector
+                .iter()
+                .map(|(idx, val)| (*idx as u32, *val));
+            delta.create(offset, sparse_iter);
+        }
+
+        // Write the batch
+        sparse_writer
+            .write_delta(delta)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to write delta: {:?}", e))?;
+        pb.inc(chunk.len() as u64);
+    }
+
+    pb.finish_with_message("Index built");
+
+    // Commit and flush writers
+    let flusher = sparse_writer
+        .commit()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to commit sparse writer: {:?}", e))?;
+
+    flusher
+        .flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to flush sparse writer: {:?}", e))?;
+
+    let elapsed = start.elapsed();
+    println!("Index build time: {:.2} ms", elapsed.as_secs_f64() * 1000.0);
+
+    Ok((temp_dir, provider, max_writer_id, offset_value_writer_id))
+}
+
+async fn search_with_wand(
+    provider: &BlockfileProvider,
+    max_reader_id: Uuid,
+    offset_value_reader_id: Uuid,
+    queries: &[SparseQuery],
+    top_k: usize,
+) -> anyhow::Result<Vec<SearchResult>> {
+    println!("\nSearching with Block-Max WAND...");
+
+    // Open readers for the sparse index using the writer IDs
+    let max_reader = provider
+        .read::<u32, f32>(
+            chroma_blockstore::arrow::provider::BlockfileReaderOptions::new(
+                max_reader_id,
+                SPARSE_MAX_PREFIX.to_string(),
+            ),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open max reader: {:?}", e))?;
+
+    let offset_value_reader = provider
+        .read::<u32, f32>(
+            chroma_blockstore::arrow::provider::BlockfileReaderOptions::new(
+                offset_value_reader_id,
+                SPARSE_OFFSET_VALUE_PREFIX.to_string(),
+            ),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to open offset value reader: {:?}", e))?;
+
+    let sparse_reader = SparseReader::new(max_reader, offset_value_reader);
+
+    let mut results = Vec::new();
+    let pb = ProgressBar::new(queries.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )
+            .unwrap()
+            .progress_chars("#>-"),
+    );
+
+    for query in queries {
+        let start = Instant::now();
+
+        // Convert query sparse vector to iterator
+        let query_vec: Vec<(u32, f32)> = query
+            .sparse_vector
+            .iter()
+            .map(|(idx, val)| (*idx as u32, *val))
+            .collect();
+
+        // Run WAND search
+        let scores = sparse_reader
+            .wand(query_vec, top_k as u32)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to run WAND search: {:?}", e))?;
+
+        let elapsed = start.elapsed();
+
+        results.push(SearchResult {
+            query_id: query.query_id.clone(),
+            top_k_offsets: scores.iter().map(|s| s.offset).collect(),
+            scores: scores.iter().map(|s| s.score).collect(),
+            search_time_ms: elapsed.as_secs_f64() * 1000.0,
+        });
+
+        pb.inc(1);
+    }
+
+    pb.finish_with_message("WAND search complete");
+    Ok(results)
+}
+
+fn calculate_recall(ground_truth: &[SearchResult], predictions: &[SearchResult], k: usize) -> f32 {
+    let mut total_recall = 0.0;
+    let mut count = 0;
+
+    for gt in ground_truth {
+        if let Some(pred) = predictions.iter().find(|p| p.query_id == gt.query_id) {
+            let gt_set: HashSet<u32> = gt.top_k_offsets.iter().take(k).cloned().collect();
+            let pred_set: HashSet<u32> = pred.top_k_offsets.iter().take(k).cloned().collect();
+
+            let intersection = gt_set.intersection(&pred_set).count();
+            let recall = intersection as f32 / k.min(gt_set.len()) as f32;
+            total_recall += recall;
+            count += 1;
+        }
+    }
+
+    if count > 0 {
+        total_recall / count as f32
+    } else {
+        0.0
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Parse command line arguments using clap
+    let args = Args::parse();
+
+    // Construct paths to documents and queries files
+    let documents_path = format!("{}/documents.parquet", args.dataset_path);
+    let queries_path = format!("{}/queries.parquet", args.dataset_path);
+
+    println!("Sparse Index Block-Max WAND Benchmark");
+    println!("======================================");
+    println!("Configuration:");
+    println!("  Dataset: {}", args.dataset_path);
+    println!("  Documents: {}", documents_path);
+    println!("  Queries: {}", queries_path);
+    println!("  Num documents: {}", args.num_documents);
+    println!("  Num queries: {}", args.num_queries);
+    println!("  Top-k: {}", args.top_k);
+    println!("  Block size: {}", args.block_size);
+    println!();
+
+    // Load documents
+    println!("Loading documents...");
+    let documents = load_sparse_documents(documents_path, 0, args.num_documents)?;
+    println!("Loaded {} documents", documents.len());
+
+    // Load queries
+    println!("Loading queries...");
+    let queries = load_sparse_queries(queries_path, 0, args.num_queries)?;
+    println!("Loaded {} queries", queries.len());
+
+    // Build sparse index
+    let (temp_dir, provider, max_reader_id, offset_value_reader_id) =
+        build_sparse_index(&documents, args.block_size).await?;
+
+    // Run brute force search as ground truth
+    println!("\nRunning brute force search (ground truth)...");
+    let start = Instant::now();
+    let brute_force_results: Vec<SearchResult> = queries
+        .iter()
+        .map(|query| brute_force_search(&documents, query, args.top_k))
+        .collect();
+    let brute_force_time = start.elapsed().as_secs_f64() * 1000.0;
+    println!("Brute force total time: {:.2} ms", brute_force_time);
+
+    // Run WAND search
+    let wand_results = search_with_wand(
+        &provider,
+        max_reader_id,
+        offset_value_reader_id,
+        &queries,
+        args.top_k,
+    )
+    .await?;
+
+    // Calculate metrics
+    let recall = calculate_recall(&brute_force_results, &wand_results, args.top_k);
+
+    let avg_brute_force_time = brute_force_results
+        .iter()
+        .map(|r| r.search_time_ms)
+        .sum::<f64>()
+        / brute_force_results.len() as f64;
+
+    let avg_wand_time =
+        wand_results.iter().map(|r| r.search_time_ms).sum::<f64>() / wand_results.len() as f64;
+
+    let speedup = avg_brute_force_time / avg_wand_time;
+
+    // Print results
+    println!("\n======================================");
+    println!("Results:");
+    println!("  Recall@{}: {:.2}%", args.top_k, recall * 100.0);
+    println!("  Avg brute force time: {:.2} ms", avg_brute_force_time);
+    println!("  Avg WAND time: {:.2} ms", avg_wand_time);
+    println!("  Speedup: {:.2}x", speedup);
+
+    // Print detailed comparison for first few queries
+    println!("\nDetailed comparison (first 5 queries):");
+    for i in 0..5.min(queries.len()) {
+        let bf = &brute_force_results[i];
+        let wand = &wand_results[i];
+
+        println!("\nQuery {}: {}", i + 1, bf.query_id);
+        println!(
+            "  Brute force top-{} offsets: {:?}",
+            args.top_k, bf.top_k_offsets
+        );
+        println!("  Brute force top-{} scores: {:?}", args.top_k, bf.scores);
+        println!(
+            "  WAND top-{} offsets: {:?}",
+            args.top_k, wand.top_k_offsets
+        );
+        println!("  WAND top-{} scores: {:?}", args.top_k, wand.scores);
+
+        let gt_set: HashSet<u32> = bf.top_k_offsets.iter().cloned().collect();
+        let pred_set: HashSet<u32> = wand.top_k_offsets.iter().cloned().collect();
+        let overlap = gt_set.intersection(&pred_set).count();
+
+        println!("  Overlap: {}/{}", overlap, args.top_k);
+
+        // Validate scores for matching offsets
+        let mut score_differences = Vec::new();
+        for (j, wand_offset) in wand.top_k_offsets.iter().enumerate() {
+            if let Some(bf_idx) = bf.top_k_offsets.iter().position(|&o| o == *wand_offset) {
+                let score_diff = (wand.scores[j] - bf.scores[bf_idx]).abs();
+                score_differences.push(score_diff);
+                if score_diff > 1e-5 {
+                    println!(
+                        "    Score mismatch for offset {}: BF={:.6}, WAND={:.6}, diff={:.6}",
+                        wand_offset, bf.scores[bf_idx], wand.scores[j], score_diff
+                    );
+                }
+            }
+        }
+
+        if !score_differences.is_empty() {
+            let avg_diff: f32 =
+                score_differences.iter().sum::<f32>() / score_differences.len() as f32;
+            let max_diff = score_differences.iter().cloned().fold(0.0f32, f32::max);
+            println!(
+                "  Score validation: avg_diff={:.6}, max_diff={:.6}",
+                avg_diff, max_diff
+            );
+        }
+
+        println!("  Brute force time: {:.2} ms", bf.search_time_ms);
+        println!("  WAND time: {:.2} ms", wand.search_time_ms);
+    }
+
+    // Clean up
+    drop(provider);
+    drop(temp_dir);
+
+    Ok(())
+}

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -4,6 +4,7 @@ mod hnsw;
 pub mod hnsw_provider;
 pub mod metadata;
 pub mod spann;
+pub mod sparse;
 mod types;
 pub mod utils;
 

--- a/rust/index/src/sparse/README.md
+++ b/rust/index/src/sparse/README.md
@@ -1,0 +1,181 @@
+# Sparse Index Module
+
+## Overview
+
+The sparse index module implements the **Block-Max WAND (Weak AND)** algorithm for efficient sparse vector search. This implementation is built on top of Chroma's blockfile abstraction and provides high-performance top-k retrieval for sparse vectors, commonly used in text search and information retrieval systems.
+
+## Algorithm and Query Processing
+
+This implementation combines the WAND (Weak AND) algorithm from Broder et al. [1] with the Block-Max optimization from Ding and Suel [2] to achieve efficient sparse vector search.
+
+### Background: WAND Algorithm
+
+The WAND algorithm [1] introduces a two-level query evaluation process:
+- **First level**: Approximate evaluation using partial information and upper bounds
+- **Second level**: Full evaluation of promising candidates
+
+The core innovation is the WAND predicate, which generalizes AND and OR operations using weighted thresholds. For a set of terms with weights w₁, w₂, ..., wₖ and threshold θ, WAND returns true when the sum of weights for present terms exceeds θ.
+
+### Block-Max Enhancement
+
+The Block-Max WAND algorithm [2] improves upon WAND by:
+- Partitioning posting lists into fixed-size blocks (e.g., 64-256 documents)
+- Storing the maximum impact score for each block
+- Using block-level upper bounds instead of global maximums for more aggressive pruning
+
+This creates a piecewise upper-bound approximation that significantly reduces the number of documents that need full evaluation.
+
+### Query Processing Flow
+
+The algorithm maintains cursors for each query dimension and processes documents as follows:
+
+1. **Initialization**: Create a cursor for each query dimension tracking:
+   - Current document position
+   - Current block boundaries and block maximum score
+   - Dimension-level maximum score (global upper bound)
+
+2. **Pivot Selection** (following WAND):
+   - Sort cursors by current document offset
+   - Find pivot term: first term where accumulated upper bounds exceed threshold
+   - Pivot document is the smallest document ID that could be a candidate
+
+3. **Block-Level Optimization** (Block-Max enhancement):
+   - Use block maximum scores for tighter bounds
+   - Perform shallow pointer movements to check block boundaries
+   - Skip entire blocks when their maximum scores cannot contribute to top-k
+
+4. **Document Evaluation**:
+   - If pivot document contains sufficient terms with high enough scores, evaluate it
+   - Maintain a min-heap of top-k results
+   - Update threshold based on minimum score in heap
+
+5. **Cursor Advancement**:
+   - Move cursors past evaluated or skipped documents
+   - When block check fails, skip to next block boundary (not just next document)
+
+### Performance Characteristics
+
+According to the original papers:
+
+- **WAND [1]** achieves 90%+ reduction in full evaluations compared to exhaustive search
+- **Block-Max WAND [2]** provides 2-3x additional speedup over WAND
+- **Time Complexity**: O(n) worst case, but typically sublinear due to pruning
+- **Space Overhead**: ~5% increase for storing block maximum values
+- **Block Size Trade-offs**:
+  - Smaller blocks (64): Better pruning, more metadata overhead
+  - Larger blocks (256): Less metadata, coarser pruning
+  - Typical sweet spot: 128 documents per block
+
+The combination of WAND's pivot-based traversal with Block-Max's fine-grained upper bounds makes this implementation particularly effective for high-dimensional sparse vector search.
+
+### References
+
+[1] Broder, A. Z., Carmel, D., Herscovici, M., Soffer, A., & Zien, J. (2003). Efficient query evaluation using a two-level retrieval process. In Proceedings of CIKM '03.
+
+[2] Ding, S., & Suel, T. (2011). Faster top-k document retrieval using block-max indexes. In Proceedings of SIGIR '11.
+
+## Architecture
+
+The module consists of three main components:
+
+### 1. Types (`types.rs`)
+- Utility functions for encoding/decoding dimension IDs as base64 strings
+- Constants for special prefixes used in blockfile storage
+
+### 2. Writer (`writer.rs`)
+- **SparseDelta**: Accumulates changes (creates/deletes) to sparse vectors
+- **SparseWriter**: Manages the writing process with support for incremental updates
+- **SparseFlusher**: Handles the final commit and flush operations
+
+### 3. Reader (`reader.rs`)
+- **SparseReader**: Provides read access to the sparse index
+- **Cursor**: Internal structure for tracking position in each dimension's posting list
+- **Score**: Result structure containing document offset and similarity score
+
+## Data Layout on Blockfile
+
+The sparse index uses two separate blockfiles to store its data. Both blockfiles follow the standard Chroma blockfile format:
+```
+Prefix (String) -> Key (K) -> Value (V)
+```
+
+### 1. Max Blockfile (`sparse_max`)
+
+Stores block-level and dimension-level maximum values for efficient pruning.
+
+**Format:**
+```
+Prefix: String -> Key: u32 -> Value: f32
+```
+
+**Entries:**
+
+a) **Dimension-level maximums:**
+   - Prefix: `"DIMENSION"`
+   - Key: `dimension_id` (u32)
+   - Value: `dimension_max_value` (f32)
+   - Purpose: Stores the global maximum value for each dimension
+
+b) **Block-level maximums:**
+   - Prefix: `encode_u32(dimension_id)` (base64-encoded dimension ID)
+   - Key: `block_boundary_offset` (u32)
+   - Value: `block_max_value` (f32)
+   - Purpose: Stores the maximum value within each block for a dimension
+   - The `block_boundary_offset` is the exclusive upper bound of the block (i.e., one past the last document in the block)
+
+### 2. Offset-Value Blockfile (`sparse_offset_value`)
+
+Stores the actual sparse vector values for each document.
+
+**Format:**
+```
+Prefix: String -> Key: u32 -> Value: f32
+```
+
+**Entries:**
+- Prefix: `encode_u32(dimension_id)` (base64-encoded dimension ID)
+- Key: `document_offset` (u32)
+- Value: `value` (f32)
+- Purpose: Stores the actual sparse vector values for each (dimension, document) pair
+- Sorted by document offset within each dimension for efficient range queries
+
+## Data Organization Example
+
+For a sparse vector at document offset 42 with values `{dim_5: 0.8, dim_10: 0.3}` and block size 128:
+
+**Max Blockfile entries:**
+```
+Prefix: "DIMENSION", Key: 5, Value: 0.9         # Global max for dimension 5
+Prefix: "DIMENSION", Key: 10, Value: 0.7        # Global max for dimension 10
+Prefix: encode_u32(5), Key: 128, Value: 0.9     # Block [0,128) max for dim 5
+Prefix: encode_u32(10), Key: 128, Value: 0.7    # Block [0,128) max for dim 10
+```
+
+**Offset-Value Blockfile entries:**
+```
+Prefix: encode_u32(5), Key: 42, Value: 0.8      # Value for dim 5 at doc 42
+Prefix: encode_u32(10), Key: 42, Value: 0.3     # Value for dim 10 at doc 42
+```
+
+## Usage Example
+
+```rust
+// Writing sparse vectors
+let mut delta = SparseDelta::default();
+delta.create(doc_offset, vec![(dim1, val1), (dim2, val2)]);
+sparse_writer.write(delta).await;
+let flusher = sparse_writer.commit().await?;
+flusher.flush().await?;
+
+// Querying with WAND
+let query = vec![(dim1, query_val1), (dim2, query_val2)];
+let top_k_results = sparse_reader.wand(query, k).await?;
+```
+
+## Implementation Notes
+
+- Dimension IDs are encoded as base64 strings for use as blockfile keys
+- The implementation supports incremental updates through the fork mechanism
+- Cursors are maintained in sorted order by document offset for efficient processing
+- The algorithm uses a min-heap to maintain top-k results efficiently
+- Tie-breaking is handled deterministically by document offset

--- a/rust/index/src/sparse/mod.rs
+++ b/rust/index/src/sparse/mod.rs
@@ -1,0 +1,3 @@
+pub mod reader;
+pub mod types;
+pub mod writer;

--- a/rust/index/src/sparse/reader.rs
+++ b/rust/index/src/sparse/reader.rs
@@ -1,0 +1,296 @@
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap},
+};
+
+use chroma_blockstore::BlockfileReader;
+use chroma_error::ChromaError;
+use futures::{StreamExt, TryStreamExt};
+use thiserror::Error;
+
+use crate::sparse::types::{encode_u32, DIMENSION_PREFIX};
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Cursor {
+    offset: u32,
+    dimension_index: usize,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Score {
+    score: f32,
+    offset: u32,
+}
+
+impl Eq for Score {}
+
+// Reverse order by score for a min heap
+impl Ord for Score {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.score
+            .total_cmp(&other.score)
+            .then(self.offset.cmp(&other.offset))
+            .reverse()
+    }
+}
+
+impl PartialOrd for Score {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SparseReaderError {
+    #[error(transparent)]
+    Blockfile(#[from] Box<dyn ChromaError>),
+}
+
+#[derive(Debug)]
+pub struct SparseReader<'me> {
+    max_reader: BlockfileReader<'me, u32, f32>,
+    offset_value_reader: BlockfileReader<'me, u32, f32>,
+}
+
+impl<'me> SparseReader<'me> {
+    pub async fn get_dimension_max(&self) -> Result<HashMap<u32, f32>, SparseReaderError> {
+        Ok(self
+            .max_reader
+            .get_range_stream(DIMENSION_PREFIX..=DIMENSION_PREFIX, ..)
+            .map(|result| result.map(|(_, dimension_id, max)| (dimension_id, max)))
+            .try_collect::<HashMap<_, _>>()
+            .await?)
+    }
+
+    pub async fn get_blocks(
+        &self,
+        dimension_id: u32,
+    ) -> Result<Vec<(u32, f32)>, SparseReaderError> {
+        let encoded_dimension = encode_u32(dimension_id);
+        Ok(self
+            .max_reader
+            .get_range_stream(encoded_dimension.as_str()..=encoded_dimension.as_str(), ..)
+            .map(|result| {
+                result.map(|(_, block_first_offset, block_max)| (block_first_offset, block_max))
+            })
+            .try_collect::<Vec<_>>()
+            .await?)
+    }
+
+    pub async fn lower_bound_offset_value(
+        &self,
+        dimension_id: u32,
+        lower_bound: u32,
+    ) -> Result<Option<(u32, f32)>, SparseReaderError> {
+        let encoded_dimension = encode_u32(dimension_id);
+        Ok(self
+            .offset_value_reader
+            .get_range_stream(
+                encoded_dimension.clone().as_str()..=encoded_dimension.clone().as_str(),
+                lower_bound..,
+            )
+            .try_next()
+            .await?
+            .map(|(_, offset, value)| (offset, value)))
+    }
+
+    pub async fn wand(
+        &self,
+        query_vector: impl IntoIterator<Item = (u32, f32)>,
+        k: u32,
+    ) -> Result<Vec<Score>, SparseReaderError> {
+        let collected_query = query_vector.into_iter().collect::<Vec<_>>();
+        let dimension_count = collected_query.len();
+        let all_dimension_max = self.get_dimension_max().await?;
+
+        let mut block_cursor = Vec::with_capacity(dimension_count);
+        let mut block_statistic = Vec::with_capacity(dimension_count);
+        let mut dimension_cursor = Vec::with_capacity(dimension_count);
+        let mut dimension_id = Vec::with_capacity(dimension_count);
+        let mut dimension_upper_bound = Vec::with_capacity(dimension_count);
+        let mut dimension_score = Vec::with_capacity(dimension_count);
+        let mut query_weight = Vec::with_capacity(dimension_count);
+
+        for (id, weight) in collected_query {
+            if let Some(dimension_max_value) = all_dimension_max.get(&id) {
+                let blocks = self
+                    .get_blocks(id)
+                    .await?
+                    .into_iter()
+                    .map(|(offset, block_max_value)| (offset, weight * block_max_value))
+                    .collect::<Vec<_>>();
+                if let Some((offset, value)) = blocks.first().cloned() {
+                    block_cursor.push(0);
+                    block_statistic.push(blocks);
+                    let dimension_index = dimension_cursor.len();
+                    dimension_cursor.push(Cursor {
+                        offset,
+                        dimension_index,
+                    });
+                    dimension_id.push(id);
+                    dimension_upper_bound.push(weight * dimension_max_value);
+                    dimension_score.push(weight * value);
+                    query_weight.push(weight);
+                }
+            }
+        }
+
+        dimension_cursor.sort_unstable();
+
+        let Some(mut first_unchecked_offset) = dimension_cursor.first().map(|cursor| cursor.offset)
+        else {
+            return Ok(Vec::new());
+        };
+
+        let mut threshold = f32::MIN;
+        let mut top_scores = BinaryHeap::<Score>::with_capacity(k as usize);
+
+        loop {
+            let mut accumulated_dimension_upper_bound = 0.0;
+            let mut following_dimension_cursor_offset = u32::MAX;
+            let mut peak_dimension_cursor_index = 0;
+            let mut lag_dimension_cursor_index = 0;
+            let mut pivot_dimension_cursor_index = None;
+
+            for (
+                cursor_index,
+                &Cursor {
+                    offset,
+                    dimension_index,
+                },
+            ) in dimension_cursor.iter().enumerate()
+            {
+                if pivot_dimension_cursor_index.is_some() {
+                    following_dimension_cursor_offset = offset;
+                    break;
+                }
+                if dimension_upper_bound
+                    [dimension_cursor[peak_dimension_cursor_index].dimension_index]
+                    < dimension_upper_bound[dimension_index]
+                {
+                    if dimension_cursor[peak_dimension_cursor_index].offset < offset {
+                        lag_dimension_cursor_index = peak_dimension_cursor_index;
+                    }
+                    peak_dimension_cursor_index = cursor_index;
+                }
+                accumulated_dimension_upper_bound += dimension_upper_bound[dimension_index];
+                if threshold < accumulated_dimension_upper_bound {
+                    pivot_dimension_cursor_index = Some(cursor_index);
+                }
+            }
+
+            let Some(pivot_dimension_cursor_index) = pivot_dimension_cursor_index else {
+                break;
+            };
+
+            let pivot_offset = dimension_cursor[pivot_dimension_cursor_index].offset;
+            let (accumulated_block_upper_bound, min_block_cutoff) = dimension_cursor
+                [..=pivot_dimension_cursor_index]
+                .iter()
+                .filter_map(
+                    |&Cursor {
+                         offset: _,
+                         dimension_index,
+                     }| {
+                        let block_offset = loop {
+                            match block_statistic[dimension_index]
+                                .get(block_cursor[dimension_index] + 1)
+                            {
+                                Some(&(offset, _)) if offset <= pivot_offset => {
+                                    block_cursor[dimension_index] += 1
+                                }
+                                _ => break block_cursor[dimension_index],
+                            };
+                        };
+
+                        let &(_, pivot_block_upper_bound) =
+                            block_statistic[dimension_index].get(block_offset)?;
+                        let pivot_block_cutoff = block_statistic[dimension_index]
+                            .get(block_offset + 1)
+                            .map(|&(offset, _)| offset)
+                            .unwrap_or(u32::MAX);
+                        Some((pivot_block_upper_bound, pivot_block_cutoff))
+                    },
+                )
+                .fold(
+                    (0.0, following_dimension_cursor_offset),
+                    |(accumulated_block_upper_bound, min_block_cutoff),
+                     (block_upper_bound, block_cutoff)| {
+                        (
+                            accumulated_block_upper_bound + block_upper_bound,
+                            min_block_cutoff.min(block_cutoff),
+                        )
+                    },
+                );
+
+            let offset_cutoff =
+                if accumulated_block_upper_bound < threshold && pivot_offset < min_block_cutoff {
+                    min_block_cutoff
+                } else if pivot_offset < first_unchecked_offset {
+                    first_unchecked_offset
+                } else if pivot_offset <= dimension_cursor[0].offset {
+                    let score = dimension_cursor[..=pivot_dimension_cursor_index]
+                        .iter()
+                        .map(
+                            |&Cursor {
+                                 offset: _,
+                                 dimension_index,
+                             }| dimension_score[dimension_index],
+                        )
+                        .sum();
+                    if (top_scores.len() as u32) < k {
+                        top_scores.push(Score {
+                            score,
+                            offset: pivot_offset,
+                        });
+                    } else if top_scores.peek().is_none()
+                        || top_scores.peek().is_some_and(
+                            |&Score {
+                                 score: min_top_score,
+                                 offset: _,
+                             }| min_top_score < score,
+                        )
+                    {
+                        top_scores.pop();
+                        top_scores.push(Score {
+                            score,
+                            offset: pivot_offset,
+                        });
+                        threshold = top_scores
+                            .peek()
+                            .map(|&Score { score, offset: _ }| score)
+                            .unwrap_or_default();
+                    }
+                    first_unchecked_offset = pivot_offset + 1;
+                    first_unchecked_offset
+                } else {
+                    peak_dimension_cursor_index = lag_dimension_cursor_index;
+                    pivot_offset
+                };
+
+            let next_offset = self
+                .lower_bound_offset_value(
+                    dimension_id[dimension_cursor[peak_dimension_cursor_index].dimension_index],
+                    offset_cutoff,
+                )
+                .await?;
+
+            if let Some((offset, value)) = next_offset {
+                let rotate_cutoff_index =
+                    dimension_cursor.partition_point(|cursor| cursor.offset < offset);
+                let peak_dimension_index =
+                    dimension_cursor[peak_dimension_cursor_index].dimension_index;
+                dimension_score[peak_dimension_index] = query_weight[peak_dimension_index] * value;
+                dimension_cursor[peak_dimension_cursor_index].offset = offset;
+                if peak_dimension_cursor_index < rotate_cutoff_index {
+                    dimension_cursor[peak_dimension_cursor_index..rotate_cutoff_index]
+                        .rotate_left(1);
+                }
+            } else {
+                dimension_cursor.remove(peak_dimension_cursor_index);
+            }
+        }
+
+        Ok(top_scores.into_sorted_vec())
+    }
+}

--- a/rust/index/src/sparse/reader.rs
+++ b/rust/index/src/sparse/reader.rs
@@ -162,16 +162,13 @@ impl<'me> SparseReader<'me> {
         &self,
         query_vector: impl IntoIterator<Item = (u32, f32)>,
         k: u32,
-    ) -> Result<(Vec<Score>, u32), SparseReaderError> {
+    ) -> Result<Vec<Score>, SparseReaderError> {
         let collected_query = query_vector
             .into_iter()
             .map(|(dimension_id, query)| (dimension_id, encode_u32(dimension_id), query))
             .collect::<Vec<_>>();
         let dimension_count = collected_query.len();
         let all_dimension_max = self.get_dimension_max().await?;
-
-        // NOTE: This is a temporary counter for debug purpose. Should be removed later
-        let mut full_eval_counter = 0;
 
         let mut cursors = Vec::with_capacity(dimension_count);
         for (dimension_id, encoded_dimension_id, query) in &collected_query {
@@ -204,7 +201,7 @@ impl<'me> SparseReader<'me> {
         cursors.sort_unstable();
 
         let Some(mut first_unchecked_offset) = cursors.first().map(|cursor| cursor.offset) else {
-            return Ok((Vec::new(), 0));
+            return Ok(Vec::new());
         };
 
         let mut threshold = f32::MIN;
@@ -305,7 +302,6 @@ impl<'me> SparseReader<'me> {
                             .map(|score| score.score)
                             .unwrap_or_default();
                     }
-                    full_eval_counter += 1;
                     first_unchecked_offset = pivot_offset + 1;
                     first_unchecked_offset
                 } else {
@@ -332,6 +328,6 @@ impl<'me> SparseReader<'me> {
             }
         }
 
-        Ok((top_scores.into_sorted_vec(), full_eval_counter))
+        Ok(top_scores.into_sorted_vec())
     }
 }

--- a/rust/index/src/sparse/reader.rs
+++ b/rust/index/src/sparse/reader.rs
@@ -194,7 +194,7 @@ impl<'me> SparseReader<'me> {
         };
 
         let mut threshold = f32::MIN;
-        let mut top_scores = BinaryHeap::<Score>::with_capacity(k as usize);
+        let mut top_scores = BinaryHeap::with_capacity(k as usize);
 
         loop {
             let mut accumulated_dimension_upper_bound = 0.0;

--- a/rust/index/src/sparse/reader.rs
+++ b/rust/index/src/sparse/reader.rs
@@ -129,6 +129,7 @@ impl<'me> SparseReader<'me> {
                     });
                     dimension_id.push(id);
                     dimension_upper_bound.push(weight * dimension_max_value);
+                    // NOTE: This is incorrect. We need to find the value of the first record, not block max
                     dimension_score.push(weight * value);
                     query_weight.push(weight);
                 }

--- a/rust/index/src/sparse/reader.rs
+++ b/rust/index/src/sparse/reader.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use chroma_blockstore::BlockfileReader;
-use chroma_error::ChromaError;
+use chroma_error::{ChromaError, ErrorCodes};
 use chroma_types::SignedRoaringBitmap;
 use thiserror::Error;
 
@@ -86,7 +86,15 @@ pub enum SparseReaderError {
     Blockfile(#[from] Box<dyn ChromaError>),
 }
 
-#[derive(Debug)]
+impl ChromaError for SparseReaderError {
+    fn code(&self) -> ErrorCodes {
+        match self {
+            SparseReaderError::Blockfile(err) => err.code(),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct SparseReader<'me> {
     max_reader: BlockfileReader<'me, u32, f32>,
     offset_value_reader: BlockfileReader<'me, u32, f32>,

--- a/rust/index/src/sparse/types.rs
+++ b/rust/index/src/sparse/types.rs
@@ -1,0 +1,37 @@
+use base64::{prelude::BASE64_STANDARD, DecodeError, Engine};
+use thiserror::Error;
+
+pub const DIMENSION_PREFIX: &str = "DIMENSION";
+
+#[derive(Debug, Error)]
+pub enum Base64DecodeError {
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+    #[error("Unable to convert bytes to u32")]
+    Parse,
+}
+
+pub fn encode_u32(value: u32) -> String {
+    BASE64_STANDARD.encode(value.to_le_bytes())
+}
+
+pub fn decode_u32(code: &str) -> Result<u32, Base64DecodeError> {
+    let le_bytes: [u8; 4] = BASE64_STANDARD
+        .decode(code)?
+        .try_into()
+        .map_err(|_| Base64DecodeError::Parse)?;
+    Ok(u32::from_le_bytes(le_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode_u32() {
+        assert_eq!(
+            decode_u32(&encode_u32(42)).expect("Encoding should be valid"),
+            42
+        );
+    }
+}

--- a/rust/index/src/sparse/types.rs
+++ b/rust/index/src/sparse/types.rs
@@ -1,7 +1,10 @@
 use base64::{prelude::BASE64_STANDARD, DecodeError, Engine};
 use thiserror::Error;
 
-pub const DIMENSION_PREFIX: &str = "DIMENSION";
+// NOTE: This is a temporary hack to store dimension id in prefix of blockfile.
+// This should be removed once we have generic prefix type.
+
+pub const DIMENSION_PREFIX: &str = "DIM";
 
 #[derive(Debug, Error)]
 pub enum Base64DecodeError {

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -135,15 +135,15 @@ impl<'me> SparseWriter<'me> {
             } else {
                 let mut dimension_max = f32::MIN;
                 for block in offset_value_vec.chunks(self.block_size as usize) {
-                    let (min_offset, max_value) = block.iter().fold(
-                        (u32::MAX, f32::MIN),
-                        |(min_offset, max_value), (offset, value)| {
-                            (min_offset.min(*offset), max_value.max(*value))
+                    let (max_offset, max_value) = block.iter().fold(
+                        (u32::MIN, f32::MIN),
+                        |(max_offset, max_value), (offset, value)| {
+                            (max_offset.max(*offset), max_value.max(*value))
                         },
                     );
                     dimension_max = dimension_max.max(max_value);
                     self.max_writer
-                        .set(&encoded_dimension, min_offset, max_value)
+                        .set(&encoded_dimension, max_offset + 1, max_value)
                         .await?;
                 }
                 self.max_writer

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -1,0 +1,13 @@
+use std::collections::HashMap;
+
+use chroma_blockstore::BlockfileWriter;
+
+#[derive(Clone, Default)]
+pub struct SparseDelta {
+    // Posting list ID -> Offset ID -> Upsert/Delete value
+    value_updates: HashMap<u32, (u32, Option<f32>)>,
+}
+
+impl SparseDelta {
+    pub fn create(&self, offset_id: u32, sparse_vector: impl IntoIterator<Item = (u32, f32)>) {}
+}

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -1,13 +1,66 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use chroma_blockstore::BlockfileWriter;
+use chroma_error::ChromaError;
+use thiserror::Error;
+
+use crate::sparse::{
+    reader::{SparseReader, SparseReaderError},
+    types::encode_u32,
+};
 
 #[derive(Clone, Default)]
 pub struct SparseDelta {
-    // Posting list ID -> Offset ID -> Upsert/Delete value
-    value_updates: HashMap<u32, (u32, Option<f32>)>,
+    dimension_value_updates: HashMap<u32, HashMap<u32, Option<f32>>>,
 }
 
 impl SparseDelta {
-    pub fn create(&self, offset_id: u32, sparse_vector: impl IntoIterator<Item = (u32, f32)>) {}
+    pub fn create(&mut self, offset: u32, sparse_vector: impl IntoIterator<Item = (u32, f32)>) {
+        for (dimension_id, value) in sparse_vector {
+            self.dimension_value_updates
+                .entry(dimension_id)
+                .or_default()
+                .entry(offset)
+                .insert_entry(Some(value));
+        }
+    }
+
+    pub fn delete(&mut self, offset: u32, sparse_indices: impl IntoIterator<Item = u32>) {
+        for dimension_id in sparse_indices {
+            self.dimension_value_updates
+                .entry(dimension_id)
+                .or_default()
+                .entry(offset)
+                .insert_entry(None);
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SparseWriterError {
+    #[error(transparent)]
+    Blockfile(#[from] Box<dyn ChromaError>),
+    #[error(transparent)]
+    Reader(#[from] SparseReaderError),
+}
+pub struct SparseWriter<'me> {
+    block_size: u32,
+    max_writer: BlockfileWriter,
+    offset_value_writer: BlockfileWriter,
+    reader: Option<SparseReader<'me>>,
+}
+
+impl<'me> SparseWriter<'me> {
+    pub async fn write_delta(&self, delta: SparseDelta) -> Result<(), SparseWriterError> {
+        for (dimension_id, updates) in delta.dimension_value_updates {
+            let encoded_dimension = encode_u32(dimension_id);
+            let blocks = match self.reader.as_ref() {
+                Some(reader) => reader.get_blocks(dimension_id).await?,
+                None => Vec::new(),
+            }
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+        }
+        Ok(())
+    }
 }

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -1,15 +1,15 @@
 use std::collections::{BTreeMap, HashMap};
 
-use chroma_blockstore::BlockfileWriter;
+use chroma_blockstore::{BlockfileFlusher, BlockfileWriter};
 use chroma_error::ChromaError;
 use thiserror::Error;
 
 use crate::sparse::{
     reader::{SparseReader, SparseReaderError},
-    types::encode_u32,
+    types::{encode_u32, DIMENSION_PREFIX},
 };
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct SparseDelta {
     dimension_value_updates: HashMap<u32, HashMap<u32, Option<f32>>>,
 }
@@ -41,6 +41,20 @@ pub enum SparseWriterError {
     #[error(transparent)]
     Reader(#[from] SparseReaderError),
 }
+
+pub struct SparseFlusher {
+    max_flusher: BlockfileFlusher,
+    offset_value_flusher: BlockfileFlusher,
+}
+
+impl SparseFlusher {
+    pub async fn flush(self) -> Result<(), SparseWriterError> {
+        self.max_flusher.flush::<u32, f32>().await?;
+        self.offset_value_flusher.flush::<u32, f32>().await?;
+        Ok(())
+    }
+}
+
 pub struct SparseWriter<'me> {
     block_size: u32,
     max_writer: BlockfileWriter,
@@ -49,16 +63,36 @@ pub struct SparseWriter<'me> {
 }
 
 impl<'me> SparseWriter<'me> {
+    pub fn new(
+        block_size: u32,
+        max_writer: BlockfileWriter,
+        offset_value_writer: BlockfileWriter,
+        reader: Option<SparseReader<'me>>,
+    ) -> Self {
+        Self {
+            block_size,
+            max_writer,
+            offset_value_writer,
+            reader,
+        }
+    }
+
+    pub async fn commit(self) -> Result<SparseFlusher, SparseWriterError> {
+        Ok(SparseFlusher {
+            max_flusher: self.max_writer.commit::<u32, f32>().await?,
+            offset_value_flusher: self.offset_value_writer.commit::<u32, f32>().await?,
+        })
+    }
+
     pub async fn write_delta(&self, delta: SparseDelta) -> Result<(), SparseWriterError> {
         for (dimension_id, updates) in delta.dimension_value_updates {
             let encoded_dimension = encode_u32(dimension_id);
             let (commited_blocks, mut offset_values) = match self.reader.as_ref() {
                 Some(reader) => {
-                    let blocks = reader.get_blocks(dimension_id).await?.into_iter().collect();
+                    let blocks = reader.get_blocks(&encoded_dimension).await?.collect();
                     let offset_values = reader
-                        .get_offset_values(dimension_id, ..)
+                        .get_offset_values(&encoded_dimension, ..)
                         .await?
-                        .into_iter()
                         .collect();
                     (blocks, offset_values)
                 }
@@ -86,15 +120,26 @@ impl<'me> SparseWriter<'me> {
                 };
             }
             let offset_value_vec = offset_values.into_iter().collect::<Vec<_>>();
-            for block in offset_value_vec.chunks(self.block_size as usize) {
-                let (min_offset, max_value) = block.iter().fold(
-                    (u32::MAX, f32::MIN),
-                    |(min_offset, max_value), (offset, value)| {
-                        (min_offset.min(*offset), max_value.max(*value))
-                    },
-                );
+            if offset_value_vec.is_empty() {
                 self.max_writer
-                    .set(&encoded_dimension, min_offset, max_value)
+                    .delete::<_, f32>(DIMENSION_PREFIX, dimension_id)
+                    .await?;
+            } else {
+                let mut dimension_max = f32::MIN;
+                for block in offset_value_vec.chunks(self.block_size as usize) {
+                    let (min_offset, max_value) = block.iter().fold(
+                        (u32::MAX, f32::MIN),
+                        |(min_offset, max_value), (offset, value)| {
+                            (min_offset.min(*offset), max_value.max(*value))
+                        },
+                    );
+                    dimension_max = dimension_max.max(max_value);
+                    self.max_writer
+                        .set(&encoded_dimension, min_offset, max_value)
+                        .await?;
+                }
+                self.max_writer
+                    .set(DIMENSION_PREFIX, dimension_id, dimension_max)
                     .await?;
             }
         }

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -5,8 +5,8 @@ use std::{
 
 use chroma_blockstore::{BlockfileFlusher, BlockfileWriter};
 use chroma_error::ChromaError;
-use parking_lot::Mutex;
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 use crate::sparse::{
     reader::{SparseReader, SparseReaderError},
@@ -93,7 +93,7 @@ impl<'me> SparseWriter<'me> {
     }
 
     pub async fn commit(self) -> Result<SparseFlusher, SparseWriterError> {
-        for (&dimension_id, updates) in &self.delta.lock().dimension_value_updates {
+        for (&dimension_id, updates) in &self.delta.lock().await.dimension_value_updates {
             let encoded_dimension = encode_u32(dimension_id);
             let (commited_blocks, mut offset_values) = match self.reader.as_ref() {
                 Some(reader) => {
@@ -157,7 +157,7 @@ impl<'me> SparseWriter<'me> {
         })
     }
 
-    pub fn write(&self, delta: SparseDelta) {
-        self.delta.lock().merge(delta);
+    pub async fn write(&self, delta: SparseDelta) {
+        self.delta.lock().await.merge(delta);
     }
 }

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -55,6 +55,7 @@ impl SparseFlusher {
 #[derive(Clone)]
 pub struct SparseWriter<'me> {
     block_size: u32,
+    #[allow(clippy::type_complexity)]
     delta: Arc<Mutex<HashMap<u32, HashMap<u32, Option<f32>>>>>,
     max_writer: BlockfileWriter,
     offset_value_writer: BlockfileWriter,

--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -166,3 +166,248 @@ impl<'me> SparseWriter<'me> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sparse::reader::SparseReader;
+    use chroma_blockstore::{
+        arrow::provider::BlockfileReaderOptions, provider::BlockfileProvider,
+        BlockfileWriterOptions,
+    };
+
+    #[tokio::test]
+    async fn test_writer_crud_operations() {
+        let provider = BlockfileProvider::new_memory();
+
+        // Setup writers
+        let max_writer = provider
+            .write::<u32, f32>(BlockfileWriterOptions::new("".to_string()))
+            .await
+            .unwrap();
+        let offset_value_writer = provider
+            .write::<u32, f32>(BlockfileWriterOptions::new("".to_string()))
+            .await
+            .unwrap();
+
+        let writer = SparseWriter::new(64, max_writer, offset_value_writer, None);
+
+        // CREATE: Add multiple vectors including edge cases
+        // Normal vector
+        writer.set(0, vec![(1, 0.5), (5, 0.8), (10, 0.3)]).await;
+
+        // Empty vector (edge case)
+        writer.set(1, vec![]).await;
+
+        // Single dimension vector (edge case)
+        writer.set(2, vec![(100, 1.0)]).await;
+
+        // Large dimension IDs (edge case)
+        writer
+            .set(3, vec![(u32::MAX - 1, 0.1), (u32::MAX, 0.9)])
+            .await;
+
+        // Vector with zero values (edge case)
+        writer.set(4, vec![(20, 0.0), (21, 0.5)]).await;
+
+        // Dense vector spanning multiple blocks
+        let dense_vector: Vec<(u32, f32)> = (0..200).map(|i| (i, 0.1 * (i as f32))).collect();
+        writer.set(5, dense_vector.clone()).await;
+
+        // UPDATE: Overwrite existing vector
+        writer.set(0, vec![(1, 0.9), (2, 0.7)]).await;
+
+        // DELETE: Remove a vector
+        writer.delete(2, vec![100]).await;
+
+        // Commit and verify blockfile contents
+        let flusher = writer.commit().await.unwrap();
+        let max_id = flusher.max_id();
+        let offset_value_id = flusher.offset_value_id();
+        flusher.flush().await.unwrap();
+
+        // Create readers to verify final state
+        let max_reader = provider
+            .read::<u32, f32>(BlockfileReaderOptions::new(max_id, "".to_string()))
+            .await
+            .unwrap();
+        let offset_value_reader = provider
+            .read::<u32, f32>(BlockfileReaderOptions::new(offset_value_id, "".to_string()))
+            .await
+            .unwrap();
+
+        // Verify vector at offset 0 was updated
+        let dim1_encoded = encode_u32(1);
+        assert_eq!(
+            offset_value_reader.get(&dim1_encoded, 0).await.unwrap(),
+            Some(0.9)
+        );
+        let dim2_encoded = encode_u32(2);
+        assert_eq!(
+            offset_value_reader.get(&dim2_encoded, 0).await.unwrap(),
+            Some(0.7)
+        );
+        // Dimension 5 should still exist in offset 0 (not overwritten)
+        let dim5_encoded = encode_u32(5);
+        assert_eq!(
+            offset_value_reader.get(&dim5_encoded, 0).await.unwrap(),
+            Some(0.8)
+        );
+        // Dimension 10 should still exist in offset 0 (not overwritten)
+        let dim10_encoded = encode_u32(10);
+        assert_eq!(
+            offset_value_reader.get(&dim10_encoded, 0).await.unwrap(),
+            Some(0.3)
+        );
+
+        // Verify vector at offset 2 was deleted
+        let dim100_encoded = encode_u32(100);
+        assert_eq!(
+            offset_value_reader.get(&dim100_encoded, 2).await.unwrap(),
+            None
+        );
+
+        // Verify empty vector at offset 1 (should have no entries)
+        // Empty vectors don't create any entries in the blockfiles
+
+        // Verify large dimension IDs work correctly
+        let dim_max_minus_1_encoded = encode_u32(u32::MAX - 1);
+        let dim_max_encoded = encode_u32(u32::MAX);
+        assert_eq!(
+            offset_value_reader
+                .get(&dim_max_minus_1_encoded, 3)
+                .await
+                .unwrap(),
+            Some(0.1)
+        );
+        assert_eq!(
+            offset_value_reader.get(&dim_max_encoded, 3).await.unwrap(),
+            Some(0.9)
+        );
+
+        // Verify zero values are stored
+        let dim20_encoded = encode_u32(20);
+        let dim21_encoded = encode_u32(21);
+        assert_eq!(
+            offset_value_reader.get(&dim20_encoded, 4).await.unwrap(),
+            Some(0.0)
+        );
+        assert_eq!(
+            offset_value_reader.get(&dim21_encoded, 4).await.unwrap(),
+            Some(0.5)
+        );
+
+        // Verify dimension max values are correct
+        assert!(max_reader.get(DIMENSION_PREFIX, 1).await.unwrap().unwrap() > 0.0);
+        assert!(max_reader.get(DIMENSION_PREFIX, 2).await.unwrap().unwrap() > 0.0);
+
+        // Verify block max values exist for dimensions with data
+        // For the dense vector (offset 5), check dimension 50
+        // Since we only have one vector at offset 5 for dimension 50, the block max key would be offset+1 = 6
+        let dim50_encoded = encode_u32(50);
+        let block_max_value = max_reader
+            .get(&dim50_encoded, 6) // offset 5 + 1
+            .await
+            .unwrap();
+        assert!(
+            block_max_value.is_some(),
+            "Block max should exist for dimension 50"
+        );
+        // The value should be 0.1 * 50 = 5.0
+        assert_eq!(block_max_value.unwrap(), 5.0);
+
+        // Verify dimension 50 exists at offset 5 in the original data
+        let dim50_encoded = encode_u32(50);
+        assert_eq!(
+            offset_value_reader.get(&dim50_encoded, 5).await.unwrap(),
+            Some(5.0), // 0.1 * 50
+            "Dimension 50 should exist at offset 5 in original data"
+        );
+
+        // Test with old_reader (incremental update)
+        // IMPORTANT: The current implementation only writes the delta (new/updated values) to the blockfile.
+        // It uses the old_reader to calculate correct block maxes, but doesn't copy all old values.
+        // This is designed for in-place updates, not creating a new blockfile.
+        // For our test with new blockfiles, only the delta values will be present.
+        let max_writer2 = provider
+            .write::<u32, f32>(BlockfileWriterOptions::new("".to_string()))
+            .await
+            .unwrap();
+        let offset_value_writer2 = provider
+            .write::<u32, f32>(BlockfileWriterOptions::new("".to_string()))
+            .await
+            .unwrap();
+
+        let reader = SparseReader::new(max_reader, offset_value_reader);
+        let writer2 = SparseWriter::new(64, max_writer2, offset_value_writer2, Some(reader));
+
+        // Add new vectors
+        writer2.set(10, vec![(1, 0.2), (50, 0.6)]).await;
+        writer2.set(11, vec![(1, 0.3), (100, 0.7)]).await;
+
+        let flusher2 = writer2.commit().await.unwrap();
+        let _max_id2 = flusher2.max_id();
+        let offset_value_id2 = flusher2.offset_value_id();
+        flusher2.flush().await.unwrap();
+
+        let final_offset_value_reader = provider
+            .read::<u32, f32>(BlockfileReaderOptions::new(
+                offset_value_id2,
+                "".to_string(),
+            ))
+            .await
+            .unwrap();
+
+        // Only the new values from the delta should be present
+        assert_eq!(
+            final_offset_value_reader
+                .get(&dim1_encoded, 10)
+                .await
+                .unwrap(),
+            Some(0.2),
+            "New value for dimension 1 at offset 10"
+        );
+        assert_eq!(
+            final_offset_value_reader
+                .get(&dim1_encoded, 11)
+                .await
+                .unwrap(),
+            Some(0.3),
+            "New value for dimension 1 at offset 11"
+        );
+        assert_eq!(
+            final_offset_value_reader
+                .get(&dim50_encoded, 10)
+                .await
+                .unwrap(),
+            Some(0.6),
+            "New value for dimension 50 at offset 10"
+        );
+        assert_eq!(
+            final_offset_value_reader
+                .get(&dim100_encoded, 11)
+                .await
+                .unwrap(),
+            Some(0.7),
+            "New value for dimension 100 at offset 11"
+        );
+
+        // Old values should NOT be in the new blockfile (only delta is written)
+        assert_eq!(
+            final_offset_value_reader
+                .get(&dim1_encoded, 0)
+                .await
+                .unwrap(),
+            None,
+            "Old values are not copied to new blockfile"
+        );
+        assert_eq!(
+            final_offset_value_reader
+                .get(&dim50_encoded, 5)
+                .await
+                .unwrap(),
+            None,
+            "Old values are not copied to new blockfile"
+        );
+    }
+}

--- a/rust/types/src/signed_rbm.rs
+++ b/rust/types/src/signed_rbm.rs
@@ -41,6 +41,14 @@ impl SignedRoaringBitmap {
         Self::Exclude(RoaringBitmap::new())
     }
 
+    pub fn contains(&self, value: u32) -> bool {
+        use SignedRoaringBitmap::*;
+        match self {
+            Include(rbm) => rbm.contains(value),
+            Exclude(rbm) => !rbm.contains(value),
+        }
+    }
+
     pub fn flip(self) -> Self {
         use SignedRoaringBitmap::*;
         match self {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Implements prototype sparse vector reader and writer
    - The implementation is based on the [Block-Max Wand](https://user.ceng.metu.edu.tr/~isikligil/ceng334/HW3/results/1881366/recover1/file_1.pdf) algorithm
    - Some high level implementation info is provided in the `README.md` under the module directory

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
