### PR TITLE
[ENH]: Wire up MCMR with prop tests

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -118,6 +118,7 @@ jobs:
         shell: bash
         env:
           CHROMA_THIN_CLIENT: "1"
+          MULTI_REGION: "true"
           ENV_FILE: ${{ contains(inputs.runner, 'ubuntu') && 'compose-env.linux' || 'compose-env.windows' }}
           PROPERTY_TESTING_PRESET: ${{ inputs.property_testing_preset }}
 
@@ -148,21 +149,16 @@ jobs:
           - test-glob: "chromadb/test/property/test_add.py"
             parallelized: false
           - test-glob: "chromadb/test/property/test_embeddings.py"
-            parallelized: true
-          # Tests that create tenants need MULTI_REGION for spanner instance
           - test-glob: "chromadb/test/api"
-            multi_region: true
           - test-glob: "chromadb/test/property/test_collections_with_database_tenant.py"
-            multi_region: true
           - test-glob: "chromadb/test/property/test_collections_with_database_tenant_overwrite.py"
-            multi_region: true
     runs-on: blacksmith-8vcpu-ubuntu-2404
     # OIDC token auth for AWS
     permissions:
       contents: read
       id-token: write
     env:
-      MULTI_REGION: ${{ matrix.multi_region && 'true' || '' }}
+      MULTI_REGION: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/bin/cluster-test.sh
+++ b/bin/cluster-test.sh
@@ -9,4 +9,10 @@ export CHROMA_COORDINATOR_HOST="${CHROMA_COORDINATOR_HOST:-localhost}"
 echo "Chroma Server is running at port $CHROMA_SERVER_HOST"
 echo "Chroma Coordinator is running at port $CHROMA_COORDINATOR_HOST"
 
+if [ "$MULTI_REGION" = "true" ]; then
+    echo "Test is running in multi region mode"
+else
+    echo "Test is running in single region mode"
+fi
+
 "$@"

--- a/chromadb/test/api/test_collection.py
+++ b/chromadb/test/api/test_collection.py
@@ -2,8 +2,10 @@ from concurrent.futures import ThreadPoolExecutor
 import uuid
 from chromadb.api import ClientAPI
 from chromadb.errors import ChromaError, UniqueConstraintError
+from chromadb.test.conftest import multi_region_test
 
 
+@multi_region_test
 def test_duplicate_collection_create(
     client: ClientAPI,
 ) -> None:
