### PR TITLE
[ENH][wal3] introduce FragmentPublisher trait for publishing abstraction

### DIFF
--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+use tracing::Span;
+
+use crate::{Error, LogPosition, ManifestManager};
+
+pub mod s3;
+
+#[async_trait::async_trait]
+pub trait FragmentPublisher {
+    type FragmentPointer;
+
+    /// Enqueue work to be published.
+    async fn push_work(
+        &self,
+        messages: Vec<Vec<u8>>,
+        tx: tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
+        span: Span,
+    );
+    /// Take enqueued work to be published.
+    async fn take_work(
+        &self,
+        manifest_manager: &ManifestManager,
+    ) -> Result<
+        Option<(
+            Self::FragmentPointer,
+            Vec<(
+                Vec<Vec<u8>>,
+                tokio::sync::oneshot::Sender<Result<LogPosition, Error>>,
+                Span,
+            )>,
+        )>,
+        Error,
+    >;
+    /// Finish the previous call to take_work.
+    async fn finish_write(&self);
+
+    /// Wait until take_work might have work.
+    async fn wait_for_writable(&self);
+    /// How long to sleep until take work might have work.
+    fn until_next_time(&self) -> Duration;
+
+    /// Start shutting down.  The shutdown is split for historical and unprincipled reasons.
+    fn shutdown_prepare(&self);
+    /// Finish shutting down.
+    fn shutdown_finish(&self);
+}

--- a/rust/wal3/src/interfaces/s3/mod.rs
+++ b/rust/wal3/src/interfaces/s3/mod.rs
@@ -1,0 +1,3 @@
+pub mod batch_manager;
+
+pub use batch_manager::BatchManager;

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -7,11 +7,11 @@ use setsum::Setsum;
 use uuid::Uuid;
 
 mod backoff;
-mod batch_manager;
 mod copy;
 mod cursors;
 mod destroy;
 mod gc;
+mod interfaces;
 mod manifest;
 mod manifest_manager;
 mod reader;
@@ -19,11 +19,12 @@ mod snapshot_cache;
 mod writer;
 
 pub use backoff::ExponentialBackoff;
-pub use batch_manager::BatchManager;
 pub use copy::copy;
 pub use cursors::{Cursor, CursorName, CursorStore, Witness};
 pub use destroy::destroy;
 pub use gc::{Garbage, GarbageCollector};
+pub use interfaces::s3::BatchManager;
+pub use interfaces::FragmentPublisher;
 pub use manifest::{
     unprefixed_snapshot_path, Manifest, ManifestAndETag, Snapshot, SnapshotPointer,
 };

--- a/rust/wal3/src/manifest_manager.rs
+++ b/rust/wal3/src/manifest_manager.rs
@@ -308,21 +308,6 @@ impl ManifestManager {
         }
     }
 
-    /// Check for log contention at the cost of a read to S3.
-    pub async fn heartbeat(&self) -> Result<(), Error> {
-        let Some((_, e_tag)) = Manifest::load(&self.throttle, &self.storage, &self.prefix).await?
-        else {
-            return Err(Error::UninitializedLog);
-        };
-        // SAFETY(rescrv):  Mutex poisoning.
-        let staging = self.staging.lock().unwrap();
-        if e_tag == staging.stable.e_tag {
-            Ok(())
-        } else {
-            Err(Error::LogContentionFailure)
-        }
-    }
-
     /// Assign a timestamp to a record.
     pub fn assign_timestamp(
         &self,


### PR DESCRIPTION
## Description of changes

Extract FragmentPublisher trait to enable alternative fragment publishing
implementations beyond S3. This lays groundwork for supporting different
storage backends while maintaining the existing BatchManager behavior.

Changes:
- Add interfaces module with FragmentPublisher trait definition
- Move BatchManager into interfaces/s3 submodule
- Implement FragmentPublisher for BatchManager
- Make push_work, take_work, and finish_write async trait methods
- Split shutdown into shutdown_prepare and shutdown_finish methods
- Remove unused heartbeat method from ManifestManager

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
