### PR TITLE
[CHORE]: Consolidate all getters of attached functions

### DIFF
--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -69,7 +69,7 @@ func (suite *AttachFunctionTestSuite) setupAttachFunctionMocks(ctx context.Conte
 	// Phase 1: Create attached function in transaction
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -165,7 +165,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_SuccessfulCreation() {
 	// Setup mocks that will be called within the transaction (using mock.Anything for context)
 	// Check if any attached function exists for this collection
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	// Look up database
@@ -283,7 +283,8 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Alrea
 
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
-			suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
+			inputCollID := inputCollectionID
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -352,7 +353,7 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 	// Phase 1: Create attached function in transaction
 	suite.mockMetaDomain.On("AttachedFunctionDb", mock.Anything).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollectionID, false).
 		Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
 	suite.mockMetaDomain.On("DatabaseDb", mock.Anything).Return(suite.mockDatabaseDb).Once()
@@ -408,7 +409,8 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_RecoveryFlow() {
 
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
-			suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
+			inputCollID := inputCollectionID
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, false).
 				Return([]*dbmodel.AttachedFunction{incompleteAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup),
@@ -498,7 +500,8 @@ func (suite *AttachFunctionTestSuite) TestAttachFunction_IdempotentRequest_Param
 
 			// Inside transaction: check for existing attached functions
 			suite.mockMetaDomain.On("AttachedFunctionDb", txCtx).Return(suite.mockAttachedFunctionDb).Once()
-			suite.mockAttachedFunctionDb.On("GetAnyByCollectionID", inputCollectionID).
+			inputCollID := inputCollectionID
+			suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &inputCollID, false).
 				Return([]*dbmodel.AttachedFunction{existingAttachedFunction}, nil).Once()
 
 			// Note: validateAttachedFunctionMatchesRequest uses dbmodel.GetFunctionNameByID (static lookup)

--- a/go/pkg/sysdb/coordinator/heap_client_integration_test.go
+++ b/go/pkg/sysdb/coordinator/heap_client_integration_test.go
@@ -370,14 +370,15 @@ func (suite *HeapClientIntegrationTestSuite) TestPartialTaskCleanup_ThenRecreate
 	suite.T().Logf("Cleanup completed, removed %d tasks", cleanupResp.CleanedUpCount)
 
 	// STEP 3: Verify task still exists and can be retrieved
-	getResp, err := suite.sysdbClient.GetAttachedFunctionByName(ctx, &coordinatorpb.GetAttachedFunctionByNameRequest{
-		InputCollectionId: collectionID,
-		Name:              taskName,
+	getResp, err := suite.sysdbClient.GetAttachedFunctions(ctx, &coordinatorpb.GetAttachedFunctionsRequest{
+		InputCollectionId: &collectionID,
+		Name:              &taskName,
 	})
 	suite.NoError(err, "Task should still exist after cleanup")
 	suite.NotNil(getResp)
-	suite.Equal(taskResp.AttachedFunction.Id, getResp.AttachedFunction.Id)
-	suite.T().Logf("Task still exists after cleanup: %s", getResp.AttachedFunction.Id)
+	suite.Require().Len(getResp.AttachedFunctions, 1)
+	suite.Equal(taskResp.AttachedFunction.Id, getResp.AttachedFunctions[0].Id)
+	suite.T().Logf("Task still exists after cleanup: %s", getResp.AttachedFunctions[0].Id)
 
 	// STEP 4: Delete the task
 	_, err = suite.sysdbClient.DetachFunction(ctx, &coordinatorpb.DetachFunctionRequest{

--- a/go/pkg/sysdb/coordinator/list_attached_functions_test.go
+++ b/go/pkg/sysdb/coordinator/list_attached_functions_test.go
@@ -86,7 +86,7 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_Success()
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", collectionID).Return(attachedFunctions, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return(attachedFunctions, nil).Once()
 
 	functionOne := &dbmodel.Function{ID: functionID1, Name: "function-one"}
 	functionTwo := &dbmodel.Function{ID: functionID2, Name: "function-two"}
@@ -108,8 +108,8 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_Success()
 		})).
 		Return([]*dbmodel.Function{functionOne, functionTwo}, nil).Once()
 
-	req := &coordinatorpb.ListAttachedFunctionsRequest{InputCollectionId: collectionID}
-	resp, err := suite.coordinator.ListAttachedFunctions(ctx, req)
+	req := &coordinatorpb.GetAttachedFunctionsRequest{InputCollectionId: &collectionID}
+	resp, err := suite.coordinator.GetAttachedFunctions(ctx, req)
 
 	suite.Require().NoError(err)
 	suite.Require().NotNil(resp)
@@ -130,10 +130,10 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_EmptyResu
 	collectionID := "test-collection"
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", collectionID).Return([]*dbmodel.AttachedFunction{}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return([]*dbmodel.AttachedFunction{}, nil).Once()
 
-	req := &coordinatorpb.ListAttachedFunctionsRequest{InputCollectionId: collectionID}
-	resp, err := suite.coordinator.ListAttachedFunctions(ctx, req)
+	req := &coordinatorpb.GetAttachedFunctionsRequest{InputCollectionId: &collectionID}
+	resp, err := suite.coordinator.GetAttachedFunctions(ctx, req)
 
 	suite.Require().NoError(err)
 	suite.Require().NotNil(resp)
@@ -163,13 +163,13 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_FunctionD
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", collectionID).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
 
 	suite.mockMetaDomain.On("FunctionDb", ctx).Return(suite.mockFunctionDb).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).Return(nil, errors.New("db error")).Once()
 
-	req := &coordinatorpb.ListAttachedFunctionsRequest{InputCollectionId: collectionID}
-	resp, err := suite.coordinator.ListAttachedFunctions(ctx, req)
+	req := &coordinatorpb.GetAttachedFunctionsRequest{InputCollectionId: &collectionID}
+	resp, err := suite.coordinator.GetAttachedFunctions(ctx, req)
 
 	suite.Require().Error(err)
 	suite.Nil(resp)
@@ -198,15 +198,15 @@ func (suite *ListAttachedFunctionsTestSuite) TestListAttachedFunctions_InvalidPa
 	}
 
 	suite.mockMetaDomain.On("AttachedFunctionDb", ctx).Return(suite.mockAttachedFunctionDb).Once()
