### PR TITLE
[TST][rust-log-service]: add database_name parameter to log service test helpers

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -4867,6 +4867,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_k8s_mcmr_integration_rust_log_service_rollup_snapshot_after_gc() {
         let runtime = Runtime::new().unwrap();
         // NOTE: Somehow it overflow the stack under default stack limit


### PR DESCRIPTION
## Description of changes

Refactor test helper functions to accept a db_name parameter instead of
using hardcoded "test_db" strings:
- push_log_to_server
- validate_log_on_server
- get_enum_offset_on_server
- update_compact_offset_on_server
- validate_dirty_log_on_server
- garbage_collect_unused_logs
- test_push_pull_logs, test_dirty_logs, test_fork_logs, etc.

Add new k8s mcmr integration test variants that use "topo#dbname" as the
database name pattern to verify the log service works correctly with
topology-prefixed database names used in multi-cluster deployments.

NB:  There is no switching of behavior per topo/mcmr; this is scaffold.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
