### PR TITLE
[CHORE] Update ef schemas with some optional types for attrs

### DIFF
--- a/schemas/embedding_functions/cloudflare_workers_ai.json
+++ b/schemas/embedding_functions/cloudflare_workers_ai.json
@@ -18,7 +18,10 @@
             "description": "The environment variable name that contains your API key for the Cloudflare Workers AI API"
         },
         "gateway_id": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "The ID of the Cloudflare AI Gateway to use for a more customized solution"
         }
     },

--- a/schemas/embedding_functions/huggingface_server.json
+++ b/schemas/embedding_functions/huggingface_server.json
@@ -10,7 +10,10 @@
             "description": "The URL of the HuggingFace Embedding Server"
         },
         "api_key_env_var": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "The environment variable name that contains your API key for the HuggingFace API"
         }
     },

--- a/schemas/embedding_functions/instructor.json
+++ b/schemas/embedding_functions/instructor.json
@@ -14,7 +14,10 @@
       "description": "Parameter device for the instructor embedding function"
     },
     "instruction": {
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Parameter instruction for the instructor embedding function"
     }
   },

--- a/schemas/embedding_functions/jina.json
+++ b/schemas/embedding_functions/jina.json
@@ -14,28 +14,53 @@
       "description": "Parameter api_key_env_var for the jina embedding function"
     },
     "task": {
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Parameter task for the jina embedding function"
     },
     "late_chunking": {
-      "type": "boolean",
+      "type": [
+        "boolean",
+        "null"
+      ],
       "description": "Parameter late_chunking for the jina embedding function"
     },
     "truncate": {
-      "type": "boolean",
+      "type": [
+        "boolean",
+        "null"
+      ],
       "description": "Parameter truncate for the jina embedding function"
     },
     "dimensions": {
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "description": "Parameter dimensions for the jina embedding function"
     },
     "embedding_type": {
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Parameter embedding_type for the jina embedding function"
     },
     "normalized": {
-      "type": "boolean",
+      "type": [
+        "boolean",
+        "null"
+      ],
       "description": "Parameter normalized for the jina embedding function"
+    },
+    "query_config": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "Parameter query_config for the jina embedding function"
     }
   },
   "required": [

--- a/schemas/embedding_functions/onnx_mini_lm_l6_v2.json
+++ b/schemas/embedding_functions/onnx_mini_lm_l6_v2.json
@@ -6,7 +6,10 @@
   "type": "object",
   "properties": {
     "preferred_providers": {
-      "type": "array",
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "string"
       },

--- a/schemas/embedding_functions/open_clip.json
+++ b/schemas/embedding_functions/open_clip.json
@@ -14,7 +14,10 @@
       "description": "Parameter checkpoint for the open_clip embedding function"
     },
     "device": {
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Parameter device for the open_clip embedding function"
     }
   },

--- a/schemas/embedding_functions/voyageai.json
+++ b/schemas/embedding_functions/voyageai.json
@@ -14,7 +14,10 @@
       "description": "Parameter api_key_env_var for the voyageai embedding function"
     },
     "input_type": {
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Parameter input_type for the voyageai embedding function"
     },
     "truncation": {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - There are some types in ef schemas that support null json fields, which were not explicitly stated in the schemas. This PR fixes that by allowing null type
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
