### PR TITLE
[BUG]  Cleanup CI collections that fail due to forking.

### DIFF
--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -1575,6 +1575,7 @@ mod tests {
 
             let target_name = unique_collection_name("test_fork_target");
             let forked = collection.fork(target_name.clone()).await.unwrap();
+            client.track(&forked);
             println!("Forked collection: {:?}", forked);
 
             assert_eq!(forked.collection.name, target_name);
@@ -1609,6 +1610,7 @@ mod tests {
 
             let target_name = unique_collection_name("test_fork_preserves_target");
             let forked = collection.fork(target_name).await.unwrap();
+            client.track(&forked);
 
             let forked_get_response = forked
                 .get(
@@ -1646,6 +1648,7 @@ mod tests {
 
             let target_name = unique_collection_name("test_fork_independence_target");
             let forked = collection.fork(target_name).await.unwrap();
+            client.track(&forked);
 
             forked
                 .add(

--- a/rust/chroma/src/lib.rs
+++ b/rust/chroma/src/lib.rs
@@ -163,6 +163,11 @@ mod tests {
                 .await
                 .unwrap()
         }
+
+        pub fn track(&mut self, collection: &ChromaCollection) {
+            let mut collections = self.collections.lock().unwrap();
+            collections.insert(collection.collection.name.clone());
+        }
     }
 
     impl std::ops::Deref for TestClient {


### PR DESCRIPTION
## Description of changes

Fork leaks the forks.  List collections looks for a newly-created
connection.  With enough leaks, the new collection won't appear in the
first page of results and thus error.

This tracks the connections for cleanup using the same cleanup mechanism
used for non-forks.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
