### PR TITLE
[BUG]  Proxy wal3's backoff error without log contention.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -3800,6 +3800,9 @@ mod tests {
                     .expect("Logs should be valid"),
             });
             if let Err(err) = server.push_logs(proto_push_log_req).await {
+                if err.code() == Code::Unavailable {
+                    sleep(Duration::from_milllis(500)).await;
+                }
                 println!("Failed to push log: {err}");
             } else {
                 break;
@@ -3808,7 +3811,7 @@ mod tests {
             if retries >= 6 {
                 panic!("Unable to push log within six retries");
             }
-            sleep(Duration::from_millis(150)).await;
+            sleep(Duration::from_millis(1)).await;
         }
     }
 

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -3808,7 +3808,7 @@ mod tests {
             if retries >= 6 {
                 panic!("Unable to push log within six retries");
             }
-            sleep(Duration::from_millis(1)).await;
+            sleep(Duration::from_millis(150)).await;
         }
     }
 

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -3801,7 +3801,7 @@ mod tests {
             });
             if let Err(err) = server.push_logs(proto_push_log_req).await {
                 if err.code() == Code::Unavailable {
-                    sleep(Duration::from_milllis(500)).await;
+                    sleep(Duration::from_millis(500)).await;
                 }
                 println!("Failed to push log: {err}");
             } else {

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1150,7 +1150,7 @@ impl ChromaError for AddCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
             AddCollectionRecordsError::Collection(err) => err.code(),
-            AddCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
+            AddCollectionRecordsError::Backoff => ErrorCodes::ResourceExhausted,
             AddCollectionRecordsError::Other(err) => err.code(),
         }
     }
@@ -1212,7 +1212,7 @@ pub enum UpdateCollectionRecordsError {
 impl ChromaError for UpdateCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            UpdateCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
+            UpdateCollectionRecordsError::Backoff => ErrorCodes::ResourceExhausted,
             UpdateCollectionRecordsError::Other(err) => err.code(),
         }
     }
@@ -1275,7 +1275,7 @@ pub enum UpsertCollectionRecordsError {
 impl ChromaError for UpsertCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
-            UpsertCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
+            UpsertCollectionRecordsError::Backoff => ErrorCodes::ResourceExhausted,
             UpsertCollectionRecordsError::Other(err) => err.code(),
         }
     }
@@ -1338,7 +1338,7 @@ impl ChromaError for DeleteCollectionRecordsError {
     fn code(&self) -> ErrorCodes {
         match self {
             DeleteCollectionRecordsError::Get(err) => err.code(),
-            DeleteCollectionRecordsError::Backoff => ErrorCodes::Unavailable,
+            DeleteCollectionRecordsError::Backoff => ErrorCodes::ResourceExhausted,
             DeleteCollectionRecordsError::Internal(err) => err.code(),
         }
     }

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -391,6 +391,9 @@ impl LogWriter {
                         }
                     }
                 }
+                Err(Error::Backoff) => {
+                    return Err(Error::Backoff);
+                }
                 Err(err) => {
                     let mut inner = self.inner.lock().unwrap();
                     if inner.epoch == epoch {


### PR DESCRIPTION
## Description of changes

Prior to this fix, a backoff error generated from pushing too many logs
would generate the scary, "log contention and your data may or may not
be durable."  Tested that it now generates a Backoff properly.  Then,
make Backoff map to a 429, not a 5xx.

## Test plan

Manual testing + CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
