### PR TITLE
[ENH]: (Rust client): add EF config 

### DIFF
--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -578,10 +578,7 @@ impl ChromaHttpClient {
             )
             .await?;
 
-        Ok(ChromaCollection {
-            client: self.clone(),
-            collection: Arc::new(collection),
-        })
+        Ok(ChromaCollection::new(self.clone(), collection))
     }
 
     /// Removes a collection and all its records from the database.
@@ -685,10 +682,7 @@ impl ChromaHttpClient {
 
         Ok(collections
             .into_iter()
-            .map(|collection| ChromaCollection {
-                client: self.clone(),
-                collection: Arc::new(collection),
-            })
+            .map(|collection| ChromaCollection::new(self.clone(), collection))
             .collect())
     }
 
@@ -720,10 +714,7 @@ impl ChromaHttpClient {
             )
             .await?;
 
-        Ok(ChromaCollection {
-            client: self.clone(),
-            collection: Arc::new(collection),
-        })
+        Ok(ChromaCollection::new(self.clone(), collection))
     }
 
     /// Executes an HTTP request with automatic retry logic and OpenTelemetry metrics.

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -72,6 +72,13 @@ impl std::fmt::Debug for ChromaCollection {
 }
 
 impl ChromaCollection {
+    pub(crate) fn new(client: ChromaHttpClient, collection: Collection) -> Self {
+        Self {
+            client,
+            collection: Arc::new(collection),
+        }
+    }
+
     /// Returns the database ID that contains this collection.
     pub fn database(&self) -> &str {
         &self.collection.database
@@ -712,10 +719,7 @@ impl ChromaCollection {
         let collection: Collection = self
             .send("fork", "fork", Method::POST, Some(request))
             .await?;
-        Ok(ChromaCollection {
-            client: self.client.clone(),
-            collection: Arc::new(collection),
-        })
+        Ok(ChromaCollection::new(self.client.clone(), collection))
     }
 
     /// Internal transport method that constructs collection-specific API paths and delegates to the client.

--- a/rust/chroma/src/embed/mod.rs
+++ b/rust/chroma/src/embed/mod.rs
@@ -4,10 +4,9 @@
 //! text strings into embeddings. Implementations are available for various
 //! embedding models, including dense embeddings (Ollama) and sparse embeddings (BM25).
 
-use std::{
-    error::Error,
-    fmt::{Debug, Display},
-};
+use std::error::Error;
+
+use chroma_types::{EmbeddingFunctionConfiguration, SparseVector};
 
 /// BM25 sparse embedding implementation.
 pub mod bm25;
@@ -27,27 +26,26 @@ pub mod ollama;
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use chroma::embed::EmbeddingFunction;
+/// ```
+/// use chroma::embed::DenseEmbeddingFunction;
 ///
-/// async fn process_documents<E: EmbeddingFunction>(embedder: E, docs: Vec<&str>) {
+/// async fn process_documents<E: DenseEmbeddingFunction>(embedder: E, docs: Vec<&str>) {
 ///     let embeddings = embedder.embed_strs(&docs).await.unwrap();
 ///     assert_eq!(embeddings.len(), docs.len());
 /// }
 /// ```
 #[async_trait::async_trait]
-pub trait EmbeddingFunction: Send + Sync + 'static {
-    /// The embedding type produced by this function.
-    ///
-    /// Can be dense vectors (`Vec<f32>`) for neural embeddings or sparse representations
-    /// for token-based models like BM25.
-    type Embedding: Debug;
-
+pub trait DenseEmbeddingFunction: Send + Sync + 'static {
     /// The error type returned when embedding fails.
     ///
     /// Must implement standard error traits to enable composition with other error types
     /// and display meaningful diagnostic information.
-    type Error: Error + Display;
+    type Error: Error;
+
+    /// The configuration type used to serialize/deserialize the embedding function.
+    type Config: serde::Serialize
+        + serde::de::DeserializeOwned
+        + TryInto<EmbeddingFunctionConfiguration>;
 
     /// Converts a batch of text strings into their embedding representations.
     ///
@@ -62,16 +60,97 @@ pub trait EmbeddingFunction: Send + Sync + 'static {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// # use chroma::embed::EmbeddingFunction;
-    /// # async fn example<E: EmbeddingFunction>(embedder: E) -> Result<(), E::Error> {
+    /// ```
+    /// # use chroma::embed::DenseEmbeddingFunction;
+    /// # async fn example<E: DenseEmbeddingFunction>(embedder: E) -> Result<(), E::Error> {
     /// let texts = vec!["Hello world", "Embedding example"];
     /// let embeddings = embedder.embed_strs(&texts).await?;
     /// assert_eq!(embeddings.len(), 2);
     /// # Ok(())
     /// # }
     /// ```
-    async fn embed_strs(&self, batches: &[&str]) -> Result<Vec<Self::Embedding>, Self::Error>;
+    async fn embed_strs(&self, batches: &[&str]) -> Result<Vec<Vec<f32>>, Self::Error>;
+
+    /// Constructs an embedding function from a configuration object. Used to hydrate embedding functions when fetching collections.
+    fn build_from_config(config: Self::Config) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+
+    /// Serializes the embedding function's configuration to a JSON object. Used to store embedding function configurations when persisting collections.
+    fn get_config(&self) -> Result<Self::Config, Self::Error>;
+
+    /// Returns the unique name of the embedding function implementation.
+    fn get_name() -> &'static str
+    where
+        Self: Sized;
+}
+
+/// Transforms text strings into embeddings.
+///
+/// Embedding functions are the bridge between human-readable text and the vector space
+/// where similarity search operates. This trait supports both dense embeddings (e.g., from
+/// neural models) and sparse embeddings (e.g., BM25 token weights). Implementations must
+/// be thread-safe and support batch processing for efficiency.
+///
+/// # Examples
+///
+/// ```
+/// use chroma::embed::SparseEmbeddingFunction;
+///
+/// async fn process_documents<E: SparseEmbeddingFunction>(embedder: E, docs: Vec<&str>) {
+///     let embeddings = embedder.embed_strs(&docs).await.unwrap();
+///     assert_eq!(embeddings.len(), docs.len());
+/// }
+/// ```
+#[async_trait::async_trait]
+pub trait SparseEmbeddingFunction: Send + Sync + 'static {
+    /// The error type returned when embedding fails.
+    ///
+    /// Must implement standard error traits to enable composition with other error types
+    /// and display meaningful diagnostic information.
+    type Error: Error;
+
+    /// The configuration type used to serialize/deserialize the embedding function.
+    type Config: serde::Serialize
+        + serde::de::DeserializeOwned
+        + TryInto<EmbeddingFunctionConfiguration>;
+
+    /// Converts a batch of text strings into their embedding representations.
+    ///
+    /// Processes all inputs in a single request to the underlying model, returning embeddings
+    /// in the same order as the input strings. The type and dimensionality of returned embeddings
+    /// depend on the specific model implementation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the embedding model is unreachable, the input exceeds model limits,
+    /// or the model returns malformed data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chroma::embed::SparseEmbeddingFunction;
+    /// # async fn example<E: SparseEmbeddingFunction>(embedder: E) -> Result<(), E::Error> {
+    /// let texts = vec!["Hello world", "Embedding example"];
+    /// let embeddings = embedder.embed_strs(&texts).await?;
+    /// assert_eq!(embeddings.len(), 2);
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn embed_strs(&self, batches: &[&str]) -> Result<Vec<SparseVector>, Self::Error>;
+
+    /// Constructs an embedding function from a configuration object. Used to hydrate embedding functions when fetching collections.
+    fn build_from_config(config: Self::Config) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+
+    /// Serializes the embedding function's configuration to a JSON object. Used to store embedding function configurations when persisting collections.
+    fn get_config(&self) -> Result<Self::Config, Self::Error>;
+
+    /// Returns the unique name of the embedding function implementation.
+    fn get_name() -> &'static str
+    where
+        Self: Sized;
 }
 
 /// Generic tokenizer interface for text processing.

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -1745,7 +1745,7 @@ impl ServiceBasedFrontend {
                         for knn_query in knn_queries {
                             schema
                                 .is_knn_key_indexing_enabled(
-                                    &knn_query.key.to_string(),
+                                    knn_query.key.as_ref(),
                                     &knn_query.query,
                                 )
                                 .map_err(|err| {

--- a/rust/types/src/execution/operator.rs
+++ b/rust/types/src/execution/operator.rs
@@ -1826,6 +1826,18 @@ impl From<String> for Key {
     }
 }
 
+impl AsRef<str> for Key {
+    fn as_ref(&self) -> &str {
+        match self {
+            Key::Document => "#document",
+            Key::Embedding => "#embedding",
+            Key::Metadata => "#metadata",
+            Key::Score => "#score",
+            Key::MetadataField(field) => field.as_str(),
+        }
+    }
+}
+
 impl Key {
     /// Creates a Key for a custom metadata field.
     ///
@@ -2217,15 +2229,15 @@ impl TryFrom<Select> for chroma_proto::SelectOperator {
 /// fn process_results(records: Vec<SearchRecord>) {
 ///     for record in records {
 ///         println!("ID: {}", record.id);
-///         
+///
 ///         if let Some(score) = record.score {
 ///             println!("  Score: {:.3}", score);
 ///         }
-///         
+///
 ///         if let Some(doc) = record.document {
 ///             println!("  Document: {}", doc);
 ///         }
-///         
+///
 ///         if let Some(meta) = record.metadata {
 ///             println!("  Metadata: {:?}", meta);
 ///         }
@@ -2298,7 +2310,7 @@ impl TryFrom<SearchRecord> for chroma_proto::SearchRecord {
 ///
 /// fn process_search_result(result: SearchPayloadResult) {
 ///     println!("Found {} results", result.records.len());
-///     
+///
 ///     for (i, record) in result.records.iter().enumerate() {
 ///         println!("{}. {} (score: {:?})", i + 1, record.id, record.score);
 ///     }
@@ -2357,7 +2369,7 @@ impl TryFrom<SearchPayloadResult> for chroma_proto::SearchPayloadResult {
 /// fn process_single_search(result: SearchResult) {
 ///     // Single search, so results[0] contains our records
 ///     let records = &result.results[0].records;
-///     
+///
 ///     for record in records {
 ///         println!("{}: score={:?}", record.id, record.score);
 ///     }


### PR DESCRIPTION
## Description of changes

Main changes:

- There are now separate sparse and dense EF traits.
- EF traits have a config GAT which must implement `TryInto<EmbeddingFunctionConfiguration>`.

This **does not** introduce any machinery to automatically persist/hydrate EFs--currently, users must call `get_config()` / `build_from_config()` themselves (or `.try_into()` on the config). We can add that as a follow-up later but it's pretty non-trivial to build:
- must implement a registry system to map EF names to implementations, allowing third-party crates to register custom EFs
- need to remove GATs or type erase EFs so we can store refs to generic EFs during hydration
- signatures of methods like `query()` will have to change which is a significant breaking change

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
