### PR TITLE
[CHORE] make add_tracing_middleware fn public

### DIFF
--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -11,7 +11,7 @@ pub mod impls;
 pub mod quota;
 pub mod server;
 mod server_middleware;
-mod tower_tracing;
+pub mod tower_tracing;
 mod traced_json;
 mod types;
 

--- a/rust/frontend/src/tower_tracing.rs
+++ b/rust/frontend/src/tower_tracing.rs
@@ -108,7 +108,7 @@ impl<S> tower::layer::Layer<S> for SetTraceIdLayer {
     }
 }
 
-pub(crate) fn add_tracing_middleware(router: Router) -> Router {
+pub fn add_tracing_middleware(router: Router) -> Router {
     router.layer(SetTraceIdLayer::new()).layer(
         TraceLayer::new_for_http()
             .make_span_with(RequestTracing)


### PR DESCRIPTION
## Description of changes

Make the `chroma_fronted::tower_tracing::add_tracing_middleware` function public.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A