### PR TITLE
[CLN]: Revert 5742

### DIFF
--- a/rust/segment/src/distributed_hnsw.rs
+++ b/rust/segment/src/distributed_hnsw.rs
@@ -97,12 +97,9 @@ impl DistributedHNSWSegmentWriter {
     ) -> Result<Box<DistributedHNSWSegmentWriter>, Box<DistributedHNSWSegmentFromSegmentError>>
     {
         let hnsw_configuration = collection
-            .schema
-            .as_ref()
-            .map(|schema| schema.get_internal_hnsw_config_with_legacy_fallback(segment))
-            .transpose()
+            .config
+            .get_hnsw_config_with_legacy_fallback(segment)
             .map_err(DistributedHNSWSegmentFromSegmentError::InvalidHnswConfiguration)?
-            .flatten()
             .ok_or(DistributedHNSWSegmentFromSegmentError::MissingHnswConfiguration)?;
 
         // TODO: this is hacky, we use the presence of files to determine if we need to load or create the index
@@ -317,12 +314,9 @@ impl DistributedHNSWSegmentReader {
     ) -> Result<Box<DistributedHNSWSegmentReader>, Box<DistributedHNSWSegmentFromSegmentError>>
     {
         let hnsw_configuration = collection
-            .schema
-            .as_ref()
-            .map(|schema| schema.get_internal_hnsw_config_with_legacy_fallback(segment))
-            .transpose()
+            .config
+            .get_hnsw_config_with_legacy_fallback(segment)
             .map_err(DistributedHNSWSegmentFromSegmentError::InvalidHnswConfiguration)?
-            .flatten()
             .ok_or(DistributedHNSWSegmentFromSegmentError::MissingHnswConfiguration)?;
 
         // TODO: this is hacky, we use the presence of files to determine if we need to load or create the index


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Reverts https://github.com/chroma-core/chroma/pull/5742/files. We are cleaning up the schema code a little bit to have separate reconcile logic for read and write paths so this is in direction of that.
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
None

## Documentation Changes
None
