### PR TITLE
[DOC] Remove step-line bg gradient

### DIFF
--- a/docs/mintlify/style.css
+++ b/docs/mintlify/style.css
@@ -16,6 +16,7 @@
 
 [data-component-part="step-line"] {
   background-color: #000000;
+  background-image: none !important;
 }
 
 .dark [data-component-part="step-line"] {


### PR DESCRIPTION
Default styles are adding a gradient to the last step line that I don't want there