### PR TITLE
[ENH]: Feature flag rust-sysdb-migration service

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.70
+version: 0.1.71
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-sysdb-migration.yaml
+++ b/k8s/distributed-chroma/templates/rust-sysdb-migration.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.rustSysdbMigration.configuration }}
+{{- if hasKey .Values "rustSysdbMigration" }}
+{{- if and .Values.rustSysdbMigration.enabled .Values.rustSysdbMigration.configuration  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,6 +24,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: rust-sysdb-migration
+          {{- if .Values.rustSysdbMigration.enabled }}
           image: "{{ .Values.rustSysdbMigration.image.repository }}:{{ .Values.rustSysdbMigration.image.tag }}"
           imagePullPolicy: IfNotPresent
           env:
@@ -33,7 +35,11 @@ spec:
             - name: config
               mountPath: /config/
             {{- end }}
-      {{- if .Values.rustSysdbMigration.configuration }}
+          {{- else }}
+          image: "alpine:3.18"
+          command: ["echo", "rust-sysdb-migration is disabled"]
+          {{- end }}
+      {{- if and .Values.rustSysdbMigration.enabled .Values.rustSysdbMigration.configuration }}
       volumes:
         - name: config
           configMap:
@@ -48,3 +54,4 @@ spec:
         {{- toYaml .Values.rustSysdbMigration.nodeSelector | nindent 8 }}
       {{- end }}
 ---
+{{- end }}

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -69,13 +69,6 @@ sysdbMigration:
   port: 5432
   dbName: sysdb
   sslmode: disable
-# Rust Sysdb Migration Configuration
-rustSysdbMigration:
-  image:
-    repository: 'rust-sysdb-migration'
-    tag: 'latest'
-  tolerations: []
-  nodeSelector: {}
 # Add the garbage collector configuration
 garbageCollector:
   image:

--- a/k8s/distributed-chroma/values2.dev.yaml
+++ b/k8s/distributed-chroma/values2.dev.yaml
@@ -37,3 +37,6 @@ garbageCollector:
 
 rustSysdbService:
   replicaCount: 1
+
+rustSysdbMigration:
+  enabled: true

--- a/k8s/distributed-chroma/values2.yaml
+++ b/k8s/distributed-chroma/values2.yaml
@@ -69,6 +69,14 @@ sysdbMigration:
   port: 5432
   dbName: sysdb
   sslmode: disable
+# Rust Sysdb Migration Configuration
+rustSysdbMigration:
+  enabled: false
+  image:
+    repository: 'rust-sysdb-migration'
+    tag: 'latest'
+  tolerations: []
+  nodeSelector: {}
 # Add the garbage collector configuration
 garbageCollector:
   image:


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Add a configurable "enabled" to the rust-sysdb-migration service. If it is off, the service simply is a no-op.
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
