### PR TITLE
[ENH] add tracing instrumentation to pull_logs

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2045,8 +2045,10 @@ impl LogServer {
             "Pulling logs",
         );
 
+        let read_fragments_span = tracing::info_span!("read_fragments");
         let fragments = match self
             .read_fragments(topology_name.as_ref(), collection_id, &pull_logs)
+            .instrument(read_fragments_span)
             .await
         {
             Ok(fragments) => fragments,
@@ -2089,10 +2091,14 @@ impl LogServer {
                 }
             })
             .collect::<Vec<_>>();
+        let try_join_all_span = tracing::info_span!("join all");
         let record_batches = futures::future::try_join_all(futures)
+            .instrument(try_join_all_span)
             .await
             .map_err(|err: Error| Status::new(err.code().into(), err.to_string()))?;
         let mut records = Vec::with_capacity(pull_logs.batch_size as usize);
+        let record_batch_iter = tracing::info_span!("record_batch_iter");
+        let _guard = record_batch_iter.enter();
         for record_batch in record_batches.into_iter() {
             for (log_offset, record_bytes) in record_batch.into_iter() {
                 if log_offset.offset() < pull_logs.start_from_offset as u64


### PR DESCRIPTION
## Description of changes

Add info-level tracing spans to key operations in pull_logs for
performance monitoring and debugging:
- read_fragments: tracks fragment reading time
- join all: tracks parallel parquet file fetching
- record_batch_iter: tracks record batch iteration

These spans help identify performance bottlenecks in the log
pulling path.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
