### PR TITLE
[CHORE]  Disable core dumps.

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -74,27 +74,27 @@ CMD [ "run", "/config.yaml" ]
 
 FROM runner AS garbage_collector
 COPY --from=builder /chroma/garbage_collector_service .
-ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./garbage_collector_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./garbage_collector_service" ]
 
 FROM runner AS load_service
 COPY --from=builder /chroma/chroma-load .
 COPY --from=builder /chroma/chroma-load-start .
-ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./chroma-load" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./chroma-load" ]
 
 FROM runner AS log_service
 COPY --from=builder /chroma/log_service .
-ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./log_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./log_service" ]
 
 FROM runner AS query_service
 COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
 # NOTE(rescrv): We need the tilt config in the docker file.  This is temporary.
 COPY --from=builder /chroma/rust/worker/tilt_config.yaml .
 COPY --from=builder /chroma/query_service .
-ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./query_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./query_service" ]
 
 FROM runner AS compaction_service
 COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
 # NOTE(rescrv): We need the tilt config in the docker file.  This is temporary.
 COPY --from=builder /chroma/rust/worker/tilt_config.yaml .
 COPY --from=builder /chroma/compaction_service .
-ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./compaction_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./compaction_service" ]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -74,29 +74,27 @@ CMD [ "run", "/config.yaml" ]
 
 FROM runner AS garbage_collector
 COPY --from=builder /chroma/garbage_collector_service .
-ENTRYPOINT [ "./garbage_collector_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./garbage_collector_service" ]
 
 FROM runner AS load_service
 COPY --from=builder /chroma/chroma-load .
 COPY --from=builder /chroma/chroma-load-start .
-ENTRYPOINT [ "./chroma-load" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./chroma-load" ]
 
 FROM runner AS log_service
 COPY --from=builder /chroma/log_service .
-ENTRYPOINT [ "./log_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./log_service" ]
 
 FROM runner AS query_service
 COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
 # NOTE(rescrv): We need the tilt config in the docker file.  This is temporary.
 COPY --from=builder /chroma/rust/worker/tilt_config.yaml .
-
 COPY --from=builder /chroma/query_service .
-ENTRYPOINT [ "./query_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./query_service" ]
 
 FROM runner AS compaction_service
 COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
 # NOTE(rescrv): We need the tilt config in the docker file.  This is temporary.
 COPY --from=builder /chroma/rust/worker/tilt_config.yaml .
-
 COPY --from=builder /chroma/compaction_service .
-ENTRYPOINT [ "./compaction_service" ]
+ENTRYPOINT [ "sh", "-c", "ulimit -c 1073741824 && exec ./compaction_service" ]


### PR DESCRIPTION
## Description of changes

This PR restricts core dumps within docker containers to 0 bytes.  They will not dump.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
