### PR TITLE
[ENH][wal3] add type-erased LogWriterTrait and LogReaderTrait traits

### DIFF
--- a/rust/wal3/src/copy.rs
+++ b/rust/wal3/src/copy.rs
@@ -1,11 +1,8 @@
 use chroma_types::Cmek;
 use setsum::Setsum;
 
-use crate::interfaces::{
-    FragmentConsumer, FragmentPointer, FragmentPublisher, ManifestConsumer, ManifestManagerFactory,
-};
-use crate::reader::LogReader;
-use crate::{Error, Limits, LogPosition, Manifest};
+use crate::interfaces::{FragmentPointer, FragmentPublisher, ManifestManagerFactory};
+use crate::{Error, Limits, LogPosition, LogReaderTrait, Manifest};
 
 /// Copy a log from one prefix to another.
 ///
@@ -13,12 +10,10 @@ use crate::{Error, Limits, LogPosition, Manifest};
 /// from the factory.
 pub async fn copy<
     P: FragmentPointer,
-    FC: FragmentConsumer<FragmentPointer = P>,
-    MC: ManifestConsumer<P>,
     FP: FragmentPublisher<FragmentPointer = P>,
     MF: ManifestManagerFactory<FragmentPointer = P>,
 >(
-    reader: &LogReader<P, FC, MC>,
+    reader: &dyn LogReaderTrait,
     offset: LogPosition,
     fragment_publisher: &FP,
     manifest_factory: MF,

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -144,6 +144,16 @@ pub struct LogReader<
 }
 
 impl<P: FragmentPointer, FC: FragmentConsumer<FragmentPointer = P>, MC: ManifestConsumer<P>>
+    std::fmt::Debug for LogReader<P, FC, MC>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogReader")
+            .field("_options", &self._options)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P: FragmentPointer, FC: FragmentConsumer<FragmentPointer = P>, MC: ManifestConsumer<P>>
     LogReader<P, FC, MC>
 {
     pub fn new(options: LogReaderOptions, fragment_consumer: FC, manifest_consumer: MC) -> Self {


### PR DESCRIPTION
## Description of changes

Add trait-based interfaces to LogWriter and LogReader that enable dynamic
dispatch and type erasure:

- LogWriterTrait: provides append, append_many, manifest_and_witness, and
  garbage collection methods via dynamic dispatch
- LogReaderTrait: provides verify, manifest, scan, read_parquet, and scrub
  methods via dynamic dispatch
- Add Debug implementation for LogReader to satisfy trait bounds
- Re-export Setsum publicly for downstream crates
- Simplify copy() function to accept &dyn LogReaderTrait instead of
  requiring concrete generic types

These traits allow downstream code to work with log readers/writers without
knowing their concrete types, enabling more flexible API boundaries.

## Test plan

CI

## Migration plan

Backwards-compatible.

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
