### PR TITLE
[BUG]: Use stdlib override when possible

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Sequence, Optional, List
 from uuid import UUID
+import sys
 
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Sequence, Optional, List
 from uuid import UUID
+import sys
 
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     UpdateCollectionConfiguration,

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -1,7 +1,12 @@
 import httpx
 from typing import Optional, Sequence
 from uuid import UUID
-from overrides import override
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.auth import UserIdentity
 from chromadb.auth.utils import maybe_set_tenant_and_database

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -5,7 +5,12 @@ import orjson
 from typing import Any, Optional, cast, Tuple, Sequence, Dict, List
 import logging
 import httpx
-from overrides import override
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb import __version__
 from chromadb.auth import UserIdentity
 from chromadb.api.async_api import AsyncServerAPI

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -1,7 +1,11 @@
 from typing import Optional, Sequence
 from uuid import UUID
+import sys
 
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 import httpx
 from chromadb.api import AdminAPI, ClientAPI, ServerAPI
 from chromadb.api.collection_configuration import (

--- a/chromadb/api/configuration.py
+++ b/chromadb/api/configuration.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import json
-from overrides import override
+import sys
 from typing import (
     Any,
     ClassVar,
@@ -14,6 +14,11 @@ from typing import (
 )
 from typing_extensions import Self
 from multiprocessing import cpu_count
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.serde import JSONSerializable
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -4,8 +4,13 @@ from typing import Any, Dict, Optional, cast, Tuple, List
 from typing import Sequence
 from uuid import UUID
 import httpx
+import sys
 import urllib.parse
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -44,10 +44,15 @@ import chromadb_rust_bindings
 
 
 from typing import Optional, Sequence, List
-from overrides import override
 from uuid import UUID
 import json
 import platform
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 if platform.system() != "Windows":
     import resource

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -69,13 +69,18 @@ from typing import (
     Callable,
     TypeVar,
 )
-from overrides import override
 from uuid import UUID, uuid4
 from functools import wraps
 import time
 import logging
 import re
+import sys
 from chromadb.execution.expression.plan import Search
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 T = TypeVar("T", bound=Callable[..., Any])
 

--- a/chromadb/auth/basic_authn/__init__.py
+++ b/chromadb/auth/basic_authn/__init__.py
@@ -6,8 +6,12 @@ import traceback
 
 import bcrypt
 import logging
+import sys
 
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from pydantic import SecretStr
 
 from chromadb.auth import (

--- a/chromadb/auth/simple_rbac_authz/__init__.py
+++ b/chromadb/auth/simple_rbac_authz/__init__.py
@@ -1,7 +1,12 @@
 import logging
 from typing import Dict, Set
-from overrides import override
+import sys
 import yaml
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.auth import (
     AuthzAction,
     AuthzResource,

--- a/chromadb/auth/token_authn/__init__.py
+++ b/chromadb/auth/token_authn/__init__.py
@@ -2,13 +2,16 @@ import logging
 import random
 import re
 import string
+import sys
 import time
 import traceback
 from enum import Enum
 from typing import cast, Dict, List, Optional, TypedDict, TypeVar
 
-
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from pydantic import SecretStr
 import yaml
 

--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -1,14 +1,21 @@
 import importlib
 import inspect
 import logging
+import sys
 from abc import ABC
 from enum import Enum
 from graphlib import TopologicalSorter
 from typing import Optional, List, Any, Dict, Set, Iterable, Union
 from typing import Type, TypeVar, cast
 
-from overrides import EnforceOverrides
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+
+    class EnforceOverrides:
+        pass
+else:
+    from overrides import overrides as override
+    from overrides import EnforceOverrides
 from typing_extensions import Literal
 import platform
 

--- a/chromadb/db/base.py
+++ b/chromadb/db/base.py
@@ -3,7 +3,16 @@ from types import TracebackType
 from typing_extensions import Protocol, Self, Literal
 from abc import ABC, abstractmethod
 from threading import local
-from overrides import override, EnforceOverrides
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+
+    class EnforceOverrides:
+        pass
+else:
+    from overrides import overrides as override
+    from overrides import EnforceOverrides
 import pypika
 import pypika.queries
 from chromadb.config import System, Component

--- a/chromadb/db/impl/grpc/client.py
+++ b/chromadb/db/impl/grpc/client.py
@@ -1,6 +1,11 @@
 from typing import List, Optional, Sequence, Tuple, Union, cast
 from uuid import UUID
-from overrides import overrides
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
     create_collection_configuration_to_json_str,
@@ -84,7 +89,7 @@ class GrpcSysDB(SysDB):
         )
         return super().__init__(system)
 
-    @overrides
+    @override
     def start(self) -> None:
         self._channel = grpc.insecure_channel(
             f"{self._coordinator_url}:{self._coordinator_port}",
@@ -95,17 +100,17 @@ class GrpcSysDB(SysDB):
         self._sys_db_stub = SysDBStub(self._channel)  # type: ignore
         return super().start()
 
-    @overrides
+    @override
     def stop(self) -> None:
         self._channel.close()
         return super().stop()
 
-    @overrides
+    @override
     def reset_state(self) -> None:
         self._sys_db_stub.ResetState(Empty())
         return super().reset_state()
 
-    @overrides
+    @override
     def create_database(
         self, id: UUID, name: str, tenant: str = DEFAULT_TENANT
     ) -> None:
@@ -122,7 +127,7 @@ class GrpcSysDB(SysDB):
                 raise UniqueConstraintError()
             raise InternalError()
 
-    @overrides
+    @override
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         try:
             request = GetDatabaseRequest(name=name, tenant=tenant)
@@ -142,7 +147,7 @@ class GrpcSysDB(SysDB):
                 raise NotFoundError()
             raise InternalError()
 
-    @overrides
+    @override
     def delete_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
         try:
             request = DeleteDatabaseRequest(name=name, tenant=tenant)
@@ -157,7 +162,7 @@ class GrpcSysDB(SysDB):
                 raise NotFoundError()
             raise InternalError
 
-    @overrides
+    @override
     def list_databases(
         self,
         limit: Optional[int] = None,
@@ -185,7 +190,7 @@ class GrpcSysDB(SysDB):
             )
             raise InternalError()
 
-    @overrides
+    @override
     def create_tenant(self, name: str) -> None:
         try:
             request = CreateTenantRequest(name=name)
@@ -198,7 +203,7 @@ class GrpcSysDB(SysDB):
                 raise UniqueConstraintError()
             raise InternalError()
 
-    @overrides
+    @override
     def get_tenant(self, name: str) -> Tenant:
         try:
             request = GetTenantRequest(name=name)
@@ -214,7 +219,7 @@ class GrpcSysDB(SysDB):
                 raise NotFoundError()
             raise InternalError()
 
-    @overrides
+    @override
     def create_segment(self, segment: Segment) -> None:
         try:
             proto_segment = to_proto_segment(segment)
@@ -230,7 +235,7 @@ class GrpcSysDB(SysDB):
                 raise UniqueConstraintError()
             raise InternalError()
 
-    @overrides
+    @override
     def delete_segment(self, collection: UUID, id: UUID) -> None:
         try:
             request = DeleteSegmentRequest(
@@ -248,7 +253,7 @@ class GrpcSysDB(SysDB):
                 raise NotFoundError()
             raise InternalError()
 
-    @overrides
+    @override
     def get_segments(
         self,
         collection: UUID,
@@ -277,7 +282,7 @@ class GrpcSysDB(SysDB):
             )
             raise InternalError()
 
-    @overrides
+    @override
     def update_segment(
         self,
         collection: UUID,
@@ -310,7 +315,7 @@ class GrpcSysDB(SysDB):
             )
             raise InternalError()
 
-    @overrides
+    @override
     def create_collection(
         self,
         id: UUID,
@@ -350,7 +355,7 @@ class GrpcSysDB(SysDB):
                 raise UniqueConstraintError()
             raise InternalError()
 
-    @overrides
+    @override
     def delete_collection(
         self,
         id: UUID,
@@ -378,7 +383,7 @@ class GrpcSysDB(SysDB):
                 raise NotFoundError()
             raise InternalError()
 
-    @overrides
+    @override
     def get_collections(
         self,
         id: Optional[UUID] = None,
@@ -429,7 +434,7 @@ class GrpcSysDB(SysDB):
             )
             raise InternalError()
 
-    @overrides
+    @override
     def count_collections(
         self,
         tenant: str = DEFAULT_TENANT,
@@ -455,7 +460,7 @@ class GrpcSysDB(SysDB):
             logger.error(f"Failed to count collections due to error: {e}")
             raise InternalError()
 
-    @overrides
+    @override
     def get_collection_size(self, id: UUID) -> int:
         try:
             request = GetCollectionSizeRequest(id=id.hex)
@@ -470,7 +475,7 @@ class GrpcSysDB(SysDB):
     @trace_method(
         "SysDB.get_collection_with_segments", OpenTelemetryGranularity.OPERATION
     )
-    @overrides
+    @override
     def get_collection_with_segments(
         self, collection_id: UUID
     ) -> CollectionAndSegments:
@@ -491,7 +496,7 @@ class GrpcSysDB(SysDB):
             )
             raise InternalError()
 
-    @overrides
+    @override
     def update_collection(
         self,
         id: UUID,

--- a/chromadb/db/impl/grpc/server.py
+++ b/chromadb/db/impl/grpc/server.py
@@ -1,8 +1,13 @@
 from concurrent import futures
 from typing import Any, Dict, List, cast
 from uuid import UUID
-from overrides import overrides
 import json
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.config import DEFAULT_DATABASE, DEFAULT_TENANT, Component, System
 from chromadb.proto.convert import (
@@ -73,7 +78,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
         self._server_port = system.settings.require("chroma_server_grpc_port")
         return super().__init__(system)
 
-    @overrides
+    @override
     def start(self) -> None:
         self._server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
         add_SysDBServicer_to_server(self, self._server)  # type: ignore
@@ -81,12 +86,12 @@ class GrpcMockSysDB(SysDBServicer, Component):
         self._server.start()
         return super().start()
 
-    @overrides
+    @override
     def stop(self) -> None:
         self._server.stop(None)
         return super().stop()
 
-    @overrides
+    @override
     def reset_state(self) -> None:
         self._segments = {}
         self._tenants_to_databases_to_collections = {}
@@ -97,7 +102,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
         self._tenants_to_database_to_id[DEFAULT_TENANT][DEFAULT_DATABASE] = UUID(int=0)
         return super().reset_state()
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def CreateDatabase(
         self, request: CreateDatabaseRequest, context: grpc.ServicerContext
     ) -> CreateDatabaseResponse:
@@ -113,7 +118,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
         self._tenants_to_database_to_id[tenant][database] = UUID(hex=request.id)
         return CreateDatabaseResponse()
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def GetDatabase(
         self, request: GetDatabaseRequest, context: grpc.ServicerContext
     ) -> GetDatabaseResponse:
@@ -128,7 +133,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
             database=proto.Database(id=id.hex, name=database, tenant=tenant),
         )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def CreateTenant(
         self, request: CreateTenantRequest, context: grpc.ServicerContext
     ) -> CreateTenantResponse:
@@ -141,7 +146,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
         self._tenants_to_database_to_id[tenant] = {}
         return CreateTenantResponse()
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def GetTenant(
         self, request: GetTenantRequest, context: grpc.ServicerContext
     ) -> GetTenantResponse:
@@ -155,7 +160,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
     # We are forced to use check_signature=False because the generated proto code
     # does not have type annotations for the request and response objects.
     # TODO: investigate generating types for the request and response objects
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def CreateSegment(
         self, request: CreateSegmentRequest, context: grpc.ServicerContext
     ) -> CreateSegmentResponse:
@@ -173,7 +178,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
         self._segments[segment["id"].hex] = segment
         return CreateSegmentResponse()
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def DeleteSegment(
         self, request: DeleteSegmentRequest, context: grpc.ServicerContext
     ) -> DeleteSegmentResponse:
@@ -186,7 +191,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
                 grpc.StatusCode.NOT_FOUND, f"Segment {id_to_delete} not found"
             )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def GetSegments(
         self, request: GetSegmentsRequest, context: grpc.ServicerContext
     ) -> GetSegmentsResponse:
@@ -214,7 +219,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
             segments=[to_proto_segment(segment) for segment in found_segments]
         )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def UpdateSegment(
         self, request: UpdateSegmentRequest, context: grpc.ServicerContext
     ) -> UpdateSegmentResponse:
@@ -234,7 +239,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
                 segment["metadata"] = {}
             return UpdateSegmentResponse()
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def CreateCollection(
         self, request: CreateCollectionRequest, context: grpc.ServicerContext
     ) -> CreateCollectionResponse:
@@ -324,7 +329,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
             created=True,
         )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def DeleteCollection(
         self, request: DeleteCollectionRequest, context: grpc.ServicerContext
     ) -> DeleteCollectionResponse:
@@ -349,7 +354,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
                 grpc.StatusCode.NOT_FOUND, f"Collection {collection_id} not found"
             )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def GetCollections(
         self, request: GetCollectionsRequest, context: grpc.ServicerContext
     ) -> GetCollectionsResponse:
@@ -380,7 +385,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
             ]
         )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def CountCollections(
         self, request: CountCollectionsRequest, context: grpc.ServicerContext
     ) -> CountCollectionsResponse:
@@ -391,7 +396,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
         collections = self.GetCollections(request, context)
         return CountCollectionsResponse(count=len(collections.collections))
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def GetCollectionSize(
         self, request: GetCollectionSizeRequest, context: grpc.ServicerContext
     ) -> GetCollectionSizeResponse:
@@ -399,7 +404,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
             total_records_post_compaction=0,
         )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def GetCollectionWithSegments(
         self, request: GetCollectionWithSegmentsRequest, context: grpc.ServicerContext
     ) -> GetCollectionWithSegmentsResponse:
@@ -437,7 +442,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
             segments=[to_proto_segment(segment) for segment in segments],
         )
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def UpdateCollection(
         self, request: UpdateCollectionRequest, context: grpc.ServicerContext
     ) -> UpdateCollectionResponse:
