### PR TITLE
docs: add documentation for list_collections() 

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/reference/python/collection.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/python/collection.md
@@ -209,3 +209,19 @@ Delete the embeddings based on ids and/or a where filter
 **Returns**:
 
 None
+
+## list_collections
+
+```python
+def list_collections() -> List[Collection]
+```
+
+List all collections currently stored in the database.
+
+**Arguments**:
+
+None
+
+**Returns**:
+
+- `List[Collection]` - A list of collection objects currently in the database.


### PR DESCRIPTION
## Description of changes

This PR adds the missing documentation entry for the list_collections() method in the Python Collection reference page.
The new section follows the existing documentation style used for other Collection methods.

## Test plan

No code changes were made. This PR updates documentation only.

## Migration plan

No migrations required.

## Observability plan

No observability changes required.

## Documentation Changes

Yes — documentation has been updated in:
docs/docs.trychroma.com/markdoc/content/reference/python/collection.md

