### PR TITLE
[BUG] Use schema ef when trying to resolve js overallEf, remove exception on default ef

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -304,6 +304,7 @@ export class ChromaClient {
       configuration,
       embeddingFunction,
       metadata,
+      schema,
     });
 
     const { data } = await Api.createCollection({

--- a/clients/new-js/packages/chromadb/src/chroma-fetch.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-fetch.ts
@@ -12,9 +12,9 @@ import {
 const offlineError = (error: any): boolean => {
   return Boolean(
     (error?.name === "TypeError" || error?.name === "FetchError") &&
-      (error.message?.includes("fetch failed") ||
-        error.message?.includes("Failed to fetch") ||
-        error.message?.includes("ENOTFOUND")),
+    (error.message?.includes("fetch failed") ||
+      error.message?.includes("Failed to fetch") ||
+      error.message?.includes("ENOTFOUND")),
   );
 };
 
@@ -41,10 +41,9 @@ export const chromaFetch: typeof fetch = async (input, init) => {
       try {
         const responseBody = await response.json();
         status = responseBody.message || status;
-      } catch {}
+      } catch { }
       throw new ChromaClientError(
-        `Bad request to ${
-          (input as Request).url || "Chroma"
+        `Bad request to ${(input as Request).url || "Chroma"
         } with status: ${status}`,
       );
     case 401:

--- a/clients/new-js/packages/chromadb/src/collection-configuration.ts
+++ b/clients/new-js/packages/chromadb/src/collection-configuration.ts
@@ -13,6 +13,7 @@ import {
   serializeEmbeddingFunction,
 } from "./embedding-function";
 import { CollectionMetadata } from "./types";
+import { Schema } from "./schema";
 
 export interface CollectionConfiguration {
   embeddingFunction?: EmbeddingFunctionConfiguration | null;
@@ -57,11 +58,17 @@ export const processCreateCollectionConfig = async ({
   configuration,
   embeddingFunction,
   metadata,
+  schema,
 }: {
   configuration?: CreateCollectionConfiguration;
   embeddingFunction?: EmbeddingFunction | null;
   metadata?: CollectionMetadata;
+  schema?: Schema;
 }) => {
+  let schemaEmbeddingFunction: EmbeddingFunction | null | undefined = undefined;
+  if (schema) {
+    schemaEmbeddingFunction = schema.resolveEmbeddingFunction();
+  }
   if (configuration?.hnsw && configuration?.spann) {
     throw new ChromaValueError(
       "Cannot specify both HNSW and SPANN configurations",
@@ -73,7 +80,7 @@ export const processCreateCollectionConfig = async ({
     configEmbeddingFunction: configuration?.embeddingFunction,
   });
 
-  if (!embeddingFunctionConfiguration && embeddingFunction !== null) {
+  if (!embeddingFunctionConfiguration && embeddingFunction !== null && schemaEmbeddingFunction === undefined) {
     embeddingFunctionConfiguration = await getDefaultEFConfig();
   }
 
@@ -115,7 +122,7 @@ export const processCreateCollectionConfig = async ({
       ) {
         console.warn(
           `Space '${configuration.hnsw.space}' is not supported by embedding function '${overallEf.name || "unknown"}'. ` +
-            `Supported spaces: ${supportedSpaces.join(", ")}`,
+          `Supported spaces: ${supportedSpaces.join(", ")}`,
         );
       }
 
@@ -125,7 +132,7 @@ export const processCreateCollectionConfig = async ({
       ) {
         console.warn(
           `Space '${configuration.spann.space}' is not supported by embedding function '${overallEf.name || "unknown"}'. ` +
-            `Supported spaces: ${supportedSpaces.join(", ")}`,
+          `Supported spaces: ${supportedSpaces.join(", ")}`,
         );
       }
 
@@ -140,7 +147,7 @@ export const processCreateCollectionConfig = async ({
       ) {
         console.warn(
           `Space '${metadata["hnsw:space"]}' from metadata is not supported by embedding function '${overallEf.name || "unknown"}'. ` +
-            `Supported spaces: ${supportedSpaces.join(", ")}`,
+          `Supported spaces: ${supportedSpaces.join(", ")}`,
         );
       }
     }

--- a/clients/new-js/packages/chromadb/src/embedding-function.ts
+++ b/clients/new-js/packages/chromadb/src/embedding-function.ts
@@ -92,7 +92,7 @@ export interface SparseEmbeddingFunction {
  */
 export interface EmbeddingFunctionClass {
   /** Constructor for creating new instances */
-  new (...args: any[]): EmbeddingFunction;
+  new(...args: any[]): EmbeddingFunction;
   /** Name identifier for the embedding function */
   name: string;
   /** Static method to build instance from configuration */
@@ -105,7 +105,7 @@ export interface EmbeddingFunctionClass {
  */
 export interface SparseEmbeddingFunctionClass {
   /** Constructor for creating new instances */
-  new (...args: any[]): SparseEmbeddingFunction;
+  new(...args: any[]): SparseEmbeddingFunction;
   /** Name identifier for the embedding function */
   name: string;
   /** Static method to build instance from configuration */
@@ -408,8 +408,7 @@ export const getDefaultEFConfig =
         registerEmbeddingFunction("default", DefaultEmbeddingFunction);
       }
     } catch (e) {
-      console.error(e);
-      throw new Error(
+      console.warn(
         "Cannot instantiate a collection with the DefaultEmbeddingFunction. Please install @chroma-core/default-embed, or provide a different embedding function",
       );
     }

--- a/clients/new-js/packages/chromadb/test/schema.test.ts
+++ b/clients/new-js/packages/chromadb/test/schema.test.ts
@@ -24,7 +24,7 @@ import type { ChromaClient } from "../src/chroma-client";
 class MockEmbedding implements EmbeddingFunction {
   public readonly name = "mock_embedding";
 
-  constructor(private readonly modelName = "mock_model") {}
+  constructor(private readonly modelName = "mock_model") { }
 
   async generate(texts: string[]): Promise<number[][]> {
     return texts.map(() => [1, 2, 3]);
@@ -50,7 +50,7 @@ class MockEmbedding implements EmbeddingFunction {
 class MockSparseEmbedding implements SparseEmbeddingFunction {
   public readonly name = "mock_sparse";
 
-  constructor(private readonly identifier = "mock_sparse") {}
+  constructor(private readonly identifier = "mock_sparse") { }
 
   async generate(texts: string[]) {
     return texts.map(() => ({ indices: [0, 1], values: [1, 1] }));
@@ -68,7 +68,7 @@ class MockSparseEmbedding implements SparseEmbeddingFunction {
 class DeterministicSparseEmbedding implements SparseEmbeddingFunction {
   public readonly name = "deterministic_sparse";
 
-  constructor(private readonly label = "det") {}
+  constructor(private readonly label = "det") { }
 
   async generate(texts: string[]) {
     return texts.map((text, index) => {
@@ -196,7 +196,7 @@ describe("Schema", () => {
     );
     expect(
       schema.defaults.sparseVector?.sparseVectorIndex?.config.embeddingFunction,
-    ).toBeNull();
+    ).toBeUndefined();
   });
 
   it("delete string inverted index on key", () => {
@@ -569,14 +569,14 @@ describe("Schema", () => {
     );
     expect(
       deserialized?.defaults.floatList?.vectorIndex?.config.embeddingFunction,
-    ).toBeNull();
+    ).toBeUndefined();
     expect(
       deserialized?.keys[EMBEDDING_KEY].floatList?.vectorIndex?.config.space,
     ).toBe("cosine");
     expect(
       deserialized?.keys[EMBEDDING_KEY].floatList?.vectorIndex?.config
         .embeddingFunction,
-    ).toBeNull();
+    ).toBeUndefined();
   });
 
   it("serialize and deserialize with custom embedding function", async () => {
@@ -1094,7 +1094,7 @@ describe("Schema", () => {
     );
     expect(
       deserialized?.defaults.floatList?.vectorIndex?.config.embeddingFunction,
-    ).toBeNull();
+    ).toBeUndefined();
   });
 
   it("space inference remains stable across roundtrips", async () => {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Fixes https://github.com/chroma-core/chroma/issues/5829
  - there was an issue in the js client where if the ef is not provided at the highest level or config, and if default-embed isn't installed an exception was thrown before sending the create/getOrCreateCall. 2 issues there: 1. there shouldnt be an exception thrown if default embed isnt installed, it should instead warn. That way the user is aware they must install prior to adding/querying 2. processing collection config should also handle the schema EF if available to determine whether to fallback to default config
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
