### PR TITLE
[Doc] Fix docstrings to reflect actual exception types

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -148,7 +148,7 @@ class BaseAPI(ABC):
             name: The name of the collection to delete.
 
         Raises:
-            ValueError: If the collection does not exist.
+            NotFoundError: If the collection does not exist.
 
         Examples:
             ```python
@@ -434,8 +434,8 @@ class ClientAPI(BaseAPI, ABC):
             Collection: The newly created collection.
 
         Raises:
-            ValueError: If the collection already exists and get_or_create is False.
-            ValueError: If the collection name is invalid.
+            ChromaError: If the collection already exists and get_or_create is False.
+            InvalidArgumentError: If the collection name is invalid.
 
         Examples:
             ```python
@@ -468,7 +468,7 @@ class ClientAPI(BaseAPI, ABC):
             Collection: The collection
 
         Raises:
-            ValueError: If the collection does not exist
+            NotFoundError: If the collection does not exist
 
         Examples:
             ```python

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -101,7 +101,7 @@ class AsyncBaseAPI(ABC):
             name: The name of the collection to delete.
 
         Raises:
-            ValueError: If the collection does not exist.
+            NotFoundError: If the collection does not exist.
 
         Examples:
             ```python
@@ -386,8 +386,8 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
             Collection: The newly created collection.
 
         Raises:
-            ValueError: If the collection already exists and get_or_create is False.
-            ValueError: If the collection name is invalid.
+            ChromaError: If the collection already exists and get_or_create is False.
+            InvalidArgumentError: If the collection name is invalid.
 
         Examples:
             ```python


### PR DESCRIPTION
## Description of changes

Updated docstrings in `chromadb/api/__init__.py` and `chromadb/api/async_api.py` to reflect the actual exception types raised by the methods.

- Improvements & Bug fixes
  - Fixed `delete_collection` docstring: changed `ValueError` to `NotFoundError` to match actual implementation
  - Fixed `create_collection` docstring: changed `ValueError` to `ChromaError` and `InvalidArgumentError` to match actual implementation

- New functionality
  - N/A

## Test plan

No test changes needed - this is a documentation-only change that corrects existing docstrings to match the actual behavior.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

No migration needed - this is a documentation-only change with no code behavior changes.

## Observability plan

No observability changes needed - this is a documentation-only change.

## Documentation Changes

Docstrings updated in:
- `chromadb/api/__init__.py` 
- `chromadb/api/async_api.py`

No changes needed in the docs section as these are internal API docstrings.