### PR TITLE
[ENH] Add $exists operator support in filtering and validation

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -840,6 +840,11 @@ def validate_where(where: Where) -> None:
                         raise ValueError(
                             f"Expected operand value to be an int or a float for operator {operator}, got {operand}"
                         )
+                if operator == "$exists":
+                    if not isinstance(operand, bool):
+                        raise ValueError(
+                            f"Expected operand value to be a bool for operator {operator}, got {operand}"
+                        )
                 if operator in ["$in", "$nin"]:
                     if not isinstance(operand, list):
                         raise ValueError(
@@ -854,17 +859,18 @@ def validate_where(where: Where) -> None:
                     "$eq",
                     "$in",
                     "$nin",
+                    "$exists",
                 ]:
                     raise ValueError(
-                        f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, "
+                        f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, $exists, "
                         f"got {operator}"
                     )
 
-                if not isinstance(operand, (str, int, float, list)):
+                if operator != "$exists" and not isinstance(operand, (str, int, float, list)):
                     raise ValueError(
                         f"Expected where operand value to be a str, int, float, or list of those type, got {operand}"
                     )
-                if isinstance(operand, list) and (
+                if operator != "$exists" and isinstance(operand, list) and (
                     len(operand) == 0
                     or not all(isinstance(x, type(operand[0])) for x in operand)
                 ):

--- a/chromadb/base_types.py
+++ b/chromadb/base_types.py
@@ -17,6 +17,7 @@ WhereOperator = Union[
     Literal["$lte"],
     Literal["$ne"],
     Literal["$eq"],
+    Literal["$exists"],
 ]
 InclusionExclusionOperator = Union[Literal["$in"], Literal["$nin"]]
 OperatorExpression = Union[

--- a/clients/new-js/packages/chromadb/src/types.ts
+++ b/clients/new-js/packages/chromadb/src/types.ts
@@ -74,17 +74,18 @@ type LiteralValue = string | number | boolean;
 
 type LogicalOperator = "$and" | "$or";
 
-type WhereOperator = "$gt" | "$gte" | "$lt" | "$lte" | "$ne" | "$eq";
+type WhereOperator = "$gt" | "$gte" | "$lt" | "$lte" | "$ne" | "$eq" | "$exists";
 
 type InclusionExclusionOperator = "$in" | "$nin";
 
-type OperatorExpression =
+export type OperatorExpression =
   | { $gt: LiteralValue }
   | { $gte: LiteralValue }
   | { $lt: LiteralValue }
   | { $lte: LiteralValue }
   | { $ne: LiteralValue }
   | { $eq: LiteralValue }
+  | { $exists: boolean }
   | { $and: LiteralValue }
   | { $or: LiteralValue }
   | { $in: LiteralValue[] }

--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -390,16 +390,23 @@ export const validateWhere = (where: Where) => {
       }
 
       if (
-        !["$gt", "$gte", "$lt", "$lte", "$ne", "$eq", "$in", "$nin"].includes(
+        !["$gt", "$gte", "$lt", "$lte", "$ne", "$eq", "$in", "$nin", "$exists"].includes(
           operator,
         )
       ) {
         throw new ChromaValueError(
-          `Expected operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, but got ${operator}`,
+          `Expected operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, $exists, but got ${operator}`,
+        );
+      }
+
+      if (operator === "$exists" && typeof operand !== "boolean") {
+        throw new ChromaValueError(
+          `Expected operand value to be a boolean for ${operator}, but got ${typeof operand}`,
         );
       }
 
       if (
+        operator !== "$exists" &&
         !["string", "number", "boolean"].includes(typeof operand) &&
         !Array.isArray(operand)
       ) {
@@ -409,6 +416,7 @@ export const validateWhere = (where: Where) => {
       }
 
       if (
+        operator !== "$exists" &&
         Array.isArray(operand) &&
         (operand.length === 0 ||
           !operand.every((item) => typeof item === typeof operand[0]))

--- a/clients/new-js/packages/chromadb/test/get.collection.test.ts
+++ b/clients/new-js/packages/chromadb/test/get.collection.test.ts
@@ -53,9 +53,26 @@ describe("get collections", () => {
     } catch (error: any) {
       expect(error).toBeDefined();
       expect(error.message).toMatchInlineSnapshot(
-        `"Expected operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, but got $contains"`,
+        `"Expected operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, $exists, but got $contains"`,
       );
     }
+  });
+
+  test("it should filter by $exists", async () => {
+    const collection = await client.createCollection({ name: "test" });
+    await collection.add({
+      ids: ["1", "2", "3"],
+      embeddings: [
+        [0.1, 0.2],
+        [0.2, 0.3],
+        [0.3, 0.4],
+      ],
+      metadatas: [{ a: 1 }, {}, { b: 2 }],
+    });
+    const hasA = await collection.get({ where: { a: { $exists: true } } });
+    expect(hasA.ids).toEqual(["1"]);
+    const notA = await collection.get({ where: { a: { $exists: false } } });
+    expect(notA.ids.sort()).toEqual(["2", "3"]);
   });
 
   test("it should get embedding with matching documents", async () => {


### PR DESCRIPTION
## Description of changes
This commit introduces support for the `$exists` operator in the filtering and validation logic. The `$exists` operator allows users to check for the presence or absence of a key in the metadata. The implementation includes updates to type definitions, validation functions, and test cases to ensure correct behavior.

## Test plan
New tests have been added to verify the functionality of the `$exists` operator.

## Documentation Changes
N/A

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
