### PR TITLE
[ENH] Modify helm chart to make log and rust-sysdb volumes customizable

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.73
+version: 0.1.74
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/templates/rust-log-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-log-service.yaml
@@ -11,6 +11,12 @@ data:
 
 ---
 
+{{ if .Values.rustLogService.additionalConfigMaps }}
+{{ toYaml .Values.rustLogService.additionalConfigMaps }}
+{{ end }}
+
+---
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -64,6 +70,9 @@ spec:
             path: {{ $cache.hostPath }}
             type: {{ $.Values.rustLogService.cache.type }}
         {{- end }}
+        {{ if .Values.rustLogService.additionalVolumes }}
+        {{ toYaml .Values.rustLogService.additionalVolumes | nindent 8 }}
+        {{ end }}
       containers:
         - name: rust-log-service
           {{ if .Values.rustLogService.command }}
@@ -89,6 +98,9 @@ spec:
             - name: rust-log-service-cache-{{ add $i 1 }}
               mountPath: {{ $cache.mountPath }}
             {{- end }}
+            {{ if .Values.rustLogService.additionalVolumeMounts }}
+            {{ toYaml .Values.rustLogService.additionalVolumeMounts | nindent 12 }}
+            {{ end }}
           ports:
             - containerPort: 50051
           env:

--- a/k8s/distributed-chroma/templates/rust-sysdb-service.yaml
+++ b/k8s/distributed-chroma/templates/rust-sysdb-service.yaml
@@ -12,6 +12,12 @@ data:
 
 ---
 
+{{ if .Values.rustSysdbService.additionalConfigMaps }}
+{{ toYaml .Values.rustSysdbService.additionalConfigMaps }}
+{{ end }}
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,11 +33,15 @@ spec:
       labels:
         app: rust-sysdb-service
     spec:
+      serviceAccountName: sysdb-serviceaccount
       volumes:
         {{if .Values.rustSysdbService.configuration}}
         - name: rust-sysdb-service-config
           configMap:
             name: rust-sysdb-service-config
+        {{ end }}
+        {{ if .Values.rustSysdbService.additionalVolumes }}
+        {{ toYaml .Values.rustSysdbService.additionalVolumes | nindent 8 }}
         {{ end }}
       containers:
         - name: rust-sysdb-service
@@ -48,6 +58,9 @@ spec:
             - name: rust-sysdb-service-config
               mountPath: /config/
             {{ end }}
+            {{ if .Values.rustSysdbService.additionalVolumeMounts }}
+            {{ toYaml .Values.rustSysdbService.additionalVolumeMounts | nindent 12 }}
+            {{ end }}
           ports:
             - containerPort: 50051
               name: grpc
@@ -55,6 +68,9 @@ spec:
             {{if .Values.rustSysdbService.configuration}}
             - name: CONFIG_PATH
               value: "/config/config.yaml"
+            {{ end }}
+            {{ if .Values.rustSysdbService.additionalEnv }}
+            {{ toYaml .Values.rustSysdbService.additionalEnv | nindent 12 }}
             {{ end }}
           resources:
             limits:


### PR DESCRIPTION
## Description of changes

This is necessary to support cross-region auth for GCP workload identity pools: https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#deploy

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
