### PR TITLE
[BUG] Fix CLI copy arg number types

### DIFF
--- a/rust/cli/src/commands/copy.rs
+++ b/rust/cli/src/commands/copy.rs
@@ -64,7 +64,7 @@ pub struct CopyArgs {
     path: Option<String>,
     #[clap(
         long = "batch",
-        default_value_t = 300,
+        default_value_t = 100,
         value_parser = clap::value_parser!(u32).range(1..=300),
         help = "Batch size for records when copying (min 1, max 300)"
     )]


### PR DESCRIPTION
CLI "concurrent" argument type for the copy command was set to `usize` instead of `u32`