### PR TITLE
[ENH]: Get database name from get_collections_to_gc mcmr endpoint

### DIFF
--- a/go/pkg/sysdb/coordinator/model/collection.go
+++ b/go/pkg/sysdb/coordinator/model/collection.go
@@ -37,6 +37,7 @@ type CollectionToGc struct {
 	Name            string
 	VersionFilePath string
 	LineageFilePath *string
+	DatabaseName    string
 }
 
 type CreateCollection struct {

--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -62,6 +62,7 @@ func convertCollectionToGcToModel(collectionToGc []*dbmodel.CollectionToGc) []*m
 			VersionFilePath: collectionInfo.VersionFileName,
 			TenantID:        collectionInfo.TenantID,
 			LineageFilePath: collectionInfo.LineageFileName,
+			DatabaseName:    collectionInfo.DatabaseName,
 		}
 		collections = append(collections, &collection)
 	}

--- a/go/pkg/sysdb/grpc/collection_service.go
+++ b/go/pkg/sysdb/grpc/collection_service.go
@@ -720,6 +720,7 @@ func (s *Server) ListCollectionsToGc(ctx context.Context, req *coordinatorpb.Lis
 			VersionFilePath: collectionToGc.VersionFilePath,
 			TenantId:        collectionToGc.TenantID,
 			LineageFilePath: collectionToGc.LineageFilePath,
+			DatabaseName:    &collectionToGc.DatabaseName,
 		})
 	}
 	return res, nil

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -113,7 +113,7 @@ func (s *collectionDb) ListCollectionsToGc(cutoffTimeSecs *uint64, limit *uint64
 	}
 
 	query := s.read_db.Table("collections").
