### PR TITLE
[DOC] Move github link to top nav

### DIFF
--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -268,7 +268,7 @@
   "navbar": {
     "links": [
       {
-        "label": "Github",
+        "label": "GitHub",
         "icon": "github",
         "href": "https://github.com/chroma-core/chroma"
       }


### PR DESCRIPTION
<img width="1505" height="531" alt="Screenshot 2026-02-02 at 4 25 00 PM" src="https://github.com/user-attachments/assets/503919df-7fd8-4e44-819e-f1200e4a718b" />

github now in the top next to dashboard link
changelog and discord in footer