### PR TITLE
[ENH]: Added ability to use a diffferent API endpoint for OpenAI Embedding Function

### DIFF
--- a/docs/mintlify/integrations/embedding-models/openai.mdx
+++ b/docs/mintlify/integrations/embedding-models/openai.mdx
@@ -58,8 +58,6 @@ import { OpenAIEmbeddingFunction } from "@chroma-core/openai";
 const embeddingFunction = new OpenAIEmbeddingFunction({
     apiKeyEnvVar: "OPENAI_API_KEY",
     modelName: "text-embedding-3-small",
-    // Optional: specify API base (e.g. for Azure OpenAI)
-    apiBase: "your-api-base"
 });
 
 // use directly
@@ -76,14 +74,14 @@ collection = await client.getCollection({
 });
 ```
 
-To use the OpenAI embedding models on other platforms such as GitHub AI Models, you can use the `apiBase` parameter:
+To use the OpenAI embedding models on other platforms such as GitHub AI Models or Azure OpenAI, you can supply the endpoint through `apiBase` parameter:
 ```typescript
 import { OpenAIEmbeddingFunction } from "@chroma-core/openai";
 
 const embeddingFunction = new OpenAIEmbeddingFunction({
-  apiKey: "apiKey",
-  apiBase: "https://models.github.ai/inference",
-  modelName: "text-embedding-3-small",
+    apiKeyEnvVar: "YOUR_API_KEY",
+    apiBase: "https://models.github.ai/inference",
+    modelName: "text-embedding-3-small",
 });
 ```
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - Ability to change API Base URL endpoint for OpenAI Embedding Function in Typescript.
  - Updated docs to specify apiBase paramater.

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_
No need. This change is backwards compatible.

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
Documentation has been updated to reflect the changes.
