### PR TITLE
[DOC]  Make codetheweb and rescrv co-owners of the crates we publish for the client.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS for Rust components
+rust/error/ @codetheweb @rescrv
+rust/api_types/ @codetheweb @rescrv
+rust/chroma/ @codetheweb @rescrv


### PR DESCRIPTION
## Description of changes

To keep tabs on the client's changes, add code owners so that we can
automatically tag for review changes to the client that we ship.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