-	suite.mockAttachedFunctionDb.On("GetByCollectionID", collectionID).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
+	suite.mockAttachedFunctionDb.On("GetAttachedFunctions", (*uuid.UUID)(nil), (*string)(nil), &collectionID, true).Return([]*dbmodel.AttachedFunction{attachedFunction}, nil).Once()
 
 	functionModel := &dbmodel.Function{ID: functionID, Name: "function"}
 
 	suite.mockMetaDomain.On("FunctionDb", ctx).Return(suite.mockFunctionDb).Once()
 	suite.mockFunctionDb.On("GetByIDs", []uuid.UUID{functionID}).Return([]*dbmodel.Function{functionModel}, nil).Once()
 
-	req := &coordinatorpb.ListAttachedFunctionsRequest{InputCollectionId: collectionID}
-	resp, err := suite.coordinator.ListAttachedFunctions(ctx, req)
+	req := &coordinatorpb.GetAttachedFunctionsRequest{InputCollectionId: &collectionID}
+	resp, err := suite.coordinator.GetAttachedFunctions(ctx, req)
 
 	suite.Require().Error(err)
 	suite.Nil(resp)

--- a/go/pkg/sysdb/grpc/task_service.go
+++ b/go/pkg/sysdb/grpc/task_service.go
@@ -29,42 +29,16 @@ func (s *Server) AttachFunction(ctx context.Context, req *coordinatorpb.AttachFu
 	return res, nil
 }
 
