### PR TITLE
[ENH] Log masked search queries

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -2219,7 +2219,7 @@ async fn collection_search(
 
     tracing::info!(
         name: "collection_search",
-        num_queries = payload.searches.len(),
+        searches = ?payload.searches.iter().map(|s| s.masked()).collect::<Vec<_>>(),
     );
 
     // Override limit by quota


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Implements `SearchPayload::masked`, which allows us to log the structure of user query with masked values

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
