### PR TITLE
[CHORE] trace exact send error

### DIFF
--- a/rust/system/src/receiver.rs
+++ b/rust/system/src/receiver.rs
@@ -51,8 +51,8 @@ where
 // Errors
 #[derive(Error, Debug)]
 pub enum ChannelError {
-    #[error("Failed to send message")]
-    SendError,
+    #[error("Failed to send message: {0}")]
+    SendError(String),
 }
 
 impl ChromaError for ChannelError {

--- a/rust/system/src/types.rs
+++ b/rust/system/src/types.rs
@@ -177,7 +177,7 @@ impl<C: Component> ComponentSender<C> {
     {
         self.sender
             .try_send(WrappedMessage::new(message, None, tracing_context))
-            .map_err(|_| ChannelError::SendError)
+            .map_err(|error| ChannelError::SendError(error.to_string()))
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Description of changes

Trace the exact send error

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A