### PR TITLE
[CHORE]: Revert initial version in mcmr to be null

### DIFF
--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -566,12 +566,6 @@ impl SpannerBackend {
                                 "index_schema",
                                 "created_at",
                                 "updated_at",
-                                "version",
-                                "last_compacted_offset",
-                                "total_records_post_compaction",
-                                "size_bytes_post_compaction",
-                                "num_versions",
-                                "compaction_failure_count",
                             ],
                             &[
                                 &collection_id,
@@ -579,12 +573,6 @@ impl SpannerBackend {
                                 &index_schema_json,
                                 &commit_ts,
                                 &commit_ts,
-                                &(0i64),  // initial version
-                                &(0i64),  // initial last_compacted_offset
-                                &(0i64),  // initial total_records_post_compaction
-                                &(0i64),  // initial size_bytes_post_compaction
-                                &(0i64),  // initial num_versions
-                                &(0i64),  // initial compaction_failure_count
                             ],
                         ));
                     }
@@ -1429,7 +1417,7 @@ impl SpannerBackend {
                             num_versions = @num_active_versions,
                             compaction_failure_count = 0,
                             index_schema = COALESCE(PARSE_JSON(@schema_str), index_schema)
-                            WHERE collection_id = @collection_id AND version = @current_version AND region = @region AND (version_file_name = @old_version_file_name OR version_file_name IS NULL)",
+                            WHERE collection_id = @collection_id AND (version = @current_version OR version IS NULL) AND region = @region AND (version_file_name = @old_version_file_name OR version_file_name IS NULL)",
                     );
                     update_stmt.add_param("collection_id", &collection_id);
                     update_stmt.add_param("new_version", &(new_version as i64));


### PR DESCRIPTION
## Description of changes

6cb1ea1f17cc196d09bd101d6857d861c99c5bb7 sets the initial version number of a collection to 0 instead of null. This change reverts that as it makes more sense for the version number to be nonexistent or null when there are no versions.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

Existing unit tests apply + manual testing on any collections that were created before this change.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
