### PR TITLE
[DOC] fix typo in embedding functions documentation

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
+++ b/docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md
@@ -24,7 +24,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
 
 
-For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships will all embedding functions included.
+For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships with all embedding functions included.
 
 | Provider                    | Embedding Function Package                    
 | ----------                  | ------------------------- 

--- a/docs/docs.trychroma.com/public/llms-docs-embeddings-embedding-functions.txt
+++ b/docs/docs.trychroma.com/public/llms-docs-embeddings-embedding-functions.txt
@@ -23,7 +23,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [OpenAI](../../integrations/embedding-models/openai)                                     | ✓      | ✓          |
 | [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
 
-For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships will all embedding functions included.
+For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships with all embedding functions included.
 
 | Provider                    | Embedding Function Package                    
 | ----------                  | ------------------------- 

--- a/docs/docs.trychroma.com/public/llms-full.txt
+++ b/docs/docs.trychroma.com/public/llms-full.txt
@@ -9234,7 +9234,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
 
 
-For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships will all embedding functions included.
+For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships with all embedding functions included.
 
 | Provider                    | Embedding Function Package
 | ----------                  | -------------------------

--- a/docs/mintlify/docs/embeddings/embedding-functions.mdx
+++ b/docs/mintlify/docs/embeddings/embedding-functions.mdx
@@ -22,7 +22,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Together AI](../../integrations/embedding-models/together-ai)                           | ✓      | ✓          |
 
 
-For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships will all embedding functions included.
+For TypeScript users, Chroma provides packages for a number of embedding model providers. The Chromadb python package ships with all embedding functions included.
 
 | Provider                    | Embedding Function Package
 | ----------                  | -------------------------


### PR DESCRIPTION
## Description

Fixed a small typo in the embedding functions documentation.

**Before:** "The Chromadb python package ships **will** all embedding functions included."
**After:** "The Chromadb python package ships **with** all embedding functions included."

### Files changed
- `docs/mintlify/docs/embeddings/embedding-functions.mdx` (primary source)
- `docs/docs.trychroma.com/public/llms-full.txt`
- `docs/docs.trychroma.com/public/llms-docs-embeddings-embedding-functions.txt`
- `docs/docs.trychroma.com/markdoc/content/docs/embeddings/embedding-functions.md`

All four files containing this text have been updated for consistency.