### PR TITLE
[ENH] Tenant override for bm25

### DIFF
--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -5,7 +5,7 @@ use chroma_sysdb::SysDbConfig;
 use chroma_tracing::{OtelFilter, OtelFilterLevel};
 use figment::providers::{Env, Format, Yaml};
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 const DEFAULT_CONFIG_PATH: &str = "./chroma_config.yaml";
 
@@ -151,6 +151,8 @@ pub struct QueryServiceConfig {
         default = "QueryServiceConfig::default_grpc_shutdown_grace_period"
     )]
     pub grpc_shutdown_grace_period: Duration,
+    #[serde(default)]
+    pub bm25_tenant: HashSet<String>,
 }
 
 impl QueryServiceConfig {

--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -151,6 +151,8 @@ pub struct QueryServiceConfig {
         default = "QueryServiceConfig::default_grpc_shutdown_grace_period"
     )]
     pub grpc_shutdown_grace_period: Duration,
+    // TODO: This is a temporary config to enable bm25 for certain tenants.
+    // This should be removed once we have collection schema ready.
     #[serde(default)]
     pub bm25_tenant: HashSet<String>,
 }

--- a/rust/worker/src/execution/orchestration/sparse_knn.rs
+++ b/rust/worker/src/execution/orchestration/sparse_knn.rs
@@ -83,8 +83,8 @@ pub struct SparseKnnOrchestrator {
     // Collection information
     collection_and_segments: CollectionAndSegments,
 
-    // Temporary flag to enable BM25
-    // TODO: Remove this when we have schema
+    // TODO: This is a temporary config to enable bm25 for certain tenants.
+    // This should be removed once we have collection schema ready.
     use_bm25: bool,
 
     // Output from KnnFilterOrchestrator

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
@@ -58,6 +58,7 @@ pub struct WorkerServer {
     // config
     fetch_log_batch_size: u32,
     shutdown_grace_period: Duration,
+    bm25_tenant: HashSet<String>,
 }
 
 #[async_trait]
@@ -101,6 +102,7 @@ impl Configurable<(QueryServiceConfig, System)> for WorkerServer {
             jemalloc_pprof_server_port: config.jemalloc_pprof_server_port,
             fetch_log_batch_size: config.fetch_log_batch_size,
             shutdown_grace_period: config.grpc_shutdown_grace_period,
+            bm25_tenant: config.bm25_tenant.clone(),
         })
     }
 }
@@ -556,11 +558,13 @@ impl WorkerServer {
                     }
                     QueryVector::Sparse(query) => {
                         // Use Sparse KNN orchestrator
+                        let tenant = collection_and_segments_clone.collection.tenant.clone();
                         let sparse_orchestrator = SparseKnnOrchestrator::new(
                             blockfile_provider,
                             dispatcher,
                             1000,
                             collection_and_segments_clone,
+                            self.bm25_tenant.contains(&tenant),
                             knn_filter_output_clone,
                             query,
                             knn_query.key.clone(),
@@ -727,6 +731,7 @@ mod tests {
             jemalloc_pprof_server_port: None,
             fetch_log_batch_size: 100,
             shutdown_grace_period: Duration::from_secs(1),
+            bm25_tenant: HashSet::new(),
         };
 
         let dispatcher = Dispatcher::new(DispatcherConfig {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Adds a temporary config to always enable bm25 for certain tenants. This should be removed once we have collection schema ready.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
