### PR TITLE
[ENH]: add list_collections to Rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
+dependencies = [
+ "darling 0.21.3",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "rustversion",
+ "syn 2.0.102",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1446,9 @@ name = "chroma"
 version = "0.1.0"
 dependencies = [
  "backon",
+ "bon",
  "dotenvy",
+ "futures-util",
  "opentelemetry",
  "reqwest 0.12.24",
  "serde",
@@ -1431,6 +1458,7 @@ dependencies = [
  "tokio",
  "tracing",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -2624,6 +2652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,6 +2690,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "strsim 0.11.1",
+ "syn 2.0.102",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2721,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
+ "quote 1.0.40",
+ "syn 2.0.102",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote 1.0.40",
  "syn 2.0.102",
 ]
@@ -7135,9 +7198,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"

--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -12,8 +12,10 @@ opentelemetry = { version = ">=0.27,<0.32", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 utoipa = { version = "5.0.0", features = ["macros", "axum_extras", "debug", "uuid"], optional = true }
+tokio = { version = ">=1,<2", features = ["sync"] }
 thiserror.workspace = true
 tracing.workspace = true
+bon = "3.8.1"
 
 [features]
 default = ["native-tls"]
@@ -22,5 +24,7 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 dotenvy = "0.15.7"
+futures-util = "0.3.31"
 test-log = { version = "0.2.18", features = ["trace"] }
 tokio.workspace = true
+uuid.workspace = true

--- a/rust/chroma/src/client/chroma_client.rs
+++ b/rust/chroma/src/client/chroma_client.rs
@@ -1,20 +1,38 @@
-use serde::de::DeserializeOwned;
+use reqwest::Method;
+use serde::{de::DeserializeOwned, Serialize};
+use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 use crate::{
     client::ChromaClientOptions,
-    types::{GetUserIdentityResponse, HeartbeatResponse},
+    types::{GetUserIdentityResponse, HeartbeatResponse, ListCollectionsRequest},
 };
 
 #[derive(Error, Debug)]
 pub enum ChromaClientError {
     #[error("Request error: {0:?}")]
     RequestError(#[from] reqwest::Error),
+    #[error("Could not resolve database ID: {0}")]
+    CouldNotResolveDatabaseId(String),
+    #[error("Serialization/Deserialization error: {0}")]
+    SerdeError(#[from] serde_json::Error),
 }
 
+#[derive(Clone)]
 pub struct ChromaClient {
     base_url: String,
     client: reqwest::Client,
+    tenant_id: Arc<Mutex<Option<String>>>,
+    default_database_id: Arc<Mutex<Option<String>>>,
+}
+
+// TODO: remove and replace with actual Database struct
+#[derive(serde::Deserialize, Debug)]
+#[allow(dead_code)]
+pub struct Database {
+    id: String,
+    name: String,
 }
 
 impl ChromaClient {
@@ -28,26 +46,174 @@ impl ChromaClient {
         ChromaClient {
             base_url: options.base_url.clone(),
             client,
+            tenant_id: Arc::new(Mutex::new(options.tenant_id)),
+            default_database_id: Arc::new(Mutex::new(options.default_database_id)),
         }
     }
 
+    pub async fn set_default_database_id(&self, database_id: String) {
+        let mut lock = self.default_database_id.lock().await;
+        *lock = Some(database_id);
+    }
+
+    pub async fn create_database(&self, name: String) -> Result<(), ChromaClientError> {
+        // Returns empty map ({})
+        self.send::<_, (), serde_json::Value>(
+            Method::POST,
+            format!("/api/v2/tenants/{}/databases", self.get_tenant_id().await?),
+            Some(serde_json::json!({ "name": name })),
+            None,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_databases(&self) -> Result<Vec<Database>, ChromaClientError> {
+        let tenant_id = self.get_tenant_id().await?;
+
+        self.send::<(), (), _>(
+            Method::GET,
+            format!("/api/v2/tenants/{}/databases", tenant_id),
+            None,
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete_database(&self, database_name: String) -> Result<(), ChromaClientError> {
+        // Returns empty map ({})
+        self.send::<(), (), serde_json::Value>(
+            Method::DELETE,
+            format!(
+                "/api/v2/tenants/{}/databases/{}",
+                self.get_tenant_id().await?,
+                database_name
+            ),
+            None,
+            None,
+        )
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn get_auth_identity(&self) -> Result<GetUserIdentityResponse, ChromaClientError> {
-        self.send("/api/v2/auth/identity").await
+        self.send::<(), (), _>(Method::GET, "/api/v2/auth/identity".to_string(), None, None)
+            .await
     }
 
     pub async fn heartbeat(&self) -> Result<HeartbeatResponse, ChromaClientError> {
-        self.send("/api/v2/heartbeat").await
+        self.send::<(), (), _>(Method::GET, "/api/v2/heartbeat".to_string(), None, None)
+            .await
     }
 
-    async fn send<Response: DeserializeOwned, Path: AsRef<str>>(
+    pub async fn list_collections(
         &self,
-        path: Path,
+        params: ListCollectionsRequest,
+    ) -> Result<Vec<String>, ChromaClientError> {
+        let tenant_id = self.get_tenant_id().await?;
+        let database_id = self.get_database_id(params.database_id).await?;
+
+        #[derive(Serialize)]
+        struct QueryParams {
+            limit: usize,
+            offset: Option<usize>,
+        }
+
+        self.send::<(), _, _>(
+            Method::GET,
+            format!(
+                "/api/v2/tenants/{}/databases/{}/collections",
+                tenant_id, database_id
+            ),
+            None,
+            Some(QueryParams {
+                limit: params.limit,
+                offset: params.offset,
+            }),
+        )
+        .await
+    }
+
+    async fn get_database_id(
+        &self,
+        id_override: Option<String>,
+    ) -> Result<String, ChromaClientError> {
+        if let Some(id) = id_override {
+            return Ok(id);
+        }
+
+        let mut database_id_lock = self.default_database_id.lock().await;
+        if let Some(database_id) = &*database_id_lock {
+            return Ok(database_id.clone());
+        }
+
+        let identity = self.get_auth_identity().await?;
+
+        if identity.databases.len() > 1 {
+            return Err(ChromaClientError::CouldNotResolveDatabaseId(
+                "Client has access to multiple databases; please provide a database_id".to_string(),
+            ));
+        }
+
+        let database_id = identity.databases.first().ok_or_else(|| {
+            ChromaClientError::CouldNotResolveDatabaseId(
+                "Client has access to no databases".to_string(),
+            )
+        })?;
+
+        *database_id_lock = Some(database_id.clone());
+        Ok(database_id.clone())
+    }
+
+    async fn get_tenant_id(&self) -> Result<String, ChromaClientError> {
+        let mut tenant_id_lock = self.tenant_id.lock().await;
+        if let Some(tenant_id) = &*tenant_id_lock {
+            return Ok(tenant_id.clone());
+        }
+
+        let identity = self.get_auth_identity().await?;
+        let tenant_id = identity.tenant;
+        *tenant_id_lock = Some(tenant_id.clone());
+        Ok(tenant_id)
+    }
+
+    async fn send<Body: Serialize, QueryParams: Serialize, Response: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: String,
+        body: Option<Body>,
+        query_params: Option<QueryParams>,
     ) -> Result<Response, ChromaClientError> {
         // todo: / normalization
-        let url = format!("{}{}", self.base_url, path.as_ref());
-        let response = self.client.get(&url).send().await?;
+        let url = format!("{}{}", self.base_url, path);
+
+        let mut request = self.client.request(method.clone(), &url);
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        if let Some(query_params) = query_params {
+            request = request.query(&query_params);
+        }
+
+        tracing::trace!(url = url, method =? method, "Sending request");
+        let response = request.send().await?;
+
         response.error_for_status_ref()?;
-        let json = response.json::<Response>().await?;
+        let json = response.json::<serde_json::Value>().await?;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            tracing::trace!(
+                url = url,
+                method =? method,
+                "Received response: {}",
+                serde_json::to_string_pretty(&json).unwrap_or_else(|_| "<failed to serialize>".to_string())
+            );
+        }
+
+        let json = serde_json::from_value::<Response>(json)?;
+
         Ok(json)
     }
 }
@@ -56,6 +222,7 @@ impl ChromaClient {
 mod tests {
     use super::*;
     use crate::client::ChromaAuthMethod;
+    use futures_util::FutureExt;
     use std::sync::LazyLock;
 
     static CHROMA_CLIENT_OPTIONS: LazyLock<ChromaClientOptions> = LazyLock::new(|| {
@@ -77,26 +244,73 @@ mod tests {
                 &std::env::var("CHROMA_CLOUD_API_KEY").unwrap(),
             )
             .unwrap(),
+            ..Default::default()
         }
     });
 
-    fn test_client() -> ChromaClient {
-        ChromaClient::new(CHROMA_CLIENT_OPTIONS.clone())
+    async fn with_client<F, Fut>(callback: F)
+    where
+        F: FnOnce(ChromaClient) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let client = ChromaClient::new(CHROMA_CLIENT_OPTIONS.clone());
+
+        // Create isolated database for test
+        let database_name = format!("test_db_{}", uuid::Uuid::new_v4());
+        client.create_database(database_name.clone()).await.unwrap();
+        let databases = client.get_databases().await.unwrap();
+        let database_id = databases
+            .iter()
+            .find(|db| db.name == database_name)
+            .unwrap()
+            .id
+            .clone();
+        client.set_default_database_id(database_id.clone()).await;
+
+        let result = std::panic::AssertUnwindSafe(callback(client.clone()))
+            .catch_unwind()
+            .await;
+
+        // Delete test database
+        if let Err(err) = client.delete_database(database_name).await {
+            tracing::error!("Failed to delete test database {}: {}", database_id, err);
+        }
+
+        result.unwrap();
     }
 
     #[tokio::test]
     #[test_log::test]
     async fn test_live_cloud_heartbeat() {
-        let client = test_client();
-        let heartbeat = client.heartbeat().await.unwrap();
-        assert!(heartbeat.nanosecond_heartbeat > 0);
+        with_client(|client| async move {
+            let heartbeat = client.heartbeat().await.unwrap();
+            assert!(heartbeat.nanosecond_heartbeat > 0);
+        })
+        .await;
     }
 
     #[tokio::test]
     #[test_log::test]
     async fn test_live_cloud_get_auth_identity() {
-        let client = test_client();
-        let identity = client.get_auth_identity().await.unwrap();
-        assert!(!identity.tenant.is_empty());
+        with_client(|client| async move {
+            let identity = client.get_auth_identity().await.unwrap();
+            assert!(!identity.tenant.is_empty());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_live_cloud_list_collections() {
+        with_client(|client| async move {
+            let collections = client
+                .list_collections(ListCollectionsRequest::builder().build())
+                .await
+                .unwrap();
+            assert!(collections.is_empty());
+
+            // todo: create collection and assert it's returned, test limit/offset
+        })
+        .await;
     }
 }

--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -25,6 +25,10 @@ impl ChromaAuthMethod {
 pub struct ChromaClientOptions {
     pub base_url: String,
     pub auth_method: ChromaAuthMethod,
+    /// Will be automatically resolved at request time if not provided
+    pub tenant_id: Option<String>,
+    /// Will be automatically resolved at request time if not provided. It can only be resolved automatically if this client has access to exactly one database.
+    pub default_database_id: Option<String>,
 }
 
 impl Default for ChromaClientOptions {
@@ -32,6 +36,8 @@ impl Default for ChromaClientOptions {
         ChromaClientOptions {
             base_url: "https://api.trychroma.com".to_string(),
             auth_method: ChromaAuthMethod::None,
+            tenant_id: None,
+            default_database_id: None,
         }
     }
 }

--- a/rust/chroma/src/types/heartbeat.rs
+++ b/rust/chroma/src/types/heartbeat.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct HeartbeatResponse {
     #[serde(rename = "nanosecond heartbeat")]

--- a/rust/chroma/src/types/mod.rs
+++ b/rust/chroma/src/types/mod.rs
@@ -1,5 +1,7 @@
 mod heartbeat;
+mod requests;
 mod user_identity;
 
 pub use heartbeat::*;
+pub use requests::*;
 pub use user_identity::*;

--- a/rust/chroma/src/types/requests.rs
+++ b/rust/chroma/src/types/requests.rs
@@ -1,0 +1,9 @@
+use bon::Builder;
+
+#[derive(Builder)]
+pub struct ListCollectionsRequest {
+    #[builder(default = 100)]
+    pub limit: usize,
+    pub offset: Option<usize>,
+    pub database_id: Option<String>,
+}


### PR DESCRIPTION
## Description of changes

Introduces [bon](https://bon-rs.com/) for building request arguments. Adds a test helper which creates a fresh database for each test and cleans it up once the test finishes.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
