### PR TITLE
Fix Dockerfile to install chromadb from local wheel instead of PyPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ WORKDIR /chroma
 RUN make -C idl proto_python
 RUN python3 -m maturin build
 RUN pip uninstall chromadb -y
-RUN pip install --prefix="/install" --find-links target/wheels/ --upgrade  chromadb
+RUN pip install --prefix="/install" target/wheels/chromadb*.whl
 
 FROM python:3.11-slim-bookworm AS final
 


### PR DESCRIPTION
## Summary

Fixes the Dockerfile to ensure chromadb is installed from the locally-built wheel instead of potentially downloading from PyPI.

## Problem

The current Dockerfile uses `--find-links target/wheels/` which only provides a preference hint to pip. Despite this flag, pip can still download chromadb from the public PyPI repository instead of using the locally-built wheel.

**Current problematic line (Line 52):**
```dockerfile
RUN pip install --prefix="/install" --find-links target/wheels/ --upgrade chromadb
```

## Solution

Changed to directly specify the local wheel file path:
```dockerfile
RUN pip install --prefix="/install" target/wheels/chromadb*.whl
```

This explicitly installs from the locally-built wheel files, eliminating ambiguity and ensuring the Docker build uses the local code.

## Impact

- ✅ Ensures Docker builds use locally-built chromadb wheel
- ✅ Prevents unintended downloads from PyPI
- ✅ Makes build process more predictable and reliable
- ✅ Aligns with the intended build workflow

## Testing

The fix follows standard Docker/pip best practices for installing from local wheel files. The wildcard pattern `chromadb*.whl` will match the wheel built by `maturin build` in the previous step.

Fixes #5835