### PR TITLE
[BUG]: Have GetCollections in sysdb return compaction_failure_count

### DIFF
--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -164,6 +164,7 @@ func (s *collectionDb) getCollections(ids []string, name *string, tenantID strin
 		TotalRecordsPostCompaction uint64     `gorm:"column:total_records_post_compaction"`
 		SizeBytesPostCompaction    uint64     `gorm:"column:size_bytes_post_compaction"`
 		LastCompactionTimeSecs     uint64     `gorm:"column:last_compaction_time_secs"`
+		CompactionFailureCount     int32      `gorm:"column:compaction_failure_count"`
 		DatabaseName               string     `gorm:"column:database_name"`
 		TenantID                   string     `gorm:"column:db_tenant_id"`
 		Tenant                     string     `gorm:"column:tenant"`
@@ -198,7 +199,8 @@ func (s *collectionDb) getCollections(ids []string, name *string, tenantID strin
 		"NULLIF(collections.lineage_file_name, '') AS lineage_file_name, " +
 		"collections.total_records_post_compaction, " +
 		"collections.size_bytes_post_compaction, " +
-		"collections.last_compaction_time_secs, "
+		"collections.last_compaction_time_secs, " +
+		"collections.compaction_failure_count, "
 	db_targets := "databases.name as database_name, databases.tenant_id as db_tenant_id, "
 	collection_tenant := "collections.tenant as tenant"
 
@@ -305,6 +307,7 @@ func (s *collectionDb) getCollections(ids []string, name *string, tenantID strin
 				TotalRecordsPostCompaction: r.TotalRecordsPostCompaction,
 				SizeBytesPostCompaction:    r.SizeBytesPostCompaction,
 				LastCompactionTimeSecs:     r.LastCompactionTimeSecs,
+				CompactionFailureCount:     r.CompactionFailureCount,
 				Tenant:                     r.Tenant,
 				UpdatedAt:                  *r.CollectionUpdatedAt,
 				CreatedAt:                  *r.CollectionCreatedAt,

--- a/go/pkg/sysdb/metastore/db/dao/daotest/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/daotest/collection.go
@@ -172,3 +172,9 @@ func WithOldestVersionTs(oldestVersionTs time.Time) func(*dbmodel.Collection) {
 		collection.OldestVersionTs = oldestVersionTs
 	}
 }
+
+func WithCompactionFailureCount(compactionFailureCount int32) func(*dbmodel.Collection) {
+	return func(collection *dbmodel.Collection) {
+		collection.CompactionFailureCount = compactionFailureCount
+	}
+}


### PR DESCRIPTION
## Description of changes

7efd6735a9d8b65063149737a7a8ec4d386c81d3 was incomplete as the sysdb GetCollections method did not return and populate the value of compaction_failure_count. The test in the test plan of that commit only passed because it used the test_sysdb which operated correctly. This change fixes this gap.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

Added a go test to make sure GetCollections returns what's expected.

Manually tested with injected failures as well.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_