### PR TITLE
[HOTFIX] applying PR #5361 to release/2025-08-22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "hnswlib"
 version = "0.8.1"
-source = "git+https://github.com/chroma-core/hnswlib.git#340a6fff21f0ba2db2bc720636eba4d7736b9534"
+source = "git+https://github.com/chroma-core/hnswlib.git#581f689d0620fbc6601a9293142888c81b3751e1"
 dependencies = [
  "cc",
  "thiserror 1.0.69",

--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -5,7 +5,12 @@ use std::path::Path;
 use thiserror::Error;
 use tracing::instrument;
 
-pub const DEFAULT_MAX_ELEMENTS: usize = 10000;
+// Setting it to a small value to prevent
+// bloating of the index which directly impacts query latency by increasing
+// the amount of bytes that need to be fetched from s3. The trade off is that
+// there will be more data movement/allocations during compaction which is
+// acceptable since compaction is a background operation.
+pub const DEFAULT_MAX_ELEMENTS: usize = 100;
 
 // TODO: Make this config:
 // - Watchable - for dynamic updates


### PR DESCRIPTION
This PR cherry-picks the commit f7504a8a85f71387cc95635424210955151daecd onto release/2025-08-22. If there are unresolved conflicts, please resolve them manually.