### PR TITLE
[BUG] Fix config loading for enabled_schema flag, reconcile in get_collection_with_segments without flag

### DIFF
--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -167,8 +167,6 @@ pub struct FrontendServerConfig {
     pub cors_allow_origins: Option<Vec<String>>,
     #[serde(default = "default_enable_span_indexing")]
     pub enable_span_indexing: bool,
-    #[serde(default = "default_enable_schema")]
-    pub enable_schema: bool,
 }
 
 const DEFAULT_CONFIG_PATH: &str = "sample_configs/distributed.yaml";
@@ -198,9 +196,9 @@ impl FrontendServerConfig {
         if std::path::Path::new(path).exists() {
             f = figment::Figment::from(Yaml::file(path)).merge(f);
         }
-        let res: Result<Self, _> = f.extract();
+        let res = f.extract();
         match res {
-            Ok(config) => config.propogate_frontend_enable_schema(),
+            Ok(config) => config,
             Err(e) => panic!("Error loading config: {}", e),
         }
     }
@@ -212,21 +210,11 @@ impl FrontendServerConfig {
         let config_data = config.data;
         let config_str = std::str::from_utf8(&config_data).expect("Failed to parse config data");
         let f = figment::Figment::from(Yaml::string(config_str));
-        let res: Result<Self, _> = f.extract();
+        let res = f.extract();
         match res {
-            Ok(config) => config.propogate_frontend_enable_schema(),
+            Ok(config) => config,
             Err(e) => panic!("Error loading config: {}", e),
         }
-    }
-}
-
-impl FrontendServerConfig {
-    fn propogate_frontend_enable_schema(mut self) -> Self {
-        // Propagate the top-level toggle into the flattened frontend config for backward compatibility.
-        if self.enable_schema {
-            self.frontend.enable_schema = true;
-        }
-        self
     }
 }
 
@@ -267,7 +255,6 @@ mod tests {
             CacheConfig::Nop => {}
             _ => {}
         }
-        assert!(config.enable_schema);
         assert!(config.frontend.enable_schema);
     }
 

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -143,7 +143,6 @@ impl CollectionsWithSegmentsProvider {
     pub(crate) async fn get_collection_with_segments(
         &mut self,
         collection_id: CollectionUuid,
-        enable_schema: bool,
     ) -> Result<CollectionAndSegments, CollectionsWithSegmentsProviderError> {
         if let Some(collection_and_segments_with_ttl) = self
             .collections_with_segments_cache
@@ -186,18 +185,16 @@ impl CollectionsWithSegmentsProvider {
         };
 
         // reconcile schema and config
-        if enable_schema {
-            let reconciled_schema = InternalSchema::reconcile_schema_and_config(
-                collection_and_segments_sysdb.collection.schema.clone(),
-                Some(collection_and_segments_sysdb.collection.config.clone()),
-            )
-            .map_err(|reason| {
-                CollectionsWithSegmentsProviderError::InvalidSchema(SchemaError::InvalidSchema {
-                    reason,
-                })
-            })?;
-            collection_and_segments_sysdb.collection.schema = Some(reconciled_schema);
-        }
+        let reconciled_schema = InternalSchema::reconcile_schema_and_config(
+            collection_and_segments_sysdb.collection.schema.clone(),
+            Some(collection_and_segments_sysdb.collection.config.clone()),
+        )
+        .map_err(|reason| {
+            CollectionsWithSegmentsProviderError::InvalidSchema(SchemaError::InvalidSchema {
+                reason,
+            })
+        })?;
+        collection_and_segments_sysdb.collection.schema = Some(reconciled_schema);
         self.set_collection_with_segments(collection_and_segments_sysdb.clone())
             .await;
         Ok(collection_and_segments_sysdb)

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -171,7 +171,7 @@ impl ServiceBasedFrontend {
     ) -> Result<Collection, GetCollectionError> {
         Ok(self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.enable_schema)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?
             .collection)
@@ -183,7 +183,7 @@ impl ServiceBasedFrontend {
     ) -> Result<Option<u32>, GetCollectionError> {
         Ok(self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.enable_schema)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?
             .collection
@@ -1065,7 +1065,7 @@ impl ServiceBasedFrontend {
         let read_event = if let Some(where_clause) = r#where {
             let collection_and_segments = self
                 .collections_with_segments_provider
-                .get_collection_with_segments(collection_id, self.enable_schema)
+                .get_collection_with_segments(collection_id)
                 .await
                 .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
             if self.enable_schema {
@@ -1275,7 +1275,7 @@ impl ServiceBasedFrontend {
     ) -> Result<CountResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.enable_schema)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         let latest_collection_logical_size_bytes = collection_and_segments
@@ -1390,7 +1390,7 @@ impl ServiceBasedFrontend {
     ) -> Result<GetResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.enable_schema)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         if self.enable_schema {
@@ -1535,7 +1535,7 @@ impl ServiceBasedFrontend {
     ) -> Result<QueryResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.enable_schema)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         if self.enable_schema {
@@ -1692,7 +1692,7 @@ impl ServiceBasedFrontend {
         // Get collection and segments once for all queries
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(request.collection_id, self.enable_schema)
+            .get_collection_with_segments(request.collection_id)
             .await
             .map_err(|err| QueryError::Other(Box::new(err) as Box<dyn ChromaError>))?;
         if self.enable_schema {


### PR DESCRIPTION
## Description of changes

There was a bug where enabled_schema was added to both FrontendServerConfig and FrontendConfig, so when flattened one overwrote the other and config was not propagating correctly. to fix this, we removed it from the FrontendServerConfig. Also, to fix the read case where spannReader and knnFilter were requiring schema, we reconcile indiscriminantly in the internal get_collection_with_segments.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_
updated config tests to ensure flag propagation to frontend config

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

No migrations required

## Observability plan

No observability required

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
