### PR TITLE
[ENH] Update CLI connection string to CloudClient

### DIFF
--- a/rust/cli/src/commands/db.rs
+++ b/rust/cli/src/commands/db.rs
@@ -42,7 +42,7 @@ pub enum Language {
 impl Language {
     fn get_connection(&self, tenant_id: String, db_name: String, api_key: String) -> String {
         match self {
-            Language::Python => get_python_connection(db_name, api_key),
+            Language::Python => get_python_connection(tenant_id, db_name, api_key),
             Language::JavaScript => get_js_connection(tenant_id, db_name, api_key),
             Language::TypeScript => get_js_connection(tenant_id, db_name, api_key),
         }
@@ -217,15 +217,16 @@ fn db_delete_cancelled() -> String {
     )
 }
 
-fn get_python_connection(db_name: String, api_key: String) -> String {
+fn get_python_connection(tenant_id: String, db_name: String, api_key: String) -> String {
     format!(
         "Python connection snippet:
     import chromadb
     client = chromadb.CloudClient(
-        database='{}',
-        api_key='{}'
+        api_key='{}',
+        tenant='{}',
+        database='{}'
     )",
-        db_name, api_key
+        api_key, tenant_id, db_name
     )
 }
 


### PR DESCRIPTION
```bash
(venv) kylediaz@Kyles-MacBook-Pro-2 chroma % chroma db connect

Which DB would you like to connect to?
test-db

Which language would you like to use?
python
Python connection snippet:
    import chromadb
    client = chromadb.CloudClient(
        database='test-db',
        api_key='ck-...'
    )

Copied to clipboard!

(venv) kylediaz@Kyles-MacBook-Pro-2 chroma % chroma db connect

Which DB would you like to connect to?
test-db

Which language would you like to use?
typescript
Javascript/Typescript connection snippet:
    import { CloudClient } from 'chromadb';
    const client = new CloudClient({
        apiKey: 'ck-...',
        tenant: '...,
        database: 'test-db'
    });


Copied to clipboard!
```