### PR TITLE
[ENH]: (Rust client): improve std::fmt::Debug of `ChromaCollection`

### DIFF
--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -13,10 +13,22 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{client::ChromaClientError, ChromaHttpClient};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ChromaCollection {
     pub(crate) client: ChromaHttpClient,
     pub(crate) collection: Arc<Collection>,
+}
+
+impl std::fmt::Debug for ChromaCollection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChromaCollection")
+            .field("database", &self.collection.database)
+            .field("tenant", &self.collection.tenant)
+            .field("name", &self.collection.name)
+            .field("collection_id", &self.collection.collection_id)
+            .field("version", &self.collection.version)
+            .finish()
+    }
 }
 
 impl ChromaCollection {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Now looks like:

```
ChromaCollection {
    database: "test_db_408bef9f-c809-4d41-b542-92fd19cab689",
    tenant: "53975480-8732-4043-a71d-c8ca73b08ddd",
    name: "foo",
    collection_id: CollectionUuid(
        e4c77c45-f5a2-46ee-8ec3-990140f966a0,
    ),
    version: 0,
}
```

I would like to include the schema as well but it is very very verbose.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
