### PR TITLE
[BUG]: Remove unused static import in chromadb TypeScript package

### DIFF
--- a/clients/new-js/packages/chromadb/src/embedding-function.ts
+++ b/clients/new-js/packages/chromadb/src/embedding-function.ts
@@ -1,6 +1,5 @@
 import { EmbeddingFunctionConfiguration, SparseVector } from "./api";
 import { ChromaValueError } from "./errors";
-import { DefaultEmbeddingFunction } from "@chroma-core/default-embed";
 import { ChromaClient } from "./chroma-client";
 
 /**


### PR DESCRIPTION
## Description of changes

- Bug fixes
  - Remove unused static import of `DefaultEmbeddingFunction` from `@chroma-core/default-embed` in `embedding-function.ts`
  - The import was unused because `DefaultEmbeddingFunction` is only referenced via dynamic import inside `getDefaultEFConfig()`

Fixes #6225

## Test plan

- [x] Tests pass locally with `pnpm build` for js

## Migration plan

No migration needed - this is a simple removal of an unused import.

## Observability plan

N/A

## Documentation Changes

N/A