### PR TITLE
[ENH]: Rust sysdb schema migration service

### DIFF
--- a/.github/actions/tilt-setup-prebuild/docker-bake.hcl
+++ b/.github/actions/tilt-setup-prebuild/docker-bake.hcl
@@ -22,6 +22,12 @@ target "sysdb-migration" {
   tags = [ "sysdb-migration:ci" ]
 }
 
+target "rust-sysdb-migration" {
+  dockerfile = "rust/Dockerfile"
+  target = "rust-sysdb-migration"
+  tags = [ "rust-sysdb-migration:ci" ]
+}
+
 target "rust-frontend-service" {
   dockerfile = "rust/Dockerfile"
   target = "cli"
@@ -59,6 +65,7 @@ group "default" {
     "rust-sysdb-service",
     "sysdb",
     "sysdb-migration",
+    "rust-sysdb-migration",
     "rust-frontend-service",
     "query-service",
     "compactor-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,6 +7106,7 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7919,6 +7920,27 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spanner-migrations"
+version = "0.1.0"
+dependencies = [
+ "chroma-config",
+ "chroma-tracing",
+ "figment",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-spanner",
+ "regex",
+ "rust-embed",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/frontend", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server", "rust/s3heap", "rust/s3heap-service", "rust/api-types", "rust/rust-sysdb"]
+members = ["rust/benchmark", "rust/blockstore", "rust/cache", "rust/chroma", "rust/config", "rust/distance", "rust/error", "rust/frontend", "rust/garbage_collector", "rust/index", "rust/load", "rust/log", "rust/log-service", "rust/memberlist", "rust/metering-macros", "rust/metering", "rust/storage", "rust/system", "rust/sysdb", "rust/types", "rust/worker", "rust/segment", "rust/python_bindings", "rust/mdac", "rust/tracing", "rust/sqlite", "rust/cli", "rust/wal3", "rust/js_bindings", "rust/jemalloc-pprof-server", "rust/s3heap", "rust/s3heap-service", "rust/api-types", "rust/rust-sysdb", "rust/rust-sysdb/spanner-migrations"]
 
 [workspace.dependencies]
 anyhow = "1.0"
@@ -77,6 +77,7 @@ base64 = "0.22"
 tikv-jemallocator = { version = "0.6.0", features = ["profiling"] }
 google-cloud-spanner = { version = "0.33.0" }
 google-cloud-gax = { version = "0.19.2" }
+google-cloud-googleapis = { version = "0.16.1", features = ["spanner"] }
 
 chroma = { path = "rust/chroma", version = "0.10.0" }
 chroma-api-types = { path = "rust/api-types", version = "0.10.0" }

--- a/k8s/distributed-chroma/templates/rust-sysdb-migration.yaml
+++ b/k8s/distributed-chroma/templates/rust-sysdb-migration.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.rustSysdbMigration.configuration }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rust-sysdb-migration-config
+  namespace: {{ .Values.namespace }}
+data:
+  config.yaml: |
+{{ .Values.rustSysdbMigration.configuration | indent 4 }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rust-sysdb-migration-{{ .Values.rustSysdbMigration.image.tag }}
+  namespace: {{ .Values.namespace }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: rust-sysdb-migration
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: rust-sysdb-migration
+          image: "{{ .Values.rustSysdbMigration.image.repository }}:{{ .Values.rustSysdbMigration.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CONFIG_PATH
+              value: "/config/config.yaml"
+          volumeMounts:
+            {{- if .Values.rustSysdbMigration.configuration }}
+            - name: config
+              mountPath: /config/
+            {{- end }}
+      {{- if .Values.rustSysdbMigration.configuration }}
+      volumes:
+        - name: config
+          configMap:
+            name: rust-sysdb-migration-config
+      {{- end }}
+      {{- if .Values.rustSysdbMigration.tolerations }}
+      tolerations:
+        {{- toYaml .Values.rustSysdbMigration.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rustSysdbMigration.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.rustSysdbMigration.nodeSelector | nindent 8 }}
+      {{- end }}
+---

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -69,6 +69,13 @@ sysdbMigration:
   port: 5432
   dbName: sysdb
   sslmode: disable
+# Rust Sysdb Migration Configuration
+rustSysdbMigration:
+  image:
+    repository: 'rust-sysdb-migration'
+    tag: 'latest'
+  tolerations: []
+  nodeSelector: {}
 # Add the garbage collector configuration
 garbageCollector:
   image:

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.0 AS builder
+FROM rust:1.88.0 AS builder
 
 ARG RELEASE_MODE=
 ARG PROTOC_VERSION=31.1
@@ -22,11 +22,11 @@ WORKDIR /chroma
 
 RUN ARCH=$(uname -m) && \
   if [ "$ARCH" = "x86_64" ]; then \
-    PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
+  PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
   elif [ "$ARCH" = "aarch64" ]; then \
-    PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-aarch_64.zip; \
+  PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-aarch_64.zip; \
   else \
-    echo "Unsupported architecture: $ARCH" && exit 1; \
+  echo "Unsupported architecture: $ARCH" && exit 1; \
   fi && \
   curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/$PROTOC_ZIP && \
   unzip -o $PROTOC_ZIP -d /usr/local bin/protoc && \
@@ -48,18 +48,18 @@ ENV EXCLUDED_PACKAGES="chromadb_rust_bindings chromadb-js-bindings chroma-benchm
 RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
   --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
   if [ "$ENABLE_AVX512" = "1" ]; then \
-    export CXXFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
-    export CFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
-    export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+avx,+fma" && \
-    echo "Building with AVX512 optimizations for hnswlib and AVX for Rust"; \
+  export CXXFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
+  export CFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
+  export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+avx,+fma" && \
+  echo "Building with AVX512 optimizations for hnswlib and AVX for Rust"; \
   else \
-    echo "Building without AVX512 optimizations"; \
+  echo "Building without AVX512 optimizations"; \
   fi && \
   build_target=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo '--target x86_64-unknown-linux-gnu' || echo '' ) && \
   if [ "$RELEASE_MODE" = "1" ]; then cargo build ${build_target} --workspace $(printf -- '--exclude %s ' $EXCLUDED_PACKAGES) --release; else cargo build ${build_target} --workspace $(printf -- '--exclude %s ' $EXCLUDED_PACKAGES); fi && \
   build_dir=$( [ "$RELEASE_MODE" = "1" ] && echo release || echo debug ) && \
   build_dir=$( [ "${ADDRESS_SANITIZER}" = "1" ] && echo "x86_64-unknown-linux-gnu/${build_dir}" || echo "${build_dir}" ) && \
-  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service sysdb_service; do \
+  for bin in chroma garbage_collector_service chroma-load log_service heap_tender_service query_service compaction_service sysdb_service spanner_migration; do \
   mv "target/${build_dir}/${bin}" "./${bin}"; \
   done
 
@@ -113,3 +113,7 @@ ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./compaction_service" ]
 FROM runner AS sysdb_service
 COPY --from=builder /chroma/sysdb_service .
 ENTRYPOINT [ "sh", "-c", "ulimit -c 0 && exec ./sysdb_service" ]
+
+FROM runner AS rust-sysdb-migration
+COPY --from=builder /chroma/spanner_migration .
+ENTRYPOINT ["sh", "-c", "ulimit -c 0 && exec ./spanner_migration" ]

--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod assignment;
 pub mod helpers;
 pub mod registry;
+pub mod spanner;
 
 use async_trait::async_trait;
 use chroma_error::ChromaError;

--- a/rust/config/src/spanner.rs
+++ b/rust/config/src/spanner.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for connecting to a Spanner emulator (local development)
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SpannerEmulatorConfig {
+    #[serde(default = "SpannerEmulatorConfig::default_host")]
+    pub host: String,
+    #[serde(default = "SpannerEmulatorConfig::default_grpc_port")]
+    pub grpc_port: u16,
+    #[serde(default = "SpannerEmulatorConfig::default_rest_port")]
+    pub rest_port: u16,
+    #[serde(default = "SpannerEmulatorConfig::default_project")]
+    pub project: String,
+    #[serde(default = "SpannerEmulatorConfig::default_instance")]
+    pub instance: String,
+    #[serde(default = "SpannerEmulatorConfig::default_database")]
+    pub database: String,
+}
+
+impl Default for SpannerEmulatorConfig {
+    fn default() -> Self {
+        Self {
+            host: Self::default_host(),
+            grpc_port: Self::default_grpc_port(),
+            rest_port: Self::default_rest_port(),
+            project: Self::default_project(),
+            instance: Self::default_instance(),
+            database: Self::default_database(),
+        }
+    }
+}
+
+impl SpannerEmulatorConfig {
+    fn default_host() -> String {
+        "spanner.chroma.svc.cluster.local".to_string()
+    }
+    fn default_grpc_port() -> u16 {
+        9010
+    }
+    fn default_rest_port() -> u16 {
+        9020
+    }
+    fn default_project() -> String {
+        "local-project".to_string()
+    }
+    fn default_instance() -> String {
+        "test-instance".to_string()
+    }
+    fn default_database() -> String {
+        "local-database".to_string()
+    }
+
+    /// Returns the database path in the format required by the Spanner client
+    pub fn database_path(&self) -> String {
+        format!(
+            "projects/{}/instances/{}/databases/{}",
+            self.project, self.instance, self.database
+        )
+    }
+
+    /// Returns the gRPC endpoint for SPANNER_EMULATOR_HOST
+    pub fn grpc_endpoint(&self) -> String {
+        format!("{}:{}", self.host, self.grpc_port)
+    }
+
+    /// Returns the REST endpoint for admin operations
+    pub fn rest_endpoint(&self) -> String {
+        format!("http://{}:{}", self.host, self.rest_port)
+    }
+}
+
+/// Spanner configuration - either emulator or GCP (mutually exclusive)
+/// Defaults to emulator with standard local settings.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum SpannerConfig {
+    /// Emulator configuration for local development
+    Emulator(SpannerEmulatorConfig),
+    // TODO: Add GCP variant later
+    // Gcp(SpannerGcpConfig),
+}
+
+impl Default for SpannerConfig {
+    fn default() -> Self {
+        Self::Emulator(SpannerEmulatorConfig::default())
+    }
+}

--- a/rust/rust-sysdb/Cargo.toml
+++ b/rust/rust-sysdb/Cargo.toml
@@ -20,10 +20,11 @@ chroma-types = { workspace = true }
 chroma-tracing = { workspace = true, features = ["grpc"]}
 serde = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 figment = { workspace = true }
 opentelemetry = { workspace = true }
+thiserror = { workspace = true }
 google-cloud-spanner = { workspace = true }
 google-cloud-gax = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde_json = { workspace = true }
-thiserror = { workspace = true }

--- a/rust/rust-sysdb/spanner-migrations/Cargo.toml
+++ b/rust/rust-sysdb/spanner-migrations/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "spanner-migrations"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "spanner_migration"
+path = "src/main.rs"
+
+[dependencies]
+chroma-config = { workspace = true }
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+google-cloud-spanner = "0.33"
+google-cloud-googleapis = { version = "0.16", features = ["spanner"] }
+google-cloud-gax = "0.19"
+rust-embed = { version = "8.0", features = ["include-exclude"] }
+regex = "1.0"
+sha2 = "0.10"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+figment = { version = "0.10", features = ["yaml", "env"] }
+chroma-tracing = { workspace = true }
+tonic = { workspace = true }

--- a/rust/rust-sysdb/spanner-migrations/src/bootstrap.rs
+++ b/rust/rust-sysdb/spanner-migrations/src/bootstrap.rs
@@ -1,0 +1,110 @@
+//! Bootstrap functionality for Spanner emulator.
+
+use chroma_config::spanner::SpannerEmulatorConfig;
+use google_cloud_gax::conn::Environment;
+use google_cloud_googleapis::spanner::admin::database::v1::CreateDatabaseRequest;
+use google_cloud_googleapis::spanner::admin::instance::v1::{CreateInstanceRequest, Instance};
+use google_cloud_spanner::admin::client::Client as AdminClient;
+use google_cloud_spanner::admin::AdminClientConfig;
+use tonic::Code;
+
+/// Bootstrap the emulator by creating instance and database via gRPC.
+pub async fn bootstrap_emulator(
+    emulator: &SpannerEmulatorConfig,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing::info!(
+        "Bootstrapping Spanner emulator at {}",
+        emulator.grpc_endpoint()
+    );
+
+    // Configure client to connect to emulator
+    let admin_client_config = AdminClientConfig {
+        environment: Environment::Emulator(emulator.grpc_endpoint().to_string()),
+    };
+
+    let admin_client = AdminClient::new(admin_client_config).await?;
+
+    // Create instance
+    let project_path = format!("projects/{}", emulator.project);
+    tracing::info!(
+        "Creating instance {} in {}",
+        emulator.instance,
+        project_path
+    );
+
+    let instance_client = admin_client.instance();
+
+    let instance = Instance {
+        name: format!(
+            "projects/{}/instances/{}",
+            emulator.project, emulator.instance
+        ),
+        config: format!(
+            "projects/{}/instanceConfigs/emulator-config",
+            emulator.project
+        ),
+        display_name: emulator.instance.to_string(),
+        node_count: 1,
+        ..Default::default()
+    };
+
+    let create_instance_request = CreateInstanceRequest {
+        parent: project_path.clone(),
+        instance_id: emulator.instance.to_string(),
+        instance: Some(instance),
+    };
+
+    // Try to create instance, handle already exists error
+    match instance_client
+        .create_instance(create_instance_request, None)
+        .await
+    {
+        Ok(_) => {
+            tracing::info!("Created instance: {}", emulator.instance);
+        }
+        Err(e) if e.code() == Code::AlreadyExists => {
+            tracing::info!("Instance {} already exists", emulator.instance);
+        }
+        Err(e) => {
+            return Err(format!("Failed to create instance: {}", e).into());
+        }
+    }
+
+    // Create database
+    let instance_path = format!(
+        "projects/{}/instances/{}",
+        emulator.project, emulator.instance
+    );
+    tracing::info!(
+        "Creating database {} in {}",
+        emulator.database,
+        instance_path
+    );
+
+    let database_client = admin_client.database();
+
+    let create_database_request = CreateDatabaseRequest {
+        parent: instance_path,
+        create_statement: format!("CREATE DATABASE `{}`", emulator.database),
+        ..Default::default()
+    };
+
+    // Try to create database, handle already exists error
+    match database_client
+        .create_database(create_database_request, None)
+        .await
+    {
+        Ok(_) => {
+            tracing::info!("Created database: {}", emulator.database);
+        }
+        Err(e) if e.code() == Code::AlreadyExists => {
+            tracing::info!("Database {} already exists", emulator.database);
+        }
+        Err(e) => {
+            return Err(format!("Failed to create database: {}", e).into());
+        }
+    }
+
+    tracing::info!("Spanner emulator bootstrap complete");
+    Ok(())
+}

--- a/rust/rust-sysdb/spanner-migrations/src/config.rs
+++ b/rust/rust-sysdb/spanner-migrations/src/config.rs
@@ -1,0 +1,58 @@
+//! Configuration for Spanner migrations.
+
+use chroma_config::spanner::SpannerConfig;
+use figment::providers::{Env, Format, Yaml};
+use serde::Deserialize;
+use std::env;
+
+const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
+// spanner-migration is in the chroma2 namespace on tilt
+const DEFAULT_CONFIG_PATH: &str = "./chroma_config2.yaml";
+
+/// Migration-specific configuration
+#[derive(Deserialize)]
+pub struct MigrationConfig {
+    #[serde(default)]
+    pub spanner: SpannerConfig,
+    #[serde(default)]
+    pub _migration_mode: MigrationMode,
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MigrationMode {
+    Apply,
+    #[default]
+    Validate,
+}
+
+/// Root config wrapper to extract rust-sysdb-migration section
+#[derive(Deserialize)]
+pub struct RootConfig {
+    #[serde(rename = "rust-sysdb-migration")]
+    pub rust_sysdb_migration: MigrationConfig,
+}
+
+impl RootConfig {
+    pub fn load() -> Result<MigrationConfig, Box<dyn std::error::Error>> {
+        let path =
+            env::var(CONFIG_PATH_ENV_VAR).unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_string());
+        tracing::info!("Loading config from: {}", path);
+
+        println!(
+            r#"Full config is:
+================================================================================
+{}
+================================================================================
+"#,
+            std::fs::read_to_string(&path)
+                .expect("should be able to open and read config to string")
+        );
+
+        let f = figment::Figment::from(Yaml::file(&path))
+            .merge(Env::prefixed("CHROMA_").map(|k| k.as_str().replace("__", ".").into()));
+
+        let root: RootConfig = f.extract()?;
+        Ok(root.rust_sysdb_migration)
+    }
+}

--- a/rust/rust-sysdb/spanner-migrations/src/main.rs
+++ b/rust/rust-sysdb/spanner-migrations/src/main.rs
@@ -1,0 +1,35 @@
+//! Spanner migration CLI binary (stub).
+//! TODO: Implement actual migration logic in follow-up PR.
+
+mod bootstrap;
+mod config;
+
+use chroma_config::spanner::SpannerConfig;
+use config::RootConfig;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    tracing::info!("rust-sysdb-migration stub - migrations not yet implemented");
+
+    let config = match RootConfig::load() {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::error!("Failed to load configuration: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    match &config.spanner {
+        SpannerConfig::Emulator(emulator) => {
+            // Bootstrap emulator (create instance/database if needed)
+            if let Err(e) = bootstrap::bootstrap_emulator(emulator).await {
+                tracing::error!("Failed to bootstrap emulator: {}", e);
+                std::process::exit(1);
+            }
+            tracing::info!("Emulator bootstrapped at {}", emulator.grpc_endpoint());
+        }
+    }
+
+    tracing::info!("Migration stub complete");
+}

--- a/rust/rust-sysdb/src/config.rs
+++ b/rust/rust-sysdb/src/config.rs
@@ -3,93 +3,9 @@ use chroma_tracing::{OtelFilter, OtelFilterLevel};
 use figment::providers::{Env, Format, Yaml};
 use serde::{Deserialize, Serialize};
 
+pub use chroma_config::spanner::{SpannerConfig, SpannerEmulatorConfig};
+
 const DEFAULT_CONFIG_PATH: &str = "./chroma_config.yaml";
-
-/// Configuration for connecting to a Spanner emulator (local development)
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SpannerEmulatorConfig {
-    #[serde(default = "SpannerEmulatorConfig::default_host")]
-    pub host: String,
-    #[serde(default = "SpannerEmulatorConfig::default_grpc_port")]
-    pub grpc_port: u16,
-    #[serde(default = "SpannerEmulatorConfig::default_rest_port")]
-    pub rest_port: u16,
-    #[serde(default = "SpannerEmulatorConfig::default_project")]
-    pub project: String,
-    #[serde(default = "SpannerEmulatorConfig::default_instance")]
-    pub instance: String,
-    #[serde(default = "SpannerEmulatorConfig::default_database")]
-    pub database: String,
-}
-
-impl Default for SpannerEmulatorConfig {
-    fn default() -> Self {
-        Self {
-            host: Self::default_host(),
-            grpc_port: Self::default_grpc_port(),
-            rest_port: Self::default_rest_port(),
-            project: Self::default_project(),
-            instance: Self::default_instance(),
-            database: Self::default_database(),
-        }
-    }
-}
-
-impl SpannerEmulatorConfig {
-    fn default_host() -> String {
-        "spanner.chroma.svc.cluster.local".to_string()
-    }
-    fn default_grpc_port() -> u16 {
-        9010
-    }
-    fn default_rest_port() -> u16 {
-        9020
-    }
-    fn default_project() -> String {
-        "local-project".to_string()
-    }
-    fn default_instance() -> String {
-        "test-instance".to_string()
-    }
-    fn default_database() -> String {
-        "local-database".to_string()
-    }
-
-    /// Returns the database path in the format required by the Spanner client
-    pub fn database_path(&self) -> String {
-        format!(
-            "projects/{}/instances/{}/databases/{}",
-            self.project, self.instance, self.database
-        )
-    }
-
-    /// Returns the gRPC endpoint for SPANNER_EMULATOR_HOST
-    pub fn grpc_endpoint(&self) -> String {
-        format!("{}:{}", self.host, self.grpc_port)
-    }
-
-    /// Returns the REST endpoint for admin operations
-    pub fn rest_endpoint(&self) -> String {
-        format!("http://{}:{}", self.host, self.rest_port)
-    }
-}
-
-/// Spanner configuration - either emulator or GCP (mutually exclusive)
-/// Defaults to emulator with standard local settings.
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum SpannerConfig {
-    /// Emulator configuration for local development
-    Emulator(SpannerEmulatorConfig),
-    // TODO: Add GCP variant later
-    // Gcp(SpannerGcpConfig),
-}
-
-impl Default for SpannerConfig {
-    fn default() -> Self {
-        Self::Emulator(SpannerEmulatorConfig::default())
-    }
-}
 
 #[derive(Serialize, Deserialize)]
 pub struct SysDbServiceConfig {

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -6,7 +6,7 @@ use google_cloud_gax::conn::Environment;
 use google_cloud_spanner::client::{Client, ClientConfig};
 use thiserror::Error;
 
-use crate::config::{SpannerConfig, SpannerEmulatorConfig};
+use crate::config::SpannerConfig;
 
 #[derive(Error, Debug)]
 pub enum SpannerError {
@@ -26,75 +26,6 @@ pub struct Spanner {
     client: Client,
 }
 
-impl Spanner {
-    /// Creates the Spanner instance and database on the emulator if they don't exist.
-    /// Uses REST API calls to the emulator's REST endpoint.
-    async fn bootstrap_emulator(emulator: &SpannerEmulatorConfig) {
-        // TODO(Sanket): This is temporary, it will be moved out
-        // to an init container that does all the schema migrations
-        // before starting up the service.
-        let http_client = reqwest::Client::new();
-        let rest_url = emulator.rest_endpoint();
-
-        // Create instance
-        let instance_url = format!("{}/v1/projects/{}/instances", rest_url, emulator.project);
-        let instance_body = serde_json::json!({
-            "instanceId": emulator.instance,
-            "instance": {
-                "displayName": emulator.instance,
-                "nodeCount": 1
-            }
-        });
-
-        match http_client
-            .post(&instance_url)
-            .json(&instance_body)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 409 => {
-                tracing::info!("Spanner instance ready: {}", emulator.instance);
-            }
-            Ok(resp) => {
-                tracing::warn!(
-                    "Failed to create Spanner instance: {} - {}",
-                    resp.status(),
-                    resp.text().await.unwrap_or_default()
-                );
-            }
-            Err(e) => tracing::warn!("Failed to create Spanner instance: {}", e),
-        }
-
-        // Create database
-        let database_url = format!(
-            "{}/v1/projects/{}/instances/{}/databases",
-            rest_url, emulator.project, emulator.instance
-        );
-        let database_body = serde_json::json!({
-            "createStatement": format!("CREATE DATABASE `{}`", emulator.database)
-        });
-
-        match http_client
-            .post(&database_url)
-            .json(&database_body)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 409 => {
-                tracing::info!("Spanner database ready: {}", emulator.database);
-            }
-            Ok(resp) => {
-                tracing::warn!(
-                    "Failed to create Spanner database: {} - {}",
-                    resp.status(),
-                    resp.text().await.unwrap_or_default()
-                );
-            }
-            Err(e) => tracing::warn!("Failed to create Spanner database: {}", e),
-        }
-    }
-}
-
 #[async_trait::async_trait]
 impl Configurable<SpannerConfig> for Spanner {
     async fn try_from_config(
@@ -103,12 +34,6 @@ impl Configurable<SpannerConfig> for Spanner {
     ) -> Result<Self, Box<dyn ChromaError>> {
         let (database_path, client_config) = match config {
             SpannerConfig::Emulator(emulator) => {
-                // Bootstrap emulator with instance and database
-                // TODO(Sanket): This is temporary, it will be moved out
-                // to an init container that does all the schema migrations
-                // before starting up the service.
-                Self::bootstrap_emulator(emulator).await;
-
                 // Configure client to connect to emulator directly (no env var needed)
                 let client_config = ClientConfig {
                     environment: Environment::Emulator(emulator.grpc_endpoint()),

--- a/rust/worker/chroma_config2.yaml
+++ b/rust/worker/chroma_config2.yaml
@@ -287,3 +287,18 @@ sysdb_service:
       project: "local-project"
       instance: "test-instance"
       database: "local-database"
+rust-sysdb-migration:
+  service_name: "rust-sysdb-migration"
+  otel_endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"
+  otel_filters:
+    - crate_name: "spanner_migration"
+      filter_level: "trace"
+  spanner:
+    emulator:
+      host: "spanner.chroma.svc.cluster.local"
+      grpc_port: 9010
+      rest_port: 9020
+      project: "local-project"
+      instance: "test-instance"
+      database: "local-database"
+  migration_mode: "apply"


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Create a rust-sysdb-migration service that bootstraps the Spanner emulator and runs a stub migration service binary.
    - Moved spanner emulator configuration to a common crate.
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_