@@ -479,7 +484,7 @@ class GrpcMockSysDB(SysDBServicer, Component):
 
             return UpdateCollectionResponse()
 
-    @overrides(check_signature=False)
+    @override(check_signature=False)
     def ResetState(
         self, request: Empty, context: grpc.ServicerContext
     ) -> ResetStateResponse:

--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -11,7 +11,12 @@ from chromadb.telemetry.opentelemetry import (
     trace_method,
 )
 import sqlite3
-from overrides import override
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 import pypika
 from typing import Sequence, cast, Optional, Type, Any
 from typing_extensions import Literal

--- a/chromadb/db/impl/sqlite_pool.py
+++ b/chromadb/db/impl/sqlite_pool.py
@@ -2,8 +2,13 @@ import sqlite3
 import weakref
 from abc import ABC, abstractmethod
 from typing import Any, Set
+import sys
 import threading
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from typing_extensions import Annotated
 
 

--- a/chromadb/db/mixins/embeddings_queue.py
+++ b/chromadb/db/mixins/embeddings_queue.py
@@ -1,5 +1,11 @@
 from functools import cached_property
 import json
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.configuration import (
     ConfigurationParameter,
     EmbeddingsQueueConfigurationInternal,
@@ -26,7 +32,6 @@ from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
 )
