### PR TITLE
[ENH]: Add token storage for chroma cloud splade sparse vectors

### DIFF
--- a/schemas/embedding_functions/chroma-cloud-splade.json
+++ b/schemas/embedding_functions/chroma-cloud-splade.json
@@ -16,6 +16,11 @@
             "type": "string",
             "description": "Environment variable name that contains your API key for the Chroma Embedding API",
             "default": "CHROMA_API_KEY"
+        },
+        "store_tokens": {
+            "type": "boolean",
+            "description": "Whether to store token labels in the sparse vector output",
+            "default": false
         }
     },
     "required": [


### PR DESCRIPTION
## Description of changes

Added token/label storage for Splade sparse vectors.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
