### PR TITLE
[BUG] await auth on delete_database in single-node Chroma

### DIFF
--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -626,7 +626,7 @@ class FastAPI(Server):
         tenant: str,
     ) -> None:
         # NOTE(rescrv, iron will auth):  Implemented.
-        self.auth_request(
+        await self.auth_request(
             request.headers,
             AuthzAction.DELETE_DATABASE,
             tenant,

--- a/chromadb/test/auth/test_rbac_authz.py
+++ b/chromadb/test/auth/test_rbac_authz.py
@@ -1,0 +1,19 @@
+import uuid
+
+import pytest
+
+from chromadb.api import ServerAPI
+from chromadb.config import DEFAULT_TENANT
+
+
+def test_delete_database_requires_rbac_permission(
+    api_with_authn_rbac_authz: ServerAPI,
+) -> None:
+    database_name = f"db_{uuid.uuid4().hex}"
+    api_with_authn_rbac_authz.create_database(database_name, tenant=DEFAULT_TENANT)
+
+    with pytest.raises(Exception, match="Forbidden"):
+        api_with_authn_rbac_authz.delete_database(database_name, tenant=DEFAULT_TENANT)
+
+    db = api_with_authn_rbac_authz.get_database(database_name, tenant=DEFAULT_TENANT)
+    assert db["name"] == database_name


### PR DESCRIPTION
Fix auth bypass on delete database by awaiting auth_request present in single-node Chroma since v0.6.3.

Adds RBAC regression test to ensure unauthorized delete is rejected.