### PR TITLE
[CHORE] reconcile schema in compaction orchetrator and use in spann&hnsw

### DIFF
--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -97,9 +97,12 @@ impl DistributedHNSWSegmentWriter {
     ) -> Result<Box<DistributedHNSWSegmentWriter>, Box<DistributedHNSWSegmentFromSegmentError>>
     {
         let hnsw_configuration = collection
-            .config
-            .get_hnsw_config_with_legacy_fallback(segment)
+            .schema
+            .as_ref()
+            .map(|schema| schema.get_internal_hnsw_config_with_legacy_fallback(segment))
+            .transpose()
             .map_err(DistributedHNSWSegmentFromSegmentError::InvalidHnswConfiguration)?
+            .flatten()
             .ok_or(DistributedHNSWSegmentFromSegmentError::MissingHnswConfiguration)?;
 
         // TODO: this is hacky, we use the presence of files to determine if we need to load or create the index
@@ -314,9 +317,12 @@ impl DistributedHNSWSegmentReader {
     ) -> Result<Box<DistributedHNSWSegmentReader>, Box<DistributedHNSWSegmentFromSegmentError>>
     {
         let hnsw_configuration = collection
-            .config
-            .get_hnsw_config_with_legacy_fallback(segment)
+            .schema
+            .as_ref()
+            .map(|schema| schema.get_internal_hnsw_config_with_legacy_fallback(segment))
+            .transpose()
             .map_err(DistributedHNSWSegmentFromSegmentError::InvalidHnswConfiguration)?
+            .flatten()
             .ok_or(DistributedHNSWSegmentFromSegmentError::MissingHnswConfiguration)?;
 
         // TODO: this is hacky, we use the presence of files to determine if we need to load or create the index

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -15,8 +15,6 @@ use chroma_index::spann::types::{
 use chroma_index::IndexUuid;
 use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::SpannIndexWriter};
 use chroma_types::Collection;
-use chroma_types::KnnIndex;
-use chroma_types::Schema;
 use chroma_types::SchemaError;
 use chroma_types::SegmentUuid;
 use chroma_types::HNSW_PATH;
@@ -112,14 +110,13 @@ impl SpannSegmentWriter {
             return Err(SpannSegmentWriterError::InvalidArgument);
         }
 
-        let reconciled_schema = Schema::reconcile_schema_and_config(
-            collection.schema.as_ref(),
-            Some(&collection.config),
-            KnnIndex::Spann,
-        )
-        .map_err(SpannSegmentWriterError::InvalidSchema)?;
+        let schema = collection.schema.as_ref().ok_or_else(|| {
+            SpannSegmentWriterError::InvalidSchema(SchemaError::InvalidSchema {
+                reason: "Schema is None".to_string(),
+            })
+        })?;
 
-        let params = reconciled_schema
+        let params = schema
             .get_internal_spann_config()
             .ok_or(SpannSegmentWriterError::MissingSpannConfiguration)?;
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR reconciles schema and config in the compaction orchestrator so that distributed hnsw and spann can directly use it without needing to reconcile on writes
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [x ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
