### PR TITLE
[ENH]: Rust client misc cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ dependencies = [
  "futures-util",
  "httpmock",
  "opentelemetry",
+ "parking_lot",
  "reqwest 0.12.24",
  "serde",
  "serde_json",

--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = ">=1,<2", features = ["sync"] }
 thiserror.workspace = true
 tracing.workspace = true
 bon = "3.8.1"
+parking_lot.workspace = true
 
 [features]
 default = ["native-tls"]

--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -58,7 +58,7 @@ impl ChromaAuthMethod {
 
 #[derive(Debug, Clone)]
 pub struct ChromaClientOptions {
-    pub base_url: String,
+    pub base_url: reqwest::Url,
     pub auth_method: ChromaAuthMethod,
     pub retry_options: ChromaRetryOptions,
     /// Will be automatically resolved at request time if not provided
@@ -70,7 +70,7 @@ pub struct ChromaClientOptions {
 impl Default for ChromaClientOptions {
     fn default() -> Self {
         ChromaClientOptions {
-            base_url: "https://api.trychroma.com".to_string(),
+            base_url: "https://api.trychroma.com".parse().unwrap(),
             auth_method: ChromaAuthMethod::None,
             retry_options: ChromaRetryOptions::default(),
             tenant_id: None,


### PR DESCRIPTION
## Description of changes

- Adds a user-agent with the client version.
- Adds a custom Clone impl on the client so that cloned clients don't share `default_database_id` (which can be changed on the fly).
- Normalizes URLs when joining paths.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
