### PR TITLE
[ENH]: Add config file to rust sysdb service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6954,12 +6954,20 @@ dependencies = [
 name = "rust-sysdb"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "chroma-config",
+ "chroma-error",
+ "chroma-storage",
  "chroma-tracing",
  "chroma-types",
+ "figment",
+ "opentelemetry",
+ "serde",
  "tokio",
  "tokio-util",
  "tonic",
  "tonic-health",
+ "tracing",
 ]
 
 [[package]]

--- a/Tiltfile
+++ b/Tiltfile
@@ -175,7 +175,7 @@ if os.environ.get('ADDITIONAL_DISTRIBUTED_CHROMA_VALUES'):
 # We manually call helm template so we can call set-file
 k8s_yaml(
   local(
-    'helm template --set-file rustFrontendService.configuration=' + rfe_config_file + ',rustLogService.configuration=rust/worker/chroma_config.yaml,heapTenderService.configuration=rust/worker/chroma_config.yaml,compactionService.configuration=rust/worker/chroma_config.yaml,queryService.configuration=rust/worker/chroma_config.yaml,garbageCollector.configuration=rust/worker/chroma_config.yaml --values ' + distributed_chroma_values + ' k8s/distributed-chroma'
+    'helm template --set-file rustFrontendService.configuration=' + rfe_config_file + ',rustLogService.configuration=rust/worker/chroma_config.yaml,heapTenderService.configuration=rust/worker/chroma_config.yaml,compactionService.configuration=rust/worker/chroma_config.yaml,queryService.configuration=rust/worker/chroma_config.yaml,garbageCollector.configuration=rust/worker/chroma_config.yaml,rustSysdbService.configuration=rust/worker/chroma_config.yaml --values ' + distributed_chroma_values + ' k8s/distributed-chroma'
   ),
 )
 
@@ -187,7 +187,7 @@ if os.environ.get('ADDITIONAL_DISTRIBUTED_CHROMA2_VALUES'):
 
 k8s_yaml(
   local(
-    'helm template --set-file rustFrontendService.configuration=' + rfe2_config_file + ',rustLogService.configuration=rust/worker/chroma_config2.yaml,heapTenderService.configuration=rust/worker/chroma_config2.yaml,compactionService.configuration=rust/worker/chroma_config2.yaml,queryService.configuration=rust/worker/chroma_config2.yaml,garbageCollector.configuration=rust/worker/chroma_config2.yaml --values ' + distributed_chroma2_values + ' k8s/distributed-chroma'
+    'helm template --set-file rustFrontendService.configuration=' + rfe2_config_file + ',rustLogService.configuration=rust/worker/chroma_config2.yaml,heapTenderService.configuration=rust/worker/chroma_config2.yaml,compactionService.configuration=rust/worker/chroma_config2.yaml,queryService.configuration=rust/worker/chroma_config2.yaml,garbageCollector.configuration=rust/worker/chroma_config2.yaml,rustSysdbService.configuration=rust/worker/chroma_config2.yaml --values ' + distributed_chroma2_values + ' k8s/distributed-chroma'
   ),
 )
 

--- a/k8s/distributed-chroma/templates/rust-sysdb-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-sysdb-service.yaml
@@ -1,4 +1,17 @@
 {{- if gt (int .Values.rustSysdbService.replicaCount) 0 }}
