### PR TITLE
[BUG]  wal3 Sometimes returns an "Internal" when it should return "LogContentionFailure"

### DIFF
--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -353,7 +353,7 @@ impl ManifestManager {
         match rx.await {
             Ok(None) => Ok(()),
             Ok(Some(err)) => Err(err),
-            Err(_) => Err(Error::internal(file!(), line!())),
+            Err(_) => Err(Error::LogContentionFailure),
         }
     }
 


### PR DESCRIPTION
## Description of changes

Because of how work gets thrown away during contention, it was possible
for a channel to close and generate an internal error.  This casts that
condition to be more descriptive.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
