### PR TITLE
[ENH]: Adjust attach_function API to indicate if it was a first time creation or idempotent get

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -36,7 +36,7 @@ from chromadb.execution.expression import (  # noqa: F401, F403
 )
 
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional, List, Dict, Any
+from typing import Sequence, Optional, List, Dict, Any, Tuple
 from uuid import UUID
 
 from overrides import override
@@ -824,7 +824,7 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
         params: Optional[Dict[str, Any]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> "AttachedFunction":
+    ) -> Tuple["AttachedFunction", bool]:
         """Attach a function to a collection.
 
         Args:
@@ -837,7 +837,8 @@ class ServerAPI(BaseAPI, AdminAPI, Component):
             database: The database name
 
         Returns:
-            AttachedFunction: Object representing the attached function
+            Tuple of (AttachedFunction, created) where created is True if newly created,
+            False if already existed (idempotent request)
         """
         pass
 

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -773,7 +773,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         params: Optional[Dict[str, Any]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> "AttachedFunction":
+    ) -> Tuple["AttachedFunction", bool]:
         """Attach a function to a collection."""
         resp_json = self._make_request(
             "post",
@@ -786,7 +786,7 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             },
         )
 
-        return AttachedFunction(
+        attached_function = AttachedFunction(
             client=self,
             id=UUID(resp_json["attached_function"]["id"]),
             name=resp_json["attached_function"]["name"],
@@ -797,6 +797,10 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             tenant=tenant,
             database=database,
         )
+        created = resp_json.get(
+            "created", True
+        )  # Default to True for backwards compatibility
+        return (attached_function, created)
 
     @trace_method("FastAPI.get_attached_function", OpenTelemetryGranularity.ALL)
     @override

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union, List, cast, Dict, Any
+from typing import TYPE_CHECKING, Optional, Union, List, cast, Dict, Any, Tuple
 
 from chromadb.api.models.CollectionCommon import CollectionCommon
 from chromadb.api.types import (
@@ -506,7 +506,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         name: str,
         output_collection: str,
         params: Optional[Dict[str, Any]] = None,
-    ) -> "AttachedFunction":
+    ) -> Tuple["AttachedFunction", bool]:
         """Attach a function to this collection.
 
         Args:
@@ -516,7 +516,8 @@ class Collection(CollectionCommon["ServerAPI"]):
             params: Optional dictionary with function-specific parameters
 
         Returns:
-            AttachedFunction: Object representing the attached function
+            Tuple of (AttachedFunction, created) where created is True if newly created,
+            False if already existed (idempotent request)
 
         Example:
             >>> from chromadb.api.functions import STATISTICS_FUNCTION
@@ -525,6 +526,10 @@ class Collection(CollectionCommon["ServerAPI"]):
             ...     name="mycoll_stats_fn",
             ...     output_collection="mycoll_stats",
             ... )
+            >>> if created:
+            ...     print("New function attached")
+            ... else:
+            ...     print("Function already existed")
         """
         function_id = function.value if isinstance(function, Function) else function
         return self._client.attach_function(

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -49,7 +49,7 @@ from chromadb.execution.expression.plan import Search
 import chromadb_rust_bindings
 
 
-from typing import Optional, Sequence, List, Dict, Any
+from typing import Optional, Sequence, List, Dict, Any, Tuple
 from overrides import override
 from uuid import UUID
 import json
@@ -613,7 +613,7 @@ class RustBindingsAPI(ServerAPI):
         params: Optional[Dict[str, Any]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> "AttachedFunction":
+    ) -> Tuple["AttachedFunction", bool]:
         """Attached functions are not supported in the Rust bindings (local embedded mode)."""
         raise NotImplementedError(
             "Attached functions are only supported when connecting to a Chroma server via HttpClient. "

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -75,6 +75,7 @@ from typing import (
     Dict,
     Callable,
     TypeVar,
+    Tuple,
 )
 from overrides import override
 from uuid import UUID, uuid4
@@ -922,7 +923,7 @@ class SegmentAPI(ServerAPI):
         params: Optional[Dict[str, Any]] = None,
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
-    ) -> "AttachedFunction":
+    ) -> Tuple["AttachedFunction", bool]:
         """Attached functions are not supported in the Segment API (local embedded mode)."""
         raise NotImplementedError(
             "Attached functions are only supported when connecting to a Chroma server via HttpClient. "

--- a/chromadb/test/distributed/test_statistics_wrapper.py
+++ b/chromadb/test/distributed/test_statistics_wrapper.py
@@ -35,8 +35,9 @@ def test_statistics_wrapper(basic_http_client: System) -> None:
     )
 
     # Enable statistics
