### PR TITLE
[BUG] Make benchmark dev dep in index crate

### DIFF
--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -39,15 +39,13 @@ itertools = { workspace = true }
 hnswlib = { workspace = true }
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 
-# Dependencies for examples
+[dev-dependencies]
 indicatif = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 sprs = { workspace = true }
 chroma-benchmark = { workspace = true }
 regex = { workspace = true }
-
-[dev-dependencies]
 rayon = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Moves `chroma-benchmark` into development dependencies for index crate. Previously release to PyPI workflow fails because `chroma-benchmark` pulls in failing dependencies.
- New functionality
    - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_