### PR TITLE
[ENH]: fix Qwen EF hydration with custom prompts/tasks

### DIFF
--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -50,13 +50,13 @@ class TestEmbeddingFunctionSchemas:
         if ef_name == "chroma-cloud-qwen":
             from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
                 ChromaCloudQwenEmbeddingModel,
-                ChromaCloudQwenEmbeddingTask,
                 CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS,
             )
+
             mock_ef.get_config.return_value = {
                 "api_key_env_var": "CHROMA_API_KEY",
                 "model": ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B.value,
-                "task": ChromaCloudQwenEmbeddingTask.NL_TO_CODE.value,
+                "task": "nl_to_code",
                 "instructions": CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS,
             }
 

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-qwen/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-qwen/src/index.test.ts
@@ -2,7 +2,6 @@ import {
 	CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS,
 	ChromaCloudQwenEmbeddingFunction,
 	ChromaCloudQwenEmbeddingModel,
-	ChromaCloudQwenEmbeddingTask,
 } from "./index";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
@@ -13,12 +12,11 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 
 	const defaultParametersTest = "should initialize with default parameters";
 	if (!process.env.CHROMA_API_KEY) {
-		it.skip(defaultParametersTest, () => {});
+		it.skip(defaultParametersTest, () => { });
 	} else {
 		it(defaultParametersTest, () => {
 			const embedder = new ChromaCloudQwenEmbeddingFunction({
 				model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
-				task: ChromaCloudQwenEmbeddingTask.NL_TO_CODE,
 			});
 			expect(embedder.name).toBe("chroma-cloud-qwen");
 
@@ -37,7 +35,6 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 			expect(() => {
 				new ChromaCloudQwenEmbeddingFunction({
 					model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
-					task: ChromaCloudQwenEmbeddingTask.NL_TO_CODE,
 				});
 			}).toThrow("Chroma Embedding API key is required");
 		} finally {
@@ -53,7 +50,6 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 		try {
 			const embedder = new ChromaCloudQwenEmbeddingFunction({
 				model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
-				task: ChromaCloudQwenEmbeddingTask.NL_TO_CODE,
 				apiKeyEnvVar: "CUSTOM_CHROMA_API_KEY",
 			});
 
@@ -67,14 +63,14 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 
 	const buildFromConfigTest = "should build from config";
 	if (!process.env.CHROMA_API_KEY) {
-		it.skip(buildFromConfigTest, () => {});
+		it.skip(buildFromConfigTest, () => { });
 	} else {
 		it(buildFromConfigTest, () => {
 			const config = {
 				api_key_env_var: "CHROMA_API_KEY",
 				model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
-				task: ChromaCloudQwenEmbeddingTask.NL_TO_CODE,
 				instructions: CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS,
+				task: "nl_to_code",
 			};
 
 			const embedder = ChromaCloudQwenEmbeddingFunction.buildFromConfig(config);
@@ -84,12 +80,11 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 
 		const generateEmbeddingsTest = "should generate embeddings";
 		if (!process.env.CHROMA_API_KEY) {
-			it.skip(generateEmbeddingsTest, () => {});
+			it.skip(generateEmbeddingsTest, () => { });
 		} else {
 			it(generateEmbeddingsTest, async () => {
 				const embedder = new ChromaCloudQwenEmbeddingFunction({
 					model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
-					task: ChromaCloudQwenEmbeddingTask.NL_TO_CODE,
 				});
 				const texts = ["Hello world", "Test text"];
 				const embeddings = await embedder.generate(texts);


### PR DESCRIPTION
## Description of changes

The Qwen EF now correctly supports serializing/de-serializing arbitrary prompts & tasks.

Validated by fetching a collection via Python/Typescript which had a non-default prompt.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
