### PR TITLE
[ENH]: Change attach_function API to be clearer

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -53,6 +53,13 @@ from chromadb.execution.expression.operator import (
     # Reciprocal Rank Fusion for combining rankings
     Rrf,
 )
+
+# Import attachable functions
+from chromadb.api.functions import (
+    Function,
+    StatisticsFunction,
+    RecordCounterFunction,
+)
 from pathlib import Path
 import os
 
@@ -97,6 +104,10 @@ __all__ = [
     "IntInvertedIndexConfig",
     "FloatInvertedIndexConfig",
     "BoolInvertedIndexConfig",
+    # Attachable Functions
+    "Function",
+    "StatisticsFunction",
+    "RecordCounterFunction",
 ]
 
 from chromadb.types import CloudClientArg

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union, List, cast, Dict, Any
+from typing import TYPE_CHECKING, Optional, Union, List, cast
 
 from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.api.types import (
@@ -27,6 +27,7 @@ import logging
 
 if TYPE_CHECKING:
     from chromadb.api.models.AttachedFunction import AttachedFunction
+    from chromadb.api.functions import Function
 
 logger = logging.getLogger(__name__)
 
@@ -500,36 +501,34 @@ class Collection(CollectionCommon["ServerAPI"]):
 
     def attach_function(
         self,
-        function_id: str,
+        function: "Function",
         name: str,
         output_collection: str,
-        params: Optional[Dict[str, Any]] = None,
     ) -> "AttachedFunction":
         """Attach a function to this collection.
 
         Args:
-            function_id: Built-in function identifier (e.g., "record_counter")
+            function: The function to attach (e.g. StatisticsFunction(), RecordCounterFunction())
             name: Unique name for this attached function
             output_collection: Name of the collection where function output will be stored
-            params: Optional dictionary with function-specific parameters
 
         Returns:
             AttachedFunction: Object representing the attached function
 
         Example:
+            >>> from chromadb.api.functions import StatisticsFunction
             >>> attached_fn = collection.attach_function(
-            ...     function_id="record_counter",
+            ...     function=StatisticsFunction(),
             ...     name="mycoll_stats_fn",
-            ...     output_collection="mycoll_stats",
-            ...     params={"threshold": 100}
+            ...     output_collection="mycoll_stats"
             ... )
         """
         return self._client.attach_function(
-            function_id=function_id,
+            function_id=function.name,
             name=name,
             input_collection_id=self.id,
             output_collection=output_collection,
-            params=params,
+            params=function.params,
             tenant=self.tenant,
             database=self.database,
         )

--- a/chromadb/utils/statistics.py
+++ b/chromadb/utils/statistics.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Optional, Dict, Any, cast
 from collections import defaultdict
 
 from chromadb.api.types import Where
+from chromadb.api.functions import StatisticsFunction
 
 if TYPE_CHECKING:
     from chromadb.api.models.Collection import Collection
@@ -75,10 +76,9 @@ def attach_statistics_function(
         stats_collection_name = f"{collection.name}_statistics"
 
     return collection.attach_function(
+        function=StatisticsFunction(),
         name=get_statistics_fn_name(collection),
-        function_id="statistics",
         output_collection=stats_collection_name,
-        params=None,
     )
 
 

--- a/examples/task_api_example.py
+++ b/examples/task_api_example.py
@@ -7,6 +7,7 @@ collections as new records are added.
 """
 
 import chromadb
+from chromadb import RecordCounterFunction
 import time
 
 # Connect to Chroma server
@@ -37,10 +38,9 @@ print(f"✅ Created collection '{collection.name}' with {collection.count()} doc
 # Attach a function that counts records in the collection
 # The 'record_counter' function processes each record and outputs {"count": N}
 attached_fn = collection.attach_function(
-    function_id="record_counter",  # Built-in function that counts records
+    function=RecordCounterFunction(),
     name="count_my_docs",
-    output_collection="my_documents_counts",  # Auto-created
-    params=None,  # No additional parameters needed
+    output_collection="my_documents_counts",
 )
 
 print("✅ Function attached successfully!")


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - attach_function now accepts a Function() object in its arguments instead of a `function_id` + `params`. This API change should make the definition of `attach_function` clearer.
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