-from overrides import override
 from collections import defaultdict
 from typing import Sequence, Optional, Dict, Set, Tuple, cast
 from uuid import UUID

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -2,7 +2,11 @@ import logging
 import sys
 from typing import Optional, Sequence, Any, Tuple, cast, Dict, Union, Set
 from uuid import UUID
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from pypika import Table, Column
 from itertools import groupby
 

--- a/chromadb/errors.py
+++ b/chromadb/errors.py
@@ -1,6 +1,15 @@
 from abc import abstractmethod
 from typing import Dict, Optional, Type
-from overrides import overrides, EnforceOverrides
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+
+    class EnforceOverrides:
+        pass
+else:
+    from overrides import overrides as override
+    from overrides import EnforceOverrides
 
 
 class ChromaError(Exception, EnforceOverrides):
@@ -22,153 +31,153 @@ class ChromaError(Exception, EnforceOverrides):
 
 class InvalidDimensionException(ChromaError):
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "InvalidDimension"
 
 
 class IDAlreadyExistsError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 409  # Conflict
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "IDAlreadyExists"
 
 
 class ChromaAuthError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 403
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "AuthError"
 
-    @overrides
+    @override
     def message(self) -> str:
         return "Forbidden"
 
 
 class DuplicateIDError(ChromaError):
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "DuplicateID"
 
 
 class InvalidArgumentError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 400
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "InvalidArgument"
 
 
 class InvalidUUIDError(ChromaError):
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "InvalidUUID"
 
 
 class InvalidHTTPVersion(ChromaError):
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "InvalidHTTPVersion"
 
 
 class AuthorizationError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 401
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "AuthorizationError"
 
 
 class NotFoundError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 404
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "NotFoundError"
 
 
 class UniqueConstraintError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 409
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "UniqueConstraintError"
 
 
 class BatchSizeExceededError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 413
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "BatchSizeExceededError"
 
 
 class VersionMismatchError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 500
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "VersionMismatchError"
 
 
 class InternalError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 500
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "InternalError"
 
 
 class RateLimitError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 429
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "RateLimitError"
 
 
 class QuotaError(ChromaError):
