### PR TITLE
[ENH] Drop block ref when copy to end

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
@@ -96,7 +96,7 @@ impl OrderedBlockDelta {
 
     pub fn copy_to_end<K: ArrowWriteableKey, V: ArrowWriteableValue>(&mut self) {
         // Copy remaining rows
-        if let Some(old_block) = self.old_block.as_ref() {
+        if let Some(old_block) = self.old_block.take() {
             #[cfg(debug_assertions)]
             let mut last_key = None;
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Drop the block reference in `copy_to_end`, because the delta should contain all relevant data
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
