### PR TITLE
[ENH] Add support for base url specification in js client open ai ef

### DIFF
--- a/clients/new-js/packages/ai-embeddings/openai/README.md
+++ b/clients/new-js/packages/ai-embeddings/openai/README.md
@@ -22,6 +22,8 @@ const embedder = new OpenAIEmbeddingFunction({
   dimensions: 512,
   // Optional: specify organization ID
   organizationId: 'your-org-id'
+  // Optional: specify API base (e.g. for Azure OpenAI)
+  apiBase: 'your-api-base'
 });
 
 // Create a new ChromaClient

--- a/clients/new-js/packages/ai-embeddings/openai/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/openai/src/index.test.ts
@@ -10,7 +10,7 @@ describe("OpenAIEmbeddingFunction", () => {
 
   const defaultParametersTest = "should initialize with default parameters";
   if (!process.env.OPENAI_API_KEY) {
-    it.skip(defaultParametersTest, () => {});
+    it.skip(defaultParametersTest, () => { });
   } else {
     it(defaultParametersTest, () => {
       const embedder = new OpenAIEmbeddingFunction({ modelName: MODEL });
@@ -21,12 +21,13 @@ describe("OpenAIEmbeddingFunction", () => {
       expect(config.api_key_env_var).toBe("OPENAI_API_KEY");
       expect(config.dimensions).toBeUndefined();
       expect(config.organization_id).toBeUndefined();
+      expect(config.api_base).toBeUndefined();
     });
   }
 
   const customParametersTest = "should initialize with custom parameters";
   if (!process.env.OPENAI_API_KEY) {
-    it.skip(customParametersTest, () => {});
+    it.skip(customParametersTest, () => { });
   } else {
     it(customParametersTest, () => {
       const embedder = new OpenAIEmbeddingFunction({
@@ -34,6 +35,7 @@ describe("OpenAIEmbeddingFunction", () => {
         dimensions: 2000,
         apiKeyEnvVar: "OPENAI_API_KEY",
         organizationId: "custom-organization-id",
+        apiBase: "https://custom-api.example.com/v1",
       });
 
       const config = embedder.getConfig();
@@ -41,6 +43,7 @@ describe("OpenAIEmbeddingFunction", () => {
       expect(config.organization_id).toBe("custom-organization-id");
       expect(config.dimensions).toBe(2000);
       expect(config.api_key_env_var).toBe("OPENAI_API_KEY");
+      expect(config.api_base).toBe("https://custom-api.example.com/v1");
     });
   }
 
@@ -78,7 +81,7 @@ describe("OpenAIEmbeddingFunction", () => {
 
   const buildFromConfigTest = "should build from config";
   if (!process.env.OPENAI_API_KEY) {
-    it.skip(buildFromConfigTest, () => {});
+    it.skip(buildFromConfigTest, () => { });
   } else {
     it(buildFromConfigTest, () => {
       const config = {
@@ -86,6 +89,7 @@ describe("OpenAIEmbeddingFunction", () => {
         model_name: "config-model",
         dimensions: 2000,
         organization_id: "custom-organization-id",
+        api_base: "https://custom-api.example.com/v1",
       };
 
       const embedder = OpenAIEmbeddingFunction.buildFromConfig(config);
@@ -95,7 +99,7 @@ describe("OpenAIEmbeddingFunction", () => {
 
     const generateEmbeddingsTest = "should generate embeddings";
     if (!process.env.OPENAI_API_KEY) {
-      it.skip(generateEmbeddingsTest, () => {});
+      it.skip(generateEmbeddingsTest, () => { });
     } else {
       it(generateEmbeddingsTest, async () => {
         const embedder = new OpenAIEmbeddingFunction({ modelName: MODEL });

--- a/clients/new-js/packages/ai-embeddings/openai/src/index.ts
+++ b/clients/new-js/packages/ai-embeddings/openai/src/index.ts
@@ -14,6 +14,7 @@ export interface OpenAIConfig {
   model_name: string;
   organization_id?: string;
   dimensions?: number;
+  api_base?: string;
 }
 
 export interface OpenAIArgs {
@@ -22,6 +23,7 @@ export interface OpenAIArgs {
   organizationId?: string;
   dimensions?: number;
   apiKey?: string;
+  apiBase?: string;
 }
 
 export class OpenAIEmbeddingFunction implements EmbeddingFunction {
@@ -30,6 +32,7 @@ export class OpenAIEmbeddingFunction implements EmbeddingFunction {
   private readonly modelName: string;
   private readonly dimensions: number | undefined;
   private readonly organizationId: string | undefined;
+  private readonly apiBase: string | undefined;
   private client: OpenAI;
 
   constructor(args: OpenAIArgs) {
@@ -38,6 +41,7 @@ export class OpenAIEmbeddingFunction implements EmbeddingFunction {
       modelName,
       dimensions,
       organizationId,
+      apiBase,
     } = args;
 
     const apiKey = args.apiKey || process.env[apiKeyEnvVar];
@@ -51,8 +55,13 @@ export class OpenAIEmbeddingFunction implements EmbeddingFunction {
     this.organizationId = organizationId;
     this.apiKeyEnvVar = apiKeyEnvVar;
     this.dimensions = dimensions;
+    this.apiBase = apiBase;
 
-    this.client = new OpenAI({ apiKey, organization: this.organizationId });
+    this.client = new OpenAI({
+      apiKey,
+      organization: this.organizationId,
+      ...(this.apiBase && { baseURL: this.apiBase }),
+    });
   }
 
   public async generate(texts: string[]): Promise<number[][]> {
@@ -78,6 +87,7 @@ export class OpenAIEmbeddingFunction implements EmbeddingFunction {
       modelName: config.model_name,
       organizationId: config.organization_id,
       dimensions: config.dimensions,
+      apiBase: config.api_base,
     });
   }
 
@@ -87,6 +97,7 @@ export class OpenAIEmbeddingFunction implements EmbeddingFunction {
       model_name: this.modelName,
       organization_id: this.organizationId,
       dimensions: this.dimensions,
+      api_base: this.apiBase,
     };
   }
 

--- a/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/openai.md
+++ b/docs/docs.trychroma.com/markdoc/content/integrations/embedding-models/openai.md
@@ -60,6 +60,8 @@ import { OpenAIEmbeddingFunction } from "@chroma-core/openai";
 const embeddingFunction = new OpenAIEmbeddingFunction({
   apiKey: "apiKey",
   modelName: "text-embedding-3-small",
+  // Optional: specify API base (e.g. for Azure OpenAI)
+  apiBase: "your-api-base"
 });
 
 // use directly


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds support for specifying the base url
- New functionality
  - None

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
Legacy configs with this value not set are fine, they will deserialize to the value being empty and work. The schema already supported this.

## Observability plan
None

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_

Readme, docs and code docs are updated in accordance