-		Select("collections.id, collections.name, collections.version_file_name, sub.min_oldest_version_ts AS oldest_version_ts, databases.tenant_id, NULLIF(collections.lineage_file_name, '') AS lineage_file_name").
+		Select("collections.id, collections.name, collections.version_file_name, sub.min_oldest_version_ts AS oldest_version_ts, databases.tenant_id, NULLIF(collections.lineage_file_name, '') AS lineage_file_name, databases.name AS database_name").
 		Joins("INNER JOIN databases ON collections.database_id = databases.id").
 		Joins("INNER JOIN (?) AS sub ON collections.id = sub.id", sub)
 

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -38,6 +38,7 @@ type CollectionToGc struct {
 	VersionFileName string    `gorm:"version_file_name"`
 	OldestVersionTs time.Time `gorm:"oldest_version_ts;type:timestamp"`
 	LineageFileName *string   `gorm:"lineage_file_name"`
+	DatabaseName    string    `gorm:"database_name"`
 }
 
 func (v Collection) TableName() string {

--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -517,6 +517,7 @@ message CollectionToGcInfo {
   reserved 4; // used to be "latest_version"
   string tenant_id = 5;
   optional string lineage_file_path = 6;
+  optional string database_name = 7;
 }
 
 message ListCollectionsToGcResponse {

--- a/rust/garbage_collector/src/bin/garbage_collector_tool.rs
+++ b/rust/garbage_collector/src/bin/garbage_collector_tool.rs
@@ -231,9 +231,12 @@ async fn main() {
             }
 
             let collection = collections.pop().unwrap();
+            let database_name = chroma_types::DatabaseName::new(&collection.database)
+                .expect("Collection has invalid database name");
 
             let orchestrator = GarbageCollectorOrchestrator::new(
                 collection_id,
+                database_name,
                 collection.version_file_path.unwrap(),
                 collection.lineage_file_path,
                 version_absolute_cutoff_time,

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -249,6 +249,7 @@ impl GarbageCollector {
         let orchestrator =
             crate::garbage_collector_orchestrator_v2::GarbageCollectorOrchestrator::new(
                 collection.id,
+                collection.database,
                 collection.version_file_path,
                 collection.lineage_file_path,
                 version_absolute_cutoff_time,

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -76,7 +76,7 @@ pub struct GarbageCollectorOrchestrator {
     graph: Option<VersionGraph>,
     soft_deleted_collections_to_gc: HashSet<CollectionUuid>,
     tenant: Option<String>,
-    database_name: Option<String>,
+    database_name: DatabaseName,
 
     num_files_deleted: u32,
     num_versions_deleted: u32,
@@ -88,6 +88,7 @@ pub struct GarbageCollectorOrchestrator {
 impl GarbageCollectorOrchestrator {
     pub fn new(
         collection_id: CollectionUuid,
+        database_name: DatabaseName,
         version_file_path: String,
         lineage_file_path: Option<String>,
         version_absolute_cutoff_time: DateTime<Utc>,
@@ -129,7 +130,7 @@ impl GarbageCollectorOrchestrator {
             graph: None,
             soft_deleted_collections_to_gc: HashSet::new(),
             tenant: None,
-            database_name: None,
+            database_name,
 
             num_files_deleted: 0,
             num_versions_deleted: 0,
@@ -795,8 +796,6 @@ impl GarbageCollectorOrchestrator {
         )?;
         let tenant_id = collection_info.tenant_id.clone();
         self.tenant = Some(tenant_id.clone());
-        let database_name = collection_info.database_name.clone();
-        self.database_name = Some(database_name.clone());
 
         let task = wrap(
             Box::new(DeleteUnusedFilesOperator::new(
@@ -1003,11 +1002,7 @@ impl GarbageCollectorOrchestrator {
                             .ok_or(GarbageCollectorError::InvariantViolation(
                                 "Expected tenant to be set".to_string(),
                             ))?,
-                        self.database_name.clone().ok_or(
-                            GarbageCollectorError::InvariantViolation(
-                                "Expected database to be set".to_string(),
-                            ),
-                        )?,
+                        self.database_name.clone().into_string(),
                         collection_id,
                     )
                     .await?;
@@ -1268,6 +1263,7 @@ mod tests {
         let logs = Log::InMemory(chroma_log::in_memory_log::InMemoryLog::default());
         let orchestrator = GarbageCollectorOrchestrator::new(
             root_collection_id,
+            database.clone(),
             root_collection.version_file_path.unwrap(),
             None,
             now,

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -320,8 +320,11 @@ impl StateMachineTest for GarbageCollectorUnderTest {
                             )
                             .unwrap();
 
+                            let db_name = DatabaseName::new(ref_state.db_name.clone())
+                                .expect("db_name should be valid");
                             let orchestrator = GarbageCollectorOrchestrator::new(
                                 collection_id,
+                                db_name,
                                 collection_to_gc.version_file_path.clone(),
                                 collection_to_gc.lineage_file_path.clone(),
                                 // This proptest does not test the cutoff time as the timestamps created by the SysDb (e.g. collection.created_at and timestamps in version files) cannot currently be faked/overridden.

--- a/rust/rust-sysdb/src/backend.rs
+++ b/rust/rust-sysdb/src/backend.rs
@@ -71,7 +71,8 @@ use crate::types::{
     CreateTenantResponse, FlushCompactionRequest, FlushCompactionResponse,
     GetCollectionWithSegmentsRequest, GetCollectionWithSegmentsResponse, GetCollectionsRequest,
     GetCollectionsResponse, GetDatabaseRequest, GetDatabaseResponse, GetTenantsRequest,
-    GetTenantsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
+    GetTenantsResponse, ListCollectionsToGcRequest, ListCollectionsToGcResponse,
+    UpdateCollectionRequest, UpdateCollectionResponse,
 };
 use chroma_config::{registry::Registry, Configurable};
 use chroma_error::ChromaError;
@@ -358,6 +359,16 @@ impl Backend {
     ) -> Result<FlushCompactionResponse, SysDbError> {
         match self {
             Backend::Spanner(s) => s.flush_collection_compaction(req).await,
+        }
+    }
+
+    /// List collections that need garbage collection.
+    pub async fn list_collections_to_gc(
+        &self,
+        req: ListCollectionsToGcRequest,
+    ) -> Result<ListCollectionsToGcResponse, SysDbError> {
+        match self {
+            Backend::Spanner(s) => s.list_collections_to_gc(req).await,
         }
     }
 

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -848,6 +848,7 @@ impl Configurable<(GrpcSysDbConfig, Option<GrpcSysDbConfig>)> for GrpcSysDb {
 pub struct CollectionToGcInfo {
     pub id: CollectionUuid,
     pub tenant: String,
+    pub database: DatabaseName,
     pub name: String,
     pub version_file_path: String,
     pub lineage_file_path: Option<String>,
@@ -885,9 +886,16 @@ impl TryFrom<chroma_proto::CollectionToGcInfo> for CollectionToGcInfo {
             Err(e) => return Err(GetCollectionsToGcError::ParsingError(e)),
         };
         let collection_id = CollectionUuid(collection_uuid);
+        let database = value
+            .database_name
+            .and_then(|name| DatabaseName::new(&name))
+            .ok_or_else(|| {
+                GetCollectionsToGcError::Internal(Box::new(TonicMissingFieldError("database name")))
+            })?;
         Ok(CollectionToGcInfo {
             id: collection_id,
             tenant: value.tenant_id,
+            database,
             name: value.name,
             version_file_path: value.version_file_path,
             lineage_file_path: value.lineage_file_path,
@@ -1615,25 +1623,54 @@ impl GrpcSysDb {
         tenant: Option<String>,
         min_versions_if_alive: Option<u64>,
     ) -> Result<Vec<CollectionToGcInfo>, GetCollectionsToGcError> {
+        let req = chroma_proto::ListCollectionsToGcRequest {
+            cutoff_time: cutoff_time.map(|t| t.into()),
+            limit,
+            tenant_id: tenant,
+            min_versions_if_alive,
+        };
+
         let res = self
             .client
-            .list_collections_to_gc(chroma_proto::ListCollectionsToGcRequest {
-                cutoff_time: cutoff_time.map(|t| t.into()),
-                limit,
-                tenant_id: tenant,
-                min_versions_if_alive,
-            })
-            .await;
+            .list_collections_to_gc(req.clone())
+            .await
+            .map_err(GetCollectionsToGcError::RequestFailed)?;
 
-        match res {
-            Ok(collections) => collections
-                .into_inner()
-                .collections
-                .into_iter()
-                .map(|collection| collection.try_into())
-                .collect::<Result<Vec<CollectionToGcInfo>, GetCollectionsToGcError>>(),
-            Err(e) => Err(GetCollectionsToGcError::RequestFailed(e)),
+        let mut collections: Vec<CollectionToGcInfo> = res
+            .into_inner()
+            .collections
+            .into_iter()
+            .map(|c| c.try_into())
+            .collect::<Result<Vec<CollectionToGcInfo>, GetCollectionsToGcError>>()?;
+
+        // NOTE(tanujnay112): We actually end up returning <= limit * |topologies| collections.
+        if let Some(mcmr_client) = self._mcmr_client.as_mut() {
+            match mcmr_client.list_collections_to_gc(req).await {
+                Ok(mcmr_res) => {
+                    let mcmr_collections: Vec<CollectionToGcInfo> = mcmr_res
+                        .into_inner()
+                        .collections
+                        .into_iter()
+                        .filter_map(|c| c.try_into().ok())
+                        .collect();
+                    let len = mcmr_collections.len();
+                    collections.extend(mcmr_collections);
+                    tracing::debug!(
+                        "Successfully retrieved {} collections from mcmr_client",
+                        len
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = ?e,
+                        "Failed to get collections from mcmr_client - collections from mcmr sysdb will be missing from GC list"
+                    );
+                    // Intentionally continue
+                }
+            }
         }
+
+        Ok(collections)
     }
 
     pub async fn get_collection_to_gc(
@@ -1667,9 +1704,16 @@ impl GrpcSysDb {
 
         let collection = collections.remove(0);
 
+        let database_name = DatabaseName::new(&collection.database).ok_or_else(|| {
+            GetCollectionsToGcError::Internal(Box::new(chroma_error::TonicMissingFieldError(
+                "database_name",
+            )))
+        })?;
+
         Ok(CollectionToGcInfo {
             id: collection.collection_id,
             tenant: collection.tenant,
+            database: database_name,
             name: collection.name,
             version_file_path: collection.version_file_path.unwrap_or_default(),
             lineage_file_path: collection.lineage_file_path,


### PR DESCRIPTION
## Description of changes

This change adds the get_collections_to_gc endpoint to spanner and has the garbage collector retrieve collections and database names from this endpoint. It edits the Go sysdb ListCollectionsToGC endpoint to also return a database name with each endpoint. This database name is saved in a GarbageCollectionOrchestrator's state. This is a breaking change on the Go sysdb protos but it is not a big deal as garbage collection might just error while this change is being deployed.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_