### PR TITLE
[ENH]: Add collection metadata to output collection to identify source attached function

### DIFF
--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -227,3 +227,29 @@ def test_function_remove_nonexistent(basic_http_client: System) -> None:
     # Trying to detach this function again should raise NotFoundError
     with pytest.raises(NotFoundError, match="does not exist"):
         attached_fn.detach(delete_output_collection=True)
+
+def test_attach_to_output_collection_fails(basic_http_client: System) -> None:
+    """Test that attaching a function to an output collection fails"""
+    client = ClientCreator.from_system(basic_http_client)
+    client.reset()
+
+    # Create input collection
+    input_collection = client.create_collection(name="input_collection")
+    input_collection.add(ids=["id1"], documents=["test"])
+
+    _ = input_collection.attach_function(
+        name="test_function",
+        function_id="record_counter",
+        output_collection="output_collection",
+        params=None,
+    )
+
+    output_collection = client.get_collection(name="output_collection")
+
+    with pytest.raises(ChromaError, match="cannot attach function to an output collection"):
+        _ = output_collection.attach_function(
+            name="test_function_2",
+            function_id="record_counter",
+            output_collection="output_collection_2",
+            params=None,
+        )

--- a/go/pkg/common/constants.go
+++ b/go/pkg/common/constants.go
@@ -3,4 +3,8 @@ package common
 const (
 	DefaultTenant   = "default_tenant"
 	DefaultDatabase = "default_database"
+
+	// SourceAttachedFunctionIDKey is the metadata key used to mark output collections
+	// and link them to their attached function.
+	SourceAttachedFunctionIDKey = "chroma:source_attached_function_id"
 )

--- a/go/pkg/common/errors.go
+++ b/go/pkg/common/errors.go
@@ -49,11 +49,12 @@ var (
 	ErrUnknownSegmentMetadataType = errors.New("segment metadata value type not supported")
 
 	// AttachedFunction errors
-	ErrAttachedFunctionAlreadyExists = errors.New("the attached function that was being created already exists for this collection")
-	ErrAttachedFunctionNotFound      = errors.New("the requested attached function was not found")
-	ErrAttachedFunctionNotReady      = errors.New("the requested attached function exists but is still initializing")
-	ErrInvalidAttachedFunctionName   = errors.New("attached function name cannot start with reserved prefix '_deleted_'")
-	ErrHeapServiceNotEnabled         = errors.New("heap service is not enabled")
+	ErrAttachedFunctionAlreadyExists  = errors.New("the attached function that was being created already exists for this collection")
+	ErrAttachedFunctionNotFound       = errors.New("the requested attached function was not found")
+	ErrAttachedFunctionNotReady       = errors.New("the requested attached function exists but is still initializing")
+	ErrInvalidAttachedFunctionName    = errors.New("attached function name cannot start with reserved prefix '_deleted_'")
+	ErrHeapServiceNotEnabled          = errors.New("heap service is not enabled")
+	ErrCannotAttachToOutputCollection = errors.New("cannot attach function to an output collection")
 
 	// Function errors
 	ErrFunctionNotFound = errors.New("function not found")


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - As titled, add a collection metadata entry to all output collections. Using this, we prevent attaching functions to collections that were made as a result of functions.
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
