### PR TITLE
[TST] Remove RUSTFLAGS on rust tests, increase distance threshold

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
-      RUSTFLAGS: "-C target-feature=+avx,+fma,+sse"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +28,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
-      RUSTFLAGS: "-C target-feature=+avx,+fma,+sse"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/rust/distance/src/distance_avx.rs
+++ b/rust/distance/src/distance_avx.rs
@@ -369,7 +369,7 @@ mod tests {
         // Test Euclidean distance
         let euclid_simd = unsafe { euclidean_distance(v1, v2) };
         let euclid = euclidean_distance_scalar(v1, v2);
-        let euclid_tolerance = (euclid.abs() * 1e-5).max(1e-6);
+        let euclid_tolerance = (euclid.abs() * 1e-4).max(1e-5);
         assert!(
             (euclid_simd - euclid).abs() < euclid_tolerance,
             "Euclidean distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -381,7 +381,7 @@ mod tests {
         // Test Cosine distance
         let cosine_simd = unsafe { cosine_distance(v1, v2) };
         let cosine = cosine_distance_scalar(v1, v2);
-        let cosine_tolerance = (cosine.abs() * 1e-5).max(1e-6);
+        let cosine_tolerance = (cosine.abs() * 1e-4).max(1e-5);
         assert!(
             (cosine_simd - cosine).abs() < cosine_tolerance,
             "Cosine distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -393,7 +393,7 @@ mod tests {
         // Test Inner product
         let inner_simd = unsafe { inner_product(v1, v2) };
         let inner = inner_product_scalar(v1, v2);
-        let inner_tolerance = (inner.abs() * 1e-5).max(1e-6);
+        let inner_tolerance = (inner.abs() * 1e-4).max(1e-5);
         assert!(
             (inner_simd - inner).abs() < inner_tolerance,
             "Inner product mismatch: SIMD={}, Scalar={}, tolerance={}",

--- a/rust/distance/src/distance_avx512.rs
+++ b/rust/distance/src/distance_avx512.rs
@@ -385,7 +385,7 @@ mod tests {
         // Test Euclidean distance
         let euclid_simd = unsafe { euclidean_distance(v1, v2) };
         let euclid = euclidean_distance_scalar(v1, v2);
-        let euclid_tolerance = (euclid.abs() * 1e-5).max(1e-6);
+        let euclid_tolerance = (euclid.abs() * 1e-4).max(1e-5);
         assert!(
             (euclid_simd - euclid).abs() < euclid_tolerance,
             "Euclidean distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -397,7 +397,7 @@ mod tests {
         // Test Cosine distance
         let cosine_simd = unsafe { cosine_distance(v1, v2) };
         let cosine = cosine_distance_scalar(v1, v2);
-        let cosine_tolerance = (cosine.abs() * 1e-5).max(1e-6);
+        let cosine_tolerance = (cosine.abs() * 1e-4).max(1e-5);
         assert!(
             (cosine_simd - cosine).abs() < cosine_tolerance,
             "Cosine distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -409,7 +409,7 @@ mod tests {
         // Test Inner product
         let inner_simd = unsafe { inner_product(v1, v2) };
         let inner = inner_product_scalar(v1, v2);
-        let inner_tolerance = (inner.abs() * 1e-5).max(1e-6);
+        let inner_tolerance = (inner.abs() * 1e-4).max(1e-5);
         assert!(
             (inner_simd - inner).abs() < inner_tolerance,
             "Inner product mismatch: SIMD={}, Scalar={}, tolerance={}",

--- a/rust/distance/src/distance_neon.rs
+++ b/rust/distance/src/distance_neon.rs
@@ -315,7 +315,7 @@ mod tests {
         // Test Euclidean distance
         let euclid_simd = unsafe { euclidean_distance(v1, v2) };
         let euclid = euclidean_distance_scalar(v1, v2);
-        let euclid_tolerance = (euclid.abs() * 1e-5).max(1e-6);
+        let euclid_tolerance = (euclid.abs() * 1e-4).max(1e-5);
         assert!(
             (euclid_simd - euclid).abs() < euclid_tolerance,
             "Euclidean distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -327,7 +327,7 @@ mod tests {
         // Test Cosine distance
         let cosine_simd = unsafe { cosine_distance(v1, v2) };
         let cosine = cosine_distance_scalar(v1, v2);
-        let cosine_tolerance = (cosine.abs() * 1e-5).max(1e-6);
+        let cosine_tolerance = (cosine.abs() * 1e-4).max(1e-5);
         assert!(
             (cosine_simd - cosine).abs() < cosine_tolerance,
             "Cosine distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -339,7 +339,7 @@ mod tests {
         // Test Inner product
         let inner_simd = unsafe { inner_product(v1, v2) };
         let inner = inner_product_scalar(v1, v2);
-        let inner_tolerance = (inner.abs() * 1e-5).max(1e-6);
+        let inner_tolerance = (inner.abs() * 1e-4).max(1e-5);
         assert!(
             (inner_simd - inner).abs() < inner_tolerance,
             "Inner product mismatch: SIMD={}, Scalar={}, tolerance={}",

--- a/rust/distance/src/distance_sse.rs
+++ b/rust/distance/src/distance_sse.rs
@@ -361,7 +361,7 @@ mod tests {
         // Test Euclidean distance
         let euclid_simd = unsafe { euclidean_distance(v1, v2) };
         let euclid = euclidean_distance_scalar(v1, v2);
-        let euclid_tolerance = (euclid.abs() * 1e-5).max(1e-6);
+        let euclid_tolerance = (euclid.abs() * 1e-4).max(1e-5);
         assert!(
             (euclid_simd - euclid).abs() < euclid_tolerance,
             "Euclidean distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -373,7 +373,7 @@ mod tests {
         // Test Cosine distance
         let cosine_simd = unsafe { cosine_distance(v1, v2) };
         let cosine = cosine_distance_scalar(v1, v2);
-        let cosine_tolerance = (cosine.abs() * 1e-5).max(1e-6);
+        let cosine_tolerance = (cosine.abs() * 1e-4).max(1e-5);
         assert!(
             (cosine_simd - cosine).abs() < cosine_tolerance,
             "Cosine distance mismatch: SIMD={}, Scalar={}, tolerance={}",
@@ -385,7 +385,7 @@ mod tests {
         // Test Inner product
         let inner_simd = unsafe { inner_product(v1, v2) };
         let inner = inner_product_scalar(v1, v2);
-        let inner_tolerance = (inner.abs() * 1e-5).max(1e-6);
+        let inner_tolerance = (inner.abs() * 1e-4).max(1e-5);
         assert!(
             (inner_simd - inner).abs() < inner_tolerance,
             "Inner product mismatch: SIMD={}, Scalar={}, tolerance={}",


### PR DESCRIPTION
## Description of changes

Tests on main are failing like this
https://github.com/chroma-core/chroma/actions/runs/17054052688/job/48348101795
due to threshold being too low on tests. This PR 1.) removes rustflags enabling avx and sse by default, 2.) increases threshold

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
