### PR TITLE
[BUG] Sparse index does not sort offset id

### DIFF
--- a/rust/types/src/execution/operator.rs
+++ b/rust/types/src/execution/operator.rs
@@ -412,7 +412,9 @@ impl Eq for RecordMeasure {}
 
 impl Ord for RecordMeasure {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.measure.total_cmp(&other.measure)
+        self.measure
+            .total_cmp(&other.measure)
+            .then_with(|| self.offset_id.cmp(&other.offset_id))
     }
 }
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - `RecordMeasure` should sort by offset id as well to break ties deterministically
  - `SparseIndexKnn` output should sort by offset id to maintain overall order
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
