### PR TITLE
[ENH]: add `chroma_cloud()` constructor for `ChromaClientOptions {}`

### DIFF
--- a/rust/chroma/src/client/options.rs
+++ b/rust/chroma/src/client/options.rs
@@ -80,6 +80,19 @@ impl Default for ChromaClientOptions {
 }
 
 impl ChromaClientOptions {
+    pub fn chroma_cloud(
+        api_key: impl Into<String>,
+        database_name: impl Into<String>,
+    ) -> Result<Self, InvalidHeaderValue> {
+        let api_key = api_key.into();
+        let database_name = database_name.into();
+        Ok(ChromaClientOptions {
+            default_database_name: Some(database_name),
+            auth_method: ChromaAuthMethod::cloud_api_key(&api_key)?,
+            ..Default::default()
+        })
+    }
+
     pub(crate) fn headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         match &self.auth_method {


### PR DESCRIPTION
## Description of changes

Makes constructing options a little easier.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
