### PR TITLE
[ENH]: Introduce backfill capabilities in compactor

### DIFF
--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -79,6 +79,8 @@ pub struct AttachedFunctionOrchestrator {
     orchestrator_context: OrchestratorContext,
 
     dispatcher: ComponentHandle<Dispatcher>,
+
+    is_for_backfill: bool,
 }
 
 #[derive(Error, Debug)]
@@ -212,6 +214,7 @@ impl AttachedFunctionOrchestrator {
         output_context: CompactionContext,
         dispatcher: ComponentHandle<Dispatcher>,
         data_fetch_records: Vec<MaterializeLogOutput>,
+        is_for_backfill: bool,
     ) -> Self {
         let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
 
@@ -224,6 +227,7 @@ impl AttachedFunctionOrchestrator {
             state: ExecutionState::MaterializeApplyCommitFlush,
             orchestrator_context,
             dispatcher,
+            is_for_backfill,
         }
     }
 
@@ -778,6 +782,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
             output_record_segment: message.record_segment.clone(),
             blockfile_provider: self.output_context.blockfile_provider.clone(),
             is_rebuild: self.output_context.is_rebuild,
+            is_for_backfill: self.is_for_backfill,
         };
 
         let task = wrap(

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -156,9 +156,17 @@ pub(crate) struct RequireCompactionOffsetRepair {
 }
 
 #[derive(Debug)]
+pub(crate) struct RequireFunctionBackfill {
+    pub materialized: Vec<MaterializeLogOutput>,
+    pub collection_info: CollectionCompactInfo,
+}
+
+#[derive(Debug)]
 pub(crate) enum LogFetchOrchestratorResponse {
     Success(Success),
     RequireCompactionOffsetRepair(RequireCompactionOffsetRepair),
+    #[allow(dead_code)]
+    RequireFunctionBackfill(RequireFunctionBackfill),
 }
 
 impl Success {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

This change makes compactor changes required to support function backfill.

- A `run_backfill_attached_function_workflow`​ function has been made in compact.rs that wraps on `run_attached_function_workflow`​. It checks if a backfill is needed before  calling `run_apply_logs`​ to fetch all compacted records and feeding the results of this to  `run_attached_function_workflow`​.
- This change doesn't have any callers to `run_backfill_attached_function_workflow`​. Another change is stacked onto this to complete that call-stack.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_