### PR TITLE
[BUG] Allow SparseVector values in metadata for JS

### DIFF
--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -234,7 +234,9 @@ export const validateSparseVector = (v: any) => {
     "indices" in v &&
     "values" in v &&
     Array.isArray(v.indices) &&
-    Array.isArray(v.values)
+    v.indices.every((e: any) => typeof e === "number") &&
+    Array.isArray(v.values) &&
+    v.values.every((e: any) => typeof e === "number")
   );
 };
 

--- a/clients/new-js/packages/chromadb/src/utils.ts
+++ b/clients/new-js/packages/chromadb/src/utils.ts
@@ -227,6 +227,17 @@ export const validateIDs = (ids: string[]) => {
   }
 };
 
+export const validateSparseVector = (v: any) => {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "indices" in v &&
+    "values" in v &&
+    Array.isArray(v.indices) &&
+    Array.isArray(v.values)
+  );
+};
+
 /**
  * Validates metadata object for correct types and non-emptiness.
  * @param metadata - Metadata object to validate
@@ -248,11 +259,12 @@ export const validateMetadata = (metadata?: Metadata) => {
         v === undefined ||
         typeof v === "string" ||
         typeof v === "number" ||
-        typeof v === "boolean",
+        typeof v === "boolean" ||
+        validateSparseVector(v),
     )
   ) {
     throw new ChromaValueError(
-      "Expected metadata to be a string, number, boolean, or nullable",
+      "Expected metadata to be a string, number, boolean, SparseVector, or nullable",
     );
   }
 };


### PR DESCRIPTION
Adding validation for `SparseVector` metadata values in the JS client