### PR TITLE
[ENH]  Improve our usage of the AWS S3 SDK.

### DIFF
--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -116,6 +116,8 @@ impl Default for S3StorageConfig {
             credentials: S3CredentialsConfig::default(),
             connect_timeout_ms: S3StorageConfig::default_connect_timeout_ms(),
             request_timeout_ms: S3StorageConfig::default_request_timeout_ms(),
+            request_retry_count: S3StorageConfig::default_request_retry_count(),
+            stall_protection_ms: S3StorageConfig::default_stall_protection_ms(),
             upload_part_size_bytes: S3StorageConfig::default_upload_part_size_bytes(),
             download_part_size_bytes: S3StorageConfig::default_download_part_size_bytes(),
         }
@@ -133,28 +135,12 @@ pub struct LocalStorageConfig {
     pub root: String,
 }
 
-#[derive(Deserialize, Debug, Clone, Serialize)]
+#[derive(Deserialize, Debug, Default, Clone, Serialize)]
 pub struct AdmissionControlledS3StorageConfig {
     #[serde(default)]
     pub s3_config: S3StorageConfig,
     #[serde(default)]
     pub rate_limiting_policy: RateLimitingConfig,
-}
-
-impl Default for AdmissionControlledS3StorageConfig {
-    fn default() -> Self {
-        AdmissionControlledS3StorageConfig {
-            s3_config: S3StorageConfig {
-                bucket: S3StorageConfig::default_bucket(),
-                credentials: S3CredentialsConfig::default(),
-                connect_timeout_ms: S3StorageConfig::default_connect_timeout_ms(),
-                request_timeout_ms: S3StorageConfig::default_request_timeout_ms(),
-                upload_part_size_bytes: S3StorageConfig::default_upload_part_size_bytes(),
-                download_part_size_bytes: S3StorageConfig::default_download_part_size_bytes(),
-            },
-            rate_limiting_policy: RateLimitingConfig::default(),
-        }
-    }
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize)]

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -89,7 +89,7 @@ impl S3StorageConfig {
     }
 
     fn default_request_timeout_ms() -> u64 {
-        30000
+        60000
     }
 
     fn default_request_retry_count() -> u32 {
@@ -97,7 +97,7 @@ impl S3StorageConfig {
     }
 
     fn default_stall_protection_ms() -> u64 {
-        20000
+        15000
     }
 
     fn default_upload_part_size_bytes() -> usize {

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -69,6 +69,10 @@ pub struct S3StorageConfig {
     pub connect_timeout_ms: u64,
     #[serde(default = "S3StorageConfig::default_request_timeout_ms")]
     pub request_timeout_ms: u64,
+    #[serde(default = "S3StorageConfig::default_request_retry_count")]
+    pub request_retry_count: u32,
+    #[serde(default = "S3StorageConfig::default_stall_protection_ms")]
+    pub stall_protection_ms: u64,
     #[serde(default = "S3StorageConfig::default_upload_part_size_bytes")]
     pub upload_part_size_bytes: usize,
     #[serde(default = "S3StorageConfig::default_download_part_size_bytes")]
@@ -86,6 +90,14 @@ impl S3StorageConfig {
 
     fn default_request_timeout_ms() -> u64 {
         30000
+    }
+
+    fn default_request_retry_count() -> u32 {
+        3
+    }
+
+    fn default_stall_protection_ms() -> u64 {
+        20000
     }
 
     fn default_upload_part_size_bytes() -> usize {

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -1037,10 +1037,12 @@ impl Configurable<StorageConfig> for S3Storage {
             StorageConfig::S3(s3_config) => {
                 let timeout_config = TimeoutConfigBuilder::default()
                     .connect_timeout(Duration::from_millis(s3_config.connect_timeout_ms))
-                    .operation_timeout(Duration::from_millis(
-                        s3_config.request_timeout_ms * s3_config.request_retry_count as u64,
+                    .operation_timeout(Duration::from_millis(s3_config.request_timeout_ms))
+                    .operation_attempt_timeout(Duration::from_millis(
+                        (s3_config.request_timeout_ms
+                            / s3_config.request_retry_count.max(1) as u64)
+                            .max(1),
                     ))
-                    .operation_attempt_timeout(Duration::from_millis(s3_config.request_timeout_ms))
                     .build();
 
                 let stalled_config = StalledStreamProtectionConfig::enabled()


### PR DESCRIPTION
## Description of changes

This PR makes it so that we introduce two new configurations:  retry
count and stall_protection_ms.  The stall protection should be 2/3 of
the retry_timeout_ms according to examples gleamed from the Internet.
Certainly less so that it can kick in before the retry.

The current retry_timeout_ms is converted into a per-attempt value to
maximally preserve current behavior.

## Test plan

CI + Staging

## Migration plan

N/A

## Observability plan

Observe and tune the values on staging.

## Documentation Changes

N/A
