### PR TITLE
[CLN] schema: build default with config ef & default_knn_index, remove #document population in defaults

### DIFF
--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -249,7 +249,7 @@ type ValueTypes struct {
 	SparseVector *SparseVectorValueType `json:"sparse_vector,omitempty"`
 	Int          *IntValueType          `json:"int,omitempty"`
 	Float        *FloatValueType        `json:"float,omitempty"`
-	Boolean      *BoolValueType         `json:"boolean,omitempty"`
+	Boolean      *BoolValueType         `json:"bool,omitempty"`
 }
 
 type Schema struct {

--- a/go/pkg/sysdb/coordinator/model/collection_configuration_test.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration_test.go
@@ -147,7 +147,7 @@ func TestUpdateSchemaFromConfig_HnswSuccess(t *testing.T) {
 					"config": {}
 				}
 			},
-			"boolean": {
+			"bool": {
 				"bool_inverted_index": {
 					"enabled": true,
 					"config": {}
@@ -312,7 +312,7 @@ func TestUpdateSchemaFromConfig_SpannSuccess(t *testing.T) {
 					"config": {}
 				}
 			},
-			"boolean": {
+			"bool": {
 				"bool_inverted_index": {
 					"enabled": true,
 					"config": {}
@@ -481,7 +481,7 @@ func TestUpdateSchemaFromConfig_EmbeddingFunction(t *testing.T) {
 					"config": {}
 				}
 			},
-			"boolean": {
+			"bool": {
 				"bool_inverted_index": {
 					"enabled": true,
 					"config": {}

--- a/go/pkg/sysdb/coordinator/table_catalog_test.go
+++ b/go/pkg/sysdb/coordinator/table_catalog_test.go
@@ -1555,7 +1555,7 @@ func TestUpdateCollection_WithSchema(t *testing.T) {
 					"config": {}
 				}
 			},
-			"boolean": {
+			"bool": {
 				"bool_inverted_index": {
 					"enabled": true,
 					"config": {}

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -4,8 +4,7 @@ use chroma_config::Configurable;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_sysdb::SysDb;
 use chroma_types::{
-    CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError, KnnIndex, Schema,
-    SchemaError,
+    CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError, Schema, SchemaError,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -143,7 +142,6 @@ impl CollectionsWithSegmentsProvider {
     pub(crate) async fn get_collection_with_segments(
         &mut self,
         collection_id: CollectionUuid,
-        knn_index: KnnIndex,
     ) -> Result<CollectionAndSegments, CollectionsWithSegmentsProviderError> {
         if let Some(collection_and_segments_with_ttl) = self
             .collections_with_segments_cache
@@ -185,14 +183,13 @@ impl CollectionsWithSegmentsProvider {
                 .await?
         };
 
-        // reconcile schema and config
-        let reconciled_schema = Schema::reconcile_schema_and_config(
-            collection_and_segments_sysdb.collection.schema.as_ref(),
-            Some(&collection_and_segments_sysdb.collection.config),
-            knn_index,
-        )
-        .map_err(CollectionsWithSegmentsProviderError::InvalidSchema)?;
-        collection_and_segments_sysdb.collection.schema = Some(reconciled_schema);
+        if collection_and_segments_sysdb.collection.schema.is_none() {
+            collection_and_segments_sysdb.collection.schema = Some(
+                Schema::try_from(&collection_and_segments_sysdb.collection.config)
+                    .map_err(CollectionsWithSegmentsProviderError::InvalidSchema)?,
+            );
+        }
+
         self.set_collection_with_segments(collection_and_segments_sysdb.clone())
             .await;
         Ok(collection_and_segments_sysdb)

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -176,7 +176,7 @@ impl ServiceBasedFrontend {
     ) -> Result<Collection, GetCollectionError> {
         Ok(self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.default_knn_index)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?
             .collection)
@@ -188,7 +188,7 @@ impl ServiceBasedFrontend {
     ) -> Result<Option<u32>, GetCollectionError> {
         Ok(self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.default_knn_index)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?
             .collection
@@ -381,7 +381,7 @@ impl ServiceBasedFrontend {
         if self.enable_schema {
             for collection in collections.iter_mut() {
                 collection
-                    .reconcile_schema_with_config(self.default_knn_index)
+                    .reconcile_schema_for_read()
                     .map_err(GetCollectionsError::InvalidSchema)?;
             }
         }
@@ -425,7 +425,7 @@ impl ServiceBasedFrontend {
         if self.enable_schema {
             for collection in &mut collections {
                 collection
-                    .reconcile_schema_with_config(self.default_knn_index)
+                    .reconcile_schema_for_read()
                     .map_err(GetCollectionError::InvalidSchema)?;
             }
         }
@@ -450,7 +450,7 @@ impl ServiceBasedFrontend {
 
         if self.enable_schema {
             collection
-                .reconcile_schema_with_config(self.default_knn_index)
+                .reconcile_schema_for_read()
                 .map_err(GetCollectionByCrnError::InvalidSchema)?;
         }
         Ok(collection)
@@ -630,9 +630,10 @@ impl ServiceBasedFrontend {
         // that was retrieved from sysdb, rather than the one that was passed in
         if self.enable_schema {
             collection
-                .reconcile_schema_with_config(self.default_knn_index)
+                .reconcile_schema_for_read()
                 .map_err(CreateCollectionError::InvalidSchema)?;
         }
+
         Ok(collection)
     }
 
@@ -735,7 +736,7 @@ impl ServiceBasedFrontend {
             .await?;
         collection_and_segments
             .collection
-            .reconcile_schema_with_config(self.default_knn_index)
+            .reconcile_schema_for_read()
             .map_err(ForkCollectionError::InvalidSchema)?;
         let collection = collection_and_segments.collection.clone();
         let latest_collection_logical_size_bytes = collection_and_segments
@@ -1099,7 +1100,7 @@ impl ServiceBasedFrontend {
         let read_event = if let Some(where_clause) = r#where {
             let collection_and_segments = self
                 .collections_with_segments_provider
-                .get_collection_with_segments(collection_id, self.default_knn_index)
+                .get_collection_with_segments(collection_id)
                 .await
                 .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
             if self.enable_schema {
@@ -1309,7 +1310,7 @@ impl ServiceBasedFrontend {
     ) -> Result<CountResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.default_knn_index)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         let latest_collection_logical_size_bytes = collection_and_segments
@@ -1424,7 +1425,7 @@ impl ServiceBasedFrontend {
     ) -> Result<GetResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.default_knn_index)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         if self.enable_schema {
@@ -1569,7 +1570,7 @@ impl ServiceBasedFrontend {
     ) -> Result<QueryResponse, QueryError> {
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(collection_id, self.default_knn_index)
+            .get_collection_with_segments(collection_id)
             .await
             .map_err(|err| Box::new(err) as Box<dyn ChromaError>)?;
         if self.enable_schema {
@@ -1726,7 +1727,7 @@ impl ServiceBasedFrontend {
         // Get collection and segments once for all queries
         let collection_and_segments = self
             .collections_with_segments_provider
-            .get_collection_with_segments(request.collection_id, self.default_knn_index)
+            .get_collection_with_segments(request.collection_id)
             .await
             .map_err(|err| QueryError::Other(Box::new(err) as Box<dyn ChromaError>))?;
         if self.enable_schema {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR is to clean up how collections are created:
  1. when collection configuration was hnsw default and schema was any default, it blindly converted config -> schema. instead, this should use the knn index to build the correct default schema, and only take the embedding function from config
  2. when converting config -> schema, it writes #document as the source key for both defaults and #embedding vector indexes. Instead, it should only write #document as the source key for #embedding
  3. On the distributed modify path, the json mapping for the boolean type in go does not match the rust type
- New functionality
  - ...

## Test plan

_How are these changes tested?_
added unit tests for all 8 default cases (config hnsw or spann default, schema hnsw or spann default, default_knn_index), test thta #document does not populate for defaults, and embedding functions do.

- [ x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
