### PR TITLE
Make all embedding functions take Embeddable instead of Documents

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -370,7 +370,7 @@ class ClientAPI(BaseAPI, ABC):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
     ) -> Collection:
@@ -407,7 +407,7 @@ class ClientAPI(BaseAPI, ABC):
         name: str,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
         """Get a collection with the given name.
@@ -439,7 +439,7 @@ class ClientAPI(BaseAPI, ABC):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
         """Get or create a collection with the given name and metadata.

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -363,7 +363,7 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
     ) -> AsyncCollection:
@@ -400,7 +400,7 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
         name: str,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
         """Get a collection with the given name.
@@ -432,7 +432,7 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
         """Get or create a collection with the given name and metadata.

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -180,7 +180,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
     ) -> AsyncCollection:
@@ -219,7 +219,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         name: str,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
         model = await self._server.get_collection(
@@ -248,7 +248,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> AsyncCollection:
         if configuration is None:

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -156,7 +156,7 @@ class Client(SharedSystemClient, ClientAPI):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
         get_or_create: bool = False,
     ) -> Collection:
@@ -195,7 +195,7 @@ class Client(SharedSystemClient, ClientAPI):
         name: str,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
         model = self._server.get_collection(
@@ -224,7 +224,7 @@ class Client(SharedSystemClient, ClientAPI):
         metadata: Optional[CollectionMetadata] = None,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ) -> Collection:
         if configuration is None:

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -117,7 +117,7 @@ class CollectionCommon(Generic[ClientT]):
         model: CollectionModel,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),  # type: ignore
+        ] = ef.DefaultEmbeddingFunction(),
         data_loader: Optional[DataLoader[Loadable]] = None,
     ):
         """Initializes a new instance of the Collection class."""

--- a/chromadb/test/property/test_persist.py
+++ b/chromadb/test/property/test_persist.py
@@ -413,7 +413,7 @@ def test_delete_add_after_persist(settings: Settings) -> None:
                 "hnsw:batch_size": 3,
                 "hnsw:sync_threshold": 3,
             },
-            embedding_function=DefaultEmbeddingFunction(),  # type: ignore[arg-type]
+            embedding_function=DefaultEmbeddingFunction(),
             id=UUID("0851f751-2f11-4424-ab23-4ae97074887a"),
             dimension=2,
             dtype=None,

--- a/chromadb/utils/__init__.py
+++ b/chromadb/utils/__init__.py
@@ -1,6 +1,8 @@
 import importlib
 from typing import Type, TypeVar, cast
 
+from chromadb.api.types import Document, Documents, Embeddable
+
 C = TypeVar("C")
 
 
@@ -10,3 +12,16 @@ def get_class(fqn: str, type: Type[C]) -> Type[C]:
     module = importlib.import_module(module_name)
     cls = getattr(module, class_name)
     return cast(Type[C], cls)
+
+
+def text_only_embeddable_check(input: Embeddable, embedding_function_name: str) -> Documents:
+    """
+    Helper function to determine if a given Embeddable is text-only.
+
+    Once the minimum supported python version is bumped up to 3.10, this should
+    be replaced with TypeGuard:
+    https://docs.python.org/3.10/library/typing.html#typing.TypeGuard
+    """
+    if not all(isinstance(item, Document) for item in input):
+        raise ValueError(f"{embedding_function_name} only supports text documents, not images")
+    return cast(Documents, input)

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -1,11 +1,14 @@
-from typing import Dict, Any, Type, Set
+from typing import Dict, Any, Type, Set, cast
 from chromadb.api.types import (
+    Document,
+    Embeddable,
     EmbeddingFunction,
     Embeddings,
     Documents,
 )
 
 # Import all embedding functions
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.cohere_embedding_function import (
     CohereEmbeddingFunction,
 )
@@ -106,13 +109,13 @@ def get_builtins() -> Set[str]:
     return _all_classes
 
 
-class DefaultEmbeddingFunction(EmbeddingFunction[Documents]):
+class DefaultEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def __init__(self) -> None:
         if is_thin_client:
             return
 
-    def __call__(self, input: Documents) -> Embeddings:
-        # Delegate to ONNXMiniLM_L6_V2
+    def __call__(self, input: Embeddable) -> Embeddings:
+         # Delegate to ONNXMiniLM_L6_V2
         return ONNXMiniLM_L6_V2()(input)
 
     @staticmethod
