### PR TITLE
[ENH] For chroma cloud efs, extract api key from header if available to authenticate

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -2,7 +2,7 @@ import asyncio
 from uuid import UUID
 import urllib.parse
 import orjson
-from typing import Any, Optional, cast, Tuple, Sequence, Dict, List
+from typing import Any, Mapping, Optional, cast, Tuple, Sequence, Dict, List
 import logging
 import httpx
 from overrides import override
@@ -138,6 +138,14 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             )
 
         return self._clients[loop_hash]
+
+    @override
+    def get_request_headers(self) -> Mapping[str, str]:
+        return dict(self._get_client().headers)
+
+    @override
+    def get_api_url(self) -> str:
+        return self._api_url
 
     async def _make_request(
         self, method: str, path: str, **kwargs: Dict[str, Any]

--- a/chromadb/api/base_http_client.py
+++ b/chromadb/api/base_http_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, TypeVar
+from typing import Any, Dict, Mapping, Optional, TypeVar
 from urllib.parse import quote, urlparse, urlunparse
 import logging
 import orjson as json
@@ -135,3 +135,11 @@ class BaseHTTPClient(Component):
             if trace_id:
                 raise Exception(f"{resp.text} (trace ID: {trace_id})")
             raise (Exception(resp.text))
+
+    def get_request_headers(self) -> Mapping[str, str]:
+        """Return headers used for HTTP requests."""
+        return {}
+
+    def get_api_url(self) -> str:
+        """Return the API URL for this client."""
+        return ""

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -1,6 +1,6 @@
 import orjson
 import logging
-from typing import Any, Dict, Optional, cast, Tuple, List
+from typing import Any, Dict, Mapping, Optional, cast, Tuple, List
 from typing import Sequence
 from uuid import UUID
 import httpx
@@ -104,6 +104,14 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             _headers = self._auth_provider.authenticate()
             for header, value in _headers.items():
                 self._session.headers[header] = value.get_secret_value()
+
+    @override
+    def get_request_headers(self) -> Mapping[str, str]:
+        return dict(self._session.headers)
+
+    @override
+    def get_api_url(self) -> str:
+        return self._api_url
 
     def _make_request(self, method: str, path: str, **kwargs: Dict[str, Any]) -> Any:
         # If the request has json in kwargs, use orjson to serialize it,

--- a/chromadb/test/api/test_shared_system_client.py
+++ b/chromadb/test/api/test_shared_system_client.py
@@ -1,0 +1,180 @@
+import pytest
+from unittest.mock import MagicMock
+from chromadb.api.shared_system_client import SharedSystemClient
+from chromadb.api.base_http_client import BaseHTTPClient
+from chromadb.config import System
+from typing import Optional, Dict, Generator
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> Generator[None, None, None]:
+    """Automatically clear the system cache before and after each test."""
+    SharedSystemClient.clear_system_cache()
+    yield
+    SharedSystemClient.clear_system_cache()
+
+
+def create_mock_http_client(
+    api_url: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> MagicMock:
+    """Create a mock BaseHTTPClient instance with the specified configuration."""
+    mock_server_api = MagicMock(spec=BaseHTTPClient)
+
+    mock_server_api.get_api_url.return_value = api_url or ""
+    mock_server_api.get_request_headers.return_value = headers or {}
+
+    return mock_server_api
+
+
+def register_mock_system(system_id: str, mock_server_api: MagicMock) -> MagicMock:
+    """Register a mock system with the given ID and server API."""
+    mock_system = MagicMock(spec=System)
+    mock_system.instance.return_value = mock_server_api
+    SharedSystemClient._identifier_to_system[system_id] = mock_system
+    return mock_system
+
+
+def test_extracts_api_key_from_chroma_cloud_client() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"X-Chroma-Token": "test-api-key-123"},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key == "test-api-key-123"
+
+
+def test_extracts_api_key_with_lowercase_header() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"x-chroma-token": "test-api-key-456"},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key == "test-api-key-456"
+
+
+def test_extracts_api_key_from_gcp_chroma_cloud_client() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url="https://dummy.gcp.trychroma.com/api/v2",
+        headers={"X-Chroma-Token": "gcp-test-api-key"},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key == "gcp-test-api-key"
+
+
+def test_skips_non_chroma_cloud_clients() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url="https://localhost:8000/api/v2",
+        headers={"X-Chroma-Token": "local-api-key"},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key is None
+
+
+def test_skips_clients_without_api_url() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url=None,
+        headers={"X-Chroma-Token": "test-api-key"},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key is None
+
+
+def test_returns_none_when_no_api_key_in_headers() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key is None
+
+
+def test_returns_first_api_key_found_from_multiple_clients() -> None:
+    mock_server_api_1 = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"X-Chroma-Token": "first-key"},
+    )
+    mock_server_api_2 = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"X-Chroma-Token": "second-key"},
+    )
+    register_mock_system("test-id-1", mock_server_api_1)
+    register_mock_system("test-id-2", mock_server_api_2)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key == "first-key"
+
+
+def test_handles_exception_gracefully() -> None:
+    mock_system = MagicMock(spec=System)
+    mock_system.instance.side_effect = Exception("Test exception")
+    SharedSystemClient._identifier_to_system["test-id"] = mock_system
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key is None
+
+
+def test_returns_none_when_no_clients_exist() -> None:
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key is None
+
+
+def test_skips_non_http_clients() -> None:
+    """Test that non-BaseHTTPClient instances are skipped."""
+    mock_server_api = MagicMock()  # Not a BaseHTTPClient
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key is None
+
+
+def test_extracts_api_key_with_mixed_case_header() -> None:
+    mock_server_api = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"X-CHROMA-TOKEN": "mixed-case-key"},
+    )
+    register_mock_system("test-id", mock_server_api)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key == "mixed-case-key"
+
+
+def test_multiple_clients_returns_one_key() -> None:
+    """Test that multiple clients return one of the available keys."""
+    mock_api_1 = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"X-Chroma-Token": "key-1"},
+    )
+    mock_api_2 = create_mock_http_client(
+        api_url="https://api.trychroma.com/api/v2",
+        headers={"X-Chroma-Token": "key-2"},
+    )
+    register_mock_system("id-1", mock_api_1)
+    register_mock_system("id-2", mock_api_2)
+
+    api_key = SharedSystemClient.get_chroma_cloud_api_key_from_clients()
+
+    assert api_key in ["key-1", "key-2"]

--- a/chromadb/utils/embedding_functions/utils.py
+++ b/chromadb/utils/embedding_functions/utils.py
@@ -1,0 +1,11 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+
+def _get_shared_system_client() -> "type[SharedSystemClient]":
+    """Lazy import of SharedSystemClient to avoid circular imports."""
+    from chromadb.api.shared_system_client import SharedSystemClient
+
+    return SharedSystemClient


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Since chroma cloud splade & qwen are both authenticated using the same api key as Chroma Cloud, as a fallback we can iterate through the available clients and use the first api key found when the host is `api.trychroma.com`
- New functionality
  - ...

## Test plan

_How are these changes tested?_
Added tests for extraction function

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
