### PR TITLE
[ENH] Unimplement Hash + Eq for KnnQuery

### DIFF
--- a/rust/worker/src/execution/operators/rank.rs
+++ b/rust/worker/src/execution/operators/rank.rs
@@ -6,12 +6,8 @@ use std::{
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_system::Operator;
-use chroma_types::operator::{KnnQuery, Rank, RecordMeasure};
+use chroma_types::operator::{Rank, RecordMeasure};
 use thiserror::Error;
-
-struct RankProvider<'me> {
-    knn_results: &'me HashMap<KnnQuery, Vec<RecordMeasure>>,
-}
 
 // NOTE: `RankDomain` represents evaluated scores for records
 // - `support`: scores of specific records
@@ -101,8 +97,15 @@ impl RankDomain {
     }
 }
 
-impl RankProvider<'_> {
-    fn eval(&self, rank: Rank) -> RankDomain {
+struct RankProvider<R> {
+    knn_result_iter: R,
+}
+
+impl<R> RankProvider<R>
+where
+    R: Iterator<Item = Vec<RecordMeasure>>,
+{
+    fn eval(&mut self, rank: Rank) -> RankDomain {
         match rank {
             Rank::Absolute(rank) => self.eval(*rank).map(f32::abs),
             Rank::Division { left, right } => {
@@ -129,30 +132,22 @@ impl RankProvider<'_> {
                     RankDomain::merge(accumulate_domain, domain, f32::mul)
                 }),
             Rank::Knn {
-                embedding,
-                key,
-                limit,
+                embedding: _,
+                key: _,
+                limit: _,
                 default,
                 ordinal,
             } => {
-                let knn_query = KnnQuery {
-                    embedding,
-                    key,
-                    limit,
-                };
                 let support = self
-                    .knn_results
-                    .get(&knn_query)
-                    .map(|records| {
-                        records
-                            .iter()
-                            .enumerate()
-                            .map(|(index, &RecordMeasure { offset_id, measure })| {
-                                (offset_id, if ordinal { index as f32 } else { measure })
-                            })
-                            .collect()
+                    .knn_result_iter
+                    .next()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, RecordMeasure { offset_id, measure })| {
+                        (offset_id, if ordinal { index as f32 } else { measure })
                     })
-                    .unwrap_or_default();
+                    .collect();
                 RankDomain { support, default }
             }
             Rank::Subtraction { left, right } => {
@@ -169,9 +164,10 @@ impl RankProvider<'_> {
     }
 }
 
+// NOTE: We assume that the provided vector of knn results are in the DFS order of Rank expression.
 #[derive(Clone, Debug)]
 pub struct RankInput {
-    pub knn_results: HashMap<KnnQuery, Vec<RecordMeasure>>,
+    pub knn_results: Vec<Vec<RecordMeasure>>,
 }
 
 #[derive(Clone, Debug)]
@@ -194,8 +190,9 @@ impl Operator<RankInput, RankOutput> for Rank {
     type Error = RankError;
 
     async fn run(&self, input: &RankInput) -> Result<RankOutput, RankError> {
-        let rank_provider = RankProvider {
-            knn_results: &input.knn_results,
+        let knn_results = input.knn_results.clone();
+        let mut rank_provider = RankProvider {
+            knn_result_iter: knn_results.into_iter(),
         };
         let rank_domain = rank_provider.eval(self.clone());
         let mut ranks = rank_domain
@@ -211,34 +208,31 @@ impl Operator<RankInput, RankOutput> for Rank {
 
 #[cfg(test)]
 mod tests {
+    use chroma_types::operator::KnnQuery;
+
     use super::*;
 
     #[tokio::test]
     async fn test_rank_with_knn_results() {
-        // Setup KNN results
-        let mut knn_results = HashMap::new();
         let query = KnnQuery {
             embedding: chroma_types::operator::QueryVector::Dense(vec![0.1, 0.2, 0.3]),
             key: String::new(),
             limit: 3,
         };
-        knn_results.insert(
-            query.clone(),
-            vec![
-                RecordMeasure {
-                    offset_id: 1,
-                    measure: 0.9,
-                },
-                RecordMeasure {
-                    offset_id: 2,
-                    measure: 0.7,
-                },
-                RecordMeasure {
-                    offset_id: 3,
-                    measure: 0.5,
-                },
-            ],
-        );
+        let knn_results = vec![vec![
+            RecordMeasure {
+                offset_id: 1,
+                measure: 0.9,
+            },
+            RecordMeasure {
+                offset_id: 2,
+                measure: 0.7,
+            },
+            RecordMeasure {
+                offset_id: 3,
+                measure: 0.5,
+            },
+        ]];
 
         // Test simple KNN rank
         let rank = Rank::Knn {
@@ -258,8 +252,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_rank_arithmetic_operations() {
-        // Setup two KNN queries
-        let mut knn_results = HashMap::new();
         let query1 = KnnQuery {
             embedding: chroma_types::operator::QueryVector::Dense(vec![0.1]),
             key: String::new(),
@@ -273,9 +265,7 @@ mod tests {
             key: "sparse".to_string(),
             limit: 2,
         };
-
-        knn_results.insert(
-            query1.clone(),
+        let mut knn_results = vec![
             vec![
                 RecordMeasure {
                     offset_id: 1,
@@ -286,9 +276,6 @@ mod tests {
                     measure: 0.6,
                 },
             ],
-        );
-        knn_results.insert(
-            query2.clone(),
             vec![
                 RecordMeasure {
                     offset_id: 1,
@@ -299,7 +286,7 @@ mod tests {
                     measure: 0.2,
                 },
             ],
-        );
+        ];
 
         // Test summation
         let rank = Rank::Summation(vec![
@@ -328,6 +315,7 @@ mod tests {
         assert_eq!(output.ranks[0].measure, 1.2);
 
         // Test multiplication with constant
+        knn_results.pop();
         let rank = Rank::Multiplication(vec![
             Rank::Knn {
                 embedding: query1.embedding.clone(),
@@ -347,26 +335,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_rank_min_max_functions() {
-        let mut knn_results = HashMap::new();
         let query = KnnQuery {
             embedding: chroma_types::operator::QueryVector::Dense(vec![0.1]),
             key: String::new(),
             limit: 2,
         };
-
-        knn_results.insert(
-            query.clone(),
-            vec![
-                RecordMeasure {
-                    offset_id: 1,
-                    measure: 0.8,
-                },
-                RecordMeasure {
-                    offset_id: 2,
-                    measure: 0.3,
-                },
-            ],
-        );
+        let knn_results = vec![vec![
+            RecordMeasure {
+                offset_id: 1,
+                measure: 0.8,
+            },
+            RecordMeasure {
+                offset_id: 2,
+                measure: 0.3,
+            },
+        ]];
 
         // Test max
         let rank = Rank::Maximum(vec![

--- a/rust/worker/src/execution/orchestration/rank.rs
+++ b/rust/worker/src/execution/orchestration/rank.rs
@@ -6,10 +6,9 @@ use chroma_system::{
     OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{
-    operator::{KnnQuery, Limit, Rank, RecordMeasure, SearchPayloadResult, Select},
+    operator::{Limit, Rank, RecordMeasure, SearchPayloadResult, Select},
     CollectionAndSegments,
 };
-use std::collections::HashMap;
 use thiserror::Error;
 use tokio::sync::oneshot::{error::RecvError, Sender};
 use tracing::Span;
@@ -101,7 +100,7 @@ pub struct RankOrchestrator {
     queue: usize,
 
     // Input data
-    knn_results: HashMap<KnnQuery, Vec<RecordMeasure>>,
+    knn_results: Vec<Vec<RecordMeasure>>,
     rank: Rank,
     limit: Limit,
     select: Select,
@@ -120,7 +119,7 @@ impl RankOrchestrator {
         blockfile_provider: BlockfileProvider,
         dispatcher: ComponentHandle<Dispatcher>,
         queue: usize,
-        knn_results: HashMap<KnnQuery, Vec<RecordMeasure>>,
+        knn_results: Vec<Vec<RecordMeasure>>,
         rank: Rank,
         limit: Limit,
         select: Select,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Removed `Hash + Eq` implementation for `KnnQuery`. Now we assume the expression traversal is always in DFS order and we only keep a `Vec<Vec<RecordMeasure>>` in the same order instead of a `HashMap<KnnQuery, Vec<RecordMeasure>>`
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
