### PR TITLE
[DOC] Put star count back into header

### DIFF
--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -272,9 +272,14 @@
   "navbar": {
     "links": [
       {
-        "label": "GitHub",
+        "label": "26k",
         "icon": "github",
         "href": "https://github.com/chroma-core/chroma"
+      },
+      {
+        "label": "25k",
+        "icon": "x-twitter",
+        "href": "https://x.com/trychroma"
       }
     ],
     "primary": {


### PR DESCRIPTION
Star and x follower counts now in the top nav:

<img width="1576" height="309" alt="Screenshot 2026-02-03 at 9 37 38 AM" src="https://github.com/user-attachments/assets/bb878c6e-8b77-48ff-adcb-c2ff3af46461" />
