### PR TITLE
[ENH] Add hosted splade embedding function to python and js

### DIFF
--- a/chromadb/utils/embedding_functions/chroma_cloud_splade_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_splade_embedding_function.py
@@ -1,0 +1,145 @@
+from chromadb.api.types import (
+    SparseEmbeddingFunction,
+    SparseEmbeddings,
+    Documents,
+)
+from typing import Dict, Any
+from enum import Enum
+from chromadb.utils.embedding_functions.schemas import validate_config_schema
+from chromadb.utils.sparse_embedding_utils import _sort_sparse_vectors
+import os
+from typing import Union
+
+
+class ChromaCloudSpladeEmbeddingModel(Enum):
+    SPLADE_PP_EN_V1 = "prithivida/Splade_PP_en_v1"
+
+
+class ChromaCloudSpladeEmbeddingFunction(SparseEmbeddingFunction[Documents]):
+    def __init__(
+        self,
+        api_key_env_var: str = "CHROMA_API_KEY",
+        model: ChromaCloudSpladeEmbeddingModel = ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+    ):
+        """
+        Initialize the ChromaCloudSpladeEmbeddingFunction.
+
+        Args:
+            api_key_env_var (str, optional): Environment variable name that contains your API key.
+                Defaults to "CHROMA_API_KEY".
+        """
+        try:
+            import httpx
+        except ImportError:
+            raise ValueError(
+                "The httpx python package is not installed. Please install it with `pip install httpx`"
+            )
+        self.api_key_env_var = api_key_env_var
+        self.api_key = os.getenv(self.api_key_env_var)
+        if not self.api_key:
+            raise ValueError(
+                f"API key not found in environment variable {self.api_key_env_var}"
+            )
+        self.model = model
+        self._api_url = "https://embed.trychroma.com/embed_sparse"
+        self._session = httpx.Client()
+        self._session.headers.update(
+            {
+                "x-chroma-token": self.api_key,
+                "x-chroma-embedding-model": self.model.value,
+            }
+        )
+
+    def __del__(self) -> None:
+        """
+        Cleanup the HTTP client session when the object is destroyed.
+        """
+        if hasattr(self, "_session"):
+            self._session.close()
+
+    def close(self) -> None:
+        """
+        Explicitly close the HTTP client session.
+        Call this method when you're done using the embedding function.
+        """
+        if hasattr(self, "_session"):
+            self._session.close()
+
+    def __call__(self, input: Documents) -> SparseEmbeddings:
+        """
+        Generate embeddings for the given documents.
+
+        Args:
+            input (Documents): The documents to generate embeddings for.
+        """
+        if not input:
+            return []
+
+        payload: Dict[str, Union[str, Documents]] = {
+            "texts": list(input),
+            "task": "",
+            "target": "",
+        }
+
+        try:
+            import httpx
+
+            response = self._session.post(self._api_url, json=payload, timeout=60)
+            response.raise_for_status()
+            json_response = response.json()
+            return self._parse_response(json_response)
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Failed to get embeddings from Chroma Cloud API: HTTP {e.response.status_code} - {e.response.text}"
+            )
+        except httpx.TimeoutException:
+            raise RuntimeError("Request to Chroma Cloud API timed out after 60 seconds")
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Failed to get embeddings from Chroma Cloud API: {e}")
+        except Exception as e:
+            raise RuntimeError(f"Unexpected error calling Chroma Cloud API: {e}")
+
+    def _parse_response(self, response: Any) -> SparseEmbeddings:
+        """
+        Parse the response from the Chroma Cloud Sparse Embedding API.
+        """
+        embeddings: SparseEmbeddings = response["embeddings"]
+
+        # Ensure indices are sorted in ascending order
+        _sort_sparse_vectors(embeddings)
+
+        return embeddings
+
+    @staticmethod
+    def name() -> str:
+        return "chroma-cloud-splade"
+
+    @staticmethod
+    def build_from_config(
+        config: Dict[str, Any]
+    ) -> "SparseEmbeddingFunction[Documents]":
+        api_key_env_var = config.get("api_key_env_var")
+        model = config.get("model")
+        if model is None:
+            raise ValueError("model must be provided in config")
+        if not api_key_env_var:
+            raise ValueError("api_key_env_var must be provided in config")
+        return ChromaCloudSpladeEmbeddingFunction(
+            api_key_env_var=api_key_env_var,
+            model=ChromaCloudSpladeEmbeddingModel(model),
+        )
+
+    def get_config(self) -> Dict[str, Any]:
+        return {"api_key_env_var": self.api_key_env_var, "model": self.model.value}
+
+    def validate_config_update(
+        self, old_config: Dict[str, Any], new_config: Dict[str, Any]
+    ) -> None:
+        if "model" in new_config:
+            raise ValueError(
+                "model cannot be changed after the embedding function has been initialized"
+            )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        validate_config_schema(config, "chroma-cloud-splade")

