### PR TITLE
[ENH] Add blank task support for ChromaCloudQwenEmbeddingFunction

### DIFF
--- a/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
@@ -1,5 +1,5 @@
 from chromadb.api.types import Embeddings, Documents, EmbeddingFunction, Space
-from typing import List, Dict, Any, Union
+from typing import List, Dict, Any, Union, Optional
 import os
 import numpy as np
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
@@ -32,7 +32,7 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
     def __init__(
         self,
         model: ChromaCloudQwenEmbeddingModel,
-        task: str,
+        task: Optional[str],
         instructions: ChromaCloudQwenEmbeddingInstructions = CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS,
         api_key_env_var: str = "CHROMA_API_KEY",
     ):
@@ -41,7 +41,8 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
 
         Args:
             model (ChromaCloudQwenEmbeddingModel): The specific Qwen model to use for embeddings.
-            task (str): The task for which embeddings are being generated.
+            task (str, optional): The task for which embeddings are being generated. If None or empty,
+                empty instructions will be used for both documents and queries.
             instructions (ChromaCloudQwenEmbeddingInstructions, optional): A dictionary containing
                 custom instructions to use for the specified Qwen model. Defaults to CHROMA_CLOUD_QWEN_DEFAULT_INSTRUCTIONS.
             api_key_env_var (str, optional): Environment variable name that contains your API key.
@@ -102,10 +103,14 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
         if not input:
             return []
 
-        payload: Dict[str, Union[str, Documents]] = {
-            "instructions": self.instructions[self.task][
+        instruction = ""
+        if self.task and self.task in self.instructions:
+            instruction = self.instructions[self.task][
                 ChromaCloudQwenEmbeddingTarget.DOCUMENTS
-            ],
+            ]
+
+        payload: Dict[str, Union[str, Documents]] = {
+            "instructions": instruction,
             "texts": input,
         }
 
@@ -120,10 +125,14 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
         if not input:
             return []
 
-        payload: Dict[str, Union[str, Documents]] = {
-            "instructions": self.instructions[self.task][
+        instruction = ""
+        if self.task and self.task in self.instructions:
+            instruction = self.instructions[self.task][
                 ChromaCloudQwenEmbeddingTarget.QUERY
-            ],
+            ]
+
+        payload: Dict[str, Union[str, Documents]] = {
+            "instructions": instruction,
             "texts": input,
         }
 

--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-qwen/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-qwen/src/index.test.ts
@@ -17,6 +17,7 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 		it(defaultParametersTest, () => {
 			const embedder = new ChromaCloudQwenEmbeddingFunction({
 				model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
+				task: "nl_to_code",
 			});
 			expect(embedder.name).toBe("chroma-cloud-qwen");
 
@@ -35,6 +36,7 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 			expect(() => {
 				new ChromaCloudQwenEmbeddingFunction({
 					model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
+					task: "nl_to_code",
 				});
 			}).toThrow("Chroma Embedding API key is required");
 		} finally {
@@ -50,6 +52,7 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 		try {
 			const embedder = new ChromaCloudQwenEmbeddingFunction({
 				model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
+				task: "nl_to_code",
 				apiKeyEnvVar: "CUSTOM_CHROMA_API_KEY",
 			});
 
@@ -85,6 +88,7 @@ describe("ChromaCloudQwenEmbeddingFunction", () => {
 			it(generateEmbeddingsTest, async () => {
 				const embedder = new ChromaCloudQwenEmbeddingFunction({
 					model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
+					task: "nl_to_code",
 				});
 				const texts = ["Hello world", "Test text"];
 				const embeddings = await embedder.generate(texts);

--- a/schemas/embedding_functions/chroma-cloud-qwen.json
+++ b/schemas/embedding_functions/chroma-cloud-qwen.json
@@ -7,13 +7,17 @@
     "properties": {
         "model": {
             "type": "string",
-            "enum": ["Qwen/Qwen3-Embedding-0.6B"],
+            "enum": [
+                "Qwen/Qwen3-Embedding-0.6B"
+            ],
             "description": "The specific Qwen model to use for embeddings"
         },
         "task": {
-            "type": "string",
-            "enum": ["nl_to_code"],
-            "description": "The task for which embeddings are being generated"
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "The task for which embeddings are being generated. If null or empty, empty instructions will be used."
         },
         "instructions": {
             "type": "object",
@@ -31,11 +35,16 @@
                             "description": "Instructions for embedding queries"
                         }
                     },
-                    "required": ["documents", "query"],
+                    "required": [
+                        "documents",
+                        "query"
+                    ],
                     "additionalProperties": false
                 }
             },
-            "required": ["nl_to_code"],
+            "required": [
+                "nl_to_code"
+            ],
             "additionalProperties": false
         },
         "api_key_env_var": {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Fixes https://github.com/chroma-core/chroma/issues/5772
  - adds support for empty task (and as a byproduct, empty instruction) for the qwen embedding function
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
