### PR TITLE
[CHORE] Bump min stack size because it encounters stack overflow otherwise (rare)

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
+      RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,6 +29,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
+      RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,6 +59,7 @@ jobs:
       id-token: write
     env:
       CARGO_TERM_COLOR: always
+      RUST_MIN_STACK_SIZE: 8388608
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,6 +97,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     env:
       RUST_BACKTRACE: 1
+      RUST_MIN_STACK_SIZE: 8388608
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
@@ -108,6 +112,7 @@ jobs:
   can-build-release:
     runs-on: blacksmith-16vcpu-ubuntu-2404
     env:
+      RUST_MIN_STACK_SIZE: 8388608
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description of changes

For context we're seeing CI failures that overflow the stack.

First attempt is to up the stack size.

2MB was the default.  Now try 8MB.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
