### PR TITLE
[ENH]: add create_collection() to Rust client

### DIFF
--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -64,7 +64,7 @@ pub struct ChromaClientOptions {
     /// Will be automatically resolved at request time if not provided
     pub tenant_id: Option<String>,
     /// Will be automatically resolved at request time if not provided. It can only be resolved automatically if this client has access to exactly one database.
-    pub default_database_id: Option<String>,
+    pub default_database_name: Option<String>,
 }
 
 impl Default for ChromaClientOptions {
@@ -74,7 +74,7 @@ impl Default for ChromaClientOptions {
             auth_method: ChromaAuthMethod::None,
             retry_options: ChromaRetryOptions::default(),
             tenant_id: None,
-            default_database_id: None,
+            default_database_name: None,
         }
     }
 }

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -14,8 +14,8 @@ use crate::{client::ChromaClientError, ChromaClient};
 
 #[derive(Clone, Debug)]
 pub struct ChromaCollection {
-    client: ChromaClient,
-    collection: Arc<Collection>,
+    pub(crate) client: ChromaClient,
+    pub(crate) collection: Arc<Collection>,
 }
 
 impl ChromaCollection {

--- a/rust/chroma/src/types.rs
+++ b/rust/chroma/src/types.rs
@@ -1,4 +1,5 @@
 mod requests;
 
 pub use chroma_api_types::{GetUserIdentityResponse, HeartbeatResponse};
+pub use requests::CreateCollectionRequest;
 pub use requests::ListCollectionsRequest;

--- a/rust/chroma/src/types/requests.rs
+++ b/rust/chroma/src/types/requests.rs
@@ -1,9 +1,18 @@
 use bon::Builder;
+use chroma_types::{CollectionConfiguration, Metadata};
 
 #[derive(Builder)]
+pub struct CreateCollectionRequest {
+    pub name: String,
+    pub configuration: Option<CollectionConfiguration>,
+    pub metadata: Option<Metadata>,
+    pub database_name: Option<String>,
+}
+
+#[derive(Default, Builder)]
 pub struct ListCollectionsRequest {
     #[builder(default = 100)]
     pub limit: usize,
     pub offset: Option<usize>,
-    pub database_id: Option<String>,
+    pub database_name: Option<String>,
 }


### PR DESCRIPTION
## Description of changes

Adds `create_collection()` and `get_or_create_collection()` to the Rust client, also wires up `list_collections()`.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
