### PR TITLE
[BUG] Sparse vector index incorrect blockfile path

### DIFF
--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -117,8 +117,8 @@ impl<'me> MetadataSegmentWriter<'me> {
             return Err(MetadataSegmentError::InvalidSegmentType);
         }
         // NOTE: We hope that all blockfiles of the same collection should live under the same prefix.
-        // But according to the implementation above the forking child collection will live under the root
-        // collection prefix. Although this is not a desired behavior, as a temporary fix we create the sparse
+        // The implementation below implies all collections in the fork tree share the same prefix for
+        // blockfiles. Although this is not a desired behavior, as a temporary fix we create the sparse
         // vector index blockfiles under the same prefix as other blockfiles if they are present.
         let prefix_path =
             if let Some(existing_file_path) = segment.file_path.values().flatten().next() {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - After collection fork, the sparse vector blockfile are put under the child collection prefix, which is inconsistent to the existing behavior where new blockfiles are put under the root collection prefix. Although the long term fix is to move all new blockfiles after fork under child collection prefix, as a temporary workaround we just put the sparse vector blockfiles under the root collection as well. 
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
