### PR TITLE
[BUG] remove metrics with unbounded cardinality from frontend

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -28,7 +28,6 @@ use chroma_types::{ForkCollectionResponse, RawWhereFields};
 use mdac::{Rule, Scorecard, ScorecardTicket};
 use opentelemetry::global;
 use opentelemetry::metrics::{Counter, Meter};
-use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -665,10 +664,7 @@ async fn create_database(
     State(mut server): State<FrontendServer>,
     Json(CreateDatabasePayload { name }): Json<CreateDatabasePayload>,
 ) -> Result<Json<CreateDatabaseResponse>, ServerError> {
-    server
-        .metrics
-        .create_database
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.create_database.add(1, &[]);
     tracing::info!(name: "create_database", tenant_name = %tenant, database_name = %name);
     server
         .authenticate_and_authorize(
@@ -727,10 +723,7 @@ async fn list_databases(
     Query(ListDatabasesParams { limit, offset }): Query<ListDatabasesParams>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<ListDatabasesResponse>, ServerError> {
-    server
-        .metrics
-        .list_databases
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.list_databases.add(1, &[]);
     tracing::info!(name: "list_databases", tenant_name = %tenant);
     server
         .authenticate_and_authorize(
@@ -770,10 +763,7 @@ async fn get_database(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<GetDatabaseResponse>, ServerError> {
-    server
-        .metrics
-        .get_database
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.get_database.add(1, &[]);
     tracing::info!(name: "get_database", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -813,10 +803,7 @@ async fn delete_database(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<DeleteDatabaseResponse>, ServerError> {
-    server
-        .metrics
-        .delete_database
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.delete_database.add(1, &[]);
     tracing::info!(name: "delete_database", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -864,10 +851,7 @@ async fn list_collections(
     Query(ListCollectionsParams { limit, offset }): Query<ListCollectionsParams>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<ListCollectionsResponse>, ServerError> {
-    server
-        .metrics
-        .list_collections
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.list_collections.add(1, &[]);
     tracing::info!(name: "list_collections", tenant_name = %tenant, database_name = %database, limit = ?limit, offset = ?offset);
     server
         .authenticate_and_authorize(
@@ -924,10 +908,7 @@ async fn count_collections(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<CountCollectionsResponse>, ServerError> {
-    server
-        .metrics
-        .count_collections
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.count_collections.add(1, &[]);
     tracing::info!(name: "count_collections", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -979,10 +960,7 @@ async fn create_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<CreateCollectionPayload>,
 ) -> Result<Json<Collection>, ServerError> {
-    server
-        .metrics
-        .create_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.create_collection.add(1, &[]);
     tracing::info!(name: "create_collection", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -1059,10 +1037,7 @@ async fn get_collection(
     Path((tenant, database, collection_name)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<Collection>, ServerError> {
-    server
-        .metrics
-        .get_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.get_collection.add(1, &[]);
     tracing::info!(name: "get_collection", tenant_name = %tenant, database_name = %database, collection_name = %collection_name);
     server
         .authenticate_and_authorize(
@@ -1101,10 +1076,7 @@ async fn get_collection_by_crn(
     Path(crn): Path<String>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<Collection>, ServerError> {
-    server
-        .metrics
-        .get_collection_by_crn
-        .add(1, &[KeyValue::new("crn", crn.clone())]);
+    server.metrics.get_collection_by_crn.add(1, &[]);
     tracing::info!(name: "get_collection_by_crn", crn = %crn);
     server
         .authenticate_and_authorize(
@@ -1152,13 +1124,7 @@ async fn update_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<UpdateCollectionPayload>,
 ) -> Result<Json<UpdateCollectionResponse>, ServerError> {
-    server.metrics.update_collection.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.update_collection.add(1, &[]);
     tracing::info!(name: "update_collection", tenant_name = %tenant, database_name = %database, collection_id = %collection_id);
     server
         .authenticate_and_authorize_collection(
@@ -1231,10 +1197,7 @@ async fn delete_collection(
     Path((tenant, database, collection_name)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<UpdateCollectionResponse>, ServerError> {
-    server
-        .metrics
-        .delete_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.delete_collection.add(1, &[]);
     tracing::info!(name: "delete_collection", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -1286,13 +1249,7 @@ async fn fork_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<ForkCollectionPayload>,
 ) -> Result<Json<ForkCollectionResponse>, ServerError> {
-    server.metrics.fork_collection.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.fork_collection.add(1, &[]);
     tracing::info!(name: "fork_collection", tenant_name = %tenant, database_name = %database, collection_id = %collection_id);
     server
         .authenticate_and_authorize(
@@ -1394,13 +1351,7 @@ async fn collection_add(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<AddCollectionRecordsPayload>,
 ) -> Result<(StatusCode, Json<AddCollectionRecordsResponse>), ServerError> {
-    server.metrics.collection_add.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_add.add(1, &[]);
     server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1506,13 +1457,7 @@ async fn collection_update(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<UpdateCollectionRecordsPayload>,
 ) -> Result<Json<UpdateCollectionRecordsResponse>, ServerError> {
-    server.metrics.collection_update.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_update.add(1, &[]);
     server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1626,13 +1571,7 @@ async fn collection_upsert(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<UpsertCollectionRecordsPayload>,
 ) -> Result<Json<UpsertCollectionRecordsResponse>, ServerError> {
-    server.metrics.collection_upsert.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_upsert.add(1, &[]);
     server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1738,13 +1677,7 @@ async fn collection_delete(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<DeleteCollectionRecordsPayload>,
 ) -> Result<Json<DeleteCollectionRecordsResponse>, ServerError> {
-    server.metrics.collection_delete.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_delete.add(1, &[]);
     let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1827,13 +1760,7 @@ async fn collection_count(
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<CountResponse>, ServerError> {
-    server.metrics.collection_count.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_count.add(1, &[]);
     tracing::info!(
         name: "collection_count",
         tenant = tenant,
@@ -1927,13 +1854,7 @@ async fn collection_get(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<GetRequestPayload>,
 ) -> Result<Json<GetResponse>, ServerError> {
-    server.metrics.collection_get.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_get.add(1, &[]);
     let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
@@ -2066,13 +1987,7 @@ async fn collection_query(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<QueryRequestPayload>,
 ) -> Result<Json<QueryResponse>, ServerError> {
-    server.metrics.collection_query.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_query.add(1, &[]);
     let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,


### PR DESCRIPTION
## Description of changes

We have metrics that have unbounded cardinality on the frontend because we attach attributes like tenant, collection ID, and CRN. These may clog our otel pipeline and increase our storage costs significantly. This PR removes them.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

Update Honeycomb queries to not use `breakdowns` on corresponding terraform

## Documentation Changes

N/A
