### PR TITLE
[CHORE]  Set version numbers for 0.12 client release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,14 +79,14 @@ google-cloud-spanner = { git = "https://github.com/yoshidan/google-cloud-rust", 
 google-cloud-gax = { git = "https://github.com/yoshidan/google-cloud-rust", tag = "v20251222", package = "gcloud-gax" }
 google-cloud-googleapis = { git = "https://github.com/yoshidan/google-cloud-rust", tag = "v20251222", package = "gcloud-googleapis", features = ["spanner"] }
 
-chroma = { path = "rust/chroma", version = "0.11.0" }
-chroma-api-types = { path = "rust/api-types", version = "0.11.0" }
+chroma = { path = "rust/chroma", version = "0.12.0" }
+chroma-api-types = { path = "rust/api-types", version = "0.12.0" }
 chroma-benchmark = { path = "rust/benchmark" }
 chroma-blockstore = { path = "rust/blockstore" }
 chroma-cache = { path = "rust/cache" }
 chroma-config = { path = "rust/config" }
 chroma-distance = { path = "rust/distance" }
-chroma-error = { path = "rust/error", version = "0.11.0" }
+chroma-error = { path = "rust/error", version = "0.12.0" }
 chroma-frontend = { path = "rust/frontend" }
 chroma-index = { path = "rust/index" }
 chroma-log = { path = "rust/log" }
@@ -98,7 +98,7 @@ chroma-storage = { path = "rust/storage" }
 chroma-system = { path = "rust/system" }
 chroma-sysdb = { path = "rust/sysdb" }
 chroma-tracing = { path = "rust/tracing" }
-chroma-types = { path = "rust/types", version = "0.11.0" }
+chroma-types = { path = "rust/types", version = "0.12.0" }
 chroma-sqlite = { path = "rust/sqlite" }
 chroma-cli = { path = "rust/cli" }
 chroma-jemalloc-pprof-server = { path = "rust/jemalloc-pprof-server" }

--- a/rust/api-types/Cargo.toml
+++ b/rust/api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-api-types"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Chroma-provided crate for api-types used in the Chroma API."
 license = "Apache-2.0"

--- a/rust/chroma/Cargo.toml
+++ b/rust/chroma/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Client for Chroma, the AI-native cloud database."
 license = "Apache-2.0"

--- a/rust/error/Cargo.toml
+++ b/rust/error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-error"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Chroma-provided crate for errors returned from Chroma."
 license = "Apache-2.0"

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroma-types"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Chroma-provided crate for internal types used in the Chroma API."
 license = "Apache-2.0"


### PR DESCRIPTION
## Description of changes

This is version 0.12 of the Chroma client crate.

## Test plan

CI

## Migration plan

New APIs only.

## Observability plan

N/A

## Documentation Changes

Incorporated in other PRs as appropriate.
