### PR TITLE
[CLN]: Remove spans + add tracing for slow operations

### DIFF
--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -636,9 +636,7 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
                     Err(e) => Err(Box::new(e) as Box<dyn ChromaError>),
                 }
             }
-            .instrument(
-                tracing::trace_span!(parent: Span::current(), "Fetching block", block_id = %block_id),
-            )
+            .instrument(Span::current())
         });
 
         let blocks = try_join_all(block_futures).await?;

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -668,9 +668,14 @@ impl RootManager {
         match index {
             Some(index) => Ok(Some(index)),
             None => {
-                tracing::info!("Cache miss - fetching root from storage");
                 let key = Self::get_storage_key(prefix_path, id);
-                tracing::debug!("Reading root from storage with key: {}", key);
+                let _slow_operation_log = LogSlowOperation::new(
+                    format!(
+                        "Cold root fetch from storage and deserialize for key: {}",
+                        key
+                    ),
+                    Duration::from_millis(50),
+                );
                 match self
                     .storage
                     .get(&key, GetOptions::new(StorageRequestPriority::P0))

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -487,7 +487,7 @@ impl BlockManager {
                     "Cold block fetch from storage and deserialize: {}",
                     key_clone
                 ),
-                Duration::from_millis(500),
+                Duration::from_millis(100),
             );
             self.storage
                 .fetch(&key, GetOptions::new(priority), move |bytes| async move {

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -22,6 +22,7 @@ use futures::future;
 use opentelemetry::{global, KeyValue};
 use rand::seq::SliceRandom;
 use thiserror::Error;
+use tracing::{Instrument, Span};
 use uuid::Uuid;
 
 use crate::{
@@ -2620,12 +2621,14 @@ impl<'me> SpannIndexReader<'me> {
             match (pl_blockfile_id, versions_map_blockfile_id) {
                 (Some(pl_id), Some(versions_id)) => {
                     let (pl_result, vm_result) = tokio::join!(
-                        Self::posting_list_reader_from_id(pl_id, blockfile_provider, prefix_path),
+                        Self::posting_list_reader_from_id(pl_id, blockfile_provider, prefix_path)
+                            .instrument(Span::current()),
                         Self::versions_map_reader_from_id(
                             versions_id,
                             blockfile_provider,
                             prefix_path
                         )
+                        .instrument(Span::current())
                     );
                     (pl_result?, vm_result?)
                 }

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -35,6 +35,8 @@ use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use tantivy::tokenizer::NgramTokenizer;
 use thiserror::Error;
+use tracing::Instrument;
+use tracing::Span;
 
 #[derive(Clone)]
 pub struct MetadataSegmentWriter<'me> {
@@ -1011,21 +1013,27 @@ impl MetadataSegmentReader<'_> {
         let pls_future = Self::load_index_reader(segment, FULL_TEXT_PLS, blockfile_provider);
 
         let string_metadata_future =
-            Self::load_index_reader(segment, STRING_METADATA, blockfile_provider);
+            Self::load_index_reader(segment, STRING_METADATA, blockfile_provider)
+                .instrument(Span::current());
 
         let bool_metadata_future =
-            Self::load_index_reader(segment, BOOL_METADATA, blockfile_provider);
+            Self::load_index_reader(segment, BOOL_METADATA, blockfile_provider)
+                .instrument(Span::current());
 
         let f32_metadata_future =
-            Self::load_index_reader(segment, F32_METADATA, blockfile_provider);
+            Self::load_index_reader(segment, F32_METADATA, blockfile_provider)
+                .instrument(Span::current());
 
         let u32_metadata_future =
-            Self::load_index_reader(segment, U32_METADATA, blockfile_provider);
+            Self::load_index_reader(segment, U32_METADATA, blockfile_provider)
+                .instrument(Span::current());
 
-        let sparse_max_future = Self::load_index_reader(segment, SPARSE_MAX, blockfile_provider);
+        let sparse_max_future = Self::load_index_reader(segment, SPARSE_MAX, blockfile_provider)
+            .instrument(Span::current());
 
         let sparse_offset_value_future =
-            Self::load_index_reader(segment, SPARSE_OFFSET_VALUE, blockfile_provider);
+            Self::load_index_reader(segment, SPARSE_OFFSET_VALUE, blockfile_provider)
+                .instrument(Span::current());
 
         let (
             pls_reader,

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -22,6 +22,7 @@ use std::ops::RangeBounds;
 use std::sync::atomic::{self, AtomicU32};
 use std::sync::Arc;
 use thiserror::Error;
+use tracing::{Instrument, Span};
 
 #[derive(Clone)]
 pub struct RecordSegmentWriter {
@@ -763,16 +764,20 @@ impl RecordSegmentReader<'_> {
             match segment.file_path.len() {
                 4 => {
                     let user_id_to_id_future =
-                        Self::load_index_reader(segment, USER_ID_TO_OFFSET_ID, blockfile_provider);
+                        Self::load_index_reader(segment, USER_ID_TO_OFFSET_ID, blockfile_provider)
+                            .instrument(Span::current());
 
                     let id_to_user_id_future =
-                        Self::load_index_reader(segment, OFFSET_ID_TO_USER_ID, blockfile_provider);
+                        Self::load_index_reader(segment, OFFSET_ID_TO_USER_ID, blockfile_provider)
+                            .instrument(Span::current());
 
                     let id_to_data_future =
-                        Self::load_index_reader(segment, OFFSET_ID_TO_DATA, blockfile_provider);
+                        Self::load_index_reader(segment, OFFSET_ID_TO_DATA, blockfile_provider)
+                            .instrument(Span::current());
 
                     let max_offset_id_future =
-                        Self::load_index_reader(segment, MAX_OFFSET_ID, blockfile_provider);
+                        Self::load_index_reader(segment, MAX_OFFSET_ID, blockfile_provider)
+                            .instrument(Span::current());
 
                     let (
                         max_offset_id_result,

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -625,9 +625,7 @@ pub async fn materialize_logs(
             }
             Ok(())
         }
-        .instrument(
-            tracing::info_span!(parent: Span::current(), "Materialization read from storage"),
-        )
+        .instrument(Span::current())
         .await?;
     }
     // Populate updates to these and fresh records that are being
@@ -895,7 +893,7 @@ pub async fn materialize_logs(
             }
         }
         Ok(())
-    }.instrument(tracing::info_span!(parent: Span::current(), "Materialization main iteration")).await?;
+    }.instrument(Span::current()).await?;
     let mut res = vec![];
     for (_key, value) in existing_id_to_materialized {
         // Ignore records that only had invalid ADDS on the log.

--- a/rust/tracing/src/util.rs
+++ b/rust/tracing/src/util.rs
@@ -46,3 +46,33 @@ pub fn get_current_trace_id() -> TraceId {
     let span = tracing::Span::current();
     span.context().span().span_context().trace_id()
 }
+
+pub struct LogSlowOperation {
+    start_time: std::time::Instant,
+    operation_name: String,
+    threshold: std::time::Duration,
+}
+
+impl LogSlowOperation {
+    pub fn new(operation_name: String, threshold: std::time::Duration) -> Self {
+        Self {
+            start_time: std::time::Instant::now(),
+            operation_name,
+            threshold,
+        }
+    }
+}
+
+impl Drop for LogSlowOperation {
+    fn drop(&mut self) {
+        let elapsed = self.start_time.elapsed();
+        if elapsed > self.threshold {
+            tracing::warn!(
+                "Operation '{}' took {:?}, which exceeds the threshold of {:?}",
+                self.operation_name,
+                elapsed,
+                self.threshold
+            );
+        }
+    }
+}

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -254,10 +254,7 @@ impl MetadataProvider<'_> {
                                         Ok::<(u32, Option<DataRecord>), Box<dyn ChromaError>>((
                                             id, data,
                                         ))
-                                    }.instrument(tracing::trace_span!(parent: Span::current(),
-                                        "DataRecord fetch for offset id",
-                                        offset_id = %id
-                                    ))
+                                    }.instrument(Span::current())
                                         })
                                         .collect();
                                 let data_results = try_join_all(fetch_futures).await?;

--- a/rust/worker/src/execution/operators/knn_projection.rs
+++ b/rust/worker/src/execution/operators/knn_projection.rs
@@ -62,8 +62,6 @@ impl Operator<KnnProjectionInput, KnnProjectionOutput> for KnnProjection {
         &self,
         input: &KnnProjectionInput,
     ) -> Result<KnnProjectionOutput, KnnProjectionError> {
-        tracing::debug!("[{}]: {:?}", self.get_name(), input);
-
         let projection_input = ProjectionInput {
             logs: input.logs.clone(),
             blockfile_provider: input.blockfile_provider.clone(),

--- a/rust/worker/src/execution/operators/limit.rs
+++ b/rust/worker/src/execution/operators/limit.rs
@@ -181,9 +181,6 @@ impl Operator<LimitInput, LimitOutput> for Limit {
     type Error = LimitError;
 
     async fn run(&self, input: &LimitInput) -> Result<LimitOutput, LimitError> {
-        tracing::debug!("[{}]: num log entries {:?}, record segment {:?}, log offset ids {:?}, compact ids {:?}", self.get_name(),
-            input.logs.len(), input.record_segment, input.log_offset_ids, input.compact_offset_ids);
-
         let record_segment_reader = match RecordSegmentReader::from_segment(
             &input.record_segment,
             &input.blockfile_provider,

--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
@@ -11,7 +8,6 @@ use chroma_segment::{
     types::{materialize_logs, LogMaterializerError},
 };
 use chroma_system::Operator;
-use chroma_tracing::util::LogSlowOperation;
 use chroma_types::{
     operator::{Projection, ProjectionOutput, ProjectionRecord},
     Chunk, LogRecord, Segment,
@@ -117,11 +113,6 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
             .iter()
             .map(|offset_id| {
                 async {
-                    // Emit a warning if the projection operation on this record takes > 500ms.
-                    let _slow_operation_log = LogSlowOperation::new(
-                        format!("Projection for offset id {}", *offset_id),
-                        Duration::from_millis(100),
-                    );
                     let record = match offset_id_to_log_record.get(offset_id) {
                         // The offset id is in the log
                         Some(log) => {

--- a/rust/worker/src/execution/operators/spann_fetch_pl.rs
+++ b/rust/worker/src/execution/operators/spann_fetch_pl.rs
@@ -14,7 +14,6 @@ pub(crate) struct SpannFetchPlInput<'referred_data> {
 #[derive(Debug)]
 pub(crate) struct SpannFetchPlOutput {
     pub(crate) posting_list: Vec<SpannPosting>,
-    pub(crate) head_id: u32,
 }
 
 #[derive(Error, Debug)]
@@ -58,10 +57,7 @@ impl Operator<SpannFetchPlInput<'_>, SpannFetchPlOutput> for SpannFetchPlOperato
                     .fetch_posting_list(input.head_id)
                     .await
                     .map_err(|_| SpannFetchPlError::SpannSegmentReaderError)?;
-                Ok(SpannFetchPlOutput {
-                    posting_list,
-                    head_id: input.head_id,
-                })
+                Ok(SpannFetchPlOutput { posting_list })
             }
             None => {
                 return Err(SpannFetchPlError::SpannSegmentReaderCreationError);

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_distance::{normalize, DistanceFunction};
@@ -61,7 +59,6 @@ pub struct SpannKnnOrchestrator {
     heads_searched: bool,
     num_outstanding_bf_pl: usize,
     bruteforce_log_done: bool,
-    pl_spans: HashMap<u32, Span>,
 
     // Knn output
     records: Vec<Vec<RecordDistance>>,
@@ -114,7 +111,6 @@ impl SpannKnnOrchestrator {
             heads_searched: false,
             num_outstanding_bf_pl: 0,
             bruteforce_log_done: false,
-            pl_spans: HashMap::new(),
             records: Vec::new(),
             merge: KnnMerge { fetch: k as u32 },
             knn_projection,
@@ -270,12 +266,6 @@ impl Handler<TaskResult<SpannCentersSearchOutput, SpannCentersSearchError>>
         self.num_outstanding_bf_pl = output.center_ids.len();
         // Spawn fetch posting list tasks for the centers.
         for head_id in output.center_ids {
-            let pl_span = tracing::info_span!(
-                parent: Span::current(),
-                "Fetch posting list",
-                head_id = head_id,
-            );
-            self.pl_spans.insert(head_id as u32, pl_span.clone());
             // Invoke Head search operator.
             let fetch_pl_task = wrap(
                 Box::new(self.fetch_pl.clone()),
@@ -287,7 +277,7 @@ impl Handler<TaskResult<SpannCentersSearchOutput, SpannCentersSearchError>>
                 self.context.task_cancellation_token.clone(),
             );
 
-            self.send(fetch_pl_task, ctx, Some(pl_span)).await;
+            self.send(fetch_pl_task, ctx, Some(Span::current())).await;
         }
     }
 }
@@ -305,10 +295,6 @@ impl Handler<TaskResult<SpannFetchPlOutput, SpannFetchPlError>> for SpannKnnOrch
             Some(output) => output,
             None => return,
         };
-        let pl_span = self
-            .pl_spans
-            .remove(&output.head_id)
-            .unwrap_or_else(Span::current);
         // Spawn brute force posting list task.
         let bf_pl_task = wrap(
             Box::new(self.bf_pl.clone()),
@@ -327,7 +313,7 @@ impl Handler<TaskResult<SpannFetchPlOutput, SpannFetchPlError>> for SpannKnnOrch
             self.context.task_cancellation_token.clone(),
         );
 
-        self.send(bf_pl_task, ctx, Some(pl_span)).await;
+        self.send(bf_pl_task, ctx, Some(Span::current())).await;
     }
 }
 


### PR DESCRIPTION
## Description of changes


- Improvements & Bug fixes
  - Removes really spammy spans
  - Also adds ability to log slow operations by adding a RAII guard that tracks the duration of the operation. Used it to log slow cold block gets and slow sparse index fetches as an expt
- New functionality
  - ...

## Test plan
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
Observe on staging

## Documentation Changes
None