-    @overrides
+    @override
     def code(self) -> int:
         return 400
 
     @classmethod
-    @overrides
+    @override
     def name(cls) -> str:
         return "QuotaError"
 

--- a/chromadb/execution/executor/distributed.py
+++ b/chromadb/execution/executor/distributed.py
@@ -2,7 +2,12 @@ import threading
 import random
 from typing import Callable, Dict, List, Optional, TypeVar
 import grpc
-from overrides import overrides
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.types import GetResult, Metadata, QueryResult
 from chromadb.config import System
 from chromadb.execution.executor.abstract import Executor
@@ -109,7 +114,7 @@ class DistributedExecutor(Executor):
         # NOTE(hammadb) because Retrying() will always either return or raise an exception, this line should never be reached
         raise Exception("Unreachable code error - should never reach here")
 
-    @overrides
+    @override
     def count(self, plan: CountPlan) -> int:
         endpoints = self._get_grpc_endpoints(plan.scan)
         count_funcs = [self._get_stub(endpoint).Count for endpoint in endpoints]
@@ -118,7 +123,7 @@ class DistributedExecutor(Executor):
         )
         return convert.from_proto_count_result(count_result)
 
-    @overrides
+    @override
     def get(self, plan: GetPlan) -> GetResult:
         endpoints = self._get_grpc_endpoints(plan.scan)
         get_funcs = [self._get_stub(endpoint).Get for endpoint in endpoints]
