### PR TITLE
[ENH]: Add HNSW loading from memory to the write path

### DIFF
--- a/rust/index/src/hnsw.rs
+++ b/rust/index/src/hnsw.rs
@@ -267,6 +267,12 @@ impl PersistentIndex<HnswIndexConfig> for HnswIndex {
             distance_function: index_config.distance_function.clone(),
         })
     }
+
+    fn serialize_to_hnsw_data(&self) -> Result<hnswlib::HnswData, WrappedHnswError> {
+        self.index
+            .serialize_index_to_hnsw_data()
+            .map_err(WrappedHnswError)
+    }
 }
 
 fn map_distance_function(distance_function: DistanceFunction) -> hnswlib::HnswDistanceFunction {

--- a/rust/index/src/spann/types.rs
+++ b/rust/index/src/spann/types.rs
@@ -2304,7 +2304,7 @@ impl SpannIndexWriter {
                         let index_guard = self.hnsw_index.inner.read();
                         (index_guard.hnsw_index.id, index_guard.prefix_path.clone())
                     };
-                    (id, prefix_path, self.hnsw_index)
+                    (id, prefix_path, self.hnsw_index.clone())
                 }
             };
             self.hnsw_provider.commit(hnsw_index).map_err(|e| {
@@ -2326,6 +2326,7 @@ impl SpannIndexWriter {
                 provider: self.hnsw_provider,
                 prefix_path,
                 index_id: hnsw_id,
+                hnsw_index: self.hnsw_index,
             },
             collection_id: self.collection_id,
             metrics: SpannIndexFlusherMetrics {
@@ -2442,7 +2443,11 @@ impl SpannIndexFlusher {
             );
             self.hnsw_flusher
                 .provider
-                .flush(&self.hnsw_flusher.prefix_path, &self.hnsw_flusher.index_id)
+                .flush(
+                    &self.hnsw_flusher.prefix_path,
+                    &self.hnsw_flusher.index_id,
+                    &self.hnsw_flusher.hnsw_index,
+                )
                 .await
                 .map_err(|e| {
                     tracing::error!("Error flushing hnsw index {}: {}", res.hnsw_id, e);

--- a/rust/index/src/types.rs
+++ b/rust/index/src/types.rs
@@ -2,6 +2,8 @@ use chroma_distance::DistanceFunction;
 use chroma_error::ChromaError;
 use uuid::Uuid;
 
+use crate::WrappedHnswError;
+
 #[derive(Clone, Debug)]
 pub struct IndexConfig {
     pub dimensionality: i32,
@@ -79,6 +81,8 @@ pub trait PersistentIndex<C>: Index<C> {
     ) -> Result<Self, Box<dyn ChromaError>>
     where
         Self: Sized;
+
+    fn serialize_to_hnsw_data(&self) -> Result<hnswlib::HnswData, WrappedHnswError>;
 }
 
 /// IndexUuid is a wrapper around Uuid to provide a type for the index id.

--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -265,7 +265,7 @@ impl DistributedHNSWSegmentWriter {
         };
         match self
             .hnsw_index_provider
-            .flush(&prefix_path, &hnsw_index_id)
+            .flush(&prefix_path, &hnsw_index_id, &self.index)
             .await
         {
             Ok(_) => {}

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -447,12 +447,11 @@ impl Configurable<(CompactionServiceConfig, System)> for CompactionManager {
         )
         .await?;
 
-        // TODO(tanujnay112): Remove this after we support loading hnsw from memory
-        // on the write path.
-        let mut hnsw_config = config.hnsw_provider.clone();
-        hnsw_config.use_direct_hnsw = false;
-        let hnsw_index_provider =
-            HnswIndexProvider::try_from_config(&(hnsw_config, storage.clone()), registry).await?;
+        let hnsw_index_provider = HnswIndexProvider::try_from_config(
+            &(config.hnsw_provider.clone(), storage.clone()),
+            registry,
+        )
+        .await?;
 
         let spann_provider = SpannProvider::try_from_config(
             &(


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - This change opens up functionality for the Spann write path to also avoid using a disk intermediary for its HNSW indexes.
- New functionality
  - As described above, this would still be gated by the `load_hnsw_from_memory` config flag for `hnsw_provider`.

## Test plan

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
