### PR TITLE
[CHORE]: Add tracing for mcmr sysdb connection

### DIFF
--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -809,6 +809,7 @@ impl Configurable<(GrpcSysDbConfig, Option<GrpcSysDbConfig>)> for GrpcSysDb {
         let mcmr_client = if let Some(mcmr_config) = &config.1 {
             let host = &mcmr_config.host;
             let port = &mcmr_config.port;
+            tracing::info!("Connecting to mcmr sysdb at {}:{}", host, port);
             let connection_string = format!("http://{}:{}", host, port);
             let endpoint = match Endpoint::from_shared(connection_string) {
                 Ok(endpoint) => endpoint,


### PR DESCRIPTION
## Description of changes

This change adds a small info log line when a mcmr config is being processed and an mcmr sysdb connection attempt is being made.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
