### PR TITLE
[ENH] add ExternalCollectionReadContext to MeterEvent enum

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -7,10 +7,10 @@ use chroma_config::{registry, Configurable};
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::{LocalCompactionManager, LocalCompactionManagerConfig, Log};
 use chroma_metering::{
-    CollectionForkContext, CollectionReadContext, CollectionWriteContext, Enterable, FinishRequest,
-    FtsQueryLength, LatestCollectionLogicalSizeBytes, LogSizeBytes, MetadataPredicateCount,
-    MeterEvent, MeteredFutureExt, PulledLogSizeBytes, QueryEmbeddingCount, ReturnBytes,
-    WriteAction,
+    CollectionForkContext, CollectionReadContext, CollectionWriteContext, Enterable,
+    ExternalCollectionReadContext, FinishRequest, FtsQueryLength, LatestCollectionLogicalSizeBytes,
+    LogSizeBytes, MetadataPredicateCount, MeterEvent, MeteredFutureExt, PulledLogSizeBytes,
+    QueryEmbeddingCount, ReturnBytes, WriteAction,
 };
 use chroma_segment::local_segment_manager::LocalSegmentManager;
 use chroma_sqlite::db::SqliteDb;
@@ -1239,9 +1239,16 @@ impl ServiceBasedFrontend {
                     .submit()
                     .await;
             }
-            Err(e) => {
-                tracing::error!("Failed to submit metering event to receiver: {:?}", e)
-            }
+            Err(_) => match chroma_metering::close::<ExternalCollectionReadContext>() {
+                Ok(external_collection_read_context) => {
+                    MeterEvent::ExternalCollectionRead(external_collection_read_context)
+                        .submit()
+                        .await;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to submit metering event to receiver: {:?}", e)
+                }
+            },
         }
 
         Ok(count_result.count)
@@ -1364,9 +1371,16 @@ impl ServiceBasedFrontend {
                     .submit()
                     .await;
             }
-            Err(e) => {
-                tracing::error!("Failed to submit metering event to receiver: {:?}", e)
-            }
+            Err(_) => match chroma_metering::close::<ExternalCollectionReadContext>() {
+                Ok(external_collection_read_context) => {
+                    MeterEvent::ExternalCollectionRead(external_collection_read_context)
+                        .submit()
+                        .await;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to submit metering event to receiver: {:?}", e)
+                }
+            },
         }
 
         Ok((get_result, include).into())
@@ -1493,9 +1507,16 @@ impl ServiceBasedFrontend {
                     .submit()
                     .await;
             }
-            Err(e) => {
-                tracing::error!("Failed to submit metering event to receiver: {:?}", e)
-            }
+            Err(_) => match chroma_metering::close::<ExternalCollectionReadContext>() {
+                Ok(external_collection_read_context) => {
+                    MeterEvent::ExternalCollectionRead(external_collection_read_context)
+                        .submit()
+                        .await;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to submit metering event to receiver: {:?}", e)
+                }
+            },
         }
 
         Ok((query_result, include).into())

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1745,7 +1745,7 @@ async fn collection_delete(
             KeyValue::new("collection_id", collection_id.clone()),
         ],
     );
-    server
+    let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Delete,
@@ -1782,6 +1782,7 @@ async fn collection_delete(
     // NOTE(c-gamble): This is a read context because read happens first on delete, then write.
     let metering_context_container =
         chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            requester_identity.tenant.clone(),
             tenant.clone(),
             database.clone(),
             collection_id.0.to_string(),
@@ -1840,7 +1841,7 @@ async fn collection_count(
         database = database,
         collection_id = collection_id
     );
-    let authorized = server
+    let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Count,
@@ -1856,12 +1857,13 @@ async fn collection_count(
         "op:read",
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
-        format!("requester:{}", authorized.tenant).as_str(),
+        format!("requester:{}", requester_identity.tenant).as_str(),
     ])?;
 
     // Create a metering context
     let metering_context_container =
         chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            requester_identity.tenant.clone(),
             tenant.clone(),
             database.clone(),
             collection_id.clone(),
@@ -1924,7 +1926,7 @@ async fn collection_get(
             KeyValue::new("collection_id", collection_id.clone()),
         ],
     );
-    let authorized = server
+    let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Get,
@@ -1965,12 +1967,13 @@ async fn collection_get(
         "op:read",
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
-        format!("requester:{}", authorized.tenant).as_str(),
+        format!("requester:{}", requester_identity.tenant).as_str(),
     ])?;
 
     // Create a metering context
     let metering_context_container =
         chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            requester_identity.tenant.clone(),
             tenant.clone(),
             database.clone(),
             collection_id.0.to_string(),
@@ -2053,7 +2056,7 @@ async fn collection_query(
             KeyValue::new("collection_id", collection_id.clone()),
         ],
     );
-    let authorized = server
+    let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
             AuthzAction::Query,
