### PR TITLE
[ENH] On search, traverse through rank expression to check if indexing is enabled

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -1705,6 +1705,17 @@ impl ServiceBasedFrontend {
                                 QueryError::Other(Box::new(err) as Box<dyn ChromaError>)
                             })?;
                     }
+                    // for rank expressions, if knn has a key, check if the key is enabled
+                    if let Some(rank_expr) = &payload.rank.expr {
+                        let knn_queries = rank_expr.knn_queries();
+                        for knn_query in knn_queries {
+                            schema
+                                .is_knn_key_indexing_enabled(&knn_query.key, &knn_query.query)
+                                .map_err(|err| {
+                                    QueryError::Other(Box::new(err) as Box<dyn ChromaError>)
+                                })?;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - On search api, there previously was not checks for if sparse vectors were enabled in the rank knn expressions. To fix this, we iterate through the knn operations found in the expression and validate the key is indexed with sparse vectors
- New functionality
  - ...

## Test plan

_How are these changes tested?_
unit tests & manually

```
schema = Schema().create_index(key="metadata_key1", config=SparseVectorIndexConfig())
collection3 = client.get_or_create_collection("collection3", schema=schema)

print("collection3 schema:")
print(json.dumps(collection3.schema.serialize_to_json(), indent=2))

collection3.add(
    ids=["1"],
    documents=["Hello, world!"],
    metadatas=[{"metadata_key1": {
        "indices": [1, 2, 3],
        "values": [0.1, 0.2, 0.3]
    },"metadata_key2": {
        "indices": [1, 2, 3],
        "values": [0.1, 0.2, 0.3]
    }}]
)

print("collection3 search on metadata_key1:")
print(json.dumps(collection3.search(
    Search().rank(Knn(key="metadata_key1", query={"indices": [1, 2, 3], "values": [0.1, 0.2, 0.3]}))
), indent=2))

# this should fail
print("collection3 search on metadata_key2:")
try:
    print(json.dumps(collection3.search(
            Search().rank(Knn(key="metadata_key2", query={"indices": [1, 2, 3], "values": [0.1, 0.2, 0.3]}))
        ), indent=2))
except Exception as e:
    print("collection3 search on metadata_key2 failed: ", e)
```

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
