### PR TITLE
[BUG]  When two threads attempt to concurrently init a manifest.

### DIFF
--- a/rust/wal3/src/interfaces/repl/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/repl/manifest_manager.rs
@@ -8,7 +8,7 @@ use google_cloud_spanner::key::Key;
 use google_cloud_spanner::mutation::{delete, insert, update};
 use google_cloud_spanner::statement::Statement;
 use setsum::Setsum;
-use tonic::{Code, Status};
+use tonic::Code;
 use uuid::Uuid;
 
 use crate::interfaces::{ManifestConsumer, ManifestPublisher, PositionWitness};


### PR DESCRIPTION
## Description of changes

One would see their op succeed, but the other gets a nasty error
message.  Instead, return an error wal3 knows how to retry.

## Test plan

CI => staging

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
