### PR TITLE
[FIX] Update LlamaIndex links

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/integrations/frameworks/llamaindex.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/frameworks/llamaindex.md
@@ -5,6 +5,6 @@ name: LlamaIndex
 
 # LlamaIndex
 
-- `LlamaIndex` [Vector Store page](https://docs.llamaindex.ai/en/stable/examples/vector_stores/ChromaIndexDemo.html)
-- [Demo](https://github.com/jerryjliu/llama_index/blob/main/docs/docs/examples/vector_stores/ChromaIndexDemo.ipynb)
+- `LlamaIndex` [Vector Store page](https://developers.llamaindex.ai/python/examples/vector_stores/chroma_metadata_filter/)
+- [Demo](https://github.com/run-llama/llama_index/blob/f8da51d9fdfe6541831b1d7fb90c0f6d381bf08d/docs/examples/vector_stores/ChromaIndexDemo.ipynb#L4)
 - [Chroma Loader on Llamahub](https://llamahub.ai/l/vector_stores/llama-index-vector-stores-chroma)


### PR DESCRIPTION
## Description of changes
closes #4446

- Change link for vector store page to point to correct link on LlamaIndex
- Change link of demo Jupyter notebook file to point to correct place in LlamaIndex repository

- Improvements & Bug fixes
  - LlamaIndex link fixes
- New functionality
  - /

## Test plan

Open link in a tab and see a non-404 page

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

No

## Observability plan

Open the link in a browser

## Documentation Changes

No
