### PR TITLE
[ENH]: Change attach_function::function_id param to be clearer

### DIFF
--- a/chromadb/api/functions.py
+++ b/chromadb/api/functions.py
@@ -1,0 +1,33 @@
+"""Attachable function definitions for ChromaDB collections.
+
+This module provides function constants that can be attached to collections
+to perform automatic computations on collection data.
+
+Example:
+    >>> from chromadb.api.functions import STATISTICS_FUNCTION
+    >>> attached_fn = collection.attach_function(
+    ...     function=STATISTICS_FUNCTION,
+    ...     name="my_stats",
+    ...     output_collection="my_stats_output"
+    ... )
+"""
+
+from enum import Enum
+
+
+class Function(str, Enum):
+    """Available functions that can be attached to collections."""
+
+    STATISTICS = "statistics"
+    """Computes metadata value frequencies for a collection."""
+
+    RECORD_COUNTER = "record_counter"
+    """Counts records in a collection."""
+
+    # Used only for failure testing - not a real function
+    _NONEXISTENT_TEST_ONLY = "nonexistent_function"
+
+
+# Convenience aliases for cleaner imports
+STATISTICS_FUNCTION = Function.STATISTICS
+RECORD_COUNTER_FUNCTION = Function.RECORD_COUNTER

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -25,6 +25,8 @@ from chromadb.execution.expression.plan import Search
 
 import logging
 
+from chromadb.api.functions import Function
+
 if TYPE_CHECKING:
     from chromadb.api.models.AttachedFunction import AttachedFunction
 
