### PR TITLE
[BUG]: Allow repairing partially created attached functions

### DIFF
--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -69,7 +69,7 @@ func (suite *AttachFunctionTestSuite) setupAttachFunctionMocks(ctx context.Conte
 	// Phase 1: Create attached function in transaction
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", inputCollectionID).
+	suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -165,7 +165,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 	// Setup mocks that will be called within the transaction (using mock.Anything for context)
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", inputCollectionID).
+	suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	// Look up database
@@ -283,7 +283,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Alrea
 
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
-			suite.mockAttachedFunctionDb.On("GetByCollectionID", inputCollectionID).
+			suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -352,7 +352,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 	// Phase 1: Create attached function in transaction
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", inputCollectionID).
+	suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -408,7 +408,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
-			suite.mockAttachedFunctionDb.On("GetByCollectionID", inputCollectionID).
+			suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
 				Return([]*dbmodel.AttachedFunction{incompleteAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -484,6 +484,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 		OutputCollectionName:    outputCollectionName,
 		FunctionID:              existingOperatorID,
 		MinRecordsForInvocation: int64(MinRecordsForInvocation),
+		IsReady:                 true,
 		CreatedAt:               now,
 		UpdatedAt:               now,
 	}
@@ -497,7 +498,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
-			suite.mockAttachedFunctionDb.On("GetByCollectionID", inputCollectionID).
+			suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup)

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -153,6 +153,21 @@ func (s *attachedFunctionDb) GetByCollectionID(inputCollectionID string) ([]*dbm
 	return attachedFunctions, nil
 }
 
+func (s *attachedFunctionDb) GetAnyByCollectionID(inputCollectionID string) ([]*dbmodel.AttachedFunction, error) {
+	var attachedFunctions []*dbmodel.AttachedFunction
+	err := s.db.
+		Where("input_collection_id = ?", inputCollectionID).
+		Where("is_deleted = ?", false).
+		Find(&attachedFunctions).Error
+
+	if err != nil {
+		log.Error("GetAnyByCollectionID failed", zap.Error(err), zap.String("input_collection_id", inputCollectionID))
+		return nil, err
+	}
+
+	return attachedFunctions, nil
+}
+
 func (s *attachedFunctionDb) SoftDelete(inputCollectionID string, name string) error {
 	// Update name and is_deleted in a single query
 	// Format: _deleted_<original_name>_<id>

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -202,6 +202,36 @@ func (_m *IAttachedFunctionDb) GetAnyByName(inputCollectionID string, name strin
 	return r0, r1
 }
 
+// GetAnyByCollectionID provides a mock function with given fields: inputCollectionID
+func (_m *IAttachedFunctionDb) GetAnyByCollectionID(inputCollectionID string) ([]*dbmodel.AttachedFunction, error) {
+	ret := _m.Called(inputCollectionID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAnyByCollectionID")
+	}
+
+	var r0 []*dbmodel.AttachedFunction
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]*dbmodel.AttachedFunction, error)); ok {
+		return rf(inputCollectionID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []*dbmodel.AttachedFunction); ok {
+		r0 = rf(inputCollectionID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*dbmodel.AttachedFunction)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(inputCollectionID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAnyByID provides a mock function with given fields: id
 func (_m *IAttachedFunctionDb) GetAnyByID(id uuid.UUID) (*dbmodel.AttachedFunction, error) {
 	ret := _m.Called(id)

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -42,6 +42,7 @@ type IAttachedFunctionDb interface {
 	GetByID(id uuid.UUID) (*AttachedFunction, error)
 	GetAnyByID(id uuid.UUID) (*AttachedFunction, error) // TODO(tanujnay112): Consolidate all the getters.
 	GetByCollectionID(inputCollectionID string) ([]*AttachedFunction, error)
+	GetAnyByCollectionID(inputCollectionID string) ([]*AttachedFunction, error)
 	Update(attachedFunction *AttachedFunction) error
 	Finish(id uuid.UUID) error
 	SoftDelete(inputCollectionID string, name string) error


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - The attach_function codepath did not allow repairing a nonready function that was a result of a previously failed attach. This diff fixes that.
    - This diff also adds code to the FinishCreateAttachedFunction method to ensure the invariant that there can only be one function attached to a collection.
- New functionality
    - ...

Many changes and tests here were ported from a change @rescrv had made.

## Test plan

_How are these changes tested?_

test_task_api.py has been edited for this change.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_