### PR TITLE
[BUG] Mem leak handles in scheduler

### DIFF
--- a/rust/system/src/scheduler.rs
+++ b/rust/system/src/scheduler.rs
@@ -22,7 +22,7 @@ impl Debug for SchedulerTaskHandle {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct TaskId(u64);
 
-pub struct HandleGuard {
+pub(crate) struct HandleGuard {
     weak_handles: Weak<RwLock<HashMap<TaskId, SchedulerTaskHandle>>>,
     task_id: TaskId,
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Fixes a memory leak of handles in the scheduler by adding a drop guard to handles and tracking them in a hashmap
- New functionality
  - None

## Test plan

_How are these changes tested?_
Added a test to ensure map is empty after schedule finished
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None required

## Observability plan
None required

## Documentation Changes
None required