### PR TITLE
[ENH] reject fork_collection for multi-region databases

### DIFF
--- a/rust/frontend/src/server.rs
+++ b/rust/frontend/src/server.rs
@@ -3432,9 +3432,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_ne!(
+        assert_eq!(
             res.status(),
-            200,
+            reqwest::StatusCode::BAD_REQUEST,
             "multi-region database fork should be rejected"
         );
         let response_json = res.json::<serde_json::Value>().await.unwrap();


### PR DESCRIPTION
## Description of changes

Multi-region databases (those with a topology prefix in their name) do
not support collection forking. Add a validation check early in the
fork_collection handler to return an InvalidArgumentError before
proceeding with the operation.

Include a test that exercises the rejection path by sending a fork
request with a topology-prefixed database name.

## Test plan

Locally the new test passes; CI for the rest.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
