### PR TITLE
[BLD] Add maturin to dev dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ grpcio-tools==1.67.1 # Later version not compatible with protobuf 4.25.5
 httpx
 hypothesis==6.112.2 # TODO: Resolve breaking changes and bump version
 hypothesis[numpy]==6.112.2 # TODO: Resolve breaking changes and bump version
-maturin
+maturin>=1.0
 mypy-protobuf
 opentelemetry-instrumentation-fastapi>=0.41b0
 pandas

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ grpcio-tools==1.67.1 # Later version not compatible with protobuf 4.25.5
 httpx
 hypothesis==6.112.2 # TODO: Resolve breaking changes and bump version
 hypothesis[numpy]==6.112.2 # TODO: Resolve breaking changes and bump version
+maturin
 mypy-protobuf
 opentelemetry-instrumentation-fastapi>=0.41b0
 pandas


### PR DESCRIPTION
`DEVELOP.md` tells people to use maturin to build the rust codebase, so it should be a dev dependency.

Is `DEVELOP.md` even up to date with how we do development in this repo? 