### PR TITLE
[CHORE]  Wire up `s3_*` metrics for object storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chroma"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "backon",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-api-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "utoipa",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-error"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "http 1.3.1",
  "sqlx",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "chroma-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -38,7 +38,7 @@ use tokio::{
 #[derive(Clone)]
 pub enum ACStorageProvider {
     S3(Box<S3Storage>),
-    Object(ObjectStorage),
+    Object(Box<ObjectStorage>),
 }
 
 impl ACStorageProvider {
@@ -606,7 +606,7 @@ impl AdmissionControlledS3Storage {
 
     pub fn new_object_with_default_policy(storage: ObjectStorage) -> Self {
         Self {
-            storage: ACStorageProvider::Object(storage),
+            storage: ACStorageProvider::Object(Box::new(storage)),
             outstanding_read_requests: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             rate_limiter: Arc::new(RateLimitPolicy::CountBasedPolicy(CountBasedPolicy::new(
                 2,
@@ -618,7 +618,7 @@ impl AdmissionControlledS3Storage {
 
     pub fn new_object(storage: ObjectStorage, policy: RateLimitPolicy) -> Self {
         Self {
-            storage: ACStorageProvider::Object(storage),
+            storage: ACStorageProvider::Object(Box::new(storage)),
             outstanding_read_requests: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             rate_limiter: Arc::new(policy),
             metrics: AdmissionControlledS3StorageMetrics::default(),

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -9,6 +9,7 @@ use chroma_error::{ChromaError, ErrorCodes};
 pub mod admissioncontrolleds3;
 pub mod config;
 pub mod local;
+pub mod metrics;
 pub mod object_storage;
 pub mod s3;
 pub mod stream;

--- a/rust/storage/src/metrics.rs
+++ b/rust/storage/src/metrics.rs
@@ -1,0 +1,127 @@
+//! Metrics for storage operations.
+
+use opentelemetry::metrics::{Counter, Histogram};
+
+/// Metrics for tracking S3 and object storage operations.
+///
+/// All metrics are registered under the `chroma.storage` meter.
+#[derive(Clone)]
+pub(crate) struct StorageMetrics {
+    /// Number of S3 get operations.
+    pub(crate) s3_get_count: Counter<u64>,
+    /// Number of S3 put operations.
+    pub(crate) s3_put_count: Counter<u64>,
+    /// Number of S3 delete operations.
+    pub(crate) s3_delete_count: Counter<u64>,
+    /// Number of keys deleted via batch delete operations.
+    pub(crate) s3_delete_many_count: Counter<u64>,
+    /// Latency of S3 get operations in milliseconds.
+    pub(crate) s3_get_latency_ms: Histogram<u64>,
+    /// Latency of S3 put operations in milliseconds.
+    pub(crate) s3_put_latency_ms: Histogram<u64>,
+    /// Bytes written per S3 put operation.
+    pub(crate) s3_put_bytes: Histogram<u64>,
+    /// Bytes written per S3 put operation that took more than 1 second.
+    pub(crate) s3_put_bytes_slow: Histogram<u64>,
+    /// Number of parts in multipart uploads.
+    pub(crate) s3_multipart_upload_parts: Histogram<u64>,
+    /// Bytes per upload part in multipart uploads.
+    pub(crate) s3_upload_part_bytes: Histogram<u64>,
+    /// Number of failed S3 put operations.
+    pub(crate) s3_put_error_count: Counter<u64>,
+    /// Number of S3 copy operations.
+    pub(crate) s3_copy_count: Counter<u64>,
+    /// Latency of S3 copy operations in milliseconds.
+    pub(crate) s3_copy_latency_ms: Histogram<u64>,
+    /// Number of S3 rename operations.
+    pub(crate) s3_rename_count: Counter<u64>,
+    /// Latency of S3 rename operations in milliseconds.
+    pub(crate) s3_rename_latency_ms: Histogram<u64>,
+    /// Number of S3 list operations.
+    pub(crate) s3_list_count: Counter<u64>,
+    /// Latency of S3 list operations in milliseconds.
+    pub(crate) s3_list_latency_ms: Histogram<u64>,
+}
+
+impl Default for StorageMetrics {
+    fn default() -> Self {
+        Self {
+            s3_get_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_get_count")
+                .with_description("Number of S3 get operations")
+                .build(),
+            s3_put_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_put_count")
+                .with_description("Number of S3 put operations")
+                .build(),
+            s3_delete_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_delete_count")
+                .with_description("Number of S3 delete operations")
+                .build(),
+            s3_delete_many_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_delete_many_count")
+                .with_description("Number of S3 delete many operations")
+                .build(),
+            s3_get_latency_ms: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_get_latency_ms")
+                .with_description("Latency of S3 get operations in milliseconds")
+                .with_unit("ms")
+                .build(),
+            s3_put_latency_ms: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_put_latency_ms")
+                .with_description("Latency of S3 put operations in milliseconds")
+                .with_unit("ms")
+                .build(),
+            s3_put_bytes: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_put_bytes")
+                .with_description("Bytes written per S3 put operation")
+                .with_unit("bytes")
+                .build(),
+            s3_put_bytes_slow: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_put_bytes_slow")
+                .with_description("Bytes written per S3 put operation that took more than 1 second")
+                .with_unit("bytes")
+                .build(),
+            s3_multipart_upload_parts: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_multipart_upload_parts")
+                .with_description("Number of parts in multipart uploads")
+                .build(),
+            s3_upload_part_bytes: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_upload_part_bytes")
+                .with_description("Bytes per upload part in multipart uploads")
+                .with_unit("bytes")
+                .build(),
+            s3_put_error_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_put_error_count")
+                .with_description("Number of failed S3 put operations")
+                .build(),
+            s3_copy_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_copy_count")
+                .with_description("Number of S3 copy operations")
+                .build(),
+            s3_copy_latency_ms: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_copy_latency_ms")
+                .with_description("Latency of S3 copy operations in milliseconds")
+                .with_unit("ms")
+                .build(),
+            s3_rename_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_rename_count")
+                .with_description("Number of S3 rename operations")
+                .build(),
+            s3_rename_latency_ms: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_rename_latency_ms")
+                .with_description("Latency of S3 rename operations in milliseconds")
+                .with_unit("ms")
+                .build(),
+            s3_list_count: opentelemetry::global::meter("chroma.storage")
+                .u64_counter("s3_list_count")
+                .with_description("Number of S3 list operations")
+                .build(),
+            s3_list_latency_ms: opentelemetry::global::meter("chroma.storage")
+                .u64_histogram("s3_list_latency_ms")
+                .with_description("Latency of S3 list operations in milliseconds")
+                .with_unit("ms")
+                .build(),
+        }
+    }
+}

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -9,6 +9,7 @@
 // streaming from s3.
 
 use super::config::{S3CredentialsConfig, StorageConfig};
+use super::metrics::StorageMetrics;
 use super::stream::ByteStreamItem;
 use super::stream::S3ByteStream;
 use super::StorageConfigError;
@@ -36,7 +37,6 @@ use futures::stream;
 use futures::FutureExt;
 use futures::Stream;
 use futures::StreamExt;
-use opentelemetry::metrics::{Counter, Histogram};
 use rand::Rng;
 use std::clone::Clone;
 use std::ops::Range;
@@ -49,109 +49,6 @@ use tracing::Instrument;
 pub struct DeletedObjects {
     pub deleted: Vec<String>,
     pub errors: Vec<StorageError>,
-}
-#[derive(Clone)]
-pub struct StorageMetrics {
-    s3_get_count: Counter<u64>,
-    s3_put_count: Counter<u64>,
-    s3_delete_count: Counter<u64>,
-    s3_delete_many_count: Counter<u64>,
-    s3_get_latency_ms: Histogram<u64>,
-    s3_put_latency_ms: Histogram<u64>,
-    s3_put_bytes: Histogram<u64>,
-    s3_put_bytes_slow: Histogram<u64>,
-    s3_multipart_upload_parts: Histogram<u64>,
-    s3_upload_part_bytes: Histogram<u64>,
-    s3_put_error_count: Counter<u64>,
-    s3_copy_count: Counter<u64>,
-    s3_copy_latency_ms: Histogram<u64>,
-    s3_rename_count: Counter<u64>,
-    s3_rename_latency_ms: Histogram<u64>,
-    s3_list_count: Counter<u64>,
-    s3_list_latency_ms: Histogram<u64>,
-}
-
-impl Default for StorageMetrics {
-    fn default() -> Self {
-        Self {
-            s3_get_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_get_count")
-                .with_description("Number of S3 get operations")
-                .build(),
-            s3_put_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_put_count")
-                .with_description("Number of S3 put operations")
-                .build(),
-            s3_delete_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_delete_count")
-                .with_description("Number of S3 delete operations")
-                .build(),
-            s3_delete_many_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_delete_many_count")
-                .with_description("Number of S3 delete many operations")
-                .build(),
-            s3_get_latency_ms: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_get_latency_ms")
-                .with_description("Latency of S3 get operations in milliseconds")
-                .with_unit("ms")
-                .build(),
-            s3_put_latency_ms: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_put_latency_ms")
-                .with_description("Latency of S3 put operations in milliseconds")
-                .with_unit("ms")
-                .build(),
-            s3_put_bytes: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_put_bytes")
-                .with_description("Bytes written per S3 put operation")
-                .with_unit("bytes")
-                .build(),
-            s3_put_bytes_slow: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_put_bytes_slow")
-                .with_description("Bytes written per S3 put operation that took more than 1 second")
-                .with_unit("bytes")
-                .build(),
-            s3_multipart_upload_parts: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_multipart_upload_parts")
-                .with_description("Number of parts in multipart uploads")
-                .build(),
-            s3_upload_part_bytes: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_upload_part_bytes")
-                .with_description("Bytes per upload part in multipart uploads")
-                .with_unit("bytes")
-                .build(),
-            s3_put_error_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_put_error_count")
-                .with_description("Number of failed S3 put operations")
-                .build(),
-            s3_copy_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_copy_count")
-                .with_description("Number of S3 copy operations")
-                .build(),
-            s3_copy_latency_ms: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_copy_latency_ms")
-                .with_description("Latency of S3 copy operations in milliseconds")
-                .with_unit("ms")
-                .build(),
-            s3_rename_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_rename_count")
-                .with_description("Number of S3 rename operations")
-                .build(),
-            s3_rename_latency_ms: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_rename_latency_ms")
-                .with_description("Latency of S3 rename operations in milliseconds")
-                .with_unit("ms")
-                .build(),
-            s3_list_count: opentelemetry::global::meter("chroma.storage")
-                .u64_counter("s3_list_count")
-                .with_description("Number of S3 list operations")
-                .build(),
-            s3_list_latency_ms: opentelemetry::global::meter("chroma.storage")
-                .u64_histogram("s3_list_latency_ms")
-                .with_description("Latency of S3 list operations in milliseconds")
-                .with_unit("ms")
-                .build(),
-        }
-    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description of changes

Stats alone.

## Test plan

I trust OTEL and will verify the stats on staging.

## Migration plan

N/A

## Observability plan

Look for `s3_put_count` in the rust-log-service on Honeycomb.

## Documentation Changes

N/A
