### PR TITLE
[CHORE] Add default annotation to replicated fragment options.

### DIFF
--- a/rust/wal3/src/interfaces/repl/fragment_manager.rs
+++ b/rust/wal3/src/interfaces/repl/fragment_manager.rs
@@ -33,12 +33,12 @@ pub struct ReplicatedFragmentOptions {
 
 impl ReplicatedFragmentOptions {
     /// Returns the minimum allowed replication factor.
-    pub fn default_minimum_allowed_replication_factor() -> usize {
+    fn default_minimum_allowed_replication_factor() -> usize {
         1
     }
 
     /// Returns the minimum failures to exclude a replica.
-    pub fn default_minimum_failures_to_exclude_replica() -> usize {
+    fn default_minimum_failures_to_exclude_replica() -> usize {
         1000
     }
 
@@ -64,10 +64,11 @@ impl ReplicatedFragmentOptions {
 impl Default for ReplicatedFragmentOptions {
     fn default() -> Self {
         Self {
-            minimum_allowed_replication_factor: 1,
-            minimum_failures_to_exclude_replica: 1000,
-            decimation_interval_secs: 30,
-            slow_writer_tolerance_secs: 15,
+            minimum_allowed_replication_factor: Self::default_minimum_allowed_replication_factor(),
+            minimum_failures_to_exclude_replica: Self::default_minimum_failures_to_exclude_replica(
+            ),
+            decimation_interval_secs: Self::default_decimation_interval_secs(),
+            slow_writer_tolerance_secs: Self::default_slow_writer_tolerance_secs(),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

They aren't defaulted, so if they're missing nothing comes up.  Default-init them.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
