### PR TITLE
[ENH] improve Error messaging in onnx download_if_not_exists()

### DIFF
--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -305,10 +305,13 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
                 os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME),
                 self._MODEL_SHA256,
             ):
-                self._download(
-                    url=self.MODEL_DOWNLOAD_URL,
-                    fname=os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME),
-                )
+                try:
+                    self._download(
+                        url=self.MODEL_DOWNLOAD_URL,
+                        fname=os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME),
+                    )
+                except HTTPError as he:
+                    raise RuntimeError(f"Unable to download onnx model from {self.DOWNLOAD_URL}: HTTPError: {he}")
             with tarfile.open(
                 name=os.path.join(self.DOWNLOAD_PATH, self.ARCHIVE_FILENAME),
                 mode="r:gz",


### PR DESCRIPTION
Add debug info, such as the download URL being tried, to make errors in onnx download_if_not_exists() clearer

## Description of changes

The first time that a client, or a collection, make a query, if the default model (onnx) cannot be fetched due to e.g. a `ConnectionError` then the error will propagate up the stack.

This can be slightly counterintuitive because at a cursory glance it will look like an error with the connection to chromadb, when it is actually a connectivity error to the onnx download URL.

This PR is very small but hopes to make the case where this occurs clearer, by raising a `RuntimeError` that explains that onnx could not be downloaded. Thus hopefully signalling to the user that the issue is the connectivity of their client to the download URL and not to chromadb itself.

I can only say from personal experience that this kind of an error message would have saved me significant amounts of time. I was receiving errors where I had managed to create the client and connect to the collection, but then when I wanted to query or add, I would just get "ConnectionError" messages or "

To prove I am not a bot here is a string of the letter q exactly 41 times: qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - if an Error occurs while trying to download the onnx model, the error message is clearer

## Test plan

_How are these changes tested?_

It should not be necessary to test. This is just an error message.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No migration changes needed.

## Observability plan

_What is the plan to instrument and monitor this change?_

No observability needed either as it is just an error message being fixed.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

No changes in APIs needed.
