### PR TITLE
[DOC] Re-add the client reference pages

### DIFF
--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -219,6 +219,27 @@
         "tab": "API Reference",
         "icon": "brackets-curly",
         "openapi": "openapi.json"
+      },
+      {
+        "tab": "Client Reference",
+        "hidden": true,
+        "pages": [
+          "reference/chroma-reference",
+          {
+            "group": "Python",
+            "pages": [
+              "reference/python/client",
+              "reference/python/collection"
+            ]
+          },
+          {
+            "group": "Typescript",
+            "pages": [
+              "reference/js/client",
+              "reference/js/collection"
+            ]
+          }
+        ]
       }
     ],
     "global": {

--- a/docs/mintlify/reference/chroma-reference.mdx
+++ b/docs/mintlify/reference/chroma-reference.mdx
@@ -1,0 +1,16 @@
+---
+title: "Client Reference"
+---
+
+Chroma currently maintains 1st party clients for Python and Typescript. For other clients in other languages, use their repos for documentation.
+
+`Client` - is the object that wraps a connection to a backing Chroma DB
+
+`Collection` - is the object that wraps a collection
+
+|            | Client                              | Collection                                  |
+| ---------- | ----------------------------------- | ------------------------------------------- |
+| Python     | [Client](/reference/python/client)  | [Collection](/reference/python/collection)  |
+| Typescript | [Client](/reference/js/client)      | [Collection](/reference/js/collection)      |
+
+

--- a/docs/mintlify/reference/js/client.mdx
+++ b/docs/mintlify/reference/js/client.mdx
@@ -1,0 +1,296 @@
+---
+title: "Typescript Client"
+---
+
+## Class: ChromaClient
+
+### constructor
+
+- `new ChromaClient(params?)`
+
+Creates a new ChromaClient instance.
+
+#### Parameters
+
+| Name            | Type                 | Description                              |
+| :-------------- | :------------------- | :--------------------------------------- |
+| `params.host?`  | `string`             | The host address of the Chroma server. Defaults to `'localhost'`. |
+| `params.port?`  | `number`             | The port number of the Chroma server. Defaults to `8000`. |
+| `params.ssl?`   | `boolean`            | Whether to use SSL/HTTPS for connections. Defaults to `false`. |
+| `params.tenant?` | `string`             | The tenant name in the Chroma server to connect to. |
+| `params.database?` | `string`            | The database name to connect to. |
+| `params.headers?` | `Record<string, string>` | Additional HTTP headers to send with requests. |
+| `params.fetchOptions?` | `RequestInit`      | Additional fetch options for HTTP requests. |
+
+**Example**
+
+```typescript
+const client = new ChromaClient({
+  host: "localhost",
+  port: 8000,
+  ssl: false,
+  tenant: "my_tenant",
+  database: "my_database",
+});
+```
+
+## Methods
+
+### countCollections
+
+- `countCollections(): Promise<number>`
+
+Counts all collections.
+
+#### Returns
+
+`Promise<number>`
+
+A promise that resolves to the number of collections.
+
+**Throws**
+
+If there is an issue counting the collections.
+
+**Example**
+
+```typescript
+const collections = await client.countCollections();
+```
+
+### createCollection
+
+- `createCollection(params): Promise<Collection>`
+
+Creates a new collection with the specified properties.
+
+#### Parameters
+
+| Name                      | Type                        | Description                                   |
+| :------------------------ | :-------------------------- | :-------------------------------------------- |
+| `params.name`             | `string`                    | The name of the collection (required).        |
+| `params.configuration?`   | `CreateCollectionConfiguration` | Optional collection configuration.         |
+| `params.metadata?`        | `CollectionMetadata`       | Optional metadata for the collection.         |
+| `params.embeddingFunction?` | `EmbeddingFunction \| null` | Optional embedding function to use. Defaults to `DefaultEmbeddingFunction` from @chroma-core/default-embed. |
+| `params.schema?`          | `Schema`                    | Optional schema describing index configuration. |
+
+#### Returns
+
+`Promise<Collection>`
+
+A promise that resolves to the created collection.
+
+**Throws**
+
+- If the client is unable to connect to the server.
+- If there is an issue creating the collection.
+
+**Example**
+
+```typescript
+const collection = await client.createCollection({
+  name: "my_collection",
+  metadata: {
+    description: "My first collection",
+  },
+});
+```
+
+### deleteCollection
+
+- `deleteCollection(params): Promise<void>`
+
+Deletes a collection with the specified name.
+
+#### Parameters
+
+| Name         | Type     | Description                               |
+| :----------- | :------- | :---------------------------------------- |
+| `params.name` | `string` | The name of the collection to delete (required). |
+
+#### Returns
+
+`Promise<void>`
+
+A promise that resolves when the collection is deleted.
+
+**Throws**
+
+If there is an issue deleting the collection.
+
+**Example**
+
+```typescript
+await client.deleteCollection({
+  name: "my_collection",
+});
+```
+
+### getCollection
+
+- `getCollection(params): Promise<Collection>`
+
+Gets a collection with the specified name.
+
+#### Parameters
+
+| Name                      | Type                | Description                              |
+| :------------------------ | :------------------ | :--------------------------------------- |
+| `params.name`             | `string`            | The name of the collection to retrieve (required). |
+| `params.embeddingFunction?` | `EmbeddingFunction` | Optional embedding function. Should match the one used to create the collection. |
+
+#### Returns
+
+`Promise<Collection>`
+
+A promise that resolves to the collection.
+
+**Throws**
+
+If there is an issue getting the collection.
+
+**Example**
+
+```typescript
+const collection = await client.getCollection({
+  name: "my_collection",
+});
+```
+
+### getOrCreateCollection
+
+- `getOrCreateCollection(params): Promise<Collection>`
+
+Gets or creates a collection with the specified properties.
+
+#### Parameters
+
+| Name                      | Type                        | Description                                   |
+| :------------------------ | :-------------------------- | :-------------------------------------------- |
+| `params.name`             | `string`                    | The name of the collection (required).        |
+| `params.configuration?`   | `CreateCollectionConfiguration` | Optional collection configuration (used only if creating). |
+| `params.metadata?`        | `CollectionMetadata`       | Optional metadata for the collection (used only if creating). |
+| `params.embeddingFunction?` | `EmbeddingFunction \| null` | Optional embedding function to use. |
+| `params.schema?`          | `Schema`                    | Optional schema describing index configuration (used only if creating). |
+
+
+
+#### Returns
+
+`Promise<Collection>`
+
+A promise that resolves to the got or created collection.
+
+**Throws**
+
+If there is an issue getting or creating the collection.
+
+**Example**
+
+```typescript
+const collection = await client.getOrCreateCollection({
+  name: "my_collection",
+  metadata: {
+    description: "My first collection",
+  },
+});
+```
+
+### heartbeat
+
+- `heartbeat(): Promise<number>`
+
+Returns a heartbeat from the Chroma API.
+
+#### Returns
+
+`Promise<number>`
+
+A promise that resolves to the heartbeat from the Chroma API.
+
+**Throws**
+
+If the client is unable to connect to the server.
+
+**Example**
+
+```typescript
+const heartbeat = await client.heartbeat();
+```
+
+### listCollections
+
+- `listCollections(params?): Promise<Collection[]>`
+
+Lists all collections.
+
+#### Parameters
+
+| Name            | Type     | Description                                                      |
+| :-------------- | :------- | :--------------------------------------------------------------- |
+| `params.limit?` | `number` | Maximum number of collections to return. Default: `100`.          |
+| `params.offset?` | `number` | Number of collections to skip. Default: `0`.                     |
+
+#### Returns
+
+`Promise<Collection[]>`
+
+A promise that resolves to an array of Collection instances.
+
+**Throws**
+
+If there is an issue listing the collections.
+
+**Example**
+
+```typescript
+const collections = await client.listCollections({
+  limit: 10,
+  offset: 0,
+});
+```
+
+### reset
+
+- `reset(): Promise<void>`
+
+Resets the entire database, deleting all collections and data.
+
+#### Returns
+
+`Promise<void>`
+
+A promise that resolves when the reset is complete.
+
+**Throws**
+
+- If the client is unable to connect to the server.
+- If the server experienced an error while resetting.
+
+**Example**
+
+```typescript
+await client.reset();
+```
+
+### version
+
+- `version(): Promise<string>`
+
+Returns the version of the Chroma API.
+
+#### Returns
+
+`Promise<string>`
+
+A promise that resolves to the version of the Chroma API.
+
+**Throws**
+
+If the client is unable to connect to the server.
+
+**Example**
+
+```typescript
+const version = await client.version();
+```

--- a/docs/mintlify/reference/js/collection.mdx
+++ b/docs/mintlify/reference/js/collection.mdx
@@ -1,0 +1,356 @@
+---
+title: "Typescript Collection"
+---
+
+## Properties
+
+- `id: string`
+- `metadata: CollectionMetadata`
+- `name: string`
+
+## Methods
+
+### add
+
+- `add(params): Promise<void>`
+
+Add items to the collection
+
+#### Parameters
+
+| Name                | Type          | Description                                                      |
+| :------------------ | :------------ | :--------------------------------------------------------------- |
+| `params.ids`        | `string[]`    | Unique identifiers for the records (required).                   |
+| `params.embeddings?` | `number[][]`  | Optional pre-computed embeddings.                                 |
+| `params.metadatas?` | `Metadata[]`  | Optional metadata for each record.                               |
+| `params.documents?` | `string[]`    | Optional document text (will be embedded if embeddings not provided). |
+| `params.uris?`      | `string[]`    | Optional URIs for the records.                                  |
+
+#### Returns
+
+`Promise<void>`
+
+- The response from the API.
+
+**Example**
+
+```typescript
+const response = await collection.add({
+  ids: ["id1", "id2"],
+  embeddings: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+  metadatas: [{ key: "value" }, { key: "value" }],
+  documents: ["document1", "document2"],
+});
+```
+
+### count
+
+- `count(): Promise<number>`
+
+Count the number of items in the collection
+
+#### Returns
+
+`Promise<number>`
+
+- The number of items in the collection.
+
+**Example**
+
+```typescript
+const count = await collection.count();
+```
+
+### delete
+
+- `delete(params?): Promise<void>`
+
+Deletes items from the collection.
+
+#### Parameters
+
+| Name                 | Type          | Description                                            |
+| :------------------- | :------------ | :----------------------------------------------------- |
+| `params.ids?`        | `string[]`    | Specific record IDs to delete.                         |
+| `params.where?`      | `Where`       | Metadata-based filtering for deletion.                 |
+| `params.whereDocument?` | `WhereDocument` | Document content-based filtering for deletion.      |
+
+#### Returns
+
+`Promise<void>`
+
+A promise that resolves when the deletion is complete.
+
+**Throws**
+
+If there is an issue deleting items from the collection.
+
+**Example**
+
+```typescript
+const results = await collection.delete({
+  ids: ["some_id"],
+  where: { name: { $eq: "John Doe" } },
+  whereDocument: { $contains: "search_string" },
+});
+```
+
+### get
+
+- `get(params?): Promise<GetResult>`
+
+Get items from the collection
+
+#### Parameters
+
+| Name                 | Type            | Description                                                      |
+| :------------------- | :-------------- | :--------------------------------------------------------------- |
+| `params.ids?`        | `string[]`      | Specific record IDs to retrieve.                                 |
+| `params.where?`      | `Where`         | Metadata-based filtering conditions.                              |
+| `params.limit?`      | `number`        | Maximum number of records to return.                             |
+| `params.offset?`     | `number`        | Number of records to skip.                                      |
+| `params.whereDocument?` | `WhereDocument` | Document content-based filtering conditions.                      |
+| `params.include?`     | `Include[]`     | Fields to include in the response. Options: `"distances"`, `"documents"`, `"embeddings"`, `"metadatas"`, `"uris"`. Default: `["documents", "metadatas"]`. |
+
+#### Returns
+
+`Promise<GetResult>`
+
+The response from the server.
+
+**Example**
+
+```typescript
+const response = await collection.get({
+  ids: ["id1", "id2"],
+  where: { key: "value" },
+  limit: 10,
+  offset: 0,
+  include: ["embeddings", "metadatas", "documents"],
+  whereDocument: { $contains: "value" },
+});
+```
+
+### modify
+
+- `modify(params): Promise<void>`
+
+Modify the collection name, metadata, or configuration
+
+#### Parameters
+
+| Name                    | Type                        | Description                               |
+| :---------------------- | :-------------------------- | :---------------------------------------- |
+| `params.name?`          | `string`                    | Optional new name for the collection.     |
+| `params.metadata?`       | `CollectionMetadata`       | Optional new metadata for the collection. |
+| `params.configuration?` | `UpdateCollectionConfiguration` | Optional new configuration settings.     |
+
+#### Returns
+
+`Promise<void>`
+
+A promise that resolves when the modification is complete.
+
+**Example**
+
+```typescript
+await collection.modify({
+  name: "new name",
+  metadata: { key: "value" },
+  configuration: {
+    hnsw: {
+      ef_search: 100,
+      batch_size: 1000
+    }
+  }
+});
+```
+
+### peek
+
+- `peek(params?): Promise<GetResult>`
+
+Peek inside the collection
+
+#### Parameters
+
+| Name            | Type     | Description                   |
+| :-------------- | :------- | :---------------------------- |
+| `params.limit?` | `number` | Maximum number of records to return. Default: `10`. |
+
+#### Returns
+
+`Promise<GetResult>`
+
+A promise that resolves to the query results.
+
+**Throws**
+
+If there is an issue executing the query.
+
+**Example**
+
+```typescript
+const results = await collection.peek({
+  limit: 10,
+});
+```
+
+### query
+
+- `query(params): Promise<QueryResult>`
+
+Performs a query on the collection using the specified parameters.
+
+#### Parameters
+
+| Name                  | Type            | Description                                                      |
+| :-------------------- | :-------------- | :--------------------------------------------------------------- |
+| `params.queryEmbeddings?` | `number[][]` | Pre-computed query embedding vectors.                           |
+| `params.queryTexts?` | `string[]`      | Query text to be embedded and searched.                          |
+| `params.queryURIs?`   | `string[]`      | Query URIs to be processed.                                      |
+| `params.ids?`         | `string[]`      | Filter to specific record IDs.                                  |
+| `params.nResults?`    | `number`        | Maximum number of results per query. Default: `10`.              |
+| `params.where?`       | `Where`         | Metadata-based filtering conditions.                            |
+| `params.whereDocument?` | `WhereDocument` | Full-text search conditions.                                    |
+| `params.include?`       | `Include[]`     | Fields to include in the response. Options: `"distances"`, `"documents"`, `"embeddings"`, `"metadatas"`, `"uris"`. Default: `["metadatas", "documents", "distances"]`. |
+
+#### Returns
+
+`Promise<QueryResult>`
+
+A promise that resolves to the query results.
+
+**Throws**
+
+If there is an issue executing the query.
+
+**Example**
+
+```typescript
+// Query the collection using embeddings
+const embeddingsResults = await collection.query({
+  queryEmbeddings: [[0.1, 0.2, ...], ...],
+  ids: ["id1", "id2", ...],
+  nResults: 10,
+  where: {"name": {"$eq": "John Doe"}},
+  include: ["metadatas", "documents"]
+});
+
+// Query the collection using query text
+const textResults = await collection.query({
+    queryTexts: ["some text"],
+    ids: ["id1", "id2", ...],
+    nResults: 10,
+    where: {"name": {"$eq": "John Doe"}},
+    include: ["metadatas", "documents"]
+});
+```
+
+### search
+
+- `search(searches): Promise<SearchResult>`
+
+Performs hybrid search on the collection using expression builders. This method provides a flexible, composable API for building complex search queries with filtering, ranking, and result selection.
+
+#### Parameters
+
+| Name      | Type                              | Description                                                      |
+| :-------- | :-------------------------------- | :--------------------------------------------------------------- |
+| `searches` | `SearchLike \| SearchLike[]`      | A single search expression or an array of search expressions.   |
+
+#### Returns
+
+`Promise<SearchResult>`
+
+A promise that resolves to search results in column-major format. Use the `.rows()` method to convert to row-major format.
+
+**Throws**
+
+If there is an issue executing the search or if no search payload is provided.
+
+**Example**
+
+```typescript
+import { Search, K, Knn, Rrf, Val } from "chromadb";
+
+// Basic search with KNN ranking
+const results = await collection.search(
+  new Search()
+    .where(K("category").eq("science"))
+    .rank(Knn({ query: [0.1, 0.2, 0.3], limit: 10 }))
+    .limit(5)
+    .select(K.DOCUMENT, K.SCORE, "title")
+);
+```
+
+### update
+
+- `update(params): Promise<void>`
+
+Update items in the collection
+
+#### Parameters
+
+| Name                | Type         | Description                   |
+| :------------------ | :----------- | :---------------------------- |
+| `params.ids`         | `string[]`   | IDs of records to update (required). |
+| `params.embeddings?` | `number[][]` | New embedding vectors.        |
+| `params.metadatas?`  | `Metadata[]` | New metadata.                 |
+| `params.documents?`  | `string[]`   | New document text.            |
+| `params.uris?`       | `string[]`   | New URIs.                     |
+
+#### Returns
+
+`Promise<void>`
+
+**Example**
+
+```typescript
+await collection.update({
+  ids: ["id1", "id2"],
+  embeddings: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+  metadatas: [{ key: "value" }, { key: "value" }],
+  documents: ["document1", "document2"],
+});
+```
+
+### upsert
+
+- `upsert(params): Promise<void>`
+
+Upsert items to the collection (inserts new records or updates existing ones)
+
+#### Parameters
+
+| Name                | Type         | Description                   |
+| :------------------ | :----------- | :---------------------------- |
+| `params.ids`         | `string[]`   | IDs of records to upsert (required). |
+| `params.embeddings?`  | `number[][]` | Embedding vectors.            |
+| `params.metadatas?`  | `Metadata[]` | Metadata.                     |
+| `params.documents?`  | `string[]`   | Document text.                |
+| `params.uris?`       | `string[]`   | URIs.                         |
+
+#### Returns
+
+`Promise<void>`
+
+**Example**
+
+```typescript
+await collection.upsert({
+  ids: ["id1", "id2"],
+  embeddings: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+  metadatas: [{ key: "value" }, { key: "value" }],
+  documents: ["document1", "document2"],
+});
+```

--- a/docs/mintlify/reference/python/client.mdx
+++ b/docs/mintlify/reference/python/client.mdx
@@ -1,0 +1,523 @@
+---
+title: "Python Client"
+---
+
+## configure
+
+```python
+def configure(**kwargs) -> None
+```
+
+Override Chroma's default settings, environment variables or .env files
+
+## EphemeralClient
+
+```python
+def EphemeralClient(settings: Optional[Settings] = None,
+                    tenant: str = DEFAULT_TENANT,
+                    database: str = DEFAULT_DATABASE) -> ClientAPI
+```
+
+Creates an in-memory instance of Chroma. This is useful for testing and
+development, but not recommended for production use.
+
+**Arguments**:
+
+- `tenant` - The tenant to use for this client. Defaults to the default tenant.
+- `database` - The database to use for this client. Defaults to the default database.
+
+## PersistentClient
+
+```python
+def PersistentClient(path: str = "./chroma",
+                     settings: Optional[Settings] = None,
+                     tenant: str = DEFAULT_TENANT,
+                     database: str = DEFAULT_DATABASE) -> ClientAPI
+```
+
+Creates a persistent instance of Chroma that saves to disk. This is useful for
+testing and development, but not recommended for production use.
+
+**Arguments**:
+
+- `path` - The directory to save Chroma's data to. Defaults to "./chroma".
+- `tenant` - The tenant to use for this client. Defaults to the default tenant.
+- `database` - The database to use for this client. Defaults to the default database.
+
+## HttpClient
+
+```python
+def HttpClient(host: str = "localhost",
+               port: int = 8000,
+               ssl: bool = False,
+               headers: Optional[Dict[str, str]] = None,
+               settings: Optional[Settings] = None,
+               tenant: str = DEFAULT_TENANT,
+               database: str = DEFAULT_DATABASE) -> ClientAPI
+```
+
+Creates a client that connects to a remote Chroma server. This supports
+many clients connecting to the same server, and is the recommended way to
+use Chroma in production.
+
+**Arguments**:
+
+- `host` - The hostname of the Chroma server. Defaults to "localhost".
+- `port` - The port of the Chroma server. Defaults to 8000.
+- `ssl` - Whether to use SSL to connect to the Chroma server. Defaults to False.
+- `headers` - A dictionary of headers to send to the Chroma server. Defaults to {}.
+- `settings` - A dictionary of settings to communicate with the chroma server.
+- `tenant` - The tenant to use for this client. Defaults to the default tenant.
+- `database` - The database to use for this client. Defaults to the default database.
+
+## AsyncHttpClient
+
+```python
+async def AsyncHttpClient(host: str = "localhost",
+                          port: int = 8000,
+                          ssl: bool = False,
+                          headers: Optional[Dict[str, str]] = None,
+                          settings: Optional[Settings] = None,
+                          tenant: str = DEFAULT_TENANT,
+                          database: str = DEFAULT_DATABASE) -> AsyncClientAPI
+```
+
+Creates an async client that connects to a remote Chroma server. This supports
+many clients connecting to the same server, and is the recommended way to
+use Chroma in production.
+
+**Arguments**:
+
+- `host` - The hostname of the Chroma server. Defaults to "localhost".
+- `port` - The port of the Chroma server. Defaults to 8000.
+- `ssl` - Whether to use SSL to connect to the Chroma server. Defaults to False.
+- `headers` - A dictionary of headers to send to the Chroma server. Defaults to {}.
+- `settings` - A dictionary of settings to communicate with the chroma server.
+- `tenant` - The tenant to use for this client. Defaults to the default tenant.
+- `database` - The database to use for this client. Defaults to the default database.
+
+## CloudClient
+
+```python
+def CloudClient(tenant: str,
+                database: str,
+                api_key: Optional[str] = None,
+                settings: Optional[Settings] = None,
+                *,
+                cloud_host: str = "api.trychroma.com",
+                cloud_port: int = 8000,
+                enable_ssl: bool = True) -> ClientAPI
+```
+
+Creates a client to connect to a tenant and database on the Chroma cloud.
+
+**Arguments**:
+
+- `tenant` - The tenant to use for this client.
+- `database` - The database to use for this client.
+- `api_key` - The api key to use for this client.
+
+## Client
+
+```python
+def Client(settings: Settings = __settings,
+           tenant: str = DEFAULT_TENANT,
+           database: str = DEFAULT_DATABASE) -> ClientAPI
+```
+
+Return a running `chroma.API` instance
+
+**Arguments**:
+
+- `tenant`: The tenant to use for this client. Defaults to the `default` tenant.
+- `database`: The database to use for this client. Defaults to the `default` database.
+
+## AdminClient
+
+```python
+def AdminClient(settings: Settings = Settings()) -> AdminAPI
+```
+
+Creates an admin client that can be used to create tenants and databases.
+
+---
+
+# BaseClient Methods
+
+```python
+class BaseAPI(ABC)
+```
+
+## heartbeat
+
+```python
+def heartbeat() -> int
+```
+
+Get the current time in nanoseconds since epoch.
+Used to check if the server is alive.
+
+**Returns**:
+
+- `int` - The current time in nanoseconds since epoch
+
+## count_collections
+
+```python
+def count_collections() -> int
+```
+
+Count the number of collections.
+
+**Returns**:
+
+- `int` - The number of collections.
+
+**Examples**:
+
+```python
+client.count_collections()
+# 1
+```
+
+## delete_collection
+
+```python
+def delete_collection(name: str) -> None
+```
+
+Delete a collection with the given name.
+
+**Arguments**:
+
+- `name` - The name of the collection to delete.
+
+**Raises**:
+
+- `chromadb.errors.NotFoundError` - If the collection does not exist.
+
+**Examples**:
+
+    ```python
+    client.delete_collection("my_collection")
+    ```
+
+## reset
+
+```python
+def reset() -> bool
+```
+
+Resets the database. This will delete all collections and entries.
+
+**Returns**:
+
+- `bool` - True if the database was reset successfully.
+
+## get_version
+
+```python
+def get_version() -> str
+```
+
+Get the version of Chroma.
+
+**Returns**:
+
+- `str` - The version of Chroma
+
+## get_settings
+
+```python
+def get_settings() -> Settings
+```
+
+Get the settings used to initialize.
+
+**Returns**:
+
+- `Settings` - The settings used to initialize.
+
+## get_max_batch_size
+
+```python
+def get_max_batch_size() -> int
+```
+
+Return the maximum number of records that can be created or mutated in a single call.
+
+---
+
+# ClientClient Methods
+
+```python
+class ClientAPI(BaseAPI, ABC)
+```
+
+## list_collections
+
+```python
+def list_collections(limit: Optional[int] = None,
+                     offset: Optional[int] = None) -> Sequence[Collection]
+```
+
+List all collections.
+
+**Arguments**:
+
+- `limit` - The maximum number of entries to return. Defaults to None.
+- `offset` - The number of entries to skip before returning. Defaults to None.
+
+**Returns**:
+
+- `Sequence[Collection]` - A list of collection objects.
+
+**Examples**:
+
+```python
+client.list_collections()
+# ['my_collection']
+```
+
+## create_collection
+
+```python
+def create_collection(name: str,
+                      configuration: Optional[CollectionConfiguration] = None,
+                      metadata: Optional[CollectionMetadata] = None,
+                      embedding_function: Optional[EmbeddingFunction[
+                          Embeddable]] = ef.DefaultEmbeddingFunction(),
+                      data_loader: Optional[DataLoader[Loadable]] = None,
+                      get_or_create: bool = False) -> Collection
+```
+
+Create a new collection with the given name and metadata.
+
+**Arguments**:
+
+- `name` - The name of the collection to create.
+- `metadata` - Optional metadata to associate with the collection.
+- `embedding_function` - Optional function to use to embed documents.
+  Uses the default embedding function if not provided.
+- `get_or_create` - If True, return the existing collection if it exists.
+- `data_loader` - Optional function to use to load records (documents, images, etc.)
+
+**Returns**:
+
+- `Collection` - The newly created collection.
+
+**Raises**:
+
+- `ValueError` - If the collection already exists and get_or_create is False.
+- `ValueError` - If the collection name is invalid.
+
+**Examples**:
+
+```python
+client.create_collection("my_collection")
+# collection(name="my_collection", metadata={})
+
+client.create_collection("my_collection", metadata={"foo": "bar"})
+# collection(name="my_collection", metadata={"foo": "bar"})
+```
+
+## get_collection
+
+```python
+def get_collection(
+        name: str,
+        id: Optional[UUID] = None,
+        embedding_function: Optional[
+            EmbeddingFunction[Embeddable]] = ef.DefaultEmbeddingFunction(),
+        data_loader: Optional[DataLoader[Loadable]] = None) -> Collection
+```
+
+Get a collection with the given name.
+
+**Arguments**:
+
+- `id` - The UUID of the collection to get. Id and Name are simultaneously used for lookup if provided.
+- `name` - The name of the collection to get
+- `embedding_function` - Optional function to use to embed documents.
+  Uses the default embedding function if not provided.
+- `data_loader` - Optional function to use to load records (documents, images, etc.)
+
+**Returns**:
+
+- `Collection` - The collection
+
+**Raises**:
+
+- `chromadb.errors.NotFoundError` - If the collection does not exist
+
+**Examples**:
+
+```python
+client.get_collection("my_collection")
+# collection(name="my_collection", metadata={})
+```
+
+## get_or_create_collection
+
+```python
+def get_or_create_collection(
+        name: str,
+        configuration: Optional[CollectionConfiguration] = None,
+        metadata: Optional[CollectionMetadata] = None,
+        embedding_function: Optional[
+            EmbeddingFunction[Embeddable]] = ef.DefaultEmbeddingFunction(),
+        data_loader: Optional[DataLoader[Loadable]] = None) -> Collection
+```
+
+Get or create a collection with the given name and metadata.
+
+**Arguments**:
+
+- `name` - The name of the collection to get or create
+- `metadata` - Optional metadata to associate with the collection. If
+  the collection alredy exists, the metadata will be ignored. If the collection does not exist, the
+  new collection will be created with the provided metadata.
+- `embedding_function` - Optional function to use to embed documents
+- `data_loader` - Optional function to use to load records (documents, images, etc.)
+
+**Returns**:
+
+The collection
+
+**Examples**:
+
+```python
+client.get_or_create_collection("my_collection")
+# collection(name="my_collection", metadata={})
+```
+
+## set_tenant
+
+```python
+def set_tenant(tenant: str, database: str = DEFAULT_DATABASE) -> None
+```
+
+Set the tenant and database for the client. Raises an error if the tenant or
+database does not exist.
+
+**Arguments**:
+
+- `tenant` - The tenant to set.
+- `database` - The database to set.
+
+## set_database
+
+```python
+def set_database(database: str) -> None
+```
+
+Set the database for the client. Raises an error if the database does not exist.
+
+**Arguments**:
+
+- `database` - The database to set.
+
+## clear_system_cache
+
+```python
+@staticmethod
+def clear_system_cache() -> None
+```
+
+Clear the system cache so that new systems can be created for an existing path.
+This should only be used for testing purposes.
+
+---
+
+# AdminClient Methods
+
+```python
+class AdminAPI(ABC)
+```
+
+## create_database
+
+```python
+def create_database(name: str, tenant: str = DEFAULT_TENANT) -> None
+```
+
+Create a new database. Raises an error if the database already exists.
+
+**Arguments**:
+
+- `database` - The name of the database to create.
+
+## get_database
+
+```python
+def get_database(name: str, tenant: str = DEFAULT_TENANT) -> Database
+```
+
+Get a database. Raises an error if the database does not exist.
+
+**Arguments**:
+
+- `database` - The name of the database to get.
+- `tenant` - The tenant of the database to get.
+
+## delete_database
+
+```python
+def delete_database(name: str, tenant: str = DEFAULT_TENANT) -> None
+```
+
+Delete a database and all associated collections. Raises an error if the database does not exist.
+
+**Arguments**:
+
+- `database` - The name of the database to delete.
+- `tenant` - The tenant of the database to delete.
+
+## list_databases
+
+```python
+def list_databases(limit: Optional[int] = None, offset: Optional[int] = None, tenant: str = DEFAULT_TENANT) -> Sequence[Database]
+```
+
+List databases for a tenant.
+
+**Arguments**:
+
+- `limit` - The maximum number of entries to return. Defaults to None.
+- `offset` - The number of entries to skip before returning. Defaults to None.
+- `tenant` - The tenant to list databases for.
+
+## create_tenant
+
+```python
+def create_tenant(name: str) -> None
+```
+
+Create a new tenant. Raises an error if the tenant already exists.
+
+**Arguments**:
+
+- `tenant` - The name of the tenant to create.
+
+## get_tenant
+
+```python
+def get_tenant(name: str) -> Tenant
+```
+
+Get a tenant. Raises an error if the tenant does not exist.
+
+**Arguments**:
+
+- `tenant` - The name of the tenant to get.
+
+---
+
+# ServerClient Methods
+
+```python
+class ServerAPI(BaseAPI, AdminAPI, Component)
+```
+
+An API instance that extends the relevant Base API methods by passing
+in a tenant and database. This is the root component of the Chroma System

--- a/docs/mintlify/reference/python/collection.mdx
+++ b/docs/mintlify/reference/python/collection.mdx
@@ -1,0 +1,208 @@
+---
+title: "Python Collection"
+---
+
+```python
+class Collection(BaseModel)
+```
+
+## count
+
+```python
+def count() -> int
+```
+
+The total number of embeddings added to the database
+
+**Returns**:
+
+- `int` - The total number of embeddings added to the database
+
+## add
+
+```python
+def add(ids: OneOrMany[ID],
+        embeddings: Optional[OneOrMany[Embedding]] = None,
+        metadatas: Optional[OneOrMany[Metadata]] = None,
+        documents: Optional[OneOrMany[Document]] = None) -> None
+```
+
+Add embeddings to the data store.
+
+**Arguments**:
+
+- `ids` - The ids of the embeddings you wish to add
+- `embeddings` - The embeddings to add. If None, embeddings will be computed based on the documents using the embedding_function set for the Collection. Optional.
+- `metadatas` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
+- `documents` - The documents to associate with the embeddings. Optional.
+
+**Returns**:
+
+None
+
+**Raises**:
+
+- `ValueError` - If you don't provide either embeddings or documents
+- `ValueError` - If the length of ids, embeddings, metadatas, or documents don't match
+- `ValueError` - If you don't provide an embedding function and don't provide embeddings
+- `DuplicateIDError` - If you provide an id that already exists
+
+## get
+
+```python
+def get(ids: Optional[OneOrMany[ID]] = None,
+        where: Optional[Where] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Include = ["metadatas", "documents"]) -> GetResult
+```
+
+Get embeddings and their associate data from the data store. If no ids or where filter is provided returns
+all embeddings up to limit starting at offset.
+
+**Arguments**:
+
+- `ids` - The ids of the embeddings to get. Optional.
+- `where` - A Where type dict used to filter results by. E.g. `{$and: [{"color" : "red"}, {"price": 4.20}]}`. Optional.
+- `limit` - The number of documents to return. Optional.
+- `offset` - The offset to start returning results from. Useful for paging results with limit. Optional.
+- `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{"$contains" : "hello"}`. Optional.
+- `include` - A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`. Ids are always included. Defaults to `["metadatas", "documents"]`. Optional.
+
+**Returns**:
+
+- `GetResult` - A GetResult object containing the results.
+
+## peek
+
+```python
+def peek(limit: int = 10) -> GetResult
+```
+
+Get the first few results in the database up to limit
+
+**Arguments**:
+
+- `limit` - The number of results to return.
+
+**Returns**:
+
+- `GetResult` - A GetResult object containing the results.
+
+## query
+
+```python
+def query(
+        query_embeddings: Optional[OneOrMany[Embedding]] = None,
+        query_texts: Optional[OneOrMany[Document]] = None,
+        ids: Optional[OneOrMany[ID]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Include = ["metadatas", "documents",
+                            "distances"]) -> QueryResult
+```
+
+Get the n_results nearest neighbor embeddings for provided query_embeddings or query_texts.
+
+**Arguments**:
+
+- `query_embeddings` - The embeddings to get the closest neighbors of. Optional.
+- `query_texts` - The document texts to get the closest neighbors of. Optional.
+- `ids` - The list of ids to limit search space to. Optional.
+- `n_results` - The number of neighbors to return for each query_embedding or query_texts. Optional.
+- `where` - A Where type dict used to filter results by. E.g. `{$and: [{"color" : "red"}, {"price": 4.20}]}`. Optional.
+- `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{"$contains" : "hello"}`. Optional.
+- `include` - A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`, `"distances"`. Ids are always included. Defaults to `["metadatas", "documents", "distances"]`. Optional.
+
+**Returns**:
+
+- `QueryResult` - A QueryResult object containing the results.
+
+**Raises**:
+
+- `ValueError` - If you don't provide either query_embeddings or query_texts
+- `ValueError` - If you provide both query_embeddings and query_texts
+
+## modify
+
+```python
+def modify(name: Optional[str] = None,
+           metadata: Optional[CollectionMetadata] = None) -> None
+```
+
+Modify the collection name or metadata
+
+**Arguments**:
+
+- `name` - The updated name for the collection. Optional.
+- `metadata` - The updated metadata for the collection. Optional.
+
+**Returns**:
+
+None
+
+## update
+
+```python
+def update(ids: OneOrMany[ID],
+           embeddings: Optional[OneOrMany[Embedding]] = None,
+           metadatas: Optional[OneOrMany[Metadata]] = None,
+           documents: Optional[OneOrMany[Document]] = None) -> None
+```
+
+Update the embeddings, metadatas or documents for provided ids.
+
+**Arguments**:
+
+- `ids` - The ids of the embeddings to update
+- `embeddings` - The embeddings to add. If None, embeddings will be computed based on the documents using the embedding_function set for the Collection. Optional.
+- `metadatas` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
+- `documents` - The documents to associate with the embeddings. Optional.
+
+**Returns**:
+
+None
+
+## upsert
+
+```python
+def upsert(ids: OneOrMany[ID],
+           embeddings: Optional[OneOrMany[Embedding]] = None,
+           metadatas: Optional[OneOrMany[Metadata]] = None,
+           documents: Optional[OneOrMany[Document]] = None) -> None
+```
+
+Update the embeddings, metadatas or documents for provided ids, or create them if they don't exist.
+
+**Arguments**:
+
+- `ids` - The ids of the embeddings to update
+- `embeddings` - The embeddings to add. If None, embeddings will be computed based on the documents using the embedding_function set for the Collection. Optional.
+- `metadatas` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
+- `documents` - The documents to associate with the embeddings. Optional.
+
+**Returns**:
+
+None
+
+## delete
+
+```python
+def delete(ids: Optional[IDs] = None,
+           where: Optional[Where] = None,
+           where_document: Optional[WhereDocument] = None) -> None
+```
+
+Delete the embeddings based on ids and/or a where filter
+
+**Arguments**:
+
+- `ids` - The ids of the embeddings to delete
+- `where` - A Where type dict used to filter the deletion by. E.g. `{$and: [{"color" : "red"}, {"price": 4.20}]}`. Optional.
+- `where_document` - A WhereDocument type dict used to filter the deletion by the document content. E.g. `{"$contains" : "hello"}`. Optional.
+
+**Returns**:
+
+None


### PR DESCRIPTION
Adds a hidden tab group for the old client reference pages with the same urls, for those using them.