### PR TITLE
[BUG] Reduce RFE metric cardinality

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -30,7 +30,6 @@ use chroma_types::{ForkCollectionResponse, RawWhereFields};
 use mdac::{Rule, Scorecard, ScorecardTicket};
 use opentelemetry::global;
 use opentelemetry::metrics::{Counter, Meter};
-use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 use std::sync::{
     atomic::{AtomicBool, Ordering},

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -673,10 +673,7 @@ async fn create_database(
     State(mut server): State<FrontendServer>,
     Json(CreateDatabasePayload { name }): Json<CreateDatabasePayload>,
 ) -> Result<Json<CreateDatabaseResponse>, ServerError> {
-    server
-        .metrics
-        .create_database
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.create_database.add(1, &[]);
     tracing::info!(name: "create_database", tenant_name = %tenant, database_name = %name);
     server
         .authenticate_and_authorize(
@@ -735,10 +732,7 @@ async fn list_databases(
     Query(ListDatabasesParams { limit, offset }): Query<ListDatabasesParams>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<ListDatabasesResponse>, ServerError> {
-    server
-        .metrics
-        .list_databases
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.list_databases.add(1, &[]);
     tracing::info!(name: "list_databases", tenant_name = %tenant);
     server
         .authenticate_and_authorize(
@@ -778,10 +772,7 @@ async fn get_database(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<GetDatabaseResponse>, ServerError> {
-    server
-        .metrics
-        .get_database
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.get_database.add(1, &[]);
     tracing::info!(name: "get_database", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -821,10 +812,7 @@ async fn delete_database(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<DeleteDatabaseResponse>, ServerError> {
-    server
-        .metrics
-        .delete_database
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.delete_database.add(1, &[]);
     tracing::info!(name: "delete_database", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -872,10 +860,7 @@ async fn list_collections(
     Query(ListCollectionsParams { limit, offset }): Query<ListCollectionsParams>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<ListCollectionsResponse>, ServerError> {
-    server
-        .metrics
-        .list_collections
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.list_collections.add(1, &[]);
     tracing::info!(name: "list_collections", tenant_name = %tenant, database_name = %database, limit = ?limit, offset = ?offset);
     server
         .authenticate_and_authorize(
@@ -932,10 +917,7 @@ async fn count_collections(
     Path((tenant, database)): Path<(String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<CountCollectionsResponse>, ServerError> {
-    server
-        .metrics
-        .count_collections
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.count_collections.add(1, &[]);
     tracing::info!(name: "count_collections", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -987,10 +969,7 @@ async fn create_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<CreateCollectionPayload>,
 ) -> Result<Json<Collection>, ServerError> {
-    server
-        .metrics
-        .create_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.create_collection.add(1, &[]);
     tracing::info!(name: "create_collection", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -1067,10 +1046,7 @@ async fn get_collection(
     Path((tenant, database, collection_name)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<Collection>, ServerError> {
-    server
-        .metrics
-        .get_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.get_collection.add(1, &[]);
     tracing::info!(name: "get_collection", tenant_name = %tenant, database_name = %database, collection_name = %collection_name);
     server
         .authenticate_and_authorize(
@@ -1109,10 +1085,7 @@ async fn get_collection_by_crn(
     Path(crn): Path<String>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<Collection>, ServerError> {
-    server
-        .metrics
-        .get_collection_by_crn
-        .add(1, &[KeyValue::new("crn", crn.clone())]);
+    server.metrics.get_collection_by_crn.add(1, &[]);
     tracing::info!(name: "get_collection_by_crn", crn = %crn);
     server
         .authenticate_and_authorize(
@@ -1160,10 +1133,7 @@ async fn update_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<UpdateCollectionPayload>,
 ) -> Result<Json<UpdateCollectionResponse>, ServerError> {
-    server
-        .metrics
-        .update_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.update_collection.add(1, &[]);
     tracing::info!(name: "update_collection", tenant_name = %tenant, database_name = %database, collection_id = %collection_id);
     server
         .authenticate_and_authorize_collection(
@@ -1236,10 +1206,7 @@ async fn delete_collection(
     Path((tenant, database, collection_name)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<UpdateCollectionResponse>, ServerError> {
-    server
-        .metrics
-        .delete_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.delete_collection.add(1, &[]);
     tracing::info!(name: "delete_collection", tenant_name = %tenant, database_name = %database);
     server
         .authenticate_and_authorize(
@@ -1291,10 +1258,7 @@ async fn fork_collection(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<ForkCollectionPayload>,
 ) -> Result<Json<ForkCollectionResponse>, ServerError> {
-    server
-        .metrics
-        .fork_collection
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.fork_collection.add(1, &[]);
     tracing::info!(name: "fork_collection", tenant_name = %tenant, database_name = %database, collection_id = %collection_id);
     server
         .authenticate_and_authorize(
@@ -1396,10 +1360,7 @@ async fn collection_add(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<AddCollectionRecordsPayload>,
 ) -> Result<(StatusCode, Json<AddCollectionRecordsResponse>), ServerError> {
-    server
-        .metrics
-        .collection_add
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_add.add(1, &[]);
     server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1505,10 +1466,7 @@ async fn collection_update(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<UpdateCollectionRecordsPayload>,
 ) -> Result<Json<UpdateCollectionRecordsResponse>, ServerError> {
-    server
-        .metrics
-        .collection_update
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_update.add(1, &[]);
     server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1622,10 +1580,7 @@ async fn collection_upsert(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<UpsertCollectionRecordsPayload>,
 ) -> Result<Json<UpsertCollectionRecordsResponse>, ServerError> {
-    server
-        .metrics
-        .collection_upsert
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_upsert.add(1, &[]);
     server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1731,10 +1686,7 @@ async fn collection_delete(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<DeleteCollectionRecordsPayload>,
 ) -> Result<Json<DeleteCollectionRecordsResponse>, ServerError> {
-    server
-        .metrics
-        .collection_delete
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_delete.add(1, &[]);
     let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
@@ -1817,10 +1769,7 @@ async fn collection_count(
     Path((tenant, database, collection_id)): Path<(String, String, String)>,
     State(mut server): State<FrontendServer>,
 ) -> Result<Json<CountResponse>, ServerError> {
-    server
-        .metrics
-        .collection_count
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_count.add(1, &[]);
     tracing::info!(
         name: "collection_count",
         tenant = tenant,
@@ -1914,10 +1863,7 @@ async fn collection_get(
     State(mut server): State<FrontendServer>,
     Json(payload): Json<GetRequestPayload>,
 ) -> Result<Json<GetResponse>, ServerError> {
-    server
-        .metrics
-        .collection_get
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_get.add(1, &[]);
     let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
@@ -2050,10 +1996,7 @@ async fn collection_query(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<QueryRequestPayload>,
 ) -> Result<Json<QueryResponse>, ServerError> {
-    server
-        .metrics
-        .collection_query
-        .add(1, &[KeyValue::new("tenant", tenant.clone())]);
+    server.metrics.collection_query.add(1, &[]);
     let requester_identity = server
         .authenticate_and_authorize_collection(
             &headers,
@@ -2175,13 +2118,7 @@ async fn collection_search(
     State(mut server): State<FrontendServer>,
     TracedJson(payload): TracedJson<SearchRequestPayload>,
 ) -> Result<Json<SearchResponse>, ServerError> {
-    server.metrics.collection_search.add(
-        1,
-        &[
-            KeyValue::new("tenant", tenant.clone()),
-            KeyValue::new("collection_id", collection_id.clone()),
-        ],
-    );
+    server.metrics.collection_search.add(1, &[]);
     // TODO: Maybe add AuthzAction:Search
     let requester_identity = server
         .authenticate_and_authorize_collection(


### PR DESCRIPTION
## Description of changes

Adding the "tenant_id" attribute to the metrics causes an excessive number of events to be emitted.

This is a continuation of the effort from
https://github.com/chroma-core/chroma/pull/5373. Turns out, to reduce event volume even further, we want to omit the attribute for `tenatnt_id` (in addition to removing the attribute for `collection_id`).

## Test plan

Unit tests passing, otherwise untested. Manually inspected our metrics dashboards to ensure we aren't currently using these attributes.

## Migration plan

N/A

## Observability plan

Ensure dashboards remain unaffected.

## Documentation Changes

N/A
