### PR TITLE
[CHORE]: Plumb topo name to sysdb client

### DIFF
--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -190,6 +190,7 @@ message GetCollectionsRequest {
   optional int32 offset = 7;
   optional CollectionIdsFilter ids_filter = 8;
   optional bool include_soft_deleted = 9;
+  optional string topology_name = 10;
 }
 
 message GetCollectionsResponse {

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -16,7 +16,7 @@ use chroma_metering::{
 };
 use chroma_segment::local_segment_manager::LocalSegmentManager;
 use chroma_sqlite::db::SqliteDb;
-use chroma_sysdb::{GetCollectionsOptions, SysDb};
+use chroma_sysdb::{DatabaseOrTopology, GetCollectionsOptions, SysDb};
 use chroma_system::System;
 use chroma_types::{
     operator::{Filter, KnnBatch, KnnProjection, Limit, Projection, Scan},
@@ -372,7 +372,7 @@ impl ServiceBasedFrontend {
             .sysdb_client
             .get_collections(GetCollectionsOptions {
                 tenant: Some(tenant_id.clone()),
-                database: Some(database_name.clone()),
+                database_or_topology: Some(DatabaseOrTopology::Database(database_name.clone())),
                 limit,
                 offset,
                 ..Default::default()
@@ -417,7 +417,7 @@ impl ServiceBasedFrontend {
             .get_collections(GetCollectionsOptions {
                 name: Some(collection_name.clone()),
                 tenant: Some(tenant_id.clone()),
-                database: Some(database_name.clone()),
+                database_or_topology: Some(DatabaseOrTopology::Database(database_name.clone())),
                 limit: Some(1),
                 ..Default::default()
             })

--- a/rust/rust-sysdb/src/backend.rs
+++ b/rust/rust-sysdb/src/backend.rs
@@ -161,13 +161,17 @@ impl BackendFactory {
     pub fn backend_from_database_name(&self, db_name: &chroma_types::DatabaseName) -> Backend {
         if let Some(topo_str) = db_name.topology() {
             if let Ok(topology) = TopologyName::new(topo_str) {
-                return Backend::Spanner(self.spanner(&topology).clone());
+                return self.backend_from_topo_name(&topology);
             }
         }
         // Fall back to default backend if no topology or invalid topology
         // TODO(Sanket): Should fall back to Aurora here.
         tracing::warn!("No topology found in database name, falling back to default backend");
         Backend::Spanner(self.one_spanner().clone())
+    }
+
+    pub fn backend_from_topo_name(&self, topo_name: &TopologyName) -> Backend {
+        Backend::Spanner(self.spanner(topo_name).clone())
     }
 }
 

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -761,7 +761,7 @@ impl SpannerBackend {
             where_clauses.push("c.tenant_id = @tenant_id".to_string());
         }
 
-        // Filter by database_name
+        // Filter by database_name only
         if filter.database_name.is_some() {
             where_clauses.push("c.database_name = @database_name".to_string());
         }

--- a/rust/sysdb/src/types.rs
+++ b/rust/sysdb/src/types.rs
@@ -1,4 +1,10 @@
-use chroma_types::{CollectionUuid, DatabaseName};
+use chroma_types::{CollectionUuid, DatabaseName, TopologyName};
+
+#[derive(Debug, Clone)]
+pub enum DatabaseOrTopology {
+    Database(DatabaseName),
+    Topology(TopologyName),
+}
 
 #[derive(Default, Debug)]
 pub struct GetCollectionsOptions {
@@ -7,7 +13,7 @@ pub struct GetCollectionsOptions {
     pub include_soft_deleted: bool,
     pub name: Option<String>,
     pub tenant: Option<String>,
-    pub database: Option<DatabaseName>,
+    pub database_or_topology: Option<DatabaseOrTopology>,
     pub limit: Option<u32>,
     pub offset: u32,
 }


### PR DESCRIPTION
## Description of changes

Adds a DatabaseOrTopology optional field in the GetCollections proto filter and extends this sysdb client routing layer to route based on topology and not just database name.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

Tests are added to verify GetCollections routing based on DatabaseOrTopology.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_