### PR TITLE
Fix incorrect parameter name in docs (queryTexts → query_texts)

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/guides/build/intro-to-retrieval.md
+++ b/docs/docs.trychroma.com/markdoc/content/guides/build/intro-to-retrieval.md
@@ -196,7 +196,7 @@ Similarly, Chroma handles the embedding of queries for you out-of-the-box.
 user_query = "What is your return policy for tooth brushes?"
 
 context = customer_support_collection.query(
-    queryTexts=[user_query],
+    query_texts=[user_query],
     n_results=1
 )['documents'][0]
 

--- a/docs/docs.trychroma.com/markdoc/content/guides/build/intro-to-retrieval.md
+++ b/docs/docs.trychroma.com/markdoc/content/guides/build/intro-to-retrieval.md
@@ -212,7 +212,7 @@ const user_query = "What is your return policy for tooth brushes?";
 
 const context = (
   await customer_support_collection.query({
-    queryTexts: [user_query],
+    query_texts: [user_query],
     n_results: 1,
   })
 ).documents[0];


### PR DESCRIPTION
## Description of changes

Corrected the argument name in intro-to-retrieval.md examples:

queryTexts → query_texts

Updated both Python and TypeScript code snippets in the “Process the User's Query” section.

This resolves runtime errors when users copy the example code.

- Improvements & Bug fixes
  -  Documentation bug fix: corrected parameter name to match actual API.
- New functionality
  - No new functionality

## Test plan

- Verified by running the example with collection.query(query_texts=[user_query], n_results=3) — no error occurs.

## Migration plan

- No migrations needed.
- No backward compatibility issues (API itself is unchanged; this is just correcting docs).

## Observability plan

- Not applicable (docs change only).

## Documentation Changes

- Updated docs/docs.trychroma.com (intro-to-retrieval.md) with correct parameter name.

- No further doc changes required.
