### PR TITLE
[CHORE]  Make all clippy warnings errors.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -232,7 +232,7 @@ jobs:
         shell: bash
         run: cargo fmt -- --check
       - name: Clippy
-        run: cargo clippy --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures
+        run: cargo clippy --all-targets --all-features --keep-going -- -D warnings -D clippy::large_futures -D clippy::all
 
   # This job exists for our branch protection rule.
   # We want to require status checks to pass before merging, but the set of


### PR DESCRIPTION
## Description of changes

We've kept the code base remarkably clean, but it's not actually
enforced by CI that there are no clippy warnings.  This should fix that.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
