### PR TITLE
[BUG] use keys instead of key_overrides in query embedding strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "sea-query-binder",
  "serde",
  "serde-pickle",
+ "serde_json",
  "shuttle",
  "sqlx",
  "tantivy",

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -17,7 +17,6 @@ import numpy as np
 from uuid import UUID
 
 from chromadb.api.types import (
-    EMBEDDING_KEY,
     URI,
     Schema,
     SparseVectorIndexConfig,
@@ -840,22 +839,22 @@ class CollectionCommon(Generic[ClientT]):
 
         # Handle metadata field with potential sparse embedding
         schema = self.schema
-        if schema is None or key not in schema.key_overrides:
+        if schema is None or key not in schema.keys:
             raise ValueError(
                 f"Cannot embed string query for key '{key}': "
                 f"key not found in schema. Please provide an embedded vector or "
                 f"configure an embedding function for this key in the schema."
             )
 
-        value_type = schema.key_overrides[key]
+        value_type = schema.keys[key]
 
         # Check for sparse vector with embedding function
         if value_type.sparse_vector is not None:
             sparse_index = value_type.sparse_vector.sparse_vector_index
             if sparse_index is not None and sparse_index.enabled:
-                config = sparse_index.config
-                if config.embedding_function is not None:
-                    embedding_func = config.embedding_function
+                sparse_config = sparse_index.config
+                if sparse_config.embedding_function is not None:
+                    embedding_func = sparse_config.embedding_function
                     if not isinstance(embedding_func, SparseEmbeddingFunction):
                         embedding_func = cast(
                             SparseEmbeddingFunction[Any], embedding_func
@@ -887,9 +886,9 @@ class CollectionCommon(Generic[ClientT]):
         if value_type.float_list is not None:
             vector_index = value_type.float_list.vector_index
             if vector_index is not None and vector_index.enabled:
-                config = vector_index.config
-                if config.embedding_function is not None:
-                    embedding_func = config.embedding_function
+                dense_config = vector_index.config
+                if dense_config.embedding_function is not None:
+                    embedding_func = dense_config.embedding_function
                     validate_embedding_function(embedding_func)
 
                     # Embed the query using the schema's embedding function


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - There was a bug in sparse embedding query texts where `key_overrides` was used during query embedding instead of `keys`, as per the rename. This PR fixes that, and adds tests to ensure the happy path of embedding query strings works as intended
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [x ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
