### PR TITLE
[BUG] Reconcile schema and config on retryable_fork

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1017,6 +1017,8 @@ pub enum ForkCollectionError {
     NotFound(String),
     #[error("Failed to convert proto segment")]
     SegmentConversionError(#[from] SegmentConversionError),
+    #[error("Failed to reconcile schema: {0}")]
+    InvalidSchema(#[from] SchemaError),
 }
 
 impl ChromaError for ForkCollectionError {
@@ -1030,6 +1032,7 @@ impl ChromaError for ForkCollectionError {
             ForkCollectionError::Local => ErrorCodes::Unimplemented,
             ForkCollectionError::Internal(e) => e.code(),
             ForkCollectionError::SegmentConversionError(e) => e.code(),
+            ForkCollectionError::InvalidSchema(e) => e.code(),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

There was a bug where on a call to .fork(), there was no reconciliation happening. therefore, a call to .fork() -> a query caused an invalidSchema error. This PR fixes that bug

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan
Manual test, monitor smoke tests

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
