### PR TITLE
[BUG]  Don't drop errors on the floor and silently return.

### DIFF
--- a/rust/storage/src/admissioncontrolleds3.rs
+++ b/rust/storage/src/admissioncontrolleds3.rs
@@ -684,10 +684,13 @@ impl AdmissionControlledS3Storage {
             futures.push(fut);
         }
         // Await all futures and return the result.
-        let _ = stream::iter(futures)
+        let results = stream::iter(futures)
             .buffer_unordered(num_parts)
             .collect::<Vec<_>>()
             .await;
+        for result in results.into_iter() {
+            result?;
+        }
         Ok((Arc::new(output_buffer), e_tag))
     }
 


### PR DESCRIPTION
## Description of changes

Drops errors and returns silently.  Fix that.

## Test plan

CI + CD

## Migration plan

N/A

## Observability plan

Watch latency metrics.

## Documentation Changes

N/A
