### PR TITLE
[ENH]  Make a describe-all.txt that describes the cluster state after testing.

### DIFF
--- a/bin/get-logs.sh
+++ b/bin/get-logs.sh
@@ -17,6 +17,9 @@ TEMP_DIR=$(mktemp -d)
 mkdir "$TEMP_DIR/logs"
 mkdir "$TEMP_DIR/traces"
 
+# Create a description of the k8s cluster
+kubectl describe -A all > "${TEMP_DIR}/logs/describe-all.txt" || true
+
 # Get the list of all pods in the namespace
 PODS=$(kubectl get pods -n $NAMESPACE -o jsonpath='{.items[*].metadata.name}')
 echo "Got all the pods: $PODS"


### PR DESCRIPTION
## Description of changes

I suspect that our test add failures are because of memory pressure
causing a pod to crash.  I suspect this because I've seen failures to
connect to etcd and the kind cluster, which shouldn't happen once tilt
believes itself to be up and alive.

This PR dumps kubectl describe -A all to get stuff like pod restarts
into the test data that we log per test run.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Look for the file.

## Documentation Changes

N/A
