### PR TITLE
build: add flake8-tidy-imports to ban relative imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,9 @@ repos:
         args:
           - "--extend-ignore=E203,E501,E503"
           - "--max-line-length=88"
+          - "--ban-relative-imports=true"
+        additional_dependencies:
+          - flake8-tidy-imports>=4.10.0
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"


### PR DESCRIPTION
## Description of changes

Fixes #2334

This PR adds `flake8-tidy-imports` to the pre-commit flake8 hook with the `--ban-relative-imports=true` flag to enforce absolute imports throughout the codebase.

## Changes

- Added `flake8-tidy-imports>=4.10.0` as an additional dependency to the flake8 pre-commit hook
- Added `--ban-relative-imports=true` argument to enforce absolute imports

## Why?

- Absolute imports are more explicit and easier to understand
- They avoid confusion about where modules are located
- They're more consistent across the codebase
- They help prevent circular import issues

## Test plan

The pre-commit hook will now flag any relative imports (e.g., `from . import foo` or `from .module import bar`).