### PR TITLE
[BUG]: Make sure an input collection soft delete cascades to attached functions

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
 	s3metastore "github.com/chroma-core/chroma/go/pkg/sysdb/metastore/s3"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
@@ -1921,6 +1923,75 @@ func (suite *APIsTestSuite) TestGetCollectionByResourceName() {
 	_, err = suite.coordinator.GetCollectionByResourceName(ctx, "non_existent_tenant_resource_name", suite.databaseName, testCollection.Name)
 	suite.Error(err)
 	suite.True(errors.Is(err, common.ErrCollectionNotFound))
+}
+
+func (suite *APIsTestSuite) TestDeleteCollectionWithAttachedFunction() {
+	ctx := context.Background()
+
+	// Create a test collection
+	collectionID := types.NewUniqueID()
+	collectionName := "test_collection_with_function"
+	createCollection := &model.CreateCollection{
+		ID:           collectionID,
+		Name:         collectionName,
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	}
+	_, _, err := suite.coordinator.CreateCollection(ctx, createCollection)
+	suite.NoError(err)
+
+	// Create a dummy function in the database
+	functionID := uuid.New()
+	functionName := "test_function"
+	err = suite.db.Create(&dbmodel.Function{
+		ID:            functionID,
+		Name:          functionName,
+		IsIncremental: false,
+		ReturnType:    "{}",
+	}).Error
+	suite.NoError(err)
+
+	// Attach function to the collection
+	attachedFnName := "test_attached_fn"
+	params := &structpb.Struct{Fields: map[string]*structpb.Value{}}
+
+	attachReq := &coordinatorpb.AttachFunctionRequest{
+		Name:                    attachedFnName,
+		InputCollectionId:       collectionID.String(),
+		OutputCollectionName:    "test_output_collection",
+		FunctionName:            functionName,
+		TenantId:                suite.tenantName,
+		Database:                suite.databaseName,
+		MinRecordsForInvocation: 100,
+		Params:                  params,
+	}
+	attachRes, err := suite.coordinator.AttachFunction(ctx, attachReq)
+	suite.NoError(err)
+	attachedFnIDStr := attachRes.AttachedFunction.Id
+
+	attachedFnID, _ := uuid.Parse(attachedFnIDStr)
+
+	// Manually set is_ready = true so that GetByCollectionID picks it up
+	err = suite.db.Model(&dbmodel.AttachedFunction{}).Where("id = ?", attachedFnID).Update("is_ready", true).Error
+	suite.NoError(err)
+
+	// Soft delete the collection
+	deleteCollection := &model.DeleteCollection{
+		ID:           collectionID,
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	}
+	err = suite.coordinator.SoftDeleteCollection(ctx, deleteCollection)
+	suite.NoError(err)
+
+	// Verify attached function is soft deleted
+	var count int64
+	suite.db.Model(&dbmodel.AttachedFunction{}).Where("id = ? AND is_deleted = ?", attachedFnID, true).Count(&count)
+	suite.Equal(int64(1), count)
+
+	// Verify collection is soft deleted
+	suite.db.Model(&dbmodel.Collection{}).Where("id = ? AND is_deleted = ?", collectionID.String(), true).Count(&count)
+	suite.Equal(int64(1), count)
 }
 
 func TestAPIsTestSuite(t *testing.T) {

--- a/go/pkg/sysdb/coordinator/table_catalog.go
+++ b/go/pkg/sysdb/coordinator/table_catalog.go
@@ -713,6 +713,18 @@ func (tc *Catalog) softDeleteCollection(ctx context.Context, deleteCollection *m
 			return common.ErrCollectionDeleteNonExistingCollection
 		}
 
+		// List attached functions for this collection and soft delete them
+		attachedFunctions, err := tc.metaDomain.AttachedFunctionDb(txCtx).GetByCollectionID(deleteCollection.ID.String())
+		if err != nil {
+			return err
+		}
+		for _, attachedFunction := range attachedFunctions {
+			log.Info("Soft deleting attached function for collection", zap.String("attached_function_id", attachedFunction.ID.String()), zap.String("collection_id", deleteCollection.ID.String()))
+			if err := tc.metaDomain.AttachedFunctionDb(txCtx).SoftDeleteByID(attachedFunction.ID); err != nil {
+				return err
+			}
+		}
+
 		// Generate new name with timestamp and random number
 		oldName := *collections[0].Collection.Name
 		newName := fmt.Sprintf("_deleted_%s_%s", oldName, deleteCollection.ID.String())


### PR DESCRIPTION
## Description of changes

This diff ensures that an input collection's soft deletion cascades to any attached functions.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
