### PR TITLE
[CHORE] default to rustls in chroma client

### DIFF
--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot.workspace = true
 chroma-api-types = { workspace = true }
 
 [features]
-default = ["native-tls"]
+default = ["rustls"]
 native-tls = ["reqwest/default-tls", "reqwest/default"]
 rustls = ["reqwest/rustls-tls"]
 


### PR DESCRIPTION
## Description of changes

Cannot build the wheels on linux without openssl.  Switch the default to
something that doesn't bring back linker trauma.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
