### PR TITLE
[ENH]: Client changes for flush_compaction on rust-sysdb

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -1175,7 +1175,7 @@ mod tests {
         sysdb
             .create_collection(
                 tenant.clone(),
-                database,
+                database.clone(),
                 root_collection_id,
                 "Root Collection".to_string(),
                 vec![segment],
@@ -1192,6 +1192,7 @@ mod tests {
         sysdb
             .flush_compaction(
                 tenant.clone(),
+                database.clone(),
                 root_collection_id,
                 0,
                 0,
@@ -1210,6 +1211,7 @@ mod tests {
         sysdb
             .flush_compaction(
                 tenant.clone(),
+                database.clone(),
                 root_collection_id,
                 0,
                 1,
@@ -1231,6 +1233,7 @@ mod tests {
         sysdb
             .flush_compaction(
                 tenant,
+                database.clone(),
                 root_collection_id,
                 0,
                 2,

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -239,6 +239,8 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                         .sysdb
                         .flush_compaction(
                             ref_state.tenant.clone(),
+                            DatabaseName::new(ref_state.db_name.clone())
+                                .expect("db_name should be valid"),
                             collection_id,
                             0,
                             ref_state.max_version_for_collection(collection_id).unwrap() as i32 - 1,

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -14,6 +14,7 @@ use std::fmt::Debug;
 pub struct CollectionRecord {
     pub collection_id: CollectionUuid,
     pub tenant_id: String,
+    pub database_name: String,
     pub last_compaction_time: i64,
     #[allow(dead_code)]
     pub first_record_time: i64,

--- a/rust/sysdb/src/test_sysdb.rs
+++ b/rust/sysdb/src/test_sysdb.rs
@@ -128,12 +128,20 @@ impl TestSysDb {
     fn filter_collections(
         collection: &Collection,
         collection_id: Option<CollectionUuid>,
+        collection_ids: Option<&Vec<CollectionUuid>>,
         name: Option<String>,
         tenant: Option<String>,
         database: Option<String>,
     ) -> bool {
+        // Filter by collection_id (singular) if provided
         if collection_id.is_some() && collection_id.unwrap() != collection.collection_id {
             return false;
+        }
+        // Filter by collection_ids (plural) if provided
+        if let Some(ids) = collection_ids {
+            if !ids.contains(&collection.collection_id) {
+                return false;
+            }
         }
         if name.is_some() && name.unwrap() != collection.name {
             return false;
@@ -175,7 +183,7 @@ impl TestSysDb {
     ) -> Result<Vec<Collection>, GetCollectionsError> {
         let GetCollectionsOptions {
             collection_id,
-            collection_ids: _,
+            collection_ids,
             include_soft_deleted: _,
             name,
             tenant,
@@ -200,6 +208,7 @@ impl TestSysDb {
             if !TestSysDb::filter_collections(
                 collection,
                 collection_id,
+                collection_ids.as_ref(),
                 name.clone(),
                 tenant.clone(),
                 database_string.clone(),

--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -16,10 +16,11 @@ query_service:
       connect_timeout_ms: 5000
       request_timeout_ms: 5000
   mcmr_sysdb:
-    host: "rust-sysdb-service.chroma"
-    port: 50051
-    connect_timeout_ms: 60000
-    request_timeout_ms: 60000
+    grpc:
+      host: "rust-sysdb-service.chroma"
+      port: 50051
+      connect_timeout_ms: 60000
+      request_timeout_ms: 60000
   storage:
     admission_controlled_s3:
       s3_config:
@@ -108,6 +109,11 @@ compaction_service:
       port: 50051
       connect_timeout_ms: 5000
       request_timeout_ms: 5000
+  mcmr_sysdb:
+    host: "rust-sysdb-service.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
   storage:
     admission_controlled_s3:
       s3_config:

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -15,6 +15,11 @@ query_service:
       port: 50051
       connect_timeout_ms: 5000
       request_timeout_ms: 5000
+  mcmr_sysdb:
+    host: "rust-sysdb-service.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
   storage:
     admission_controlled_s3:
       s3_config:
@@ -103,6 +108,11 @@ compaction_service:
       port: 50051
       connect_timeout_ms: 5000
       request_timeout_ms: 5000
+  mcmr_sysdb:
+    host: "rust-sysdb-service.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
   storage:
     admission_controlled_s3:
       s3_config:

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -108,6 +108,11 @@ compaction_service:
       port: 50051
       connect_timeout_ms: 5000
       request_timeout_ms: 5000
+  mcmr_sysdb:
+    host: "rust-sysdb-service.chroma2"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
   storage:
     admission_controlled_s3:
       s3_config:

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -202,7 +202,7 @@ impl CompactionManager {
             let future = self
                 .context
                 .clone()
-                .compact(job.collection_id, false)
+                .compact(job.collection_id, job.database_name.clone(), false)
                 .instrument(instrumented_span);
             if let Err(e) = compact_awaiter_channel
                 .send(CompactionTask {
@@ -222,9 +222,14 @@ impl CompactionManager {
 
     #[instrument(name = "CompactionManager::rebuild_batch", skip(self))]
     pub(crate) async fn rebuild_batch(&mut self, collection_ids: &[CollectionUuid]) {
+        // TODO(tanujnay112): Implement this for MCMR by accepting a database/topo name on this method.
         let _ = collection_ids
             .iter()
-            .map(|id| self.context.clone().compact(*id, true))
+            .map(|id| {
+                let database_name =
+                    chroma_types::DatabaseName::new("default").expect("default should be valid");
+                self.context.clone().compact(*id, database_name, true)
+            })
             .collect::<FuturesUnordered<_>>()
             .collect::<Vec<_>>()
             .await;
@@ -339,8 +344,11 @@ impl CompactionManager {
                         }
                     }
                 },
-                Err(_) => {
-                    self.scheduler.fail_job(resp.job_id).await;
+                Err(ref e) => {
+                    let job_id = resp.job_id;
+                    let error_msg = e.to_string();
+                    self.scheduler.fail_job(job_id).await;
+                    tracing::error!("Failed to compact collection: {} - {}", job_id, error_msg);
                 }
             }
             completed_collections.push(resp);
@@ -360,6 +368,7 @@ impl CompactionManagerContext {
     async fn compact(
         self,
         collection_id: CollectionUuid,
+        database_name: chroma_types::DatabaseName,
         is_rebuild: bool,
     ) -> Result<CompactionResponse, Box<dyn ChromaError>> {
         tracing::info!("Compacting collection: {}", collection_id);
@@ -374,9 +383,11 @@ impl CompactionManagerContext {
         // fetch data to compact -> execute_task/compact -> register
         // Use the compact function to handle the entire orchestration process
         let is_function_disabled = self.disabled_function_collections.contains(&collection_id);
+
         let compact_result = Box::pin(compact(
             self.system.clone(),
             collection_id,
+            database_name,
             is_rebuild,
             self.fetch_log_batch_size,
             self.max_compaction_size,

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -1,9 +1,10 @@
-use chroma_types::{CollectionUuid, JobId};
+use chroma_types::{CollectionUuid, DatabaseName, JobId};
 use tokio::sync::oneshot;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct CompactionJob {
     pub(crate) collection_id: CollectionUuid,
+    pub(crate) database_name: DatabaseName,
 }
 
 #[derive(Clone, Debug)]

--- a/rust/worker/src/execution/functions/statistics.rs
+++ b/rust/worker/src/execution/functions/statistics.rs
@@ -493,7 +493,7 @@ mod tests {
         types::{materialize_logs, MaterializeLogsResult},
     };
     use chroma_types::{
-        Chunk, LogRecord, Operation, OperationRecord, SparseVector, UpdateMetadata,
+        Chunk, DatabaseName, LogRecord, Operation, OperationRecord, SparseVector, UpdateMetadata,
         UpdateMetadataValue,
     };
 
@@ -1257,6 +1257,7 @@ mod tests {
         sysdb
             .flush_compaction(
                 tenant.clone(),
+                DatabaseName::new(db.clone()).expect("database name should be valid"),
                 collection_id,
                 -1,
                 0,
@@ -1339,9 +1340,12 @@ mod tests {
             .await
             .unwrap();
 
+        let database_name = DatabaseName::new(test_segments.collection.database.clone())
+            .expect("database name should be valid");
         Box::pin(compact::compact(
             system.clone(),
             collection_id,
+            database_name,
             false,
             50,
             1000,

--- a/rust/worker/src/execution/operators/get_collection_and_segments.rs
+++ b/rust/worker/src/execution/operators/get_collection_and_segments.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 use chroma_error::ChromaError;
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::{CollectionAndSegments, CollectionUuid, GetCollectionWithSegmentsError};
+use chroma_types::{
+    CollectionAndSegments, CollectionUuid, DatabaseName, GetCollectionWithSegmentsError,
+};
 use thiserror::Error;
 
 /// The `GetCollectionAndSegmentsOperator` fetches a consistent snapshot of collection and segment information
@@ -20,13 +22,15 @@ use thiserror::Error;
 pub struct GetCollectionAndSegmentsOperator {
     pub sysdb: SysDb,
     pub collection_id: CollectionUuid,
+    pub database_name: DatabaseName,
 }
 
 impl GetCollectionAndSegmentsOperator {
-    pub fn new(sysdb: SysDb, collection_id: CollectionUuid) -> Self {
+    pub fn new(sysdb: SysDb, collection_id: CollectionUuid, database_name: DatabaseName) -> Self {
         Self {
             sysdb,
             collection_id,
+            database_name,
         }
     }
 }
@@ -73,11 +77,10 @@ impl Operator<GetCollectionAndSegmentsInput, GetCollectionAndSegmentsOutput>
             self.get_name(),
             self.collection_id.0
         );
-        // TODO(Sanket): Add database name to the sysdb call.
         Ok(self
             .sysdb
             .clone()
-            .get_collection_with_segments(None, self.collection_id)
+            .get_collection_with_segments(Some(self.database_name.clone()), self.collection_id)
             .await?)
     }
 }

--- a/rust/worker/src/execution/operators/register.rs
+++ b/rust/worker/src/execution/operators/register.rs
@@ -135,6 +135,7 @@ impl Operator<RegisterInput, RegisterOutput> for RegisterOperator {
         let result = sysdb
             .flush_compaction(
                 input.tenant.clone(),
+                input.database_name.clone(),
                 input.collection_id,
                 input.log_position,
                 input.collection_version,

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -16,7 +16,7 @@ use chroma_segment::{
     spann_provider::SpannProvider,
     types::VectorSegmentWriter,
 };
-use chroma_sysdb::SysDb;
+use chroma_sysdb::sysdb::SysDb;
 use chroma_system::{
     wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
     OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
@@ -232,6 +232,7 @@ impl From<RequireFunctionBackfill> for LogFetchOrchestratorResponse {
 #[derive(Debug)]
 pub(crate) struct LogFetchOrchestrator {
     collection_id: CollectionUuid,
+    database_name: chroma_types::DatabaseName,
     context: CompactionContext,
     dispatcher: ComponentHandle<Dispatcher>,
     result_channel: Option<Sender<Result<LogFetchOrchestratorResponse, LogFetchOrchestratorError>>>,
@@ -271,6 +272,7 @@ impl Orchestrator for LogFetchOrchestrator {
                 Box::new(GetCollectionAndSegmentsOperator {
                     sysdb: self.context.sysdb.clone(),
                     collection_id: self.collection_id,
+                    database_name: self.database_name.clone(),
                 }),
                 (),
                 ctx.receiver(),
@@ -288,6 +290,7 @@ impl LogFetchOrchestrator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         collection_id: CollectionUuid,
+        database_name: chroma_types::DatabaseName,
         is_rebuild: bool,
         fetch_log_batch_size: u32,
         max_compaction_size: usize,
@@ -314,6 +317,7 @@ impl LogFetchOrchestrator {
         );
         LogFetchOrchestrator {
             collection_id,
+            database_name,
             context,
             dispatcher,
             result_channel: None,


### PR DESCRIPTION
## Description of changes

This change integrates the compaction service with the rust sysdb flush compaction end point. The main work involved here was threading the topology name + database name of the compacted collection throughout all of compaction's sysdb calls.



test_sysdb::GetCollections ignored batch collection_ids filters before this change, that has also been addressed in this change.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

Manual end to end testing was done. Created an MCMR collection on two regions, added 300 records to it and observed two independent compactions (one for each region).

Will add automated end to end tests in a followup change.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_