### PR TITLE
[ENH]: Route to rust sysdb based on topo prefix for create and get collection

### DIFF
--- a/rust/cli/src/commands/vacuum.rs
+++ b/rust/cli/src/commands/vacuum.rs
@@ -11,7 +11,7 @@ use chroma_segment::local_segment_manager::LocalSegmentManager;
 use chroma_sqlite::db::SqliteDb;
 use chroma_sysdb::SysDb;
 use chroma_system::System;
-use chroma_types::{CollectionUuid, ListCollectionsRequest, Schema};
+use chroma_types::{CollectionUuid, DatabaseName, ListCollectionsRequest, Schema};
 use clap::Parser;
 use colored::Colorize;
 use dialoguer::Confirm;
@@ -157,7 +157,8 @@ pub async fn vacuum_chroma(config: FrontendConfig) -> Result<(), Box<dyn Error>>
     trigger_vector_segments_max_seq_id_migration(&sqlite, &mut sysdb, &segment_manager).await?;
 
     let tenant = String::from("default_tenant");
-    let database = String::from("default_database");
+    let database = DatabaseName::new("default_database")
+        .ok_or("Invalid database name: must be at least 3 characters")?;
 
     let list_collections_request = ListCollectionsRequest::try_new(tenant, database, None, 0)?;
     let collections = frontend.list_collections(list_collections_request).await?;

