### PR TITLE
[PERF] Reduce copy in storage layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "bincode",
+ "bytes",
  "chroma-cache",
  "chroma-config",
  "chroma-error",
@@ -1578,6 +1579,7 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "serde",
+ "serde_bytes",
  "shuttle",
  "tempfile",
  "thiserror 1.0.69",
@@ -7648,6 +7650,16 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/rust/blockstore/Cargo.toml
+++ b/rust/blockstore/Cargo.toml
@@ -8,6 +8,8 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
+serde_bytes = "0.11"
+bytes = { workspace = true }
 arrow = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/rust/blockstore/src/arrow/provider.rs
+++ b/rust/blockstore/src/arrow/provider.rs
@@ -506,7 +506,10 @@ impl BlockManager {
                         }
                     };
                     num_get_requests_metric_clone.record(1, &[]);
-                    let block = Block::from_bytes(&bytes, id_clone);
+                    let block = match Arc::try_unwrap(bytes) {
+                        Ok(vec) => Block::from_bytes_owned(vec, id_clone),
+                        Err(arc) => Block::from_bytes(&arc, id_clone),
+                    };
                     match block {
                         Ok(block) => {
                             block_cache_clone.insert(id_clone, block.clone()).await;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Reduces copies in the storage layer by switching to Bytes and using serde_bytes for more efficient disk cache representation
  - Refactors all callers to use this where possible via load_from_bytes_owned
- New functionality
  - None

## Test plan
_How are these changes tested?_
Existing ser/de tests cover this
- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan
Caches on nodes will degrade. Manual failover is expected.

## Observability plan
Existing observability covers this

## Documentation Changes
None