### PR TITLE
[BUG] Remove `chroma` crate from default tracing list

### DIFF
--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -47,7 +47,6 @@ pub fn init_global_filter_layer(
     // converts all hyphens in crate names to underscores to make them valid
     // Rust identifiers
     let default_crate_names = vec![
-        "chroma",
         "chroma_blockstore",
         "chroma_config",
         "chroma_cache",


### PR DESCRIPTION
## Description of changes

The `chroma` crate is really noisy at `trace` level.

## Test plan

Tested locally via tilt

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
