### PR TITLE
[BUG] Use vendored openssl for build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = { version = "1.4" }
 lexical-core = "1.0"
 num_cpus = "1.16.0"
 once_cell = "1.21.3"
+openssl = { version = "0.10", features = ["vendored"] }
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.27", features = ["http-proto"] }
 opentelemetry-http = { version = "0.27", features = ["reqwest-rustls"] }


### PR DESCRIPTION
## Description of changes

We are seeing the following error in github action builds:

```
  thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/openssl-sys-0.9.103/build/main.rs:263:13:

  Header expansion error:
  Error { kind: ToolExecError, message: "Command \"/home/runner/.cache/cargo-zigbuild/0.20.0/zigcc-x86_64-unknown-linux-gnu.2.17-d94d.sh\" \"-O3\" \"-ffunction-sections\" \"-fdata-sections\" \"-fPIC\" \"-gdwarf-4\" \"-fno-omit-frame-pointer\" \"-m64\" \"--target=x86_64-unknown-linux-gnu\" \"-I\" \"/usr/include\" \"-Wall\" \"-Wextra\" \"-E\" \"build/expando.c\" with args zigcc-x86_64-unknown-linux-gnu.2.17-d94d.sh did not execute successfully (status code exit status: 1)." }

  Failed to find OpenSSL development headers.

  You can try fixing this setting the `OPENSSL_DIR` environment variable
  pointing to your OpenSSL installation or installing OpenSSL headers package
  specific to your distribution:
```

Ref: https://github.com/chroma-core/chroma/actions/runs/18479788585/job/52656655136

I veriried that we actually have `libssl-dev` installed in the github runners. So, it's unclear why this started failing all of the sudden.

According to some sources online, this can be fixed by vendoring openssl.

* https://github.com/PyO3/maturin-action/issues/205
* https://github.com/rust-openssl/rust-openssl/issues/2217#issuecomment-2723005691
* https://stackoverflow.com/questions/65553557/why-rust-is-failing-to-build-command-for-openssl-sys-v0-9-60-even-after-local-in#comment118424959_65554916
* https://stackoverflow.com/questions/76593417/package-openssl-was-not-found-in-the-pkg-config-search-path

So, it seems worth trying out this potential fix.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A