### PR TITLE
[PERF] Execute rate limited get in same future

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -919,7 +919,13 @@ impl AdmissionControlledS3Storage {
                     // NOTE(hammadb): If the upstream request gets cancelled, we still
                     // finish the request once it has been spawned, if its cancelled
                     // before it has been spawned, then the task will never run.
-                    tokio::spawn(async move {
+                    // NOTE(sicheng): The following block used to be executed with tokio::spawn.
+                    // It could lead to unbounded growth in tokio task queue, and could cause
+                    // performance degration in tokio runtime. As a temporary solution, since
+                    // we do not cancel tasks right now, this block of logic is moved out
+                    // of tokio::spawn. If we introduce the cancellation logic in the future
+                    // we need to address the issue in the comment above.
+                    {
                         // Fetch all keys in parallel
                         let fetch_futures: Vec<_> = keys_clone
                             .iter()
@@ -990,7 +996,7 @@ impl AdmissionControlledS3Storage {
                                 }
                             }
                         }
-                    });
+                    }
                     output_rx.await.map_err(|e| {
                         tracing::error!("Unexpected channel closure: {}", e);
                         StorageError::Generic {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Move rate limited object get logic out of dedicated tokio task to avoid unbounded task growth in tokio scheduler
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
