### PR TITLE
[ENH] Use AVX in distance calculations

### DIFF
--- a/rust/distance/src/types.rs
+++ b/rust/distance/src/types.rs
@@ -244,15 +244,6 @@ impl DistanceFunction {
                     }
                 }
                 #[cfg(all(
-                    any(target_arch = "x86_64", target_arch = "x86"),
-                    target_feature = "sse"
-                ))]
-                {
-                    if std::arch::is_x86_feature_detected!("sse") {
-                        return unsafe { crate::distance_sse::euclidean_distance(a, b) };
-                    }
-                }
-                #[cfg(all(
                     target_arch = "x86_64",
                     all(target_feature = "avx", target_feature = "fma")
                 ))]
@@ -261,6 +252,15 @@ impl DistanceFunction {
                         && std::arch::is_x86_feature_detected!("fma")
                     {
                         return unsafe { crate::distance_avx::euclidean_distance(a, b) };
+                    }
+                }
+                #[cfg(all(
+                    any(target_arch = "x86_64", target_arch = "x86"),
+                    target_feature = "sse"
+                ))]
+                {
+                    if std::arch::is_x86_feature_detected!("sse") {
+                        return unsafe { crate::distance_sse::euclidean_distance(a, b) };
                     }
                 }
                 let mut sum = 0.0;
@@ -277,15 +277,6 @@ impl DistanceFunction {
                     }
                 }
                 #[cfg(all(
-                    any(target_arch = "x86_64", target_arch = "x86"),
-                    target_feature = "sse"
-                ))]
-                {
-                    if std::arch::is_x86_feature_detected!("sse") {
-                        return unsafe { crate::distance_sse::cosine_distance(a, b) };
-                    }
-                }
-                #[cfg(all(
                     target_arch = "x86_64",
                     all(target_feature = "avx", target_feature = "fma")
                 ))]
@@ -294,6 +285,15 @@ impl DistanceFunction {
                         && std::arch::is_x86_feature_detected!("fma")
                     {
                         return unsafe { crate::distance_avx::cosine_distance(a, b) };
+                    }
+                }
+                #[cfg(all(
+                    any(target_arch = "x86_64", target_arch = "x86"),
+                    target_feature = "sse"
+                ))]
+                {
+                    if std::arch::is_x86_feature_detected!("sse") {
+                        return unsafe { crate::distance_sse::cosine_distance(a, b) };
                     }
                 }
                 // For cosine we just assume the vectors have been normalized, since that
@@ -312,15 +312,6 @@ impl DistanceFunction {
                     }
                 }
                 #[cfg(all(
-                    any(target_arch = "x86_64", target_arch = "x86"),
-                    target_feature = "sse"
-                ))]
-                {
-                    if std::arch::is_x86_feature_detected!("sse") {
-                        return unsafe { crate::distance_sse::inner_product(a, b) };
-                    }
-                }
-                #[cfg(all(
                     target_arch = "x86_64",
                     all(target_feature = "avx", target_feature = "fma")
                 ))]
@@ -329,6 +320,15 @@ impl DistanceFunction {
                         && std::arch::is_x86_feature_detected!("fma")
                     {
                         return unsafe { crate::distance_avx::inner_product(a, b) };
+                    }
+                }
+                #[cfg(all(
+                    any(target_arch = "x86_64", target_arch = "x86"),
+                    target_feature = "sse"
+                ))]
+                {
+                    if std::arch::is_x86_feature_detected!("sse") {
+                        return unsafe { crate::distance_sse::inner_product(a, b) };
                     }
                 }
                 let mut sum = 0.0;


### PR DESCRIPTION
## Description of changes

This PR updates the distance crate to prioritize AVX over SSE, and forces builds with AVX flags when ENABLE_AVX512 is set in the Dockerfile

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
