### PR TITLE
[ENH] On query path, check where clause for unindexed metadata keys

### DIFF
--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -1215,6 +1215,17 @@ pub enum MetadataSetValue {
     Str(Vec<String>),
 }
 
+impl MetadataSetValue {
+    pub fn value_type(&self) -> MetadataValueType {
+        match self {
+            MetadataSetValue::Bool(_) => MetadataValueType::Bool,
+            MetadataSetValue::Int(_) => MetadataValueType::Int,
+            MetadataSetValue::Float(_) => MetadataValueType::Float,
+            MetadataSetValue::Str(_) => MetadataValueType::Str,
+        }
+    }
+}
+
 // TODO: Deprecate where_document
 impl TryFrom<chroma_proto::WhereDocument> for Where {
     type Error = WhereConversionError;


### PR DESCRIPTION
## Description of changes

This PR errors the query path when the user attempts to use a disabled metadata index in a where clause
- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
