### PR TITLE
[BUG]: fix typo in collection_upsert() handler: AuthzAction::Update -> Upsert

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1553,7 +1553,7 @@ async fn collection_upsert(
     server
         .authenticate_and_authorize_collection(
             &headers,
-            AuthzAction::Update,
+            AuthzAction::Upsert,
             AuthzResource {
                 tenant: Some(tenant.clone()),
                 database: Some(database.clone()),


### PR DESCRIPTION
## Description of changes

The collection upsert route currently uses the wrong authz action.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
