### PR TITLE
[ENH]: Skip caching for output collections in frontend

### DIFF
--- a/chromadb/test/distributed/test_statistics_wrapper.py
+++ b/chromadb/test/distributed/test_statistics_wrapper.py
@@ -3,7 +3,6 @@ Integration test for the Collection statistics wrapper methods
 """
 
 import json
-import time
 from chromadb.api.client import Client as ClientCreator
 from chromadb.base_types import SparseVector
 from chromadb.config import System
@@ -51,7 +50,6 @@ def test_statistics_wrapper(basic_http_client: System) -> None:
 
     # Wait for statistics to be computed
     wait_for_version_increase(client, collection.name, initial_version)
-    time.sleep(60)
 
     # Get statistics
     stats = get_statistics(collection)
@@ -222,7 +220,6 @@ def test_statistics_wrapper_key_filter(basic_http_client: System) -> None:
     )
 
     wait_for_version_increase(client, collection.name, initial_version)
-    time.sleep(60)
 
     # Get all statistics (no key filter)
     all_stats = get_statistics(collection)
@@ -290,9 +287,6 @@ def test_statistics_wrapper_incremental_updates(basic_http_client: System) -> No
     )
 
     wait_for_version_increase(client, collection.name, next_version)
-    # TODO(tanujnay112): Remove this sleep once query cache invalidation is solidified
-    # or figure out a different testing harness where we don't have to wait for query cache invalidation
-    time.sleep(70)
 
     # Check updated statistics
     stats = get_statistics(collection)

--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -13,7 +13,6 @@ from chromadb.test.utils.wait_for_version_increase import (
     get_collection_version,
     wait_for_version_increase,
 )
-from time import sleep
 
 
 def test_count_function_attach_and_detach(basic_http_client: System) -> None:
@@ -49,8 +48,6 @@ def test_count_function_attach_and_detach(basic_http_client: System) -> None:
     assert collection.count() == 300
 
     wait_for_version_increase(client, collection.name, initial_version)
-    # Give some time to invalidate the frontend query cache
-    sleep(60)
 
     result = client.get_collection("my_documents_counts").get("function_output")
     assert result["metadatas"] is not None

--- a/idl/makefile
+++ b/idl/makefile
@@ -26,7 +26,8 @@ proto_go:
     	--plugin protoc-gen-go-grpc="${PROTOC_GEN_GO_GRPC_BIN_PATH}" \
 			chromadb/proto/chroma.proto \
 			chromadb/proto/coordinator.proto \
-			chromadb/proto/logservice.proto
+			chromadb/proto/logservice.proto \
+			chromadb/proto/heapservice.proto
 	@mv ../go/pkg/proto/coordinatorpb/chromadb/proto/logservice*.go ../go/pkg/proto/logservicepb/
 	@mv ../go/pkg/proto/coordinatorpb/chromadb/proto/*.go ../go/pkg/proto/coordinatorpb/
 	@rm -rf ../go/pkg/proto/coordinatorpb/chromadb

--- a/rust/frontend/src/get_collection_with_segments_provider.rs
+++ b/rust/frontend/src/get_collection_with_segments_provider.rs
@@ -199,6 +199,11 @@ impl CollectionsWithSegmentsProvider {
         &mut self,
         collection_and_segments: CollectionAndSegments,
     ) {
+        // Don't cache output collections (created by attached functions).
+        if collection_and_segments.collection.is_output_collection() {
+            return;
+        }
+
         // Insert only if the collection dimension is set.
         if collection_and_segments.collection.dimension.is_some() {
             let collection_id = collection_and_segments.collection.collection_id;

--- a/rust/types/src/collection.rs
+++ b/rust/types/src/collection.rs
@@ -14,6 +14,9 @@ use uuid::Uuid;
 #[cfg(feature = "pyo3")]
 use pyo3::{exceptions::PyValueError, types::PyAnyMethods};
 
+/// Metadata key used to mark output collections and link them to their source attached function.
+pub const SOURCE_ATTACHED_FUNCTION_ID_KEY: &str = "chroma:source_attached_function_id";
+
 /// CollectionUuid is a wrapper around Uuid to provide a type for the collection id.
 #[derive(
     Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize,
@@ -253,6 +256,14 @@ impl Collection {
             database_id: DatabaseUuid::new(),
             ..Default::default()
         }
+    }
+
+    /// Returns true if this collection is an output collection created by an attached function.
+    pub fn is_output_collection(&self) -> bool {
+        self.metadata
+            .as_ref()
+            .map(|m| m.contains_key(SOURCE_ATTACHED_FUNCTION_ID_KEY))
+            .unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Check collection metadata to see if a collection is an output collection and prevent caching its CollectionAndSegments in the frontend if it's true.
  - Get rid of sleep(60) instances in function end to end test cases.
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
