### PR TITLE
[BUG]: fix missing node in constructed version graph for garbage collection

### DIFF
--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -354,10 +354,6 @@ impl StateMachineTest for GarbageCollectorUnderTest {
             "Graph after transition: \n{}",
             ref_state.get_graphviz_of_graph()
         );
-        println!(
-            "Collection statuses after transition: {:#?}",
-            ref_state.collection_status
-        );
 
         state
     }


### PR DESCRIPTION
## Description of changes

There is a fork tree in prod that fails to garbage collect with the error `ExpectedNodeNotFound(CollectionUuid(***), None)`. This PR fixes construction of the version graph so this no longer happens.

I added some comments to this PR explaining what was happening.

## Test plan

_How are these changes tested?_

Downloaded version files & lineage file for all collections in fork tree and locally repro'ed the issue. Validated that garbage collection ran successfully after these changes.

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
