### PR TITLE
[ENH] Return JSON from InspectLogState.

### DIFF
--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -129,6 +129,7 @@ message InspectLogStateResponse {
   string debug = 1;
   uint64 start = 2;
   uint64 limit = 3;
+  string json = 4;
 }
 
 message ScrubLogRequest {


### PR DESCRIPTION
## Description of changes

This is so that cops service can pull in the types and pretty-print
them.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
