### PR TITLE
[DOC] update quota info for concurrent reads and writes per collection

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/cloud/quotas-limits.md
+++ b/docs/docs.trychroma.com/markdoc/content/cloud/quotas-limits.md
@@ -27,8 +27,8 @@ Most quotas can be increased upon request. If your application requires higher l
 | Maximum number of where predicates                  | 8           |
 | Maximum size of full text search or regex search    | 256         |
 | Maximum number of results returned                  | 300         |
-| Maximum number of concurrent reads per collection   | 5           |
-| Maximum number of concurrent writes per collection  | 5           |
+| Maximum number of concurrent reads per collection   | 10          |
+| Maximum number of concurrent writes per collection  | 10          |
 | Maximum number of collections                       | 1,000,000   |
 | Maximum number of records per collection            | 5,000,000   |
 | Maximum fork edges from root                        | 4,096       |


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - This PR updates docs to reflect the correct quota info for number of concurrent reads and writes
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
