### PR TITLE
[BUG](wal3): skip setsum computation in log read path

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2069,16 +2069,17 @@ impl LogServer {
                         let cache_key = cache_key_for_fragment(collection_id, &fragment.path);
                         if let Ok(Some(answer)) = cache.get(&cache_key).await {
                             if answer.version == Some(1) {
-                                let (_, records, _, _) = log_reader
-                                    .parse_parquet(&answer.bytes, fragment.start)
+                                let (records, _, _) = log_reader
+                                    .parse_parquet_fast(&answer.bytes, fragment.start)
                                     .await?;
                                 return Ok(records);
                             }
                         }
                         let bytes = log_reader.read_bytes(&fragment).await?;
                         let cache_value = CachedBytes::new((*bytes).clone());
-                        let (_, answer, _, _) =
-                            log_reader.parse_parquet(&bytes, fragment.start).await?;
+                        let (answer, _, _) = log_reader
+                            .parse_parquet_fast(&bytes, fragment.start)
+                            .await?;
                         cache.insert(cache_key, cache_value).await;
                         Ok(answer)
                     } else {

--- a/rust/wal3/src/interfaces/repl/fragment_manager.rs
+++ b/rust/wal3/src/interfaces/repl/fragment_manager.rs
@@ -511,6 +511,16 @@ impl FragmentConsumer for FragmentReader {
         crate::interfaces::s3::parse_parquet(parquet, Some(starting_log_position)).await
     }
 
+    async fn parse_parquet_fast(
+        &self,
+        parquet: &[u8],
+        starting_log_position: LogPosition,
+    ) -> Result<(Vec<(LogPosition, Vec<u8>)>, u64, u64), Error> {
+        // NOTE(rescrv):  ReplciatedFragmentManager deals with relatives; we therefore pass an
+        // offset.
+        crate::interfaces::s3::parse_parquet_fast(parquet, Some(starting_log_position)).await
+    }
+
     async fn read_fragment(
         &self,
         path: &str,

--- a/rust/wal3/src/interfaces/s3/fragment_puller.rs
+++ b/rust/wal3/src/interfaces/s3/fragment_puller.rs
@@ -41,6 +41,16 @@ impl FragmentConsumer for S3FragmentPuller {
         super::parse_parquet(parquet, None).await
     }
 
+    async fn parse_parquet_fast(
+        &self,
+        parquet: &[u8],
+        _starting_log_position: LogPosition,
+    ) -> Result<(Vec<(LogPosition, Vec<u8>)>, u64, u64), Error> {
+        // NOTE(rescrv):  S3FragmentPuller deals with absolutes; we therefore do not pass an
+        // offset.
+        super::parse_parquet_fast(parquet, None).await
+    }
+
     async fn read_fragment(&self, path: &str, _: LogPosition) -> Result<Option<Fragment>, Error> {
         super::read_fragment(&self.storage, &self.prefix, path, None).await
     }

--- a/rust/wal3/src/lib.rs
+++ b/rust/wal3/src/lib.rs
@@ -1007,6 +1007,13 @@ pub trait LogReaderTrait: std::fmt::Debug + Send + Sync + 'static {
         starting_log_position: LogPosition,
     ) -> Result<(Setsum, Vec<(LogPosition, Vec<u8>)>, u64, u64), Error>;
 
+    /// Parse parquet previously returned by read_bytes, skipping setsum computation.
+    async fn parse_parquet_fast(
+        &self,
+        parquet: &[u8],
+        starting_log_position: LogPosition,
+    ) -> Result<(Vec<(LogPosition, Vec<u8>)>, u64, u64), Error>;
+
     /// Scrub the log to verify its integrity.
     async fn scrub(&self, limits: reader::Limits) -> Result<ScrubSuccess, Vec<Error>>;
 }
@@ -1073,6 +1080,14 @@ impl<
         starting_log_position: LogPosition,
     ) -> Result<(Setsum, Vec<(LogPosition, Vec<u8>)>, u64, u64), Error> {
         LogReader::parse_parquet(self, parquet, starting_log_position).await
+    }
+
+    async fn parse_parquet_fast(
+        &self,
+        parquet: &[u8],
+        starting_log_position: LogPosition,
+    ) -> Result<(Vec<(LogPosition, Vec<u8>)>, u64, u64), Error> {
+        LogReader::parse_parquet_fast(self, parquet, starting_log_position).await
     }
 
     async fn scrub(&self, limits: reader::Limits) -> Result<ScrubSuccess, Vec<Error>> {

--- a/rust/wal3/src/reader.rs
+++ b/rust/wal3/src/reader.rs
@@ -341,6 +341,19 @@ impl<P: FragmentPointer, FC: FragmentConsumer, MC: ManifestConsumer<P>> LogReade
             .await
     }
 
+    /// Parse parquet previously returned by read_bytes, skipping setsum computation.
+    #[tracing::instrument(skip(self, parquet))]
+    #[allow(clippy::type_complexity)]
+    pub async fn parse_parquet_fast(
+        &self,
+        parquet: &[u8],
+        starting_log_position: LogPosition,
+    ) -> Result<(Vec<(LogPosition, Vec<u8>)>, u64, u64), Error> {
+        self.fragment_consumer
+            .parse_parquet_fast(parquet, starting_log_position)
+            .await
+    }
+
     #[tracing::instrument(skip(self), ret)]
     pub async fn scrub(&self, limits: Limits) -> Result<ScrubSuccess, Vec<Error>> {
         let Some((manifest, _)) = self

--- a/rust/wal3/src/writer.rs
+++ b/rust/wal3/src/writer.rs
@@ -1381,7 +1381,7 @@ mod tests {
 
         // Read back with checksum_parquet (no starting position)
         let (setsum_from_reader, records, uses_relative_offsets, _) =
-            checksum_parquet(&buffer, Some(LogPosition::from_offset(100)))
+            checksum_parquet(&buffer, true, Some(LogPosition::from_offset(100)))
                 .expect("checksum_parquet should succeed");
 
         println!(
@@ -1418,7 +1418,7 @@ mod tests {
 
         // Read back with checksum_parquet
         let (setsum_from_reader, records, uses_relative_offsets, _) =
-            checksum_parquet(&buffer, None).expect("checksum_parquet should succeed");
+            checksum_parquet(&buffer, true, None).expect("checksum_parquet should succeed");
 
         println!(
             "absolute_offset_setsum_consistency: setsum_from_writer = {}, setsum_from_reader = {}",


### PR DESCRIPTION
## Description of changes

Add parse_parquet_fast to FragmentConsumer trait and its S3 and repl
implementations. This variant skips the per-record setsum insertion in
checksum_parquet by gating it behind a compute_setsum flag, avoiding
unnecessary work when the caller only needs records.

Update log-service to use parse_parquet_fast for fragment reads where
the setsum was already being discarded.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
