### PR TITLE
[ENH] Add schema reconciliation to get_collection_by_crn

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -724,7 +724,7 @@ pub enum CreateCollectionError {
     #[error("Could not deserialize configuration: {0}")]
     Configuration(serde_json::Error),
     #[error("Could not serialize schema: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(#[source] SchemaError),
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
     #[error("The operation was aborted, {0}")]
@@ -736,7 +736,7 @@ pub enum CreateCollectionError {
     #[error("Failed to parse db id")]
     DatabaseIdParseError,
     #[error("Failed to reconcile schema: {0}")]
-    InvalidSchema(String),
+    InvalidSchema(#[source] SchemaError),
 }
 
 impl ChromaError for CreateCollectionError {
@@ -754,7 +754,7 @@ impl ChromaError for CreateCollectionError {
             CreateCollectionError::SpannNotImplemented => ErrorCodes::InvalidArgument,
             CreateCollectionError::HnswNotSupported => ErrorCodes::InvalidArgument,
             CreateCollectionError::DatabaseIdParseError => ErrorCodes::Internal,
-            CreateCollectionError::InvalidSchema(_) => ErrorCodes::InvalidArgument,
+            CreateCollectionError::InvalidSchema(e) => e.code(),
             CreateCollectionError::Schema(e) => e.code(),
         }
     }
@@ -846,6 +846,8 @@ pub type GetCollectionByCrnResponse = Collection;
 
 #[derive(Debug, Error)]
 pub enum GetCollectionByCrnError {
+    #[error("Failed to reconcile schema: {0}")]
+    InvalidSchema(#[from] SchemaError),
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
     #[error("Collection [{0}] does not exist")]
@@ -855,6 +857,7 @@ pub enum GetCollectionByCrnError {
 impl ChromaError for GetCollectionByCrnError {
     fn code(&self) -> ErrorCodes {
         match self {
+            GetCollectionByCrnError::InvalidSchema(e) => e.code(),
             GetCollectionByCrnError::Internal(err) => err.code(),
             GetCollectionByCrnError::NotFound(_) => ErrorCodes::NotFound,
         }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR adds schema reconciliation logic for get collection by crn, to match the other public facing apis
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
