### PR TITLE
[DOC] Correct collection metadata sentence documentation

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/collections/manage-collections.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/collections/manage-collections.md
@@ -175,7 +175,7 @@ const collection = await client.createCollection({
 
 ### Collection Metadata
 
-When creating collections, you can pass the optional `metadata` argument to add a mapping of metadata key-value pairs to your collections. This can be useful for adding general about the collection like creation time, description of the data stored in the collection, and more.
+When creating collections, you can pass the optional `metadata` argument to add a mapping of metadata key-value pairs to your collections. This can be useful for adding general information about the collection like creation time, description of the data stored in the collection, and more.
 
 {% TabbedCodeBlock %}
 


### PR DESCRIPTION
## Description of changes

Add a missing word to a sentence in the documentation.

`This can be useful for adding general about the collection like creation time, ...`
to
`This can be useful for adding general information about the collection like creation time, ...`

## Test plan

N/A

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

Documentation changes included.
