### PR TITLE
[BUG]  Mark dirty on rollback of cursor to guarantee compaction picks it up.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -916,6 +916,15 @@ impl LogServer {
                 }
             }
         }
+        if allow_rollback {
+            let mark_dirty = MarkDirty {
+                collection_id,
+                dirty_log: Arc::clone(&self.dirty_log),
+            };
+            let _ = mark_dirty
+                .mark_dirty(LogPosition::from_offset(adjusted_log_offset as u64), 1usize)
+                .await;
+        }
         let mut need_to_compact = self.need_to_compact.lock();
         if let Entry::Occupied(mut entry) = need_to_compact.entry(collection_id) {
             let rollup = entry.get_mut();


### PR DESCRIPTION
## Description of changes

The tests flaked because compaction is now faster.  This will make the
test robust, but also make it so that DR does the right thing.

## Test plan

CI

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
