### PR TITLE
fix: Default to SegmentAPI on Windows to avoid Rust bindings hang

### DIFF
--- a/chromadb/config.py
+++ b/chromadb/config.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import logging
+import platform
 from abc import ABC
 from enum import Enum
 from graphlib import TopologicalSorter
@@ -125,7 +126,13 @@ class Settings(BaseSettings):  # type: ignore
     environment: str = ""
 
     # Can be "chromadb.api.segment.SegmentAPI" or "chromadb.api.fastapi.FastAPI" or "chromadb.api.rust.RustBindingsAPI"
-    chroma_api_impl: str = "chromadb.api.rust.RustBindingsAPI"
+    # On Windows, Rust bindings have a bug that causes collection.add() to hang indefinitely
+    # See: https://github.com/chroma-core/chroma/issues/5937
+    chroma_api_impl: str = (
+        "chromadb.api.segment.SegmentAPI"
+        if platform.system() == "Windows"
+        else "chromadb.api.rust.RustBindingsAPI"
+    )
 
     @validator("chroma_server_nofile", pre=True, always=True, allow_reuse=True)
     def empty_str_to_none(cls, v: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

Fixes #5937

On Windows, the Rust bindings (`chromadb_rust_bindings.pyd`) cause `collection.add()` to hang indefinitely. This PR defaults to using `SegmentAPI` on Windows platform as a workaround until the underlying Rust issue is resolved.

## Root Cause

The `chromadb_rust_bindings.Bindings.add()` method never returns on Windows. This was identified through Python line-by-line tracing using `sys.settrace()`.

## Changes

- Added `import platform` to `chromadb/config.py`
- Modified default `chroma_api_impl` to use `SegmentAPI` on Windows, `RustBindingsAPI` on other platforms

## Testing

- Tested on Windows 10/11 with Python 3.10/3.11
- `collection.add()` now completes successfully on Windows
- No impact on Linux/macOS (still uses Rust bindings)