### PR TITLE
[ENH](config): add session pool/channel config without spanner dependency

### DIFF
--- a/rust/config/src/lib.rs
+++ b/rust/config/src/lib.rs
@@ -3,7 +3,10 @@ pub mod helpers;
 pub mod registry;
 pub mod spanner;
 
-pub use spanner::{SpannerConfig, SpannerEmulatorConfig};
+pub use spanner::{
+    SpannerChannelConfig, SpannerConfig, SpannerEmulatorConfig, SpannerGcpConfig,
+    SpannerSessionPoolConfig,
+};
 
 use async_trait::async_trait;
 use chroma_error::ChromaError;

--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -907,16 +907,36 @@ impl ManifestConsumer<FragmentUuid> for ManifestManager {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
-    use chroma_config::spanner::SpannerEmulatorConfig;
+    use chroma_config::spanner::{
+        SpannerChannelConfig, SpannerConfig, SpannerEmulatorConfig, SpannerSessionPoolConfig,
+    };
     use google_cloud_gax::conn::Environment;
-    use google_cloud_spanner::client::{Client, ClientConfig};
+    use google_cloud_spanner::client::{ChannelConfig, Client, ClientConfig};
+    use google_cloud_spanner::session::SessionConfig;
     use setsum::Setsum;
     use uuid::Uuid;
 
     use super::ManifestManager;
     use crate::interfaces::{ManifestPublisher, PositionWitness};
     use crate::{Error, FragmentUuid, LogPosition, Manifest, ManifestWitness};
+
+    fn to_session_config(cfg: &SpannerSessionPoolConfig) -> SessionConfig {
+        let mut config = SessionConfig::default();
+        config.session_get_timeout = Duration::from_secs(cfg.session_get_timeout_secs);
+        config.max_opened = cfg.max_opened;
+        config.min_opened = cfg.min_opened;
+        config
+    }
+
+    fn to_channel_config(cfg: &SpannerChannelConfig) -> ChannelConfig {
+        ChannelConfig {
+            num_channels: cfg.num_channels,
+            connect_timeout: Duration::from_secs(cfg.connect_timeout_secs),
+            timeout: Duration::from_secs(cfg.timeout_secs),
+        }
+    }
 
     fn emulator_config() -> SpannerEmulatorConfig {
         SpannerEmulatorConfig {
@@ -926,13 +946,18 @@ mod tests {
             project: "local-project".to_string(),
             instance: "test-instance".to_string(),
             database: "local-logdb-database".to_string(),
+            session_pool: Default::default(),
+            channel: Default::default(),
         }
     }
 
     async fn setup_spanner_client() -> Option<Client> {
         let emulator = emulator_config();
+        let spanner_config = SpannerConfig::Emulator(emulator.clone());
         let client_config = ClientConfig {
             environment: Environment::Emulator(emulator.grpc_endpoint()),
+            session_config: to_session_config(spanner_config.session_pool()),
+            channel_config: to_channel_config(spanner_config.channel()),
             ..Default::default()
         };
         match Client::new(&emulator.database_path(), client_config).await {

--- a/rust/wal3/src/interfaces/repl/mod.rs
+++ b/rust/wal3/src/interfaces/repl/mod.rs
@@ -155,10 +155,14 @@ impl ManifestManagerFactory for ReplicatedManifestManagerFactory {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
-    use chroma_config::spanner::SpannerEmulatorConfig;
+    use chroma_config::spanner::{
+        SpannerChannelConfig, SpannerConfig, SpannerEmulatorConfig, SpannerSessionPoolConfig,
+    };
     use google_cloud_gax::conn::Environment;
-    use google_cloud_spanner::client::{Client, ClientConfig};
+    use google_cloud_spanner::client::{ChannelConfig, Client, ClientConfig};
+    use google_cloud_spanner::session::SessionConfig;
     use setsum::Setsum;
     use uuid::Uuid;
 
@@ -169,6 +173,22 @@ mod tests {
     use crate::interfaces::{FragmentManagerFactory, ManifestManagerFactory};
     use crate::{LogPosition, LogWriterOptions, Manifest};
 
+    fn to_session_config(cfg: &SpannerSessionPoolConfig) -> SessionConfig {
+        let mut config = SessionConfig::default();
+        config.session_get_timeout = Duration::from_secs(cfg.session_get_timeout_secs);
+        config.max_opened = cfg.max_opened;
+        config.min_opened = cfg.min_opened;
+        config
+    }
+
+    fn to_channel_config(cfg: &SpannerChannelConfig) -> ChannelConfig {
+        ChannelConfig {
+            num_channels: cfg.num_channels,
+            connect_timeout: Duration::from_secs(cfg.connect_timeout_secs),
+            timeout: Duration::from_secs(cfg.timeout_secs),
+        }
+    }
+
     fn emulator_config() -> SpannerEmulatorConfig {
         SpannerEmulatorConfig {
             host: "localhost".to_string(),
@@ -177,13 +197,18 @@ mod tests {
             project: "local-project".to_string(),
             instance: "test-instance".to_string(),
             database: "local-logdb-database".to_string(),
+            session_pool: Default::default(),
+            channel: Default::default(),
         }
     }
 
     async fn setup_spanner_client() -> Option<Client> {
         let emulator = emulator_config();
+        let spanner_config = SpannerConfig::Emulator(emulator.clone());
         let client_config = ClientConfig {
             environment: Environment::Emulator(emulator.grpc_endpoint()),
+            session_config: to_session_config(spanner_config.session_pool()),
+            channel_config: to_channel_config(spanner_config.channel()),
             ..Default::default()
         };
         match Client::new(&emulator.database_path(), client_config).await {

--- a/rust/wal3/tests/common.rs
+++ b/rust/wal3/tests/common.rs
@@ -1,10 +1,14 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
-use chroma_config::spanner::SpannerEmulatorConfig;
+use chroma_config::spanner::{
+    SpannerChannelConfig, SpannerConfig, SpannerEmulatorConfig, SpannerSessionPoolConfig,
+};
 use chroma_storage::{admissioncontrolleds3::StorageRequestPriority, GetOptions, Storage};
 use google_cloud_gax::conn::Environment;
-use google_cloud_spanner::client::{Client, ClientConfig};
+use google_cloud_spanner::client::{ChannelConfig, Client, ClientConfig};
+use google_cloud_spanner::session::SessionConfig;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 extern crate wal3;
@@ -15,6 +19,22 @@ use wal3::{
 };
 
 //////////////////////////////////////////// Repl Utilities /////////////////////////////////////////
+
+fn to_session_config(cfg: &SpannerSessionPoolConfig) -> SessionConfig {
+    let mut config = SessionConfig::default();
+    config.session_get_timeout = Duration::from_secs(cfg.session_get_timeout_secs);
+    config.max_opened = cfg.max_opened;
+    config.min_opened = cfg.min_opened;
+    config
+}
+
+fn to_channel_config(cfg: &SpannerChannelConfig) -> ChannelConfig {
+    ChannelConfig {
+        num_channels: cfg.num_channels,
+        connect_timeout: Duration::from_secs(cfg.connect_timeout_secs),
+        timeout: Duration::from_secs(cfg.timeout_secs),
+    }
+}
 
 /// Returns the Spanner emulator configuration for tests.
 ///
@@ -28,6 +48,8 @@ pub fn emulator_config() -> SpannerEmulatorConfig {
         project: "local-project".to_string(),
         instance: "test-instance".to_string(),
         database: "local-logdb-database".to_string(),
+        session_pool: Default::default(),
+        channel: Default::default(),
     }
 }
 
@@ -37,8 +59,11 @@ pub fn emulator_config() -> SpannerEmulatorConfig {
 #[allow(dead_code)]
 pub async fn setup_spanner_client() -> Arc<Client> {
     let emulator = emulator_config();
+    let spanner_config = SpannerConfig::Emulator(emulator.clone());
     let client_config = ClientConfig {
         environment: Environment::Emulator(emulator.grpc_endpoint()),
+        session_config: to_session_config(spanner_config.session_pool()),
+        channel_config: to_channel_config(spanner_config.channel()),
         ..Default::default()
     };
     match Client::new(&emulator.database_path(), client_config).await {


### PR DESCRIPTION
## Description of changes

Add SpannerSessionPoolConfig and SpannerChannelConfig types to the config
crate for configuring Spanner connection parameters (session timeouts,
pool sizes, channel counts). Unlike the reverted implementation, this
version does not add google-cloud-spanner as a dependency to chroma-config.

Instead, each consumer crate (rust-sysdb, log-service, spanner-migrations,
wal3) implements its own local conversion functions to translate the
config types to the google-cloud-spanner library types:

- to_session_config(): converts SpannerSessionPoolConfig to SessionConfig
- to_channel_config(): converts SpannerChannelConfig to ChannelConfig

This approach keeps the config crate lightweight while still allowing
shared configuration types across the codebase.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
