### PR TITLE
[CHORE]: Cleanup task operator codegen

### DIFF
--- a/bin/generate_operator_constants.sh
+++ b/bin/generate_operator_constants.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -x
+
+# Script to generate Rust operator constants from Go source
+# Run this whenever go/pkg/sysdb/metastore/db/dbmodel/constants.go changes
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Generating Rust operator constants from Go source..."
+
+cd "$WORKSPACE_ROOT"
+
+# Temporarily modify build.rs to enable code generation
+BUILD_RS="rust/types/build.rs"
+BUILD_RS_BACKUP="$BUILD_RS.backup"
+
+# Backup the original build.rs
+cp "$BUILD_RS" "$BUILD_RS_BACKUP"
+
+# Add the module and function call back temporarily
+sed -i.tmp '1i\
+mod operator_codegen;' "$BUILD_RS"
+sed -i.tmp '/Note: Operator constants/,/This avoids/d' "$BUILD_RS"
+sed -i.tmp 's|Ok(())|// Generate operator constants from Go source\n    operator_codegen::generate_operator_constants()?;\n\n    Ok(())|' "$BUILD_RS"
+rm -f "$BUILD_RS.tmp"
+
+# Run cargo build to trigger generation
+echo "Running code generation..."
+cargo build -p chroma-types --quiet 2>&1 || {
+    # Restore on error
+    mv "$BUILD_RS_BACKUP" "$BUILD_RS"
+    echo "Error: Code generation failed"
+    exit 1
+}
+
+# Restore the original build.rs
+mv "$BUILD_RS_BACKUP" "$BUILD_RS"
+
+# Find and copy the generated file
+GENERATED_FILE=$(find target/debug/build/chroma-types-*/out/operators_generated.rs -type f 2>/dev/null | head -1)
+
+if [ -z "$GENERATED_FILE" ]; then
+    echo "Error: Could not find generated file"
+    exit 1
+fi
+
+TARGET_FILE="$WORKSPACE_ROOT/rust/types/src/operators_generated.rs"
+cp "$GENERATED_FILE" "$TARGET_FILE"
+
+echo "✓ Generated $TARGET_FILE"
+echo ""
+echo "The file has been updated. Please review and commit the changes."

--- a/rust/types/README_OPERATORS.md
+++ b/rust/types/README_OPERATORS.md
@@ -19,4 +19,4 @@
    - `go/pkg/sysdb/metastore/db/dbmodel/constants.go`
    - `rust/types/src/operators_generated.rs`
 
-The test `test_operator_constants_match_database` will verify everything is in sync.
+The test `test_k8s_integration_operator_constants` will verify everything is in sync.


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._
This polishes the documentation for operator codegen added in 94817fb555542527a14d41efdb4dbeee7c0b937a and also adds the mentioned script to generate rust constants for these operators.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_