### PR TITLE
[BUG]: (Rust client): fix collection.modify() API path

### DIFF
--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -749,11 +749,11 @@ impl ChromaHttpClient {
         &self,
         operation_name: &str,
         method: Method,
-        path: String,
+        path: impl AsRef<str>,
         body: Option<Body>,
         query_params: Option<QueryParams>,
     ) -> Result<Response, ChromaHttpClientError> {
-        let url = self.base_url.join(&path).expect(
+        let url = self.base_url.join(path.as_ref()).expect(
             "The base URL is valid and we control all path construction, so this should never fail",
         );
 
@@ -946,13 +946,7 @@ mod tests {
         });
 
         let response: serde_json::Value = client
-            .send::<(), (), serde_json::Value>(
-                "retry_get",
-                Method::GET,
-                "/retry-get".into(),
-                None,
-                None,
-            )
+            .send::<(), (), serde_json::Value>("retry_get", Method::GET, "/retry-get", None, None)
             .await
             .unwrap();
 
@@ -1003,7 +997,7 @@ mod tests {
             .send::<serde_json::Value, (), serde_json::Value>(
                 "retry_post",
                 Method::POST,
-                "/retry-post".into(),
+                "/retry-post",
                 Some(serde_json::json!({"request": "body"})),
                 None::<()>,
             )


### PR DESCRIPTION
## Description of changes

The constructed API route for `collection.modify()` was incorrect, leading to 404s.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
