### PR TITLE
Revert "[CHORE]  CI failed with INTERNALERROR"

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -16,6 +16,7 @@ runs:
         kubectl -n chroma port-forward svc/sysdb 50051:50051 &
         kubectl -n chroma port-forward svc/rust-log-service 50054:50051 &
         kubectl -n chroma port-forward svc/query-service 50053:50051 &
+        kubectl -n chroma port-forward svc/frontend-service 8000:8000 &
         kubectl -n chroma port-forward svc/rust-frontend-service 8000:8000 &
         kubectl -n chroma port-forward svc/minio 9000:9000 &
         kubectl -n chroma port-forward svc/jaeger 16686:16686 &

--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -31,7 +31,7 @@ jobs:
           - "chromadb/test/property/test_cross_version_persist.py"
         include:
           - test-glob: "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
-            parallelized: false  # Disabled to fix INTERNALERROR crashes in CI
+            parallelized: true
 
     runs-on: ${{ inputs.runner }}
     steps:
@@ -143,7 +143,7 @@ jobs:
           - "chromadb/test/distributed/test_repair_collection_log_offset.py"
         include:
           - test-glob: "chromadb/test/property/test_add.py"
-            parallelized: false
+            parallelized: true
           - test-glob: "chromadb/test/property/test_embeddings.py"
             parallelized: true
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -283,7 +283,7 @@ jobs:
         shell: bash
         run: pip install --no-index --find-links target/wheels/ chromadb
       - name: Run tests
-        run: python -m pytest chromadb/test/test_api.py ${{ matrix.parallelized && '-n auto --dist worksteal' || '' }} -v --color=yes --durations 10
+        run: python -m pytest chromadb/test/test_api.py -n auto --dist worksteal -v --color=yes --durations 10
         shell: bash
         env:
           CHROMA_RUST_BINDINGS_TEST_ONLY: "1"


### PR DESCRIPTION
Reverts chroma-core/chroma#5380

This re-enables parallel python tests.