@@ -500,7 +502,7 @@ class Collection(CollectionCommon["ServerAPI"]):
 
     def attach_function(
         self,
-        function_id: str,
+        function: Function,
         name: str,
         output_collection: str,
         params: Optional[Dict[str, Any]] = None,
@@ -508,7 +510,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         """Attach a function to this collection.
 
         Args:
-            function_id: Built-in function identifier (e.g., "record_counter")
+            function: A Function enum value (e.g., STATISTICS_FUNCTION, RECORD_COUNTER_FUNCTION)
             name: Unique name for this attached function
             output_collection: Name of the collection where function output will be stored
             params: Optional dictionary with function-specific parameters
@@ -517,13 +519,14 @@ class Collection(CollectionCommon["ServerAPI"]):
             AttachedFunction: Object representing the attached function
 
         Example:
+            >>> from chromadb.api.functions import STATISTICS_FUNCTION
             >>> attached_fn = collection.attach_function(
-            ...     function_id="record_counter",
+            ...     function=STATISTICS_FUNCTION,
             ...     name="mycoll_stats_fn",
             ...     output_collection="mycoll_stats",
-            ...     params={"threshold": 100}
             ... )
         """
+        function_id = function.value if isinstance(function, Function) else function
         return self._client.attach_function(
             function_id=function_id,
             name=name,

--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -7,6 +7,7 @@ for automatically processing collections.
 
 import pytest
 from chromadb.api.client import Client as ClientCreator
+from chromadb.api.functions import RECORD_COUNTER_FUNCTION, Function
 from chromadb.config import System
 from chromadb.errors import ChromaError, NotFoundError
 from chromadb.test.utils.wait_for_version_increase import (
@@ -30,7 +31,7 @@ def test_count_function_attach_and_detach(basic_http_client: System) -> None:
     # Create a task that counts records in the collection
     attached_fn = collection.attach_function(
         name="count_my_docs",
-        function_id="record_counter",  # Built-in operator that counts records
+        function=RECORD_COUNTER_FUNCTION,
         output_collection="my_documents_counts",
         params=None,
     )
@@ -77,8 +78,8 @@ def test_task_with_invalid_function(basic_http_client: System) -> None:
     # Attempt to create task with non-existent function should raise ChromaError
     with pytest.raises(ChromaError, match="function not found"):
         collection.attach_function(
+            function=Function._NONEXISTENT_TEST_ONLY,
             name="invalid_task",
-            function_id="nonexistent_function",
             output_collection="output_collection",
             params=None,
         )
@@ -94,8 +95,8 @@ def test_attach_function_returns_function_name(basic_http_client: System) -> Non
 
     # Attach a function and verify function_name field in response
     attached_fn = collection.attach_function(
+        function=RECORD_COUNTER_FUNCTION,
         name="my_counter",
-        function_id="record_counter",
         output_collection="output_collection",
         params=None,
     )
@@ -122,8 +123,8 @@ def test_function_multiple_collections(basic_http_client: System) -> None:
     collection1.add(ids=["id1", "id2"], documents=["doc1", "doc2"])
 
     attached_fn1 = collection1.attach_function(
+        function=RECORD_COUNTER_FUNCTION,
         name="task_1",
-        function_id="record_counter",
         output_collection="output_1",
         params=None,
     )
@@ -135,8 +136,8 @@ def test_function_multiple_collections(basic_http_client: System) -> None:
     collection2.add(ids=["id3", "id4"], documents=["doc3", "doc4"])
 
     attached_fn2 = collection2.attach_function(
+        function=RECORD_COUNTER_FUNCTION,
         name="task_2",
-        function_id="record_counter",
         output_collection="output_2",
         params=None,
     )
@@ -170,8 +171,8 @@ def test_functions_one_attached_function_per_collection(
 
     # Create first task on the collection
     attached_fn1 = collection.attach_function(
+        function=RECORD_COUNTER_FUNCTION,
         name="task_1",
-        function_id="record_counter",
         output_collection="output_1",
         params=None,
     )
@@ -182,8 +183,8 @@ def test_functions_one_attached_function_per_collection(
     # (only one attached function allowed per collection)
     with pytest.raises(ChromaError, match="already has an attached function"):
         collection.attach_function(
+            function=RECORD_COUNTER_FUNCTION,
             name="task_2",
-            function_id="record_counter",
             output_collection="output_2",
             params=None,
         )
@@ -191,8 +192,8 @@ def test_functions_one_attached_function_per_collection(
     # Attempt to create a task with the same name but different params should also fail
     with pytest.raises(ChromaError, match="already exists"):
         collection.attach_function(
+            function=RECORD_COUNTER_FUNCTION,
             name="task_1",
-            function_id="record_counter",
             output_collection="output_different",  # Different output collection
             params=None,
         )
@@ -205,8 +206,8 @@ def test_functions_one_attached_function_per_collection(
 
     # Now we should be able to attach a new function
     attached_fn2 = collection.attach_function(
+        function=RECORD_COUNTER_FUNCTION,
         name="task_2",
-        function_id="record_counter",
         output_collection="output_2",
         params=None,
     )
@@ -229,8 +230,8 @@ def test_function_remove_nonexistent(basic_http_client: System) -> None:
     collection = client.create_collection(name="test_collection")
     collection.add(ids=["id1"], documents=["test"])
     attached_fn = collection.attach_function(
+        function=RECORD_COUNTER_FUNCTION,
         name="test_function",
-        function_id="record_counter",
         output_collection="output_collection",
         params=None,
     )
@@ -253,7 +254,7 @@ def test_attach_to_output_collection_fails(basic_http_client: System) -> None:
 
     _ = input_collection.attach_function(
         name="test_function",
-        function_id="record_counter",
+        function=RECORD_COUNTER_FUNCTION,
         output_collection="output_collection",
         params=None,
     )
@@ -264,7 +265,7 @@ def test_attach_to_output_collection_fails(basic_http_client: System) -> None:
     ):
         _ = output_collection.attach_function(
             name="test_function_2",
-            function_id="record_counter",
+            function=RECORD_COUNTER_FUNCTION,
             output_collection="output_collection_2",
             params=None,
         )
@@ -281,7 +282,7 @@ def test_delete_output_collection_detaches_function(basic_http_client: System) -
 
     attached_fn = input_collection.attach_function(
         name="my_function",
-        function_id="record_counter",
+        function=RECORD_COUNTER_FUNCTION,
         output_collection="output_collection",
         params=None,
     )
@@ -306,7 +307,7 @@ def test_delete_orphaned_output_collection(basic_http_client: System) -> None:
 
     attached_fn = input_collection.attach_function(
         name="my_function",
-        function_id="record_counter",
+        function=RECORD_COUNTER_FUNCTION,
         output_collection="output_collection",
         params=None,
     )

--- a/chromadb/utils/statistics.py
+++ b/chromadb/utils/statistics.py
@@ -28,8 +28,8 @@ Example:
 
 from typing import TYPE_CHECKING, Optional, Dict, Any, cast
 from collections import defaultdict
-
 from chromadb.api.types import OneOrMany, Where, maybe_cast_one_to_many
+from chromadb.api.functions import STATISTICS_FUNCTION
 
 if TYPE_CHECKING:
     from chromadb.api.models.Collection import Collection
@@ -71,8 +71,8 @@ def attach_statistics_function(
         >>> stats = get_statistics(collection, "my_collection_statistics")
     """
     return collection.attach_function(
+        function=STATISTICS_FUNCTION,
         name=get_statistics_fn_name(collection),
-        function_id="statistics",
         output_collection=stats_collection_name,
         params=None,
     )

--- a/examples/task_api_example.py
+++ b/examples/task_api_example.py
@@ -8,6 +8,7 @@ collections as new records are added.
 
 import chromadb
 import time
+from chromadb.api.functions import RECORD_COUNTER_FUNCTION
 
 # Connect to Chroma server
 client = chromadb.HttpClient(host="localhost", port=8000)
@@ -37,10 +38,10 @@ print(f"✅ Created collection '{collection.name}' with {collection.count()} doc
 # Attach a function that counts records in the collection
 # The 'record_counter' function processes each record and outputs {"count": N}
 attached_fn = collection.attach_function(
-    function_id="record_counter",  # Built-in function that counts records
+    function=RECORD_COUNTER_FUNCTION,
     name="count_my_docs",
-    output_collection="my_documents_counts",  # Auto-created
-    params=None,  # No additional parameters needed
+    output_collection="my_documents_counts",
+    params=None,
 )
 
 print("✅ Function attached successfully!")


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - attach_function now accepts a Function enum in its new `function` parameter. The old `function_id` parameter has been removed. This API change should make the definition of attach_function clearer.
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
