### PR TITLE
[ENH] increase cloud quotas in docs + defaults

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/cloud/quotas-limits.md
+++ b/docs/docs.trychroma.com/markdoc/content/cloud/quotas-limits.md
@@ -11,26 +11,28 @@ To ensure the stability and fairness in a multi-tenant environment, Chroma Cloud
 Most quotas can be increased upon request. If your application requires higher limits, please [contact us](mailto:support@trychroma.com).
 {% /Banner %}
 
-| **Quota**                                          | **Value** |
-| -------------------------------------------------- | --------- |
-| Maximum embedding dimensions                       | 3072      |
-| Maximum document bytes                             | 16,384    |
-| Maximum URI bytes                                  | 256       |
-| Maximum ID size bytes                              | 128       |
-| Maximum database name size bytes                   | 128       |
-| Maximum collection name size bytes                 | 128       |
-| Maximum metadata value size bytes                  | 256       |
-| Maximum metadata key size bytes                    | 36        |
-| Maximum number of metadata keys                    | 16        |
-| Maximum number of where predicates                 | 8         |
-| Maximum size of full text search or regex search   | 256       |
-| Maximum number of results returned                 | 300       |
-| Maximum number of concurrent reads per collection  | 5         |
-| Maximum number of concurrent writes per collection | 5         |
-| Maximum number of collections                      | 1,000,000 |
-| Maximum number of records per collection           | 5,000,000 |
-| Maximum fork edges from root                       | 4,096     |
-| Maximum number of records per write                | 300       |
+| **Quota**                                           | **Value**   |
+| --------------------------------------------------- | ----------- |
+| Maximum embedding dimensions                        | 4,096       |
+| Maximum document bytes                              | 16,384      |
+| Maximum URI bytes                                   | 256         |
+| Maximum ID size bytes                               | 128         |
+| Maximum database name size bytes                    | 128         |
+| Maximum collection name size bytes                  | 128         |
+| Maximum record metadata value size bytes            | 4,096       |
+| Maximum collection metadata value size bytes        | 256         |
+| Maximum metadata key size bytes                     | 36          |
+| Maximum number of record metadata keys              | 32          |
+| Maximum number of collection metadata keys          | 32          |
+| Maximum number of where predicates                  | 8           |
+| Maximum size of full text search or regex search    | 256         |
+| Maximum number of results returned                  | 300         |
+| Maximum number of concurrent reads per collection   | 5           |
+| Maximum number of concurrent writes per collection  | 5           |
+| Maximum number of collections                       | 1,000,000   |
+| Maximum number of records per collection            | 5,000,000   |
+| Maximum fork edges from root                        | 4,096       |
+| Maximum number of records per write                 | 300         |
 
 These limits apply per request or per collection as appropriate. For example, concurrent read/write limits are tracked independently per collection, and full-text query limits apply to the length of the input string, not the number of documents searched.
 

--- a/rust/frontend/src/quota/mod.rs
+++ b/rust/frontend/src/quota/mod.rs
@@ -353,7 +353,7 @@ impl DefaultQuota for UsageType {
             UsageType::NumWhereDocumentPredicates => 8,
             UsageType::WhereDocumentValueLength => 130,
             UsageType::NumRecords => 100,
-            UsageType::EmbeddingDimensions => 3072,
+            UsageType::EmbeddingDimensions => 4096,
             UsageType::SparseVectorPopulatedDimensions => 2048,
             UsageType::DocumentSizeBytes => 5000,
             UsageType::UriSizeBytes => 32,


### PR DESCRIPTION
## Description of changes

- Updates cloud docs for latest embedding dimension + metadata quota limits
- Updates rust code for default embedding dimension quota. (Cannot update metadata quota limits here until refactor to support per-action defaults, instead of per-rule defaults). 

## Test plan

n/a

## Migration plan

n/a

## Observability plan

n/a

## Documentation Changes

n/a