### PR TITLE
fix: correct typo 'seperate' to 'separate'

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -159,7 +159,7 @@ class SqliteMetadataSegment(MetadataReader):
         )
 
         # If there is a query that touches the metadata table, it uses
-        # where and where_document filters, we treat this case seperately
+        # where and where_document filters, we treat this case separately
         if where is not None or where_document is not None:
             metadata_q = (
                 self._db.querybuilder()

--- a/chromadb/test/client/test_multiple_clients_concurrency.py
+++ b/chromadb/test/client/test_multiple_clients_concurrency.py
@@ -21,7 +21,7 @@ def test_multiple_clients_concurrently(client_factories: ClientFactories) -> Non
 
     collections = [f"collection{i}" for i in range(COLLECTION_COUNT)]
 
-    # Create N clients, each on a seperate thread, each with their own database
+    # Create N clients, each on a separate thread, each with their own database
     def run_target(n: int) -> None:
         thread_client = client_factories.create_client(
             tenant=DEFAULT_TENANT,


### PR DESCRIPTION
Fixes typo 'seperate' → 'separate' in comments.