### PR TITLE
[CHORE] Register package name for chroma-bm25 in js client, fix default-embed warning in getOrCreate

### DIFF
--- a/clients/new-js/packages/ai-embeddings/chroma-bm25/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/chroma-bm25/src/index.ts
@@ -268,4 +268,6 @@ export class ChromaBm25EmbeddingFunction implements SparseEmbeddingFunction {
     }
 }
 
+// register with both name (chroma_bm25) and mapped package name (chroma-bm25)
 registerSparseEmbeddingFunction(NAME, ChromaBm25EmbeddingFunction);
+registerSparseEmbeddingFunction("chroma-bm25", ChromaBm25EmbeddingFunction);

--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -441,6 +441,7 @@ export class ChromaClient {
       configuration,
       embeddingFunction,
       metadata,
+      schema,
     });
 
     const { data } = await Api.createCollection({


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Register both package name (chroma-bm25) and ef name from python/js (chroma_bm25) in js client
  - fixes https://github.com/chroma-core/chroma/issues/5885
  - this also fixes a warning issue where in the getOrCreate path, where the schema ef was not used to resolve the embedding function, leading to a warning if the default-embed was not installed. i have confirmed that previously, the default embed was not used in the collection but was just giving a warning. this PR fixes that as well
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
