### PR TITLE
[CHORE]  Do not log errors stemming from NotFound files.

### DIFF
--- a/rust/garbage_collector/src/operators/list_files_at_version.rs
+++ b/rust/garbage_collector/src/operators/list_files_at_version.rs
@@ -71,6 +71,10 @@ impl ChromaError for ListFilesAtVersionError {
             ListFilesAtVersionError::VersionFileMissingCollectionId => ErrorCodes::InvalidArgument,
         }
     }
+
+    fn should_trace_error(&self) -> bool {
+        self.code() != ErrorCodes::NotFound
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Description of changes

The code handles NotFound.  Don't trace said error because it's spammy.

## Test plan

CI

## Migration plan

N/A

## Observability plan

I don't think getting error on NotFound when it's expected aids in
debugging, so I expect this to be strictly more observable.

## Documentation Changes

N/A
