### PR TITLE
[ENH] Do not retry permission denied error in wal3

### DIFF
--- a/rust/storage/src/object_storage.rs
+++ b/rust/storage/src/object_storage.rs
@@ -102,8 +102,8 @@ impl From<object_store::Error> for StorageError {
             object_store::Error::InvalidPath { source } => StorageError::Generic {
                 source: Arc::new(source),
             },
-            object_store::Error::Generic { store, source } => StorageError::Generic {
-                source: Arc::new(std::io::Error::other(format!("{}: {}", store, source))),
+            err @ object_store::Error::Generic { .. } => StorageError::Generic {
+                source: Arc::new(err),
             },
             object_store::Error::JoinError { source } => StorageError::Generic {
                 source: Arc::new(source),
@@ -111,8 +111,8 @@ impl From<object_store::Error> for StorageError {
             object_store::Error::UnknownConfigurationKey { store, key } => {
                 StorageError::UnknownConfigurationKey { store, key }
             }
-            _ => StorageError::Generic {
-                source: Arc::new(e),
+            err => StorageError::Generic {
+                source: Arc::new(err),
             },
         }
     }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Do not retry permission denied error during parquet upload in wal3
  - Trace retried error in wal3
  - Improve error conversion in storage
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
