### PR TITLE
[BUG]: CLI `browse` command race condition

### DIFF
--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -377,8 +377,11 @@ pub async fn standup_local_chroma(
     }
 
     Err(UtilsError::LocalConnect(
-        last_error.map(|e| e.to_string()).unwrap_or_else(|| "Health check failed".to_string())
-    ).into())
+        last_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "Health check failed".to_string()),
+    )
+    .into())
 }
 
 pub async fn parse_path(path: String) -> Result<(AdminClient, JoinHandle<()>), CliError> {


### PR DESCRIPTION
Closes #6030 

## Description of changes

Fixes a race condition in CLI `browse` (also possibly `copy`) command. This is not a perfect fix but it is least invasive. Ideal case would be to use `tokio::sync::oneshot::channel` or `tokio::sync::Notify` but that requires plumbing across at least 3 layers ( spawn -> frontend_service_entrypoint_with_config_system_registry -> FrontendServer::run) 

- Improvements & Bug fixes
  - Fixed a race condition where `spawn()` of a local chroma server and admin client health-check. https://github.com/chroma-core/chroma/blob/46ccc5b00ec632aa58cfb3855db4b275d6869419/rust/cli/src/utils.rs#L361 and https://github.com/chroma-core/chroma/blob/46ccc5b00ec632aa58cfb3855db4b275d6869419/rust/cli/src/utils.rs#L366

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `cargo test` for rust + verification 

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