@@ -42,6 +44,7 @@ def test_not_existing_collection_delete(
         assert "does not exist" in e.args[0]
 
 
+# TODO: Spanner emulator only supports one transaction at a time
 def test_multithreaded_get_or_create(client: ClientAPI) -> None:
     N_THREADS = 50
     new_name = str(uuid.uuid4())

--- a/chromadb/test/api/test_list_databases.py
+++ b/chromadb/test/api/test_list_databases.py
@@ -4,7 +4,7 @@ from chromadb.test.conftest import (
     ClientFactories,
 )
 import hypothesis.strategies as st
-import os
+from chromadb.test.conftest import MULTI_REGION_ENABLED
 
 
 def test_list_databases(client_factories: ClientFactories) -> None:
@@ -16,10 +16,7 @@ def test_list_databases(client_factories: ClientFactories) -> None:
         admin_client.create_database(f"test_list_databases_{i}")
 
     databases = admin_client.list_databases()
-    # TODO(tanujnay112): Derive this to a global in conftest.py
-    total_default_databases = (
-        2 if os.getenv("MULTI_REGION") == "true" else 1
-    )  # 1 default db for each topology (single region is a topology)
+    total_default_databases = 2 if MULTI_REGION_ENABLED else 1
     assert len(databases) == 10 + total_default_databases
 
     for i in range(10):
@@ -27,7 +24,7 @@ def test_list_databases(client_factories: ClientFactories) -> None:
 
     assert any(d["name"] == "default_database" for d in databases)
 
-    if os.getenv("MULTI_REGION") == "true":
+    if MULTI_REGION_ENABLED:
         assert any(d["name"] == "tilt-spanning+default_database" for d in databases)
 
 

--- a/chromadb/test/client/test_database_tenant.py
+++ b/chromadb/test/client/test_database_tenant.py
@@ -104,12 +104,12 @@ def test_database_collections_add(client_factories: ClientFactories) -> None:
     coll_default.add(**records_default)  # type: ignore
 
     # Make sure the collections are isolated
-    res = coll_new.get(include=["embeddings", "documents"])  # type: ignore
+    res = coll_new.get(include=["embeddings", "documents"])
     assert res["ids"] == records_new["ids"]
     check_embeddings(res=res, records=records_new)
     assert res["documents"] == records_new["documents"]
 
-    res = coll_default.get(include=["embeddings", "documents"])  # type: ignore
+    res = coll_default.get(include=["embeddings", "documents"])
     assert res["ids"] == records_default["ids"]
     check_embeddings(res=res, records=records_default)
     assert res["documents"] == records_default["documents"]
@@ -151,12 +151,12 @@ def test_tenant_collections_add(client_factories: ClientFactories) -> None:
     coll_tenant2.add(**records_tenant2)  # type: ignore
 
     # Make sure the collections are isolated
-    res = coll_tenant1.get(include=["embeddings", "documents"])  # type: ignore
+    res = coll_tenant1.get(include=["embeddings", "documents"])
     assert res["ids"] == records_tenant1["ids"]
     check_embeddings(res=res, records=records_tenant1)
     assert res["documents"] == records_tenant1["documents"]
 
-    res = coll_tenant2.get(include=["embeddings", "documents"])  # type: ignore
+    res = coll_tenant2.get(include=["embeddings", "documents"])
     assert res["ids"] == records_tenant2["ids"]
     check_embeddings(res=res, records=records_tenant2)
     assert res["documents"] == records_tenant2["documents"]

--- a/chromadb/test/conftest.py
+++ b/chromadb/test/conftest.py
@@ -27,8 +27,7 @@ from chromadb.api.async_fastapi import AsyncFastAPI
 from chromadb.api.fastapi import FastAPI
 import chromadb.server.fastapi
 from chromadb.api import ClientAPI, ServerAPI, BaseAPI
-from chromadb.config import Settings, System
-from chromadb.db.mixins import embeddings_queue
+from chromadb.config import DEFAULT_DATABASE, Settings, System
 from chromadb.ingest import Producer
 from chromadb.types import SeqId, OperationRecord
 from chromadb.api.client import Client as ClientCreator, AdminClient
@@ -144,6 +143,9 @@ def override_hypothesis_profile(
 
 
 NOT_CLUSTER_ONLY = os.getenv("CHROMA_CLUSTER_TEST_ONLY") != "1"
+MULTI_REGION_ENABLED = not NOT_CLUSTER_ONLY and os.getenv("MULTI_REGION") == "true"
+MULTI_REGION_TOPOLOGY = "tilt-spanning"
+DEFAULT_MCMR_DATABASE = f"{MULTI_REGION_TOPOLOGY}+{DEFAULT_DATABASE}"
 COMPACTION_SLEEP = 120
 
 
@@ -394,14 +396,25 @@ def fastapi_ssl() -> Generator[System, None, None]:
     )
 
 
-@pytest.fixture()
-def basic_http_client() -> Generator[System, None, None]:
+def _get_server_host_port_from_env() -> Tuple[str, int]:
+    """Get server host and port from CHROMA_SERVER_HOST environment variable.
+
+    Returns:
+        Tuple of (host, port) from environment, or defaults (localhost, 8000) if not set.
+    """
     port = 8000
     host = "localhost"
 
     if os.getenv("CHROMA_SERVER_HOST"):
         host = os.getenv("CHROMA_SERVER_HOST", "").split(":")[0]
         port = int(os.getenv("CHROMA_SERVER_HOST", "").split(":")[1])
+
+    return host, port
+
+
+@pytest.fixture()
+def basic_http_client() -> Generator[System, None, None]:
+    host, port = _get_server_host_port_from_env()
 
     settings = Settings(
         chroma_api_impl="chromadb.api.fastapi.FastAPI",
@@ -534,6 +547,29 @@ users:
 def fastapi_fixture_admin_and_singleton_tenant_db_user() -> (
     Generator[System, None, None]
 ):
+    # Check if we should connect to existing server instead of spawning a new one
+    if os.getenv("CHROMA_SERVER_HOST") and not NOT_CLUSTER_ONLY:
+        # Connect to existing Tilt instance using the same pattern as basic_http_client
+        host, port = _get_server_host_port_from_env()
+
+        settings = Settings(
+            chroma_api_impl="chromadb.api.fastapi.FastAPI",
+            chroma_server_host=host,
+            chroma_server_http_port=port,
+            allow_reset=True,
+            chroma_client_auth_provider="chromadb.auth.token_authn.TokenAuthClientProvider",
+            chroma_client_auth_credentials="admin-token",
+            # Don't overwrite tenant/database from auth when connecting to external Tilt
+            chroma_overwrite_singleton_tenant_database_access_from_auth=False,
+        )
+        system = System(settings)
+        api = system.instance(ServerAPI)
+        _await_server(api)
+        system.start()
+        yield system
+        return
+
+    # Original behavior: spawn isolated server
     with tempfile.NamedTemporaryFile("w", suffix=".authn", delete=False) as f:
         f.write(
             """
@@ -685,7 +721,7 @@ def rust_sqlite_persistent() -> Generator[System, None, None]:
     else ["python_sqlite_ephemeral"]
 )
 def sqlite(request: pytest.FixtureRequest) -> Generator[System, None, None]:
-    return request.getfixturevalue(request.param)
+    return request.getfixturevalue(request.param)  # type: ignore
 
 
 @pytest.fixture(
@@ -694,7 +730,7 @@ def sqlite(request: pytest.FixtureRequest) -> Generator[System, None, None]:
     else ["python_sqlite_persistent"]
 )
 def sqlite_persistent(request: pytest.FixtureRequest) -> Generator[System, None, None]:
-    return request.getfixturevalue(request.param)
+    return request.getfixturevalue(request.param)  # type: ignore
 
 
 def filtered_fixture_names() -> List[str]:
@@ -783,12 +819,12 @@ def system_authn_rbac_authz(
 def system_http_server(
     request: pytest.FixtureRequest,
 ) -> Generator[ServerAPI, None, None]:
-    return request.getfixturevalue(request.param)
+    return request.getfixturevalue(request.param)  # type: ignore
 
 
 @pytest.fixture(scope="function", params=filtered_fixture_names())
 def system(request: pytest.FixtureRequest) -> Generator[ServerAPI, None, None]:
-    return request.getfixturevalue(request.param)
+    return request.getfixturevalue(request.param)  # type: ignore
 
 
 @pytest.fixture(scope="module", params=system_fixtures_ssl())
@@ -839,6 +875,9 @@ class ClientFactories:
         if kwargs.get("settings") is None:
             kwargs["settings"] = self._system.settings
 
+        if kwargs.get("database") is None and MULTI_REGION_ENABLED:
+            kwargs["database"] = DEFAULT_MCMR_DATABASE
+
         if (
             self._system.settings.chroma_api_impl
             == "chromadb.api.async_fastapi.AsyncFastAPI"
@@ -872,11 +911,11 @@ class ClientFactories:
             == "chromadb.api.async_fastapi.AsyncFastAPI"
         ):
             client = cast(AdminClient, AsyncAdminClientSync(*args, **kwargs))
-            self._created_clients.append(client)
+            self._created_clients.append(client)  # type: ignore
             return client
 
         client = AdminClient(*args, **kwargs)
-        self._created_clients.append(client)
+        self._created_clients.append(client)  # type: ignore
         return client
 
     def create_admin_client_from_system(self) -> AdminClient:
@@ -885,11 +924,11 @@ class ClientFactories:
             == "chromadb.api.async_fastapi.AsyncFastAPI"
         ):
             client = cast(AdminClient, AsyncAdminClientSync.from_system(self._system))
-            self._created_clients.append(client)
+            self._created_clients.append(client)  # type: ignore
             return client
 
         client = AdminClient.from_system(self._system)
-        self._created_clients.append(client)
+        self._created_clients.append(client)  # type: ignore
         return client
 
 
@@ -906,45 +945,100 @@ def client_factories(system: System) -> Generator[ClientFactories, None, None]:
         del client
 
 
-def create_isolated_database(client: ClientAPI) -> None:
-    """Create an isolated database for a test and updates the client to use it."""
+def get_topology_name(database_name: str) -> Optional[str]:
+    return database_name.split("+")[0] if len(database_name.split("+")) > 1 else None
+
+
+def create_database(client: ClientAPI, database_name: str) -> None:
     admin_settings = client.get_settings()
     if admin_settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
         admin_settings.chroma_api_impl = "chromadb.api.fastapi.FastAPI"
-
     admin = AdminClient(admin_settings)
+    admin.create_database(database_name)
+
+
+def create_isolated_database(client: ClientAPI) -> None:
+    """Create an isolated database for a test and updates the client to use it."""
     database = "test_" + str(uuid.uuid4())
-    admin.create_database(database)
+    topo_name = get_topology_name(client.database)
+    if topo_name is not None:
+        database = topo_name + "+" + database
+    create_database(client, database)
     client.set_database(database)
 
 
 @pytest.fixture(scope="function")
-def client(system: System) -> Generator[ClientAPI, None, None]:
+def client(system: System, database_name: str) -> Generator[ClientAPI, None, None]:
     system.reset_state()
 
     if system.settings.chroma_api_impl == "chromadb.api.async_fastapi.AsyncFastAPI":
-        client = cast(Any, AsyncClientCreatorSync.from_system_async(system))
-        yield client
-        client.clear_system_cache()
+        client = cast(
+            Any,
+            AsyncClientCreatorSync.from_system_async(system, database=database_name),
+        )
     else:
-        client = ClientCreator.from_system(system)
-        yield client
-        client.clear_system_cache()
+        client = ClientCreator.from_system(system, database=database_name)
+
+    yield client
+    client.clear_system_cache()
+
+
+@pytest.fixture()
+def database_name(request: pytest.FixtureRequest) -> str:
+    # Check if test has the test_with_multi_region mark
+    has_mark = request.node.get_closest_marker("test_with_multi_region")
+    if has_mark and MULTI_REGION_ENABLED:
+        return DEFAULT_MCMR_DATABASE
+    return DEFAULT_DATABASE
+
+
+def multi_region_test(test_func: Callable[..., Any]) -> Any:
+    """Opt-in decorator for multi-region testing.
+
+    If MULTI_REGION_ENABLED: Test runs with MCMR database (tilt-spanning+default_database)
+    If not MULTI_REGION_ENABLED: Test runs with default database only
+    """
+    return pytest.mark.test_with_multi_region(test_func)
+
+
+# For backward compatibility, also provide test_with_multi_region
+test_with_multi_region = multi_region_test
+
+
+def pytest_itemcollected(item: pytest.Item) -> None:
+    """Modify test names to show database type"""
+    if hasattr(item, "iter_markers"):
+        for marker in item.iter_markers():
+            if marker.name == "test_with_multi_region":
+                # Add multi-region suffix to test node ID
+                suffix = "[mcmr]" if MULTI_REGION_ENABLED else "[single-region]"
+                item._nodeid = f"{item._nodeid}{suffix}"
+                break
+        else:
+            # No multi-region marker, show single-region
+            item._nodeid = f"{item._nodeid}[single-region]"
 
 
 @pytest.fixture(scope="function")
-def http_client(system_http_server: System) -> Generator[ClientAPI, None, None]:
+def http_client(
+    system_http_server: System, database_name: str
+) -> Generator[ClientAPI, None, None]:
     system_http_server.reset_state()
 
     if (
         system_http_server.settings.chroma_api_impl
         == "chromadb.api.async_fastapi.AsyncFastAPI"
     ):
-        client = cast(Any, AsyncClientCreatorSync.from_system_async(system_http_server))
+        client = cast(
+            Any,
+            AsyncClientCreatorSync.from_system_async(
+                system_http_server, database=database_name
+            ),
+        )
         yield client
         client.clear_system_cache()
     else:
-        client = ClientCreator.from_system(system_http_server)
+        client = ClientCreator.from_system(system_http_server, database=database_name)
         yield client
         client.clear_system_cache()
 
@@ -1039,8 +1133,13 @@ def produce_fns(
     yield request.param
 
 
-def pytest_configure(config):  # type: ignore
-    embeddings_queue._called_from_test = True
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers"""
+    config.addinivalue_line("markers", "dual_database: run test with both databases")
+    config.addinivalue_line(
+        "markers",
+        "test_with_multi_region: run test with MCMR database when MULTI_REGION_ENABLED",
+    )
 
 
 def is_client_in_process(client: ClientAPI) -> bool:

--- a/chromadb/test/distributed/test_statistics_wrapper.py
+++ b/chromadb/test/distributed/test_statistics_wrapper.py
@@ -35,7 +35,9 @@ def test_statistics_wrapper(basic_http_client: System) -> None:
     )
 
     # Enable statistics
-    attached_fn, created = attach_statistics_function(collection, "test_collection_statistics")
+    attached_fn, created = attach_statistics_function(
+        collection, "test_collection_statistics"
+    )
     assert attached_fn is not None
     assert created is True
     assert attached_fn.function_name == "statistics"
@@ -129,7 +131,9 @@ def test_backfill_statistics(basic_http_client: System) -> None:
     initial_version = get_collection_version(client, collection.name)
 
     # Enable statistics
-    attached_fn, created = attach_statistics_function(collection, "my_collection_statistics")
+    attached_fn, created = attach_statistics_function(
+        collection, "my_collection_statistics"
+    )
     assert created is True
     assert attached_fn.function_name == "statistics"
     assert attached_fn.output_collection == "my_collection_statistics"
@@ -370,7 +374,9 @@ def test_sparse_vector_statistics(basic_http_client: System) -> None:
             {"category": "A", "vec": sparse_vec3},
         ],
     )
