### PR TITLE
[ENH] Set reasonable defaults for dispatcher config values

### DIFF
--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -247,7 +247,6 @@ impl Configurable<DispatcherConfig> for Dispatcher {
         config: &DispatcherConfig,
         _registry: &Registry,
     ) -> Result<Self, Box<dyn ChromaError>> {
-        tracing::info!("Creating dispatcher with config: {:#?}", config);
         Ok(Dispatcher::new(config.clone()))
     }
 }

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -13,6 +13,7 @@ use compactor::compaction_server::CompactionServer;
 use tokio::runtime::Handle;
 use tokio::select;
 use tokio::signal::unix::{signal, SignalKind};
+use tracing::info;
 
 // Required for benchmark
 pub mod config;
@@ -41,6 +42,8 @@ pub async fn query_service_entrypoint() {
         &config.otel_filters,
         &config.otel_endpoint,
     );
+
+    info!("Loaded configuration successfully: {:#?}", config);
 
     let system = chroma_system::System::new();
     let dispatcher =
@@ -101,6 +104,8 @@ pub async fn compaction_service_entrypoint() {
         &config.otel_filters,
         &config.otel_endpoint,
     );
+
+    info!("Loaded configuration successfully: {:#?}", config);
 
     let system = chroma_system::System::new();
 


### PR DESCRIPTION
## Description of changes

Attempt to size dispatcher based on the number of available CPUs. This should ideally provide "reasonable defaults" that scale correctly based on the compute allocated to the system, meaning an operator would only ever need to modify these values in abnormal circumstances.

## Test plan

CI + integration + load tests on staging

## Migration plan

Manually remove config overrides for these values one-by-one. Run load tests and bake in staging env.

## Observability plan

Monitor (existing) Honeycomb metrics:
* `worker_queue_depth` -- ensure it never fills
* `io_task_depth` -- ensure it never reaches 0
* `aborted_tasks` -- ensure this never increments

Check for any aborted (errored) requests.

## Documentation Changes

N/A
