### PR TITLE
[BUG]: Fix test flake in test_task_api.py

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -13,6 +13,7 @@ from chromadb.test.utils.wait_for_version_increase import (
     get_collection_version,
     wait_for_version_increase,
 )
+from time import sleep
 
 
 def test_count_function_attach_and_detach(basic_http_client: System) -> None:
@@ -48,6 +49,8 @@ def test_count_function_attach_and_detach(basic_http_client: System) -> None:
     assert collection.count() == 300
 
     wait_for_version_increase(client, collection.name, initial_version)
+    # Give some time to invalidate the frontend query cache
+    sleep(60)
 
     result = client.get_collection("my_documents_counts").get("function_output")
     assert result["metadatas"] is not None
@@ -103,7 +106,7 @@ def test_attach_function_returns_function_name(basic_http_client: System) -> Non
     # Get the attached function and verify function_name field is also present
     retrieved_fn = collection.get_attached_function("my_counter")
     assert retrieved_fn == attached_fn
-    
+
     # Clean up
     attached_fn.detach(delete_output_collection=True)
 


### PR DESCRIPTION
## Description of changes

Function output results can show stale data due to the frontend cache, causing some tests to be flaky. This diff fixes that.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