-func (s *Server) GetAttachedFunctionByName(ctx context.Context, req *coordinatorpb.GetAttachedFunctionByNameRequest) (*coordinatorpb.GetAttachedFunctionByNameResponse, error) {
-	log.Info("GetAttachedFunctionByName", zap.String("input_collection_id", req.InputCollectionId), zap.String("name", req.Name))
+func (s *Server) GetAttachedFunctions(ctx context.Context, req *coordinatorpb.GetAttachedFunctionsRequest) (*coordinatorpb.GetAttachedFunctionsResponse, error) {
+	log.Info("GetAttachedFunctions",
+		zap.Any("id", req.Id),
+		zap.Any("name", req.Name),
+		zap.Any("input_collection_id", req.InputCollectionId),
+		zap.Any("only_ready", req.OnlyReady))
 
-	res, err := s.coordinator.GetAttachedFunctionByName(ctx, req)
+	res, err := s.coordinator.GetAttachedFunctions(ctx, req)
 	if err != nil {
-		log.Error("GetAttachedFunctionByName failed", zap.Error(err))
-		if err == common.ErrAttachedFunctionNotFound {
-			return nil, grpcutils.BuildNotFoundGrpcError(err.Error())
-		}
-		return nil, err
-	}
-
-	return res, nil
-}
-
-func (s *Server) ListAttachedFunctions(ctx context.Context, req *coordinatorpb.ListAttachedFunctionsRequest) (*coordinatorpb.ListAttachedFunctionsResponse, error) {
-	log.Info("ListAttachedFunctions", zap.String("input_collection_id", req.InputCollectionId))
-
-	res, err := s.coordinator.ListAttachedFunctions(ctx, req)
-	if err != nil {
-		log.Error("ListAttachedFunctions failed", zap.Error(err))
-		return nil, err
-	}
-
-	return res, nil
-}
-
-func (s *Server) GetAttachedFunctionByUuid(ctx context.Context, req *coordinatorpb.GetAttachedFunctionByUuidRequest) (*coordinatorpb.GetAttachedFunctionByUuidResponse, error) {
-	log.Info("GetAttachedFunctionByUuid", zap.String("id", req.Id))
-
-	res, err := s.coordinator.GetAttachedFunctionByUuid(ctx, req)
-	if err != nil {
-		log.Error("GetAttachedFunctionByUuid failed", zap.Error(err))
-		if err == common.ErrAttachedFunctionNotFound {
-			return nil, grpcutils.BuildNotFoundGrpcError(err.Error())
-		}
+		log.Error("GetAttachedFunctions failed", zap.Error(err))
 		return nil, err
 	}
 

--- a/go/pkg/sysdb/metastore/db/dao/task.go
+++ b/go/pkg/sysdb/metastore/db/dao/task.go
@@ -61,107 +61,41 @@ func (s *attachedFunctionDb) Update(attachedFunction *dbmodel.AttachedFunction) 
 	return nil
 }
 
-func (s *attachedFunctionDb) GetByName(inputCollectionID string, name string) (*dbmodel.AttachedFunction, error) {
-	var attachedFunction dbmodel.AttachedFunction
-	err := s.db.
-		Where("input_collection_id = ?", inputCollectionID).
-		Where("name = ?", name).
-		Where("is_deleted = ?", false).
-		Where("is_ready = ?", true).
-		First(&attachedFunction).Error
-
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		log.Error("GetByName failed", zap.Error(err))
-		return nil, err
-	}
-
-	return &attachedFunction, nil
-}
-
-func (s *attachedFunctionDb) GetAnyByName(inputCollectionID string, name string) (*dbmodel.AttachedFunction, error) {
-	var attachedFunction dbmodel.AttachedFunction
-	err := s.db.
-		Where("input_collection_id = ?", inputCollectionID).
-		Where("name = ?", name).
-		Where("is_deleted = ?", false).
-		First(&attachedFunction).Error
-
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		log.Error("GetAnyByName failed", zap.Error(err))
-		return nil, err
-	}
-
-	return &attachedFunction, nil
-}
-
-func (s *attachedFunctionDb) GetByID(id uuid.UUID) (*dbmodel.AttachedFunction, error) {
-	var attachedFunction dbmodel.AttachedFunction
-	err := s.db.
-		Where("id = ?", id).
-		Where("is_deleted = ?", false).
-		Where("is_ready = ?", true).
-		First(&attachedFunction).Error
-
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		log.Error("GetByID failed", zap.Error(err), zap.String("id", id.String()))
-		return nil, err
-	}
-
-	return &attachedFunction, nil
-}
-
-func (s *attachedFunctionDb) GetAnyByID(id uuid.UUID) (*dbmodel.AttachedFunction, error) {
-	var attachedFunction dbmodel.AttachedFunction
-	err := s.db.
-		Where("id = ?", id).
-		Where("is_deleted = ?", false).
-		First(&attachedFunction).Error
-
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		log.Error("GetAnyByID failed", zap.Error(err), zap.String("id", id.String()))
-		return nil, err
-	}
-
-	return &attachedFunction, nil
-}
-
-func (s *attachedFunctionDb) GetByCollectionID(inputCollectionID string) ([]*dbmodel.AttachedFunction, error) {
+// GetAttachedFunctions is a consolidated getter that supports various query patterns
+// Parameters can be nil to indicate they should not be filtered on
+// - id: Filter by attached function ID
+// - name: Filter by attached function name
+// - inputCollectionID: Filter by input collection ID
+// - onlyReady: If true, only returns attached functions where is_ready = true
+func (s *attachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
 	var attachedFunctions []*dbmodel.AttachedFunction
-	err := s.db.
-		Where("input_collection_id = ?", inputCollectionID).
-		Where("is_deleted = ?", false).
-		Where("is_ready = ?", true).
-		Find(&attachedFunctions).Error
 
-	if err != nil {
-		log.Error("GetByCollectionID failed", zap.Error(err), zap.String("input_collection_id", inputCollectionID))
-		return nil, err
+	query := s.db.Where("is_deleted = ?", false)
+
+	if id != nil {
+		query = query.Where("id = ?", *id)
 	}
 
-	return attachedFunctions, nil
-}
+	if name != nil {
+		query = query.Where("name = ?", *name)
+	}
 
-func (s *attachedFunctionDb) GetAnyByCollectionID(inputCollectionID string) ([]*dbmodel.AttachedFunction, error) {
-	var attachedFunctions []*dbmodel.AttachedFunction
-	err := s.db.
-		Where("input_collection_id = ?", inputCollectionID).
-		Where("is_deleted = ?", false).
-		Find(&attachedFunctions).Error
+	if inputCollectionID != nil {
+		query = query.Where("input_collection_id = ?", *inputCollectionID)
+	}
 
+	if onlyReady {
+		query = query.Where("is_ready = ?", true)
+	}
+
+	err := query.Find(&attachedFunctions).Error
 	if err != nil {
-		log.Error("GetAnyByCollectionID failed", zap.Error(err), zap.String("input_collection_id", inputCollectionID))
+		log.Error("GetAttachedFunctions failed",
+			zap.Error(err),
+			zap.Any("id", id),
+			zap.Any("name", name),
+			zap.Any("input_collection_id", inputCollectionID),
+			zap.Bool("only_ready", onlyReady))
 		return nil, err
 	}
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -82,179 +82,29 @@ func (_m *IAttachedFunctionDb) Finish(attachedFunctionID uuid.UUID) error {
 	return r0
 }
 
-// GetByID provides a mock function with given fields: attachedFunctionID
-func (_m *IAttachedFunctionDb) GetByID(attachedFunctionID uuid.UUID) (*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(attachedFunctionID)
+// GetAttachedFunctions provides a mock function with given fields: id, name, inputCollectionID, onlyReady
+func (_m *IAttachedFunctionDb) GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, onlyReady bool) ([]*dbmodel.AttachedFunction, error) {
+	ret := _m.Called(id, name, inputCollectionID, onlyReady)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetByID")
-	}
-
-	var r0 *dbmodel.AttachedFunction
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uuid.UUID) (*dbmodel.AttachedFunction, error)); ok {
-		return rf(attachedFunctionID)
-	}
-	if rf, ok := ret.Get(0).(func(uuid.UUID) *dbmodel.AttachedFunction); ok {
-		r0 = rf(attachedFunctionID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dbmodel.AttachedFunction)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(uuid.UUID) error); ok {
-		r1 = rf(attachedFunctionID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetByCollectionID provides a mock function with given fields: inputCollectionID
-func (_m *IAttachedFunctionDb) GetByCollectionID(inputCollectionID string) ([]*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(inputCollectionID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetByCollectionID")
+		panic("no return value specified for GetAttachedFunctions")
 	}
 
 	var r0 []*dbmodel.AttachedFunction
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]*dbmodel.AttachedFunction, error)); ok {
-		return rf(inputCollectionID)
+	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, bool) ([]*dbmodel.AttachedFunction, error)); ok {
+		return rf(id, name, inputCollectionID, onlyReady)
 	}
