### PR TITLE
[ENH]: Persist a backfill record on log to trigger backfill

### DIFF
--- a/idl/chromadb/proto/chroma.proto
+++ b/idl/chromadb/proto/chroma.proto
@@ -12,6 +12,7 @@ enum Operation {
     UPDATE = 1;
     UPSERT = 2;
     DELETE = 3;
+    BACKFILL_FN = 4;
 }
 
 enum ScalarEncoding {

--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -609,6 +609,7 @@ fn operation_from_code(code: u32) -> Operation {
         1 => Operation::Update,
         2 => Operation::Upsert,
         3 => Operation::Delete,
+        4 => Operation::BackfillFn,
         _ => panic!("Invalid operation code"),
     }
 }
@@ -619,6 +620,7 @@ fn operation_to_code(operation: Operation) -> u32 {
         Operation::Update => 1,
         Operation::Upsert => 2,
         Operation::Delete => 3,
+        Operation::BackfillFn => 4,
     }
 }
 

--- a/rust/segment/src/local_hnsw.rs
+++ b/rust/segment/src/local_hnsw.rs
@@ -666,6 +666,10 @@ impl LocalHnswSegmentWriter {
             guard.num_elements_since_last_persist += 1;
             max_seq_id = max_seq_id.max(log.log_offset as u64);
             match log.record.operation {
+                Operation::BackfillFn => {
+                    tracing::warn!("BackfillFn not supported for hnsw index");
+                    continue;
+                }
                 Operation::Add => {
                     // only update if the id is not already present
                     if !guard.id_map.id_to_label.contains_key(&log.record.id) {
@@ -784,6 +788,9 @@ impl LocalHnswSegmentWriter {
             .map(|(_, records)| {
                 for (label, log_record) in records {
                     match log_record.operation {
+                        Operation::BackfillFn => {
+                            continue;
+                        }
                         Operation::Add | Operation::Upsert | Operation::Update => {
                             let embedding = log_record.embedding.as_ref().expect(
                                 "Add, update or upsert should have an embedding at this point",

--- a/rust/segment/src/sqlite_metadata.rs
+++ b/rust/segment/src/sqlite_metadata.rs
@@ -369,6 +369,9 @@ impl SqliteMetadataWriter {
                 metadata_owned = Some(doc_embedded_meta);
             }
             match operation {
+                Operation::BackfillFn => {
+                    continue;
+                }
                 Operation::Add => {
                     if let Some(offset_id) =
                         Self::add_record(tx, segment_id, log_offset_unsigned, id.clone()).await?

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -312,6 +312,9 @@ impl TestReferenceSegment {
                 Operation::Delete => {
                     coll.remove(&id);
                 }
+                Operation::BackfillFn => {
+                    continue;
+                }
             };
         }
     }

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -2330,6 +2330,8 @@ pub struct AttachFunctionResponse {
 pub enum AttachFunctionError {
     #[error(" Attached Function with name [{0}] already exists")]
     AlreadyExists(String),
+    #[error("Failed to get collection and segments")]
+    GetCollectionError(#[from] GetCollectionError),
     #[error("Input collection [{0}] does not exist")]
     InputCollectionNotFound(String),
     #[error("Output collection [{0}] already exists")]
@@ -2344,6 +2346,7 @@ impl ChromaError for AttachFunctionError {
     fn code(&self) -> ErrorCodes {
         match self {
             AttachFunctionError::AlreadyExists(_) => ErrorCodes::AlreadyExists,
+            AttachFunctionError::GetCollectionError(err) => err.code(),
             AttachFunctionError::InputCollectionNotFound(_) => ErrorCodes::NotFound,
             AttachFunctionError::OutputCollectionExists(_) => ErrorCodes::AlreadyExists,
             AttachFunctionError::Validation(err) => err.code(),

--- a/rust/types/src/operation.rs
+++ b/rust/types/src/operation.rs
@@ -9,6 +9,7 @@ pub enum Operation {
     Update,
     Upsert,
     Delete,
+    BackfillFn,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -53,6 +54,7 @@ impl TryFrom<chroma_proto::Operation> for Operation {
             chroma_proto::Operation::Upsert => Ok(Operation::Upsert),
             chroma_proto::Operation::Update => Ok(Operation::Update),
             chroma_proto::Operation::Delete => Ok(Operation::Delete),
+            chroma_proto::Operation::BackfillFn => Ok(Operation::BackfillFn),
         }
     }
 }
@@ -68,6 +70,7 @@ impl TryFrom<i32> for Operation {
                 chroma_proto::Operation::Upsert => Ok(Operation::Upsert),
                 chroma_proto::Operation::Update => Ok(Operation::Update),
                 chroma_proto::Operation::Delete => Ok(Operation::Delete),
+                chroma_proto::Operation::BackfillFn => Ok(Operation::BackfillFn),
             },
             Err(_) => Err(OperationConversionError::DecodeError(
                 ConversionError::DecodeError,

--- a/rust/types/src/strategies.rs
+++ b/rust/types/src/strategies.rs
@@ -100,6 +100,7 @@ impl Arbitrary for OperationRecord {
                             }
                         }
                         Operation::Delete => None,
+                        Operation::BackfillFn => None,
                     };
                     let encoding = embedding.as_ref().map(|_| ScalarEncoding::FLOAT32);
 

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -95,6 +95,7 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
                                     seen_id_set.remove(log_record.record.id.as_str());
                                 }
                                 Operation::Update => {}
+                                Operation::BackfillFn => {}
                             }
                         }
                         return Ok(CountRecordsOutput {
@@ -163,6 +164,7 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
                         non_deleted_present_in_segment.remove(log_record.record.id.as_str());
                     }
                     Operation::Update => {}
+                    Operation::BackfillFn => {}
                 }
             } else {
                 match log_record.record.operation {
@@ -173,6 +175,7 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
                         non_deleted_absent_in_segment.remove(log_record.record.id.as_str());
                     }
                     Operation::Update => {}
+                    Operation::BackfillFn => {}
                 }
             }
         }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

This diff persists a backfill signal that goes from a call to `attach_function`​ to `run_backfilled_attached_function_workflow`​, introduced by #5896 . This diff achieves that by pushing a new `backfill_fn`​ log to the concerned input collection's logs. This log should effectively be a no-op on the compactor path as materialize_logs makes sure to ignore these logs. In compact.rs::compact(), if the initial `run_fetch_logs`​ call detects the presence of this backfill log, `run_backfilled_attached_function_workflow` will be called. If this call succeeds, we return and ignore the usual compaction flow. If backfill was not needed, the usual pre-existing compaction + attached function execution is called.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_