### PR TITLE
[BUG] AttributeError on "FastAPI.get"

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -1123,8 +1123,7 @@ class FastAPI(Server):
 
         if get_result["embeddings"] is not None:
             get_result["embeddings"] = [
-                cast(Embedding, embedding).tolist()
-                for embedding in get_result["embeddings"]
+                cast(Embedding, embedding) for embedding in get_result["embeddings"]
             ]
 
         return get_result


### PR DESCRIPTION
## Description of changes
- Bug fixes
  - I got an `AttributeError` during using `get` operation through the chromadb server running with fastapi.
    This raises by calling `.tolist()` on the `list`, so simply removed calling `.tolist()`, then the bug is fixed.
 ```
  File "/my/python/install/localtion/site-packages/chromadb/server/fastapi/__init__.py", line 1128, in get
    cast(Embedding, embedding).tolist()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'tolist'
```

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
