### PR TITLE
[PERF] Skip sparse vector in log filter reader

### DIFF
--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -125,7 +125,10 @@ impl<'me> MetadataLogReader<'me> {
                 let log = log.hydrate(record_segment_reader.as_ref()).await?;
                 user_id_to_offset_id.insert(log.get_user_id(), log.get_offset_id());
                 let log_metadata = log.merged_metadata();
-                for (key, val) in log_metadata.into_iter() {
+                for (key, val) in log_metadata {
+                    if let MetadataValue::SparseVector(_) = val {
+                        continue;
+                    }
                     compact_metadata
                         .entry(key)
                         .or_default()


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Skip using sparse vector values in metadata log reader, we do not support filter for sparse vectors now
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
