### PR TITLE
[ENH] Commit eagerly in ordered blockfile writer

### DIFF
--- a/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
+++ b/rust/blockstore/src/arrow/block/delta/ordered_block_delta.rs
@@ -127,10 +127,6 @@ impl OrderedBlockDelta {
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.builder.len()
-    }
-
     fn copy_up_to<'me, K: ArrowReadableKey<'me>, V: ArrowReadableValue<'me>>(
         &'me mut self,
         excluded_prefix: &str,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - N/A
- New functionality
  - Eagerly commit blocks in ordered blockfile writer to avoid excessive memory usage

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
