### PR TITLE
[BUG]: Fixing wrong parameter use in httpx limits

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -123,7 +123,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
                 + " (https://github.com/chroma-core/chroma)"
             )
 
-            limits = httpx.Limits(max_keepalive_connections=self.keepalive_secs)
+            limits = httpx.Limits(keepalive_expiry=self.keepalive_secs)
             self._clients[loop_hash] = httpx.AsyncClient(
                 timeout=None,
                 headers=headers,

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -70,7 +70,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             default_api_path=system.settings.chroma_server_api_default_path,
         )
 
-        limits = httpx.Limits(max_keepalive_connections=self.keepalive_secs)
+        limits = httpx.Limits(keepalive_expiry=self.keepalive_secs)
         self._session = httpx.Client(timeout=None, limits=limits)
 
         self._header = system.settings.chroma_server_headers or {}


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Fixes wrong parameter use in Limits should be `keepalive_expiry` instead of `max_keepalive_connections` docs - https://www.python-httpx.org/advanced/resource-limits/
  - Reduces new connections to Chroma Cloud HAProxy

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

No new tests are introduced

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
