### PR TITLE
[BUG] Re-add logservice to tilt so it does not break hosted

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -258,6 +258,7 @@ k8s_resource(
 k8s_resource('postgres', resource_deps=['k8s_setup'], labels=["infrastructure"], port_forwards='5432:5432')
 # Jobs are suffixed with the image tag to ensure they are unique. In this context, the image tag is defined in k8s/distributed-chroma/values.yaml.
 k8s_resource('sysdb-migration-latest', resource_deps=['postgres'], labels=["infrastructure"])
+k8s_resource('logservice', resource_deps=['sysdb-migration-latest'], labels=["chroma"], port_forwards='50052:50051')
 k8s_resource('logservice-migration-latest', resource_deps=['postgres'], labels=["infrastructure"])
 k8s_resource('rust-log-service', labels=["chroma"], port_forwards='50054:50051')
 k8s_resource('sysdb', resource_deps=['sysdb-migration-latest'], labels=["chroma"], port_forwards='50051:50051')


### PR DESCRIPTION
## Description of changes

A prior commit removed some k8s resources from tilt that break hosted.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Make hosted pass.

## Documentation Changes

N/A
