### PR TITLE
[ENH] Add schema type to create_collection and Collection object type

### DIFF
--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -12,6 +12,22 @@ export type AddCollectionRecordsResponse = {
     [key: string]: unknown;
 };
 
+export type BoolInvertedIndexConfig = {
+    [key: string]: never;
+};
+
+export type BoolInvertedIndexType = {
+    config: BoolInvertedIndexConfig;
+    enabled: boolean;
+};
+
+/**
+ * Boolean value type index configurations
+ */
+export type BoolValueType = {
+    $bool_inverted_index?: null | BoolInvertedIndexType;
+};
+
 export type ChecklistResponse = {
     max_batch_size: number;
     supports_base64_encoding: boolean;
@@ -25,6 +41,7 @@ export type Collection = {
     log_position: number;
     metadata?: null | HashMap;
     name: string;
+    schema?: null | InternalSchema;
     tenant: string;
     version: number;
 };
@@ -45,6 +62,7 @@ export type CreateCollectionPayload = {
     get_or_create?: boolean;
     metadata?: null | HashMap;
     name: string;
+    schema?: null | InternalSchema;
 };
 
 export type CreateDatabasePayload = {
@@ -99,8 +117,40 @@ export type ErrorResponse = {
     message: string;
 };
 
+export type FloatInvertedIndexConfig = {
+    [key: string]: never;
+};
+
+export type FloatInvertedIndexType = {
+    config: FloatInvertedIndexConfig;
+    enabled: boolean;
+};
+
+/**
+ * Float list value type index configurations (for vectors)
+ */
+export type FloatListValueType = {
+    $vector_index?: null | VectorIndexType;
+};
+
+/**
+ * Float value type index configurations
+ */
+export type FloatValueType = {
+    $float_inverted_index?: null | FloatInvertedIndexType;
+};
+
 export type ForkCollectionPayload = {
     new_name: string;
+};
+
+export type FtsIndexConfig = {
+    [key: string]: never;
+};
+
+export type FtsIndexType = {
+    config: FtsIndexConfig;
+    enabled: boolean;
 };
 
 export type GetRequestPayload = RawWhereFields & {
@@ -147,9 +197,55 @@ export type HnswConfiguration = {
     sync_threshold?: number | null;
 };
 
+/**
+ * Configuration for HNSW vector index algorithm parameters
+ */
+export type HnswIndexConfig = {
+    batch_size?: number | null;
+    ef_construction?: number | null;
+    ef_search?: number | null;
+    max_neighbors?: number | null;
+    num_threads?: number | null;
+    resize_factor?: number | null;
+    sync_threshold?: number | null;
+};
+
 export type Include = 'distances' | 'documents' | 'embeddings' | 'metadatas' | 'uris';
 
 export type IncludeList = Array<Include>;
+
+export type IntInvertedIndexConfig = {
+    [key: string]: never;
+};
+
+export type IntInvertedIndexType = {
+    config: IntInvertedIndexConfig;
+    enabled: boolean;
+};
+
+/**
+ * Integer value type index configurations
+ */
+export type IntValueType = {
+    $int_inverted_index?: null | IntInvertedIndexType;
+};
+
+/**
+ * Internal schema representation for collection index configurations
+ * This represents the server-side schema structure used for index management
+ */
+export type InternalSchema = {
+    /**
+     * Default index configurations for each value type
+     */
+    defaults: ValueTypes;
+    /**
+     * Key-specific index overrides
+     */
+    key_overrides: {
+        [key: string]: ValueTypes;
+    };
+};
 
 export type Key = 'Document' | 'Embedding' | 'Metadata' | 'Score' | {
     MetadataField: string;
@@ -224,6 +320,28 @@ export type SpannConfiguration = {
 };
 
 /**
+ * Configuration for SPANN vector index algorithm parameters
+ */
+export type SpannIndexConfig = {
+    ef_construction?: number | null;
+    ef_search?: number | null;
+    initial_lambda?: number | null;
+    max_neighbors?: number | null;
+    merge_threshold?: number | null;
+    nreplica_count?: number | null;
+    num_centers_to_merge_to?: number | null;
+    num_samples_kmeans?: number | null;
+    reassign_neighbor_count?: number | null;
+    search_nprobe?: number | null;
+    search_rng_epsilon?: number | null;
+    search_rng_factor?: number | null;
+    split_threshold?: number | null;
+    write_nprobe?: number | null;
+    write_rng_epsilon?: number | null;
+    write_rng_factor?: number | null;
+};
+
+/**
  * Represents a sparse vector using parallel arrays for indices and values.
  */
 export type SparseVector = {
@@ -235,6 +353,47 @@ export type SparseVector = {
      * Values corresponding to each index
      */
     values: Array<number>;
+};
+
+export type SparseVectorIndexConfig = {
+    /**
+     * Embedding function configuration (flexible JSON for dynamic configurations)
+     * TODO(Sanket): Strongly type ef.
+     */
+    embedding_function?: unknown;
+    /**
+     * Key to source the sparse vector from
+     */
+    source_key?: string | null;
+};
+
+export type SparseVectorIndexType = {
+    config: SparseVectorIndexConfig;
+    enabled: boolean;
+};
+
+/**
+ * Sparse vector value type index configurations
+ */
+export type SparseVectorValueType = {
+    $sparse_vector_index?: null | SparseVectorIndexType;
+};
+
+export type StringInvertedIndexConfig = {
+    [key: string]: never;
+};
+
+export type StringInvertedIndexType = {
+    config: StringInvertedIndexConfig;
+    enabled: boolean;
+};
+
+/**
+ * String value type index configurations
+ */
+export type StringValueType = {
+    $fts_index?: null | FtsIndexType;
+    $string_inverted_index?: null | StringInvertedIndexType;
 };
 
 export type UpdateCollectionConfiguration = {
@@ -301,6 +460,19 @@ export type UpsertCollectionRecordsResponse = {
     [key: string]: unknown;
 };
 
+/**
+ * Strongly-typed value type configurations
+ * Contains optional configurations for each supported value type
+ */
+export type ValueTypes = {
+    '#bool'?: null | BoolValueType;
+    '#float'?: null | FloatValueType;
+    '#float_list'?: null | FloatListValueType;
+    '#int'?: null | IntValueType;
+    '#sparse_vector'?: null | SparseVectorValueType;
+    '#string'?: null | StringValueType;
+};
+
 export type Vec = Array<{
     configuration_json: CollectionConfiguration;
     database: string;
@@ -309,9 +481,26 @@ export type Vec = Array<{
     log_position: number;
     metadata?: null | HashMap;
     name: string;
+    schema?: null | InternalSchema;
     tenant: string;
     version: number;
 }>;
+
+export type VectorIndexConfig = {
+    embedding_function?: null | EmbeddingFunctionConfiguration;
+    hnsw?: null | HnswIndexConfig;
+    /**
+     * Key to source the vector from
+     */
+    source_key?: string | null;
+    space?: null | Space;
+    spann?: null | SpannIndexConfig;
+};
+
+export type VectorIndexType = {
+    config: VectorIndexConfig;
+    enabled: boolean;
+};
 
 export type U32 = number;
 

--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -71,6 +71,7 @@ message Collection {
   google.protobuf.Timestamp updated_at = 16;
   // This is the database id of the collection.
   optional string database_id = 17;
+  optional string schema_str = 18;
 }
 
 message Database {

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -133,6 +133,7 @@ message CreateCollectionRequest {
   // When segments are set, then the collection and segments will be created as
   // a single atomic operation.
   repeated Segment segments = 9;  // Optional.
+  optional string schema_str = 10;
 }
 
 message CreateCollectionResponse {

--- a/rust/cli/src/client/chroma_client.rs
+++ b/rust/cli/src/client/chroma_client.rs
@@ -116,6 +116,7 @@ impl ChromaClient {
             configuration,
             metadata,
             get_or_create: false,
+            schema: None,
         };
         let response = send_request::<CreateCollectionPayload, CollectionModel>(
             &self.host,

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -60,6 +60,7 @@ circuit_breaker:
   requests: 1000
 enable_span_indexing: true
 default_knn_index: "spann"
+enable_schema: false
 tenants_to_migrate_immediately:
 - "default_tenant"
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -69,6 +69,8 @@ pub struct FrontendConfig {
     pub tenants_to_migrate_immediately: Vec<String>,
     #[serde(default = "Default::default")]
     pub tenants_to_migrate_immediately_threshold: Option<String>,
+    #[serde(default = "default_enable_schema")]
+    pub enable_schema: bool,
 }
 
 impl FrontendConfig {
@@ -87,6 +89,7 @@ impl FrontendConfig {
             default_knn_index: default_default_knn_index(),
             tenants_to_migrate_immediately: vec![],
             tenants_to_migrate_immediately_threshold: None,
+            enable_schema: default_enable_schema(),
         }
     }
 }
@@ -135,6 +138,10 @@ fn default_enable_span_indexing() -> bool {
     false
 }
 
+fn default_enable_schema() -> bool {
+    false
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct FrontendServerConfig {
     #[serde(flatten)]
@@ -160,6 +167,8 @@ pub struct FrontendServerConfig {
     pub cors_allow_origins: Option<Vec<String>>,
     #[serde(default = "default_enable_span_indexing")]
     pub enable_span_indexing: bool,
+    #[serde(default = "default_enable_schema")]
+    pub enable_schema: bool,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "sample_configs/distributed.yaml";

--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -371,6 +371,7 @@ mod tests {
                     "test".to_string(),
                     None,
                     None,
+                    None,
                     false,
                 )
                 .unwrap(),
@@ -396,8 +397,8 @@ mod tests {
             .unwrap();
 
         // Knn should work
-        let result = frontend
-            .query(
+        let result = Box::pin(
+            frontend.query(
                 QueryRequest::try_new(
                     "default_tenant".to_string(),
                     "default_database".to_string(),
@@ -409,14 +410,15 @@ mod tests {
                     IncludeList::default_query(),
                 )
                 .unwrap(),
-            )
-            .await
-            .unwrap();
+            ),
+        )
+        .await
+        .unwrap();
         assert_eq!(result.ids[0], vec!["id2".to_string(), "id1".to_string()]);
 
         // An empty list of IDs should return no results
-        let result = frontend
-            .query(
+        let result = Box::pin(
+            frontend.query(
                 QueryRequest::try_new(
                     "default_tenant".to_string(),
                     "default_database".to_string(),
@@ -428,9 +430,10 @@ mod tests {
                     IncludeList::default_query(),
                 )
                 .unwrap(),
-            )
-            .await
-            .unwrap();
+            ),
+        )
+        .await
+        .unwrap();
         assert_eq!(result.ids[0].len(), 0);
     }
 }

--- a/rust/frontend/src/impls/in_memory_frontend.rs
+++ b/rust/frontend/src/impls/in_memory_frontend.rs
@@ -700,6 +700,7 @@ mod tests {
             collection_name.clone(),
             None,
             None,
+            None,
             false,
         )
         .unwrap();

--- a/rust/frontend/tests/proptest_helpers/frontend_reference.rs
+++ b/rust/frontend/tests/proptest_helpers/frontend_reference.rs
@@ -132,6 +132,7 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
                         "test".to_string(),
                         None,
                         None,
+                        None,
                         false,
                     )
                     .unwrap(),

--- a/rust/frontend/tests/proptest_helpers/frontend_under_test.rs
+++ b/rust/frontend/tests/proptest_helpers/frontend_under_test.rs
@@ -62,6 +62,7 @@ impl StateMachineTest for FrontendUnderTest {
                                 "test".to_string(),
                                 None,
                                 None,
+                                None,
                                 false,
                             )
                             .unwrap(),

--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -666,6 +666,7 @@ mod tests {
                     None,
                     None,
                     None,
+                    None,
                     false,
                 )
                 .await

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -1212,6 +1212,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 false,
             )
             .await

--- a/rust/garbage_collector/src/helper.rs
+++ b/rust/garbage_collector/src/helper.rs
@@ -109,6 +109,7 @@ impl ChromaGrpcClients {
             database: database_name.to_string(),
             dimension: Some(3),
             configuration_json_str: config_str,
+            schema_str: None,
             get_or_create: Some(true),
             metadata: None,
             segments,

--- a/rust/garbage_collector/tests/prop_test_local_files.rs
+++ b/rust/garbage_collector/tests/prop_test_local_files.rs
@@ -718,6 +718,7 @@ impl GcTest {
                 None,
                 None,
                 None,
+                None,
                 false,
             )
             .await;

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -198,6 +198,7 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                             None,
                             None,
                             None,
+                            None,
                             false,
                         )
                         .await

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -112,6 +112,7 @@ impl Bindings {
         let executor_config = ExecutorConfig::Local(LocalExecutorConfig {});
 
         let knn_index = KnnIndex::Hnsw;
+        let enable_schema = false;
 
         let frontend_config = FrontendConfig {
             allow_reset,
@@ -124,6 +125,7 @@ impl Bindings {
             default_knn_index: knn_index,
             tenants_to_migrate_immediately: vec![],
             tenants_to_migrate_immediately_threshold: None,
+            enable_schema,
         };
 
         let frontend = runtime.block_on(async {
@@ -293,6 +295,7 @@ impl Bindings {
             name,
             metadata,
             configuration,
+            None,
             get_or_create,
         )?;
 

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -347,6 +347,7 @@ impl SqliteSysDb {
             database,
             config: configuration,
             metadata,
+            schema: None,
             dimension,
             log_position: 0,
             total_records_post_compaction: 0,
@@ -744,6 +745,7 @@ impl SqliteSysDb {
                 Some(Ok(Collection {
                     collection_id,
                     config: configuration,
+                    schema: None,
                     metadata,
                     total_records_post_compaction: 0,
                     version: 0,

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -743,6 +743,18 @@ impl InternalSchema {
         Self::convert_collection_config_to_schema(collection_config)
     }
 
+    pub fn reconcile_schema_and_config(
+        schema: Option<InternalSchema>,
+        configuration: Option<InternalCollectionConfiguration>,
+    ) -> Result<InternalSchema, String> {
+        let reconciled_schema = Self::reconcile_with_defaults(schema)?;
+        if let Some(config) = configuration {
+            Self::reconcile_with_collection_config(reconciled_schema, config)
+        } else {
+            Ok(reconciled_schema)
+        }
+    }
+
     /// Check if schema is default by comparing it word-by-word with new_default
     fn is_schema_default(schema: &InternalSchema) -> bool {
         // Compare with both possible default schemas (HNSW and SPANN)

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1242,6 +1242,7 @@ mod tests {
                 ],
                 None,
                 None,
+                None,
                 test_segments.collection.dimension,
                 false,
             )


### PR DESCRIPTION
## Description of changes

This PR adds the necessary proto & rust changes to support schema as part of the server for create and get collection. It also adds a config flag enable_schema to allow us to feature flag until we are ready to enable & use it.
- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
