### PR TITLE
[BUG] Resolve deadlock in system crate?

### DIFF
--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -76,8 +76,8 @@ where
 /// It contains the task id for tracking purposes.
 #[derive(Debug)]
 pub struct TaskResult<Output, Error> {
-    result: Result<Output, TaskError<Error>>,
-    task_id: Uuid,
+    pub(crate) result: Result<Output, TaskError<Error>>,
+    pub(crate) task_id: Uuid,
 }
 
 impl<Output, Error> TaskResult<Output, Error> {

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -294,8 +294,7 @@ mod tests {
             message: TaskResult<(), TestError>,
             _ctx: &ComponentContext<Self>,
         ) -> Self::Result {
-            // We expect these to be cancelled, so we ignore the results
-            let _ = message;
+            message.result.unwrap();
         }
     }
 
@@ -347,7 +346,6 @@ mod tests {
         type Error = TestError;
 
         async fn run(&self, _: &()) -> Result<(), Self::Error> {
-            // Sleep forever (or until cancelled)
             Ok(())
         }
     }
@@ -395,7 +393,7 @@ mod tests {
         });
         let dispatcher_handle = system.start_component(dispatcher);
 
-        let orchestrator = TestOrchestrator::new(dispatcher_handle.clone(), 2);
+        let orchestrator = TestOrchestrator::new(dispatcher_handle.clone(), 1);
 
         // Run the orchestrator with a timeout - this should cancel all tasks
         let res = timeout(Duration::from_secs(1), orchestrator.run(system.clone())).await;

--- a/rust/system/src/scheduler.rs
+++ b/rust/system/src/scheduler.rs
@@ -126,9 +126,9 @@ impl Scheduler {
     // Note: this method holds the lock on the handles, should call it only after stop is
     // called.
     pub(crate) async fn join(&self) {
-        // NOTE(rescrv):  Leaving this clippy in place until we can re-arch our way out.
-        // Do NOT simply silence this warning.
         let mut handles = {
+            // NOTE(rescrv):  We take the handles in a block so the lock is released prior to
+            // awaiting the handles.
             let mut handles = self.handles.write();
             handles
                 .iter_mut()

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -176,8 +176,7 @@ impl<C: Component> ComponentSender<C> {
         M: Message,
     {
         self.sender
-            .send(WrappedMessage::new(message, None, tracing_context))
-            .await
+            .try_send(WrappedMessage::new(message, None, tracing_context))
             .map_err(|_| ChannelError::SendError)
     }
 

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -176,11 +176,7 @@ impl<C: Component> ComponentSender<C> {
         M: Message,
     {
         self.sender
-            .send_timeout(
-                WrappedMessage::new(message, None, tracing_context),
-                std::time::Duration::from_secs(1),
-            )
-            .await
+            .try_send(WrappedMessage::new(message, None, tracing_context))
             .map_err(|_| ChannelError::SendError)
     }
 

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -176,7 +176,11 @@ impl<C: Component> ComponentSender<C> {
         M: Message,
     {
         self.sender
-            .try_send(WrappedMessage::new(message, None, tracing_context))
+            .send_timeout(
+                WrappedMessage::new(message, None, tracing_context),
+                std::time::Duration::from_secs(1),
+            )
+            .await
             .map_err(|_| ChannelError::SendError)
     }
 


### PR DESCRIPTION
## Description of changes

Summary from Claude, guided by me:

```claude
I've identified a critical deadlock pattern in the dispatcher-worker thread communication system. This is a classic bounded-buffer deadlock (not livelock or starvation).

The Deadlock Pattern:

1. WorkerThread (rust/system/src/execution/worker_thread.rs:58-61):
  - After processing a task, sends TaskRequestMessage to dispatcher
  - This send operation blocks if dispatcher's channel is full
2. Dispatcher (rust/system/src/execution/dispatcher.rs:199-204):
  - When receiving tasks, if no workers are waiting, tries to send task to a worker
  - This send operation blocks if worker's channel is full

Precise Computer Science Classification:

This is a circular wait deadlock with the following characteristics:

- Resource type: Bounded channel buffer space
- Deadlock condition: All four Coffman conditions are met:
  a. Mutual exclusion: Channel slots are exclusively owned
  b. Hold and wait: Worker holds its channel while waiting on dispatcher's channel
  c. No preemption: Messages cannot be forcibly removed from channels
  d. Circular wait: Worker→Dispatcher→Worker circular dependency

Specific Deadlock Scenario:

1. Dispatcher's channel reaches capacity (dispatcher_queue_size limit)
2. Worker completes task and tries to send TaskRequestMessage at line worker_thread.rs:61
3. Worker blocks because dispatcher's channel is full
4. Dispatcher tries to send new task to worker at line dispatcher.rs:199
5. Dispatcher blocks because worker's channel is full (worker_queue_size limit)
6. DEADLOCK: Both components are blocked waiting for each other

Critical Code Locations:

- Worker blocking point: rust/system/src/execution/worker_thread.rs:61
- Dispatcher blocking point: rust/system/src/execution/dispatcher.rs:199
- Channel creation: rust/system/src/system.rs:39 (bounded channel with queue_size())
- Queue limits: Configured via DispatcherConfig with dispatcher_queue_size and worker_queue_size

This is not a livelock (no active spinning) or starvation (not a fairness issue), but a true deadlock where progress is impossible once both channels are full and each component is trying to send to the other.
```

Fix is to make it so that sending errors and breaks the deadlock.  This
will fail the task.  If this works on staging we'll test it, make it
robust, etc.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Watch staging not deadlock.

## Documentation Changes

N/A
