### PR TITLE
fix: Add curl to runner stage for healthcheck compatibility

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -60,7 +60,7 @@ RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
 
 FROM debian:stable-slim AS runner
 
-RUN apt-get update && apt-get install -y dumb-init libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y dumb-init libssl-dev ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 FROM runner AS cli
 


### PR DESCRIPTION
## Problem
The current Docker healthcheck in `docker-compose.yml` uses `curl` to check the `/api/v2/heartbeat` endpoint, but the runner stage doesn't have `curl` installed. This causes healthcheck failures when using the official Docker setup.

## Solution
Add `curl` installation to the runner stage in Dockerfile to support healthcheck functionality.

## Changes
- Modified `rust/Dockerfile` to install `curl` in the runner stage
- This ensures healthcheck commands work as expected in docker-compose

## Impact
- **Minimal**: Only adds `curl` to existing apt-get install command
- **Backward Compatible**: No breaking changes
- **Useful**: Fixes a real usability issue that many users encounter

## Testing
The healthcheck command `curl -f http://localhost:8000/api/v2/heartbeat` now works correctly in containers built from this Dockerfile.

## Related Issues
This resolves the healthcheck failure issue described in various community discussions.
