### PR TITLE
[ENH]: Delete attached function when output collection is deleted

### DIFF
--- a/go/pkg/sysdb/coordinator/coordinator_test.go
+++ b/go/pkg/sysdb/coordinator/coordinator_test.go
@@ -2056,6 +2056,83 @@ func (suite *APIsTestSuite) TestCannotAttachToOutputCollection() {
 	suite.NoError(err)
 }
 
+func (suite *APIsTestSuite) TestDeleteOutputCollectionDeletesAttachedFunction() {
+	ctx := context.Background()
+
+	// Create a test input collection
+	inputCollectionID := types.NewUniqueID()
+	inputCollectionName := "test_input_for_delete_output"
+	createInputCollection := &model.CreateCollection{
+		ID:           inputCollectionID,
+		Name:         inputCollectionName,
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	}
+	_, _, err := suite.coordinator.CreateCollection(ctx, createInputCollection)
+	suite.NoError(err)
+
+	// Create a dummy function
+	functionID := uuid.New()
+	functionName := "test_function_for_delete_output"
+	err = suite.db.Create(&dbmodel.Function{
+		ID:            functionID,
+		Name:          functionName,
+		IsIncremental: false,
+		ReturnType:    "{}",
+	}).Error
+	suite.NoError(err)
+
+	// Get database ID
+	databases, err := suite.coordinator.GetDatabase(ctx, &model.GetDatabase{Name: suite.databaseName, Tenant: suite.tenantName})
+	suite.NoError(err)
+
+	// Create attached function first (need its ID for the output collection metadata)
+	attachedFunctionID := uuid.New()
+	outputCollectionID := types.NewUniqueID()
+	outputCollectionIDStr := outputCollectionID.String()
+	err = suite.db.Create(&dbmodel.AttachedFunction{
+		ID:                   attachedFunctionID,
+		Name:                 "test_attached_for_delete_output",
+		TenantID:             suite.tenantName,
+		DatabaseID:           databases.ID,
+		InputCollectionID:    inputCollectionID.String(),
+		OutputCollectionName: "test_output_for_delete",
+		OutputCollectionID:   &outputCollectionIDStr,
+		FunctionID:           functionID,
+		FunctionParams:       "{}",
+		IsReady:              true,
+		IsDeleted:            false,
+	}).Error
+	suite.NoError(err)
+
+	// Create an output collection with metadata pointing to the attached function
+	outputCollectionMetadata := model.NewCollectionMetadata[model.CollectionMetadataValueType]()
+	outputCollectionMetadata.Add(common.SourceAttachedFunctionIDKey, &model.CollectionMetadataValueStringType{Value: attachedFunctionID.String()})
+	createOutputCollection := &model.CreateCollection{
+		ID:           outputCollectionID,
+		Name:         "test_output_for_delete",
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+		Metadata:     outputCollectionMetadata,
+	}
+	_, _, err = suite.coordinator.CreateCollection(ctx, createOutputCollection)
+	suite.NoError(err)
+
+	// Delete the output collection
+	deleteCollection := &model.DeleteCollection{
+		ID:           outputCollectionID,
+		TenantID:     suite.tenantName,
+		DatabaseName: suite.databaseName,
+	}
+	err = suite.coordinator.SoftDeleteCollection(ctx, deleteCollection)
+	suite.NoError(err)
+
+	// Verify attached function is soft deleted
+	var count int64
+	suite.db.Model(&dbmodel.AttachedFunction{}).Where("id = ? AND is_deleted = ?", attachedFunctionID, true).Count(&count)
+	suite.Equal(int64(1), count)
+}
+
 func TestAPIsTestSuite(t *testing.T) {
 	testSuite := new(APIsTestSuite)
 	suite.Run(t, testSuite)


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - As titled, delete an attached function if its output collection is deleted.
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
