### PR TITLE
[BUG] Catch panic when applied migration exceeds source migrations in sqlite

### DIFF
--- a/rust/sqlite/src/db.rs
+++ b/rust/sqlite/src/db.rs
@@ -154,6 +154,10 @@ impl SqliteDb {
             }
         }
 
+        if applied_migrations.len() > source_migrations.len() {
+            return Ok(vec![]);
+        }
+
         let unapplied = source_migrations[applied_migrations.len()..].to_vec();
         Ok(unapplied)
     }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - A panic occurs when applied migrations exceeds source migrations on sysdb. This can occur when a user upgrades to a version with a new sysdb migration, then downgrades to a prior version. This PR catches this panic and assumes that since applied migrations exceeds source migrations, the migrations run a.) include up to source migrations and b.) are backwards compatible
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
