### PR TITLE
[ENH] Separate schema errors on read/write path to give 400 on user errors, 500 for internal errors

### DIFF
--- a/chromadb/test/api/test_schema_e2e.py
+++ b/chromadb/test/api/test_schema_e2e.py
@@ -31,7 +31,7 @@ from chromadb.utils.embedding_functions import (
 )
 from chromadb.api.models.Collection import Collection
 from chromadb.api.models.CollectionCommon import CollectionCommon
-from chromadb.errors import InvalidArgumentError, InternalError
+from chromadb.errors import InvalidArgumentError
 from chromadb.execution.expression import Knn, Search
 from chromadb.types import Collection as CollectionModel
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, cast
@@ -509,7 +509,7 @@ def test_sparse_vector_not_allowed_locally(
     schema = Schema()
     schema.create_index(key="sparse_metadata", config=SparseVectorIndexConfig())
     with pytest.raises(
-        InternalError, match="Sparse vector indexing is not enabled in local"
+        InvalidArgumentError, match="Sparse vector indexing is not enabled in local"
     ):
         _create_isolated_collection(client_factories, schema=schema)
 

--- a/rust/frontend/src/impls/in_memory_frontend.rs
+++ b/rust/frontend/src/impls/in_memory_frontend.rs
@@ -230,7 +230,7 @@ impl InMemoryFrontend {
         .map_err(CreateCollectionError::InvalidSchema)?;
 
         let config = InternalCollectionConfiguration::try_from(&schema).map_err(|e| {
-            CreateCollectionError::InvalidSchema(SchemaError::InvalidSchema { reason: e })
+            CreateCollectionError::InvalidSchema(SchemaError::InvalidUserInput { reason: e })
         })?;
 
         let collection = Collection {

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -576,7 +576,7 @@ impl ServiceBasedFrontend {
                     if let Some(schema) = reconciled_schema.as_ref() {
                         if schema.is_sparse_index_enabled() {
                             return Err(CreateCollectionError::InvalidSchema(
-                                SchemaError::InvalidSchema {
+                                SchemaError::InvalidUserInput {
                                     reason: "Sparse vector indexing is not enabled in local"
                                         .to_string(),
                                 },


### PR DESCRIPTION
## Description of changes

This PR separates the read and write path error codes for schema, so if its a user supplied error then it errors back with a 400 to inform them, and if the error is internal then it gives back a 500 since the error is internal. Fixes https://github.com/chroma-core/chroma/issues/5886

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
