### PR TITLE
[ENH] Use usearch on fast writer

### DIFF
--- a/rust/index/src/usearch.rs
+++ b/rust/index/src/usearch.rs
@@ -281,6 +281,7 @@ impl Weighted for USearchIndex {
 /// Cache key ensures fairness: at most one index per collection per type
 /// (raw vs quantized) in cache, preventing a single hot collection from
 /// monopolizing cache space.
+#[derive(Clone)]
 pub struct USearchIndexProvider {
     cache: Arc<dyn Cache<CacheKey, USearchIndex>>,
     storage: Storage,


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Swapping the hnsw impl in fast spann writer to usearch
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