-    attached_fn = attach_statistics_function(collection, "test_collection_statistics")
+    attached_fn, created = attach_statistics_function(collection, "test_collection_statistics")
     assert attached_fn is not None
+    assert created is True
     assert attached_fn.function_name == "statistics"
     assert attached_fn.output_collection == "test_collection_statistics"
 
@@ -128,7 +129,8 @@ def test_backfill_statistics(basic_http_client: System) -> None:
     initial_version = get_collection_version(client, collection.name)
 
     # Enable statistics
-    attached_fn = attach_statistics_function(collection, "my_collection_statistics")
+    attached_fn, created = attach_statistics_function(collection, "my_collection_statistics")
+    assert created is True
     assert attached_fn.function_name == "statistics"
     assert attached_fn.output_collection == "my_collection_statistics"
 
@@ -177,9 +179,10 @@ def test_statistics_wrapper_custom_output_collection(basic_http_client: System) 
     collection = client.create_collection(name="my_collection")
 
     # Enable statistics with custom output collection name
-    attached_fn = attach_statistics_function(
+    attached_fn, created = attach_statistics_function(
         collection, stats_collection_name="my_custom_stats"
     )
+    assert created is True
     assert attached_fn.output_collection == "my_custom_stats"
 
     initial_version = get_collection_version(client, collection.name)
@@ -210,7 +213,8 @@ def test_statistics_wrapper_key_filter(basic_http_client: System) -> None:
     collection = client.create_collection(name="key_filter_test")
 
     # Enable statistics
-    attach_statistics_function(collection, "key_filter_test_statistics")
+    _, created = attach_statistics_function(collection, "key_filter_test_statistics")
+    assert created is True
 
     initial_version = get_collection_version(client, collection.name)
 
@@ -295,7 +299,8 @@ def test_statistics_wrapper_incremental_updates(basic_http_client: System) -> No
     client.reset()
 
     collection = client.create_collection(name="incremental_test")
-    attach_statistics_function(collection, "incremental_test_statistics")
+    _, created = attach_statistics_function(collection, "incremental_test_statistics")
+    assert created is True
 
     initial_version = get_collection_version(client, collection.name)
 
@@ -365,7 +370,8 @@ def test_sparse_vector_statistics(basic_http_client: System) -> None:
             {"category": "A", "vec": sparse_vec3},
         ],
     )
-    attach_statistics_function(collection, "sparse_vector_test1_statistics")
+    _, created = attach_statistics_function(collection, "sparse_vector_test1_statistics")
+    assert created is True
 
     initial_version = get_collection_version(client, collection.name)
 
@@ -441,7 +447,8 @@ def test_statistics_high_cardinality(basic_http_client: System) -> None:
     initial_version = get_collection_version(client, collection.name)
 
     # Enable statistics
-    attach_statistics_function(collection, "high_cardinality_test_statistics")
+    _, created = attach_statistics_function(collection, "high_cardinality_test_statistics")
+    assert created is True
 
     # Wait for statistics to be computed
     wait_for_version_increase(client, collection.name, initial_version)

