### PR TITLE
[CHORE] Add support for non-prefixed ef env vars in python

### DIFF
--- a/chromadb/utils/embedding_functions/baseten_embedding_function.py
+++ b/chromadb/utils/embedding_functions/baseten_embedding_function.py
@@ -35,12 +35,16 @@ class BasetenEmbeddingFunction(OpenAIEmbeddingFunction):
                 DeprecationWarning,
             )
 
-        self.api_key_env_var = api_key_env_var
+        if os.getenv("BASETEN_API_KEY") is not None:
+            self.api_key_env_var = "BASETEN_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
         # Prioritize api_key argument, then environment variable
-        resolved_api_key = api_key or os.getenv(api_key_env_var)
+        resolved_api_key = api_key or os.getenv(self.api_key_env_var)
         if not resolved_api_key:
             raise ValueError(
-                f"API key not provided and {api_key_env_var} environment variable is not set."
+                f"API key not provided and {self.api_key_env_var} environment variable is not set."
             )
         self.api_key = resolved_api_key
         if not api_base:

--- a/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cloudflare_workers_ai_embedding_function.py
@@ -53,12 +53,19 @@ class CloudflareWorkersAIEmbeddingFunction(EmbeddingFunction[Documents]):
             )
         self.model_name = model_name
         self.account_id = account_id
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+
+        if os.getenv("CLOUDFLARE_API_KEY") is not None:
+            self.api_key_env_var = "CLOUDFLARE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         self.gateway_id = gateway_id
 
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         if self.gateway_id:
             self._api_url = f"{GATEWAY_BASE_URL}/{self.account_id}/{self.gateway_id}/workers-ai/{self.model_name}"

--- a/chromadb/utils/embedding_functions/cohere_embedding_function.py
+++ b/chromadb/utils/embedding_functions/cohere_embedding_function.py
@@ -43,10 +43,16 @@ class CohereEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
             )
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("COHERE_API_KEY") is not None:
+            self.api_key_env_var = "COHERE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
 

--- a/chromadb/utils/embedding_functions/google_embedding_function.py
+++ b/chromadb/utils/embedding_functions/google_embedding_function.py
@@ -38,10 +38,16 @@ class GooglePalmEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
             )
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("GOOGLE_API_KEY") is not None:
+            self.api_key_env_var = "GOOGLE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
 
@@ -154,10 +160,16 @@ class GoogleGenerativeAiEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
             )
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("GOOGLE_API_KEY") is not None:
+            self.api_key_env_var = "GOOGLE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
         self.task_type = task_type
@@ -289,10 +301,16 @@ class GoogleVertexEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
             )
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("GOOGLE_API_KEY") is not None:
+            self.api_key_env_var = "GOOGLE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
         self.project_id = project_id

--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -40,10 +40,16 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
             )
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("HUGGINGFACE_API_KEY") is not None:
+            self.api_key_env_var = "HUGGINGFACE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
 
@@ -160,6 +166,9 @@ class HuggingFaceEmbeddingServer(EmbeddingFunction[Documents]):
         self.url = url
 
         self.api_key_env_var = api_key_env_var
+        if os.getenv("HUGGINGFACE_API_KEY") is not None:
+            self.api_key_env_var = "HUGGINGFACE_API_KEY"
+
         if self.api_key_env_var is not None:
             self.api_key = api_key or os.getenv(self.api_key_env_var)
         else:

--- a/chromadb/utils/embedding_functions/jina_embedding_function.py
+++ b/chromadb/utils/embedding_functions/jina_embedding_function.py
@@ -81,10 +81,16 @@ class JinaEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 DeprecationWarning,
             )
 
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("JINA_API_KEY") is not None:
+            self.api_key_env_var = "JINA_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
 

--- a/chromadb/utils/embedding_functions/openai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/openai_embedding_function.py
@@ -57,10 +57,16 @@ class OpenAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 DeprecationWarning,
             )
 
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("OPENAI_API_KEY") is not None:
+            self.api_key_env_var = "OPENAI_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
         self.organization_id = organization_id

--- a/chromadb/utils/embedding_functions/roboflow_embedding_function.py
+++ b/chromadb/utils/embedding_functions/roboflow_embedding_function.py
@@ -45,10 +45,16 @@ class RoboflowEmbeddingFunction(EmbeddingFunction[Embeddable]):
                 "Please use environment variables via api_key_env_var for persistent storage.",
                 DeprecationWarning,
             )
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("ROBOFLOW_API_KEY") is not None:
+            self.api_key_env_var = "ROBOFLOW_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.api_url = api_url
 

--- a/chromadb/utils/embedding_functions/together_ai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/together_ai_embedding_function.py
@@ -48,15 +48,16 @@ class TogetherAIEmbeddingFunction(EmbeddingFunction[Documents]):
             )
 
         self.model_name = model_name
-        self.api_key = api_key
-        self.api_key_env_var = api_key_env_var
 
-        if not self.api_key:
-            self.api_key = os.getenv(self.api_key_env_var)
+        if os.getenv("TOGETHER_API_KEY") is not None:
+            self.api_key_env_var = "TOGETHER_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
 
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
             raise ValueError(
-                f"API key not found in environment variable {self.api_key_env_var}"
+                f"The {self.api_key_env_var} environment variable is not set."
             )
 
         self._session = httpx.Client()

--- a/chromadb/utils/embedding_functions/voyageai_embedding_function.py
+++ b/chromadb/utils/embedding_functions/voyageai_embedding_function.py
@@ -47,10 +47,16 @@ class VoyageAIEmbeddingFunction(EmbeddingFunction[Documents]):
                 DeprecationWarning,
             )
 
-        self.api_key_env_var = api_key_env_var
-        self.api_key = api_key or os.getenv(api_key_env_var)
+        if os.getenv("VOYAGE_API_KEY") is not None:
+            self.api_key_env_var = "VOYAGE_API_KEY"
+        else:
+            self.api_key_env_var = api_key_env_var
+
+        self.api_key = api_key or os.getenv(self.api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"The {api_key_env_var} environment variable is not set.")
+            raise ValueError(
+                f"The {self.api_key_env_var} environment variable is not set."
+            )
 
         self.model_name = model_name
         self.input_type = input_type


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR allows users to set env vars without the CHROMA_ prefix on embedding functions in python, while still supporting the default env var as fallback
- New functionality
  - ...
<img width="490" height="421" alt="image" src="https://github.com/user-attachments/assets/2edc560e-e8f4-41b3-9a64-612488d8a3e1" />
<img width="916" height="160" alt="image" src="https://github.com/user-attachments/assets/45223204-1cf1-4fc0-9f20-3b5241744b61" />
<img width="727" height="161" alt="image" src="https://github.com/user-attachments/assets/b78f3f4f-5e6d-4ae5-95d8-90c009235722" />
<img width="619" height="195" alt="image" src="https://github.com/user-attachments/assets/2c32f124-6a3d-48b1-b771-c5441f47c6b9" />
<img width="829" height="250" alt="image" src="https://github.com/user-attachments/assets/7ccb1f98-6877-4f7b-8457-5b40337c0d97" />

for cloudflare, jina -> used the same naming convention as JS client

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
