### PR TITLE
[CHORE]  Refactor the log client to always use memberlist.

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -761,15 +761,9 @@ mod tests {
             port: 50055,
             root_cache_config: Default::default(),
             jemalloc_pprof_server_port: None,
-            log: LogConfig::Grpc(GrpcLogConfig {
-                host: "localhost".to_string(),
-                port: 50054,
-                alt_host: Some("localhost".to_string()),
-                ..Default::default()
-            }),
+            log: LogConfig::Grpc(GrpcLogConfig::default()),
             enable_log_gc_for_tenant: Vec::new(),
-            enable_log_gc_for_tenant_threshold: "tenant-ffffffff-ffff-ffff-ffff-ffffffffffff"
-                .to_string(),
+            enable_log_gc_for_tenant_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff".to_string(),
             enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
         };
         let registry = Registry::new();
@@ -901,12 +895,7 @@ mod tests {
             jemalloc_pprof_server_port: None,
             enable_log_gc_for_tenant: Vec::new(),
             enable_log_gc_for_tenant_threshold: "tenant-threshold".to_string(),
-            log: LogConfig::Grpc(GrpcLogConfig {
-                host: "localhost".to_string(),
-                port: 50054,
-                alt_host: Some("localhost".to_string()),
-                ..Default::default()
-            }),
+            log: LogConfig::Grpc(GrpcLogConfig::default()),
             enable_dangerous_option_to_ignore_min_versions_for_wal3: false,
         };
         let registry = Registry::new();
@@ -1108,14 +1097,8 @@ mod tests {
             root_cache_config: Default::default(),
             jemalloc_pprof_server_port: None,
             enable_log_gc_for_tenant: Vec::new(),
-            enable_log_gc_for_tenant_threshold:
-                "tenant-delete-mode-ffffffff-ffff-ffff-ffff-ffffffffffff".to_string(),
-            log: LogConfig::Grpc(GrpcLogConfig {
-                host: "localhost".to_string(),
-                port: 50054,
-                alt_host: Some("localhost".to_string()),
-                ..Default::default()
-            }),
+            enable_log_gc_for_tenant_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff".to_string(),
+            log: LogConfig::Grpc(GrpcLogConfig::default()),
             ..Default::default()
         };
         let registry = Registry::new();

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -117,12 +117,7 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                 .await
                 .unwrap();
             let system = System::new();
-            let log_config = LogConfig::Grpc(GrpcLogConfig {
-                host: "localhost".to_string(),
-                port: 50054,
-                alt_host: Some("localhost".to_string()),
-                ..Default::default()
-            });
+            let log_config = LogConfig::Grpc(GrpcLogConfig::default());
             let logs = Log::try_from_config(&(log_config, system), &registry)
                 .await
                 .unwrap();