@@ -158,7 +163,7 @@ class DistributedExecutor(Executor):
             included=plan.projection.included,
         )
 
-    @overrides
+    @override
     def knn(self, plan: KNNPlan) -> QueryResult:
         endpoints = self._get_grpc_endpoints(plan.scan)
         knn_funcs = [self._get_stub(endpoint).KNN for endpoint in endpoints]

--- a/chromadb/execution/executor/local.py
+++ b/chromadb/execution/executor/local.py
@@ -1,6 +1,10 @@
 from typing import Optional, Sequence
+import sys
 
-from overrides import overrides
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.api.types import GetResult, Metadata, QueryResult
 from chromadb.config import System
@@ -47,11 +51,11 @@ class LocalExecutor(Executor):
         super().__init__(system)
         self._manager = self.require(LocalSegmentManager)
 
-    @overrides
+    @override
     def count(self, plan: CountPlan) -> int:
         return self._metadata_segment(plan.scan.collection).count(plan.scan.version)
 
-    @overrides
+    @override
     def get(self, plan: GetPlan) -> GetResult:
         records = self._metadata_segment(plan.scan.collection).get_metadata(
             request_version_context=plan.scan.version,
@@ -103,7 +107,7 @@ class LocalExecutor(Executor):
             included=included,
         )
 
-    @overrides
+    @override
     def knn(self, plan: KNNPlan) -> QueryResult:
         prefiltered_ids = None
         if plan.filter.user_ids or plan.filter.where or plan.filter.where_document:

--- a/chromadb/logservice/logservice.py
+++ b/chromadb/logservice/logservice.py
@@ -23,7 +23,11 @@ from chromadb.telemetry.opentelemetry import (
     add_attributes_to_current_span,
     trace_method,
 )
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from typing import Sequence, Optional, cast
 from uuid import UUID
 import logging

