### PR TITLE
[CHORE] Sort SparseEmbeddings in EFs in ascending order

### DIFF
--- a/chromadb/utils/embedding_functions/fastembed_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/fastembed_sparse_embedding_function.py
@@ -6,6 +6,7 @@ from chromadb.api.types import (
 from typing import Dict, Any, TypedDict, Optional
 from typing import cast, Literal
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
+from chromadb.utils.sparse_embedding_utils import _sort_sparse_vectors
 
 TaskType = Literal["document", "query"]
 
@@ -75,6 +76,7 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
                 {"indices": vec.indices.tolist(), "values": vec.values.tolist()}
             )
 
+        _sort_sparse_vectors(sparse_embeddings)
         return sparse_embeddings
 
     def embed_query(self, input: Documents) -> SparseEmbeddings:
@@ -105,6 +107,7 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
                     {"indices": vec.indices.tolist(), "values": vec.values.tolist()}
                 )
 
+            _sort_sparse_vectors(sparse_embeddings)
             return sparse_embeddings
 
         else:

--- a/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, TypedDict, Optional
 import numpy as np
 from typing import cast, Literal
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
+from chromadb.utils.sparse_embedding_utils import _sort_sparse_vectors
 
 TaskType = Literal["document", "query"]
 
@@ -98,6 +99,7 @@ class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
                 {"indices": nz.tolist(), "values": vec_dense[nz].tolist()}
             )
 
+        _sort_sparse_vectors(sparse_embeddings)
         return sparse_embeddings
 
     def embed_query(self, input: Documents) -> SparseEmbeddings:
@@ -134,6 +136,7 @@ class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
                     {"indices": nz.tolist(), "values": vec_dense[nz].tolist()}
                 )
 
+            _sort_sparse_vectors(sparse_embeddings)
             return sparse_embeddings
 
         else:

--- a/chromadb/utils/sparse_embedding_utils.py
+++ b/chromadb/utils/sparse_embedding_utils.py
@@ -1,0 +1,12 @@
+from chromadb.api.types import SparseEmbeddings
+
+
+def _sort_sparse_vectors(vectors: SparseEmbeddings) -> None:
+    for vector in vectors:
+        items = sorted(
+            zip(vector["indices"], vector["values"]), key=lambda pair: pair[0]
+        )
+        if items:
+            indices, values = zip(*items)
+            vector["indices"] = list(indices)
+            vector["values"] = list(values)


### PR DESCRIPTION
## Description of changes

The Embedding functions assume the values returned from the model have indexes sorted in ascending order. This is not true for the BM25 model, so the embedding functions are both updated to sort prior to returning.
- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
