### PR TITLE
[CHORE]: Add test_statistics_wrapper to CI

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -142,6 +142,7 @@ jobs:
           - "chromadb/test/distributed/test_log_backpressure.py"
           - "chromadb/test/distributed/test_repair_collection_log_offset.py"
           - "chromadb/test/distributed/test_task_api.py"
+          - "chromadb/test/distributed/test_statistics_wrapper.py"
         include:
           - test-glob: "chromadb/test/property/test_add.py"
             parallelized: false

--- a/chromadb/test/distributed/test_statistics_wrapper.py
+++ b/chromadb/test/distributed/test_statistics_wrapper.py
@@ -4,6 +4,7 @@ Integration test for the Collection statistics wrapper methods
 
 import pytest
 import json
+import time
 from chromadb.api.client import Client as ClientCreator
 from chromadb.config import System
 from chromadb.test.utils.wait_for_version_increase import (


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

#5899 Added test_statistics_wrapper.py to the repository but forgot to add it to the CI list of tests to run. This diff fixes that.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_