### PR TITLE
Replace Deprecated logging Exporter with debug in otel-collector-config.yaml

### DIFF
--- a/examples/observability/otel-collector-config.yaml
+++ b/examples/observability/otel-collector-config.yaml
@@ -5,7 +5,7 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"
 


### PR DESCRIPTION
## Description of changes

The current configuration leads to the following error:
```
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

'exporters' the logging exporter has been deprecated, use the debug exporter instead
```
related to https://github.com/open-telemetry/opentelemetry-collector/issues/3524
