### PR TITLE
[DOC] Update custom EF code sample

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
@@ -267,7 +267,7 @@ class MyEmbeddingFunction(EmbeddingFunction):
 
     @staticmethod
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction":
-        return MyEmbeddingFunction(config.model)
+        return MyEmbeddingFunction(config['model'])
 ```
 
 {% /Tab %}


### PR DESCRIPTION
This updates the sample code to show how to use custom EFs correctly. The old snippets would result in legacy EFs.

You need to register the EF, and if you don't define the extra functions it's considered a legacy EF.
