### PR TITLE
[BUG](log-service): hoist LogReader out of per-fragment loop in pull_logs

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2055,16 +2055,17 @@ impl LogServer {
                 return Err(Status::new(err.code().into(), err.to_string()));
             }
         };
+        let log_reader = self
+            .make_log_reader(topology_name.as_ref(), collection_id)
+            .await
+            .map_err(|err| Status::new(err.code().into(), err.to_string()))?;
         let futures = fragments
             .iter()
             .map(|fragment| {
+                let log_reader = Arc::clone(&log_reader);
                 let this = self;
-                let topology_name = topology_name.clone();
                 let fragment = fragment.clone();
                 async move {
-                    let log_reader = this
-                        .make_log_reader(topology_name.as_ref(), collection_id)
-                        .await?;
                     if let Some(cache) = this.cache.as_ref() {
                         let cache_key = cache_key_for_fragment(collection_id, &fragment.path);
                         if let Ok(Some(answer)) = cache.get(&cache_key).await {


### PR DESCRIPTION
## Description of changes

pull_logs was calling make_log_reader() inside the per-fragment async
closure, creating a new LogReader (and fetching the manifest from
storage) for every fragment. With N fragments this caused N redundant
manifest fetches, leading to 30s timeouts on the server.

Hoist the single make_log_reader() call above the fragment loop and
Arc::clone the reader into each closure, matching the pattern already
used by scout_logs and read_fragments_via_log_reader.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
