### PR TITLE
Fix HNSW k=0 query crash

### DIFF
--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -153,6 +153,9 @@ class LocalHnswSegment(VectorReader):
             if len(labels) < k:
                 k = len(labels)
 
+        if k == 0:
+            return [[] for _ in range(len(query["vectors"]))]
+
         def filter_function(label: int) -> bool:
             return label in labels
 


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Fix HNSW query crash when k == 0 (empty collection / fully filtered).
  - Skip persistent HNSW query when hnsw_k == 0.
## Test plan
- Not run.

## Migration plan

  - None.

## Observability plan

  - None.

## Documentation Changes

  - None.