--- a/clients/new-js/packages/ai-embeddings/all/package.json
+++ b/clients/new-js/packages/ai-embeddings/all/package.json
@@ -48,7 +48,8 @@
     "@chroma-core/openai": "workspace:^",
     "@chroma-core/together-ai": "workspace:^",
     "@chroma-core/voyageai": "workspace:^",
-    "@chroma-core/chroma-cloud-qwen": "workspace:^"
+    "@chroma-core/chroma-cloud-qwen": "workspace:^",
+    "@chroma-core/chroma-cloud-splade": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/clients/new-js/packages/ai-embeddings/all/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/all/src/index.ts
@@ -11,3 +11,4 @@ export * from "@chroma-core/openai";
 export * from "@chroma-core/together-ai";
 export * from "@chroma-core/voyageai";
 export * from "@chroma-core/chroma-cloud-qwen";
+export * from "@chroma-core/chroma-cloud-splade";

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/README.md
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/README.md
@@ -1,0 +1,43 @@
+# Chroma Cloud Splade Embeddings
+
+This package provides a sparse embedding function for the Splade model family hosted on Chroma's cloud embedding service. Splade (Sparse Lexical and Expansion) embeddings are particularly effective for information retrieval tasks, combining the benefits of sparse representations with learned relevance.
+
+## Installation
+
+```bash
+npm install @chroma-core/chroma-cloud-splade
+```
+
+## Usage
+
+```typescript
+import { ChromaClient } from "chromadb";
+import {
+  ChromaCloudSpladeEmbeddingFunction,
+  ChromaCloudSpladeEmbeddingModel,
+} from "@chroma-core/chroma-cloud-splade";
+
+// Initialize the embedder
+const embedder = new ChromaCloudSpladeEmbeddingFunction({
+  model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+  apiKeyEnvVar: "CHROMA_API_KEY",
+});
+
+## Configuration
+
+Set your Chroma API key as an environment variable:
+
+```bash
+export CHROMA_API_KEY=your-api-key
+```
+
+Get your API key from [Chroma's dashboard](https://trychroma.com/).
+
+## Configuration Options
+
+- **model**: Model to use for sparse embeddings (default: `SPLADE_PP_EN_V1`)
+- **apiKeyEnvVar**: Environment variable name for API key (default: `CHROMA_API_KEY`)
+
+## Supported Models
+
+- `prithivida/Splade_PP_en_v1` - Splade++ English v1 model optimized for information retrieval

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/jest.config.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/jest.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "jest";
+
+const config: Config = {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    testMatch: ["**/*.test.ts"],
+    transform: {
+        "^.+\\.tsx?$": [
+            "ts-jest",
+            {
+                useESM: true,
+            },
+        ],
+    },
+    extensionsToTreatAsEsm: [".ts"],
+    moduleNameMapper: {
+        "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    setupFiles: ["./jest.setup.ts"],
+};
+
+export default config;

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/jest.setup.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/jest.setup.ts
@@ -1,0 +1,3 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../../../.env" });

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/package.json
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/package.json
@@ -1,0 +1,54 @@
+{
+    "name": "@chroma-core/chroma-cloud-splade",
+    "version": "0.1.7",
+    "private": false,
+    "description": "Chroma Cloud Splade sparse embedding function",
+    "main": "dist/cjs/chroma-cloud-splade.cjs",
+    "types": "dist/chroma-cloud-splade.d.ts",
+    "module": "dist/chroma-cloud-splade.legacy-esm.js",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/chroma-cloud-splade.d.ts",
+                "default": "./dist/chroma-cloud-splade.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/chroma-cloud-splade.d.cts",
+                "default": "./dist/cjs/chroma-cloud-splade.cjs"
+            }
+        }
+    },
+    "files": [
+        "src",
+        "dist"
+    ],
+    "scripts": {
+        "clean": "rimraf dist",
+        "prebuild": "rimraf dist",
+        "build": "tsup",
+        "watch": "tsup --watch",
+        "test": "jest"
+    },
+    "devDependencies": {
+        "@jest/globals": "^29.7.0",
+        "dotenv": "^16.3.1",
+        "jest": "^29.7.0",
+        "rimraf": "^5.0.0",
+        "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
+        "tsup": "^8.3.5"
+    },
+    "peerDependencies": {
+        "chromadb": "workspace:^"
+    },
+    "dependencies": {
+        "@chroma-core/ai-embeddings-common": "workspace:^"
+    },
+    "engines": {
+        "node": ">=20"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/src/index.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+    ChromaCloudSpladeEmbeddingFunction,
+    ChromaCloudSpladeEmbeddingModel,
+} from "./index";
+
+describe("ChromaCloudSpladeEmbeddingFunction", () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const defaultParametersTest = "should initialize with default parameters";
+    if (!process.env.CHROMA_API_KEY) {
+        it.skip(defaultParametersTest, () => { });
+    } else {
+        it(defaultParametersTest, () => {
+            const embedder = new ChromaCloudSpladeEmbeddingFunction({
+                model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+            });
+            expect(embedder.name).toBe("chroma-cloud-splade");
+
+            const config = embedder.getConfig();
+            expect(config.model).toBe("prithivida/Splade_PP_en_v1");
+            expect(config.api_key_env_var).toBe("CHROMA_API_KEY");
+        });
+    }
+
+    it("should initialize with custom error for a API key", () => {
+        const originalEnv = process.env.CHROMA_API_KEY;
+        delete process.env.CHROMA_API_KEY;
+
+        try {
+            expect(() => {
+                new ChromaCloudSpladeEmbeddingFunction({
+                    model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+                });
+            }).toThrow("Chroma Embedding API key is required");
+        } finally {
+            if (originalEnv) {
+                process.env.CHROMA_API_KEY = originalEnv;
+            }
+        }
+    });
+
+    it("should use custom API key environment variable", () => {
+        process.env.CUSTOM_CHROMA_API_KEY = "test-api-key";
+
+        try {
+            const embedder = new ChromaCloudSpladeEmbeddingFunction({
+                model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+                apiKeyEnvVar: "CUSTOM_CHROMA_API_KEY",
+            });
+
+            expect(embedder.getConfig().api_key_env_var).toBe(
+                "CUSTOM_CHROMA_API_KEY",
+            );
+        } finally {
+            delete process.env.CUSTOM_CHROMA_API_KEY;
+        }
+    });
+
+    const buildFromConfigTest = "should build from config";
+    if (!process.env.CHROMA_API_KEY) {
+        it.skip(buildFromConfigTest, () => { });
+    } else {
+        it(buildFromConfigTest, () => {
+            const config = {
+                api_key_env_var: "CHROMA_API_KEY",
+                model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+            };
+
+            const embedder =
+                ChromaCloudSpladeEmbeddingFunction.buildFromConfig(config);
+
+            expect(embedder.getConfig()).toEqual(config);
+        });
+
+        const generateEmbeddingsTest = "should generate sparse embeddings";
+        if (!process.env.CHROMA_API_KEY) {
+            it.skip(generateEmbeddingsTest, () => { });
+        } else {
+            it(generateEmbeddingsTest, async () => {
+                const embedder = new ChromaCloudSpladeEmbeddingFunction({
+                    model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+                });
+                const texts = ["Hello world", "Test text"];
+                const embeddings = await embedder.generate(texts);
+
+                expect(embeddings.length).toBe(texts.length);
+
+                embeddings.forEach((embedding) => {
+                    expect(embedding.indices).toBeDefined();
+                    expect(embedding.values).toBeDefined();
+                    expect(embedding.indices.length).toBe(embedding.values.length);
+                    expect(embedding.indices.length).toBeGreaterThan(0);
+
+                    // Check that indices are sorted
+                    for (let i = 1; i < embedding.indices.length; i++) {
+                        expect(embedding.indices[i]).toBeGreaterThan(
+                            embedding.indices[i - 1],
+                        );
+                    }
+                });
+
+                // Verify embeddings are different
+                expect(embeddings[0].indices).not.toEqual(embeddings[1].indices);
+            });
+        }
+
+        const generateQueryEmbeddingsTest = "should generate query embeddings";
+        if (!process.env.CHROMA_API_KEY) {
+            it.skip(generateQueryEmbeddingsTest, () => { });
+        } else {
+            it(generateQueryEmbeddingsTest, async () => {
+                const embedder = new ChromaCloudSpladeEmbeddingFunction({
+                    model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+                });
+                const texts = ["search query"];
+                const embeddings = await embedder.generateForQueries!(texts);
+
+                expect(embeddings).toBeDefined();
+                expect(embeddings.length).toBe(1);
+                expect(embeddings[0].indices).toBeDefined();
+                expect(embeddings[0].values).toBeDefined();
+            });
+        }
+    }
+
+    const validateConfigUpdateTest = "should throw error when updating model";
+    if (!process.env.CHROMA_API_KEY) {
+        it.skip(validateConfigUpdateTest, () => { });
+    } else {
+        it(validateConfigUpdateTest, () => {
+            const embedder = new ChromaCloudSpladeEmbeddingFunction({
+                model: ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+            });
+
+            expect(() => {
+                embedder.validateConfigUpdate({ model: "new-model" });
+            }).toThrow("Model cannot be updated");
+        });
+    }
+});

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/src/index.ts
@@ -1,0 +1,178 @@
+import {
+    ChromaValueError,
+    type SparseEmbeddingFunction,
+    type SparseVector,
+    registerSparseEmbeddingFunction,
+} from "chromadb";
+import {
+    snakeCase,
+    validateConfigSchema,
+} from "@chroma-core/ai-embeddings-common";
+
+const NAME = "chroma-cloud-splade";
+
+export interface ChromaCloudSpladeConfig {
+    model: ChromaCloudSpladeEmbeddingModel;
+    api_key_env_var: string;
+}
+
+export enum ChromaCloudSpladeEmbeddingModel {
+    SPLADE_PP_EN_V1 = "prithivida/Splade_PP_en_v1",
+}
+
+export interface ChromaCloudSpladeArgs {
+    model?: ChromaCloudSpladeEmbeddingModel;
+    apiKeyEnvVar?: string;
+}
+
+interface ChromaCloudSparseEmbeddingRequest {
+    texts: string[];
+    task: string;
+    target: string;
+}
+
+export interface ChromaCloudSparseEmbeddingsResponse {
+    embeddings: SparseVector[];
+}
+
+/**
+ * Sort sparse vectors by indices in ascending order.
+ * This ensures consistency with the Python implementation.
+ * @param embeddings - Array of sparse vectors to sort
+ */
+function sortSparseVectors(embeddings: SparseVector[]): void {
+    for (const embedding of embeddings) {
+        // Create an array of [index, value] pairs
+        const pairs = embedding.indices.map((idx: number, i: number) => ({
+            index: idx,
+            value: embedding.values[i],
+        }));
+
+        // Sort by index
+        pairs.sort(
+            (a: { index: number; value: number }, b: { index: number; value: number }) =>
+                a.index - b.index,
+        );
+
+        // Update the original arrays
+        embedding.indices = pairs.map((p: { index: number; value: number }) => p.index);
+        embedding.values = pairs.map((p: { index: number; value: number }) => p.value);
+    }
+}
+
+export class ChromaCloudSpladeEmbeddingFunction
+    implements SparseEmbeddingFunction {
+    public readonly name = NAME;
+
+    private readonly apiKeyEnvVar: string;
+    private readonly model: ChromaCloudSpladeEmbeddingModel;
+    private readonly url: string;
+    private readonly headers: { [key: string]: string };
+
+    constructor(args: ChromaCloudSpladeArgs = {}) {
+        const {
+            model = ChromaCloudSpladeEmbeddingModel.SPLADE_PP_EN_V1,
+            apiKeyEnvVar = "CHROMA_API_KEY",
+        } = args;
+
+        const apiKey = process.env[apiKeyEnvVar];
+
+        if (!apiKey) {
+            throw new Error(
+                `Chroma Embedding API key is required. Please provide it in the constructor or set the environment variable ${apiKeyEnvVar}.`,
+            );
+        }
+
+        this.model = model;
+        this.apiKeyEnvVar = apiKeyEnvVar;
+
+        this.url = "https://embed.trychroma.com/embed_sparse";
+        this.headers = {
+            "x-chroma-token": apiKey,
+            "x-chroma-embedding-model": model,
+            "Content-Type": "application/json",
+        };
+    }
+
+    public async generate(texts: string[]): Promise<SparseVector[]> {
+        if (texts.length === 0) {
+            return [];
+        }
+
+        const body: ChromaCloudSparseEmbeddingRequest = {
+            texts,
+            task: "",
+            target: "",
+        };
+
+        try {
+            const response = await fetch(this.url, {
+                method: "POST",
+                headers: this.headers,
+                body: JSON.stringify(snakeCase(body)),
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(
+                    `HTTP ${response.status} ${response.statusText}: ${errorText}`,
+                );
+            }
+
+            const data =
+                (await response.json()) as ChromaCloudSparseEmbeddingsResponse;
+
+            // Validate response structure
+            if (!data || typeof data !== 'object') {
+                throw new Error("Invalid response format: expected object");
+            }
+
+            if (!Array.isArray(data.embeddings)) {
+                throw new Error("Invalid response format: missing or invalid embeddings array");
+            }
+
+            // Sort the sparse vectors to match Python behavior
+            sortSparseVectors(data.embeddings);
+
+            return data.embeddings;
+        } catch (error) {
+            if (error instanceof Error) {
+                throw new Error(`Error calling Chroma Embedding API: ${error.message}`);
+            } else {
+                throw new Error(`Error calling Chroma Embedding API: ${error}`);
+            }
+        }
+    }
+
+    public async generateForQueries(texts: string[]): Promise<SparseVector[]> {
+        return this.generate(texts);
+    }
+
+    public static buildFromConfig(
+        config: ChromaCloudSpladeConfig,
+    ): ChromaCloudSpladeEmbeddingFunction {
+        return new ChromaCloudSpladeEmbeddingFunction({
+            model: config.model,
+            apiKeyEnvVar: config.api_key_env_var,
+        });
+    }
+
+    public getConfig(): ChromaCloudSpladeConfig {
+        return {
+            model: this.model,
+            api_key_env_var: this.apiKeyEnvVar,
+        };
+    }
+
+    public validateConfigUpdate(newConfig: Record<string, any>): void {
+        if ("model" in newConfig) {
+            throw new ChromaValueError("Model cannot be updated");
+        }
+    }
+
+    public static validateConfig(config: ChromaCloudSpladeConfig): void {
+        validateConfigSchema(config, NAME);
+    }
+}
+
+registerSparseEmbeddingFunction(NAME, ChromaCloudSpladeEmbeddingFunction);

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/tsconfig.json
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "baseUrl": "./src",
+        "stripInternal": true,
+        "composite": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist",
+        "test",
+        "**/*.test.ts"
+    ],
+    "references": [
+        {
+            "path": "../common"
+        },
+        {
+            "path": "../../chromadb"
+        }
+    ]
+}

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/tsup.config.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-splade/tsup.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, type Options } from "tsup";
+import * as fs from "fs";
+
+export default defineConfig((options: Options) => {
+    const commonOptions: Partial<Options> = {
+        entry: {
+            "chroma-cloud-splade": "src/index.ts",
+        },
+        sourcemap: true,
+        dts: {
+            compilerOptions: {
+                composite: false,
+                declaration: true,
+                emitDeclarationOnly: false,
+            },
+        },
+        ...options,
+    };
+
+    return [
+        {
+            ...commonOptions,
+            format: ["esm"],
+            outExtension: () => ({ js: ".mjs" }),
+            clean: true,
+            async onSuccess() {
+                // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+                fs.copyFileSync(
+                    "dist/chroma-cloud-splade.mjs",
+                    "dist/chroma-cloud-splade.legacy-esm.js",
+                );
+            },
+        },
+        {
+            ...commonOptions,
+            format: "cjs",
+            outDir: "./dist/cjs/",
+            outExtension: () => ({ js: ".cjs" }),
+        },
+    ];
+});

--- a/clients/new-js/packages/ai-embeddings/common/src/schema-utils.ts
+++ b/clients/new-js/packages/ai-embeddings/common/src/schema-utils.ts
@@ -24,6 +24,7 @@ import togetherAiSchema from "../../../../../../schemas/embedding_functions/toge
 import mistralSchema from "../../../../../../schemas/embedding_functions/mistral.json";
 import morphSchema from "../../../../../../schemas/embedding_functions/morph.json";
 import chromaCloudQwenSchema from "../../../../../../schemas/embedding_functions/chroma-cloud-qwen.json";
+import chromaCloudSpladeSchema from "../../../../../../schemas/embedding_functions/chroma-cloud-splade.json";
 import Ajv from "ajv";
 
 // Define a common interface for all schemas
@@ -72,6 +73,7 @@ const schemaMap = {
 	mistral: mistralSchema as Schema,
 	morph: morphSchema as Schema,
 	"chroma-cloud-qwen": chromaCloudQwenSchema as Schema,
+	"chroma-cloud-splade": chromaCloudSpladeSchema as Schema,
 };
 
 /**

--- a/clients/new-js/packages/chromadb/src/embedding-function.ts
+++ b/clients/new-js/packages/chromadb/src/embedding-function.ts
@@ -1,4 +1,4 @@
-import { EmbeddingFunctionConfiguration } from "./api";
+import { EmbeddingFunctionConfiguration, SparseVector } from "./api";
 import { ChromaValueError } from "./errors";
 
 /**
@@ -49,6 +49,44 @@ export interface EmbeddingFunction {
 }
 
 /**
+ * Interface for sparse embedding functions.
+ * Sparse embedding functions transform text documents into sparse numerical representations
+ * where only non-zero values are stored, making them efficient for high-dimensional spaces.
+ */
+export interface SparseEmbeddingFunction {
+  /**
+   * Generates sparse embeddings for the given texts.
+   * @param texts - Array of text strings to embed
+   * @returns Promise resolving to array of sparse vectors
+   */
+  generate(texts: string[]): Promise<SparseVector[]>;
+  /**
+   * Generates sparse embeddings specifically for query texts.
+   * The client will fall back to using the implementation of `generate`
+   * if this function is not provided.
+   * @param texts - Array of query text strings to embed
+   * @returns Promise resolving to array of sparse vectors
+   */
+  generateForQueries?(texts: string[]): Promise<SparseVector[]>;
+  /** Optional name identifier for the embedding function */
+  name?: string;
+  /** Creates an instance from configuration object */
+  buildFromConfig?(config: Record<string, any>): SparseEmbeddingFunction;
+  /** Returns the current configuration as an object */
+  getConfig?(): Record<string, any>;
+  /**
+   * Validates that a configuration update is allowed.
+   * @param newConfig - New configuration to validate
+   */
+  validateConfigUpdate?(newConfig: Record<string, any>): void;
+  /**
+   * Validates that a configuration object is valid.
+   * @param config - Configuration to validate
+   */
+  validateConfig?(config: Record<string, any>): void;
+}
+
+/**
  * Interface for embedding function constructor classes.
  * Used for registering and instantiating embedding functions.
  */
@@ -62,12 +100,34 @@ export interface EmbeddingFunctionClass {
 }
 
 /**
+ * Interface for sparse embedding function constructor classes.
+ * Used for registering and instantiating sparse embedding functions.
+ */
+export interface SparseEmbeddingFunctionClass {
+  /** Constructor for creating new instances */
+  new(...args: any[]): SparseEmbeddingFunction;
+  /** Name identifier for the embedding function */
+  name: string;
+  /** Static method to build instance from configuration */
+  buildFromConfig(config: Record<string, any>): SparseEmbeddingFunction;
+}
+
+/**
  * Registry of available embedding functions.
  * Maps function names to their constructor classes.
  */
 export const knownEmbeddingFunctions = new Map<
   string,
   EmbeddingFunctionClass
+>();
+
+/**
+ * Registry of available sparse embedding functions.
+ * Maps function names to their constructor classes.
+ */
+export const knownSparseEmbeddingFunctions = new Map<
+  string,
+  SparseEmbeddingFunctionClass
 >();
 
 /**
@@ -86,6 +146,24 @@ export const registerEmbeddingFunction = (
     );
   }
   knownEmbeddingFunctions.set(name, fn);
+};
+
+/**
+ * Registers a sparse embedding function in the global registry.
+ * @param name - Unique name for the sparse embedding function
+ * @param fn - Sparse embedding function class to register
+ * @throws ChromaValueError if name is already registered
+ */
+export const registerSparseEmbeddingFunction = (
+  name: string,
+  fn: SparseEmbeddingFunctionClass,
+) => {
+  if (knownSparseEmbeddingFunctions.has(name)) {
+    throw new ChromaValueError(
+      `Sparse embedding function with name ${name} is already registered.`,
+    );
+  }
+  knownSparseEmbeddingFunctions.set(name, fn);
 };
 
 /**
@@ -137,6 +215,60 @@ export const getEmbeddingFunction = async (
   } catch (e) {
     console.warn(
       `Embedding function ${name} failed to build with config: ${constructorConfig}. 'add' and 'query' will fail unless you provide them embeddings directly. Error: ${e}`,
+    );
+    return undefined;
+  }
+};
+
+/**
+ * Retrieves and instantiates a sparse embedding function from configuration.
+ * @param collectionName - Name of the collection (for error messages)
+ * @param efConfig - Configuration for the sparse embedding function
+ * @returns Promise resolving to a SparseEmbeddingFunction instance
+ */
+export const getSparseEmbeddingFunction = async (
+  collectionName: string,
+  efConfig?: EmbeddingFunctionConfiguration,
+) => {
+  if (!efConfig) {
+    console.warn(
+      `No sparse embedding function configuration found for collection ${collectionName}.`,
+    );
+    return undefined;
+  }
+
+  if (efConfig.type === "legacy") {
+    console.warn(
+      `No sparse embedding function configuration found for collection ${collectionName}.`,
+    );
+    return undefined;
+  }
+
+  const name = efConfig.name;
+
+  const sparseEmbeddingFunction = knownSparseEmbeddingFunctions.get(name);
+  if (!sparseEmbeddingFunction) {
+    console.warn(
+      `Collection ${collectionName} was created with the ${name} sparse embedding function. However, the @chroma-core/${name} package is not installed.`,
+    );
+    return undefined;
+  }
+
+  let constructorConfig: Record<string, any> =
+    efConfig.type === "known" ? (efConfig.config as Record<string, any>) : {};
+
+  try {
+    if (sparseEmbeddingFunction.buildFromConfig) {
+      return sparseEmbeddingFunction.buildFromConfig(constructorConfig);
+    }
+
+    console.warn(
+      `Sparse embedding function ${name} does not define a 'buildFromConfig' function.`,
+    );
+    return undefined;
+  } catch (e) {
+    console.warn(
+      `Sparse embedding function ${name} failed to build with config: ${constructorConfig}. Error: ${e}`,
     );
     return undefined;
   }

--- a/clients/new-js/packages/chromadb/src/types.ts
+++ b/clients/new-js/packages/chromadb/src/types.ts
@@ -6,6 +6,11 @@ import { GetUserIdentityResponse, Include, SparseVector } from "./api";
 export type UserIdentity = GetUserIdentityResponse;
 
 /**
+ * Re-export SparseVector type for external use
+ */
+export type { SparseVector };
+
+/**
  * Metadata that can be associated with a collection.
  * Values must be boolean, number, or string types.
  */

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@chroma-core/chroma-cloud-qwen':
         specifier: workspace:^
         version: link:../chroma-cloud-qwen
+      '@chroma-core/chroma-cloud-splade':
+        specifier: workspace:^
+        version: link:../chroma-cloud-splade
       '@chroma-core/cloudflare-worker-ai':
         specifier: workspace:^
         version: link:../cloudflare-worker-ai
@@ -83,6 +86,37 @@ importers:
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
   packages/ai-embeddings/chroma-cloud-qwen:
+    dependencies:
+      '@chroma-core/ai-embeddings-common':
+        specifier: workspace:^
+        version: link:../common
+      chromadb:
+        specifier: workspace:^
+        version: link:../../chromadb
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.5.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3))
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.46)(typescript@5.8.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+
+  packages/ai-embeddings/chroma-cloud-splade:
     dependencies:
       '@chroma-core/ai-embeddings-common':
         specifier: workspace:^

--- a/schemas/embedding_functions/chroma-cloud-splade.json
+++ b/schemas/embedding_functions/chroma-cloud-splade.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Chroma Cloud Splade Embedding Function Schema",
+    "description": "Schema for the Chroma Cloud Splade sparse embedding function configuration",
+    "version": "1.0.0",
+    "type": "object",
+    "properties": {
+        "model": {
+            "type": "string",
+            "enum": [
+                "prithivida/Splade_PP_en_v1"
+            ],
+            "description": "The specific Splade model to use for sparse embeddings"
+        },
+        "api_key_env_var": {
+            "type": "string",
+            "description": "Environment variable name that contains your API key for the Chroma Embedding API",
+            "default": "CHROMA_API_KEY"
+        }
+    },
+    "required": [
+        "api_key_env_var",
+        "model"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR adds the hosted splade embedding function to both js and python, allowing users to use chroma api keys and the chroma hosted embedding service to compute sparse vectors for a given document/query. This works across both js and python clients
- New functionality
  - ...

## Test plan

_How are these changes tested?_
Manually tested both embedding functions, work as intended

- [ x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
