### PR TITLE
[ENH]: Compactor endpoint to list DLQ entries

### DIFF
--- a/idl/chromadb/proto/compactor.proto
+++ b/idl/chromadb/proto/compactor.proto
@@ -22,7 +22,16 @@ message RebuildResponse {
   // Empty
 }
 
+message ListDeadJobsRequest {
+  // Empty
+}
+
+message ListDeadJobsResponse {
+  CollectionIds ids = 1;
+}
+
 service Compactor {
   rpc Compact(CompactRequest) returns (CompactResponse) {}
   rpc Rebuild(RebuildRequest) returns (RebuildResponse) {}
+  rpc ListDeadJobs(ListDeadJobsRequest) returns (ListDeadJobsResponse) {}
 }

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -1,4 +1,5 @@
 use chroma_types::CollectionUuid;
+use tokio::sync::oneshot;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct CompactionJob {
@@ -16,4 +17,9 @@ pub struct OneOffCompactMessage {
 #[derive(Clone, Debug)]
 pub struct RebuildMessage {
     pub collection_ids: Vec<CollectionUuid>,
+}
+
+#[derive(Debug)]
+pub struct ListDeadJobsMessage {
+    pub response_tx: oneshot::Sender<Vec<CollectionUuid>>,
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - This change also refactors DLQ logic to check DLQ eligibility every time a job is scheduled instead of when it fails.
- New functionality
    - An endpoint to list the entries of the DLQ. Should work similar to rebuild from the compaction client but the name of the endpoint is 1list-dead-jobs`instead. Example usage`cargo run --bin compaction_client -- --url http://localhost:50051 list-dead-jobs` assuming the compactor is listening at 50051.

## Test plan

_How are these changes tested?_

A rust test has been added + manual testing.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_