### PR TITLE
[CHORE]: Refactor AttachedFunctionOrchestrator to return a FunctionContext instead of its individual fields

### DIFF
--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -654,8 +654,7 @@ impl CompactionContext {
                 job_id: _,
                 output_collection_info,
                 materialized_output,
-                attached_function_id,
-                completion_offset,
+                function_context,
             } => {
                 // Update self to use the output collection for apply_logs
                 self.collection_info = OnceCell::from(output_collection_info.clone());
@@ -664,12 +663,6 @@ impl CompactionContext {
                 let apply_logs_response = self
                     .run_apply_logs(materialized_output, system.clone())
                     .await?;
-
-                let function_context = FunctionContext {
-                    attached_function_id,
-                    function_id: attached_function_id.0,
-                    updated_completion_offset: completion_offset,
-                };
 
                 // Get updated collection info after running apply logs.
                 let output_collection_info = self.get_collection_info()?;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

Small refactor to have the FetchLogOrchestractor return Function related fields in an extensible FunctionContext instead of its individual fields.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_