### PR TITLE
[BUG]: Don't GC hnsw if it is empty

### DIFF
--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -1877,10 +1877,16 @@ impl SpannIndexWriter {
 
     pub async fn garbage_collect_heads(&mut self) -> Result<(), SpannIndexWriterError> {
         tracing::info!("Garbage collecting all the heads");
-        let prefix_path = {
+        let (prefix_path, non_deleted_len) = {
             let hnsw_read_guard = self.hnsw_index.inner.read();
-            hnsw_read_guard.prefix_path.clone()
+            (
+                hnsw_read_guard.prefix_path.clone(),
+                hnsw_read_guard.hnsw_index.len(),
+            )
         };
+        if non_deleted_len == 0 {
+            return Ok(());
+        }
         // Create a new hnsw index and add elements to it.
         let clean_hnsw = self
             .hnsw_provider


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - If finish() is called on spann segment on an empty index then hnsw GC fails. The old index that it is trying to GC is empty() thus it tries to malloc 0 bytes for new index and fails. Fixed to return early in this case
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_
None
## Observability plan

_What is the plan to instrument and monitor this change?_
Test rebuild on staging
## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
None
