### PR TITLE
[BLD]: fix Tiltfile dependencies

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -221,7 +221,7 @@ k8s_resource(
 k8s_resource('postgres', resource_deps=['k8s_setup'], labels=["infrastructure"], port_forwards='5432:5432')
 # Jobs are suffixed with the image tag to ensure they are unique. In this context, the image tag is defined in k8s/distributed-chroma/values.yaml.
 k8s_resource('sysdb-migration-latest', resource_deps=['postgres'], labels=["infrastructure"])
-k8s_resource('rust-log-service', labels=["chroma"], port_forwards='50054:50051')
+k8s_resource('rust-log-service', labels=["chroma"], port_forwards='50054:50051', resource_deps=['minio-deployment'])
 k8s_resource('sysdb', resource_deps=['sysdb-migration-latest'], labels=["chroma"], port_forwards='50051:50051')
 k8s_resource('rust-frontend-service', resource_deps=['sysdb', 'rust-log-service'], labels=["chroma"], port_forwards='8000:8000')
 k8s_resource('query-service', resource_deps=['sysdb'], labels=["chroma"], port_forwards='50053:50051')

--- a/k8s/test/postgres.yaml
+++ b/k8s/test/postgres.yaml
@@ -25,9 +25,16 @@ spec:
               value: chroma
           ports:
             - containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - chroma
+            periodSeconds: 1
+            failureThreshold: 10
 
 ---
-
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Description of changes

After these changes, Tilt no longer logs "WARNING: Detected container restart" for any pods in CI.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
