### PR TITLE
fix: remove duplicate length-consistency check from validate_insert_record_set

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -309,7 +309,6 @@ def validate_insert_record_set(record_set: InsertRecordSet) -> None:
     """
     Validates the InsertRecordSet, ensuring that all fields are of the right type and length.
     """
-    _validate_record_set_length_consistency(record_set)
     validate_base_record_set(record_set)
 
     validate_ids(record_set["ids"])


### PR DESCRIPTION
The length consistency check (`_validate_record_set_length_consistency`) was already performed inside `validate_base_record_set`, so calling `_validate_record_set_length_consistency` inside `validate_insert_record_set` right before the `validate_base_record_set` call caused redundant validation.
This change removes the duplicate call from `validate_insert_record_set` to avoid unnecessary work, as the function `_validate_record_set_length_consistency` does not mutate the global state.