### PR TITLE
[CHORE][wal3] move snapshot installation behind ManifestPublisher trait

### DIFF
--- a/rust/wal3/src/interfaces/mod.rs
+++ b/rust/wal3/src/interfaces/mod.rs
@@ -144,6 +144,7 @@ pub trait ManifestPublisher<FP: FragmentPointer>: Send + Sync + 'static {
 
     /// Snapshot storers and accessors
     async fn snapshot_load(&self, pointer: &SnapshotPointer) -> Result<Option<Snapshot>, Error>;
+    async fn snapshot_install(&self, snapshot: &Snapshot) -> Result<SnapshotPointer, Error>;
 
     /// Shutdown the manifest manager.  Must be called between prepare and finish of
     /// FragmentPublisher shutdown.

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -864,6 +864,7 @@ impl<P: FragmentPointer, FP: FragmentPublisher<FragmentPointer = P>, MP: Manifes
             };
             match garbage
                 .install(
+                    &self.manifest_manager,
                     &self.options.throttle_manifest,
                     &self.storage,
                     &self.prefix,

--- a/rust/wal3/tests/test_k8s_integration_0_properties.rs
+++ b/rust/wal3/tests/test_k8s_integration_0_properties.rs
@@ -160,7 +160,7 @@ proptest::proptest! {
         let start = manifest.oldest_timestamp();
         let limit = manifest.next_write_timestamp();
         let cache = Arc::new(TestingSnapshotCache::default());
-        let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+        let mock_publisher = MockManifestPublisher::new();
         let mut count = 0;
         let mut last_limit = 0;
         for offset in start.offset()..=limit.offset() {
@@ -224,7 +224,7 @@ proptest::proptest! {
         let start = manifest.oldest_timestamp();
         let limit = manifest.next_write_timestamp();
         let cache = Arc::new(TestingSnapshotCache::with_snapshots(snapshots.clone()));
-        let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+        let mock_publisher = MockManifestPublisher::new();
         eprintln!("[{:?}, {:?})", start, limit);
         let mut last_initial_seq_no = FragmentIdentifier::SeqNo(FragmentSeqNo::from_u64(0));
         for offset in start.offset()..=limit.offset() {
@@ -295,7 +295,7 @@ proptest::proptest! {
             }
         }
         let cache = Arc::new(TestingSnapshotCache::with_snapshots(snapshots.clone()));
-        let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+        let mock_publisher = MockManifestPublisher::new();
         // Pick as victim the most recent snapshot and select so that we keep just one snapshot and
         // one frag within that snapshot.
         assert!(!manifest.snapshots.is_empty());

--- a/rust/wal3/tests/test_k8s_integration_87_gc.rs
+++ b/rust/wal3/tests/test_k8s_integration_87_gc.rs
@@ -96,7 +96,7 @@ async fn test_k8s_integration_replace_snapshot_triggers_to_split_case_one_level(
     let mut first_to_keep = LogPosition::from_offset(10);
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -198,7 +198,7 @@ async fn test_k8s_integration_replace_snapshot_triggers_to_split_case_two_level(
     let mut first_to_keep = LogPosition::from_offset(10);
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -276,7 +276,7 @@ async fn test_k8s_integration_replace_snapshot_triggers_to_split_case_three_leve
     let mut first_to_keep = LogPosition::from_offset(10);
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -436,7 +436,7 @@ async fn test_k8s_integration_drop_snapshot() {
     let snapshot_ptr = main_snapshot.to_pointer();
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -523,7 +523,7 @@ async fn test_k8s_integration_replace_snapshot_flat() {
     let mut first_to_keep = LogPosition::from_offset(10); // Keep fragments starting from offset 10
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -650,7 +650,7 @@ async fn test_k8s_integration_replace_snapshot_drops_snapshots_prior_to_cutoff()
     let mut first_to_keep = LogPosition::from_offset(12); // Keep snapshots starting from offset 12
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -743,7 +743,7 @@ async fn test_k8s_integration_replace_snapshot_drops_fragments_prior_to_cutoff()
     let mut first_to_keep = LogPosition::from_offset(12); // Keep fragments starting from offset 12
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],
@@ -861,7 +861,7 @@ async fn test_k8s_integration_replace_snapshot_two_levels_rightmost_leaf() {
     let mut first_to_keep = LogPosition::from_offset(12); // Keep snapshots starting from offset 12
 
     let cache = Arc::new(cache);
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     let mut garbage = Garbage {
         snapshots_to_drop: vec![],

--- a/rust/wal3/tests/test_k8s_integration_bad_manifest1.rs
+++ b/rust/wal3/tests/test_k8s_integration_bad_manifest1.rs
@@ -58,7 +58,7 @@ async fn test_k8s_integration_garbage_new_with_bad_manifest1_offset_9340() {
     let snapshot_cache = Arc::new(MockSnapshotCache::new());
     snapshot_cache.load_from_json(snapshots_json);
 
-    let mock_publisher = MockManifestPublisher::new(Arc::clone(&snapshot_cache));
+    let mock_publisher = MockManifestPublisher::new();
 
     // The bug should occur when calling Garbage::new with offset 9340
     let first_to_keep = LogPosition::from_offset(9340);


### PR DESCRIPTION
## Description of changes

Add snapshot_install method to ManifestPublisher trait to encapsulate
snapshot installation logic behind the manifest abstraction layer.

- Add snapshot_install to ManifestPublisher trait in interfaces/mod.rs
- Move Snapshot::install implementation to ManifestManager::snapshot_install
- Update Garbage::install and install_new_snapshots to use ManifestPublisher
- Simplify MockManifestPublisher to use internal HashMap instead of SnapshotCache
- Add Hash derive to SnapshotPointer for HashMap key usage
- Update all test files to use new MockManifestPublisher::new() signature

This change continues the work of abstracting storage operations behind
trait interfaces, enabling easier testing and future alternative
implementations.

## Test plan

CI + Local clippy

## Migration plan

N/A 

## Observability plan

N/A 

## Documentation Changes

N/A 

Co-authored-by: AI
