### PR TITLE
[CLN] Remove extraneous config paths

### DIFF
--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -15,23 +15,17 @@ rustFrontendService:
       value: "true"
     - name: RUST_BACKTRACE
       value: 'value: "1"'
-    - name: CONFIG_PATH
-      value: "chroma_config.yaml"
 
 queryService:
   env:
     - name: RUST_BACKTRACE
       value: 'value: "1"'
-    - name: CONFIG_PATH
-      value: 'value: "/chroma_config.yaml"'
   jemallocConfig: "prof:true,prof_active:true,lg_prof_sample:19"
 
 compactionService:
   env:
     - name: RUST_BACKTRACE
       value: 'value: "1"'
-    - name: CONFIG_PATH
-      value: 'value: "/chroma_config.yaml"'
   jemallocConfig: "prof:true,prof_active:true,lg_prof_sample:19"
 
 rustLogService:

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -79,7 +79,6 @@ RUN apt-get update && apt-get install -y dumb-init libssl-dev ca-certificates &&
 FROM runner AS cli
 
 COPY --from=builder /chroma/rust/frontend/sample_configs/docker_single_node.yaml /config.yaml
-COPY --from=builder /chroma/rust/frontend/sample_configs/distributed.yaml /chroma_config.yaml
 COPY --from=builder /chroma/chroma /usr/local/bin/chroma
 
 EXPOSE 8000
@@ -104,11 +103,9 @@ COPY --from=builder /chroma/heap_tender_service .
 ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./heap_tender_service" ]
 
 FROM runner AS query_service
-COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
 COPY --from=builder /chroma/query_service .
 ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./query_service" ]
 
 FROM runner AS compaction_service
-COPY --from=builder /chroma/rust/worker/chroma_config.yaml .
 COPY --from=builder /chroma/compaction_service .
 ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./compaction_service" ]


### PR DESCRIPTION
## Description of changes

We already specify `CONFIG_PATH` env var via our helm chart, which loads the config provided via helm values overrides. There is no reason to override that, and use bundled-in config files instead.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
