### PR TITLE
Remove beta label from Advanced Search API

### DIFF
--- a/docs/docs.trychroma.com/markdoc/content/cloud/getting-started.md
+++ b/docs/docs.trychroma.com/markdoc/content/cloud/getting-started.md
@@ -25,7 +25,7 @@ Chroma Cloud is SOC 2 Type I certified (Type II in progress), and offers deploym
 
 Our web dashboard lets your team work together to view your data, and ensure data quality in your collections with ease. It also serves as a touchpoint for you to view billing data and usage telemetry.
 
-### Advanced Search API (Beta)
+### Advanced Search API
 
 Chroma Cloud introduces a powerful [Search API](/cloud/search-api/overview) that enables hybrid search with advanced filtering, custom ranking expressions, and batch operations. Combine vector similarity with metadata filtering using an intuitive builder pattern or flexible dictionary syntax.
 

--- a/docs/docs.trychroma.com/public/llms-cloud-getting-started.txt
+++ b/docs/docs.trychroma.com/public/llms-cloud-getting-started.txt
@@ -25,7 +25,7 @@ Chroma Cloud is SOC 2 Type I certified (Type II in progress), and offers deploym
 
 Our web dashboard lets your team work together to view your data, and ensure data quality in your collections with ease. It also serves as a touchpoint for you to view billing data and usage telemetry.
 
-### Advanced Search API (Beta)
+### Advanced Search API
 
 Chroma Cloud introduces a powerful [Search API](/cloud/search-api/overview) that enables hybrid search with advanced filtering, custom ranking expressions, and batch operations. Combine vector similarity with metadata filtering using an intuitive builder pattern or flexible dictionary syntax.
 

--- a/docs/docs.trychroma.com/public/llms-full.txt
+++ b/docs/docs.trychroma.com/public/llms-full.txt
@@ -114,7 +114,7 @@ Chroma Cloud is SOC 2 Type I certified (Type II in progress), and offers deploym
 
 Our web dashboard lets your team work together to view your data, and ensure data quality in your collections with ease. It also serves as a touchpoint for you to view billing data and usage telemetry.
 
-### Advanced Search API (Beta)
+### Advanced Search API
 
 Chroma Cloud introduces a powerful [Search API](/cloud/search-api/overview) that enables hybrid search with advanced filtering, custom ranking expressions, and batch operations. Combine vector similarity with metadata filtering using an intuitive builder pattern or flexible dictionary syntax.
 

--- a/docs/mintlify/cloud/getting-started.mdx
+++ b/docs/mintlify/cloud/getting-started.mdx
@@ -23,7 +23,7 @@ Chroma Cloud is SOC 2 Type II certified, and offers deployment flexibility to ma
 
 Our web dashboard lets your team work together to view your data, and ensure data quality in your collections with ease. It also serves as a touchpoint for you to view billing data and usage telemetry.
 
-### Advanced Search API (Beta)
+### Advanced Search API
 
 Chroma Cloud introduces a powerful [Search API](/cloud/search-api/overview) that enables hybrid search with advanced filtering, custom ranking expressions, and batch operations. Combine vector similarity with metadata filtering using an intuitive builder pattern or flexible dictionary syntax.
 


### PR DESCRIPTION
The Advanced Search API is no longer in beta.

Slack thread: https://trychroma.slack.com/archives/C094URPR1E1/p1770705878908469?thread_ts=1770704741.803739&cid=C094URPR1E1

https://claude.ai/code/session_01Vx7tuNocjLqZzFfLsu5MWt

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
