### PR TITLE
[ENH]: delete_collection for mcmr

### DIFF
--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -714,7 +714,7 @@ impl ServiceBasedFrontend {
         })?;
         let collection = self
             .get_collection(
-                GetCollectionRequest::try_new(tenant_id.clone(), db_name, collection_name)
+                GetCollectionRequest::try_new(tenant_id.clone(), db_name.clone(), collection_name)
                     .map_err(DeleteCollectionError::Validation)?,
             )
             .await?;
@@ -728,7 +728,7 @@ impl ServiceBasedFrontend {
         self.sysdb_client
             .delete_collection(
                 tenant_id,
-                database_name,
+                db_name,
                 collection.collection_id,
                 segments.into_iter().map(|s| s.id).collect(),
             )

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -209,12 +209,15 @@ impl StateMachineTest for GarbageCollectorUnderTest {
             Transition::DeleteCollection(collection_id) => {
                 ref_state
                     .runtime
-                    .block_on(state.sysdb.delete_collection(
-                        ref_state.tenant.clone(),
-                        ref_state.db_name.clone(),
-                        collection_id,
-                        vec![],
-                    ))
+                    .block_on(
+                        state.sysdb.delete_collection(
+                            ref_state.tenant.clone(),
+                            DatabaseName::new(ref_state.db_name.clone())
+                                .expect("db_name should be valid"),
+                            collection_id,
+                            vec![],
+                        ),
+                    )
                     .unwrap();
             }
 

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -1,7 +1,6 @@
-use crate::types::validate_uuid;
 use crate::types::FlushCompactionRequest;
 use crate::types::SysDbError;
-use crate::types::{self as internal};
+use crate::types::{self as internal, validate_uuid};
 use crate::{
     backend::{Assignable, BackendFactory, Runnable},
     config::RootConfig,
@@ -320,9 +319,65 @@ impl SysDb for SysdbService {
 
     async fn delete_collection(
         &self,
-        _request: Request<DeleteCollectionRequest>,
+        request: Request<DeleteCollectionRequest>,
     ) -> Result<Response<DeleteCollectionResponse>, Status> {
-        Err(Status::unimplemented("delete_collection is not supported"))
+        let proto_req = request.into_inner();
+
+        // Convert DeleteCollectionRequest to UpdateCollectionRequest for soft delete
+        let collection_id = validate_uuid(&proto_req.id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection ID: {}", e)))?;
+
+        let database_name = DatabaseName::new(&proto_req.database)
+            .ok_or_else(|| Status::invalid_argument("database name is required"))?;
+
+        // First, get the current collection to retrieve its name
+        let backend_for_get = internal::GetCollectionWithSegmentsRequest {
+            database_name: database_name.clone(),
+            id: CollectionUuid(collection_id),
+        }
+        .assign(&self.backends);
+
+        let current_collection = internal::GetCollectionWithSegmentsRequest {
+            database_name: database_name.clone(),
+            id: CollectionUuid(collection_id),
+        }
+        .run(backend_for_get)
+        .await
+        .map_err(|e: SysDbError| Status::from(e))?;
+
+        // Generate new name with "_deleted_" prefix and collection ID
+        let deleted_new_name = format!(
+            "_deleted_{}_{}",
+            current_collection.collection.name, collection_id
+        );
+
+        // NOTE: This is not a TOCTOU because the transaction below checks to make sure
+        // the concerned collection is not soft deleted before proceeding.
+
+        // Create an UpdateCollectionRequest that marks the collection as deleted with the new name
+        let internal_req = internal::UpdateCollectionRequest {
+            database_name,
+            id: CollectionUuid(collection_id),
+            name: Some(deleted_new_name),
+            dimension: None,
+            metadata: None,
+            reset_metadata: false,
+            new_configuration: None,
+            cursor_updates: None,
+            is_deleted: Some(true), // Mark as soft deleted
+        };
+
+        let backend = internal_req.assign(&self.backends);
+        let internal_resp = internal_req
+            .run(backend)
+            .await
+            .map_err(|e: SysDbError| Status::from(e))?;
+
+        let proto_resp: DeleteCollectionResponse = internal_resp
+            .try_into()
+            .map_err(|e: SysDbError| Status::from(e))?;
+
+        Ok(Response::new(proto_resp))
     }
 
     async fn finish_collection_deletion(
@@ -773,6 +828,7 @@ impl SysDb for SysdbService {
             cursor_updates: Some(internal::UpdateCollectionCursor {
                 compaction_failure_count_increment: Some(1),
             }),
+            is_deleted: None,
         };
 
         // Execute the update
@@ -2342,5 +2398,98 @@ mod tests {
             "Should have at least 2 MCMR databases, got: {}",
             mcmr_count
         );
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_mcmr_delete_collection_soft_delete() {
+        let Some(backend): Option<SpannerBackend> = setup_test_backend().await else {
+            panic!("Skipping test: Spanner emulator not reachable. Is Tilt running?");
+        };
+
+        let (service, _temp_dir) = setup_test_service(backend.clone()).await;
+
+        // Create test data
+        let (tenant_id, database_name) = setup_tenant_and_database(&backend).await;
+
+        // Create collection using the internal type like other tests
+        let collection_id = CollectionUuid(Uuid::new_v4());
+        let create_collection_req = CreateCollectionRequest {
+            id: collection_id,
+            tenant_id: tenant_id.clone(),
+            database_name: database_name.clone(),
+            name: "test_collection".to_string(),
+            dimension: Some(128),
+            metadata: Some(HashMap::new()),
+            segments: vec![Segment {
+                id: SegmentUuid(Uuid::new_v4()),
+                r#type: SegmentType::BlockfileMetadata,
+                scope: SegmentScope::METADATA,
+                collection: collection_id,
+                file_path: HashMap::new(),
+                metadata: None,
+            }],
+            index_schema: chroma_types::Schema::default(),
+            get_or_create: false,
+        };
+
+        let backend_for_create = create_collection_req.assign(&service.backends);
+        let _create_response = create_collection_req.run(backend_for_create).await.unwrap();
+
+        // Test: Delete the collection (soft delete)
+        let delete_req = chroma_types::chroma_proto::DeleteCollectionRequest {
+            tenant: tenant_id.clone(),
+            database: database_name.as_ref().to_string(),
+            id: collection_id.0.to_string(),
+            segment_ids: vec![],
+        };
+        let delete_response = service
+            .delete_collection(Request::new(delete_req))
+            .await
+            .unwrap();
+
+        // Verify the response
+        assert_eq!(
+            delete_response.into_inner(),
+            chroma_types::chroma_proto::DeleteCollectionResponse {}
+        );
+
+        // Verify the collection is soft deleted by trying to get it
+        let get_req = chroma_types::chroma_proto::GetCollectionWithSegmentsRequest {
+            database: Some(database_name.as_ref().to_string()),
+            id: collection_id.0.to_string(),
+        };
+        let get_result = service
+            .get_collection_with_segments(Request::new(get_req))
+            .await;
+
+        // Should fail because collection is soft deleted
+        assert!(get_result.is_err());
+        let status = get_result.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+
+        // Verify the collection exists in soft-deleted form using backend directly
+        let get_collections_req = internal::GetCollectionsRequest {
+            filter: internal::CollectionFilter {
+                ids: Some(vec![collection_id]),
+                database_name: Some(database_name.clone()),
+                name: None,
+                tenant_id: None,
+                include_soft_deleted: true,
+                limit: None,
+                offset: None,
+                topology_name: None,
+            },
+        };
+        let backend_for_get = get_collections_req.assign(&service.backends);
+        let get_collections_result = get_collections_req.run(backend_for_get).await;
+
+        // Should succeed and return the soft-deleted collection
+        assert!(get_collections_result.is_ok());
+        let response = get_collections_result.unwrap();
+        assert_eq!(response.collections.len(), 1);
+        // The collection should be returned when include_soft_deleted=true
+        // (even though chroma_types::Collection doesn't expose is_deleted field)
+        // because the proto structure is different. The main test is that
+        // soft delete works and the collection is not found when trying to get it.
     }
 }

--- a/rust/rust-sysdb/src/types.rs
+++ b/rust/rust-sysdb/src/types.rs
@@ -520,6 +520,8 @@ pub struct UpdateCollectionRequest {
     pub new_configuration: Option<UpdateCollectionConfiguration>,
     // Cursor updates (optional - None means don't change)
     pub cursor_updates: Option<UpdateCollectionCursor>,
+    /// If true, mark the collection as soft deleted (for delete_collection operation)
+    pub is_deleted: Option<bool>,
 }
 
 impl TryFrom<chroma_proto::UpdateCollectionRequest> for UpdateCollectionRequest {
@@ -581,6 +583,7 @@ impl TryFrom<chroma_proto::UpdateCollectionRequest> for UpdateCollectionRequest 
             reset_metadata,
             new_configuration,
             cursor_updates: None,
+            is_deleted: None, // Not supported in proto UpdateCollectionRequest
         })
     }
 }
@@ -595,6 +598,18 @@ impl TryFrom<UpdateCollectionResponse> for chroma_proto::UpdateCollectionRespons
     fn try_from(_r: UpdateCollectionResponse) -> Result<Self, Self::Error> {
         // The proto response is empty - it doesn't return the updated collection
         Ok(chroma_proto::UpdateCollectionResponse {})
+    }
+}
+
+// For delete_collection, we reuse UpdateCollectionResponse
+use chroma_types::chroma_proto::DeleteCollectionResponse;
+
+impl TryFrom<UpdateCollectionResponse> for DeleteCollectionResponse {
+    type Error = SysDbError;
+
+    fn try_from(_r: UpdateCollectionResponse) -> Result<Self, Self::Error> {
+        // The proto response is empty
+        Ok(DeleteCollectionResponse {})
     }
 }
 


### PR DESCRIPTION
## Description of changes

This change implements delete_collection in rust sysdb by reusing the internal::UpdateCollection type in the rust sysdb crate.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

Tests have been added in rust-sysdb/server.rs

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
