### PR TITLE
[ENH]  Allow freeze-drying of collections so as to avoid round trips.

### DIFF
--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -790,6 +790,11 @@ impl ChromaCollection {
         })
     }
 
+    /// Returns a JSON object that can be passed to ChromaHttpClient::hydrate_collection().
+    pub async fn dehydrate(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(&self.collection)
+    }
+
     /// Internal transport method that constructs collection-specific API paths and delegates to the client.
     async fn send<Body: Serialize, Response: DeserializeOwned>(
         &self,


### PR DESCRIPTION
## Description of changes

I need to connect to e.g. 10k collections.  Even at multiple nines this
will likely have one error.  I'd like to cache the created collections
so that I don't have to wait to re-fetch them at the start of my
benchmarking.

## Test plan

CI + new live cloud test

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
