### PR TITLE
[BUG] Default create path with no config or schema does not populate default ef in schema

### DIFF
--- a/chromadb/test/api/test_schema_e2e.py
+++ b/chromadb/test/api/test_schema_e2e.py
@@ -1458,6 +1458,12 @@ def test_default_embedding_function_when_no_schema_provided(
     # Verify it's the DefaultEmbeddingFunction, not legacy
     assert ef.name() == "default"
 
+    config = collection.configuration
+    assert config is not None
+    config_ef = config.get("embedding_function")
+    assert config_ef is not None
+    assert config_ef.name() == "default"
+
     # Serialize the schema to JSON and verify the embedding function type
     json_data = schema.serialize_to_json()
     embedding_vector = json_data["keys"]["#embedding"]["float_list"]["vector_index"]


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - There was a bug in the create collection path, where if the user provides no configuration and no schema at create time, the default schema (which has no ef) gets written to sysdb. this got hidden in the tests since on deserialization, schema builds with the default ef, so the test thought it correctly was assigned the default ef. the fix for this is to check if both config and schema are default during reconciliation, and in that case use the config to build the schema.
- New functionality
  - ...

## Test plan

updated e2e test to catch this bug. validated the test caught the bug, then fixed it

_How are these changes tested?_

- [ x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
