### PR TITLE
[ENH]: fix garbage collector version "hole" invariant

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -679,14 +679,14 @@ impl GarbageCollectorOrchestrator {
             for res in extracted_paths.into_iter() {
                 have_paths.push(res?);
             }
-            let have_hole_in_paths = have_paths
+            let has_no_paths_at_version = have_paths
                 .into_iter()
                 .skip_while(|&(_version, has_paths)| !has_paths)
                 .find(|(_version, has_paths)| !has_paths);
 
-            if let Some((version, _)) = have_hole_in_paths {
+            if let Some((version, _)) = has_no_paths_at_version {
                 return Err(GarbageCollectorError::InvariantViolation(format!(
-                    "Version {} of collection {} has no file paths, but has non-v0 ancestors. This should never happen.",
+                    "Version {} of collection {} has no file paths, but has ancestors with file paths. This should never happen.",
                     version, output.collection_id
                 )));
             }


### PR DESCRIPTION
## Description of changes

The invariant currently fails for collection versions that were no-op compactions prior to the first compaction with data.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
