### PR TITLE
[BUG]: Fix compilation issues in statistics.rs

### DIFF
--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -16,7 +16,7 @@ use chroma_types::{
 };
 use futures::StreamExt;
 
-use crate::execution::operators::execute_task::TaskExecutor;
+use crate::execution::operators::execute_task::AttachedFunctionExecutor;
 
 /// Create an accumulator for statistics.
 pub trait StatisticsFunctionFactory: std::fmt::Debug + Send + Sync {
@@ -170,7 +170,7 @@ impl Hash for StatisticsValue {
 pub struct StatisticsFunctionExecutor(pub Box<dyn StatisticsFunctionFactory>);
 
 #[async_trait]
-impl TaskExecutor for StatisticsFunctionExecutor {
+impl AttachedFunctionExecutor for StatisticsFunctionExecutor {
     async fn execute(
         &self,
         input_records: Chunk<LogRecord>,


### PR DESCRIPTION
## Description of changes

Due to a merge conflict between PRs 5733 and 5735, `rust/worker/src/execution/functions/statistics.rs` is not compiling on main. This PR fixes that.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_