### PR TITLE
Remove task import since it's recently removed

### DIFF
--- a/clients/new-js/packages/ai-embeddings/chroma-cloud-qwen/README.md
+++ b/clients/new-js/packages/ai-embeddings/chroma-cloud-qwen/README.md
@@ -15,13 +15,12 @@ import { ChromaClient } from "chromadb";
 import {
   ChromaCloudQwenEmbeddingFunction,
   ChromaCloudQwenEmbeddingModel,
-  ChromaCloudQwenEmbeddingTask,
 } from "@chroma-core/chroma-cloud-qwen";
 
 // Initialize the embedder
 const embedder = new ChromaCloudQwenEmbeddingFunction({
   model: ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
-  task: ChromaCloudQwenEmbeddingTask.CODE_TO_CODE,
+  task: null,
   apiKeyEnvVar: "CHROMA_API_KEY",
 });
 


### PR DESCRIPTION
## Description of changes

Documentation update for v0.1.10 since ChromaCloudQwenEmbeddingTask export is removed

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