+{{if .Values.rustSysdbService.configuration}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rust-sysdb-service-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+{{  .Values.rustSysdbService.configuration | indent 4 }}
+{{ end }}
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,6 +27,12 @@ spec:
       labels:
         app: rust-sysdb-service
     spec:
+      volumes:
+        {{if .Values.rustSysdbService.configuration}}
+        - name: rust-sysdb-service-config
+          configMap:
+            name: rust-sysdb-service-config
+        {{ end }}
       containers:
         - name: rust-sysdb-service
           image: "{{ .Values.rustSysdbService.image.repository }}:{{ .Values.rustSysdbService.image.tag }}"
@@ -24,9 +43,17 @@ spec:
             grpc:
               port: 50051
               service: chroma.SysDB
+          volumeMounts:
+            {{if .Values.rustSysdbService.configuration}}
+            - name: rust-sysdb-service-config
+              mountPath: /config/
+            {{ end }}
           ports:
             - containerPort: 50051
               name: grpc
+          env:
+            - name: CONFIG_PATH
+              value: "/config/config.yaml"
           resources:
             limits:
               cpu: {{ .Values.rustSysdbService.resources.limits.cpu }}

--- a/rust/rust-sysdb/Cargo.toml
+++ b/rust/rust-sysdb/Cargo.toml
@@ -8,9 +8,17 @@ name = "sysdb_service"
 path = "src/bin/sysdb_service.rs"
 
 [dependencies]
+async-trait = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tonic-health = { workspace = true }
+chroma-config = { workspace = true }
+chroma-error = { workspace = true }
+chroma-storage = { workspace = true }
 chroma-types = { workspace = true }
 chroma-tracing = { workspace = true, features = ["grpc"]}
+serde = { workspace = true }
+tracing = { workspace = true }
+figment = { workspace = true }
+opentelemetry = { workspace = true }

--- a/rust/rust-sysdb/src/config.rs
+++ b/rust/rust-sysdb/src/config.rs
@@ -1,0 +1,85 @@
+use chroma_storage::config::StorageConfig;
+use chroma_tracing::{OtelFilter, OtelFilterLevel};
+use figment::providers::{Env, Format, Yaml};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_CONFIG_PATH: &str = "./chroma_config.yaml";
+
+#[derive(Serialize, Deserialize)]
+pub struct SysDbServiceConfig {
+    #[serde(default = "SysDbServiceConfig::default_service_name")]
+    pub service_name: String,
+    #[serde(default = "SysDbServiceConfig::default_otel_endpoint")]
+    pub otel_endpoint: String,
+    #[serde(default = "SysDbServiceConfig::default_otel_filters")]
+    pub otel_filters: Vec<OtelFilter>,
+    #[serde(default = "SysDbServiceConfig::default_port")]
+    pub port: u16,
+    #[serde(default)]
+    pub storage: StorageConfig,
+}
+
+impl SysDbServiceConfig {
+    fn default_service_name() -> String {
+        "rust-sysdb-service".to_string()
+    }
+
+    fn default_otel_endpoint() -> String {
+        "http://otel-collector.chroma.svc.cluster.local:4317".to_string()
+    }
+
+    fn default_otel_filters() -> Vec<OtelFilter> {
+        vec![OtelFilter {
+            crate_name: "rust_sysdb".to_string(),
+            filter_level: OtelFilterLevel::Trace,
+        }]
+    }
+
+    fn default_port() -> u16 {
+        50051
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RootConfig {
+    pub sysdb_service: SysDbServiceConfig,
+}
+
+impl RootConfig {
+    pub fn load() -> Self {
+        Self::load_from_path(DEFAULT_CONFIG_PATH)
+    }
+
+    pub fn load_from_path(path: &str) -> Self {
+        println!("loading config from {path}");
+        println!(
+            r#"Full config is:
+================================================================================
+{}
+================================================================================
+"#,
+            std::fs::read_to_string(path)
+                .expect("should be able to open and read config to string")
+        );
+        // Unfortunately, figment doesn't support environment variables with underscores. So we have to map and replace them.
+        // Excluding our own environment variables, which are prefixed with CHROMA_.
+        let mut f = figment::Figment::from(Env::prefixed("CHROMA_").map(|k| match k {
+            k if k == "my_member_id" => k.into(),
+            k => k.as_str().replace("__", ".").into(),
+        }));
+        if std::path::Path::new(path).exists() {
+            f = figment::Figment::from(Yaml::file(path)).merge(f);
+        }
+        // Apply defaults - this seems to be the best way to do it.
+        // https://github.com/SergioBenitez/Figment/issues/77#issuecomment-1642490298
+        // f = f.join(Serialized::default(
+        //     "worker.num_indexing_threads",
+        //     num_cpus::get(),
+        // ));
+        let res = f.extract();
+        match res {
+            Ok(config) => config,
+            Err(e) => panic!("Error loading config: {}", e),
+        }
+    }
+}

--- a/rust/rust-sysdb/src/lib.rs
+++ b/rust/rust-sysdb/src/lib.rs
@@ -1,13 +1,36 @@
-use crate::server::SysdbService;
+use chroma_config::Configurable;
+
+use crate::config::RootConfig;
 
 pub mod server;
 
+pub mod config;
+
+const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
+
 pub async fn sysdb_service_entrypoint() {
-    // TODO(Sanket): Config.
-    let port = 50051;
-    let service = SysdbService::new(port);
-    if let Err(e) = service.run().await {
-        // TODO(Sanket): Switch to tracing instead of println.
-        println!("Server error: {} exiting", e);
-    }
+    let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
+        Ok(config_path) => RootConfig::load_from_path(&config_path),
+        Err(_) => RootConfig::load(),
+    };
+    let config = config.sysdb_service;
+    let registry = chroma_config::registry::Registry::new();
+    chroma_tracing::init_otel_tracing(
+        &config.service_name,
+        &config.otel_filters,
+        &config.otel_endpoint,
+    );
+    let sysdb_server = match server::SysdbService::try_from_config(&config, &registry).await {
+        Ok(sysdb_server) => sysdb_server,
+        Err(err) => {
+            tracing::error!("Failed to create sysdb server component: {:?}", err);
+            return;
+        }
+    };
+
+    // Server task will run until it receives a shutdown signal
+    let _ = tokio::spawn(async move {
+        let _ = crate::server::SysdbService::run(sysdb_server).await;
+    })
+    .await;
 }

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -259,3 +259,23 @@ garbage_collector:
           kube_namespace: "chroma"
           memberlist_name: "rust-log-service-memberlist"
           queue_size: 100
+sysdb_service:
+  service_name: "rust-sysdb-service"
+  otel_endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"
+  otel_filters:
+    - crate_name: "rust_sysdb"
+      filter_level: "trace"
+  port: 50051
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 30000 # 30 seconds
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 1000
+          bandwidth_allocation: [1.0]

--- a/rust/worker/chroma_config2.yaml
+++ b/rust/worker/chroma_config2.yaml
@@ -259,3 +259,23 @@ garbage_collector:
           kube_namespace: "chroma2"
           memberlist_name: "rust-log-service-memberlist"
           queue_size: 100
+sysdb_service:
+  service_name: "rust-sysdb-service"
+  otel_endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"
+  otel_filters:
+    - crate_name: "rust_sysdb"
+      filter_level: "trace"
+  port: 50051
+  storage:
+    admission_controlled_s3:
+      s3_config:
+        bucket: "chroma-storage"
+        credentials: "Minio"
+        connect_timeout_ms: 5000
+        request_timeout_ms: 30000 # 30 seconds
+        upload_part_size_bytes: 536870912 # 512MiB
+        download_part_size_bytes: 8388608 # 8MiB
+      rate_limiting_policy:
+        count_based_policy:
+          max_concurrent_requests: 1000
+          bandwidth_allocation: [1.0]


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Adds a rust sysdb section in existing chroma_config.yaml
  - Server loads this config and inits from it
  - Properly init otel tracing
  - Properly init storage
  - Adds a config map to k8s manifest with this config
- New functionality
  - ...

## Test plan

_How are these changes tested?_
Verified by local `tilt up`
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
None

## Documentation Changes
None
