### PR TITLE
[CHORE]: Prevent users from editing the source attached function collection metadata

### DIFF
--- a/go/pkg/common/errors.go
+++ b/go/pkg/common/errors.go
@@ -36,6 +36,7 @@ var (
 	// Collection metadata errors
 	ErrUnknownCollectionMetadataType = errors.New("collection metadata value type not supported")
 	ErrInvalidMetadataUpdate         = errors.New("invalid metadata update, reest metadata true and metadata value not empty")
+	ErrSystemMetadataKeyNotAllowed   = errors.New("cannot set or modify system-reserved metadata key")
 
 	// Segment errors
 	ErrSegmentIDFormat                  = errors.New("segment id format error")


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Make chroma::source_collection_id a protected collection metadata field by checking for this on the CreateCollection and UpdateCollection paths.
- New functionality
  - ...

## Test plan

Added a test in test_task_api.py

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
