### PR TITLE
[BUG]: Don't log offset since records can be empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-cli"
-version = "1.2.1"
+version = "1.2.0"
 dependencies = [
  "arboard",
  "axum 0.8.1",


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - There was a tracing in RLS where records[0] was printed unconditionally. However, records can be empty so records[0] goes out of bound causing a panic during pull logs. Fixed by not tracing it
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
None

## Documentation Changes
None
