### PR TITLE
[ENH](storage): add spawn_fetches config for admission control

### DIFF
--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -164,8 +164,16 @@ pub struct AdmissionControlledS3StorageConfig {
     pub rate_limiting_policy: RateLimitingConfig,
     #[serde(default)]
     pub s3_config: S3StorageConfig,
+    #[serde(default = "AdmissionControlledS3StorageConfig::default_spawn_fetches")]
+    pub spawn_fetches: bool,
     #[serde(default)]
     pub use_object_store_client: bool,
+}
+
+impl AdmissionControlledS3StorageConfig {
+    fn default_spawn_fetches() -> bool {
+        false
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize)]


### PR DESCRIPTION
## Description of changes

Add configurable option to control whether fetch futures in
AdmissionControlledS3Storage are spawned as separate tasks or awaited
directly:
- Add spawn_fetches field to AdmissionControlledS3StorageConfig
- Thread config through constructors and Configurable implementation
- Default to false (await directly) to avoid unbounded task queue growth

When spawn_fetches is true, fetches continue even if the upstream
request is cancelled. When false, fetches may be cancelled if the
caller drops the future.

Also fix clippy warning for unused result in parallel_read.

## Test plan

CI + CD

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
