### PR TITLE
[TST] Fix cross version persist test by updating __version__ in python

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -105,7 +105,7 @@ logger = logging.getLogger(__name__)
 
 __settings = Settings()
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 
 # Workaround to deal with Colab's old sqlite3 version


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Update version in chromadb/__init__.py to 1.3.3 to fix cross version persist tests
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
