### PR TITLE
[ENH] Update Fastembed embedding function with more parameters, add bm25 embedding function

### DIFF
--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -51,6 +51,7 @@ def test_get_builtins_holds() -> None:
         "DefaultEmbeddingFunction",
         "HuggingFaceSparseEmbeddingFunction",
         "FastembedSparseEmbeddingFunction",
+        "Bm25EmbeddingFunction",
     }
 
     assert expected_builtins == embedding_functions.get_builtins()

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -74,6 +74,9 @@ from chromadb.utils.embedding_functions.huggingface_sparse_embedding_function im
 from chromadb.utils.embedding_functions.fastembed_sparse_embedding_function import (
     FastembedSparseEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.bm25_embedding_function import (
+    Bm25EmbeddingFunction,
+)
 
 try:
     from chromadb.is_thin_client import is_thin_client
@@ -108,6 +111,7 @@ _all_classes: Set[str] = {
     "DefaultEmbeddingFunction",
     "HuggingFaceSparseEmbeddingFunction",
     "FastembedSparseEmbeddingFunction",
+    "Bm25EmbeddingFunction",
 }
 
 
@@ -259,6 +263,7 @@ __all__ = [
     "TogetherAIEmbeddingFunction",
     "HuggingFaceSparseEmbeddingFunction",
     "FastembedSparseEmbeddingFunction",
+    "Bm25EmbeddingFunction",
     "register_embedding_function",
     "config_to_embedding_function",
     "known_embedding_functions",

--- a/chromadb/utils/embedding_functions/bm25_embedding_function.py
+++ b/chromadb/utils/embedding_functions/bm25_embedding_function.py
@@ -11,39 +11,42 @@ from chromadb.utils.sparse_embedding_utils import _sort_sparse_vectors
 TaskType = Literal["document", "query"]
 
 
-class FastembedSparseEmbeddingFunctionQueryConfig(TypedDict):
+class Bm25EmbeddingFunctionQueryConfig(TypedDict):
     task: TaskType
 
 
-class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
+class Bm25EmbeddingFunction(SparseEmbeddingFunction[Documents]):
     def __init__(
         self,
-        model_name: str,
+        avg_len: Optional[float] = None,
         task: Optional[TaskType] = "document",
         cache_dir: Optional[str] = None,
-        threads: Optional[int] = None,
-        cuda: Optional[bool] = None,
-        device_ids: Optional[list[int]] = None,
-        lazy_load: Optional[bool] = None,
-        query_config: Optional[FastembedSparseEmbeddingFunctionQueryConfig] = None,
+        k: Optional[float] = None,
+        b: Optional[float] = None,
+        language: Optional[str] = None,
+        token_max_length: Optional[int] = None,
+        disable_stemmer: Optional[bool] = None,
+        specific_model_path: Optional[str] = None,
+        query_config: Optional[Bm25EmbeddingFunctionQueryConfig] = None,
         **kwargs: Any,
     ):
         """Initialize SparseEncoderEmbeddingFunction.
 
         Args:
-            model_name (str, optional): Identifier of the Fastembed model
-            List of commonly used models: Qdrant/bm25, prithivida/Splade_PP_en_v1, Qdrant/minicoil-v1
+            avg_len(float, optional): The average length of the documents in the corpus.
             task (str, optional): Task to perform, can be "document" or "query"
             cache_dir (str, optional): The path to the cache directory.
-            threads (int, optional): The number of threads to use for the model.
-            cuda (bool, optional): Whether to use CUDA.
-            device_ids (list[int], optional): The device IDs to use for the model.
-            lazy_load (bool, optional): Whether to lazy load the model.
+            k (float, optional): The k parameter in the BM25 formula. Defines the saturation of the term frequency.
+            b (float, optional): The b parameter in the BM25 formula. Defines the importance of the document length.
+            language (str, optional): Specifies the language for the stemmer.
+            token_max_length (int, optional): The maximum length of the tokens.
+            disable_stemmer (bool, optional): Disable the stemmer.
+            specific_model_path (str, optional): The path to the specific model.
             query_config (dict, optional): Configuration for the query, can be "task"
-            **kwargs: Additional arguments to pass to the model.
+            **kwargs: Additional arguments to pass to the Bm25 model.
         """
         try:
-            from fastembed import SparseTextEmbedding
+            from fastembed.sparse.bm25 import Bm25
         except ImportError:
             raise ValueError(
                 "The fastembed python package is not installed. Please install it with `pip install fastembed`"
@@ -51,19 +54,36 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
 
         self.task = task
         self.query_config = query_config
-        self.model_name = model_name
         self.cache_dir = cache_dir
-        self.threads = threads
-        self.cuda = cuda
-        self.device_ids = device_ids
-        self.lazy_load = lazy_load
+        self.k = k
+        self.b = b
+        self.avg_len = avg_len
+        self.language = language
+        self.token_max_length = token_max_length
+        self.disable_stemmer = disable_stemmer
+        self.specific_model_path = specific_model_path
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")
         self.kwargs = kwargs
-        self._model = SparseTextEmbedding(
-            model_name, cache_dir, threads, cuda, device_ids, lazy_load, **kwargs
-        )
+        bm25_kwargs = {
+            "model_name": "Qdrant/bm25",
+        }
+        optional_params = {
+            "cache_dir": cache_dir,
+            "k": k,
+            "b": b,
+            "avg_len": avg_len,
+            "language": language,
+            "token_max_length": token_max_length,
+            "disable_stemmer": disable_stemmer,
+            "specific_model_path": specific_model_path,
+        }
+        for key, value in optional_params.items():
+            if value is not None:
+                bm25_kwargs[key] = value
+        bm25_kwargs.update({k: v for k, v in kwargs.items() if v is not None})
+        self._model = Bm25(**bm25_kwargs)
 
     def __call__(self, input: Documents) -> SparseEmbeddings:
         """Generate embeddings for the given documents.
@@ -75,12 +95,12 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
             Embeddings for the documents.
         """
         try:
-            from fastembed import SparseTextEmbedding
+            from fastembed.sparse.bm25 import Bm25
         except ImportError:
             raise ValueError(
                 "The fastembed python package is not installed. Please install it with `pip install fastembed`"
             )
-        model = cast(SparseTextEmbedding, self._model)
+        model = cast(Bm25, self._model)
         if self.task == "document":
             embeddings = model.embed(
                 list(input),
@@ -104,12 +124,12 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
 
     def embed_query(self, input: Documents) -> SparseEmbeddings:
         try:
-            from fastembed import SparseTextEmbedding
+            from fastembed.sparse.bm25 import Bm25
         except ImportError:
             raise ValueError(
                 "The fastembed python package is not installed. Please install it with `pip install fastembed`"
             )
-        model = cast(SparseTextEmbedding, self._model)
+        model = cast(Bm25, self._model)
         if self.query_config is not None:
             task = self.query_config.get("task")
             if task == "document":
@@ -138,53 +158,56 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
 
     @staticmethod
     def name() -> str:
-        return "fastembed_sparse"
+        return "bm25"
 
     @staticmethod
     def build_from_config(
         config: Dict[str, Any]
     ) -> "SparseEmbeddingFunction[Documents]":
-        model_name = config.get("model_name")
         task = config.get("task")
         query_config = config.get("query_config")
         cache_dir = config.get("cache_dir")
-        threads = config.get("threads")
-        cuda = config.get("cuda")
-        device_ids = config.get("device_ids")
-        lazy_load = config.get("lazy_load")
+        k = config.get("k")
+        b = config.get("b")
+        avg_len = config.get("avg_len")
+        language = config.get("language")
+        token_max_length = config.get("token_max_length")
+        disable_stemmer = config.get("disable_stemmer")
+        specific_model_path = config.get("specific_model_path")
         kwargs = config.get("kwargs", {})
-        if model_name is None:
-            assert False, "This code should not be reached"
 
-        return FastembedSparseEmbeddingFunction(
-            model_name=model_name,
+        return Bm25EmbeddingFunction(
             task=task,
             query_config=query_config,
             cache_dir=cache_dir,
-            threads=threads,
-            cuda=cuda,
-            device_ids=device_ids,
-            lazy_load=lazy_load,
+            k=k,
+            b=b,
+            avg_len=avg_len,
+            language=language,
+            token_max_length=token_max_length,
+            disable_stemmer=disable_stemmer,
+            specific_model_path=specific_model_path,
             **kwargs,
         )
 
     def get_config(self) -> Dict[str, Any]:
         return {
-            "model_name": self.model_name,
             "task": self.task,
             "query_config": self.query_config,
             "cache_dir": self.cache_dir,
-            "threads": self.threads,
-            "cuda": self.cuda,
-            "device_ids": self.device_ids,
-            "lazy_load": self.lazy_load,
+            "k": self.k,
+            "b": self.b,
+            "avg_len": self.avg_len,
+            "language": self.language,
+            "token_max_length": self.token_max_length,
+            "disable_stemmer": self.disable_stemmer,
+            "specific_model_path": self.specific_model_path,
             "kwargs": self.kwargs,
         }
 
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]
     ) -> None:
-        # model_name is also used as the identifier for model path if stored locally.
         # Users should be able to change the path if needed, so we should not validate that.
         # e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
         return
@@ -200,4 +223,4 @@ class FastembedSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
         Raises:
             ValidationError: If the configuration does not match the schema
         """
-        validate_config_schema(config, "fastembed_sparse")
+        validate_config_schema(config, "bm25")

--- a/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_sparse_embedding_function.py
@@ -31,7 +31,7 @@ class HuggingFaceSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
         """Initialize SparseEncoderEmbeddingFunction.
 
         Args:
-            model_name (str, optional): Identifier of the Splade model
+            model_name (str, optional): Identifier of the Huggingface SparseEncoder model
             Some common models: prithivida/Splade_PP_en_v1, naver/splade-cocondenser-ensembledistil, naver/splade-v3
             device (str, optional): Device used for computation
             **kwargs: Additional arguments to pass to the Splade model.


### PR DESCRIPTION
This PR updates the fastembed embedding function with more parameters to support, and adds bm25 embedding function , which is a thin wrapper around the fastembed bm25 class
_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
