### PR TITLE
[DOC] Add quota for max # of records per write op

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/cloud/quotas-limits.md
+++ b/docs/docs.trychroma.com/markdoc/content/cloud/quotas-limits.md
@@ -28,6 +28,7 @@ Most quotas can be increased upon request. If your application requires higher l
 | Maximum number of collections | 1,000,000 |
 | Maximum number of records per collection | 5,000,000 |
 | Maximum fork edges from root | 4,096 |
+| Maximum number of records per write | 300 |
 
 These limits apply per request or per collection as appropriate. For example, concurrent read/write limits are tracked independently per collection, and full-text query limits apply to the length of the input string, not the number of documents searched.
 


### PR DESCRIPTION
## Description of changes

Update quota docs with max number of records per write operation
- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
