### PR TITLE
[ENH]: (Rust client) parse and return API errors

### DIFF
--- a/rust/api-types/src/error.rs
+++ b/rust/api-types/src/error.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ErrorResponse {
+    pub error: String,
+    pub message: String,
+}

--- a/rust/api-types/src/lib.rs
+++ b/rust/api-types/src/lib.rs
@@ -1,5 +1,7 @@
+mod error;
 mod heartbeat;
 mod user_identity;
 
+pub use error::*;
 pub use heartbeat::*;
 pub use user_identity::*;


### PR DESCRIPTION
## Description of changes

Prior to this change, responses containing error messages would never be visible.

## Test plan

_How are these changes tested?_

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
