### PR TITLE
[BUG] Fix chart values reference

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.66
+version: 0.1.67
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/compaction-service.yaml
+++ b/k8s/distributed-chroma/templates/compaction-service.yaml
@@ -45,7 +45,7 @@ spec:
         - name: compaction-service-cache-{{ add $i 1 }}
           hostPath:
             path: {{ $cache.hostPath }}
-            type: {{ .Values.compactionService.cache.type }}
+            type: {{ $.Values.compactionService.cache.type }}
         {{- end }}
       containers:
         - name: compaction-service

--- a/k8s/distributed-chroma/templates/query-service.yaml
+++ b/k8s/distributed-chroma/templates/query-service.yaml
@@ -64,7 +64,7 @@ spec:
         - name: query-service-cache-{{ add $i 1 }}
           hostPath:
             path: {{ $cache.hostPath }}
-            type: {{ .Values.queryService.cache.type }}
+            type: {{ $.Values.queryService.cache.type }}
         {{- end }}
       containers:
         - name: query-service

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -62,7 +62,7 @@ spec:
         - name: rust-log-service-cache-{{ add $i 1 }}
           hostPath:
             path: {{ $cache.hostPath }}
-            type: {{ .Values.rustLogService.cache.type }}
+            type: {{ $.Values.rustLogService.cache.type }}
         {{- end }}
       containers:
         - name: rust-log-service


### PR DESCRIPTION
## Description of changes

> When iterating with range in a Helm template, the scope of the current
> context (.) changes to the item being iterated over. This means that if you
> are ranging over a list or map contained within .Values, directly referencing
> .Values inside that range block will result in an error because the current
> context (.) no longer points to the top-level chart values.

## Test plan

Render chart

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
