### PR TITLE
[ENH]: Garbage collection for old non-ready attached function rows

### DIFF
--- a/go/pkg/sysdb/coordinator/create_task_test.go
+++ b/go/pkg/sysdb/coordinator/create_task_test.go
@@ -534,9 +534,9 @@ func TestAttachFunctionTestSuite(t *testing.T) {
 	suite.Run(t, new(AttachFunctionTestSuite))
 }
 
-// TestGetSoftDeletedAttachedFunctions_TimestampConsistency verifies that timestamps
+// TestGetAttachedFunctionsToGc_TimestampConsistency verifies that timestamps
 // are returned in microseconds (UnixMicro) to match other API methods
-func TestGetSoftDeletedAttachedFunctions_TimestampConsistency(t *testing.T) {
+func TestGetAttachedFunctionsToGc_TimestampConsistency(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test timestamps with known values
@@ -562,7 +562,7 @@ func TestGetSoftDeletedAttachedFunctions_TimestampConsistency(t *testing.T) {
 		},
 	}
 
-	mockAttachedFunctionDb.On("GetSoftDeletedAttachedFunctions", mock.Anything, mock.Anything).
+	mockAttachedFunctionDb.On("GetAttachedFunctionsToGc", mock.Anything, mock.Anything).
 		Return(attachedFunctions, nil)
 
 	coordinator := &Coordinator{
@@ -571,16 +571,16 @@ func TestGetSoftDeletedAttachedFunctions_TimestampConsistency(t *testing.T) {
 		},
 	}
 
-	// Call GetSoftDeletedAttachedFunctions
+	// Call GetAttachedFunctionsToGc
 	cutoffTime := timestamppb.New(testTime.Add(-24 * time.Hour))
-	resp, err := coordinator.GetSoftDeletedAttachedFunctions(ctx, &coordinatorpb.GetSoftDeletedAttachedFunctionsRequest{
+	resp, err := coordinator.GetAttachedFunctionsToGc(ctx, &coordinatorpb.GetAttachedFunctionsToGcRequest{
 		CutoffTime: cutoffTime,
 		Limit:      100,
 	})
 
 	// Verify response
 	if err != nil {
-		t.Fatalf("GetSoftDeletedAttachedFunctions failed: %v", err)
+		t.Fatalf("GetAttachedFunctionsToGc failed: %v", err)
 	}
 	if len(resp.AttachedFunctions) != 1 {
 		t.Fatalf("Expected 1 attached function, got %d", len(resp.AttachedFunctions))

--- a/go/pkg/sysdb/grpc/task_service.go
+++ b/go/pkg/sysdb/grpc/task_service.go
@@ -85,16 +85,16 @@ func (s *Server) CleanupExpiredPartialAttachedFunctions(ctx context.Context, req
 	return res, nil
 }
 
-func (s *Server) GetSoftDeletedAttachedFunctions(ctx context.Context, req *coordinatorpb.GetSoftDeletedAttachedFunctionsRequest) (*coordinatorpb.GetSoftDeletedAttachedFunctionsResponse, error) {
-	log.Info("GetSoftDeletedAttachedFunctions", zap.Time("cutoff_time", req.CutoffTime.AsTime()), zap.Int32("limit", req.Limit))
+func (s *Server) GetAttachedFunctionsToGc(ctx context.Context, req *coordinatorpb.GetAttachedFunctionsToGcRequest) (*coordinatorpb.GetAttachedFunctionsToGcResponse, error) {
+	log.Info("GetAttachedFunctionsToGc", zap.Time("cutoff_time", req.CutoffTime.AsTime()), zap.Int32("limit", req.Limit))
 
-	res, err := s.coordinator.GetSoftDeletedAttachedFunctions(ctx, req)
+	res, err := s.coordinator.GetAttachedFunctionsToGc(ctx, req)
 	if err != nil {
-		log.Error("GetSoftDeletedAttachedFunctions failed", zap.Error(err))
+		log.Error("GetAttachedFunctionsToGc failed", zap.Error(err))
 		return nil, grpcutils.BuildInternalGrpcError(err.Error())
 	}
 
-	log.Info("GetSoftDeletedAttachedFunctions succeeded", zap.Int("count", len(res.AttachedFunctions)))
+	log.Info("GetAttachedFunctionsToGc succeeded", zap.Int("count", len(res.AttachedFunctions)))
 	return res, nil
 }
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/IAttachedFunctionDb.go
@@ -292,12 +292,12 @@ func (_m *IAttachedFunctionDb) CleanupExpiredPartialAttachedFunctions(maxAgeSeco
 	return r0, r1
 }
 
-// GetSoftDeletedAttachedFunctions provides a mock function with given fields: cutoffTime, limit
-func (_m *IAttachedFunctionDb) GetSoftDeletedAttachedFunctions(cutoffTime time.Time, limit int32) ([]*dbmodel.AttachedFunction, error) {
+// GetAttachedFunctionsToGc provides a mock function with given fields: cutoffTime, limit
+func (_m *IAttachedFunctionDb) GetAttachedFunctionsToGc(cutoffTime time.Time, limit int32) ([]*dbmodel.AttachedFunction, error) {
 	ret := _m.Called(cutoffTime, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetSoftDeletedAttachedFunctions")
+		panic("no return value specified for GetAttachedFunctionsToGc")
 	}
 
 	var r0 []*dbmodel.AttachedFunction

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -326,6 +326,24 @@ func (_m *ICollectionDb) GetSoftDeletedCollections(collectionID *string, tenantI
 	return r0, r1
 }
 
+// IncrementCompactionFailureCount provides a mock function with given fields: collectionID
+func (_m *ICollectionDb) IncrementCompactionFailureCount(collectionID string) error {
+	ret := _m.Called(collectionID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IncrementCompactionFailureCount")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(collectionID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Insert provides a mock function with given fields: in
 func (_m *ICollectionDb) Insert(in *dbmodel.Collection) error {
 	ret := _m.Called(in)

--- a/go/pkg/sysdb/metastore/db/dbmodel/task.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/task.go
@@ -50,6 +50,6 @@ type IAttachedFunctionDb interface {
 	DeleteAll() error
 	GetMinCompletionOffsetForCollection(inputCollectionID string) (*int64, error)
 	CleanupExpiredPartial(maxAgeSeconds uint64) ([]uuid.UUID, error)
-	GetSoftDeletedAttachedFunctions(cutoffTime time.Time, limit int32) ([]*AttachedFunction, error)
+	GetAttachedFunctionsToGc(cutoffTime time.Time, limit int32) ([]*AttachedFunction, error)
 	HardDeleteAttachedFunction(id uuid.UUID) error
 }

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -646,12 +646,12 @@ message GetFunctionsResponse {
   repeated Function functions = 1;
 }
 
-message GetSoftDeletedAttachedFunctionsRequest {
+message GetAttachedFunctionsToGcRequest {
   google.protobuf.Timestamp cutoff_time = 1;
   int32 limit = 2;
 }
 
-message GetSoftDeletedAttachedFunctionsResponse {
+message GetAttachedFunctionsToGcResponse {
   repeated AttachedFunction attached_functions = 1;
 }
 
@@ -704,7 +704,7 @@ service SysDB {
   rpc FinishCreateAttachedFunction(FinishCreateAttachedFunctionRequest) returns (FinishCreateAttachedFunctionResponse) {}
   rpc CleanupExpiredPartialAttachedFunctions(CleanupExpiredPartialAttachedFunctionsRequest) returns (CleanupExpiredPartialAttachedFunctionsResponse) {}
   rpc GetFunctions(GetFunctionsRequest) returns (GetFunctionsResponse) {}
-  rpc GetSoftDeletedAttachedFunctions(GetSoftDeletedAttachedFunctionsRequest) returns (GetSoftDeletedAttachedFunctionsResponse) {}
+  rpc GetAttachedFunctionsToGc(GetAttachedFunctionsToGcRequest) returns (GetAttachedFunctionsToGcResponse) {}
   rpc FinishAttachedFunctionDeletion(FinishAttachedFunctionDeletionRequest) returns (FinishAttachedFunctionDeletionResponse) {}
   rpc FlushCollectionCompactionAndAttachedFunction(FlushCollectionCompactionAndAttachedFunctionRequest) returns (FlushCollectionCompactionAndAttachedFunctionResponse) {}
 }

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -149,13 +149,13 @@ impl GarbageCollector {
 
     async fn garbage_collect_attached_functions(
         &mut self,
-        attached_function_soft_delete_absolute_cutoff_time: SystemTime,
+        attached_function_gc_absolute_cutoff_time: SystemTime,
     ) -> (u32, u32) {
-        tracing::info!("Checking for soft-deleted attached functions to hard delete");
+        tracing::info!("Checking for attached functions to garbage collect (deleted or not ready)");
         match self
             .sysdb_client
-            .get_soft_deleted_attached_functions(
-                attached_function_soft_delete_absolute_cutoff_time,
+            .get_attached_functions_to_gc(
+                attached_function_gc_absolute_cutoff_time,
                 self.config.max_attached_functions_to_gc_per_run,
             )
             .await
@@ -163,7 +163,7 @@ impl GarbageCollector {
             Ok(attached_functions_to_delete) => {
                 if !attached_functions_to_delete.is_empty() {
                     tracing::info!(
-                        "Found {} soft-deleted attached functions to hard delete",
+                        "Found {} attached functions to garbage collect (deleted or not ready)",
                         attached_functions_to_delete.len()
                     );
 
@@ -212,12 +212,12 @@ impl GarbageCollector {
                     );
                     (num_deleted, num_failed)
                 } else {
-                    tracing::debug!("No soft-deleted attached functions found to hard delete");
+                    tracing::debug!("No attached functions found to garbage collect");
                     (0, 0)
                 }
             }
             Err(e) => {
-                tracing::error!("Failed to get soft-deleted attached functions: {}", e);
+                tracing::error!("Failed to get attached functions to garbage collect: {}", e);
                 (0, 0)
             }
         }


### PR DESCRIPTION
## Description of changes

_GC_ _nonready_ _attached_ _function_ _rows_ _that_ _were_ _a_ _result_ _of_ _partial_ _attach_ _calls._

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_