### PR TITLE
[ENH]: List_databases for rust sysdb

### DIFF
--- a/rust/rust-sysdb/src/backend.rs
+++ b/rust/rust-sysdb/src/backend.rs
@@ -75,8 +75,7 @@ use crate::types::{
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
 use chroma_storage::config::{RegionalStorage, TopologicalStorage};
-use chroma_types::chroma_proto::Database;
-use chroma_types::{MultiCloudMultiRegionConfiguration, TopologyName};
+use chroma_types::{Database, MultiCloudMultiRegionConfiguration, TopologyName};
 
 /// Factory that holds all configured backend instances.
 ///
@@ -273,14 +272,9 @@ impl Backend {
     }
 
     /// List databases for a tenant.
-    pub async fn list_databases(
-        &self,
-        tenant: &str,
-        limit: Option<i32>,
-        offset: i32,
-    ) -> Result<Vec<Database>, SysDbError> {
+    pub async fn list_databases(&self, tenant: &str) -> Result<Vec<Database>, SysDbError> {
         match self {
-            Backend::Spanner(s) => s.list_databases(tenant, limit, offset).await,
+            Backend::Spanner(s) => s.list_databases(tenant).await,
         }
     }
 


### PR DESCRIPTION
## Description of changes

This change adds the list_databases endpoint for MCMR sysdb. We don't allow any offset/limit parameters for the rust-sysdb endpoint. Offset and limit parameters are also not forwarded to the go sysdb anymore. Any pagination logic is done after merging results from the go and rust sysdbs. This is ok for now as we don't expect more than 100 databases per tenant in the near future.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

Manual testing + integration unit tests have been added.

- [x] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_