--- a/rust/log/src/config.rs
+++ b/rust/log/src/config.rs
@@ -3,10 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Clone, Serialize, Debug)]
 pub struct GrpcLogConfig {
-    #[serde(default = "GrpcLogConfig::default_host")]
-    pub host: String,
-    #[serde(default = "GrpcLogConfig::default_port")]
-    pub port: u16,
     #[serde(default = "GrpcLogConfig::default_connect_timeout_ms")]
     pub connect_timeout_ms: u64,
     #[serde(default = "GrpcLogConfig::default_request_timeout_ms")]
@@ -15,20 +11,6 @@ pub struct GrpcLogConfig {
     pub max_encoding_message_size: usize,
     #[serde(default = "GrpcLogConfig::default_max_decoding_message_size")]
     pub max_decoding_message_size: usize,
-    // NOTE(rescrv):  This is a hack to allow us to test migrate between two log services without
-    // breaking things or having a hard cut-over.  If alt_host_threshold is specified, it will be
-    // interpreted as a u128 (UUID == u128) and if the collection in question is <=
-    // alt_host_threshold, it go to the alt-host first.
-    //
-    // alt tenants/collections will always initialize a new log
-    #[serde(default = "Option::default")]
-    pub alt_host: Option<String>,
-    #[serde(default)]
-    pub use_alt_for_tenants: Vec<String>,
-    #[serde(default)]
-    pub use_alt_for_collections: Vec<String>,
-    #[serde(default = "Option::default")]
-    pub alt_host_threshold: Option<String>,
     #[serde(default = "GrpcLogConfig::default_memberlist_provider")]
     pub memberlist_provider: chroma_memberlist::config::MemberlistProviderConfig,
     #[serde(default = "GrpcLogConfig::default_assignment")]
@@ -36,14 +18,6 @@ pub struct GrpcLogConfig {
 }
 
 impl GrpcLogConfig {
-    fn default_host() -> String {
-        "logservice.chroma".to_string()
-    }
-
-    fn default_port() -> u16 {
-        50051
-    }
-
     fn default_connect_timeout_ms() -> u64 {
         5000
     }
@@ -82,16 +56,10 @@ impl GrpcLogConfig {
 impl Default for GrpcLogConfig {
     fn default() -> Self {
         GrpcLogConfig {
-            host: GrpcLogConfig::default_host(),
-            port: GrpcLogConfig::default_port(),
             connect_timeout_ms: GrpcLogConfig::default_connect_timeout_ms(),
             request_timeout_ms: GrpcLogConfig::default_request_timeout_ms(),
             max_encoding_message_size: GrpcLogConfig::default_max_encoding_message_size(),
             max_decoding_message_size: GrpcLogConfig::default_max_decoding_message_size(),
-            alt_host: None,
-            use_alt_for_tenants: vec![],
-            use_alt_for_collections: vec![],
-            alt_host_threshold: None,
             memberlist_provider: GrpcLogConfig::default_memberlist_provider(),
             assignment: GrpcLogConfig::default_assignment(),
         }

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -15,7 +15,6 @@ use chroma_memberlist::memberlist_provider::{
     CustomResourceMemberlistProvider, MemberlistProvider,
 };
 use chroma_system::System;
-use chroma_tracing::GrpcClientTraceService;
 use chroma_types::chroma_proto::log_service_client::LogServiceClient;
 use chroma_types::chroma_proto::{self, GetAllCollectionInfoToCompactResponse};
 use chroma_types::{
@@ -24,7 +23,7 @@ use chroma_types::{
 use std::fmt::Debug;
 use std::time::Duration;
 use thiserror::Error;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::Endpoint;
 use tower::ServiceBuilder;
 use tracing::Level;
 use uuid::Uuid;
@@ -159,6 +158,8 @@ impl ChromaError for GrpcPurgeDirtyForCollectionError {
 
 #[derive(Error, Debug)]
 pub enum GrpcSealLogError {
+    #[error("Failed to seal collection: Seal has been removed")]
+    NoMoreSeal,
     #[error("Failed to seal collection: {0}")]
     FailedToSeal(#[from] tonic::Status),
     #[error(transparent)]
@@ -168,6 +169,7 @@ pub enum GrpcSealLogError {
 impl ChromaError for GrpcSealLogError {
     fn code(&self) -> ErrorCodes {
         match self {
+            GrpcSealLogError::NoMoreSeal => ErrorCodes::Unimplemented,
             GrpcSealLogError::FailedToSeal(_) => ErrorCodes::Internal,
             GrpcSealLogError::ClientAssignerError(e) => e.code(),
         }
@@ -217,22 +219,16 @@ impl Default for GrpcLogMetrics {
 #[derive(Clone, Debug)]
 pub struct GrpcLog {
     config: GrpcLogConfig,
-    client: LogClient,
-    alt_client_assigner: Option<ClientAssigner<LogClient>>,
+    client_assigner: ClientAssigner<LogClient>,
     metrics: GrpcLogMetrics,
 }
 
 impl GrpcLog {
     #[allow(clippy::type_complexity)]
-    pub fn new(
-        config: GrpcLogConfig,
-        client: LogClient,
-        alt_client_assigner: Option<ClientAssigner<LogClient>>,
-    ) -> Self {
+    pub fn new(config: GrpcLogConfig, client_assigner: ClientAssigner<LogClient>) -> Self {
         Self {
             config,
-            client,
-            alt_client_assigner,
+            client_assigner,
             metrics: GrpcLogMetrics::default(),
         }
     }
@@ -258,16 +254,7 @@ impl Configurable<(GrpcLogConfig, System)> for GrpcLog {
         my_config: &(GrpcLogConfig, System),
         registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
-        // NOTE(rescrv):  This code is duplicated with primary_client_from_config below.  A transient hack.
         let (my_config, system) = my_config;
-        let host = &my_config.host;
-        let port = &my_config.port;
-        let connection_string = format!("http://{}:{}", host, port);
-        let client = client_for_conn_str(connection_string, my_config.clone())
-            .await
-            .map_err(|err| Box::new(GrpcLogError::FailedToConnect(err)) as Box<dyn ChromaError>)?;
-
-        // Alt client manager setup
         let assignment_policy =
             Box::<dyn AssignmentPolicy>::try_from_config(&my_config.assignment, registry).await?;
         let client_assigner = ClientAssigner::new(assignment_policy, 1);
@@ -292,98 +279,30 @@ impl Configurable<(GrpcLogConfig, System)> for GrpcLog {
         memberlist_provider.subscribe(client_manager_handle.receiver());
         let _memberlist_provider_handle = system.start_component(memberlist_provider);
 
-        return Ok(GrpcLog::new(
-            my_config.clone(),
-            client,
-            Some(client_assigner),
-        ));
+        return Ok(GrpcLog::new(my_config.clone(), client_assigner));
     }
-}
-
-async fn client_for_conn_str(
-    connection_string: String,
-    my_config: GrpcLogConfig,
-) -> Result<LogServiceClient<GrpcClientTraceService<Channel>>, tonic::transport::Error> {
-    tracing::info!("Connecting to log service at {}", connection_string);
-    let endpoint_res = Endpoint::from_shared(connection_string)?;
-    let endpoint_res = endpoint_res
-        .connect_timeout(Duration::from_millis(my_config.connect_timeout_ms))
-        .timeout(Duration::from_millis(my_config.request_timeout_ms));
-    let channel = endpoint_res.connect().await?;
-    let channel = ServiceBuilder::new()
-        .layer(chroma_tracing::GrpcClientTraceLayer)
-        .service(channel);
-    let client = LogServiceClient::new(channel)
-        .max_encoding_message_size(my_config.max_encoding_message_size)
-        .max_decoding_message_size(my_config.max_decoding_message_size);
-    Ok(client)
 }
 
 impl GrpcLog {
-    // NOTE(rescrv) This is a transient hack, so the code duplication is not worth eliminating.
-    pub async fn primary_client_from_config(
-        my_config: &GrpcLogConfig,
-    ) -> Result<
-        LogServiceClient<chroma_tracing::GrpcClientTraceService<tonic::transport::Channel>>,
-        Box<dyn ChromaError>,
-    > {
-        let host = &my_config.host;
-        let port = &my_config.port;
-        let connection_string = format!("http://{}:{}", host, port);
-        client_for_conn_str(connection_string, my_config.clone())
-            .await
-            .map_err(|err| Box::new(GrpcLogError::FailedToConnect(err)) as Box<dyn ChromaError>)
-    }
-
-    fn client_is_on_alt_log(to_evaluate: CollectionUuid, alt_host_threshold: Option<&str>) -> bool {
-        if let Some(alt_host_threshold) = alt_host_threshold {
-            let Ok(alt_host_threshold) = Uuid::parse_str(alt_host_threshold) else {
-                tracing::error!("alt_host_threshold must be a valid UUID");
-                return false;
-            };
-            let to_evaluate = to_evaluate.0.as_u64_pair().0;
-            let alt_host_threshold = alt_host_threshold.as_u64_pair().0;
-            to_evaluate <= alt_host_threshold
-        } else {
-            false
-        }
-    }
-
     fn client_for(
         &mut self,
-        tenant: &str,
+        _tenant: &str,
         collection_id: CollectionUuid,
     ) -> Result<
         LogServiceClient<chroma_tracing::GrpcClientTraceService<tonic::transport::Channel>>,
         ClientAssignmentError,
     > {
-        if let Some(client_assigner) = self.alt_client_assigner.as_mut() {
-            if self.config.use_alt_for_tenants.iter().any(|t| t == tenant)
-                || self
-                    .config
-                    .use_alt_for_collections
-                    .contains(&collection_id.to_string())
-                || Self::client_is_on_alt_log(
-                    collection_id,
-                    self.config.alt_host_threshold.as_deref(),
-                )
-            {
-                tracing::info!("using alt client for {collection_id}");
-                // Replication factor is always 1 for log service so we grab the first assigned client.
-                // NOTE(hammadb): This err should never be returned, ideally the clients() call
-                // would return a provably non-empty vector, but in lieu of that, or panic'ing
-                // on a impossible state, we return the underlying error here.
-                return client_assigner
-                    .clients(&collection_id.to_string())?
-                    .drain(..)
-                    .next()
-                    .ok_or(ClientAssignmentError::NoClientFound(
-                        "Impossible state: no client found for collection".to_string(),
-                    ));
-            }
-        }
-        tracing::info!("using standard client for {collection_id}");
-        Ok(self.client.clone())
+        // Replication factor is always 1 for log service so we grab the first assigned client.
+        // NOTE(hammadb): This err should never be returned, ideally the clients() call
+        // would return a provably non-empty vector, but in lieu of that, or panic'ing
+        // on a impossible state, we return the underlying error here.
+        self.client_assigner
+            .clients(&collection_id.to_string())?
+            .drain(..)
+            .next()
+            .ok_or(ClientAssignmentError::NoClientFound(
+                "Impossible state: no client found for collection".to_string(),
+            ))
     }
 
     // ScoutLogs returns the offset of the next record to be inserted into the log.
@@ -535,86 +454,18 @@ impl GrpcLog {
         &mut self,
         min_compaction_size: u64,
     ) -> Result<Vec<CollectionInfo>, GrpcGetCollectionsWithNewDataError> {
-        let mut norm = match self
-            ._get_collections_with_new_data(false, min_compaction_size)
-            .await
-        {
-            Ok(colls) => colls,
-            Err(err) => {
-                tracing::error!("could not contact old log: {err:?}");
-                vec![]
-            }
-        };
-        if self.config.alt_host_threshold.is_some()
-            || !self.config.use_alt_for_tenants.is_empty()
-            || !self.config.use_alt_for_collections.is_empty()
-        {
-            let alt = match self
-                ._get_collections_with_new_data(true, min_compaction_size)
-                .await
-            {
-                Ok(alt) => alt,
-                Err(err) => {
-                    tracing::error!("could not contact new log: {err:?}");
-                    vec![]
-                }
-            };
-            norm.extend(alt);
-        }
-        norm.sort_by_key(|x| (x.collection_id, x.first_log_offset));
-        norm.dedup_by_key(|x| x.collection_id);
-        Ok(norm)
-    }
-
-    async fn _get_collections_with_new_data(
-        &mut self,
-        use_alt_log: bool,
-        min_compaction_size: u64,
-    ) -> Result<Vec<CollectionInfo>, GrpcGetCollectionsWithNewDataError> {
         let mut combined_response = Vec::new();
         let mut error = None;
 
-        if use_alt_log {
-            // Iterate over all alt clients and gather collections
-            if let Some(alt_client_assigner) = self.alt_client_assigner.as_ref() {
-                let mut all_alt_clients = alt_client_assigner.all();
-                if all_alt_clients.is_empty() {
-                    tracing::error!(
-                        "No alt clients available for getting collections with new data"
-                    );
-                    return Ok(vec![]);
-                }
-                for mut alt_client in all_alt_clients.drain(..) {
-                    // We error if any subrequest errors
-                    match alt_client
-                        .get_all_collection_info_to_compact(
-                            chroma_proto::GetAllCollectionInfoToCompactRequest {
-                                min_compaction_size,
-                            },
-                        )
-                        .await
-                    {
-                        Ok(response) => {
-                            combined_response.push(response.into_inner());
-                        }
-                        Err(err) => {
-                            tracing::error!("could not get all collection info to compact: {err}");
-                            if error.is_none() {
-                                error = Some(err);
-                            }
-                            continue;
-                        }
-                    };
-                }
-            } else {
-                tracing::warn!(
-                    "No alt client assigner available for getting collections with new data"
-                );
-                return Ok(vec![]);
-            }
-        } else {
-            match self
-                .client
+        // Iterate over all alt clients and gather collections
+        let mut all_alt_clients = self.client_assigner.all();
+        if all_alt_clients.is_empty() {
+            tracing::error!("No alt clients available for getting collections with new data");
+            return Ok(vec![]);
+        }
+        for mut alt_client in all_alt_clients.drain(..) {
+            // We error if any subrequest errors
+            match alt_client
                 .get_all_collection_info_to_compact(
                     chroma_proto::GetAllCollectionInfoToCompactRequest {
                         min_compaction_size,
@@ -630,9 +481,10 @@ impl GrpcLog {
                     if error.is_none() {
                         error = Some(err);
                     }
+                    continue;
                 }
             };
-        };
+        }
         if let Some(status) = error {
             if combined_response.is_empty() {
                 return Err(status.into());
@@ -673,7 +525,6 @@ impl GrpcLog {
         // servers.  To not panic the compactor, we sort by (collection_id, offset) and then dedup.
         all_collections.sort_by_key(|x| (x.collection_id, x.first_log_offset));
         all_collections.dedup_by_key(|x| x.collection_id);
-
         Ok(all_collections)
     }
 
@@ -702,11 +553,8 @@ impl GrpcLog {
         collection_id: CollectionUuid,
         new_offset: i64,
     ) -> Result<(), GrpcUpdateCollectionLogOffsetError> {
-        let Some(assigner) = self.alt_client_assigner.as_mut() else {
-            return Ok(());
-        };
         let mut res = Ok(());
-        for client in assigner.all().into_iter() {
+        for client in self.client_assigner.all().into_iter() {
             let mut client = client.clone();
             let request = client.update_collection_log_offset(
                 chroma_proto::UpdateCollectionLogOffsetRequest {
@@ -732,12 +580,9 @@ impl GrpcLog {
         &mut self,
         collection_ids: Vec<CollectionUuid>,
     ) -> Result<(), GrpcPurgeDirtyForCollectionError> {
-        let Some(assigner) = self.alt_client_assigner.as_mut() else {
-            return Ok(());
-        };
         let mut futures = vec![];
         let limiter = Arc::new(tokio::sync::Semaphore::new(10));
-        for client in assigner.all().into_iter() {
+        for client in self.client_assigner.all().into_iter() {
             let mut client = client.clone();
             let limiter = Arc::clone(&limiter);
             let collection_ids_clone = collection_ids.clone();
@@ -764,81 +609,36 @@ impl GrpcLog {
         Ok(())
     }
 
-    pub async fn seal_log(
-        &mut self,
-        collection_id: CollectionUuid,
-    ) -> Result<(), GrpcSealLogError> {
-        // NOTE(rescrv):  Seal log only goes to the go log service, so use the classic connection.
-        let _response = self
-            .client
-            .seal_log(chroma_proto::SealLogRequest {
-                collection_id: collection_id.to_string(),
-            })
-            .await?;
-        Ok(())
-    }
-
-    pub async fn migrate_log(
-        &mut self,
-        collection_id: CollectionUuid,
-    ) -> Result<(), GrpcMigrateLogError> {
-        // NOTE(rescrv): Migrate log only goes to the rust log service, so use alt client assigner.
-        if let Some(client_assigner) = self.alt_client_assigner.as_mut() {
-            let mut client = client_assigner
-                .clients(&collection_id.to_string())?
-                .drain(..)
-                .next()
-                .ok_or(ClientAssignmentError::NoClientFound(
-                    "Impossible state: no client found for collection".to_string(),
-                ))?;
-            client
-                .migrate_log(chroma_proto::MigrateLogRequest {
-                    collection_id: collection_id.to_string(),
-                })
-                .await?;
-            Ok(())
-        } else {
-            Err(GrpcMigrateLogError::NotSupported)
-        }
-    }
-
     /// If the log client is configured to use a memberlist-based client assigner,
     /// this function checks if the client assigner is ready to serve requests.
     /// This is useful to ensure that the client assigner has enough information about the cluster
     /// before making requests to the log service.
     pub fn is_ready(&self) -> bool {
-        if let Some(client_assigner) = &self.alt_client_assigner {
-            !client_assigner.is_empty()
-        } else {
-            true // If no client assigner is configured, we assume it's ready.
-        }
+        !self.client_assigner.is_empty()
     }
 
     pub async fn garbage_collect_phase2(
         &mut self,
         collection_id: CollectionUuid,
     ) -> Result<(), GarbageCollectError> {
-        if let Some(client_assigner) = self.alt_client_assigner.as_mut() {
-            let mut client = client_assigner
-                .clients(&collection_id.to_string())?
-                .drain(..)
-                .next()
-                .ok_or(ClientAssignmentError::NoClientFound(
-                    "Impossible state: no client found for collection".to_string(),
-                ))?;
-            client
-                .garbage_collect_phase2(chroma_proto::GarbageCollectPhase2Request {
-                    log_to_collect: Some(
-                        chroma_proto::garbage_collect_phase2_request::LogToCollect::CollectionId(
-                            collection_id.to_string(),
-                        ),
+        let mut client = self
+            .client_assigner
+            .clients(&collection_id.to_string())?
+            .drain(..)
+            .next()
+            .ok_or(ClientAssignmentError::NoClientFound(
+                "Impossible state: no client found for collection".to_string(),
+            ))?;
+        client
+            .garbage_collect_phase2(chroma_proto::GarbageCollectPhase2Request {
+                log_to_collect: Some(
+                    chroma_proto::garbage_collect_phase2_request::LogToCollect::CollectionId(
+                        collection_id.to_string(),
                     ),
-                })
-                .await?;
-            Ok(())
-        } else {
-            Err(GarbageCollectError::NotEnabled)
-        }
+                ),
+            })
+            .await?;
+        Ok(())
     }
 
     pub async fn garbage_collect_phase2_for_dirty_log(
@@ -886,30 +686,6 @@ impl GrpcLog {
 mod tests {
     use super::*;
     use chroma_types::chroma_proto::CollectionInfo as ProtoCollectionInfo;
-
-    #[test]
-    fn client_is_on_alt_log() {
-        assert!(!GrpcLog::client_is_on_alt_log(
-            CollectionUuid(Uuid::parse_str("fffdb379-d592-41d1-8de6-412abc6e0b35").unwrap()),
-            None
-        ));
-        assert!(!GrpcLog::client_is_on_alt_log(
-            CollectionUuid(Uuid::parse_str("fffdb379-d592-41d1-8de6-412abc6e0b35").unwrap()),
-            Some("00088272-cfc4-419d-997a-baebfb25034a"),
-        ));
-        assert!(GrpcLog::client_is_on_alt_log(
-            CollectionUuid(Uuid::parse_str("00088272-cfc4-419d-997a-baebfb25034a").unwrap()),
-            Some("fffdb379-d592-41d1-8de6-412abc6e0b35"),
-        ));
-        assert!(GrpcLog::client_is_on_alt_log(
-            CollectionUuid(Uuid::parse_str("fffdb379-d592-41d1-8de6-412abc6e0b35").unwrap()),
-            Some("fffdb379-d592-41d1-8de6-412abc6e0b35"),
-        ));
-        assert!(GrpcLog::client_is_on_alt_log(
-            CollectionUuid(Uuid::parse_str("fffdb379-d592-41d1-8de6-412abc6e0b35").unwrap()),
-            Some("ffffffff-ffff-ffff-ffff-ffffffffffff"),
-        ));
-    }
 
     #[test]
     fn post_process_get_all_returns_smaller_first_log_offset() {

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -243,13 +243,9 @@ impl Log {
         }
     }
 
-    pub async fn seal_log(
-        &mut self,
-        _: &str,
-        collection_id: CollectionUuid,
-    ) -> Result<(), GrpcSealLogError> {
+    pub async fn seal_log(&mut self, _: &str, _: CollectionUuid) -> Result<(), GrpcSealLogError> {
         match self {
-            Log::Grpc(log) => log.seal_log(collection_id).await,
+            Log::Grpc(_) => Err(GrpcSealLogError::NoMoreSeal),
             Log::Sqlite(_) => unimplemented!(),
             Log::InMemory(_) => unimplemented!(),
         }


### PR DESCRIPTION
## Description of changes

This removes the alt client piece from the log client in favor of always
using a memberlist to get the host to contact.

## Test plan

CI + Staging

## Migration plan

Cleanup of a migration in progress.

## Observability plan

No errors.

## Documentation Changes

N/A
