### PR TITLE
[BUG]: Prevent persisting hnsw to disk when direct_hnsw is enable

### DIFF
--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -590,6 +590,12 @@ impl HnswIndexProvider {
     }
 
     pub fn commit(&self, index: HnswIndexRef) -> Result<(), Box<dyn ChromaError>> {
+        if self.use_direct_hnsw {
+            // If we are using direct HNSW, we don't need to commit since we're going off the in-memory index.
+            // Each preceding write will have already made changes to the in-memory index.
+            return Ok(());
+        }
+
         match index.inner.write().hnsw_index.save() {
             Ok(_) => {}
             Err(e) => {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Prevent calls to persist_dirty when direct_hnsw is enabled. Such calls aren't necessary when the hnsw index is served from memory.
- New functionality
    - ...

## Test plan

_How are these changes tested?_

Tests in hnsw_provider.rs were run with direct_hnsw set to true.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_