### PR TITLE
[ENH]  Explicitly convert SlowDown from S3 to StorageError::Backoff

### DIFF
--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -145,6 +145,10 @@ pub enum StorageError {
         /// The configuration key used
         key: String,
     },
+
+    // Back off and retry---usually indicates an explicit 429/SlowDown.
+    #[error("Back off and retry---usually indicates an explicit 429/SlowDown.")]
+    Backoff,
 }
 
 impl ChromaError for StorageError {
@@ -163,6 +167,7 @@ impl ChromaError for StorageError {
             StorageError::PermissionDenied { .. } => ErrorCodes::PermissionDenied,
             StorageError::Unauthenticated { .. } => ErrorCodes::Unauthenticated,
             StorageError::UnknownConfigurationKey { .. } => ErrorCodes::InvalidArgument,
+            StorageError::Backoff { .. } => ErrorCodes::ResourceExhausted,
         }
     }
 }

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -610,7 +610,7 @@ impl S3Storage {
                     path: key.to_string(),
                     source: Arc::new(err),
                 }
-            } else if err.meta().code() == Some("PreconditionFailed") {
+            } else if err.meta().code() == Some("SlowDown") {
                 StorageError::Backoff
             } else {
                 StorageError::Generic {


### PR DESCRIPTION
## Description of changes

Amazon periodically tells us to slow down and that manifests as a
gruesome error trace.  Make a specific error type so callers can handle
the error.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
