### PR TITLE
[BLD]: strip debug symbols from JS bindings

### DIFF
--- a/rust/js_bindings/package.json
+++ b/rust/js_bindings/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --platform --release",
+    "build": "napi build --platform --release --strip",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm-scoped",
     "test": "ava",


### PR DESCRIPTION
## Description of changes

Our published `chromadb-js-bindings-linux-x64-gnu` and `chromadb-js-bindings-linux-arm64-gnu` packages are currently over 400MB. Together they receive > 30k weekly downloads.

The majority of the binary size comes from debug symbols. The `chromadb` PyPi package ships with a similar set of bindings, but properly strips the debug symbols and [its wheels are < 20MB](https://pypi.org/project/chromadb/#files). This PR updates the JS bindings to strip the debug symbols as well.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
