### PR TITLE
[ENH] Update schema to reconcile with config on read path, and use in knn and spann

### DIFF
--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -60,7 +60,7 @@ circuit_breaker:
   requests: 1000
 enable_span_indexing: true
 default_knn_index: "spann"
-enable_schema: false
+enable_schema: true
 tenants_to_migrate_immediately:
 - "default_tenant"
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -3,7 +3,10 @@ use chroma_cache::{AysncPartitionedMutex, Cache, CacheError, Weighted};
 use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
-use chroma_types::{CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError};
+use chroma_types::{
+    CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError, InternalSchema,
+    SchemaError,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     sync::Arc,
@@ -118,6 +121,8 @@ pub(crate) enum CollectionsWithSegmentsProviderError {
     Cache(#[from] CacheError),
     #[error(transparent)]
     SysDB(#[from] GetCollectionWithSegmentsError),
+    #[error("Failed to reconcile schema: {0}")]
+    InvalidSchema(#[from] SchemaError),
 }
 
 impl ChromaError for CollectionsWithSegmentsProviderError {
@@ -125,6 +130,7 @@ impl ChromaError for CollectionsWithSegmentsProviderError {
         match self {
             CollectionsWithSegmentsProviderError::Cache(e) => e.code(),
             CollectionsWithSegmentsProviderError::SysDB(e) => e.code(),
+            CollectionsWithSegmentsProviderError::InvalidSchema(e) => e.code(),
         }
     }
 }
@@ -137,6 +143,7 @@ impl CollectionsWithSegmentsProvider {
     pub(crate) async fn get_collection_with_segments(
         &mut self,
         collection_id: CollectionUuid,
+        enable_schema: bool,
     ) -> Result<CollectionAndSegments, CollectionsWithSegmentsProviderError> {
         if let Some(collection_and_segments_with_ttl) = self
             .collections_with_segments_cache
@@ -152,7 +159,7 @@ impl CollectionsWithSegmentsProvider {
             }
         }
 
-        let collection_and_segments_sysdb = {
+        let mut collection_and_segments_sysdb = {
             // We acquire a lock to prevent the sysdb from experiencing a thundering herd.
             // This can happen when a large number of threads try to get the same collection
             // at the same time.
@@ -178,6 +185,19 @@ impl CollectionsWithSegmentsProvider {
                 .await?
         };
 
+        // reconcile schema and config
+        if enable_schema {
+            let reconciled_schema = InternalSchema::reconcile_schema_and_config(
+                collection_and_segments_sysdb.collection.schema.clone(),
+                Some(collection_and_segments_sysdb.collection.config.clone()),
+            )
+            .map_err(|reason| {
+                CollectionsWithSegmentsProviderError::InvalidSchema(SchemaError::InvalidSchema {
+                    reason,
+                })
+            })?;
+            collection_and_segments_sysdb.collection.schema = Some(reconciled_schema);
+        }
         self.set_collection_with_segments(collection_and_segments_sysdb.clone())
             .await;
         Ok(collection_and_segments_sysdb)

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -640,6 +640,8 @@ pub type GetCollectionResponse = Collection;
 
 #[derive(Debug, Error)]
 pub enum GetCollectionError {
+    #[error("Failed to reconcile schema: {0}")]
+    InvalidSchema(#[from] SchemaError),
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
     #[error("Collection [{0}] does not exist")]
@@ -649,6 +651,7 @@ pub enum GetCollectionError {
 impl ChromaError for GetCollectionError {
     fn code(&self) -> ErrorCodes {
         match self {
+            GetCollectionError::InvalidSchema(e) => e.code(),
             GetCollectionError::Internal(err) => err.code(),
             GetCollectionError::NotFound(_) => ErrorCodes::NotFound,
         }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -206,7 +206,7 @@ pub enum CompactionError {
     Register(#[from] RegisterError),
     #[error("Error receiving final result: {0}")]
     Result(#[from] RecvError),
-    #[error("Error creaitng spann writer: {0}")]
+    #[error("Error creating spann writer: {0}")]
     SpannSegment(#[from] SpannSegmentWriterError),
     #[error("Error sourcing record segment: {0}")]
     SourceRecordSegment(#[from] SourceRecordSegmentError),


### PR DESCRIPTION
## Description of changes

This PR adds logic to reconcile schema and config during get_collection and in the get path of get_or_create_collection. It then uses this reconciled schema where config was used previously (hnsw, spann, knn)

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
