### PR TITLE
[ENH] add Spanner migration checksum validation to PR workflow

### DIFF
--- a/.github/workflows/_check_spanner_migrations.yml
+++ b/.github/workflows/_check_spanner_migrations.yml
@@ -1,0 +1,27 @@
+name: Check Spanner migrations
+
+on:
+  workflow_call:
+
+jobs:
+  check-migrations:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+      - name: Generate migration sum
+        run: cargo run --bin spanner_migration -- generate-sum --root rust/spanner-migrations
+      - name: Check for uncommitted changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Repository is dirty after generating migration sum. Please run 'cargo run --bin spanner_migration -- generate-sum --root rust/spanner-migrations' and commit the changes."
+            git status
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -206,6 +206,13 @@ jobs:
     uses: ./.github/workflows/_go-tests.yml
     secrets: inherit
 
+  check-spanner-migrations:
+    name: Check Spanner migrations
+    needs: change-detection
+    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+    uses: ./.github/workflows/_check_spanner_migrations.yml
+    secrets: inherit
+
   lint:
     name: Lint
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -256,6 +263,7 @@ jobs:
     - rust-tests
     - rust-feature-tests
     - go-tests
+    - check-spanner-migrations
     - lint
     - check-helm-version-bump
     - delete-helm-comment
@@ -265,7 +273,7 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
-        allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-helm-version-bump,delete-helm-comment
+        allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-spanner-migrations,check-helm-version-bump,delete-helm-comment
 
   notify-slack-on-failure:
     name: Notify Slack on Test Failure
@@ -277,6 +285,7 @@ jobs:
     - rust-tests
     - rust-feature-tests
     - go-tests
+    - check-spanner-migrations
     - lint
     - check-helm-version-bump
     - delete-helm-comment


### PR DESCRIPTION
## Description of changes

a new reusable workflow that ensures Spanner migration checksums are
up-to-date by running spanner_migration generate-sum and failing if the
repository becomes dirty afterward.

Integrate the check into the PR workflow:
- Run when rust changes are detected
- Add to required checks for PR completion
- Include in slack failure notifications
- Allow skipping when no rust changes

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
