### PR TITLE
[ENH]  Export types from `chroma` crate

### DIFF
--- a/rust/chroma/src/types.rs
+++ b/rust/chroma/src/types.rs
@@ -1,1 +1,9 @@
 pub use chroma_api_types::{GetUserIdentityResponse, HeartbeatResponse};
+
+pub use chroma_types::{
+    plan::SearchPayload, AddCollectionRecordsRequest, AddCollectionRecordsResponse, Collection,
+    DeleteCollectionRecordsRequest, DeleteCollectionRecordsResponse, ForkCollectionRequest,
+    GetRequest, GetResponse, IncludeList, InternalSchema, Metadata, QueryRequest, QueryResponse,
+    SearchRequest, SearchResponse, UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse,
+    UpdateMetadata, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, Where,
+};


### PR DESCRIPTION
## Description of changes

For ergonomics, export every type referenced by the chroma::collection crate from chroma::types::*.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
