### PR TITLE
[ENH]: Make error messages in attach_function clearer

### DIFF
--- a/go/pkg/sysdb/coordinator/task.go
+++ b/go/pkg/sysdb/coordinator/task.go
@@ -3,10 +3,12 @@ package coordinator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/chroma-core/chroma/go/pkg/common"
+	"github.com/chroma-core/chroma/go/pkg/grpcutils"
 	"github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator/model"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbmodel"
@@ -21,59 +23,64 @@ import (
 )
 
 // validateAttachedFunctionMatchesRequest validates that an existing attached function's parameters match the request parameters.
-// Returns an error if any parameters don't match. This is used for idempotency and race condition handling.
-func (s *Coordinator) validateAttachedFunctionMatchesRequest(ctx context.Context, attachedFunction *dbmodel.AttachedFunction, req *coordinatorpb.AttachFunctionRequest) error {
-	// Look up the function for the existing attached function
-	existingFunction, err := s.catalog.metaDomain.FunctionDb(ctx).GetByID(attachedFunction.FunctionID)
-	if err != nil {
-		log.Error("validateAttachedFunctionMatchesRequest: failed to get attached function's function", zap.Error(err))
-		return err
+// Returns (true, nil) if all parameters match (idempotent request).
+// Returns (false, nil) if parameters don't match.
+// Returns (false, err) if there's an error during validation (e.g., DB lookup failure).
+func (s *Coordinator) validateAttachedFunctionMatchesRequest(ctx context.Context, attachedFunction *dbmodel.AttachedFunction, req *coordinatorpb.AttachFunctionRequest) (bool, error) {
+	if attachedFunction.Name != req.Name {
+		// Different attached function exists - error
+		log.Error("validateAttachedFunctionMatchesRequest: collection already has an attached function with different name",
+			zap.String("existing_name", attachedFunction.Name),
+			zap.String("requested_name", req.Name))
+		return false, nil
 	}
-	if existingFunction == nil {
-		log.Error("validateAttachedFunctionMatchesRequest: attached function's function not found")
-		return common.ErrFunctionNotFound
+	if attachedFunction.TenantID != req.TenantId {
+		log.Error("validateAttachedFunctionMatchesRequest: attached function has different tenant")
+		return false, nil
+	}
+	if attachedFunction.OutputCollectionName != req.OutputCollectionName {
+		log.Error("validateAttachedFunctionMatchesRequest: attached function has different output collection name",
+			zap.String("existing", attachedFunction.OutputCollectionName),
+			zap.String("requested", req.OutputCollectionName))
+		return false, nil
+	}
+	if attachedFunction.MinRecordsForInvocation != int64(req.MinRecordsForInvocation) {
+		log.Error("validateAttachedFunctionMatchesRequest: attached function has different min_records_for_invocation",
+			zap.Int64("existing", attachedFunction.MinRecordsForInvocation),
+			zap.Uint64("requested", req.MinRecordsForInvocation))
+		return false, nil
+	}
+
+	// Check if the function matches using the ID-to-name mapping
+	existingFunctionName, err := dbmodel.GetFunctionNameByID(attachedFunction.FunctionID)
+	if err != nil {
+		log.Error("validateAttachedFunctionMatchesRequest: unknown function ID", zap.Error(err))
+		return false, err
+	}
+	if existingFunctionName != req.FunctionName {
+		log.Error("validateAttachedFunctionMatchesRequest: attached function has different function",
+			zap.String("existing", existingFunctionName),
+			zap.String("requested", req.FunctionName))
+		return false, nil
 	}
 
 	// Look up database for comparison
 	databases, err := s.catalog.metaDomain.DatabaseDb(ctx).GetDatabases(req.TenantId, req.Database)
 	if err != nil {
 		log.Error("validateAttachedFunctionMatchesRequest: failed to get database for validation", zap.Error(err))
-		return err
+		return false, err
 	}
 	if len(databases) == 0 {
 		log.Error("validateAttachedFunctionMatchesRequest: database not found")
-		return common.ErrDatabaseNotFound
+		return false, common.ErrDatabaseNotFound
 	}
 
-	// Validate attributes match
-	if existingFunction.Name != req.FunctionName {
-		log.Error("validateAttachedFunctionMatchesRequest: attached function has different function",
-			zap.String("existing", existingFunction.Name),
-			zap.String("requested", req.FunctionName))
-		return status.Errorf(codes.AlreadyExists, "attached function already exists with different function: existing=%s, requested=%s", existingFunction.Name, req.FunctionName)
-	}
-	if attachedFunction.TenantID != req.TenantId {
-		log.Error("validateAttachedFunctionMatchesRequest: attached function has different tenant")
-		return status.Errorf(codes.AlreadyExists, "attached function already exists with different tenant")
-	}
 	if attachedFunction.DatabaseID != databases[0].ID {
 		log.Error("validateAttachedFunctionMatchesRequest: attached function has different database")
-		return status.Errorf(codes.AlreadyExists, "attached function already exists with different database")
-	}
-	if attachedFunction.OutputCollectionName != req.OutputCollectionName {
-		log.Error("validateAttachedFunctionMatchesRequest: attached function has different output collection name",
-			zap.String("existing", attachedFunction.OutputCollectionName),
-			zap.String("requested", req.OutputCollectionName))
-		return status.Errorf(codes.AlreadyExists, "attached function already exists with different output collection: existing=%s, requested=%s", attachedFunction.OutputCollectionName, req.OutputCollectionName)
-	}
-	if attachedFunction.MinRecordsForInvocation != int64(req.MinRecordsForInvocation) {
-		log.Error("validateAttachedFunctionMatchesRequest: attached function has different min_records_for_invocation",
-			zap.Int64("existing", attachedFunction.MinRecordsForInvocation),
-			zap.Uint64("requested", req.MinRecordsForInvocation))
-		return status.Errorf(codes.AlreadyExists, "attached function already exists with different min_records_for_invocation: existing=%d, requested=%d", attachedFunction.MinRecordsForInvocation, req.MinRecordsForInvocation)
+		return false, nil
 	}
 
-	return nil
+	return true, nil
 }
 
 // AttachFunction creates an output collection and attached function in a single transaction
@@ -104,21 +111,26 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			}
 
 			existingAttachedFunction := existingAttachedFunctions[0]
-			// There's already an attached function for this collection
-			if existingAttachedFunction.Name != req.Name {
-				// Different attached function exists - error
-				log.Error("AttachFunction: collection already has an attached function with different name",
-					zap.String("existing_name", existingAttachedFunction.Name),
-					zap.String("requested_name", req.Name))
-				return status.Errorf(codes.AlreadyExists, "collection already has an attached function: %s", existingAttachedFunction.Name)
-			}
 
 			// Same name - validate it matches our request (idempotency)
 			log.Info("AttachFunction: attached function exists with same name, validating parameters",
 				zap.String("attached_function_id", existingAttachedFunction.ID.String()))
 
-			if err := s.validateAttachedFunctionMatchesRequest(txCtx, existingAttachedFunction, req); err != nil {
+			matches, err := s.validateAttachedFunctionMatchesRequest(txCtx, existingAttachedFunction, req)
+			if err != nil {
 				return err
+			}
+			if !matches {
+				functionName, err := dbmodel.GetFunctionNameByID(existingAttachedFunction.FunctionID)
+				if err != nil {
+					log.Error("AttachFunction: unknown function ID", zap.Error(err))
+					return err
+				}
+				return status.Errorf(codes.AlreadyExists,
+					"collection already has an attached function: name=%s, function=%s, output_collection=%s",
+					existingAttachedFunction.Name,
+					functionName,
+					existingAttachedFunction.OutputCollectionName)
 			}
 
 			// Validation passed, reuse the existing attached function ID (idempotent)
@@ -168,18 +180,14 @@ func (s *Coordinator) AttachFunction(ctx context.Context, req *coordinatorpb.Att
 			}
 		}
 
-		// Serialize params
-		var paramsJSON string
-		if req.Params != nil {
-			paramsBytes, err := req.Params.MarshalJSON()
-			if err != nil {
-				log.Error("AttachFunction: failed to marshal params", zap.Error(err))
-				return err
-			}
-			paramsJSON = string(paramsBytes)
-		} else {
-			paramsJSON = "{}"
+		// Validate params - currently no functions accept params
+		if req.Params != nil && len(req.Params.Fields) > 0 {
+			log.Error("AttachFunction: params must be empty - no functions currently accept parameters")
+			return status.Errorf(codes.InvalidArgument, "params must be empty - no functions currently accept parameters")
 		}
+
+		// Serialize params
+		paramsJSON := "{}"
 
 		// Create attached function
 		now := time.Now()
@@ -597,6 +605,9 @@ func (s *Coordinator) FinishCreateAttachedFunction(ctx context.Context, req *coo
 		_, _, err = s.catalog.CreateCollectionAndSegments(txCtx, collection, segments, 0)
 		if err != nil {
 			log.Error("FinishCreateAttachedFunction: failed to create output collection", zap.Error(err))
+			if err == common.ErrCollectionUniqueConstraintViolation {
+				return grpcutils.BuildAlreadyExistsGrpcError(fmt.Sprintf("output collection '%s' already exists", collection.Name))
+			}
 			return err
 		}
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/constants.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/constants.go
@@ -1,6 +1,10 @@
 package dbmodel
 
-import "github.com/google/uuid"
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 // Constants for pre-populated functions.
 // These UUIDs must match what's in the database migrations.
@@ -28,6 +32,22 @@ const (
 	// FunctionNameStatistics must match rust/types/src/functions.rs::FUNCTION_STATISTICS_NAME
 	FunctionNameStatistics = "statistics"
 )
+
+// functionIDToName maps function UUIDs to their names.
+// This avoids DB lookups for known built-in functions.
+var functionIDToName = map[uuid.UUID]string{
+	FunctionRecordCounter: FunctionNameRecordCounter,
+	FunctionStatistics:    FunctionNameStatistics,
+}
+
+// GetFunctionNameByID returns the function name for a given function ID.
+// Returns an error if the function ID is not a known built-in.
+func GetFunctionNameByID(id uuid.UUID) (string, error) {
+	if name, ok := functionIDToName[id]; ok {
+		return name, nil
+	}
+	return "", fmt.Errorf("unknown function ID: %s", id.String())
+}
 
 // Function metadata
 const (

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -675,7 +675,7 @@ impl SqliteSysDb {
         _min_records_for_attached_function: u64,
     ) -> Result<chroma_types::AttachedFunctionUuid, crate::AttachFunctionError> {
         // TODO: Implement this when attached function support is added to SqliteSysDb
-        Err(crate::AttachFunctionError::FailedToCreateAttachedFunction(
+        Err(crate::AttachFunctionError::InternalError(
             tonic::Status::unimplemented(
                 " Attached Function operations not yet implemented in SqliteSysDb",
             ),

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -2396,16 +2396,24 @@ pub struct GetAttachedFunctionResponse {
 
 #[derive(Error, Debug)]
 pub enum AttachFunctionError {
-    #[error(" Attached Function with name [{0}] already exists")]
+    #[error("{0}")]
     AlreadyExists(String),
+    #[error("{0}")]
+    CollectionAlreadyHasFunction(String),
     #[error("Failed to get collection and segments")]
     GetCollectionError(#[from] GetCollectionError),
     #[error("Input collection [{0}] does not exist")]
     InputCollectionNotFound(String),
     #[error("Output collection [{0}] already exists")]
     OutputCollectionExists(String),
+    #[error("{0}")]
+    InvalidArgument(String),
+    #[error("{0}")]
+    FunctionNotFound(String),
     #[error(transparent)]
     Validation(#[from] ChromaValidationError),
+    #[error(transparent)]
+    FinishCreate(#[from] crate::FinishCreateAttachedFunctionError),
     #[error(transparent)]
     Internal(#[from] Box<dyn ChromaError>),
 }
@@ -2414,10 +2422,14 @@ impl ChromaError for AttachFunctionError {
     fn code(&self) -> ErrorCodes {
         match self {
             AttachFunctionError::AlreadyExists(_) => ErrorCodes::AlreadyExists,
+            AttachFunctionError::CollectionAlreadyHasFunction(_) => ErrorCodes::FailedPrecondition,
             AttachFunctionError::GetCollectionError(err) => err.code(),
             AttachFunctionError::InputCollectionNotFound(_) => ErrorCodes::NotFound,
             AttachFunctionError::OutputCollectionExists(_) => ErrorCodes::AlreadyExists,
+            AttachFunctionError::InvalidArgument(_) => ErrorCodes::InvalidArgument,
+            AttachFunctionError::FunctionNotFound(_) => ErrorCodes::NotFound,
             AttachFunctionError::Validation(err) => err.code(),
+            AttachFunctionError::FinishCreate(err) => err.code(),
             AttachFunctionError::Internal(err) => err.code(),
         }
     }

--- a/rust/types/src/flush.rs
+++ b/rust/types/src/flush.rs
@@ -55,6 +55,8 @@ pub enum FinishCreateAttachedFunctionError {
     FailedToFinishCreateAttachedFunction(#[from] tonic::Status),
     #[error("Attached function not found")]
     AttachedFunctionNotFound,
+    #[error("Output collection already exists")]
+    OutputCollectionExists,
 }
 
 impl ChromaError for FinishCreateAttachedFunctionError {
@@ -64,6 +66,7 @@ impl ChromaError for FinishCreateAttachedFunctionError {
                 ErrorCodes::Internal
             }
             FinishCreateAttachedFunctionError::AttachedFunctionNotFound => ErrorCodes::NotFound,
+            FinishCreateAttachedFunctionError::OutputCollectionExists => ErrorCodes::AlreadyExists,
         }
     }
 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Errors fixed:
        - Param validation
        - Output collection already exists error looks nicer now
        - Function already exists error looks cleaner
        - Invalid function to be attached error added
        - Collection already has an attached function
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_