### PR TITLE
[CHORE] Remove unused legacy metadata reconcile in sysdb

### DIFF
--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -20,7 +20,7 @@ use chroma_types::{
     ListCollectionVersionsError, ListDatabasesError, ListDatabasesResponse, Metadata, ResetError,
     ResetResponse, ScheduleEntry, ScheduleEntryConversionError, SegmentFlushInfo,
     SegmentFlushInfoConversionError, SegmentUuid, UpdateCollectionError, UpdateTenantError,
-    UpdateTenantResponse, VectorIndexConfiguration,
+    UpdateTenantResponse,
 };
 use chroma_types::{
     AdvanceTaskError, AdvanceTaskResponse, BatchGetCollectionSoftDeleteStatusError,
@@ -295,17 +295,6 @@ impl SysDb {
         dimension: Option<i32>,
         get_or_create: bool,
     ) -> Result<Collection, CreateCollectionError> {
-        let configuration = match configuration {
-            Some(mut config) => {
-                let hnsw_params = config.get_hnsw_config_from_legacy_metadata(&metadata)?;
-                if let Some(hnsw_params) = hnsw_params {
-                    config.vector_index = VectorIndexConfiguration::Hnsw(hnsw_params);
-                }
-                Some(config)
-            }
-            None => None,
-        };
-
         match self {
             SysDb::Grpc(grpc) => {
                 grpc.create_collection(


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - collection configuration's try_from_config already handles legacy metadata reconciliation, and with schema enabled, this code path is no longer accessed. removing to remove code debt
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [x ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
