### PR TITLE
[ENH]: Plumb database name into update collection

### DIFF
--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -235,6 +235,7 @@ message CheckCollectionsResponse {
 
 message UpdateCollectionRequest {
   string id = 1;
+  optional string database = 2;
   optional string name = 3;
   optional int32 dimension = 4;
   oneof metadata_update {

--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -1217,6 +1217,9 @@ async fn update_collection(
         quota_payload = quota_payload.with_update_collection_metadata(new_metadata);
     }
     let _ = server.quota_enforcer.enforce(&quota_payload).await?;
+    let database_name = DatabaseName::new(&database).ok_or_else(|| {
+        ValidationError::InvalidArgument("database name must be at least 3 characters".to_string())
+    })?;
     let collection_id =
         CollectionUuid::from_str(&collection_id).map_err(|_| ValidationError::CollectionId)?;
 
@@ -1226,6 +1229,7 @@ async fn update_collection(
     };
 
     let request = chroma_types::UpdateCollectionRequest::try_new(
+        Some(database_name),
         collection_id,
         payload.new_name,
         payload

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -377,6 +377,7 @@ impl Bindings {
         };
 
         let request = UpdateCollectionRequest::try_new(
+            None,
             collection_id,
             new_name,
             new_metadata.map(CollectionMetadataUpdate::UpdateMetadata),

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -987,6 +987,7 @@ impl SpannerBackend {
             metadata,
             reset_metadata,
             new_configuration,
+            ..
         } = req;
 
         let collection_id = id.0.to_string();
@@ -6340,6 +6341,7 @@ mod tests {
 
         // Update name only
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: Some(new_name.clone()),
             dimension: None,
@@ -6385,6 +6387,7 @@ mod tests {
 
         // Update dimension only
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: Some(256),
@@ -6437,6 +6440,7 @@ mod tests {
 
         // Update both name and dimension
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: Some(new_name.clone()),
             dimension: Some(512),
@@ -6505,6 +6509,7 @@ mod tests {
         .collect();
 
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: None,
@@ -6566,6 +6571,7 @@ mod tests {
 
         // Reset metadata (delete all)
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: None,
@@ -6617,6 +6623,7 @@ mod tests {
 
         // Try to rename collection1 to collection2's name (should fail)
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id1,
             name: Some(name2.clone()),
             dimension: None,
@@ -6659,11 +6666,12 @@ mod tests {
         };
 
         // Setup tenant/database but don't create collection
-        let (_tenant_id, _db_name) = setup_tenant_and_database(&backend).await;
+        let (_tenant_id, db_name) = setup_tenant_and_database(&backend).await;
 
         let nonexistent_id = CollectionUuid(Uuid::new_v4());
 
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: nonexistent_id,
             name: Some("new_name".to_string()),
             dimension: None,
@@ -6715,6 +6723,7 @@ mod tests {
 
         // Update with no changes (all None/false)
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: None,
@@ -6779,6 +6788,7 @@ mod tests {
                 .collect();
 
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: Some(new_name.clone()),
             dimension: Some(1024),
@@ -6827,6 +6837,7 @@ mod tests {
 
         // Set dimension
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: Some(384),
@@ -6881,6 +6892,7 @@ mod tests {
         };
 
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: None,
@@ -6933,6 +6945,7 @@ mod tests {
 
         // Update name to same name (should succeed - it's a no-op effectively)
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: Some(name.clone()),
             dimension: None,
@@ -6985,6 +6998,7 @@ mod tests {
         );
 
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: None,
@@ -7058,6 +7072,7 @@ mod tests {
         };
 
         let update_req = UpdateCollectionRequest {
+            database_name: db_name.clone(),
             id: collection_id,
             name: None,
             dimension: None,

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -919,6 +919,7 @@ pub enum CollectionMetadataUpdate {
 #[derive(Clone, Validate, Debug, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct UpdateCollectionRequest {
+    pub database_name: Option<DatabaseName>,
     pub collection_id: CollectionUuid,
     #[validate(custom(function = "validate_name"))]
     pub new_name: Option<String>,
@@ -929,12 +930,14 @@ pub struct UpdateCollectionRequest {
 
 impl UpdateCollectionRequest {
     pub fn try_new(
+        database_name: Option<DatabaseName>,
         collection_id: CollectionUuid,
         new_name: Option<String>,
         new_metadata: Option<CollectionMetadataUpdate>,
         new_configuration: Option<InternalUpdateCollectionConfiguration>,
     ) -> Result<Self, ChromaValidationError> {
         let request = Self {
+            database_name,
             collection_id,
             new_name,
             new_metadata,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - added db name to the request proto and plumbed it all the way from top to the db query
- New functionality
  - ...

## Test plan

_How are these changes tested?_
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
None

## Observability plan
None

## Documentation Changes
None