-	if rf, ok := ret.Get(0).(func(string) []*dbmodel.AttachedFunction); ok {
-		r0 = rf(inputCollectionID)
+	if rf, ok := ret.Get(0).(func(*uuid.UUID, *string, *string, bool) []*dbmodel.AttachedFunction); ok {
+		r0 = rf(id, name, inputCollectionID, onlyReady)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*dbmodel.AttachedFunction)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(inputCollectionID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetByName provides a mock function with given fields: inputCollectionID, attachedFunctionName
-func (_m *IAttachedFunctionDb) GetByName(inputCollectionID string, attachedFunctionName string) (*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(inputCollectionID, attachedFunctionName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetByName")
-	}
-
-	var r0 *dbmodel.AttachedFunction
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*dbmodel.AttachedFunction, error)); ok {
-		return rf(inputCollectionID, attachedFunctionName)
-	}
-	if rf, ok := ret.Get(0).(func(string, string) *dbmodel.AttachedFunction); ok {
-		r0 = rf(inputCollectionID, attachedFunctionName)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dbmodel.AttachedFunction)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(inputCollectionID, attachedFunctionName)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetAnyByName provides a mock function with given fields: inputCollectionID, name
-func (_m *IAttachedFunctionDb) GetAnyByName(inputCollectionID string, name string) (*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(inputCollectionID, name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAnyByName")
-	}
-
-	var r0 *dbmodel.AttachedFunction
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*dbmodel.AttachedFunction, error)); ok {
-		return rf(inputCollectionID, name)
-	}
-	if rf, ok := ret.Get(0).(func(string, string) *dbmodel.AttachedFunction); ok {
-		r0 = rf(inputCollectionID, name)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dbmodel.AttachedFunction)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(inputCollectionID, name)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetAnyByCollectionID provides a mock function with given fields: inputCollectionID
-func (_m *IAttachedFunctionDb) GetAnyByCollectionID(inputCollectionID string) ([]*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(inputCollectionID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAnyByCollectionID")
-	}
-
-	var r0 []*dbmodel.AttachedFunction
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string) ([]*dbmodel.AttachedFunction, error)); ok {
-		return rf(inputCollectionID)
-	}
-	if rf, ok := ret.Get(0).(func(string) []*dbmodel.AttachedFunction); ok {
-		r0 = rf(inputCollectionID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*dbmodel.AttachedFunction)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(inputCollectionID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetAnyByID provides a mock function with given fields: id
-func (_m *IAttachedFunctionDb) GetAnyByID(id uuid.UUID) (*dbmodel.AttachedFunction, error) {
-	ret := _m.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAnyByID")
-	}
-
-	var r0 *dbmodel.AttachedFunction
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uuid.UUID) (*dbmodel.AttachedFunction, error)); ok {
-		return rf(id)
-	}
-	if rf, ok := ret.Get(0).(func(uuid.UUID) *dbmodel.AttachedFunction); ok {
-		r0 = rf(id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dbmodel.AttachedFunction)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(uuid.UUID) error); ok {
-		r1 = rf(id)
+	if rf, ok := ret.Get(1).(func(*uuid.UUID, *string, *string, bool) error); ok {
+		r1 = rf(id, name, inputCollectionID, onlyReady)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -36,13 +36,13 @@ func (v AttachedFunction) TableName() string {
 //go:generate mockery --name=IAttachedFunctionDb
 type IAttachedFunctionDb interface {
 	Insert(attachedFunction *AttachedFunction) error
-	// TODO(tanujnay112): clean up this interface
-	GetByName(inputCollectionID string, name string) (*AttachedFunction, error)
-	GetAnyByName(inputCollectionID string, name string) (*AttachedFunction, error)
-	GetByID(id uuid.UUID) (*AttachedFunction, error)
-	GetAnyByID(id uuid.UUID) (*AttachedFunction, error) // TODO(tanujnay112): Consolidate all the getters.
-	GetByCollectionID(inputCollectionID string) ([]*AttachedFunction, error)
-	GetAnyByCollectionID(inputCollectionID string) ([]*AttachedFunction, error)
+	// GetAttachedFunctions is a consolidated getter that supports various query patterns
+	// Parameters can be nil to indicate they should not be filtered on
+	// - id: Filter by attached function ID
+	// - name: Filter by attached function name
+	// - inputCollectionID: Filter by input collection ID
+	// - onlyReady: If true, only returns attached functions where is_ready = true
+	GetAttachedFunctions(id *uuid.UUID, name *string, inputCollectionID *string, onlyReady bool) ([]*AttachedFunction, error)
 	Update(attachedFunction *AttachedFunction) error
 	Finish(id uuid.UUID) error
 	SoftDelete(inputCollectionID string, name string) error

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -569,9 +569,20 @@ message AttachFunctionResponse {
   bool created = 2;  // True if newly created, false if already existed (idempotent)
 }
 
-message GetAttachedFunctionByNameRequest {
-  string input_collection_id = 1;
-  string name = 2;
+message GetAttachedFunctionsRequest {
+  // All parameters are optional - nil means don't filter on that field
+  // - id: Filter by attached function ID (UUID string)
+  // - name: Filter by attached function name
+  // - input_collection_id: Filter by input collection ID
+  // - only_ready: If true, only returns attached functions where is_ready = true (default: true)
+  optional string id = 1;
+  optional string name = 2;
+  optional string input_collection_id = 3;
+  optional bool only_ready = 4;
+}
+
+message GetAttachedFunctionsResponse {
+  repeated AttachedFunction attached_functions = 1;
 }
 
 message AttachedFunction {
@@ -589,26 +600,6 @@ message AttachedFunction {
   uint64 created_at = 15;
   uint64 updated_at = 16;
   string function_id = 17;
-}
-
-message GetAttachedFunctionByNameResponse {
-  AttachedFunction attached_function = 1;
-}
-
-message GetAttachedFunctionByUuidRequest {
-  string id = 1;
-}
-
-message GetAttachedFunctionByUuidResponse {
-  AttachedFunction attached_function = 1;
-}
-
-message ListAttachedFunctionsRequest {
-  string input_collection_id = 1;
-}
-
-message ListAttachedFunctionsResponse {
-  repeated AttachedFunction attached_functions = 1;
 }
 
 message DetachFunctionRequest {
@@ -708,9 +699,7 @@ service SysDB {
   rpc BatchGetCollectionSoftDeleteStatus(BatchGetCollectionSoftDeleteStatusRequest) returns (BatchGetCollectionSoftDeleteStatusResponse) {}
   rpc FlushCollectionCompaction(FlushCollectionCompactionRequest) returns (FlushCollectionCompactionResponse) {}
   rpc AttachFunction(AttachFunctionRequest) returns (AttachFunctionResponse) {}
-  rpc GetAttachedFunctionByName(GetAttachedFunctionByNameRequest) returns (GetAttachedFunctionByNameResponse) {}
-  rpc GetAttachedFunctionByUuid(GetAttachedFunctionByUuidRequest) returns (GetAttachedFunctionByUuidResponse) {}
-  rpc ListAttachedFunctions(ListAttachedFunctionsRequest) returns (ListAttachedFunctionsResponse) {}
+  rpc GetAttachedFunctions(GetAttachedFunctionsRequest) returns (GetAttachedFunctionsResponse) {}
   rpc DetachFunction(DetachFunctionRequest) returns (DetachFunctionResponse) {}
   rpc FinishCreateAttachedFunction(FinishCreateAttachedFunctionRequest) returns (FinishCreateAttachedFunctionResponse) {}
   rpc CleanupExpiredPartialAttachedFunctions(CleanupExpiredPartialAttachedFunctionsRequest) returns (CleanupExpiredPartialAttachedFunctionsResponse) {}

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -2029,9 +2029,19 @@ impl ServiceBasedFrontend {
             })?);
 
         // Get the attached function by name
-        self.sysdb_client
-            .get_attached_function_by_name(collection_uuid, function_name)
-            .await
+        let attached_functions = self
+            .sysdb_client
+            .get_attached_functions(
+                None,
+                Some(function_name.clone()),
+                Some(collection_uuid),
+                true,
+            )
+            .await?;
+        attached_functions
+            .into_iter()
+            .next()
+            .ok_or_else(|| chroma_sysdb::GetAttachedFunctionError::NotFound)
     }
 
     pub async fn detach_function(

--- a/rust/sysdb/src/bin/chroma-task-manager.rs
+++ b/rust/sysdb/src/bin/chroma-task-manager.rs
@@ -138,15 +138,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             input_collection_id,
             name,
         } => {
-            let request = chroma_proto::GetAttachedFunctionByNameRequest {
-                input_collection_id,
-                name,
+            let request = chroma_proto::GetAttachedFunctionsRequest {
+                id: None,
+                name: Some(name),
+                input_collection_id: Some(input_collection_id),
+                only_ready: Some(true),
             };
 
-            let response = client.get_attached_function_by_name(request).await?;
-            let attached_function = response
-                .into_inner()
-                .attached_function
+            let response = client.get_attached_functions(request).await?;
+            let attached_functions = response.into_inner().attached_functions;
+            let attached_function = attached_functions
+                .into_iter()
+                .next()
                 .ok_or("Server did not return attached function")?;
 
             println!("Attached Function ID: {:?}", attached_function.id);

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -682,21 +682,6 @@ impl SqliteSysDb {
         ))
     }
 
-    pub(crate) async fn get_attached_function_by_name(
-        &self,
-        _input_collection_id: chroma_types::CollectionUuid,
-        _attached_function_name: String,
-    ) -> Result<chroma_types::AttachedFunction, crate::GetAttachedFunctionError> {
-        // TODO: Implement this when attached function support is added to SqliteSysDb
-        Err(
-            crate::GetAttachedFunctionError::FailedToGetAttachedFunction(
-                tonic::Status::unimplemented(
-                    " Attached Function operations not yet implemented in SqliteSysDb",
-                ),
-            ),
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     async fn get_collections_with_conn<'a, C>(
         &self,

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -1353,9 +1353,18 @@ mod tests {
         .expect("Compaction should succeed");
 
         // Verify statistics were generated
-        let updated_attached_function = sysdb
-            .get_attached_function_by_name(collection_id, attached_function_name.clone())
+        let attached_functions = sysdb
+            .get_attached_functions(
+                None,
+                Some(attached_function_name.clone()),
+                Some(collection_id),
+                true,
+            )
             .await
+            .expect("Attached function query should succeed");
+        let updated_attached_function = attached_functions
+            .into_iter()
+            .next()
             .expect("Attached function should be found");
 
         // Note: completion_offset is 14, all 15 records (0-14) were processed

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -2919,9 +2919,18 @@ mod tests {
         println!("First compaction completed");
 
         // Verify the attached function was executed
-        let attached_function_after_compact = sysdb
-            .get_attached_function_by_name(collection_id, attached_function_name.clone())
+        let attached_functions = sysdb
+            .get_attached_functions(
+                None,
+                Some(attached_function_name.clone()),
+                Some(collection_id),
+                true,
+            )
             .await
+            .expect("Attached function query should succeed");
+        let attached_function_after_compact = attached_functions
+            .into_iter()
+            .next()
             .expect("Attached function should be found");
         assert_eq!(
             attached_function_after_compact.completion_offset, 9,
@@ -2994,9 +3003,18 @@ mod tests {
         println!("Second compaction completed");
 
         // Verify the attached function was NOT executed (completion_offset should still be 9)
-        let attached_function_after_disabled = sysdb
-            .get_attached_function_by_name(collection_id, attached_function_name.clone())
+        let attached_functions = sysdb
+            .get_attached_functions(
+                None,
+                Some(attached_function_name.clone()),
+                Some(collection_id),
+                true,
+            )
             .await
+            .expect("Attached function query should succeed");
+        let attached_function_after_disabled = attached_functions
+            .into_iter()
+            .next()
             .expect("Attached function should be found");
         assert_eq!(
             attached_function_after_disabled.completion_offset, 9,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Consolidate the Get paths in attached functions to match the pattern of the getters for the Collections table

  - AttachedFunction.{Get.*By.*} have been replaced by GetAttachedFunctions(...)
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
