### PR TITLE
[BUG]: update `collection_metadata.updated_at` timestamp when row is updated

### DIFF
--- a/go/pkg/sysdb/metastore/db/dao/collection_metadata.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_metadata.go
@@ -22,7 +22,13 @@ func (s *collectionMetadataDb) DeleteByCollectionID(collectionID string) (int, e
 
 func (s *collectionMetadataDb) Insert(in []*dbmodel.CollectionMetadata) error {
 	return s.db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "collection_id"}, {Name: "key"}},
-		DoUpdates: clause.AssignmentColumns([]string{"str_value", "int_value", "float_value", "bool_value"}),
+		Columns: []clause.Column{{Name: "collection_id"}, {Name: "key"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"str_value":  gorm.Expr("excluded.str_value"),
+			"int_value":  gorm.Expr("excluded.int_value"),
+			"float_value": gorm.Expr("excluded.float_value"),
+			"bool_value":  gorm.Expr("excluded.bool_value"),
+			"updated_at": gorm.Expr("CURRENT_TIMESTAMP"),
+		}),
 	}).Create(in).Error
 }

--- a/go/pkg/sysdb/metastore/db/dao/collection_metadata_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_metadata_test.go
@@ -1,0 +1,64 @@
+package dao
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao/daotest"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
+)
+
+func TestCollectionMetadataUpdatedAtIsRefreshedOnUpsert(t *testing.T) {
+	db, _ := dbcore.ConfigDatabaseForTesting()
+	collectionMetadata := &collectionMetadataDb{db: db}
+
+	tenant := "test_collection_metadata_updated_at_tenant"
+	database := "test_collection_metadata_updated_at_database"
+	collectionName := "test_collection_metadata_updated_at_collection"
+
+	databaseID, err := CreateTestTenantAndDatabase(db, tenant, database)
+	require.NoError(t, err)
+
+	defer func() {
+		err := CleanUpTestTenant(db, tenant)
+		require.NoError(t, err)
+	}()
+
+	collectionID, err := CreateTestCollection(db, daotest.NewDefaultTestCollection(collectionName, 128, databaseID, nil))
+	require.NoError(t, err)
+
+	key := "metadata_key"
+	initialValue := "initial"
+	err = collectionMetadata.Insert([]*dbmodel.CollectionMetadata{{
+		CollectionID: collectionID,
+		Key:          &key,
+		StrValue:     &initialValue,
+	}})
+	require.NoError(t, err)
+
+	var stored dbmodel.CollectionMetadata
+	err = db.Where("collection_id = ? AND key = ?", collectionID, key).First(&stored).Error
+	require.NoError(t, err)
+	initialUpdatedAt := stored.UpdatedAt
+
+	time.Sleep(50 * time.Millisecond)
+
+	updatedValue := "updated"
+	err = collectionMetadata.Insert([]*dbmodel.CollectionMetadata{{
+		CollectionID: collectionID,
+		Key:          &key,
+		StrValue:     &updatedValue,
+	}})
+	require.NoError(t, err)
+
+	var refreshed dbmodel.CollectionMetadata
+	err = db.Where("collection_id = ? AND key = ?", collectionID, key).First(&refreshed).Error
+	require.NoError(t, err)
+
+	require.Equal(t, updatedValue, *refreshed.StrValue)
+	require.True(t, refreshed.UpdatedAt.After(initialUpdatedAt), "expected updated_at (%s) to be after initial updated_at (%s)", refreshed.UpdatedAt, initialUpdatedAt)
+	require.Equal(t, stored.CreatedAt, refreshed.CreatedAt)
+}


### PR DESCRIPTION
## Description of changes

Prior to this PR, the `collection_metadata.updated_at` column was not correctly updated when a metadata attribute was changed.

## Test plan

_How are these changes tested?_

Added a new test.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
