### PR TITLE
[ENH] - Add tables to list out what embedding model packages we provide

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
@@ -11,17 +11,35 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 
 |                                                                                          | Python | Typescript |
 | ---------------------------------------------------------------------------------------- | ------ | ---------- |
-| [OpenAI](../../integrations/embedding-models/openai)                                     | ✓      | ✓          |
-| [Google Generative AI](../../integrations/embedding-models/google-gemini)                | ✓      | ✓          |
-| [Cohere](../../integrations/embedding-models/cohere)                                     | ✓      | ✓          |
-| [Hugging Face](../../integrations/embedding-models/hugging-face)                         | ✓      | -          |
-| [Instructor](../../integrations/embedding-models/instructor)                             | ✓      | -          |
-| [Hugging Face Embedding Server](../../integrations/embedding-models/hugging-face-server) | ✓      | ✓          |
-| [Jina AI](../../integrations/embedding-models/jina-ai)                                   | ✓      | ✓          |
 | [Cloudflare Workers AI](../../integrations/embedding-models/cloudflare-workers-ai)       | ✓      | ✓          |
-| [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
+| [Cohere](../../integrations/embedding-models/cohere)                                     | ✓      | ✓          |
+| [Google Generative AI](../../integrations/embedding-models/google-gemini)                | ✓      | ✓          |
+| [Hugging Face](../../integrations/embedding-models/hugging-face)                         | ✓      | -          |
+| [Hugging Face Embedding Server](../../integrations/embedding-models/hugging-face-server) | ✓      | ✓          |
+| [Instructor](../../integrations/embedding-models/instructor)                             | ✓      | -          |
+| [Jina AI](../../integrations/embedding-models/jina-ai)                                   | ✓      | ✓          |
 | [Mistral](../../integrations/embedding-models/mistral)                                   | ✓      | ✓          |
 | [Morph](../../integrations/embedding-models/morph)                                       | ✓      | ✓          |
+| [OpenAI](../../integrations/embedding-models/openai)                                     | ✓      | ✓          |
+| [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
+
+
+For TypeScript users, Chroma provides packages for a number of embedding model providers.
+
+| Provider                    | Embedding Function Package                    
+| ----------                  | ------------------------- 
+| All (installs all packages) | [@chroma-core/all](https://www.npmjs.com/package/@chroma-core/all)     
+| Cloudflare Workers AI       | [@chroma-core/cloudflare-worker-ai](https://www.npmjs.com/package/@chroma-core/cloudflare-worker-ai)     
+| Cohere                      | [@chroma-core/cohere](https://www.npmjs.com/package/@chroma-core/cohere) 
+| Google Gemini               | [@chroma-core/google-gemini](https://www.npmjs.com/package/@chroma-core/google-gemini)     
+| Hugging Face Server         | [@chroma-core/huggingface-server](https://www.npmjs.com/package/@chroma-core/huggingface-server)     
+| Jina                        | [@chroma-core/jina](https://www.npmjs.com/package/@chroma-core/jina)     
+| Mistral                     | [@chroma-core/mistral](https://www.npmjs.com/package/@chroma-core/mistral)     
+| Morph                       | [@chroma-core/morph](https://www.npmjs.com/package/@chroma-core/morph)     
+| Ollama                      | [@chroma-core/ollama](https://www.npmjs.com/package/@chroma-core/ollama)     
+| OpenAI                      | [@chroma-core/openai](https://www.npmjs.com/package/@chroma-core/huggingface-server)     
+| Together AI                 | [@chroma-core/together-ai](https://www.npmjs.com/package/@chroma-core/together-ai)     
+| Voyage AI                   | [@chroma-core/voyageai](https://www.npmjs.com/package/@chroma-core/voyageai)     
 
 We welcome pull requests to add new Embedding Functions to the community.
 

--- a/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/overview/getting-started.md
@@ -101,6 +101,23 @@ bun add chromadb @chroma-core/default-embed
 
 {% /TabbedUseCaseCodeBlock %}
 
+We offer a number of first party embedding fuctions for use with the TypeScript package.
+
+| Provider                    | Embedding Function Package                    
+| ----------                  | ------------------------- 
+| All (installs all packages) | [@chroma-core/all](https://www.npmjs.com/package/@chroma-core/all)     
+| Cloudflare Workers AI       | [@chroma-core/cloudflare-worker-ai](https://www.npmjs.com/package/@chroma-core/cloudflare-worker-ai)     
+| Cohere                      | [@chroma-core/cohere](https://www.npmjs.com/package/@chroma-core/cohere) 
+| Google Gemini               | [@chroma-core/google-gemini](https://www.npmjs.com/package/@chroma-core/google-gemini)     
+| Hugging Face Server         | [@chroma-core/huggingface-server](https://www.npmjs.com/package/@chroma-core/huggingface-server)     
+| Jina                        | [@chroma-core/jina](https://www.npmjs.com/package/@chroma-core/jina)     
+| Mistral                     | [@chroma-core/mistral](https://www.npmjs.com/package/@chroma-core/mistral)     
+| Morph                       | [@chroma-core/morph](https://www.npmjs.com/package/@chroma-core/morph)     
+| Ollama                      | [@chroma-core/ollama](https://www.npmjs.com/package/@chroma-core/ollama)     
+| OpenAI                      | [@chroma-core/openai](https://www.npmjs.com/package/@chroma-core/huggingface-server)     
+| Together AI                 | [@chroma-core/together-ai](https://www.npmjs.com/package/@chroma-core/together-ai)     
+| Voyage AI                   | [@chroma-core/voyageai](https://www.npmjs.com/package/@chroma-core/voyageai)     
+
 {% /Tab %}
 
 {% /Tabs %}


### PR DESCRIPTION
We previously do not have a list of all the embedding model packages we provide on the docs site. This PR adds that list in two different place.