### PR TITLE
[ENH]  Try to update to blacksmith build-push-action v2.

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -36,6 +36,6 @@ runs:
         password: ${{ inputs.dockerhub-password }}
     - name: Set up Blacksmith builder
       if: ${{ inputs.setup-blacksmith == 'true' }}
-      uses: useblacksmith/build-push-action@v1.1
+      uses: useblacksmith/build-push-action@v2
       with:
         setup-only: true

--- a/.github/workflows/_build_release_container.yml
+++ b/.github/workflows/_build_release_container.yml
@@ -101,7 +101,7 @@ jobs:
           docker pull --platform ${{ matrix.docker_platform }} debian:stable-slim
 
       - name: Build and push image
-        uses: useblacksmith/build-push-action@v1.1
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: rust/Dockerfile

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/actions/python
         with:
           python-version: "3.12"
-      - uses: useblacksmith/build-push-action@v1.1
+      - uses: useblacksmith/build-push-action@v2
         with:
           setup-only: true
       - uses: ./.github/actions/tilt


### PR DESCRIPTION
## Description of changes

Blacksmith is deprecating the old runner.  UPdate.

## Test plan

CI

## Migration plan

If this lands, it's migrated.

## Observability plan

N/A

## Documentation Changes

N/A
