### PR TITLE
[ENH] Only load blocks for updated records

### DIFF
--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -609,10 +609,6 @@ pub async fn materialize_logs(
                     );
                 };
             }
-
-            reader
-                .load_id_to_data(existing_offset_ids.iter().cloned())
-                .await;
             Ok::<_, LogMaterializerError>(())
         }
         .instrument(Span::current())


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Optimizes the materialize logic by moving record segment block load out into materialize operator, and selectively load only the updated records.
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
