### PR TITLE
[CHORE] make usearch an optional dep

### DIFF
--- a/rust/index/Cargo.toml
+++ b/rust/index/Cargo.toml
@@ -3,6 +3,10 @@ name = "chroma-index"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+usearch = ["dep:usearch"]
+
 [lib]
 path = "src/lib.rs"
 
@@ -33,7 +37,7 @@ hnswlib = { workspace = true }
 opentelemetry = { version = "0.27.0", default-features = false, features = ["trace", "metrics"] }
 simsimd = { workspace = true }
 dashmap = { workspace = true }
-usearch = { workspace = true }
+usearch = { workspace = true, optional = true }
 crossbeam = { workspace = true }
 
 chroma-error = { workspace = true }

--- a/rust/index/src/lib.rs
+++ b/rust/index/src/lib.rs
@@ -7,6 +7,7 @@ pub mod quantization;
 pub mod spann;
 pub mod sparse;
 pub mod types;
+#[cfg(feature = "usearch")]
 pub mod usearch;
 pub mod utils;
 


### PR DESCRIPTION
## Description of changes

usearch isn't needed for the python client

Make it an optional crate dep so that we can build python bindings.

## Test plan

Yolo it until CI on main passes.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
