### PR TITLE
[DOC]: Add missing make proto_python instruction to DEVELOP.md

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -20,6 +20,12 @@ pre-commit install # install the precommit hooks
 Install protobuf:
 for MacOS `brew install protobuf`
 
+Generate the protobuf files (required before running tests):
+
+```bash
+cd idl && make proto_python
+```
+
 You can also install `chromadb` the `pypi` package locally and in editable mode with `pip install -e .`.
 
 ## Local dev setup for distributed chroma

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -23,7 +23,7 @@ for MacOS `brew install protobuf`
 Generate the protobuf files (required before running tests):
 
 ```bash
-cd idl && make proto_python
+make -C idl proto_python
 ```
 
 You can also install `chromadb` the `pypi` package locally and in editable mode with `pip install -e .`.


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Add documentation for generating protobuf files before running tests
  - First-time contributors need to run `make proto_python` from the `idl` directory before running pytest

Fixes #6194

## Test plan

N/A - documentation change only

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

Added the following instruction to DEVELOP.md after the protobuf installation step:

```bash
cd idl && make proto_python
```