### PR TITLE
[ENH]  Support a read-only mode for the rust log service.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -104,8 +104,6 @@ pub enum Error {
     Wal3(#[from] wal3::Error),
     #[error("serialization error: {0:?}")]
     Json(#[from] serde_json::Error),
-    #[error("Service is in read-only mode")]
-    ReadOnlyMode,
     #[error("Dirty log writer failed to provide a reader")]
     CouldNotGetDirtyLogReader,
     #[error("Dirty log writer failed to provide a cursor store")]

--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -600,6 +600,15 @@ impl LogServer {
         Ok(())
     }
 
+    /// Verify that the service is not in read-only mode.
+    fn ensure_write_mode(&self) -> Result<(), Status> {
+        if self.config.is_read_only() {
+            Err(Status::permission_denied("service is in read-only mode"))
+        } else {
+            Ok(())
+        }
+    }
+
     #[tracing::instrument(skip(self, request), err(Display))]
     async fn _update_collection_log_offset(
         &self,
@@ -607,10 +616,8 @@ impl LogServer {
         active: tokio::sync::MutexGuard<'_, ActiveLog>,
         allow_rollback: bool,
     ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
+        self.ensure_write_mode()?;
         let request = request.into_inner();
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
         let adjusted_log_offset = request.log_offset + 1;
         let collection_id = Uuid::parse_str(&request.collection_id)
             .map(CollectionUuid)
@@ -1104,9 +1111,7 @@ impl LogServer {
         &self,
         request: Request<PushLogsRequest>,
     ) -> Result<Response<PushLogsResponse>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let push_logs = request.into_inner();
         let collection_id = Uuid::parse_str(&push_logs.collection_id)
             .map(CollectionUuid)
@@ -1409,9 +1414,7 @@ impl LogServer {
         &self,
         request: Request<ForkLogsRequest>,
     ) -> Result<Response<ForkLogsResponse>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let request = request.into_inner();
         let source_collection_id = Uuid::parse_str(&request.source_collection_id)
             .map(CollectionUuid)
@@ -1506,9 +1509,7 @@ impl LogServer {
         &self,
         request: Request<UpdateCollectionLogOffsetRequest>,
     ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let request = request.into_inner();
         let collection_id = Uuid::parse_str(&request.collection_id)
             .map(CollectionUuid)
@@ -1526,9 +1527,7 @@ impl LogServer {
         &self,
         request: Request<UpdateCollectionLogOffsetRequest>,
     ) -> Result<Response<UpdateCollectionLogOffsetResponse>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let request = request.into_inner();
         let collection_id = Uuid::parse_str(&request.collection_id)
             .map(CollectionUuid)
@@ -1547,9 +1546,7 @@ impl LogServer {
         &self,
         request: Request<PurgeDirtyForCollectionRequest>,
     ) -> Result<Response<PurgeDirtyForCollectionResponse>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let request = request.into_inner();
         let collection_ids = request
             .collection_ids
@@ -1759,9 +1756,7 @@ impl LogServer {
         &self,
         request: Request<GarbageCollectPhase2Request>,
     ) -> Result<Response<GarbageCollectPhase2Response>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let gc2 = request.into_inner();
 
         fn handle_error_properly(err: wal3::Error) -> Status {
@@ -1819,9 +1814,7 @@ impl LogServer {
         &self,
         request: Request<PurgeFromCacheRequest>,
     ) -> Result<Response<PurgeFromCacheResponse>, Status> {
-        if self.config.is_read_only() {
-            return Err(Status::permission_denied("service is in read-only mode"));
-        }
+        self.ensure_write_mode()?;
         let purge = request.into_inner();
 
         let key = match purge.entry_to_evict {


### PR DESCRIPTION
## Description of changes

Add a read-only mode to the rust log service so it can be brought up for DR.

## Test plan

Tested in tilt:

```
rust-fronten… │   2025-09-30T15:03:08.056409Z ERROR  error: Failed to push logs: status: PermissionDenied, message: "service is in read-only mode", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Tue, 30 Sep 2025 15:03:07 GMT", "content-length": "0"} }
rust-fronten… │     at rust/log/src/log.rs:96
rust-fronten… │     in push_logs with tenant: "default_tenant", collection_id: CollectionUuid(e101eb7d-69e9-4473-9cee-27ced3c39b53)
rust-fronten… │     in collection_add
rust-fronten… │     in HTTP request with http.method: POST, http.uri: /api/v2/tenants/default_tenant/databases/test_54f26162-81f4-4f1b-9c18-8e884d5537f1/collections/e101eb7d-69e9-4473-9cee-27ced3c39b53/add, http.route: "/api/v2/tenants/{tenant}/databases/{database}/collections/{collection_id}/add", http.version: HTTP/1.1, http.host: localhost:8000, http.user_agent: Chroma Python Client v1.1.0 (https://github.com/chroma-core/chroma), otel.name: "POST /api/v2/tenants/{tenant}/databases/{database}/collections/{collection_id}/add"
```

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
