### PR TITLE
[ENH] Reduce max backoff retry interval in wal3

### DIFF
--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -1150,12 +1150,14 @@ pub async fn upload_parquet(
                     error.message = err.to_string(),
                     "failed to upload parquet, backing off"
                 );
-                if start.elapsed() > Duration::from_secs(60) {
+                // NOTE(sicheng): The frontend will fail the request on its end if we retry for too long here
+                // TODO(sicheng): Organize the magic numbers in the code at one place
+                if start.elapsed() > Duration::from_secs(20) {
                     return Err(Error::StorageError(Arc::new(err)));
                 }
                 let mut backoff = exp_backoff.next();
-                if backoff > Duration::from_secs(60) {
-                    backoff = Duration::from_secs(60);
+                if backoff > Duration::from_secs(10) {
+                    backoff = Duration::from_secs(10);
                 }
                 tokio::time::sleep(backoff).await;
             }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Reduces the max backoff retry interval for `parquet_upload`. Previously it can retry for longer than one minute, which will result in frontend cutting off the request on its end and return timeout error, and this will not be intuitive for the user
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
