### PR TITLE
[DOC] Fix doc 500

### DIFF
--- a/docs/docs.trychroma.com/components/markdoc/tabs.tsx
+++ b/docs/docs.trychroma.com/components/markdoc/tabs.tsx
@@ -46,18 +46,15 @@ export const Tabs: React.FC<{ children: ReactElement<TabProps>[] }> = ({
   children,
 }) => {
   const { language } = useContext(AppContext);
-  // If there is only one tab, children is not an array, so we need to convert it to an array.
-  const childrenArray = Array.isArray(children) ? children : [children].filter(Boolean);
-  const languages = childrenArray.map((tab) => tab.props.label);
-  const defaultValue = languages.includes(language) ? language : languages[0];
   return (
     <div className="my-4">
       <UITabs
-        defaultValue={defaultValue}
+        defaultValue={children[0].props.label}
+        value={language}
         className="flex flex-col mt-2 pb-2"
       >
         <TabsList className="justify-start bg-transparent dark:bg-transparent rounded-none p-0 h-fit border-b border-gray-300 mb-4 dark:border-gray-700">
-          {childrenArray.map((tab) => (
+          {children.map((tab) => (
             <TabsTrigger
               key={`${tab.props.label}-header`}
               value={tab.props.label}
@@ -71,7 +68,7 @@ export const Tabs: React.FC<{ children: ReactElement<TabProps>[] }> = ({
           ))}
         </TabsList>
         <div>
-          {childrenArray.map((tab) => (
+          {children.map((tab) => (
             <TabsContent
               key={`${tab.props.label}-content`}
               value={tab.props.label}
@@ -79,10 +76,10 @@ export const Tabs: React.FC<{ children: ReactElement<TabProps>[] }> = ({
             >
               {tab.props.children.type === CodeBlock
                 ? React.cloneElement(tab, {
-                  children: React.cloneElement(tab.props.children, {
-                    showHeader: false,
-                  }),
-                })
+                    children: React.cloneElement(tab.props.children, {
+                      showHeader: false,
+                    }),
+                  })
                 : tab}
             </TabsContent>
           ))}

--- a/docs/docs.trychroma.com/middleware.ts
+++ b/docs/docs.trychroma.com/middleware.ts
@@ -78,7 +78,7 @@ const legacyPathsMapping: Record<string, string> = {
 };
 
 export const middleware = (request: NextRequest) => {
-  const path = request.nextUrl.pathname.toLowerCase();
+  const path = request.nextUrl.pathname;
 
   if (path in legacyPathsMapping) {
     const currentPath = legacyPathsMapping[path];


### PR DESCRIPTION
https://docs.trychroma.com/integrations/embedding-models/sentence-transformer
We're getting a 500 on this page because it uses the wrong markdoc component.

Prod:
<img width="1690" height="963" alt="Screenshot 2025-12-08 at 3 20 38 PM" src="https://github.com/user-attachments/assets/2c16952c-f6a8-4e4a-9a64-14930754bbd8" />

With my change:
<img width="1690" height="963" alt="Screenshot 2025-12-08 at 3 20 24 PM" src="https://github.com/user-attachments/assets/40ecb830-5f99-4342-9ebf-5d409144ef63" />