@@ -136,7 +139,7 @@ class DefaultEmbeddingFunction(EmbeddingFunction[Documents]):
 
 
 # Dictionary of supported embedding functions
-known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignore
+known_embedding_functions: Dict[str, Type[EmbeddingFunction[Embeddable]]] = {
     "cohere": CohereEmbeddingFunction,
     "openai": OpenAIEmbeddingFunction,
     "huggingface": HuggingFaceEmbeddingFunction,
@@ -197,7 +200,7 @@ def register_embedding_function(ef_class=None):  # type: ignore
 
 
 # Function to convert config to embedding function
-def config_to_embedding_function(config: Dict[str, Any]) -> EmbeddingFunction:  # type: ignore
+def config_to_embedding_function(config: Dict[str, Any]) -> EmbeddingFunction[Embeddable]:
     """Convert a config dictionary to an embedding function.
 
     Args:

--- a/chromadb/utils/embedding_functions/amazon_bedrock_embedding_function.py
+++ b/chromadb/utils/embedding_functions/amazon_bedrock_embedding_function.py
@@ -1,11 +1,12 @@
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction
+from chromadb.api.types import Embeddable, Embeddings, EmbeddingFunction
 from typing import Dict, Any, cast
 import json
 import numpy as np
 
 
-class AmazonBedrockEmbeddingFunction(EmbeddingFunction[Documents]):
+class AmazonBedrockEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """
     This class is used to generate embeddings for a list of texts using Amazon Bedrock.
     """
@@ -51,7 +52,7 @@ class AmazonBedrockEmbeddingFunction(EmbeddingFunction[Documents]):
             **kwargs,
         )
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
@@ -65,6 +66,7 @@ class AmazonBedrockEmbeddingFunction(EmbeddingFunction[Documents]):
         content_type = "application/json"
         embeddings = []
 
+        input = text_only_embeddable_check(input, "Amazon Bedrock")
         for text in input:
             input_body = {"inputText": text}
             body = json.dumps(input_body)
@@ -86,7 +88,7 @@ class AmazonBedrockEmbeddingFunction(EmbeddingFunction[Documents]):
         return "amazon_bedrock"
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         try:
             import boto3
         except ImportError:

--- a/chromadb/utils/embedding_functions/chroma_langchain_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_langchain_embedding_function.py
@@ -1,12 +1,10 @@
 from chromadb.api.types import (
-    Documents,
     Embeddings,
-    Images,
     Embeddable,
     EmbeddingFunction,
 )
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
-from typing import List, Dict, Any, Union, cast, Sequence
+from typing import List, Dict, Any, cast, Sequence
 import numpy as np
 
 
@@ -100,7 +98,7 @@ class ChromaLangchainEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "The provided embedding function does not support image embeddings."
             )
 
-    def __call__(self, input: Union[Documents, Images]) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Get the embeddings for a list of texts or images.
 
@@ -134,7 +132,7 @@ class ChromaLangchainEmbeddingFunction(EmbeddingFunction[Embeddable]):
     @staticmethod
     def build_from_config(
         config: Dict[str, Any]
-    ) -> "EmbeddingFunction[Union[Documents, Images]]":
+    ) -> "EmbeddingFunction[Embeddable]":
         # This is a placeholder implementation since we can't easily serialize and deserialize
         # langchain embedding functions. Users will need to recreate the langchain embedding function
         # and pass it to create_langchain_embedding.

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -1,13 +1,14 @@
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.api.types import Embeddable, Embeddings, EmbeddingFunction, Space
 from typing import List, Dict, Any, cast, Optional
 import os
 import numpy as np
 import numpy.typing as npt
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 import warnings
 
 
-class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
+class GooglePalmEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """To use this EmbeddingFunction, you must have the google.generativeai Python package installed and have a PaLM API key."""
 
     def __init__(
@@ -48,19 +49,18 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
         palm.configure(api_key=self.api_key)
         self._palm = palm
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
         Args:
-            input: Documents or images to generate embeddings for.
+            input: Documents to generate embeddings for.
 
         Returns:
             Embeddings for the documents.
         """
         # Google PaLM only works with text documents
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError("Google PaLM only supports text documents, not images")
+        input = text_only_embeddable_check(input, "Google PaLM")
 
         return [
             np.array(
@@ -83,7 +83,7 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
 
@@ -119,7 +119,7 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
         validate_config_schema(config, "google_palm")
 
 
-class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
+class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """To use this EmbeddingFunction, you must have the google.generativeai Python package installed and have a Google API key."""
 
     def __init__(
@@ -165,21 +165,18 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
         genai.configure(api_key=self.api_key)
         self._genai = genai
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
         Args:
-            input: Documents or images to generate embeddings for.
+            input: Documents to generate embeddings for.
 
         Returns:
             Embeddings for the documents.
         """
         # Google Generative AI only works with text documents
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError(
-                "Google Generative AI only supports text documents, not images"
-            )
+        input = text_only_embeddable_check(input, "Google Generative AI")
 
         embeddings_list: List[npt.NDArray[np.float32]] = []
         for text in input:
@@ -206,7 +203,7 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
         task_type = config.get("task_type")
@@ -251,7 +248,7 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
         validate_config_schema(config, "google_generative_ai")
 
 
-class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
+class GoogleVertexEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """To use this EmbeddingFunction, you must have the vertexai Python package installed and have Google Cloud credentials configured."""
 
     def __init__(
@@ -301,19 +298,18 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
         vertexai.init(project=project_id, location=region)
         self._model = TextEmbeddingModel.from_pretrained(model_name)
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
         Args:
-            input: Documents or images to generate embeddings for.
+            input: Documents to generate embeddings for.
 
         Returns:
             Embeddings for the documents.
         """
         # Google Vertex only works with text documents
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError("Google Vertex only supports text documents, not images")
+        input = text_only_embeddable_check(input, "Google Vertex")
 
         embeddings_list: List[npt.NDArray[np.float32]] = []
         for text in input:
@@ -336,7 +332,7 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
         project_id = config.get("project_id")

--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -1,4 +1,5 @@
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.api.types import Embeddable, Embeddings, EmbeddingFunction, Space
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any, Union, Optional
 import os
@@ -6,7 +7,7 @@ import numpy as np
 import warnings
 
 
-class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
+class JinaEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """
     This class is used to get embeddings for a list of texts using the Jina AI API.
     It requires an API key and a model name. The default model name is "jina-embeddings-v2-base-en".
@@ -81,12 +82,12 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
             {"Authorization": f"Bearer {self.api_key}", "Accept-Encoding": "identity"}
         )
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Get the embeddings for a list of texts.
 
         Args:
-            input (Documents): A list of texts to get embeddings for.
+            input (Embeddable): A list of texts to get embeddings for.
 
         Returns:
             Embeddings: The embeddings for the texts.
@@ -96,8 +97,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
             >>> input = ["Hello, world!", "How are you?"]
         """
         # Jina AI only works with text documents
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError("Jina AI only supports text documents, not images")
+        input = text_only_embeddable_check(input, "Jina AI")
 
         payload: Dict[str, Any] = {
             "input": input,
@@ -150,7 +150,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
         task = config.get("task")

--- a/chromadb/utils/embedding_functions/mistral_embedding_function.py
+++ b/chromadb/utils/embedding_functions/mistral_embedding_function.py
@@ -1,11 +1,12 @@
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.api.types import Embeddable, Embeddings, EmbeddingFunction, Space
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any
 import os
 import numpy as np
 
 
-class MistralEmbeddingFunction(EmbeddingFunction[Documents]):
+class MistralEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def __init__(
         self,
         model: str,
@@ -31,15 +32,14 @@ class MistralEmbeddingFunction(EmbeddingFunction[Documents]):
             raise ValueError(f"The {api_key_env_var} environment variable is not set.")
         self.client = Mistral(api_key=self.api_key)
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Get the embeddings for a list of texts.
 
         Args:
-            input (Documents): A list of texts to get embeddings for.
+            input (Embeddable): A list of texts to get embeddings for.
         """
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError("Mistral only supports text documents, not images")
+        input = text_only_embeddable_check(input, "Mistral")
         output = self.client.embeddings.create(
             model=self.model,
             inputs=input,
@@ -59,7 +59,7 @@ class MistralEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         model = config.get("model")
         api_key_env_var = config.get("api_key_env_var")
 

--- a/chromadb/utils/embedding_functions/morph_embedding_function.py
+++ b/chromadb/utils/embedding_functions/morph_embedding_function.py
@@ -1,12 +1,13 @@
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.api.types import Embeddable, Embeddings, Documents, EmbeddingFunction, Space
 from typing import List, Dict, Any, Optional
 import os
 import numpy as np
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 import warnings
 
 
-class MorphEmbeddingFunction(EmbeddingFunction[Documents]):
+class MorphEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -60,7 +61,7 @@ class MorphEmbeddingFunction(EmbeddingFunction[Documents]):
             base_url=self.api_base,
         )
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
@@ -70,6 +71,8 @@ class MorphEmbeddingFunction(EmbeddingFunction[Documents]):
         Returns:
             Embeddings for the documents.
         """
+        input = text_only_embeddable_check(input, type(self).__name__)
+
         # Handle empty input
         if not input:
             return []
@@ -99,7 +102,7 @@ class MorphEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         # Extract parameters from config
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")

--- a/chromadb/utils/embedding_functions/ollama_embedding_function.py
+++ b/chromadb/utils/embedding_functions/ollama_embedding_function.py
@@ -1,4 +1,5 @@
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.api.types import Embeddable, Embeddings, EmbeddingFunction, Space
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any
 import numpy as np
@@ -7,7 +8,7 @@ from urllib.parse import urlparse
 DEFAULT_MODEL_NAME = "chroma/all-minilm-l6-v2-f32"
 
 
-class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
+class OllamaEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """
     This class is used to generate embeddings for a list of texts using the Ollama Embedding API
     (https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings).
@@ -47,12 +48,12 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
 
         self._client = Client(host=self._base_url, timeout=timeout)
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Get the embeddings for a list of texts.
 
         Args:
-            input (Documents): A list of texts to get embeddings for.
+            input (Embeddable): A list of texts to get embeddings for.
 
         Returns:
             Embeddings: The embeddings for the texts.
@@ -62,6 +63,8 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
             >>> texts = ["Hello, world!", "How are you?"]
             >>> embeddings = ollama_ef(texts)
         """
+        input = text_only_embeddable_check(input, "Ollama")
+
         # Call Ollama client
         response = self._client.embed(model=self.model_name, input=input)
 
@@ -82,7 +85,7 @@ class OllamaEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         url = config.get("url")
         model_name = config.get("model_name")
         timeout = config.get("timeout")

--- a/chromadb/utils/embedding_functions/open_clip_embedding_function.py
+++ b/chromadb/utils/embedding_functions/open_clip_embedding_function.py
@@ -142,7 +142,7 @@ class OpenCLIPEmbeddingFunction(EmbeddingFunction[Embeddable]):
     @staticmethod
     def build_from_config(
         config: Dict[str, Any]
-    ) -> "EmbeddingFunction[Union[Documents, Images]]":
+    ) -> "EmbeddingFunction[Embeddable]":
         model_name = config.get("model_name")
         checkpoint = config.get("checkpoint")
         device = config.get("device")

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -1,12 +1,13 @@
-from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
+from chromadb.api.types import Embeddable, Embeddings, EmbeddingFunction, Space
 from typing import List, Dict, Any, Optional
 import os
 import numpy as np
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 import warnings
 
 
-class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
+class OpenAIEmbeddingFunction(EmbeddingFunction[Embeddable]):
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -102,7 +103,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 default_headers=self.default_headers,
             )
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
         Args:
@@ -110,6 +111,8 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
         Returns:
             Embeddings for the documents.
         """
+        input = text_only_embeddable_check(input, type(self).__name__)
+
         # Handle batching
         if not input:
             return []
@@ -141,7 +144,7 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         # Extract parameters from config
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -1,10 +1,11 @@
-from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
+from chromadb.api.types import Embeddable, EmbeddingFunction, Space, Embeddings, Documents
 from typing import List, Dict, Any
 import numpy as np
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 
 
-class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
+class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Embeddable]):
     # Since we do dynamic imports we have to type this as Any
     models: Dict[str, Any] = {}
 
@@ -46,7 +47,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
             )
         self._model = self.models[model_name]
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """Generate embeddings for the given documents.
 
         Args:
@@ -55,6 +56,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         Returns:
             Embeddings for the documents.
         """
+        input = text_only_embeddable_check(input, "Sentence Transformers")
         embeddings = self._model.encode(
             list(input),
             convert_to_numpy=True,
@@ -75,7 +77,7 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         model_name = config.get("model_name")
         device = config.get("device")
         normalize_embeddings = config.get("normalize_embeddings")

--- a/chromadb/utils/embedding_functions/text2vec_embedding_function.py
+++ b/chromadb/utils/embedding_functions/text2vec_embedding_function.py
@@ -1,10 +1,11 @@
-from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
+from chromadb.api.types import Embeddable, EmbeddingFunction, Space, Embeddings
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any
 import numpy as np
 
 
-class Text2VecEmbeddingFunction(EmbeddingFunction[Documents]):
+class Text2VecEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """
     This class is used to generate embeddings for a list of texts using the Text2Vec model.
     """
@@ -27,19 +28,18 @@ class Text2VecEmbeddingFunction(EmbeddingFunction[Documents]):
         self.model_name = model_name
         self._model = SentenceModel(model_name_or_path=model_name)
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
         Args:
-            input: Documents or images to generate embeddings for.
+            input: Documents to generate embeddings for.
 
         Returns:
             Embeddings for the documents.
         """
         # Text2Vec only works with text documents
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError("Text2Vec only supports text documents, not images")
+        input = text_only_embeddable_check(input, "Text2Vec")
 
         embeddings = self._model.encode(list(input), convert_to_numpy=True)
 
@@ -57,7 +57,7 @@ class Text2VecEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         model_name = config.get("model_name")
 
         if model_name is None:

--- a/chromadb/utils/embedding_functions/together_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/together_ai_embedding_function.py
@@ -1,11 +1,12 @@
 from chromadb.api.types import (
+    Embeddable,
     Embeddings,
-    Documents,
     EmbeddingFunction,
     Space,
 )
 from typing import List, Dict, Any, Optional
 import os
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import cast
 import warnings
@@ -13,7 +14,7 @@ import warnings
 ENDPOINT = "https://api.together.xyz/v1/embeddings"
 
 
-class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
+class TogetherAIEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """
     This class is used to get embeddings for a list of texts using the Together AI API.
     """
@@ -68,7 +69,7 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
             }
         )
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Embed a list of texts using the Together AI API.
 
@@ -82,8 +83,7 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
         if not isinstance(input, list):
             raise ValueError("Input must be a list")
 
-        if not all(isinstance(item, str) for item in input):
-            raise ValueError("All items in input must be strings")
+        input = text_only_embeddable_check(input, "Together AI")
 
         response = self._session.post(
             ENDPOINT,
@@ -109,7 +109,7 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
 

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -1,4 +1,5 @@
-from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
+from chromadb.api.types import Embeddable, EmbeddingFunction, Space, Embeddings
+from chromadb.utils import text_only_embeddable_check
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 from typing import List, Dict, Any, Optional
 import os
@@ -6,7 +7,7 @@ import numpy as np
 import warnings
 
 
-class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
+class VoyageAIEmbeddingFunction(EmbeddingFunction[Embeddable]):
     """
     This class is used to generate embeddings for a list of texts using the VoyageAI API.
     """
@@ -57,7 +58,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
         self.truncation = truncation
         self._client = voyageai.Client(api_key=self.api_key)
 
-    def __call__(self, input: Documents) -> Embeddings:
+    def __call__(self, input: Embeddable) -> Embeddings:
         """
         Generate embeddings for the given documents.
 
@@ -67,6 +68,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
         Returns:
             Embeddings for the documents.
         """
+        input = text_only_embeddable_check(input, "VoyageAI")
         embeddings = self._client.embed(
             texts=input,
             model=self.model_name,
@@ -90,7 +92,7 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
         return ["cosine", "l2", "ip"]
 
     @staticmethod
-    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
+    def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Embeddable]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
         input_type = config.get("input_type")


### PR DESCRIPTION
## Description of changes

fixes #5241.

As discussed there, we align the types of the provided embedding functions, such that they all implement `EmbeddingFunction[Embeddable]`. This was the second option among my proposed solutions.

## Test plan

Both code snippets given in the issue now type-check with mypy in strict mode, whereas previously only one of them passed.

I'll see what github actions says about all the existing tests before fiddling around with installing k8s / tilt / whatever else is needed to run those.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

This is technically a breaking change for anyone who wrote something along those lines:

```py
class MyCustomEmbeddingFunction(EmbeddingFunction[Documents])
    ....

client.get_or_create_collection("asdf", configuration={"embedding_function": MyCustomEmbeddingFunction()})
```

Any users of the built-in embedding functions won't notice anything.

If you consider this to be an issue, then I guess we'll have to re-add some `# type: ignore` comments which sort of defeats the whole point of this PR. Let me know what you think.

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

No documentation changes needed, since as far as I can tell the docs on [docs.trychroma.com](https://docs.trychroma.com) don't show any type annotations anyway.
