### PR TITLE
Revert "[ENH][PERF] Optimize block decoding"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,6 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "serde",
- "serde_bytes",
  "shuttle",
  "tempfile",
  "thiserror 1.0.69",
@@ -7339,15 +7338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ sea-query = "0.32"
 sea-query-binder = "0.7"
 serde = { version = "1.0.215", features = ["derive", "rc"] }
 serde_json = "1.0.133"
-serde_bytes = "0.11.17"
 setsum = "0.7"
 sprs = "0.11"
 tantivy = "0.22.0"

--- a/rust/blockstore/Cargo.toml
+++ b/rust/blockstore/Cargo.toml
@@ -8,7 +8,6 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-serde_bytes = { workspace = true }
 arrow = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
Reverts chroma-core/chroma#5396

we started to see this error in compaction, reverting this PR and testing seems to resolve it

```
  2025-09-17T16:13:37.371431Z ERROR  [lodc load]: load error, hash: 514103273599114905, addr: EntryAddress { region: 1525, offset: 188751872, len: 1103342, sequence: 216277 }, header: EntryHeader { key_len: 24, value_len: 1103282, hash: 514103273599114905, sequence: 216277, checksum: 588865358018273739, compression: None }, e: Code(Bincode(Custom("invalid type: byte array,
 expected a borrowed byte array")))
    at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/foyer-storage-0.17.3/src/large/generic.rs:453
```