### PR TITLE
[ENH]: update the version file prefix to match the prefix used by segments

### DIFF
--- a/go/pkg/sysdb/metastore/s3/impl.go
+++ b/go/pkg/sysdb/metastore/s3/impl.go
@@ -22,10 +22,10 @@ import (
 
 // Path to Version Files in S3.
 // Example:
-// s3://<bucket-name>/<sysdbPathPrefix>/<tenant_id>/databases/<database_id>/collections/<collection_id>/versionfiles/file_name
+// s3://<bucket-name>/tenant/<tenant_id>/databases/<database_id>/collections/<collection_id>/versionfiles/file_name
 const (
-	lineageFilesPathFormat = "%s/databases/%s/collections/%s/lineagefiles/%s"
-	versionFilesPathFormat = "%s/databases/%s/collections/%s/versionfiles/%s"
+	lineageFilesPathFormat = "tenant/%s/database/%s/collection/%s/lineagefiles/%s"
+	versionFilesPathFormat = "tenant/%s/database/%s/collection/%s/versionfiles/%s"
 )
 
 type S3MetaStoreConfig struct {


### PR DESCRIPTION
## Description of changes

Validated the new prefix in Minio's UI. I updated the only place in our codebase that constructs version & lineage prefixes. We store the full path to the version file.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
