### PR TITLE
[CLN] Remove bm25 tenant override from query config

### DIFF
--- a/rust/worker/src/config.rs
+++ b/rust/worker/src/config.rs
@@ -5,7 +5,7 @@ use chroma_sysdb::SysDbConfig;
 use chroma_tracing::{OtelFilter, OtelFilterLevel};
 use figment::providers::{Env, Format, Yaml};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, time::Duration};
+use std::time::Duration;
 
 const DEFAULT_CONFIG_PATH: &str = "./chroma_config.yaml";
 
@@ -144,10 +144,6 @@ pub struct QueryServiceConfig {
         default = "QueryServiceConfig::default_grpc_shutdown_grace_period"
     )]
     pub grpc_shutdown_grace_period: Duration,
-    // TODO: This is a temporary config to enable bm25 for certain tenants.
-    // This should be removed once we have collection schema ready.
-    #[serde(default)]
-    pub bm25_tenant: HashSet<String>,
 }
 
 impl QueryServiceConfig {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Remove BM25 override config from query service, collection schema contains relevant config
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
