### PR TITLE
[CHORE] Bump max concurrent streams for log service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chroma"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-api-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "utoipa",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-error"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "http 1.1.0",
  "sqlx",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Increase max concurrent streams for log service
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
