### PR TITLE
[ENH][log]  Cache the manifest and etag.

### DIFF
--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -23,7 +23,9 @@ pub use copy::copy;
 pub use cursors::{Cursor, CursorName, CursorStore, Witness};
 pub use destroy::destroy;
 pub use gc::{Garbage, GarbageCollector};
-pub use manifest::{unprefixed_snapshot_path, Manifest, Snapshot, SnapshotPointer};
+pub use manifest::{
+    unprefixed_snapshot_path, Manifest, ManifestAndETag, Snapshot, SnapshotPointer,
+};
 pub use manifest_manager::ManifestManager;
 pub use reader::{Limits, LogReader};
 pub use snapshot_cache::SnapshotCache;

--- a/rust/wal3/src/manifest.rs
+++ b/rust/wal3/src/manifest.rs
@@ -925,6 +925,14 @@ impl Manifest {
     }
 }
 
+////////////////////////////////////////// ManifestAndETag /////////////////////////////////////////
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ManifestAndETag {
+    pub manifest: Manifest,
+    pub e_tag: ETag,
+}
+
 /////////////////////////////////////////////// tests //////////////////////////////////////////////
 
 #[cfg(test)]

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -4,21 +4,13 @@ use std::time::Instant;
 use chroma_storage::{ETag, Storage};
 
 use crate::gc::Garbage;
-use crate::manifest::{Manifest, Snapshot};
+use crate::manifest::{Manifest, ManifestAndETag, Snapshot};
 use crate::reader::read_fragment;
 use crate::writer::MarkDirty;
 use crate::{
     unprefixed_fragment_path, Error, Fragment, FragmentSeqNo, GarbageCollectionOptions,
     LogPosition, SnapshotCache, SnapshotOptions, SnapshotPointerOrFragmentSeqNo, ThrottleOptions,
 };
-
-////////////////////////////////////////// ManifestAndETag /////////////////////////////////////////
-
-#[derive(Debug)]
-struct ManifestAndETag {
-    manifest: Manifest,
-    e_tag: ETag,
-}
 
 ////////////////////////////////////////////// Staging /////////////////////////////////////////////
 
@@ -270,9 +262,9 @@ impl ManifestManager {
     }
 
     /// Return the latest stable manifest
-    pub fn latest(&self) -> Manifest {
+    pub fn latest(&self) -> ManifestAndETag {
         let staging = self.staging.lock().unwrap();
-        staging.stable.manifest.clone()
+        staging.stable.clone()
     }
 
     /// Recover from a fault in writing.  It is possible that fragments have been written that are

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -276,12 +276,7 @@ impl LogWriter {
     }
 
     pub fn manifest(&self) -> Option<Manifest> {
-        // SAFETY(rescrv):  Mutex poisoning.
-        let inner = self.inner.lock().unwrap();
-        inner
-            .writer
-            .as_ref()
-            .map(|writer| writer.manifest_manager.latest().manifest)
+        self.manifest_and_etag().map(|m| m.manifest)
     }
 
     pub fn manifest_and_etag(&self) -> Option<ManifestAndETag> {


### PR DESCRIPTION
## Description of changes

Prior to this commit, the code cached just the manifest.  By caching the
etag we can HEAD the manifest if it hasn't changed and get some latency
improvements for scout logs.

## Test plan

CI

## Migration plan

I changed the cache key, so even if we had a disk cache it would be backwards-compatible.

## Observability plan

N/A

## Documentation Changes

N/A
