### PR TITLE
[ENH]: add OpenTelemetry metrics to Rust client

### DIFF
--- a/rust/chroma/src/client/metrics.rs
+++ b/rust/chroma/src/client/metrics.rs
@@ -1,0 +1,35 @@
+use opentelemetry::metrics::Histogram;
+
+#[derive(Clone, Debug)]
+pub struct Metrics {
+    pub request_latency: Histogram<f64>,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        let meter = opentelemetry::global::meter("chroma_client");
+
+        let request_latency = meter
+            .f64_histogram("chroma_client_request_latency_ms")
+            .with_description("Latency of requests in milliseconds")
+            .build();
+
+        Metrics { request_latency }
+    }
+
+    pub fn record_request(&self, operation_name: &str, status_code: u16, latency_ms: f64) {
+        self.request_latency.record(
+            latency_ms,
+            &[
+                opentelemetry::KeyValue::new("operation", operation_name.to_string()),
+                opentelemetry::KeyValue::new("status_code", status_code.to_string()),
+            ],
+        );
+    }
+}

--- a/rust/chroma/src/client/mod.rs
+++ b/rust/chroma/src/client/mod.rs
@@ -1,4 +1,6 @@
 mod chroma_client;
+#[cfg(feature = "opentelemetry")]
+mod metrics;
 mod options;
 
 pub use chroma_client::*;


### PR DESCRIPTION
## Description of changes

Adds optional latency metrics to the client.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
