### PR TITLE
[DOC] Enhance JS reference docs

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/reference/js/client.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/js/client.md
@@ -15,15 +15,25 @@ Creates a new ChromaClient instance.
 
 #### Parameters
 
-| Name     | Type                 | Description                              |
-| :------- | :------------------- | :--------------------------------------- |
-| `params` | `ChromaClientParams` | The parameters for creating a new client |
+| Name            | Type                 | Description                              |
+| :-------------- | :------------------- | :--------------------------------------- |
+| `params.host?`  | `string`             | The host address of the Chroma server. Defaults to `'localhost'`. |
+| `params.port?`  | `number`             | The port number of the Chroma server. Defaults to `8000`. |
+| `params.ssl?`   | `boolean`            | Whether to use SSL/HTTPS for connections. Defaults to `false`. |
+| `params.tenant?` | `string`             | The tenant name in the Chroma server to connect to. |
+| `params.database?` | `string`            | The database name to connect to. |
+| `params.headers?` | `Record<string, string>` | Additional HTTP headers to send with requests. |
+| `params.fetchOptions?` | `RequestInit`      | Additional fetch options for HTTP requests. |
 
 **Example**
 
 ```typescript
 const client = new ChromaClient({
-  path: "http://localhost:8000",
+  host: "localhost",
+  port: 8000,
+  ssl: false,
+  tenant: "my_tenant",
+  database: "my_database",
 });
 ```
 
@@ -59,9 +69,13 @@ Creates a new collection with the specified properties.
 
 #### Parameters
 
-| Name     | Type                     | Description                                   |
-| :------- | :----------------------- | :-------------------------------------------- |
-| `params` | `CreateCollectionParams` | The parameters for creating a new collection. |
+| Name                      | Type                        | Description                                   |
+| :------------------------ | :-------------------------- | :-------------------------------------------- |
+| `params.name`             | `string`                    | The name of the collection (required).        |
+| `params.configuration?`   | `CreateCollectionConfiguration` | Optional collection configuration.         |
+| `params.metadata?`        | `CollectionMetadata`       | Optional metadata for the collection.         |
+| `params.embeddingFunction?` | `EmbeddingFunction \| null` | Optional embedding function to use. Defaults to `DefaultEmbeddingFunction` from @chroma-core/default-embed. |
+| `params.schema?`          | `Schema`                    | Optional schema describing index configuration. |
 
 #### Returns
 
@@ -93,9 +107,9 @@ Deletes a collection with the specified name.
 
 #### Parameters
 
-| Name     | Type                     | Description                               |
-| :------- | :----------------------- | :---------------------------------------- |
-| `params` | `DeleteCollectionParams` | The parameters for deleting a collection. |
+| Name         | Type     | Description                               |
+| :----------- | :------- | :---------------------------------------- |
+| `params.name` | `string` | The name of the collection to delete (required). |
 
 #### Returns
 