--- a/rust/frontend/src/executor/local.rs
+++ b/rust/frontend/src/executor/local.rs
@@ -351,7 +351,8 @@ mod tests {
     use chroma_config::Configurable;
     use chroma_system::System;
     use chroma_types::{
-        AddCollectionRecordsRequest, CreateCollectionRequest, IncludeList, QueryRequest,
+        AddCollectionRecordsRequest, CreateCollectionRequest, DatabaseName, IncludeList,
+        QueryRequest,
     };
 
     use crate::{Frontend, FrontendConfig};
@@ -367,11 +368,13 @@ mod tests {
             .unwrap();
 
         // Add data
+        let database_name =
+            DatabaseName::new("default_database").expect("database name should be valid");
         let collection = frontend
             .create_collection(
                 CreateCollectionRequest::try_new(
                     "default_tenant".to_string(),
-                    "default_database".to_string(),
+                    database_name,
                     "test".to_string(),
                     None,
                     None,

--- a/rust/frontend/src/impls/in_memory_frontend.rs
+++ b/rust/frontend/src/impls/in_memory_frontend.rs
@@ -236,7 +236,7 @@ impl InMemoryFrontend {
         let collection = Collection {
             name: request.name.clone(),
             tenant: request.tenant_id.clone(),
-            database: request.database_name.clone(),
+            database: request.database_name.as_ref().to_string(),
             metadata: request.metadata,
             config,
             schema: Some(schema),
@@ -717,7 +717,7 @@ mod tests {
 
         let request = chroma_types::CreateCollectionRequest::try_new(
             tenant_name.clone(),
-            database_name.into_string(),
+            database_name,
             collection_name.clone(),
             None,
             None,

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -951,7 +951,10 @@ async fn list_collections(
     };
 
     // TODO: Limit shouldn't be optional here
-    let request = ListCollectionsRequest::try_new(tenant, database, validated_limit, offset)?;
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
+    let request = ListCollectionsRequest::try_new(tenant, database_name, validated_limit, offset)?;
     Ok(Json(server.frontend.list_collections(request).await?))
 }
 
@@ -992,7 +995,10 @@ async fn count_collections(
         format!("tenant:{}", tenant).as_str(),
     ])?;
 
-    let request = CountCollectionsRequest::try_new(tenant, database)?;
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
+    let request = CountCollectionsRequest::try_new(tenant, database_name)?;
     Ok(Json(server.frontend.count_collections(request).await?))
 }
 
@@ -1060,9 +1066,12 @@ async fn create_collection(
         )?),
     };
 
+    let database_name = DatabaseName::new(database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
     let request = CreateCollectionRequest::try_new(
         tenant,
-        database,
+        database_name,
         payload.name,
         payload.metadata,
         configuration,
@@ -1110,7 +1119,10 @@ async fn get_collection(
         .await?;
     let _guard =
         server.scorecard_request(&["op:get_collection", format!("tenant:{}", tenant).as_str()])?;
-    let request = GetCollectionRequest::try_new(tenant, database, collection_name)?;
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
+    let request = GetCollectionRequest::try_new(tenant, database_name, collection_name)?;
     let collection = server.frontend.get_collection(request).await?;
     Ok(Json(collection))
 }

--- a/rust/frontend/tests/proptest_helpers/frontend_reference.rs
+++ b/rust/frontend/tests/proptest_helpers/frontend_reference.rs
@@ -1,6 +1,6 @@
 use crate::CollectionRequest;
 use chroma_frontend::impls::in_memory_frontend::InMemoryFrontend;
-use chroma_types::{Collection, CreateCollectionRequest, GetRequest, IncludeList};
+use chroma_types::{Collection, CreateCollectionRequest, DatabaseName, GetRequest, IncludeList};
 use proptest::prelude::*;
 use proptest_state_machine::ReferenceStateMachine;
 use std::sync::Arc;
@@ -123,12 +123,14 @@ impl ReferenceStateMachine for FrontendReferenceStateMachine {
     fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
         if let CollectionRequest::Init { dimension } = transition {
             let mut frontend = InMemoryFrontend::new();
+            let database_name =
+                DatabaseName::new("default_database").expect("database name should be valid");
 
             let mut collection = frontend
                 .create_collection(
                     CreateCollectionRequest::try_new(
                         "default_tenant".to_string(),
-                        "default_database".to_string(),
+                        database_name,
                         "test".to_string(),
                         None,
                         None,

--- a/rust/frontend/tests/proptest_helpers/frontend_under_test.rs
+++ b/rust/frontend/tests/proptest_helpers/frontend_under_test.rs
@@ -4,7 +4,9 @@ use chroma_config::{registry::Registry, Configurable};
 use chroma_frontend::{config::FrontendServerConfig, Frontend};
 use chroma_sqlite::config::SqliteDBConfig;
 use chroma_system::System;
-use chroma_types::{Collection, CountRequest, CreateCollectionRequest, GetRequest, IncludeList};
+use chroma_types::{
+    Collection, CountRequest, CreateCollectionRequest, DatabaseName, GetRequest, IncludeList,
+};
 use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
 use std::sync::Arc;
 
@@ -53,12 +55,14 @@ impl StateMachineTest for FrontendUnderTest {
         state.runtime.block_on(async {
             match transition {
                 CollectionRequest::Init { .. } => {
+                    let database_name = DatabaseName::new("default_database")
+                        .expect("database name should be valid");
                     let collection = state
                         .frontend
                         .create_collection(
                             CreateCollectionRequest::try_new(
                                 "default_tenant".to_string(),
-                                "default_database".to_string(),
+                                database_name,
                                 "test".to_string(),
                                 None,
                                 None,

--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -650,6 +650,8 @@ mod tests {
         let collection_id_c = CollectionUuid::new();
         let collection_id_d = CollectionUuid::new();
 
+        let database_name = chroma_types::DatabaseName::new("test_database")
+            .expect("database name should be valid");
         for collection_id in [
             collection_id_a,
             collection_id_b,
@@ -659,7 +661,7 @@ mod tests {
             sysdb
                 .create_collection(
                     "test_tenant".to_string(),
-                    "test_database".to_string(),
+                    database_name.clone(),
                     collection_id,
                     format!("test_collection_{}", collection_id),
                     vec![],

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -1158,7 +1158,8 @@ mod tests {
         let root_manager = RootManager::new(storage.clone(), Box::new(NopCache));
 
         let tenant = "test_tenant".to_string();
-        let database = "test_database".to_string();
+        let database = chroma_types::DatabaseName::new("test_database")
+            .expect("database name should be valid");
 
         let root_collection_id = CollectionUuid::new();
         let segment_id = SegmentUuid::new();

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -14,7 +14,7 @@ use chroma_sysdb::{GetCollectionsOptions, GrpcSysDb, GrpcSysDbConfig, SysDb};
 use chroma_system::Orchestrator;
 use chroma_system::{Dispatcher, DispatcherConfig, System};
 use chroma_types::chroma_proto::CollectionVersionFile;
-use chroma_types::{CollectionUuid, Segment, SegmentScope, SegmentType};
+use chroma_types::{CollectionUuid, DatabaseName, Segment, SegmentScope, SegmentType};
 use chrono::DateTime;
 use futures::StreamExt;
 use garbage_collector_library::garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator;
@@ -108,12 +108,10 @@ impl StateMachineTest for GarbageCollectorUnderTest {
             );
 
             sysdb.create_tenant(ref_state.tenant.clone()).await.unwrap();
+            let db_name =
+                DatabaseName::new(ref_state.db_name.clone()).expect("db_name should be valid");
             sysdb
-                .create_database(
-                    ref_state.db_id.0,
-                    ref_state.db_name.clone(),
-                    ref_state.tenant.clone(),
-                )
+                .create_database(ref_state.db_id.0, db_name, ref_state.tenant.clone())
                 .await
                 .unwrap();
             let system = System::new();
@@ -187,11 +185,13 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                         .collection_id_to_segment_ids
                         .insert(collection_id, segment_ids);
 
+                    let db_name = DatabaseName::new(ref_state.db_name.clone())
+                        .expect("db_name should be valid");
                     state
                         .sysdb
                         .create_collection(
                             ref_state.tenant.clone(),
-                            ref_state.db_name.clone(),
+                            db_name,
                             collection_id,
                             format!("Collection {}", collection_id),
                             segments,

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -232,7 +232,9 @@ impl Bindings {
 
     ////////////////////////////// Base API //////////////////////////////
     fn count_collections(&self, tenant: String, database: String) -> ChromaPyResult<u32> {
-        let request = CountCollectionsRequest::try_new(tenant, database)?;
+        let database_name =
+            DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
+        let request = CountCollectionsRequest::try_new(tenant, database_name)?;
         let mut frontend = self.frontend.clone();
         let count = self
             .runtime
@@ -248,8 +250,10 @@ impl Bindings {
         tenant: String,
         database: String,
     ) -> ChromaPyResult<Vec<Collection>> {
+        let database_name =
+            DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
         let request =
-            ListCollectionsRequest::try_new(tenant, database, limit, offset.unwrap_or(0))?;
+            ListCollectionsRequest::try_new(tenant, database_name, limit, offset.unwrap_or(0))?;
         let mut frontend = self.frontend.clone();
         let collections = self
             .runtime
@@ -305,9 +309,11 @@ impl Bindings {
             None => None,
         };
 
+        let database_name =
+            DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
         let request = CreateCollectionRequest::try_new(
             tenant,
-            database,
+            database_name,
             name,
             metadata,
             configuration,
@@ -329,7 +335,9 @@ impl Bindings {
         tenant: String,
         database: String,
     ) -> ChromaPyResult<Collection> {
-        let request = GetCollectionRequest::try_new(tenant, database, name)?;
+        let database_name =
+            DatabaseName::new(database.clone()).ok_or(InvalidDatabaseNameError(database))?;
+        let request = GetCollectionRequest::try_new(tenant, database_name, name)?;
         let mut frontend = self.frontend.clone();
         let collection = self
             .runtime

--- a/rust/sysdb/src/sqlite.rs
+++ b/rust/sysdb/src/sqlite.rs
@@ -563,7 +563,7 @@ impl SqliteSysDb {
             collection_id,
             name,
             tenant,
-            database,
+            database.map(|d| d.into_string()),
             limit,
             offset,
         )

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -181,7 +181,7 @@ impl TestSysDb {
                 collection_id,
                 name.clone(),
                 tenant.clone(),
-                database.clone(),
+                database.clone().map(|d| d.into_string()),
             ) {
                 continue;
             }

--- a/rust/sysdb/src/types.rs
+++ b/rust/sysdb/src/types.rs
@@ -1,4 +1,4 @@
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionUuid, DatabaseName};
 
 #[derive(Default, Debug)]
 pub struct GetCollectionsOptions {
@@ -7,7 +7,7 @@ pub struct GetCollectionsOptions {
     pub include_soft_deleted: bool,
     pub name: Option<String>,
     pub tenant: Option<String>,
-    pub database: Option<String>,
+    pub database: Option<DatabaseName>,
     pub limit: Option<u32>,
     pub offset: u32,
 }

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -610,7 +610,7 @@ impl ChromaError for FinishDatabaseDeletionError {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ListCollectionsRequest {
     pub tenant_id: String,
-    pub database_name: String,
+    pub database_name: DatabaseName,
     pub limit: Option<u32>,
     pub offset: u32,
 }
@@ -618,7 +618,7 @@ pub struct ListCollectionsRequest {
 impl ListCollectionsRequest {
     pub fn try_new(
         tenant_id: String,
-        database_name: String,
+        database_name: DatabaseName,
         limit: Option<u32>,
         offset: u32,
     ) -> Result<Self, ChromaValidationError> {
@@ -640,13 +640,13 @@ pub type ListCollectionsResponse = Vec<Collection>;
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct CountCollectionsRequest {
     pub tenant_id: String,
-    pub database_name: String,
+    pub database_name: DatabaseName,
 }
 
 impl CountCollectionsRequest {
     pub fn try_new(
         tenant_id: String,
-        database_name: String,
+        database_name: DatabaseName,
     ) -> Result<Self, ChromaValidationError> {
         let request = Self {
             tenant_id,
@@ -664,14 +664,14 @@ pub type CountCollectionsResponse = u32;
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct GetCollectionRequest {
     pub tenant_id: String,
-    pub database_name: String,
+    pub database_name: DatabaseName,
     pub collection_name: String,
 }
 
 impl GetCollectionRequest {
     pub fn try_new(
         tenant_id: String,
-        database_name: String,
+        database_name: DatabaseName,
         collection_name: String,
     ) -> Result<Self, ChromaValidationError> {
         let request = Self {
@@ -711,7 +711,7 @@ impl ChromaError for GetCollectionError {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct CreateCollectionRequest {
     pub tenant_id: String,
-    pub database_name: String,
+    pub database_name: DatabaseName,
     #[validate(custom(function = "validate_name"))]
     pub name: String,
     #[validate(custom(function = "validate_optional_metadata"))]
@@ -725,7 +725,7 @@ pub struct CreateCollectionRequest {
 impl CreateCollectionRequest {
     pub fn try_new(
         tenant_id: String,
-        database_name: String,
+        database_name: DatabaseName,
         name: String,
         metadata: Option<Metadata>,
         configuration: Option<InternalCollectionConfiguration>,

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -1226,11 +1226,14 @@ mod tests {
         // Create input collection
         let collection_name = format!("test_statistics_{}", uuid::Uuid::new_v4());
         let collection_id = CollectionUuid::new();
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
 
         sysdb
             .create_collection(
                 test_segments.collection.tenant,
-                test_segments.collection.database,
+                database_name,
                 collection_id,
                 collection_name,
                 vec![

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1040,10 +1040,13 @@ mod tests {
         let mut sysdb = SysDb::Test(TestSysDb::new());
         let test_segments = TestDistributedSegment::new().await;
         let collection_id = test_segments.collection.collection_id;
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
         sysdb
             .create_collection(
                 test_segments.collection.tenant,
-                test_segments.collection.database,
+                database_name,
                 collection_id,
                 test_segments.collection.name,
                 vec![
@@ -1235,10 +1238,13 @@ mod tests {
         let mut sysdb = SysDb::Test(TestSysDb::new());
         let test_segments = TestDistributedSegment::new().await;
         let collection_id = test_segments.collection.collection_id;
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
         sysdb
             .create_collection(
                 test_segments.collection.tenant,
-                test_segments.collection.database,
+                database_name,
                 collection_id,
                 test_segments.collection.name,
                 vec![
@@ -2807,11 +2813,14 @@ mod tests {
         // Create input collection
         let collection_name = format!("test_rebuild_fn_{}", uuid::Uuid::new_v4());
         let collection_id = CollectionUuid::new();
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
 
         sysdb
             .create_collection(
                 test_segments.collection.tenant.clone(),
-                test_segments.collection.database.clone(),
+                database_name,
                 collection_id,
                 collection_name,
                 vec![


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Makes database name strongly typed in create_collection, get_collection, list and count collection
  - Enforces validation on the name as a consequence. Local and distributed both have this validation. this is intentional
  - Sysdb client routes to rust sysdb for these endpoints if topology prefix is present.
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
None

## Documentation Changes
None
