### PR TITLE
[ENH]: implement Display for Where

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-cli"
-version = "1.1.12"
+version = "1.2.0"
 dependencies = [
  "arboard",
  "axum 0.8.1",

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -1337,7 +1337,7 @@ impl std::fmt::Display for MetadataExpression {
                 write!(f, "{} {} {}", self.key, op, value)
             }
             MetadataComparison::Set(op, set_value) => {
-                write!(f, "{} {} {:?}", self.key, op, set_value)
+                write!(f, "{} {} {}", self.key, op, set_value)
             }
         }
     }
@@ -1590,6 +1590,45 @@ pub enum MetadataSetValue {
     Int(Vec<i64>),
     Float(Vec<f64>),
     Str(Vec<String>),
+}
+
+impl std::fmt::Display for MetadataSetValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MetadataSetValue::Bool(values) => {
+                let values_str = values
+                    .iter()
+                    .map(|v| format!("\"{}\"", v))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "[{}]", values_str)
+            }
+            MetadataSetValue::Int(values) => {
+                let values_str = values
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "[{}]", values_str)
+            }
+            MetadataSetValue::Float(values) => {
+                let values_str = values
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "[{}]", values_str)
+            }
+            MetadataSetValue::Str(values) => {
+                let values_str = values
+                    .iter()
+                    .map(|v| format!("\"{}\"", v))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "[{}]", values_str)
+            }
+        }
+    }
 }
 
 impl MetadataSetValue {


### PR DESCRIPTION
## Description of changes

Produces much more readable output when debugging. E.g. for 

```rust
println!(
    "{}",
    Key::field("foo").eq("bar")
        | (Key::field("baz").eq("quux")
            & Key::field("year").is_in([2023, 2024])
            & (Key::field("source").eq(1) | Key::field("source").eq(2)))
);

println!(
    "{}",
    Key::Document.contains("foo") & Key::field("foo").eq("bar")
);
```

Before (with debug/`{:?}`):

```
Composite(CompositeExpression { operator: Or, children: [Metadata(MetadataExpression { key: "foo", comparison: Primitive(Equal, Str("bar")) }), Composite(CompositeExpression { operator: And, children: [Metadata(MetadataExpression { key: "baz", comparison: Primitive(Equal, Str("quux")) }), Metadata(MetadataExpression { key: "year", comparison: Set(In, Int([2023, 2024])) }), Composite(CompositeExpression { operator: Or, children: [Metadata(MetadataExpression { key: "source", comparison: Primitive(Equal, Int(1)) }), Metadata(MetadataExpression { key: "source", comparison: Primitive(Equal, Int(2)) })] })] })] })
Composite(CompositeExpression { operator: And, children: [Document(DocumentExpression { operator: Contains, pattern: "foo" }), Metadata(MetadataExpression { key: "foo", comparison: Primitive(Equal, Str("bar")) })] })
```

After:

```
(foo="bar" | (baz="quux" & year IN Int([2023, 2024]) & (source=1 | source=2)))
(#document CONTAINS "foo" & foo="bar")
```

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
