### PR TITLE
[ENH][wal3] Allow different config of the dirty log writer.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2328,7 +2328,7 @@ impl Configurable<LogServerConfig> for LogServer {
         let storage = Storage::try_from_config(&config.storage, registry).await?;
         let storage = Arc::new(storage);
         let dirty_log = LogWriter::open_or_initialize(
-            config.dirty.clone().unwrap_or(config.writer.clone()),
+            config.dirty.as_ref().unwrap_or(&config.writer).clone(),
             Arc::clone(&storage),
             &MarkDirty::path_for_hostname(&config.my_member_id),
             "dirty log writer",


### PR DESCRIPTION
## Description of changes

This allows us to, for example, set the dirty log writer's fragment
write interval to 1s so that the dirty log won't flush more than once
per second.

## Test plan

CI

## Migration plan

Configure on staging, push to prod.

## Observability plan

N/A

## Documentation Changes

N/A