-    _, created = attach_statistics_function(collection, "sparse_vector_test1_statistics")
+    _, created = attach_statistics_function(
+        collection, "sparse_vector_test1_statistics"
+    )
     assert created is True
 
     initial_version = get_collection_version(client, collection.name)
@@ -447,7 +453,9 @@ def test_statistics_high_cardinality(basic_http_client: System) -> None:
     initial_version = get_collection_version(client, collection.name)
 
     # Enable statistics
-    _, created = attach_statistics_function(collection, "high_cardinality_test_statistics")
+    _, created = attach_statistics_function(
+        collection, "high_cardinality_test_statistics"
+    )
     assert created is True
 
     # Wait for statistics to be computed

--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -393,6 +393,7 @@ def test_delete_orphaned_output_collection(basic_http_client: System) -> None:
         # Try to use the function - it should fail since it's detached
         client.get_collection("output_collection")
 
+
 def test_partial_attach_function_repair(
     basic_http_client: System,
 ) -> None:
@@ -551,6 +552,7 @@ def test_count_function_attach_and_detach_attach_attach(
     )
     assert created is False
     assert attached_fn is not None
+
 
 def test_attach_function_idempotency(basic_http_client: System) -> None:
     """Test that attach_function is idempotent - calling it twice with same params returns created=False"""

