### PR TITLE
# [ENH] Add timeout parameter to JinaEmbeddingFunction

### DIFF
--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -23,6 +23,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
         dimensions: Optional[int] = None,
         embedding_type: Optional[str] = None,
         normalized: Optional[bool] = None,
+        timeout: Optional[float] = None,
     ):
         """
         Initialize the JinaEmbeddingFunction.
@@ -44,6 +45,8 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
                 Defaults to None.
             normalized (bool, optional): Whether to normalize the Jina AI API.
                 Defaults to None.
+            timeout (float, optional): The timeout in seconds for API requests.
+                Defaults to None (uses httpx default of 5 seconds).
 
         """
         try:
@@ -74,9 +77,13 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
         self.dimensions = dimensions
         self.embedding_type = embedding_type
         self.normalized = normalized
+        self.timeout = timeout
 
         self._api_url = "https://api.jina.ai/v1/embeddings"
-        self._session = httpx.Client()
+        client_kwargs = {}
+        if self.timeout is not None:
+            client_kwargs["timeout"] = self.timeout
+        self._session = httpx.Client(**client_kwargs)
         self._session.headers.update(
             {"Authorization": f"Bearer {self.api_key}", "Accept-Encoding": "identity"}
         )
@@ -159,6 +166,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
         dimensions = config.get("dimensions")
         embedding_type = config.get("embedding_type")
         normalized = config.get("normalized")
+        timeout = config.get("timeout")
 
         if api_key_env_var is None or model_name is None:
             assert False, "This code should not be reached"  # this is for type checking
@@ -172,6 +180,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
             dimensions=dimensions,
             embedding_type=embedding_type,
             normalized=normalized,
+            timeout=timeout,
         )
 
     def get_config(self) -> Dict[str, Any]:
@@ -184,6 +193,7 @@ class JinaEmbeddingFunction(EmbeddingFunction[Documents]):
             "dimensions": self.dimensions,
             "embedding_type": self.embedding_type,
             "normalized": self.normalized,
+            "timeout": self.timeout,
         }
 
     def validate_config_update(


### PR DESCRIPTION
## Summary
Add configurable timeout parameter to `JinaEmbeddingFunction` to allow API calls that take longer than the default 5 seconds. The timeout can be specified during initialization and is applied to all API requests through the httpx client.

## Changes
- Added `timeout` parameter to `JinaEmbeddingFunction` constructor
- Implemented timeout handling for all API requests via httpx client
- Maintains backward compatibility with default timeout behavior

## Usage
```python
# With custom timeout (e.g., 30 seconds)
embedding_function = JinaEmbeddingFunction(
    timeout=30.0,
    # other parameters...
)

## Description of changes

### Improvements & Bug fixes
- Fixed timeout issues when Jina AI API calls take longer than 5 seconds

### New functionality
- Added configurable timeout parameter to `JinaEmbeddingFunction` constructor
- Updated `build_from_config()` and `get_config()` methods to support timeout serialization
- Enhanced httpx client initialization to respect custom timeout settings

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` 

## Migration plan
No migrations required. This is a backward-compatible change:
  - Existing code will continue to work without modification (timeout defaults to None)
  - The change only adds an optional parameter with sensible defaults
  - No breaking changes to existing API surface 

## Observability plan
No additional observability changes needed. The timeout behavior is handled at the httpx client level and will:
  - Use existing httpx timeout handling and error reporting
  - Raise standard httpx.TimeoutException when timeouts occur
  - Maintain existing error handling patterns in the codebase

## Documentation Changes
- Updated docstring for JinaEmbeddingFunction.__init__() to document the new timeout parameter
  - External documentation could be updated about the optional parameter enhancement about timeout configuration for users experiencing slow API responses
