### PR TITLE
[CHORE] Do not trace errors stemming from NotFound sparse indexes

### DIFF
--- a/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
+++ b/rust/garbage_collector/src/operators/fetch_sparse_index_files.rs
@@ -59,6 +59,10 @@ impl ChromaError for FetchSparseIndexFilesError {
             FetchSparseIndexFilesError::ParsingIdFailed => ErrorCodes::Internal,
         }
     }
+
+    fn should_trace_error(&self) -> bool {
+        self.code() != ErrorCodes::NotFound
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Description of changes

This isn't really an "error", more of a warning.

Mirroring implementation of similar fix: https://github.com/chroma-core/chroma/pull/5516

## Test plan

CI

## Migration plan

N/A

## Observability plan

Ensure traces are no longer generated for this condition.

## Documentation Changes

N/A
