### PR TITLE
[ENH] Python client cleanup: export hosted ef from utils, fix sparse auto-embed

### DIFF
--- a/chromadb/test/api/test_schema_e2e.py
+++ b/chromadb/test/api/test_schema_e2e.py
@@ -149,7 +149,10 @@ class DeterministicSparseEmbeddingFunction(SparseEmbeddingFunction[List[str]]):
         self._label = label
 
     def __call__(self, input: List[str]) -> List[SparseVector]:
-        return [SparseVector(indices=[idx], values=[float(len(text) + idx)]) for idx, text in enumerate(input)]
+        return [
+            SparseVector(indices=[idx], values=[float(len(text) + idx)])
+            for idx, text in enumerate(input)
+        ]
 
     @staticmethod
     def name() -> str:
@@ -872,3 +875,556 @@ def test_schema_precedence_for_overrides_discoverables_and_defaults(
 
     with pytest.raises(Exception):
         collection.get(where={"discover_key": "discover_5"})
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_document_source_no_metadata(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse embedding auto-generation using #document as source with no metadata."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="doc_no_meta")
+
+    schema = Schema().create_index(
+        key="auto_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Add documents without metadata
+    collection.add(
+        ids=["doc1", "doc2", "doc3"],
+        documents=["hello world", "test document", "short"],
+    )
+
+    # Verify sparse embeddings were auto-generated in metadata
+    result = collection.get(ids=["doc1", "doc2", "doc3"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Expected embeddings from batched call (indices will be [0, 1, 2])
+    expected_batch = sparse_ef(["hello world", "test document", "short"])
+
+    for i, doc_id in enumerate(["doc1", "doc2", "doc3"]):
+        metadata = result["metadatas"][i]
+        assert metadata is not None
+        assert "auto_sparse" in metadata
+
+        # Verify the sparse embedding matches expected output from batch
+        actual = cast(SparseVector, metadata["auto_sparse"])
+        assert actual.indices == expected_batch[i].indices
+        assert actual.values == expected_batch[i].values
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_document_source_and_metadata(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse embedding with #document source when metadata is also provided."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="doc_with_meta")
+
+    schema = Schema().create_index(
+        key="doc_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Add documents with metadata
+    collection.add(
+        ids=["m1", "m2"],
+        documents=["alpha", "beta"],
+        metadatas=[
+            {"category": "test", "value": 42},
+            {"category": "prod", "value": 99},
+        ],
+    )
+
+    result = collection.get(ids=["m1", "m2"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Verify original metadata is preserved
+    assert result["metadatas"][0]["category"] == "test"
+    assert result["metadatas"][0]["value"] == 42
+    assert result["metadatas"][1]["category"] == "prod"
+    assert result["metadatas"][1]["value"] == 99
+
+    # Verify sparse embeddings were added
+    assert "doc_sparse" in result["metadatas"][0]
+    assert "doc_sparse" in result["metadatas"][1]
+
+    # Expected from batch call
+    expected_batch = sparse_ef(["alpha", "beta"])
+    actual_m1 = cast(SparseVector, result["metadatas"][0]["doc_sparse"])
+    assert actual_m1.indices == expected_batch[0].indices
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_metadata_source_key(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse embedding using a metadata field as source."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="meta_source")
+
+    schema = Schema().create_index(
+        key="content_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="content",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Add with source field in metadata
+    collection.add(
+        ids=["s1", "s2", "s3"],
+        documents=["doc1", "doc2", "doc3"],
+        metadatas=[
+            {"content": "sparse content one"},
+            {"content": "sparse content two"},
+            {"content": "sparse content three"},
+        ],
+    )
+
+    result = collection.get(ids=["s1", "s2", "s3"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Expected from batch call
+    expected_batch = sparse_ef(
+        ["sparse content one", "sparse content two", "sparse content three"]
+    )
+
+    for i in range(3):
+        metadata = result["metadatas"][i]
+        assert metadata is not None
+        assert "content_sparse" in metadata
+
+        # Original content field should still exist
+        assert "content" in metadata
+
+        # Verify sparse embedding was generated from content field
+        actual = cast(SparseVector, metadata["content_sparse"])
+        assert actual.indices == expected_batch[i].indices
+        assert actual.values == expected_batch[i].values
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_mixed_metadata_none_and_filled(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse embedding with mixed metadata (None, empty, filled)."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="mixed_meta")
+
+    schema = Schema().create_index(
+        key="mixed_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Add with None metadata items mixed in
+    collection.add(
+        ids=["n1", "n2", "n3", "n4"],
+        documents=["doc one", "doc two", "doc three", "doc four"],
+        metadatas=[
+            None,  # type: ignore
+            None,  # type: ignore
+            {"existing": "data"},  # Filled metadata
+            None,  # type: ignore
+        ],
+    )
+
+    result = collection.get(ids=["n1", "n2", "n3", "n4"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Expected from batch call
+    expected_batch = sparse_ef(["doc one", "doc two", "doc three", "doc four"])
+
+    # All should have sparse embeddings added
+    for i, metadata in enumerate(result["metadatas"]):
+        assert metadata is not None
+        assert "mixed_sparse" in metadata
+
+        # Verify correct embedding for each document
+        actual = cast(SparseVector, metadata["mixed_sparse"])
+        assert actual.indices == expected_batch[i].indices
+
+    # Third one should still have existing data
+    assert result["metadatas"][2]["existing"] == "data"
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_skips_existing_values(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test that sparse auto-embedding doesn't overwrite existing values."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="preserve")
+
+    schema = Schema().create_index(
+        key="preserve_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Pre-create a sparse vector
+    existing_sparse = SparseVector(indices=[999], values=[123.456])
+
+    collection.add(
+        ids=["preserve1", "preserve2"],
+        documents=["auto document", "manual document"],
+        metadatas=[
+            None,  # type: ignore
+            {"preserve_sparse": existing_sparse},  # Should be preserved
+        ],
+    )
+
+    result = collection.get(ids=["preserve1", "preserve2"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # First should have auto-generated embedding (only one doc was auto-embedded)
+    auto_meta = result["metadatas"][0]
+    assert auto_meta is not None
+    assert "preserve_sparse" in auto_meta
+    expected_auto = sparse_ef(["auto document"])[0]  # Single item batch
+    actual_auto = cast(SparseVector, auto_meta["preserve_sparse"])
+    assert actual_auto.indices == expected_auto.indices
+
+    # Second should preserve the manually provided one
+    manual_meta = result["metadatas"][1]
+    assert manual_meta is not None
+    actual_manual = cast(SparseVector, manual_meta["preserve_sparse"])
+    assert actual_manual.indices == [999]
+    assert actual_manual.values == [123.456]
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_missing_source_field(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse embedding when source metadata field is missing or wrong type."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="missing_field")
+
+    schema = Schema().create_index(
+        key="field_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="text_field",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    collection.add(
+        ids=["f1", "f2", "f3", "f4"],
+        documents=["doc1", "doc2", "doc3", "doc4"],
+        metadatas=[
+            {"text_field": "valid text"},  # Valid string
+            {"text_field": 123},  # Wrong type (int)
+            {"other_field": "value"},  # Missing source field
+            None,  # type: ignore
+        ],
+    )
+
+    result = collection.get(ids=["f1", "f2", "f3", "f4"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Only first one should have sparse embedding (single item batch)
+    assert "field_sparse" in result["metadatas"][0]
+    expected = sparse_ef(["valid text"])[0]  # Single item batch
+    actual = cast(SparseVector, result["metadatas"][0]["field_sparse"])
+    assert actual.indices == expected.indices
+
+    # Others should NOT have sparse embedding
+    assert "field_sparse" not in result["metadatas"][1]
+    assert "field_sparse" not in result["metadatas"][2]
+    assert result["metadatas"][3] is None  # No metadata provided, stays None
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_string_inverted_index(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse auto-embedding works alongside string inverted indexes."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="with_string_index")
+
+    schema = Schema()
+    schema.create_index(
+        key="category",
+        config=StringInvertedIndexConfig(),
+    )
+    schema.create_index(
+        key="sparse_field",
+        config=SparseVectorIndexConfig(
+            source_key="custom_text",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    collection.add(
+        ids=["multi1", "multi2"],
+        documents=["main document", "another document"],
+        metadatas=[
+            {"custom_text": "field content", "category": "cat1"},
+            {"custom_text": "different content", "category": "cat2"},
+        ],
+    )
+
+    result = collection.get(ids=["multi1", "multi2"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Expected from batch call
+    expected_batch = sparse_ef(["field content", "different content"])
+
+    for i, metadata in enumerate(result["metadatas"]):
+        assert metadata is not None
+
+        # Sparse embedding should be present
+        assert "sparse_field" in metadata
+
+        # Verify sparse embedding uses custom_text field
+        actual_field = cast(SparseVector, metadata["sparse_field"])
+        assert actual_field.indices == expected_batch[i].indices
+
+        # Category should be searchable
+        assert "category" in metadata
+
+    # Test filtering with string inverted index
+    filtered = collection.get(where={"category": "cat1"})
+    assert set(filtered["ids"]) == {"multi1"}
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_dense_and_sparse_auto_embeddings_together(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test that dense and sparse auto-embeddings work together."""
+    dense_ef = SimpleEmbeddingFunction(dim=4)
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="with_dense")
+
+    schema = Schema()
+    schema.create_index(config=VectorIndexConfig(embedding_function=dense_ef))
+    schema.create_index(
+        key="sparse_key",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(
+        client_factories,
+        schema=schema,
+        embedding_function=dense_ef,
+    )
+
+    collection.add(
+        ids=["both1", "both2"],
+        documents=["combined document", "another doc"],
+    )
+
+    result = collection.get(
+        ids=["both1", "both2"],
+        include=["embeddings", "metadatas"],
+    )
+
+    # Verify dense embeddings
+    assert result["embeddings"] is not None
+    assert len(result["embeddings"]) == 2
+    assert len(result["embeddings"][0]) == 4
+
+    # Verify sparse embeddings in metadata
+    assert result["metadatas"] is not None
+    for metadata in result["metadatas"]:
+        assert metadata is not None
+        assert "sparse_key" in metadata
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_update_and_upsert(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse auto-embedding with update and upsert operations."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="update_upsert")
+
+    schema = Schema().create_index(
+        key="update_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Initial add
+    collection.add(
+        ids=["up1"],
+        documents=["original doc"],
+    )
+
+    # Update with new document
+    collection.update(
+        ids=["up1"],
+        documents=["updated doc"],
+    )
+
+    result_update = collection.get(ids=["up1"], include=["metadatas", "documents"])
+    assert result_update["metadatas"] is not None
+    assert result_update["documents"] is not None
+    assert result_update["documents"][0] == "updated doc"
+    assert "update_sparse" in result_update["metadatas"][0]
+
+    # Verify sparse embedding matches updated document (single item batch)
+    expected = sparse_ef(["updated doc"])[0]
+    actual = cast(SparseVector, result_update["metadatas"][0]["update_sparse"])
+    assert actual.indices == expected.indices
+
+    # Upsert new document
+    collection.upsert(
+        ids=["up2"],
+        documents=["upserted doc"],
+    )
+
+    result_upsert = collection.get(ids=["up2"], include=["metadatas"])
+    assert result_upsert["metadatas"] is not None
+    assert "update_sparse" in result_upsert["metadatas"][0]
+
+    # Single item batch
+    expected_upsert = sparse_ef(["upserted doc"])[0]
+    actual_upsert = cast(SparseVector, result_upsert["metadatas"][0]["update_sparse"])
+    assert actual_upsert.indices == expected_upsert.indices
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_persistence_across_client_reload(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test that sparse auto-embedding config persists across client reloads."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="persist_test")
+
+    schema = Schema().create_index(
+        key="persist_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, client = _create_isolated_collection(client_factories, schema=schema)
+    collection_name = collection.name
+
+    collection.add(
+        ids=["persist1"],
+        documents=["persistent document"],
+    )
+
+    # Reload client
+    reloaded_client = client_factories.create_client_from_system()
+    reloaded_collection = reloaded_client.get_collection(
+        name=collection_name,
+    )
+
+    # Verify schema persisted
+    assert reloaded_collection.schema is not None
+    assert "persist_sparse" in reloaded_collection.schema.keys
+
+    # Add new document with reloaded collection
+    reloaded_collection.add(
+        ids=["persist2"],
+        documents=["new document after reload"],
+    )
+
+    # Verify both documents have sparse embeddings
+    result = reloaded_collection.get(
+        ids=["persist1", "persist2"],
+        include=["metadatas"],
+    )
+    assert result["metadatas"] is not None
+    assert "persist_sparse" in result["metadatas"][0]
+    assert "persist_sparse" in result["metadatas"][1]
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_batch_operations(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse auto-embedding with large batch of documents."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="batch_test")
+
+    schema = Schema().create_index(
+        key="batch_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Add large batch
+    batch_size = 100
+    ids = [f"batch-{i}" for i in range(batch_size)]
+    documents = [f"document number {i}" for i in range(batch_size)]
+
+    collection.add(ids=ids, documents=documents)
+
+    # Verify all have sparse embeddings
+    result = collection.get(ids=ids[:10], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Expected from batch call (batch of 100, we check first 10)
+    expected_batch = sparse_ef(documents)
+
+    for i, metadata in enumerate(result["metadatas"]):
+        assert metadata is not None
+        assert "batch_sparse" in metadata
+
+        actual = cast(SparseVector, metadata["batch_sparse"])
+        assert actual.indices == expected_batch[i].indices
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_sparse_auto_embedding_with_empty_documents(
+    client_factories: "ClientFactories",
+) -> None:
+    """Test sparse auto-embedding handles empty/None documents gracefully."""
+    sparse_ef = DeterministicSparseEmbeddingFunction(label="empty_test")
+
+    schema = Schema().create_index(
+        key="empty_sparse",
+        config=SparseVectorIndexConfig(
+            source_key="#document",
+            embedding_function=sparse_ef,
+        ),
+    )
+
+    collection, _ = _create_isolated_collection(client_factories, schema=schema)
+
+    # Add with empty string document
+    collection.add(
+        ids=["empty1"],
+        documents=[""],
+    )
+
+    result = collection.get(ids=["empty1"], include=["metadatas"])
+    assert result["metadatas"] is not None
+
+    # Should still generate sparse embedding (empty vector)
+    metadata = result["metadatas"][0]
+    assert metadata is not None
+    assert "empty_sparse" in metadata

--- a/chromadb/test/ef/test_ef.py
+++ b/chromadb/test/ef/test_ef.py
@@ -53,6 +53,7 @@ def test_get_builtins_holds() -> None:
         "FastembedSparseEmbeddingFunction",
         "Bm25EmbeddingFunction",
         "ChromaCloudQwenEmbeddingFunction",
+        "ChromaCloudSpladeEmbeddingFunction",
     }
 
     assert expected_builtins == embedding_functions.get_builtins()

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -80,6 +80,9 @@ from chromadb.utils.embedding_functions.bm25_embedding_function import (
 from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
     ChromaCloudQwenEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.chroma_cloud_splade_embedding_function import (
+    ChromaCloudSpladeEmbeddingFunction,
+)
 
 
 # Get all the class names for backward compatibility
@@ -112,6 +115,7 @@ _all_classes: Set[str] = {
     "FastembedSparseEmbeddingFunction",
     "Bm25EmbeddingFunction",
     "ChromaCloudQwenEmbeddingFunction",
+    "ChromaCloudSpladeEmbeddingFunction",
 }
 
 
@@ -152,6 +156,7 @@ sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  
     "huggingface_sparse": HuggingFaceSparseEmbeddingFunction,
     "fastembed_sparse": FastembedSparseEmbeddingFunction,
     "bm25": Bm25EmbeddingFunction,
+    "chroma-cloud-splade": ChromaCloudSpladeEmbeddingFunction,
 }
 
 
@@ -267,6 +272,7 @@ __all__ = [
     "FastembedSparseEmbeddingFunction",
     "Bm25EmbeddingFunction",
     "ChromaCloudQwenEmbeddingFunction",
+    "ChromaCloudSpladeEmbeddingFunction",
     "register_embedding_function",
     "config_to_embedding_function",
     "known_embedding_functions",


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR exports the hosted chroma ef to make it easier for imports, and fixes sparse auto-embedding to allow for edge cases, such as using `#document` with empty metadata
- New functionality
  - ...

## Test plan

_How are these changes tested?_

Added more schema_e2e tests for both dense and sparse autoembedding from different source keys

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