--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -348,24 +348,25 @@ def ann_accuracy(
                 limit=Limit(limit=n_results),
             ).select_all()
             search_requests.append(search)
-        
-        # Call _search API
-        api = collection._client  # type: ignore
-        search_results = api._search(
-            collection_id=collection.id,
+
+        # Call search API
+        search_results = collection.search(
             searches=search_requests,
-            tenant='default_tenant',
-            database='default_database',
         )
-        
+
         # Convert search results to query-like format
-        query_results = cast(types.QueryResult, {
-            "ids": search_results["ids"],
-            "distances": search_results["scores"],  # scores is distances in search API
-            "embeddings": search_results["embeddings"],
-            "documents": search_results["documents"],
-            "metadatas": search_results["metadatas"],
-        })
+        query_results = cast(
+            types.QueryResult,
+            {
+                "ids": search_results["ids"],
+                "distances": search_results[
+                    "scores"
+                ],  # scores is distances in search API
+                "embeddings": search_results["embeddings"],
+                "documents": search_results["documents"],
+                "metadatas": search_results["metadatas"],
+            },
+        )
     else:
         query_results = collection.query(
             query_embeddings=query_embeddings if have_embeddings else None,

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 from hypothesis import given, settings
 from chromadb.api import ClientAPI
 from chromadb.api.types import Embeddings, Metadatas
+from chromadb.test.conftest import multi_region_test
 from chromadb.test.conftest import (
     NOT_CLUSTER_ONLY,
     override_hypothesis_profile,
@@ -20,6 +21,7 @@ from chromadb.utils.batch_utils import create_batches
 
 
 collection_st = st.shared(strategies.collections(with_hnsw_params=True), key="coll")
+
 
 @given(
     collection=collection_st,
@@ -79,6 +81,7 @@ def test_add_small(
     _test_add(client, collection, record_set, should_compact)
 
 
+@multi_region_test
 @given(
     collection=collection_st,
     record_set=strategies.recordsets(

--- a/chromadb/test/property/test_fork.py
+++ b/chromadb/test/property/test_fork.py
@@ -7,8 +7,10 @@ import logging
 import pytest
 
 from chromadb.api.models.Collection import Collection
-from chromadb.test.conftest import reset, skip_if_not_cluster
-from chromadb.test.utils.wait_for_version_increase import wait_for_version_increase
+from chromadb.test.conftest import (
+    reset,
+    skip_if_not_cluster,
+)
 from hypothesis.stateful import (
     Bundle,
     RuleBasedStateMachine,

--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.76
+version: 0.1.77
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/rust/rust-sysdb/src/types.rs
+++ b/rust/rust-sysdb/src/types.rs
@@ -446,15 +446,26 @@ impl TryFrom<chroma_proto::GetCollectionsRequest> for GetCollectionsRequest {
             filter = filter.limit(limit);
         }
         if let Some(offset) = req.offset {
-            if req.limit.is_none() {
-                return Err(SysDbError::InvalidArgument(
-                    "offset requires limit to be specified".to_string(),
-                ));
+            if offset < 0 {
+                return Err(SysDbError::InvalidArgument(format!(
+                    "offset must be non-negative, got {}",
+                    offset
+                )));
             }
-            let offset = u32::try_from(offset).map_err(|_| {
-                SysDbError::InvalidArgument(format!("offset must be non-negative, got {}", offset))
-            })?;
-            filter = filter.offset(offset);
+            if offset > 0 {
+                if req.limit.is_none() {
+                    return Err(SysDbError::InvalidArgument(
+                        "offset requires limit to be specified".to_string(),
+                    ));
+                }
+                let offset = u32::try_from(offset).map_err(|_| {
+                    SysDbError::InvalidArgument(format!(
+                        "offset must be non-negative, got {}",
+                        offset
+                    ))
+                })?;
+                filter = filter.offset(offset);
+            }
         }
 
         // Handle include_soft_deleted


### PR DESCRIPTION
## Description of changes

This change adds the capability for our python cluster tests to also test against an MCMR database if it is decorated with `@multi_region_test`.

In that process, this change also fixed a bug that caused GetCollections on spanner to error out when passed in an offset of 0 with no limit.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_