### PR TITLE
[BUG]  Set the grpc route for mcmr configs.

### DIFF
--- a/rust/frontend/sample_configs/distributed2.yaml
+++ b/rust/frontend/sample_configs/distributed2.yaml
@@ -13,10 +13,11 @@ sysdb:
     connect_timeout_ms: 60000
     request_timeout_ms: 60000
 mcmr_sysdb:
-  host: "rust-sysdb-service.chroma2"
-  port: 50051
-  connect_timeout_ms: 60000
-  request_timeout_ms: 60000
+  grpc:
+    host: "rust-sysdb-service.chroma2"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
 collections_with_segments_provider:
   cache:
     lru:

--- a/rust/frontend/sample_configs/distributed_mcmr.yaml
+++ b/rust/frontend/sample_configs/distributed_mcmr.yaml
@@ -13,10 +13,11 @@ sysdb:
     connect_timeout_ms: 60000
     request_timeout_ms: 60000
 mcmr_sysdb:
-  host: "rust-sysdb-service.chroma"
-  port: 50051
-  connect_timeout_ms: 60000
-  request_timeout_ms: 60000
+  grpc:
+    host: "rust-sysdb-service.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
 collections_with_segments_provider:
   cache:
     lru:


### PR DESCRIPTION
## Description of changes

The `grpc:` block was absent.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
