### PR TITLE
[ENH] Add retry in CLI for standing up local chroma

### DIFF
--- a/rust/cli/src/utils.rs
+++ b/rust/cli/src/utils.rs
@@ -377,12 +377,10 @@ pub async fn standup_local_chroma(
         }
     }
 
-    Err(UtilsError::LocalConnect(
-        last_error
-            .map(|e| e.to_string())
-            .unwrap_or_else(|| "Health check failed".to_string()),
+    Err(
+        UtilsError::LocalConnect(last_error.unwrap_or_else(|| "Health check failed".to_string()))
+            .into(),
     )
-        .into())
 }
 
 pub async fn parse_path(path: String) -> Result<(AdminClient, JoinHandle<()>), CliError> {


### PR DESCRIPTION
## Description of changes

Adding retry logic for standing up local chroma by the CLI. Fixes a race condition where `spawn()` of a local chroma server and admin client health-check. Thanks tazarov 