### PR TITLE
[DOC] Add a title prop to Callout

### DIFF
--- a/docs/mintlify/guides/deploy/docker.mdx
+++ b/docs/mintlify/guides/deploy/docker.mdx
@@ -33,10 +33,7 @@ chroma_client = chromadb.HttpClient(host='localhost', port=8000)
 chroma_client.heartbeat()
 ```
 
-<Callout>
-
-**Client-only package**
-<br/>
+<Callout title="Client-only package">
 If you're using Python, you may want to use the [client-only package](/production/chroma-server/python-thin-client) for a smaller install size.
 </Callout>
 </Tab>

--- a/docs/mintlify/guides/deploy/observability.mdx
+++ b/docs/mintlify/guides/deploy/observability.mdx
@@ -9,9 +9,7 @@ import { Callout } from '/snippets/callout.mdx';
 
 Chroma is instrumented with [OpenTelemetry](https://opentelemetry.io/) hooks for observability.
 
-<Callout>
-**Telemetry vs Observability**
-<br/>
+<Callout title="Telemetry vs Observability">
 "[Telemetry](../../docs/overview/telemetry)" refers to anonymous product usage statistics we collect. "Observability" refers to metrics, logging, and tracing which can be used by anyone operating a Chroma deployment. Observability features listed on this page are **never** sent back to Chroma; they are for end-users to better understand how their Chroma deployment is behaving.
 </Callout>
 

--- a/docs/mintlify/snippets/callout.mdx
+++ b/docs/mintlify/snippets/callout.mdx
@@ -1,30 +1,33 @@
-export const Callout = ({ children }) => (
+export const Callout = ({ title, children }) => (
   <div className="my-6">
     <div className="relative pr-1.5 pb-1.5">
       <div className="absolute top-1.5 left-1.5 right-0 bottom-0 bg-blue-500" />
       <div className="relative border border-black dark:border-white px-5 py-4 bg-white dark:bg-neutral-900">
+        {title && <p className="block mb-2"><strong>{title}</strong></p>}
         {children}
       </div>
     </div>
   </div>
 );
 
-export const Warning = ({ children }) => (
+export const Warning = ({ title, children }) => (
   <div className="my-6">
     <div className="relative pr-1.5 pb-1.5">
       <div className="absolute top-1.5 left-1.5 right-0 bottom-0 bg-yellow-500" />
       <div className="relative border border-black dark:border-white px-5 py-4 bg-white dark:bg-neutral-900">
+        {title && <p className="block mb-2"><strong>{title}</strong></p>}
         {children}
       </div>
     </div>
   </div>
 );
 
-export const Danger = ({ children }) => (
+export const Danger = ({ title, children }) => (
   <div className="my-6">
     <div className="relative pr-1.5 pb-1.5">
       <div className="absolute top-1.5 left-1.5 right-0 bottom-0 bg-red-500" />
       <div className="relative border border-black dark:border-white px-5 py-4 bg-white dark:bg-neutral-900">
+        {title && <p className="block mb-2"><strong>{title}</strong></p>}
         {children}
       </div>
     </div>


### PR DESCRIPTION
Removes the manual `**` and `<br/>` stuff

<img width="732" height="266" alt="Screenshot 2026-01-30 at 4 01 42 PM" src="https://github.com/user-attachments/assets/dcbd95a0-4456-493a-8f24-5dc8f2b6217c" />
