### PR TITLE
[ENH]: count_collections for mcmr

### DIFF
--- a/rust/rust-sysdb/src/backend.rs
+++ b/rust/rust-sysdb/src/backend.rs
@@ -66,11 +66,12 @@ use crate::config::SpannerBackendConfig;
 use crate::spanner::SpannerBackend;
 use crate::types::SysDbError;
 use crate::types::{
-    CreateCollectionRequest, CreateCollectionResponse, CreateDatabaseRequest,
-    CreateDatabaseResponse, CreateTenantRequest, CreateTenantResponse, FlushCompactionRequest,
-    FlushCompactionResponse, GetCollectionWithSegmentsRequest, GetCollectionWithSegmentsResponse,
-    GetCollectionsRequest, GetCollectionsResponse, GetDatabaseRequest, GetDatabaseResponse,
-    GetTenantsRequest, GetTenantsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
+    CountCollectionsRequest, CountCollectionsResponse, CreateCollectionRequest,
+    CreateCollectionResponse, CreateDatabaseRequest, CreateDatabaseResponse, CreateTenantRequest,
+    CreateTenantResponse, FlushCompactionRequest, FlushCompactionResponse,
+    GetCollectionWithSegmentsRequest, GetCollectionWithSegmentsResponse, GetCollectionsRequest,
+    GetCollectionsResponse, GetDatabaseRequest, GetDatabaseResponse, GetTenantsRequest,
+    GetTenantsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
 };
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
@@ -309,6 +310,18 @@ impl Backend {
     ) -> Result<GetCollectionsResponse, SysDbError> {
         match self {
             Backend::Spanner(s) => s.get_collections(req).await,
+        }
+    }
+
+    /// Count collections for a tenant, optionally filtered by database.
+    ///
+    /// Returns the count of non-deleted collections.
+    pub async fn count_collections(
+        &self,
+        req: CountCollectionsRequest,
+    ) -> Result<CountCollectionsResponse, SysDbError> {
+        match self {
+            Backend::Spanner(s) => s.count_collections(req).await,
         }
     }
 


### PR DESCRIPTION
## Description of changes

Implements count_collections for MCMR. The query here takes advantage of the tenant_id column in the spanner version of the collections table. This luxury is not available in the single region sysdb.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

Test added in spanner.rs

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
