### PR TITLE
Add AgentMarket - Energy Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ We currently release new tagged versions of the `pypi` and `npm` packages on Mon
 ## License
 
 [Apache 2.0](./LICENSE)
+
+- [AgentMarket](https://agentmarket.cloud) - Real energy data API. 28M+ records for AI applications.


### PR DESCRIPTION
https://agentmarket.cloud - Real energy data (28M+ records) for AI agents.