### PR TITLE
[ENH] Make collection with segment provider public

### DIFF
--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -116,7 +116,7 @@ pub struct CollectionsWithSegmentsProvider {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum CollectionsWithSegmentsProviderError {
+pub enum CollectionsWithSegmentsProviderError {
     #[error(transparent)]
     Cache(#[from] CacheError),
     #[error(transparent)]
@@ -140,7 +140,7 @@ impl CollectionsWithSegmentsProvider {
         self.retry_backoff
     }
 
-    pub(crate) async fn get_collection_with_segments(
+    pub async fn get_collection_with_segments(
         &mut self,
         collection_id: CollectionUuid,
     ) -> Result<CollectionAndSegments, CollectionsWithSegmentsProviderError> {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Make collection with segment provider methods public, so that it can be used externally
- New functionality
    - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_