@@ -117,15 +131,16 @@ await client.deleteCollection({
 
 ### getCollection
 
-`getCollection(params): Promise<Collection>`
+- `getCollection(params): Promise<Collection>`
 
 Gets a collection with the specified name.
 
 #### Parameters
 
-| Name     | Type                  | Description                              |
-| :------- | :-------------------- | :--------------------------------------- |
-| `params` | `GetCollectionParams` | The parameters for getting a collection. |
+| Name                      | Type                | Description                              |
+| :------------------------ | :------------------ | :--------------------------------------- |
+| `params.name`             | `string`            | The name of the collection to retrieve (required). |
+| `params.embeddingFunction?` | `EmbeddingFunction` | Optional embedding function. Should match the one used to create the collection. |
 
 #### Returns
 
@@ -153,9 +168,15 @@ Gets or creates a collection with the specified properties.
 
 #### Parameters
 
-| Name     | Type                     | Description                                   |
-| :------- | :----------------------- | :-------------------------------------------- |
-| `params` | `CreateCollectionParams` | The parameters for creating a new collection. |
+| Name                      | Type                        | Description                                   |
+| :------------------------ | :-------------------------- | :-------------------------------------------- |
+| `params.name`             | `string`                    | The name of the collection (required).        |
+| `params.configuration?`   | `CreateCollectionConfiguration` | Optional collection configuration (used only if creating). |
+| `params.metadata?`        | `CollectionMetadata`       | Optional metadata for the collection (used only if creating). |
+| `params.embeddingFunction?` | `EmbeddingFunction \| null` | Optional embedding function to use. |
+| `params.schema?`          | `Schema`                    | Optional schema describing index configuration (used only if creating). |
+
+
 
 #### Returns
 
@@ -202,21 +223,22 @@ const heartbeat = await client.heartbeat();
 
 ### listCollections
 
-- `listCollections(params?): Promise<CollectionParams>`
+- `listCollections(params?): Promise<Collection[]>`
 
 Lists all collections.
 
 #### Parameters
 
-| Name     | Type                    |
-| :------- | :---------------------- |
-| `params` | `ListCollectionsParams` |
+| Name            | Type     | Description                                                      |
+| :-------------- | :------- | :--------------------------------------------------------------- |
+| `params.limit?` | `number` | Maximum number of collections to return. Default: `100`.          |
+| `params.offset?` | `number` | Number of collections to skip. Default: `0`.                     |
 
 #### Returns
 
-`Promise<CollectionParams>`
+`Promise<Collection[]>`
 
-A promise that resolves to a list of collection names.
+A promise that resolves to an array of Collection instances.
 
 **Throws**
 
@@ -233,20 +255,20 @@ const collections = await client.listCollections({
 
 ### reset
 
-- `reset(): Promise<boolean>`
+- `reset(): Promise<void>`
 
-Resets the state of the object by making an API call to the reset endpoint.
+Resets the entire database, deleting all collections and data.
 
 #### Returns
 
-`Promise<boolean>`
+`Promise<void>`
 
-A promise that resolves when the reset operation is complete.
+A promise that resolves when the reset is complete.
 
 **Throws**
 
 - If the client is unable to connect to the server.
-- If the server experienced an error while the state.
+- If the server experienced an error while resetting.
 
 **Example**
 

--- a/docs/docs.trychroma.com/markdoc/content/reference/js/collection.md
+++ b/docs/docs.trychroma.com/markdoc/content/reference/js/collection.md
@@ -21,9 +21,13 @@ Add items to the collection
 
 #### Parameters
 
-| Name     | Type               | Description                   |
-| :------- | :----------------- | :---------------------------- |
-| `params` | `AddRecordsParams` | The parameters for the query. |
+| Name                | Type          | Description                                                      |
+| :------------------ | :------------ | :--------------------------------------------------------------- |
+| `params.ids`        | `string[]`    | Unique identifiers for the records (required).                   |
+| `params.embeddings?` | `number[][]`  | Optional pre-computed embeddings.                                 |
+| `params.metadatas?` | `Metadata[]`  | Optional metadata for each record.                               |
+| `params.documents?` | `string[]`    | Optional document text (will be embedded if embeddings not provided). |
+| `params.uris?`      | `string[]`    | Optional URIs for the records.                                  |
 
 #### Returns
 
@@ -65,21 +69,23 @@ const count = await collection.count();
 
 ### delete
 
-- `delete(params?): Promise<string[]>`
+- `delete(params?): Promise<void>`
 
 Deletes items from the collection.
 
 #### Parameters
 
-| Name     | Type           | Description                                            |
-| :------- | :------------- | :----------------------------------------------------- |
-| `params` | `DeleteParams` | The parameters for deleting items from the collection. |
+| Name                 | Type          | Description                                            |
+| :------------------- | :------------ | :----------------------------------------------------- |
+| `params.ids?`        | `string[]`    | Specific record IDs to delete.                         |
+| `params.where?`      | `Where`       | Metadata-based filtering for deletion.                 |
+| `params.whereDocument?` | `WhereDocument` | Document content-based filtering for deletion.      |
 
 #### Returns
 
-`Promise<string[]>`
+`Promise<void>`
 
-A promise that resolves to the IDs of the deleted items.
+A promise that resolves when the deletion is complete.
 
 **Throws**
 
@@ -89,7 +95,7 @@ If there is an issue deleting items from the collection.
 
 ```typescript
 const results = await collection.delete({
-  ids: "some_id",
+  ids: ["some_id"],
   where: { name: { $eq: "John Doe" } },
   whereDocument: { $contains: "search_string" },
 });
@@ -97,19 +103,24 @@ const results = await collection.delete({
 
 ### get
 
-- `get(params?): Promise<MultiGetResponse>`
+- `get(params?): Promise<GetResult>`
 
 Get items from the collection
 
 #### Parameters
 
-| Name     | Type            | Description                   |
-| :------- | :-------------- | :---------------------------- |
-| `params` | `BaseGetParams` | The parameters for the query. |
+| Name                 | Type            | Description                                                      |
+| :------------------- | :-------------- | :--------------------------------------------------------------- |
+| `params.ids?`        | `string[]`      | Specific record IDs to retrieve.                                 |
+| `params.where?`      | `Where`         | Metadata-based filtering conditions.                              |
+| `params.limit?`      | `number`        | Maximum number of records to return.                             |
+| `params.offset?`     | `number`        | Number of records to skip.                                      |
+| `params.whereDocument?` | `WhereDocument` | Document content-based filtering conditions.                      |
+| `params.include?`     | `Include[]`     | Fields to include in the response. Options: `"distances"`, `"documents"`, `"embeddings"`, `"metadatas"`, `"uris"`. Default: `["documents", "metadatas"]`. |
 
 #### Returns
 
-`Promise<MultiGetResponse>`
+`Promise<GetResult>`
 
 The response from the server.
 
@@ -128,48 +139,54 @@ const response = await collection.get({
 
 ### modify
 
-- `modify(params): Promise<CollectionParams>`
+- `modify(params): Promise<void>`
 
-Modify the collection name or metadata
+Modify the collection name, metadata, or configuration
 
 #### Parameters
 
-| Name               | Type                 | Description                               |
-| :----------------- | :------------------- | :---------------------------------------- |
-| `params`           | `Object`             | The parameters for the query.             |
-| `params.metadata?` | `CollectionMetadata` | Optional new metadata for the collection. |
-| `params.name?`     | `string`             | Optional new name for the collection.     |
+| Name                    | Type                        | Description                               |
+| :---------------------- | :-------------------------- | :---------------------------------------- |
+| `params.name?`          | `string`                    | Optional new name for the collection.     |
+| `params.metadata?`       | `CollectionMetadata`       | Optional new metadata for the collection. |
+| `params.configuration?` | `UpdateCollectionConfiguration` | Optional new configuration settings.     |
 
 #### Returns
 
-`Promise<CollectionParams>`
+`Promise<void>`
 
-The response from the API.
+A promise that resolves when the modification is complete.
 
 **Example**
 
 ```typescript
-const response = await client.updateCollection({
+await collection.modify({
   name: "new name",
   metadata: { key: "value" },
+  configuration: {
+    hnsw: {
+      ef_search: 100,
+      batch_size: 1000
+    }
+  }
 });
 ```
 
 ### peek
 
-- `peek(params?): Promise<MultiGetResponse>`
+- `peek(params?): Promise<GetResult>`
 
 Peek inside the collection
 
 #### Parameters
 
-| Name     | Type         | Description                   |
-| :------- | :----------- | :---------------------------- |
-| `params` | `PeekParams` | The parameters for the query. |
+| Name            | Type     | Description                   |
+| :-------------- | :------- | :---------------------------- |
+| `params.limit?` | `number` | Maximum number of records to return. Default: `10`. |
 
 #### Returns
 
-`Promise<MultiGetResponse>`
+`Promise<GetResult>`
 
 A promise that resolves to the query results.
 
@@ -187,19 +204,26 @@ const results = await collection.peek({
 
 ### query
 
-- `query(params): Promise<MultiQueryResponse>`
+- `query(params): Promise<QueryResult>`
 
 Performs a query on the collection using the specified parameters.
 
 #### Parameters
 
-| Name     | Type                 | Description                   |
-| :------- | :------------------- | :---------------------------- |
-| `params` | `QueryRecordsParams` | The parameters for the query. |
+| Name                  | Type            | Description                                                      |
+| :-------------------- | :-------------- | :--------------------------------------------------------------- |
+| `params.queryEmbeddings?` | `number[][]` | Pre-computed query embedding vectors.                           |
+| `params.queryTexts?` | `string[]`      | Query text to be embedded and searched.                          |
+| `params.queryURIs?`   | `string[]`      | Query URIs to be processed.                                      |
+| `params.ids?`         | `string[]`      | Filter to specific record IDs.                                  |
+| `params.nResults?`    | `number`        | Maximum number of results per query. Default: `10`.              |
+| `params.where?`       | `Where`         | Metadata-based filtering conditions.                            |
+| `params.whereDocument?` | `WhereDocument` | Full-text search conditions.                                    |
+| `params.include?`       | `Include[]`     | Fields to include in the response. Options: `"distances"`, `"documents"`, `"embeddings"`, `"metadatas"`, `"uris"`. Default: `["metadatas", "documents", "distances"]`. |
 
 #### Returns
 
-`Promise<MultiQueryResponse>`
+`Promise<QueryResult>`
 
 A promise that resolves to the query results.
 
@@ -216,17 +240,54 @@ const embeddingsResults = await collection.query({
   ids: ["id1", "id2", ...],
   nResults: 10,
   where: {"name": {"$eq": "John Doe"}},
-  include: ["metadata", "document"]
+  include: ["metadatas", "documents"]
 });
 
 // Query the collection using query text
 const textResults = await collection.query({
-    queryTexts: "some text",
+    queryTexts: ["some text"],
     ids: ["id1", "id2", ...],
     nResults: 10,
     where: {"name": {"$eq": "John Doe"}},
-    include: ["metadata", "document"]
+    include: ["metadatas", "documents"]
 });
+```
+
+### search
+
+- `search(searches): Promise<SearchResult>`
+
+Performs hybrid search on the collection using expression builders. This method provides a flexible, composable API for building complex search queries with filtering, ranking, and result selection.
+
+#### Parameters
+
+| Name      | Type                              | Description                                                      |
+| :-------- | :-------------------------------- | :--------------------------------------------------------------- |
+| `searches` | `SearchLike \| SearchLike[]`      | A single search expression or an array of search expressions.   |
+
+#### Returns
+
+`Promise<SearchResult>`
+
+A promise that resolves to search results in column-major format. Use the `.rows()` method to convert to row-major format.
+
+**Throws**
+
+If there is an issue executing the search or if no search payload is provided.
+
+**Example**
+
+```typescript
+import { Search, K, Knn, Rrf, Val } from "chromadb";
+
+// Basic search with KNN ranking
+const results = await collection.search(
+  new Search()
+    .where(K("category").eq("science"))
+    .rank(Knn({ query: [0.1, 0.2, 0.3], limit: 10 }))
+    .limit(5)
+    .select(K.DOCUMENT, K.SCORE, "title")
+);
 ```
 
 ### update
@@ -237,9 +298,13 @@ Update items in the collection
 
 #### Parameters
 
-| Name     | Type                  | Description                   |
-| :------- | :-------------------- | :---------------------------- |
-| `params` | `UpdateRecordsParams` | The parameters for the query. |
+| Name                | Type         | Description                   |
+| :------------------ | :----------- | :---------------------------- |
+| `params.ids`         | `string[]`   | IDs of records to update (required). |
+| `params.embeddings?` | `number[][]` | New embedding vectors.        |
+| `params.metadatas?`  | `Metadata[]` | New metadata.                 |
+| `params.documents?`  | `string[]`   | New document text.            |
+| `params.uris?`       | `string[]`   | New URIs.                     |
 
 #### Returns
 
@@ -248,7 +313,7 @@ Update items in the collection
 **Example**
 
 ```typescript
-const response = await collection.update({
+await collection.update({
   ids: ["id1", "id2"],
   embeddings: [
     [1, 2, 3],
@@ -263,13 +328,17 @@ const response = await collection.update({
 
 - `upsert(params): Promise<void>`
 
-Upsert items to the collection
+Upsert items to the collection (inserts new records or updates existing ones)
 
 #### Parameters
 
-| Name     | Type               | Description                   |
-| :------- | :----------------- | :---------------------------- |
-| `params` | `AddRecordsParams` | The parameters for the query. |
+| Name                | Type         | Description                   |
+| :------------------ | :----------- | :---------------------------- |
+| `params.ids`         | `string[]`   | IDs of records to upsert (required). |
+| `params.embeddings?`  | `number[][]` | Embedding vectors.            |
+| `params.metadatas?`  | `Metadata[]` | Metadata.                     |
+| `params.documents?`  | `string[]`   | Document text.                |
+| `params.uris?`       | `string[]`   | URIs.                         |
 
 #### Returns
 
@@ -278,7 +347,7 @@ Upsert items to the collection
 **Example**
 
 ```typescript
-const response = await collection.upsert({
+await collection.upsert({
   ids: ["id1", "id2"],
   embeddings: [
     [1, 2, 3],


### PR DESCRIPTION
I added the new Search API to the docs

Additionally, I expanded the params to be useful. For example, this is how the docs currently look like.

![Screenshot 2025-12-17 at 4.46.36 PM.png](https://app.graphite.com/user-attachments/assets/e4a65bc9-ff33-4c42-94e2-553b4d37ffa7.png)

This doesn't really help me because what I really want to know is what the params are. I expanded the tables to this:

![Screenshot 2025-12-17 at 4.46.55 PM.png](https://app.graphite.com/user-attachments/assets/81b30280-822c-4077-8252-a3e192f161f8.png)

