### PR TITLE
[ENH]: Disallow setting only source_key without an ef

### DIFF
--- a/chromadb/test/api/test_schema.py
+++ b/chromadb/test/api/test_schema.py
@@ -246,7 +246,7 @@ class TestNewSchema:
         # 1. Create sparse vector index on "embeddings_key"
         # 2. Disable string inverted index on "text_key_1"
         # 3. Disable string inverted index on "text_key_2"
-        sparse_config = SparseVectorIndexConfig(source_key="raw_text")
+        sparse_config = SparseVectorIndexConfig(source_key="raw_text", embedding_function=MockSparseEmbeddingFunction())
         string_config = StringInvertedIndexConfig()
 
         result = (
@@ -1268,7 +1268,7 @@ class TestNewSchema:
         schema = Schema()
 
         # Enable sparse vector on "multi_field"
-        sparse_config = SparseVectorIndexConfig(source_key="source")
+        sparse_config = SparseVectorIndexConfig(source_key="source", embedding_function=MockSparseEmbeddingFunction())
         schema.create_index(config=sparse_config, key="multi_field")
 
         # Also enable string_inverted_index on the same key
@@ -1454,7 +1454,7 @@ class TestNewSchema:
                 hnsw=hnsw_config
             )
             original.create_index(config=vector_config)
-            original.create_index(config=SparseVectorIndexConfig(source_key="text"), key="embeddings")
+            original.create_index(config=SparseVectorIndexConfig(source_key="text", embedding_function=MockSparseEmbeddingFunction()), key="embeddings")
             original.delete_index(config=StringInvertedIndexConfig(), key="tags")
 
             # First roundtrip
@@ -1514,7 +1514,7 @@ class TestNewSchema:
             key_name = f"field_{i}"
             if i == 0:
                 # Enable sparse vector on ONE key only
-                schema.create_index(config=SparseVectorIndexConfig(source_key=f"source_{i}"), key=key_name)
+                schema.create_index(config=SparseVectorIndexConfig(source_key=f"source_{i}", embedding_function=MockSparseEmbeddingFunction()), key=key_name)
             elif i % 2 == 1:
                 # Disable string inverted index
                 schema.delete_index(config=StringInvertedIndexConfig(), key=key_name)
@@ -1578,7 +1578,7 @@ class TestNewSchema:
 
         # Chain multiple operations
         result = (schema
-                  .create_index(config=SparseVectorIndexConfig(source_key="text"), key="field1")
+                  .create_index(config=SparseVectorIndexConfig(source_key="text", embedding_function=MockSparseEmbeddingFunction()), key="field1")
                   .delete_index(config=StringInvertedIndexConfig(), key="field2")
                   .delete_index(config=StringInvertedIndexConfig(), key="field3")
                   .delete_index(config=IntInvertedIndexConfig(), key="field4"))
@@ -1820,7 +1820,7 @@ class TestNewSchema:
         schema = Schema()
 
         # Enable sparse vector on a key - it gets exactly what we specify
-        sparse_config = SparseVectorIndexConfig(source_key="default_source")
+        sparse_config = SparseVectorIndexConfig(source_key="default_source", embedding_function=MockSparseEmbeddingFunction())
         schema.create_index(config=sparse_config, key="field1")
 
         # Verify field1 has the sparse vector with the specified source_key
@@ -1907,7 +1907,7 @@ class TestNewSchema:
         schema = Schema()
 
         # Create sparse vector on one key and string indexes on others
-        schema.create_index(config=SparseVectorIndexConfig(source_key="source_a"), key="key_a")
+        schema.create_index(config=SparseVectorIndexConfig(source_key="source_a", embedding_function=MockSparseEmbeddingFunction()), key="key_a")
         schema.create_index(config=StringInvertedIndexConfig(), key="key_b")
         schema.create_index(config=StringInvertedIndexConfig(), key="key_c")
 
@@ -1992,7 +1992,7 @@ class TestNewSchema:
         schema = Schema()
 
         # Enable sparse vector on a key
-        schema.create_index(config=SparseVectorIndexConfig(source_key="my_source"), key="multi_index_field")
+        schema.create_index(config=SparseVectorIndexConfig(source_key="my_source", embedding_function=MockSparseEmbeddingFunction()), key="multi_index_field")
 
         # This key now has sparse_vector overridden, but string, int, etc. should still follow global defaults
         field = schema.keys["multi_index_field"]
@@ -2337,3 +2337,23 @@ def test_config_source_key_validates_special_keys() -> None:
     # Regular keys (no #) are allowed
     config6 = SparseVectorIndexConfig(source_key="my_field")
     assert config6.source_key == "my_field"
+
+
+def test_sparse_vector_config_requires_ef_with_source_key() -> None:
+    """Test that SparseVectorIndexConfig raises ValueError when source_key is provided without embedding_function."""
+    schema = Schema()
+
+    # Attempt to create sparse vector index with source_key but no embedding_function
+    with pytest.raises(ValueError) as exc_info:
+        schema.create_index(
+            key="invalid_sparse",
+            config=SparseVectorIndexConfig(
+                source_key="text_field",
+                # No embedding_function provided - should raise ValueError
+            ),
+        )
+
+    # Verify the error message mentions both source_key and embedding_function
+    error_msg = str(exc_info.value)
+    assert "source_key" in error_msg.lower()
+    assert "embedding_function" in error_msg.lower()

--- a/rust/types/src/validators.rs
+++ b/rust/types/src/validators.rs
@@ -281,6 +281,11 @@ pub fn validate_schema(schema: &Schema) -> Result<(), ValidationError> {
                             .into(),
                     ));
                 }
+                if svit.config.source_key.is_some() && svit.config.embedding_function.is_none() {
+                    return Err(ValidationError::new("schema").with_message(
+                        "If source_key is provided then embedding_function must also be provided since there is no default embedding function.".into(),
+                    ));
+                }
             }
             // Validate source_key for sparse vector index
             if let Some(source_key) = &svit.config.source_key {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Setting only source_key without an ef in the sparse vector index config now returns an error
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
