### PR TITLE
[CHORE] add metrics for metering events sent to receiver

### DIFF
--- a/rust/metering/src/errors.rs
+++ b/rust/metering/src/errors.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MeteringError {
+    #[error("Unable to send meter event: {0}")]
+    SendError(String),
+}

--- a/rust/metering/src/lib.rs
+++ b/rust/metering/src/lib.rs
@@ -1,4 +1,5 @@
 mod core;
+mod errors;
 mod receiver;
 mod types;
 
@@ -10,5 +11,6 @@ pub use {
         MeterEvent, MeteredFutureExt, PulledLogSizeBytes, QueryEmbeddingCount, ReadAction,
         ReturnBytes, StartRequest, WriteAction,
     },
+    errors::MeteringError,
     types::{MeteringAtomicU64, MeteringInstant},
 };


### PR DESCRIPTION
## Description of changes

Adds a metric for metering events sent by the frontend to the metering event receiver.

## Test plan

- Tested in Jaeger
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
