### PR TITLE
[BUG]: Fix deadlock in orchestrator test

### DIFF
--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -368,8 +368,9 @@ mod tests {
         }
     }
 
+    // TODO(tanujnay112): Write a test that actually tests cancellation
     #[tokio::test]
-    async fn test_operator_cancellation() {
+    async fn test_simple_operator() {
         let system = System::new();
         let num_workers = 2;
 
@@ -377,7 +378,8 @@ mod tests {
         let dispatcher = Dispatcher::new(DispatcherConfig {
             num_worker_threads: num_workers,
             task_queue_limit: 1,
-            dispatcher_queue_size: 1,
+            // 1 message for the task + 1 for each worker thread's TaskRequestMessage
+            dispatcher_queue_size: 3,
             worker_queue_size: 1,
             active_io_tasks: 10,
         });


### PR DESCRIPTION
## Description of changes

`test_operator_cancellation` had a race condition before this change. It spawned a dispatcher with a max size of one with 2 worker threads before sending a task to it. If the task gets sent before the worker threads are able to send a `TaskRequestMessage` to this queue then the worker threads don't get registered with the dispatcher and there is nobody to process the enqueued task.

This diff fixes that by bumping the dispatcher size to 3. Also, this test does not seem to test cancellation anymore so it has been renamed.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
