### PR TITLE
[ENH] expose bucket name in S3

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -42,7 +42,7 @@ use tokio::{
 /// For writes, it will rate limit the number of concurrent requests.
 #[derive(Clone)]
 pub struct AdmissionControlledS3Storage {
-    storage: S3Storage,
+    pub(crate) storage: S3Storage,
     #[allow(clippy::type_complexity)]
     outstanding_read_requests: Arc<tokio::sync::Mutex<HashMap<String, InflightRequest>>>,
     rate_limiter: Arc<RateLimitPolicy>,

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -231,6 +231,15 @@ impl ChromaError for StorageConfigError {
 }
 
 impl Storage {
+    /// Get the bucket name for S3-based storage, or None for local storage
+    pub fn bucket_name(&self) -> Option<&str> {
+        match self {
+            Storage::S3(s3) => Some(&s3.bucket),
+            Storage::AdmissionControlledS3(ac_s3) => Some(&ac_s3.storage.bucket),
+            Storage::Local(_) => None,
+        }
+    }
+
     pub async fn get(&self, key: &str, options: GetOptions) -> Result<Arc<Vec<u8>>, StorageError> {
         match self {
             Storage::S3(s3) => s3.get(key, options).await,

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -156,7 +156,7 @@ impl Default for StorageMetrics {
 
 #[derive(Clone)]
 pub struct S3Storage {
-    pub(super) bucket: String,
+    pub(crate) bucket: String,
     pub(super) client: aws_sdk_s3::Client,
     pub(super) upload_part_size_bytes: usize,
     pub(super) download_part_size_bytes: usize,


### PR DESCRIPTION
## Description of changes


This exposes the S3 bucket name to consumers of the `chroma::storage` crate.  This will allow for detailed error messages.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
