### PR TITLE
[CHORE]  Split Python tests that run on main so half run on mcmr.

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -128,7 +128,6 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
-        always_multi_region: ${{ fromJson(inputs.always_multi_region) }}
         test-glob:
           - "chromadb/test/api"
           - "chromadb/test/api/test_collection.py"
@@ -164,7 +163,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      MULTI_REGION: ${{ matrix.always_multi_region || matrix.multi_region || "false" }}
+      MULTI_REGION: ${{ (inputs.always_multi_region || matrix.multi_region) && 'true' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -88,6 +88,7 @@ jobs:
       - check-tag
       - get-version
       - python-tests-linux
+      - python-tests-linux-mcmr
       - python-tests-windows
       - javascript-client-tests
       - rust-tests
@@ -105,6 +106,7 @@ jobs:
       - check-tag
       - get-version
       - python-tests-linux
+      - python-tests-linux-mcmr
       - python-tests-windows
       - javascript-client-tests
       - rust-tests
@@ -122,6 +124,7 @@ jobs:
     needs:
       - check-tag
       - python-tests-linux
+      - python-tests-linux-mcmr
       - python-tests-windows
       - javascript-client-tests
       - rust-tests


### PR DESCRIPTION
## Description of changes

We want to test multi-cloud, multi-region without doubling CI wait times
or the overall sum of CPU consumed.  The fix is simple:  We already run
multiple Python versions, so run half of them on mcmr and half on the
classic tilt file.

## Test plan

CI will be the test.

## Migration plan

N/A

## Observability plan

Watch CI on landing.

## Documentation Changes

N/A