@@ -2091,12 +2094,13 @@ async fn collection_query(
         "op:read",
         format!("tenant:{}", tenant).as_str(),
         format!("collection:{}", collection_id).as_str(),
-        format!("requester:{}", authorized.tenant).as_str(),
+        format!("requester:{}", requester_identity.tenant).as_str(),
     ])?;
 
     // Create a metering context
     let metering_context_container =
         chroma_metering::create::<CollectionReadContext>(CollectionReadContext::new(
+            requester_identity.tenant.clone(),
             tenant.clone(),
             database.clone(),
             collection_id.0.to_string(),

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -149,9 +149,6 @@ initialize_metering! {
     #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "snake_case")]
     pub struct CollectionReadContext {
-        /// The tenant that is requesting the resource
-        pub requester_tenant: String,
-        /// The tenant who owns the requested resource
         pub tenant: String,
         pub database: String,
         pub collection_id: String,
@@ -170,14 +167,12 @@ initialize_metering! {
 
     impl CollectionReadContext {
         pub fn new(
-            requester_tenant: String,
             tenant: String,
             database: String,
             collection_id: String,
             action: ReadAction,
         ) -> Self {
             CollectionReadContext {
-                requester_tenant,
                 tenant,
                 database,
                 collection_id,
@@ -361,6 +356,159 @@ initialize_metering! {
             }
         }
     }
+
+    ////////////////////////////////// external_collection_read //////////////////////////////////
+    #[context(
+        capabilities = [
+            FtsQueryLength,
+            MetadataPredicateCount,
+            QueryEmbeddingCount,
+            PulledLogSizeBytes,
+            LatestCollectionLogicalSizeBytes,
+            ReturnBytes,
+            StartRequest,
+            FinishRequest,
+        ],
+        handlers = [
+            __handler_external_collection_read_fts_query_length,
+            __handler_external_collection_read_metadata_predicate_count,
+            __handler_external_collection_read_query_embedding_count,
+            __handler_external_collection_read_pulled_log_size_bytes,
+            __handler_external_collection_read_latest_collection_logical_size_bytes,
+            __handler_external_collection_read_return_bytes,
+            __handler_external_collection_read_start_request,
+            __handler_external_collection_read_finish_request,
+        ]
+    )]
+    #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    pub struct ExternalCollectionReadContext {
+        pub tenant: String,
+        pub database: String,
+        pub collection_id: String,
+        #[serde(flatten)]
+        pub action: ReadAction,
+        #[serde(skip, default = "MeteringInstant::now")]
+        pub request_received_at: MeteringInstant,
+        pub fts_query_length: MeteringAtomicU64,
+        pub metadata_predicate_count: MeteringAtomicU64,
+        pub query_embedding_count: MeteringAtomicU64,
+        pub pulled_log_size_bytes: MeteringAtomicU64,
+        pub latest_collection_logical_size_bytes: MeteringAtomicU64,
+        pub return_bytes: MeteringAtomicU64,
+        pub request_execution_time_ms: MeteringAtomicU64,
+    }
+
+    impl ExternalCollectionReadContext {
+        pub fn new(
+            tenant: String,
+            database: String,
+            collection_id: String,
+            action: ReadAction,
+        ) -> Self {
+            ExternalCollectionReadContext {
+                tenant,
+                database,
+                collection_id,
+                action,
+                request_received_at: MeteringInstant::now(),
+                fts_query_length: MeteringAtomicU64::new(0),
+                metadata_predicate_count: MeteringAtomicU64::new(0),
+                query_embedding_count: MeteringAtomicU64::new(0),
+                pulled_log_size_bytes: MeteringAtomicU64::new(0),
+                latest_collection_logical_size_bytes: MeteringAtomicU64::new(0),
+                return_bytes: MeteringAtomicU64::new(0),
+                request_execution_time_ms: MeteringAtomicU64::new(0)
+            }
+        }
+    }
+
+    /// Handler for [`crate::core::FtsQueryLength`] capability for collection read contexts
+    fn __handler_external_collection_read_fts_query_length(
+        context: &ExternalCollectionReadContext,
+        fts_query_length: u64,
+    ) {
+        context
+            .fts_query_length
+            .store(fts_query_length, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::MetadataPredicateCount`] capability for collection read contexts
+    fn __handler_external_collection_read_metadata_predicate_count(
+        context: &ExternalCollectionReadContext,
+        metadata_predicate_count: u64,
+    ) {
+        context
+            .metadata_predicate_count
+            .store(metadata_predicate_count, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::QueryEmbeddingCount`] capability for collection read contexts
+    fn __handler_external_collection_read_query_embedding_count(
+        context: &ExternalCollectionReadContext,
+        query_embedding_count: u64,
+    ) {
+        context
+            .query_embedding_count
+            .store(query_embedding_count, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::PulledLogSizeBytes`] capability for collection read contexts
+    fn __handler_external_collection_read_pulled_log_size_bytes(
+        context: &ExternalCollectionReadContext,
+        pulled_log_size_bytes: u64,
+    ) {
+        context
+            .pulled_log_size_bytes
+            .store(pulled_log_size_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::LatestCollectionLogicalSizeBytes`] capability for collection read contexts
+    fn __handler_external_collection_read_latest_collection_logical_size_bytes(
+        context: &ExternalCollectionReadContext,
+        latest_collection_logical_size_bytes: u64,
+    ) {
+        context
+            .latest_collection_logical_size_bytes
+            .store(latest_collection_logical_size_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::ReturnBytes`] capability for collection read contexts
+    fn __handler_external_collection_read_return_bytes(
+        context: &ExternalCollectionReadContext,
+        return_bytes: u64,
+    ) {
+        context
+            .return_bytes
+            .store(return_bytes, Ordering::SeqCst);
+    }
+
+    /// Handler for [`crate::core::StartRequest`] capability for collection read contexts
+    fn __handler_external_collection_read_start_request(
+        context: &ExternalCollectionReadContext,
+        started_at: Instant,
+    ) {
+        match context.request_received_at.store(started_at) {
+            Ok(()) => {}
+            Err(error) => tracing::error!("Failed to exercise `StartRequest` capability on `ExternalCollectionReadContext`: {:?}", error),
+        }
+    }
+
+    /// Handler for [`crate::core::FinishRequest`] capability for collection read contexts
+    fn __handler_external_collection_read_finish_request(
+        context: &ExternalCollectionReadContext,
+        finished_at: Instant,
+    ) {
+        match context.request_received_at.load() {
+            Ok(started_at) => {
+                let duration_ms = finished_at.duration_since(started_at).as_millis() as u64;
+                context.request_execution_time_ms.store(duration_ms, Ordering::SeqCst);
+            }
+            Err(error) => {
+                tracing::error!("Failed to exercise `FinishRequest` capability on `CollectionReadContext`: {:?}", error);
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -369,6 +517,7 @@ pub enum MeterEvent {
     CollectionFork(CollectionForkContext),
     CollectionRead(CollectionReadContext),
     CollectionWrite(CollectionWriteContext),
+    ExternalCollectionRead(ExternalCollectionReadContext),
 }
 
 #[cfg(test)]
@@ -403,6 +552,9 @@ mod tests {
                 write_context.request_received_at = request_received_at
             }
             MeterEvent::CollectionFork(_) => {}
+            MeterEvent::ExternalCollectionRead(external_collection_read_context) => {
+                external_collection_read_context.request_received_at = request_received_at
+            }
         }
         assert_eq!(json_event, event);
     }

--- a/rust/metering/src/core.rs
+++ b/rust/metering/src/core.rs
@@ -149,6 +149,9 @@ initialize_metering! {
     #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
     #[serde(rename_all = "snake_case")]
     pub struct CollectionReadContext {
+        /// The tenant that is requesting the resource
+        pub requester_tenant: String,
+        /// The tenant who owns the requested resource
         pub tenant: String,
         pub database: String,
         pub collection_id: String,
@@ -167,12 +170,14 @@ initialize_metering! {
 
     impl CollectionReadContext {
         pub fn new(
+            requester_tenant: String,
             tenant: String,
             database: String,
             collection_id: String,
             action: ReadAction,
         ) -> Self {
             CollectionReadContext {
+                requester_tenant,
                 tenant,
                 database,
                 collection_id,

--- a/rust/metering/src/lib.rs
+++ b/rust/metering/src/lib.rs
@@ -5,10 +5,10 @@ mod types;
 pub use {
     core::{
         close, create, get_current, with_current, CollectionForkContext, CollectionReadContext,
-        CollectionWriteContext, Enterable, FinishRequest, FtsQueryLength,
-        LatestCollectionLogicalSizeBytes, LogSizeBytes, MetadataPredicateCount, MeterEvent,
-        MeteredFutureExt, PulledLogSizeBytes, QueryEmbeddingCount, ReadAction, ReturnBytes,
-        StartRequest, WriteAction,
+        CollectionWriteContext, Enterable, ExternalCollectionReadContext, FinishRequest,
+        FtsQueryLength, LatestCollectionLogicalSizeBytes, LogSizeBytes, MetadataPredicateCount,
+        MeterEvent, MeteredFutureExt, PulledLogSizeBytes, QueryEmbeddingCount, ReadAction,
+        ReturnBytes, StartRequest, WriteAction,
     },
     types::{MeteringAtomicU64, MeteringInstant},
 };


### PR DESCRIPTION
## Description of changes

We need to detect when tenants perform read operations on collections that are not theirs. To achieve this, we introduce an `ExternalCollectionRead` variant on the `MeterEvent` enum. For the get, query, and count paths, we conditionally create this context if the requesting tenant does not match the tenant that owns the requested resource. In the flushing logic, we first attempt to flush the current `CollectionReadContext`, and if that fails, we attempt to flush the new `ExternalCollectionReadContext`.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

This will break hosted. The plan is to merge this PR and then shortly after merge the corresponding hosted PR: 

## Observability plan

N/A

## Documentation Changes

N/A
