### PR TITLE
[ENH] Add transformers.js embedding function, keep compat with python

### DIFF
--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/README.md
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/README.md
@@ -1,0 +1,86 @@
+# Sentence Transformers Embedding Function for Chroma
+
+This package provides a Sentence Transformers embedding provider for Chroma using transformers.js (`@huggingface/transformers`). It allows you to run Sentence Transformer models directly in Node.js without requiring a separate server.
+
+## Installation
+
+```bash
+npm install @chroma-core/sentence-transformer
+```
+
+## Usage
+
+```typescript
+import { ChromaClient } from 'chromadb';
+import { SentenceTransformersEmbeddingFunction } from '@chroma-core/sentence-transformer';
+
+// Initialize the embedder with the default model (all-MiniLM-L6-v2)
+const embedder = new SentenceTransformersEmbeddingFunction();
+
+// Or initialize with a custom model
+const customEmbedder = new SentenceTransformersEmbeddingFunction({
+  modelName: 'Xenova/all-mpnet-base-v2', // Higher quality model
+  device: 'cpu', // 'cpu' or 'gpu' (default: 'cpu')
+  normalizeEmbeddings: false, // Whether to normalize embeddings (default: false)
+  kwargs: { quantized: true }, // Optional: additional arguments like quantized
+});
+
+// Create a new ChromaClient
+const client = new ChromaClient({
+  path: 'http://localhost:8000',
+});
+
+// Create a collection with the embedder
+const collection = await client.createCollection({
+  name: 'my-collection',
+  embeddingFunction: embedder,
+});
+
+// Add documents
+await collection.add({
+  ids: ["1", "2", "3"],
+  documents: ["Document 1", "Document 2", "Document 3"],
+});
+
+// Query documents
+const results = await collection.query({
+  queryTexts: ["Sample query"],
+  nResults: 2,
+});
+```
+
+## Configuration Options
+
+- **modelName**: The Sentence Transformer model to use (default: `"all-MiniLM-L6-v2"`)
+  - **Short names** (recommended): Use short names like `"all-MiniLM-L6-v2"` for cross-client compatibility with Python. These are automatically resolved to `Xenova/all-MiniLM-L6-v2` for transformers.js.
+  - **Full names**: You can also use full model identifiers like `Xenova/all-MiniLM-L6-v2` or `sentence-transformers/all-MiniLM-L6-v2` if you need to specify a particular variant.
+  - Popular models: `all-MiniLM-L6-v2` (default), `all-mpnet-base-v2`, `bge-small-en-v1.5`
+- **device**: Device to run the model on - `'cpu'` or `'gpu'` (default: `'cpu'`)
+- **normalizeEmbeddings**: Whether to normalize returned vectors (default: `false`)
+- **kwargs**: Additional arguments to pass to the model (e.g., `{ quantized: true }`)
+
+## Supported Models
+
+You can use any Sentence Transformer model that is compatible with transformers.js. Popular models include:
+
+- `Xenova/all-MiniLM-L6-v2` - Fast, lightweight model (384 dimensions)
+- `Xenova/all-mpnet-base-v2` - Higher quality model (768 dimensions)
+- `sentence-transformers/all-MiniLM-L6-v2` - Alternative model identifier
+- `sentence-transformers/all-mpnet-base-v2` - Alternative model identifier
+
+Check the [transformers.js documentation](https://huggingface.co/docs/transformers.js) for more available models.
+
+## Features
+
+- **Local Execution**: Run models directly in Node.js without external API calls
+- **Multiple Models**: Support for various Sentence Transformer models
+- **GPU Support**: Optional GPU acceleration when available
+- **No API Keys**: No external API keys required
+- **Configurable Normalization**: Control whether embeddings are normalized
+
+## Notes
+
+- Models are downloaded and cached on first use
+- You can pass `quantized: true` in `kwargs` for faster loading and reduced memory usage
+- GPU support requires appropriate hardware and drivers
+- Model loading may take some time on first use

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/jest.config.ts
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/jest.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from "jest";
+
+const config: Config = {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    testMatch: ["**/*.test.ts"],
+    transform: {
+        "^.+\\.tsx?$": [
+            "ts-jest",
+            {
+                useESM: true,
+            },
+        ],
+    },
+    extensionsToTreatAsEsm: [".ts"],
+    moduleNameMapper: {
+        "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    setupFiles: ["./jest.setup.ts"],
+    testTimeout: 60000,
+};
+
+export default config;

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/jest.setup.ts
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/jest.setup.ts
@@ -1,0 +1,3 @@
+import * as dotenv from "dotenv";
+
+dotenv.config({ path: "../../../.env" });

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/package.json
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/package.json
@@ -1,0 +1,55 @@
+{
+    "name": "@chroma-core/sentence-transformer",
+    "version": "0.1.0",
+    "private": false,
+    "description": "Sentence Transformer embedding provider for Chroma using transformers.js",
+    "main": "dist/cjs/sentence-transformer.cjs",
+    "types": "dist/sentence-transformer.d.ts",
+    "module": "dist/sentence-transformer.legacy-esm.js",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/sentence-transformer.d.ts",
+                "default": "./dist/sentence-transformer.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/sentence-transformer.d.cts",
+                "default": "./dist/cjs/sentence-transformer.cjs"
+            }
+        }
+    },
+    "files": [
+        "src",
+        "dist"
+    ],
+    "scripts": {
+        "clean": "rimraf dist",
+        "prebuild": "rimraf dist",
+        "build": "tsup",
+        "watch": "tsup --watch",
+        "test": "jest"
+    },
+    "devDependencies": {
+        "@jest/globals": "^29.7.0",
+        "dotenv": "^16.3.1",
+        "jest": "^29.7.0",
+        "rimraf": "^5.0.0",
+        "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
+        "tsup": "^8.3.5"
+    },
+    "peerDependencies": {
+        "chromadb": "workspace:^"
+    },
+    "dependencies": {
+        "@chroma-core/ai-embeddings-common": "workspace:^",
+        "@huggingface/transformers": "^3.7.6"
+    },
+    "engines": {
+        "node": ">=20"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/src/index.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { SentenceTransformersEmbeddingFunction } from "./index";
+
+// Store reference to mock dispose for test access
+let mockDispose: ReturnType<typeof jest.fn>;
+
+// Mock the transformers pipeline
+jest.mock("@huggingface/transformers", () => {
+  // Create a mock embeddings result
+  const mockEmbeddings = [
+    Array(384)
+      .fill(0)
+      .map((_, i) => i / 1000),
+    Array(384)
+      .fill(0)
+      .map((_, i) => (i + 100) / 1000),
+  ];
+
+  // Create a mock dispose function
+  mockDispose = jest.fn().mockImplementation(async () => { });
+
+  // Create the pipeline mock that returns a function
+  const pipelineFunction = jest.fn().mockImplementation(() => {
+    // When the pipeline result is called with text, it returns this object with tolist
+    const pipelineInstance = function (texts: string[], options: any) {
+      return {
+        tolist: () => mockEmbeddings,
+      };
+    };
+    // Add dispose method to the pipeline instance
+    pipelineInstance.dispose = mockDispose;
+    return pipelineInstance;
+  });
+
+  return {
+    pipeline: pipelineFunction,
+  };
+});
+
+describe("SentenceTransformersEmbeddingFunction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const MODEL = "Xenova/all-MiniLM-L6-v2";
+
+  const defaultParametersTest = "should initialize with default parameters";
+  it(defaultParametersTest, () => {
+    const embedder = new SentenceTransformersEmbeddingFunction();
+    expect(embedder.name).toBe("sentence_transformer");
+
+    const config = embedder.getConfig();
+    expect(config.model_name).toBe("all-MiniLM-L6-v2");
+    expect(config.device).toBe("cpu");
+    expect(config.normalize_embeddings).toBe(false);
+    expect(config.kwargs).toEqual({});
+  });
+
+  it("should initialize with custom parameters", () => {
+    const embedder = new SentenceTransformersEmbeddingFunction({
+      modelName: "custom-model",
+      device: "cpu",
+      normalizeEmbeddings: true,
+      kwargs: { test: "value" },
+    });
+
+    const config = embedder.getConfig();
+    expect(config.model_name).toBe("custom-model");
+    expect(config.device).toBe("cpu");
+    expect(config.normalize_embeddings).toBe(true);
+    expect(config.kwargs).toEqual({ test: "value" });
+  });
+
+  it("should throw error for invalid kwargs", () => {
+    expect(() => {
+      new SentenceTransformersEmbeddingFunction({
+        modelName: MODEL,
+        kwargs: { invalid: () => { } },
+      });
+    }).toThrow("Keyword argument 'invalid' has a value of type 'function', which is not supported. Only JSON-serializable values are allowed.");
+  });
+
+  const buildFromConfigTest = "should build from config";
+  it(buildFromConfigTest, () => {
+    const config = {
+      model_name: "config-model",
+      device: "cpu",
+      normalize_embeddings: true,
+      kwargs: { test: "value" },
+    };
+
+    const embedder = SentenceTransformersEmbeddingFunction.buildFromConfig(
+      config,
+    );
+
+    expect(embedder.getConfig()).toEqual(config);
+  });
+
+  it("should throw error when required fields are missing in buildFromConfig", () => {
+    expect(() => {
+      SentenceTransformersEmbeddingFunction.buildFromConfig({
+        model_name: "test",
+      } as any);
+    }).toThrow("model_name, device, and normalize_embeddings are required");
+  });
+
+  const generateEmbeddingsTest = "should generate embeddings";
+  it(generateEmbeddingsTest, async () => {
+    const embedder = new SentenceTransformersEmbeddingFunction({
+      modelName: MODEL,
+    });
+    const texts = ["Hello world", "Test text"];
+    const embeddings = await embedder.generate(texts);
+
+    expect(embeddings.length).toBe(texts.length);
+
+    embeddings.forEach((embedding) => {
+      expect(embedding.length).toBeGreaterThan(0);
+      expect(Array.isArray(embedding)).toBe(true);
+    });
+
+    expect(embeddings[0]).not.toEqual(embeddings[1]);
+  }, 60000); // Increase timeout for model loading
+
+  it("should allow config update", () => {
+    const embedder = new SentenceTransformersEmbeddingFunction({
+      modelName: MODEL,
+    });
+
+    // validateConfigUpdate should not throw (allows updates)
+    expect(() => {
+      embedder.validateConfigUpdate({
+        model_name: "different-model",
+        device: "gpu",
+        normalize_embeddings: true,
+      });
+    }).not.toThrow();
+  });
+
+  it("should dispose resources correctly", async () => {
+    const embedder = new SentenceTransformersEmbeddingFunction({
+      modelName: MODEL,
+    });
+
+    // Generate embeddings to initialize the pipeline
+    await embedder.generate(["test"]);
+
+    // Verify dispose hasn't been called yet
+    expect(mockDispose).not.toHaveBeenCalled();
+
+    // Dispose should clean up resources
+    await embedder.dispose();
+
+    // Verify dispose was called on the pipeline
+    expect(mockDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should dispose resources even when called during pipeline initialization", async () => {
+    const embedder = new SentenceTransformersEmbeddingFunction({
+      modelName: MODEL,
+    });
+
+    // Start generating embeddings (this starts pipeline initialization)
+    const generatePromise = embedder.generate(["test"]);
+
+    // Immediately call dispose while pipeline is still initializing
+    // This tests the race condition fix
+    await embedder.dispose();
+
+    // Wait for generate to complete (it should handle the disposed state)
+    await generatePromise;
+
+    // Verify dispose was called on the pipeline
+    expect(mockDispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/src/index.ts
@@ -1,0 +1,181 @@
+import {
+    ChromaValueError,
+    EmbeddingFunction,
+    EmbeddingFunctionSpace,
+    registerEmbeddingFunction,
+} from "chromadb";
+import {
+    validateConfigSchema,
+} from "@chroma-core/ai-embeddings-common";
+import { pipeline } from "@huggingface/transformers";
+
+const NAME = "sentence_transformer";
+
+export interface SentenceTransformersConfig {
+    model_name: string;
+    device: string;
+    normalize_embeddings: boolean;
+    kwargs?: Record<string, any>;
+}
+
+export interface SentenceTransformersArgs {
+    modelName?: string;
+    device?: string;
+    normalizeEmbeddings?: boolean;
+    kwargs?: Record<string, any>;
+}
+
+export class SentenceTransformersEmbeddingFunction
+    implements EmbeddingFunction {
+    public readonly name = NAME;
+    private readonly modelName: string;
+    private readonly device: string;
+    private readonly normalizeEmbeddings: boolean;
+    private readonly kwargs: Record<string, any>;
+    private pipelinePromise: Promise<any> | null = null;
+    private pipeline: any = null;
+
+    constructor(args: SentenceTransformersArgs = {}) {
+        const {
+            modelName = "all-MiniLM-L6-v2",
+            device = "cpu",
+            normalizeEmbeddings = false,
+            kwargs = {},
+        } = args;
+
+        // Validate kwargs are JSON-serializable (no functions or symbols)
+        for (const [key, value] of Object.entries(kwargs)) {
+            if (typeof value === "function" || typeof value === "symbol") {
+                throw new ChromaValueError(
+                    `Keyword argument '${key}' has a value of type '${typeof value}', which is not supported. Only JSON-serializable values are allowed.`
+                );
+            }
+        }
+
+        this.modelName = modelName;
+        this.device = device;
+        this.normalizeEmbeddings = normalizeEmbeddings;
+        this.kwargs = kwargs;
+    }
+
+    private async getPipeline(): Promise<any> {
+        if (this.pipeline) {
+            return this.pipeline;
+        }
+
+        if (!this.pipelinePromise) {
+            // Resolve model name: if it doesn't contain a '/', prefix with 'Xenova/'
+            // to form a full model identifier for transformers.js
+            // This allows short names like "all-MiniLM-L6-v2" to work while maintaining
+            // compatibility with Python client which uses short names
+            let resolvedModelName = this.modelName;
+            if (!resolvedModelName.includes("/")) {
+                resolvedModelName = `Xenova/${resolvedModelName}`;
+            }
+
+            this.pipelinePromise = pipeline(
+                "feature-extraction",
+                resolvedModelName,
+                {
+                    device: this.device as any,
+                    ...this.kwargs,
+                } as any
+            ).catch((error) => {
+                // Reset pipelinePromise on error to allow retry on next call
+                this.pipelinePromise = null;
+                throw error;
+            });
+        }
+
+        this.pipeline = await this.pipelinePromise;
+        return this.pipeline;
+    }
+
+    public async generate(texts: string[]): Promise<number[][]> {
+        if (!texts || texts.length === 0) {
+            return [];
+        }
+
+        const pipe = await this.getPipeline();
+
+        // Process all texts in batch
+        const output = await pipe(texts, {
+            pooling: "mean",
+            normalize: this.normalizeEmbeddings,
+        });
+
+        // Convert tensor output to JavaScript array
+        return output.tolist();
+    }
+
+    public async dispose(): Promise<void> {
+        // To avoid race conditions, we capture the promise and then nullify the
+        // instance properties to prevent new operations from starting.
+        const promiseToDispose = this.pipelinePromise;
+        this.pipeline = null;
+        this.pipelinePromise = null;
+
+        if (!promiseToDispose) return;
+
+        try {
+            // If pipeline is already initialized, this will resolve immediately.
+            // Otherwise, it will wait for initialization to complete.
+            const pipeline = await promiseToDispose;
+            if (pipeline && typeof pipeline.dispose === "function") {
+                await pipeline.dispose();
+            }
+        } catch {
+            // If the pipeline promise fails, there's nothing to dispose.
+            // This error will be handled by callers of generate(), so we can ignore it here.
+        }
+    }
+
+    public defaultSpace(): EmbeddingFunctionSpace {
+        return "cosine";
+    }
+
+    public supportedSpaces(): EmbeddingFunctionSpace[] {
+        return ["cosine", "l2", "ip"];
+    }
+
+    public static buildFromConfig(
+        config: SentenceTransformersConfig,
+    ): SentenceTransformersEmbeddingFunction {
+        const { model_name, device, normalize_embeddings, kwargs } = config;
+
+        if (model_name === undefined || device === undefined || normalize_embeddings === undefined) {
+            throw new ChromaValueError("model_name, device, and normalize_embeddings are required");
+        }
+
+        return new SentenceTransformersEmbeddingFunction({
+            modelName: model_name,
+            device,
+            normalizeEmbeddings: normalize_embeddings,
+            kwargs: kwargs || {},
+        });
+    }
+
+    public getConfig(): SentenceTransformersConfig {
+        return {
+            model_name: this.modelName,
+            device: this.device,
+            normalize_embeddings: this.normalizeEmbeddings,
+            kwargs: this.kwargs,
+        };
+    }
+
+    public validateConfigUpdate(newConfig: Record<string, any>): void {
+        // Model name is also used as the identifier for model path if stored locally.
+        // Users should be able to change the path if needed, so we should not validate that.
+        // e.g. moving file path from /v1/my-model.bin to /v2/my-model.bin
+        return;
+    }
+
+    public static validateConfig(config: SentenceTransformersConfig): void {
+        validateConfigSchema(config, "sentence-transformer");
+    }
+}
+
+// Register with both the Python name (sentence_transformer) and the mapped JS name (sentence-transformer)
+registerEmbeddingFunction(NAME, SentenceTransformersEmbeddingFunction);
+registerEmbeddingFunction("sentence-transformer", SentenceTransformersEmbeddingFunction);

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/tsconfig.json
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "baseUrl": "./src",
+        "stripInternal": true,
+        "composite": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist",
+        "test",
+        "**/*.test.ts"
+    ],
+    "references": [
+        {
+            "path": "../common"
+        },
+        {
+            "path": "../../chromadb"
+        }
+    ]
+}

--- a/clients/new-js/packages/ai-embeddings/sentence-transformer/tsup.config.ts
+++ b/clients/new-js/packages/ai-embeddings/sentence-transformer/tsup.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, Options } from "tsup";
+import * as fs from "fs";
+
+export default defineConfig((options: Options) => {
+    const commonOptions: Partial<Options> = {
+        entry: {
+            "sentence-transformer": "src/index.ts",
+        },
+        sourcemap: true,
+        dts: {
+            compilerOptions: {
+                composite: false,
+                declaration: true,
+                emitDeclarationOnly: false,
+            },
+        },
+        ...options,
+    };
+
+    return [
+        {
+            ...commonOptions,
+            format: ["esm"],
+            outExtension: () => ({ js: ".mjs" }),
+            clean: true,
+            async onSuccess() {
+                // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+                fs.copyFileSync(
+                    "dist/sentence-transformer.mjs",
+                    "dist/sentence-transformer.legacy-esm.js",
+                );
+            },
+        },
+        {
+            ...commonOptions,
+            format: "cjs",
+            outDir: "./dist/cjs/",
+            outExtension: () => ({ js: ".cjs" }),
+        },
+    ];
+});

--- a/clients/new-js/packages/chromadb/src/embedding-function.ts
+++ b/clients/new-js/packages/chromadb/src/embedding-function.ts
@@ -93,7 +93,7 @@ export interface SparseEmbeddingFunction {
  */
 export interface EmbeddingFunctionClass {
   /** Constructor for creating new instances */
-  new (...args: any[]): EmbeddingFunction;
+  new(...args: any[]): EmbeddingFunction;
   /** Name identifier for the embedding function */
   name: string;
   /** Static method to build instance from configuration */
@@ -106,7 +106,7 @@ export interface EmbeddingFunctionClass {
  */
 export interface SparseEmbeddingFunctionClass {
   /** Constructor for creating new instances */
-  new (...args: any[]): SparseEmbeddingFunction;
+  new(...args: any[]): SparseEmbeddingFunction;
   /** Name identifier for the embedding function */
   name: string;
   /** Static method to build instance from configuration */
@@ -126,6 +126,7 @@ const pythonEmbeddingFunctions: Record<string, string> = {
   onnx_mini_lm_l6_v2: "default-embed",
   default: "default-embed",
   together_ai: "together-ai",
+  sentence_transformer: "sentence-transformer",
 };
 
 const unsupportedEmbeddingFunctions: Set<string> = new Set([
@@ -137,7 +138,6 @@ const unsupportedEmbeddingFunctions: Set<string> = new Set([
   "instructor",
   "open_clip",
   "roboflow",
-  "sentence_transformer",
   "text2vec",
 ]);
 

--- a/clients/new-js/pnpm-lock.yaml
+++ b/clients/new-js/pnpm-lock.yaml
@@ -290,7 +290,7 @@ importers:
   packages/ai-embeddings/google-gemini:
     dependencies:
       '@chroma-core/ai-embeddings-common':
-        specifier: workspace:^0.1.0
+        specifier: workspace:^
         version: link:../common
       '@google/genai':
         specifier: ^0.14.1
@@ -522,6 +522,40 @@ importers:
         specifier: ^8.3.5
         version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
 
+  packages/ai-embeddings/sentence-transformer:
+    dependencies:
+      '@chroma-core/ai-embeddings-common':
+        specifier: workspace:^
+        version: link:../common
+      '@huggingface/transformers':
+        specifier: ^3.7.6
+        version: 3.7.6
+      chromadb:
+        specifier: workspace:^
+        version: link:../../chromadb
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.5.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3))
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.3.2(@babel/core@7.27.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.1))(jest@29.7.0(@types/node@20.17.46)(ts-node@10.9.2(@types/node@20.17.46)(typescript@5.8.3)))(typescript@5.8.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.17.46)(typescript@5.8.3)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.4.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+
   packages/ai-embeddings/together-ai:
     dependencies:
       '@chroma-core/ai-embeddings-common':
@@ -670,20 +704,20 @@ importers:
         version: 8.0.3
     optionalDependencies:
       chromadb-js-bindings-darwin-arm64:
-        specifier: ^1.0.8
-        version: 1.0.8
+        specifier: ^1.1.0
+        version: 1.1.0
       chromadb-js-bindings-darwin-x64:
-        specifier: ^1.0.8
-        version: 1.0.8
+        specifier: ^1.1.0
+        version: 1.1.0
       chromadb-js-bindings-linux-arm64-gnu:
-        specifier: ^1.0.8
-        version: 1.0.8
+        specifier: ^1.1.0
+        version: 1.1.0
       chromadb-js-bindings-linux-x64-gnu:
-        specifier: ^1.0.8
-        version: 1.0.8
+        specifier: ^1.1.0
+        version: 1.1.0
       chromadb-js-bindings-win32-x64-msvc:
-        specifier: ^1.0.8
-        version: 1.0.8
+        specifier: ^1.1.0
+        version: 1.1.0
 
 packages:
 
@@ -1192,8 +1226,15 @@ packages:
     resolution: {integrity: sha512-3WXbMFaPkk03LRCM0z0sylmn8ddDm4ubjU7X+Hg4M2GOuMklwoGAFXp9V2keq7vltoB/c7McE5aHUVVddAewsw==}
     engines: {node: '>=18'}
 
+  '@huggingface/jinja@0.5.1':
+    resolution: {integrity: sha512-yUZLld4lrM9iFxHCwFQ7D1HW2MWMwSbeB7WzWqFYDWK+rEb+WldkLdAJxUPOmgICMHZLzZGVcVjFh3w/YGubng==}
+    engines: {node: '>=18'}
+
   '@huggingface/transformers@3.5.1':
     resolution: {integrity: sha512-qWsPoJMBPYcrGuzRMVL//3dwcLXED9r+j+Hzw+hZpBfrMPdyq57ehNs7lew0D34Paj0DO0E0kZQjOZcIVN17hQ==}
+
+  '@huggingface/transformers@3.7.6':
+    resolution: {integrity: sha512-OYlIRY8vj8r/pNx2CdXcDHz4KqpEC+bUMKzdVW5Dx//gp4XRmK+/g8as0h3cssRQYT0vG1A6VCfZy8SV0F4RDQ==}
 
   '@img/sharp-darwin-arm64@0.34.1':
     resolution: {integrity: sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==}
@@ -2255,32 +2296,32 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  chromadb-js-bindings-darwin-arm64@1.0.8:
-    resolution: {integrity: sha512-QPKG6Q76y0kEsSueZB1s6M/bk0OUGjojG4LQIa5T2zUgHHKplWRpQCUk1ziMTYzUt2AP9MynBYvh8/BoLefZAg==}
+  chromadb-js-bindings-darwin-arm64@1.1.0:
+    resolution: {integrity: sha512-0N2MpTdip9czfeUo3rXe17gowRiIhfv1EDNt+ycVPQe3Jna9cCqOU6PZDVIj/doNNE0ZS+jRF54tOZut/5Zwqw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  chromadb-js-bindings-darwin-x64@1.0.8:
-    resolution: {integrity: sha512-yBdnL7MUbR8sm4JkLYtvHuCT3Bb12xn+c0UAefJUVhn8qvud7nLAAfOKY8b911NpfpYAOPABqm8PUXhZMAD8fg==}
+  chromadb-js-bindings-darwin-x64@1.1.0:
+    resolution: {integrity: sha512-CLyGULSb1rzJvibL6Gm9esq+PtROlxIrGFi78C7xQDeJ9pOghCyFIY+RIK1yrLdFaujXk+T7wjbyn+cJLZ/vpw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  chromadb-js-bindings-linux-arm64-gnu@1.0.8:
-    resolution: {integrity: sha512-KYPeETSAGAcGSQVur5OEe0svmEmrStwXJfNOBNPwclCnKmLs8QKlMh2Jxwq6ymWjWfZggNIy8NYpgBnMcWqOtA==}
+  chromadb-js-bindings-linux-arm64-gnu@1.1.0:
+    resolution: {integrity: sha512-gUDYrWukiQY2ETsvwlzpVUI3d9mdte2qLxYqb7aBj8RKeGfsfzNnecGwx8lkmUGIlld8eWeHVrhmeAOXVfNaGw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  chromadb-js-bindings-linux-x64-gnu@1.0.8:
-    resolution: {integrity: sha512-XPNB64rulyR/qpw/VXeKETvCWtTMOBAV2mCRdRD8XGIWEcgUaYnVnCeWep2r1G2UT6B9yJxSmDIgsOxKWzNKVA==}
+  chromadb-js-bindings-linux-x64-gnu@1.1.0:
+    resolution: {integrity: sha512-4WK1TgxElFjdXBtOkMgnnaB9PVcXEEVtRY3kAOSR8sZ/ZQ2gRbqc/rM2i8pc8h/jQG8oo5nMqhipEzu3UGqKaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  chromadb-js-bindings-win32-x64-msvc@1.0.8:
-    resolution: {integrity: sha512-8m/YYe0AQos+pEU171+wefNtOLw7YZjhhEzruqz7O34SPU48oRM9+T2CefKWBkFTBcYPQGpTOorclq0nFteCvQ==}
+  chromadb-js-bindings-win32-x64-msvc@1.1.0:
+    resolution: {integrity: sha512-yfvGagYzqUa/MSG6HoXhfa+Crznhzt0L/N6QROdPXrHxQ0kG/+4/l4rh3VvZ7zThzvpDg5ncnFesf5ryIC33ow==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5386,9 +5427,18 @@ snapshots:
 
   '@huggingface/jinja@0.4.1': {}
 
+  '@huggingface/jinja@0.5.1': {}
+
   '@huggingface/transformers@3.5.1':
     dependencies:
       '@huggingface/jinja': 0.4.1
+      onnxruntime-node: 1.21.0
+      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
+      sharp: 0.34.1
+
+  '@huggingface/transformers@3.7.6':
+    dependencies:
+      '@huggingface/jinja': 0.5.1
       onnxruntime-node: 1.21.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.1
@@ -6657,19 +6707,19 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromadb-js-bindings-darwin-arm64@1.0.8:
+  chromadb-js-bindings-darwin-arm64@1.1.0:
     optional: true
 
-  chromadb-js-bindings-darwin-x64@1.0.8:
+  chromadb-js-bindings-darwin-x64@1.1.0:
     optional: true
 
-  chromadb-js-bindings-linux-arm64-gnu@1.0.8:
+  chromadb-js-bindings-linux-arm64-gnu@1.1.0:
     optional: true
 
-  chromadb-js-bindings-linux-x64-gnu@1.0.8:
+  chromadb-js-bindings-linux-x64-gnu@1.1.0:
     optional: true
 
-  chromadb-js-bindings-win32-x64-msvc@1.0.8:
+  chromadb-js-bindings-win32-x64-msvc@1.1.0:
     optional: true
 
   ci-info@3.9.0: {}

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/sentence-transformer.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/sentence-transformer.md
@@ -7,7 +7,7 @@ name: Sentence Transformer
 
 Chroma provides a convenient wrapper around the Sentence Transformers library. This embedding function runs locally and uses pre-trained models from Hugging Face.
 
-{% Tabs %}
+{% TabbedCodeBlock %}
 
 {% Tab label="python" %}
 
@@ -35,7 +35,26 @@ For a full list of available models, visit [Hugging Face Sentence Transformers](
 
 {% /Tab %}
 
-{% /Tabs %}
+{% Tab label="typescript" %}
+
+```typescript
+// npm install @chroma-core/sentence-transformer
+
+import { SentenceTransformersEmbeddingFunction } from "@chroma-core/sentence-transformer";
+
+const sentenceTransformerEF = new SentenceTransformersEmbeddingFunction({
+  modelName: "all-MiniLM-L6-v2",
+  device: "cpu",
+  normalizeEmbeddings: false,
+});
+
+const texts = ["Hello, world!", "How are you?"];
+const embeddings = await sentenceTransformerEF.generate(texts);
+```
+
+{% /Tab %}
+
+{% /TabbedCodeBlock %}
 
 {% Banner type="tip" %}
 Sentence Transformers are great for semantic search tasks. Popular models include `all-MiniLM-L6-v2` (fast and efficient) and `all-mpnet-base-v2` (higher quality). Visit [SBERT documentation](https://www.sbert.net/docs/pretrained_models.html) for more model recommendations.


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds transformers.js embedding function to js client, keeping compatibility with the python implementation of sentence-transformer ef. Validated it works by creating a collection in python and getting it in js, ensuring that the ef was found and registered
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
