### PR TITLE
[CHORE] move middleware helper behind a feature in chroma-tracing

### DIFF
--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -41,7 +41,7 @@ chroma-metering = { workspace = true }
 chroma-segment = { workspace = true }
 chroma-sysdb = { workspace = true }
 chroma-system = { workspace = true }
-chroma-tracing = { workspace = true }
+chroma-tracing = { workspace = true, features = ["middleware"] }
 chroma-types = { workspace = true }
 chroma-sqlite = { workspace = true }
 utoipa = { workspace = true }

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -26,4 +26,4 @@ chroma-system = { workspace = true }
 
 [features]
 grpc = ["dep:tower", "dep:http"]
-middleware = ["dep:axum", "dep:tower-http", "dep:futures"]
+middleware = ["dep:tower", "dep:axum", "dep:tower-http", "dep:futures"]

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -18,11 +18,12 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-axum = { workspace = true }
-tower-http = { workspace = true }
-futures = { workspace = true }
+axum = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 
 chroma-system = { workspace = true }
 
 [features]
 grpc = ["dep:tower", "dep:http"]
+middleware = ["dep:axum", "dep:tower-http", "dep:futures"]

--- a/rust/tracing/src/lib.rs
+++ b/rust/tracing/src/lib.rs
@@ -14,4 +14,6 @@ pub use init_tracer::{
     init_global_filter_layer, init_otel_layer, init_otel_tracing, init_panic_tracing_hook,
     init_stdout_layer, init_tracing, OtelFilter, OtelFilterLevel,
 };
+
+#[cfg(feature = "middleware")]
 pub use tower_tracing::add_tracing_middleware;

--- a/rust/tracing/src/lib.rs
+++ b/rust/tracing/src/lib.rs
@@ -3,6 +3,7 @@ pub mod grpc_client_trace_layer;
 #[cfg(feature = "grpc")]
 pub mod grpc_server_trace_layer;
 pub mod init_tracer;
+#[cfg(feature = "middleware")]
 mod tower_tracing;
 pub mod util;
 


### PR DESCRIPTION
## Description of changes

Move the middleware helper behind a `middleware` feature in `chroma-tracing`.

## Test plan

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
