### PR TITLE
[ENH] Support using schema embedding function for dense vectors, allow document source key for sparse

### DIFF
--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -148,7 +148,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "chroma-cloud-qwen": ChromaCloudQwenEmbeddingFunction,
 }
 
-sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {
+sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  # type: ignore
     "huggingface_sparse": HuggingFaceSparseEmbeddingFunction,
     "fastembed_sparse": FastembedSparseEmbeddingFunction,
     "bm25": Bm25EmbeddingFunction,
@@ -184,6 +184,30 @@ def register_embedding_function(ef_class=None):  # type: ignore
         return _register(ef_class)  # type: ignore
 
     # If called without arguments, return a decorator
+    return _register
+
+
+def register_sparse_embedding_function(ef_class=None):  # type: ignore
+    """Register a custom sparse embedding function.
+
+    Can be used as a decorator:
+        @register_sparse_embedding_function
+        class MySparseEmbeddingFunction(SparseEmbeddingFunction):
+            @classmethod
+            def name(cls): return "my_sparse_embedding"
+    """
+
+    def _register(cls):  # type: ignore
+        try:
+            name = cls.name()
+            sparse_known_embedding_functions[name] = cls
+        except Exception as e:
+            raise ValueError(f"Failed to register sparse embedding function: {e}")
+        return cls  # Return the class unchanged
+
+    if ef_class is not None:
+        return _register(ef_class)  # type: ignore
+
     return _register
 
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR adds support for using the embedding function defined in the schema on a collection during _embed. This lets auto embedding via schema occur on inserts and queries
- New functionality
  - ...

## Test plan

_How are these changes tested?_
added tests in stacked pr for e2e schema tests

- [x ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
