### PR TITLE
[ENH] Better outside-docs ci filter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,12 +32,14 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          predicate-quantifier: 'every'
           filters: |
             # documentation changes
             docs:
               - 'docs/**'
             # Outside docs
             outside-docs:
+              - '**'
               - '!docs/**'
               - '!**/*.md'
             # Helm chart changes


### PR DESCRIPTION
Currently outside-docs only doesn't match markdown files within the docs/** directory
This change adds the `every` qualifier so that all the filters in the list need to match for a file to match, this way other filetypes like `.mdx` inside of docs are also not counted as outside-docs.

The rest of the filters only have a single conditional so every vs any shouldn't make a difference.