--- a/chromadb/quota/simple_quota_enforcer/__init__.py
+++ b/chromadb/quota/simple_quota_enforcer/__init__.py
@@ -1,6 +1,11 @@
-from overrides import override
+import sys
 from typing import Any, Callable, TypeVar, Dict, Optional
 from uuid import UUID
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.api.types import (
     Embeddings,

--- a/chromadb/rate_limit/simple_rate_limit/__init__.py
+++ b/chromadb/rate_limit/simple_rate_limit/__init__.py
@@ -1,6 +1,11 @@
-from overrides import override
+import sys
 from typing import Any, Awaitable, Callable, TypeVar
 from functools import wraps
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.rate_limit import RateLimitEnforcer
 from chromadb.config import System

--- a/chromadb/segment/distributed/__init__.py
+++ b/chromadb/segment/distributed/__init__.py
@@ -1,8 +1,16 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, List
+import sys
 
-from overrides import EnforceOverrides, overrides
+if sys.version_info >= (3, 12):
+    from typing import override
+
+    class EnforceOverrides:
+        pass
+else:
+    from overrides import overrides as override
+    from overrides import EnforceOverrides
 from chromadb.config import Component, System
 from chromadb.types import Segment
 
@@ -56,7 +64,7 @@ class MemberlistProvider(Component, EnforceOverrides):
         """Sets the memberlist that this provider will watch"""
         pass
 
-    @overrides
+    @override
     def stop(self) -> None:
         """Stops watching the memberlist"""
         self.callbacks = []

--- a/chromadb/segment/impl/distributed/segment_directory.py
+++ b/chromadb/segment/impl/distributed/segment_directory.py
@@ -1,9 +1,18 @@
+import sys
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional, cast
 from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
-from overrides import EnforceOverrides, override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+
+    class EnforceOverrides:
+        pass
+else:
+    from overrides import overrides as override
+    from overrides import EnforceOverrides
 from chromadb.config import RoutingMode, System
 from chromadb.segment.distributed import (
     Member,

--- a/chromadb/segment/impl/manager/cache/cache.py
+++ b/chromadb/segment/impl/manager/cache/cache.py
@@ -1,10 +1,15 @@
+import sys
 import threading
 import uuid
 from typing import Any, Callable
 from chromadb.types import Segment
-from overrides import override
 from typing import Dict, Optional
 from abc import ABC, abstractmethod
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 
 class SegmentCache(ABC):

--- a/chromadb/segment/impl/manager/distributed.py
+++ b/chromadb/segment/impl/manager/distributed.py
@@ -1,8 +1,12 @@
 from threading import Lock
 from typing import Dict, List, Sequence
 from uuid import UUID, uuid4
+import sys
 
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 from chromadb.config import System
 from chromadb.db.system import SysDB

--- a/chromadb/segment/impl/manager/local.py
+++ b/chromadb/segment/impl/manager/local.py
@@ -14,10 +14,15 @@ from chromadb.segment.impl.manager.cache.cache import (
     SegmentCache,
 )
 import os
+import sys
 
 from chromadb.config import System, get_class
 from chromadb.db.system import SysDB
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.segment.impl.vector.local_persistent_hnsw import (
     PersistentLocalHnswSegment,
 )

--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -1,10 +1,15 @@
 from typing import Optional, Sequence, Any, Tuple, cast, Generator, Union, Dict, List
+import sys
 from chromadb.segment import MetadataReader
 from chromadb.ingest import Consumer
 from chromadb.config import System
 from chromadb.types import RequestVersionContext, Segment, InclusionExclusionOperator
 from chromadb.db.impl.sqlite import SqliteDB
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.db.base import (
     Cursor,
     ParameterValue,

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -1,6 +1,11 @@
-from overrides import override
+import sys
 from typing import Optional, Sequence, Dict, Set, List, cast
 from uuid import UUID
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.segment import VectorReader
 from chromadb.ingest import Consumer
 from chromadb.config import System, Settings

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -1,8 +1,13 @@
 import os
 import shutil
-from overrides import override
+import sys
 import pickle
 from typing import Dict, List, Optional, Sequence, Set, cast
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.config import System
 from chromadb.db.base import ParameterValue, get_sql
 from chromadb.db.impl.sqlite import SqliteDB

--- a/chromadb/telemetry/product/posthog.py
+++ b/chromadb/telemetry/product/posthog.py
@@ -2,12 +2,16 @@ import posthog
 import logging
 import sys
 from typing import Any, Dict, Set
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.config import System
 from chromadb.telemetry.product import (
     ProductTelemetryClient,
     ProductTelemetryEvent,
 )
-from overrides import override
 
 logger = logging.getLogger(__name__)
 

--- a/chromadb/test/client/test_database_tenant_auth.py
+++ b/chromadb/test/client/test_database_tenant_auth.py
@@ -1,6 +1,11 @@
 from typing import Dict
+import sys
 from fastapi import HTTPException
-from overrides import override
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.auth import (
     AuthzAction,
     AuthzResource,

--- a/chromadb/test/configurations/test_configurations.py
+++ b/chromadb/test/configurations/test_configurations.py
@@ -1,5 +1,10 @@
-from overrides import overrides
+import sys
 import pytest
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.configuration import (
     ConfigurationInternal,
     ConfigurationDefinition,
@@ -26,7 +31,7 @@ class TestConfiguration(ConfigurationInternal):
         ),
     }
 
-    @overrides
+    @override
     def configuration_validator(self) -> None:
         pass
 
@@ -96,7 +101,7 @@ def test_configuration_validation() -> None:
             ),
         }
 
-        @overrides
+        @override
         def configuration_validator(self) -> None:
             if self.parameter_map.get("foo") != "bar":
                 raise InvalidConfigurationError("foo must be 'bar'")

--- a/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
+++ b/chromadb/test/property/test_collections_with_database_tenant_overwrite.py
@@ -1,11 +1,16 @@
 from typing import Dict, Optional, Tuple
-from overrides import overrides
+import sys
 from hypothesis.stateful import (
     initialize,
     invariant,
     rule,
     run_state_machine_as_test,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 import uuid
 import logging
@@ -81,11 +86,11 @@ class SingletonTenantDatabaseCollectionStateMachine(
             self.client = self.singleton_client
             self.admin_client = self.singleton_admin_client
 
-    @overrides
+    @override
     def set_api_tenant_database(self, tenant: str, database: str) -> None:
         self.root_client.set_tenant(tenant, database)
 
-    @overrides
+    @override
     def get_tenant_model(
         self, tenant: str
     ) -> Dict[str, Dict[str, Optional[types.CollectionMetadata]]]:
@@ -93,7 +98,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
             tenant = SINGLETON_TENANT
         return self.tenant_to_database_to_model[tenant]
 
-    @overrides
+    @override
     def set_tenant_model(
         self,
         tenant: str,
@@ -108,7 +113,7 @@ class SingletonTenantDatabaseCollectionStateMachine(
             raise ValueError("trying to overwrite the model for singleton??")
         self.tenant_to_database_to_model[tenant] = model
 
-    @overrides
+    @override
     def set_database_model_for_tenant(
         self,
         tenant: str,
@@ -124,13 +129,13 @@ class SingletonTenantDatabaseCollectionStateMachine(
             raise ValueError("trying to overwrite the model for singleton??")
         self.tenant_to_database_to_model[tenant][database] = database_model
 
-    @overrides
+    @override
     def overwrite_database(self, database: str) -> str:
         if self.client == self.singleton_client:
             return SINGLETON_DATABASE
         return database
 
-    @overrides
+    @override
     def overwrite_tenant(self, tenant: str) -> str:
         if self.client == self.singleton_client:
             return SINGLETON_TENANT

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -1,9 +1,14 @@
 import hypothesis.stateful
 import hypothesis.strategies
-from overrides import overrides
+import sys
 import pytest
 import logging
 import hypothesis
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 import hypothesis.strategies as st
 from hypothesis import given, settings, HealthCheck
 from typing import Dict, Set, cast, Union, DefaultDict, Any, List
@@ -112,7 +117,7 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
             ids=[], metadatas=[], documents=[], embeddings=[]
         )
 
-    @overrides
+    @override
     def teardown(self) -> None:
         self.client.delete_collection(self.collection.name)
 

--- a/chromadb/test/property/test_fork.py
+++ b/chromadb/test/property/test_fork.py
@@ -5,6 +5,7 @@ import copy
 import hypothesis.strategies as hyst
 import logging
 import pytest
+import sys
 
 from chromadb.api.models.Collection import Collection
 from chromadb.test.conftest import reset, skip_if_not_cluster
@@ -19,7 +20,11 @@ from hypothesis.stateful import (
     run_state_machine_as_test,
     MultipleResults,
 )
-from overrides import overrides
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from typing import Dict, cast, Union, Tuple, Set
 
 collection_st = hyst.shared(strategies.collections(with_hnsw_params=True), key="source")
@@ -53,7 +58,7 @@ class ForkStateMachine(RuleBasedStateMachine):
             ids=[], metadatas=[], documents=[], embeddings=[]
         )
 
-    @overrides
+    @override
     def teardown(self) -> None:
         reset(self.client)
 

--- a/chromadb/test/property/test_restart_persist.py
+++ b/chromadb/test/property/test_restart_persist.py
@@ -1,4 +1,9 @@
-from overrides import overrides
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from chromadb.api.client import Client
 from chromadb.config import System
 import hypothesis.strategies as st
@@ -40,7 +45,7 @@ class RestartablePersistedEmbeddingStateMachine(EmbeddingStateMachineBase):
         super().__init__(client)
 
     @initialize(collection=collection_persistent_st)  # type: ignore
-    @overrides
+    @override
     def initialize(self, collection: strategies.Collection):
         self.client.reset()
 
@@ -69,7 +74,7 @@ class RestartablePersistedEmbeddingStateMachine(EmbeddingStateMachineBase):
             self.collection.name, embedding_function=self.embedding_function
         )
 
-    @overrides
+    @override
     def teardown(self) -> None:
         super().teardown()
         # Need to manually stop the system to cleanup resources because we may have created a new system (above rule).

--- a/chromadb/test/test_config.py
+++ b/chromadb/test/test_config.py
@@ -1,7 +1,12 @@
 from chromadb.config import Component, System, Settings
-from overrides import overrides
 from threading import local
 import random
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 
 data = local()  # use thread local just in case tests ever run in parallel
 
@@ -20,11 +25,11 @@ class ComponentA(Component):
         self.require(ComponentB)
         self.require(ComponentC)
 
-    @overrides
+    @override
     def start(self) -> None:
         data.starts += "A"
 
-    @overrides
+    @override
     def stop(self) -> None:
         data.stops += "A"
 
@@ -36,11 +41,11 @@ class ComponentB(Component):
         self.require(ComponentC)
         self.require(ComponentD)
 
-    @overrides
+    @override
     def start(self) -> None:
         data.starts += "B"
 
-    @overrides
+    @override
     def stop(self) -> None:
         data.stops += "B"
 
@@ -51,11 +56,11 @@ class ComponentC(Component):
         super().__init__(system)
         self.require(ComponentD)
 
-    @overrides
+    @override
     def start(self) -> None:
         data.starts += "C"
 
-    @overrides
+    @override
     def stop(self) -> None:
         data.stops += "C"
 
@@ -65,11 +70,11 @@ class ComponentD(Component):
         data.inits += "D"
         super().__init__(system)
 
-    @overrides
+    @override
     def start(self) -> None:
         data.starts += "D"
 
-    @overrides
+    @override
     def stop(self) -> None:
         data.stops += "D"
 
@@ -165,11 +170,11 @@ class ComponentZ(Component):
         super().__init__(system)
         self.require(ComponentC)
 
-    @overrides
+    @override
     def start(self) -> None:
         pass
 
-    @overrides
+    @override
     def stop(self) -> None:
         pass
 

--- a/chromadb/types.py
+++ b/chromadb/types.py
@@ -1,10 +1,14 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Optional, Union, Sequence, Dict, Mapping, Generic
+import sys
 
 from typing_extensions import Self
 
-from overrides import override
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from overrides import overrides as override
 from typing_extensions import TypedDict, TypeVar
 from uuid import UUID
 from enum import Enum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Chroma."
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = ["Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent"]
-dependencies = ['build >= 1.0.3', 'pydantic >= 1.9', 'pybase64>=1.4.1', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0, < 6.0.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
+dependencies = ['build >= 1.0.3', 'pydantic >= 1.9', 'pybase64>=1.4.1', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0, < 6.0.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1; python_version < "3.12"', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
 
 [project.optional-dependencies]
 dev = ['chroma-hnswlib==0.7.6', 'fastapi>=0.115.9', 'opentelemetry-instrumentation-fastapi>=0.41b0']


### PR DESCRIPTION
## Description of changes

Fixes #5554 

This PR uses [`typing.override`](https://docs.python.org/3/library/typing.html#typing.override) in favor of the [`overrides`](https://pypi.org/project/overrides/) dependency when possible. As of Python 3.12, the standard library offers `typing.override` to perform a static check on overridden methods. 

### Motivation

Currently, `overrides` is incompatible with Python 3.14. As a result, any package that attempts to import `overrides` using Python 3.14+ will raise an `AttributeError`. An [issue](https://github.com/mkorpela/overrides/issues/127) has been raised and a [pull request](https://github.com/mkorpela/overrides/pull/133) has been submitted to the GitHub repo for the `overrides` project. But the maintainer has been unresponsive.

To ensure readiness for Python 3.14, this package (and any other package directly depending on `overrides`) should consider using `typing.override` instead.

### Impact

The standard library added `typing.override` as of 3.12. As a result, this change will affect only users of Python 3.12+. Previous versions will continue to rely on `overrides`. Notably, the standard library implementation is slightly different than that of `overrides`. A thorough discussion of those differences is shown in [PEP 698](https://peps.python.org/pep-0698/), and it is also summarized nicely by the maintainer of `overrides` [here](https://github.com/mkorpela/overrides/issues/126#issuecomment-2401327116). 

There are 2 main ways that switching from `overrides` to `typing.override` will have an impact on developers of this repo.
1. `typing.override` does not implement any runtime checking. Instead, it provides information to type checkers.
2. The stdlib does not provide a mixin class to enforce override decorators on child classes. (Their reasoning for this is explained in [the PEP](https://peps.python.org/pep-0698/).) This PR disables that behavior entirely by replacing the `EnforceOverrides`.

- Improvements & Bug fixes
  - The package won't crash in a Python 3.14 runtime due to `overrides` incompatibility
- New functionality
  - In Python 3.12+, the override decorations will not have a runtime impact. They merely expose information to static analysis tools

## Test plan

After applying these changes, I'm able to import the modules locally in Python 3.14.0rc2 without errors. I don't have a plan to write tests. Open to suggestions

## Migration plan

I've updated the `pyproject.toml` to use a PEP508 compliant [dependency specifier](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers) so that `overrides` need not be installed for users of newer Python versions.

## Observability plan

I don't have a plan at this time. Open to suggestions.

## Documentation Changes

As far as I can tell, the change to the decorators doesn't have a user-visible impact, and therefore shouldn't necessitate docstring or documentation updates