### PR TITLE
[BUG] No go errors for GetAllCollectionInfoToCompact.

### DIFF
--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -30,7 +30,7 @@ func (s *logServer) ForkLogs(ctx context.Context, req *logservicepb.ForkLogsRequ
 }
 
 func (s *logServer) GetAllCollectionInfoToCompact(ctx context.Context, req *logservicepb.GetAllCollectionInfoToCompactRequest) (res *logservicepb.GetAllCollectionInfoToCompactResponse, err error) {
-	return nil, errors.New("Go log service doesn't support GetAllCollectionInfoToCompact; migrated to Rust")
+	return nil, nil
 }
 
 func (s *logServer) UpdateCollectionLogOffset(ctx context.Context, req *logservicepb.UpdateCollectionLogOffsetRequest) (res *logservicepb.UpdateCollectionLogOffsetResponse, err error) {

--- a/go/pkg/log/server/server.go
+++ b/go/pkg/log/server/server.go
@@ -30,7 +30,8 @@ func (s *logServer) ForkLogs(ctx context.Context, req *logservicepb.ForkLogsRequ
 }
 
 func (s *logServer) GetAllCollectionInfoToCompact(ctx context.Context, req *logservicepb.GetAllCollectionInfoToCompactRequest) (res *logservicepb.GetAllCollectionInfoToCompactResponse, err error) {
-	return nil, nil
+	res = &logservicepb.GetAllCollectionInfoToCompactResponse{}
+	return
 }
 
 func (s *logServer) UpdateCollectionLogOffset(ctx context.Context, req *logservicepb.UpdateCollectionLogOffsetRequest) (res *logservicepb.UpdateCollectionLogOffsetResponse, err error) {


### PR DESCRIPTION
## Description of changes

During the re-apply I dropped this change.  It's causing the go service
to fail with an error contacting the old log.

## Test plan

CI

## Migration plan

N/A

## Observability plan

errors meet zero

## Documentation Changes

N/A