--- a/chromadb/utils/statistics.py
+++ b/chromadb/utils/statistics.py
@@ -26,7 +26,7 @@ Example:
     >>> print(stats)
 """
 
-from typing import TYPE_CHECKING, Optional, Dict, Any, cast
+from typing import TYPE_CHECKING, Optional, Dict, Any, cast, Tuple
 from collections import defaultdict
 from chromadb.api.types import OneOrMany, Where, maybe_cast_one_to_many
 from chromadb.api.functions import STATISTICS_FUNCTION
@@ -50,7 +50,7 @@ def get_statistics_fn_name(collection: "Collection") -> str:
 
 def attach_statistics_function(
     collection: "Collection", stats_collection_name: str
-) -> "AttachedFunction":
+) -> Tuple["AttachedFunction", bool]:
     """Attach statistics collection function to a collection.
 
     This attaches the statistics function which will automatically compute
@@ -62,10 +62,13 @@ def attach_statistics_function(
         stats_collection_name: Name of the collection where statistics will be stored.
 
     Returns:
-        AttachedFunction: The attached statistics function
+        Tuple of (AttachedFunction, created) where created is True if newly created,
+        False if already existed (idempotent request)
 
     Example:
-        >>> attach_statistics_function(collection, "my_collection_statistics")
+        >>> attached_fn, created = attach_statistics_function(collection, "my_collection_statistics")
+        >>> if created:
+        ...     print("Statistics function newly attached")
         >>> collection.add(ids=["id1"], documents=["doc1"], metadatas=[{"key": "value"}])
         >>> # Statistics are automatically computed
         >>> stats = get_statistics(collection, "my_collection_statistics")

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -21,6 +21,10 @@ export type AttachFunctionRequest = {
 
 export type AttachFunctionResponse = {
     attached_function: AttachedFunctionInfo;
+    /**
+     * True if newly created, false if already existed (idempotent request)
+     */
+    created: boolean;
 };
 
 /**

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -566,6 +566,7 @@ message AttachFunctionRequest {
 
 message AttachFunctionResponse {
   AttachedFunction attached_function = 1;
+  bool created = 2;  // True if newly created, false if already existed (idempotent)
 }
 
 message GetAttachedFunctionByNameRequest {
@@ -624,7 +625,9 @@ message FinishCreateAttachedFunctionRequest {
   string id = 1;
 }
 
-message FinishCreateAttachedFunctionResponse {}
+message FinishCreateAttachedFunctionResponse {
+  bool created = 1;  // True if newly created, false if already existed (idempotent)
+}
 
 message CleanupExpiredPartialAttachedFunctionsRequest {
   // Attached functions older than this will be deleted

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -673,7 +673,7 @@ impl SqliteSysDb {
         _tenant_id: String,
         _database_id: String,
         _min_records_for_attached_function: u64,
-    ) -> Result<chroma_types::AttachedFunctionUuid, crate::AttachFunctionError> {
+    ) -> Result<(chroma_types::AttachedFunctionUuid, bool), crate::AttachFunctionError> {
         // TODO: Implement this when attached function support is added to SqliteSysDb
         Err(crate::AttachFunctionError::InternalError(
             tonic::Status::unimplemented(

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -2330,6 +2330,8 @@ pub struct AttachedFunctionInfo {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct AttachFunctionResponse {
     pub attached_function: AttachedFunctionInfo,
+    /// True if newly created, false if already existed (idempotent request)
+    pub created: bool,
 }
 
 /// API response struct for attached function with function_name instead of function_id

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -1312,7 +1312,7 @@ mod tests {
         let output_collection_name = format!("test_stats_output_{}", test_run_id);
 
         // Create statistics attached function via sysdb
-        let attached_function_id = sysdb
+        let (attached_function_id, _created) = sysdb
             .create_attached_function(
                 attached_function_name.to_string(),
                 "statistics".to_string(),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -2875,7 +2875,7 @@ mod tests {
         let output_collection_name = format!("test_rebuild_output_{}", test_run_id);
 
         // Create statistics attached function via sysdb
-        let attached_function_id = sysdb
+        let (attached_function_id, _created) = sysdb
             .create_attached_function(
                 attached_function_name.clone(),
                 "statistics".to_string(),


### PR DESCRIPTION
## Description of changes

As titied, `attach_function` returns an extra value that indicates whether the attachment was new or it just fetched a pre-existing attached function.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
