### PR TITLE
[CHORE] Squash yet another soft-deleted collection path.

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -94,6 +94,14 @@ impl ChromaError for GetCollectionWithSegmentsError {
             GetCollectionWithSegmentsError::Internal(err) => err.code(),
         }
     }
+
+    fn should_trace_error(&self) -> bool {
+        if let Self::Grpc(status) = self {
+            status.code() != ErrorCodes::NotFound.into()
+        } else {
+            true
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/rust/worker/src/execution/operators/get_collection_and_segments.rs
+++ b/rust/worker/src/execution/operators/get_collection_and_segments.rs
@@ -38,6 +38,11 @@ impl ChromaError for GetCollectionAndSegmentsError {
             GetCollectionAndSegmentsError::SysDB(chroma_error) => chroma_error.code(),
         }
     }
+
+    fn should_trace_error(&self) -> bool {
+        let Self::SysDB(gcwse) = self;
+        gcwse.should_trace_error()
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Description of changes

There's another path that paged for soft-deleted collections.  Squash
that error so it doesn't trace at the top level.

## Test plan

CI

## Migration plan

N/A

## Observability plan

See pages decrease or unveil the next error.

## Documentation Changes

N/A
