### PR TITLE
[BUG]  Perform read-repair on collections that get written to but have a crash before manifest write.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -611,6 +611,11 @@ impl LogServer {
             collection_id,
             dirty_log: Arc::clone(&self.dirty_log),
         };
+        // NOTE(rescrv):  We use the writer and fall back to constructing a local reader in order
+        // to force a read-repair of the collection when things partially fail.
+        //
+        // The writer will read the manifest, and try to read the next fragment.  This adds
+        // latency, but improves correctness.
         let log = get_log_from_handle_with_mutex_held(
             &handle,
             active,


### PR DESCRIPTION
## Description of changes

Sequence of events:
- write to fragment
- write to dirty log
- crash writer
- compactor picks up dirty log bit
- tries to compact endlessly

This patch performs read repair.

The same loop can happen and require operator intervention when the
dirty log gets written but the fragment does not.
chroma-purge-dirty-log is the remedy for that.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
