### PR TITLE
[CHORE] add the ability to distinguish between queries and docs for js client embedding

### DIFF
--- a/clients/new-js/packages/chromadb/src/collection.ts
+++ b/clients/new-js/packages/chromadb/src/collection.ts
@@ -290,14 +290,14 @@ export class CollectionImpl implements Collection {
     };
   }
 
-  private async embed(documents: string[]): Promise<number[][]> {
+  private async embed(documents: string[], isQuery: boolean): Promise<number[][]> {
     if (!this._embeddingFunction) {
       throw new ChromaValueError(
         "Embedding function must be defined for operations requiring embeddings.",
       );
     }
 
-    return await this._embeddingFunction.generate(documents);
+    return await this._embeddingFunction.generate(documents, isQuery);
   }
 
   private async prepareRecords<T extends boolean = false>({
@@ -315,7 +315,7 @@ export class CollectionImpl implements Collection {
     validateMaxBatchSize(recordSet.ids.length, maxBatchSize);
 
     if (!recordSet.embeddings && recordSet.documents) {
-      recordSet.embeddings = await this.embed(recordSet.documents);
+      recordSet.embeddings = await this.embed(recordSet.documents, false);
     }
 
     const preparedRecordSet: PreparedRecordSet = { ...recordSet };
@@ -364,7 +364,7 @@ export class CollectionImpl implements Collection {
 
     let embeddings: number[][];
     if (!recordSet.embeddings) {
-      embeddings = await this.embed(recordSet.documents!);
+      embeddings = await this.embed(recordSet.documents!, true);
     } else {
       embeddings = recordSet.embeddings;
     }

--- a/clients/new-js/packages/chromadb/src/embedding-function.ts
+++ b/clients/new-js/packages/chromadb/src/embedding-function.ts
@@ -17,7 +17,7 @@ export interface EmbeddingFunction {
    * @param texts - Array of text strings to embed
    * @returns Promise resolving to array of embedding vectors
    */
-  generate(texts: string[]): Promise<number[][]>;
+  generate(texts: string[], isQuery?: boolean): Promise<number[][]>;
   /** Optional name identifier for the embedding function */
   name?: string;
   /** Returns the default vector space for this embedding function */


### PR DESCRIPTION
We want to allow embedding functions on the JS client to optionally define separate logic for embedding documents and queries. We achieve this by passing an isQuery param through the collection object's internal embed function, and supplying it to the embedding function object's generate function.