### PR TITLE
[CHORE]: bump jemalloc_pprof version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1657,6 +1657,7 @@ version = "0.1.0"
 dependencies = [
  "axum 0.8.1",
  "jemalloc_pprof",
+ "mappings",
  "tokio",
 ]
 
@@ -4418,9 +4419,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jemalloc_pprof"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5622af6d21ff86ed7797ef98e11b8f302da25ec69a7db9f6cde8e2e1c8df9992"
+checksum = "9770dc31e3b7797ce9ec1184c23021eae0ee50d8cac2f3c706a9cae1fb664e41"
 dependencies = [
  "anyhow",
  "libc",

--- a/rust/jemalloc-pprof-server/Cargo.toml
+++ b/rust/jemalloc-pprof-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-jemalloc_pprof = { version = "0.7.0", features = ["flamegraph"] }
+jemalloc_pprof = { version = "=0.8.0", features = ["flamegraph"] }
+mappings = "=0.7.0"                                                # needed for correct dependency resolution
 axum = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Description of changes

Needed to be able to re-use the `chroma-jemalloc-pprof-server` crate elsewhere.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
