### PR TITLE
[ENH]: add config param to garbage collector to control how many collections are fetched from SysDb

### DIFF
--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -41,7 +41,7 @@ pub struct GarbageCollectorConfig {
     )]
     pub(super) version_cutoff_time: Duration,
     pub(super) max_collections_to_gc: u32,
-    pub(super) max_collection_to_fetch: Option<u32>,
+    pub(super) max_collections_to_fetch: Option<u32>,
     pub(super) gc_interval_mins: u32,
     #[serde(default = "GarbageCollectorConfig::default_min_versions_to_keep")]
     pub min_versions_to_keep: u32,

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -365,7 +365,7 @@ impl Handler<GarbageCollectMessage> for GarbageCollector {
                 Some(version_absolute_cutoff_time.into()),
                 Some(
                     self.config
-                        .max_collection_to_fetch
+                        .max_collections_to_fetch
                         .unwrap_or(self.config.max_collections_to_gc)
                         .into(),
                 ),
@@ -735,7 +735,7 @@ mod tests {
             version_cutoff_time: Duration::from_secs(1),
             collection_soft_delete_grace_period: Duration::from_secs(1),
             max_collections_to_gc: 100,
-            max_collection_to_fetch: None,
+            max_collections_to_fetch: None,
             gc_interval_mins: 10,
             disallow_collections: HashSet::new(),
             min_versions_to_keep: 2,
@@ -873,7 +873,7 @@ mod tests {
             version_cutoff_time: Duration::from_secs(1),
             collection_soft_delete_grace_period: Duration::from_secs(1),
             max_collections_to_gc: 100,
-            max_collection_to_fetch: None,
+            max_collections_to_fetch: None,
             min_versions_to_keep: 2,
             filter_min_versions_if_alive: None,
             gc_interval_mins: 10,


### PR DESCRIPTION
## Description of changes

When `max_collections_to_gc` is small, all collections fetched by GC may be disabled by the GC config, preventing any non-disabled collections from being GC'ed. This adds a new config parameter to allow GC to initially overfetch collections before then filtering and limiting to `max_collections_to_gc`.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

Backwards compatible because new config param is optional.

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
