### PR TITLE
[ENH] Allow specifying sysdb nodeSelector and tolerations

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.58
+version: 0.1.59
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/sysdb-migration.yaml
+++ b/k8s/distributed-chroma/templates/sysdb-migration.yaml
@@ -25,5 +25,12 @@ spec:
               # TODO properly use flow control here to check which type of value we need.
 {{ .value | nindent 14 }}
             {{ end }}
-
+      {{if .Values.sysdbMigration.tolerations}}
+      tolerations:
+        {{ toYaml .Values.sysdbMigration.tolerations | nindent 8 }}
+      {{ end }}
+      {{if .Values.sysdbMigration.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.sysdbMigration.nodeSelector | nindent 8 }}
+      {{ end }}
 ---

--- a/k8s/distributed-chroma/templates/sysdb-service.yaml
+++ b/k8s/distributed-chroma/templates/sysdb-service.yaml
@@ -56,6 +56,14 @@ spec:
             requests:
               cpu: {{ .Values.sysdb.resources.requests.cpu }}
               memory: {{ .Values.sysdb.resources.requests.memory }}
+      {{if .Values.sysdb.tolerations}}
+      tolerations:
+        {{ toYaml .Values.sysdb.tolerations | nindent 8 }}
+      {{ end }}
+      {{if .Values.sysdb.nodeSelector}}
+      nodeSelector:
+        {{ toYaml .Values.sysdb.nodeSelector | nindent 8 }}
+      {{ end }}
 
 ---
 


### PR DESCRIPTION
## Description of changes

All our other services allow configuring these settings. We should add support for sysdb also.

## Test plan

This is untested -- fairly trivial change.

## Migration plan

N/A (by default these settings will not be changed, unless values overrides are set)

## Observability plan

N/A

## Documentation Changes

N/A (we do not currently document our helm chart values overrides)