### PR TITLE
[ENH]: reduce garbage collector memory usage

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator.rs
@@ -476,7 +476,6 @@ impl Handler<TaskResult<DeleteUnusedFilesOutput, DeleteUnusedFilesError>>
                 epoch_id,
                 sysdb_client: self.sysdb_client.clone(),
                 versions_to_delete,
-                unused_s3_files: output.deleted_files.clone(),
             },
             ctx.receiver(),
             self.context.task_cancellation_token.clone(),

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -911,7 +911,6 @@ impl GarbageCollectorOrchestrator {
                         collection_id: collection_id.to_string(),
                         versions,
                     },
-                    unused_s3_files: output.deleted_files.clone(),
                 },
                 ctx.receiver(),
                 self.context.task_cancellation_token.clone(),

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -5,7 +5,7 @@ use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
 use chroma_types::chroma_proto::{CollectionVersionFile, VersionListForCollection};
 use futures::stream::StreamExt;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -26,14 +26,12 @@ pub struct DeleteVersionsAtSysDbInput {
     pub epoch_id: i64,
     pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
-    pub unused_s3_files: HashSet<String>,
 }
 
 #[derive(Debug)]
 pub struct DeleteVersionsAtSysDbOutput {
     pub version_file: Arc<CollectionVersionFile>,
     pub versions_to_delete: VersionListForCollection,
-    pub unused_s3_files: HashSet<String>,
 }
 
 #[derive(Error, Debug)]
@@ -138,11 +136,6 @@ impl Operator<DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOutput>
             "Starting deletion of versions from SysDB"
         );
 
-        tracing::info!(
-            unused_files_count = input.unused_s3_files.len(),
-            "Unused S3 files that will be cleaned up after version deletion"
-        );
-
         let mut sysdb = input.sysdb_client.clone();
 
         if !input.versions_to_delete.versions.is_empty() {
@@ -189,7 +182,6 @@ impl Operator<DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOutput>
         Ok(DeleteVersionsAtSysDbOutput {
             version_file: input.version_file.clone(),
             versions_to_delete: input.versions_to_delete.clone(),
-            unused_s3_files: input.unused_s3_files.clone(),
         })
     }
 }
@@ -226,7 +218,6 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
-            unused_s3_files: HashSet::new(),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {
@@ -258,7 +249,6 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
-            unused_s3_files: HashSet::new(),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {
@@ -400,7 +390,6 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
-            unused_s3_files: HashSet::new(),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {
@@ -471,7 +460,6 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
-            unused_s3_files: HashSet::new(),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {


### PR DESCRIPTION
## Description of changes

According to profiling, the majority of memory consumption is coming from cloning the set of files to delete for every version that we're deleting. This cloning and passing around of the set is unnecessary in GCv2 so I removed it.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
