### PR TITLE
[ENH]  Add a catch to purge cursors that have been reinserted a suspicious number of times.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1053,14 +1053,17 @@ impl LogServer {
         if let Some(cache) = self.cache.as_ref() {
             let mut cache_collections_to_purge = Vec::with_capacity(after.len());
             let before = rollup.rollups;
-            for (collection_id, after_state) in after.into_iter() {
-                let Some(before_state) = before.get(&collection_id) else {
-                    continue;
-                };
-                if before_state.reinsert_count / self.config.reinsert_threshold
-                    != after_state.reinsert_count / self.config.reinsert_threshold
-                {
-                    cache_collections_to_purge.push(collection_id);
+            // Guard against division by zero if reinsert_threshold is misconfigured to 0.
+            if self.config.reinsert_threshold > 0 {
+                for (collection_id, after_state) in after.into_iter() {
+                    let Some(before_state) = before.get(&collection_id) else {
+                        continue;
+                    };
+                    if before_state.reinsert_count / self.config.reinsert_threshold
+                        != after_state.reinsert_count / self.config.reinsert_threshold
+                    {
+                        cache_collections_to_purge.push(collection_id);
+                    }
                 }
             }
             for collection_id in cache_collections_to_purge {


### PR DESCRIPTION
## Description of changes

On save of the dirty log, we take a set of collections and set them for
gactc.  This takes the old and new and diffs them to determine if the
reinsert_threshold rolls over (division).

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
