### PR TITLE
[BUG]: Fix service name extraction logic in go

### DIFF
--- a/go/pkg/leader/election.go
+++ b/go/pkg/leader/election.go
@@ -16,19 +16,20 @@ import (
 )
 
 // extractServiceName extracts the service name from a pod name.
-// The service name is expected to be the prefix before the last hyphen in the pod name.
-// For example, from pod name "chroma-query-abc123", it will return "chroma-query".
+// The service name is expected to be the prefix before the deployment hash suffix.
+// For example, from pod name "sysdb-7c85f55c69-z55lm", it will return "sysdb".
 func extractServiceName(podName string) string {
 	parts := strings.Split(podName, "-")
-	if len(parts) > 1 {
-		return strings.Join(parts[:len(parts)-1], "-")
+	if len(parts) > 2 {
+		// Remove the last two parts (replica set hash + pod hash)
+		return strings.Join(parts[:len(parts)-2], "-")
 	}
 	return podName
 }
 
 // AcquireLeaderLock starts leader election and runs the given function when leadership is acquired.
 // The context passed to onStartedLeading will be cancelled when leadership is lost.
-// The service name is automatically determined from the pod name by extracting the prefix before the last hyphen.
+// The service name is automatically determined from the pod name by extracting the base service name.
 // The lock name will be formatted as "{service-name}-leader".
 func AcquireLeaderLock(ctx context.Context, onStartedLeading func(context.Context)) {
 	podName, _ := os.LookupEnv("POD_NAME")


### PR DESCRIPTION
## Description of changes

The logic to extract the service name in go code was wrong. The logic to generate the lock name for the sysdb service during leader election was dependent on this and was faulty as a result. Every replica ended up generating different lock names.

This diff fixes that issue.

- Improvements & Bug fixes
  - ^^
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
