### PR TITLE
Add Azure OpenAI validation tests

### DIFF
--- a/chromadb/test/ef/test_openai_ef.py
+++ b/chromadb/test/ef/test_openai_ef.py
@@ -5,6 +5,7 @@ import pytest
 from chromadb.utils.embedding_functions.openai_embedding_function import (
     OpenAIEmbeddingFunction,
 )
+from chromadb.errors import InvalidArgumentError
 
 
 def test_with_embedding_dimensions() -> None:
@@ -36,3 +37,42 @@ def test_with_incorrect_api_key() -> None:
     ef = OpenAIEmbeddingFunction(api_key="incorrect_api_key", dimensions=64)
     with pytest.raises(Exception, match="Incorrect API key provided"):
         ef(["hello world"])
+
+
+def test_azure_requires_deployment_id() -> None:
+    """Azure OpenAI should require deployment_id parameter."""
+    pytest.importorskip("openai", reason="openai not installed")
+    with pytest.raises(InvalidArgumentError, match="deployment_id must be specified"):
+        OpenAIEmbeddingFunction(
+            api_key="test_key",
+            api_type="azure",
+            api_base="https://example.openai.azure.com",
+            api_version="2023-05-15",
+            # Missing deployment_id should raise
+        )
+
+
+def test_azure_requires_api_version() -> None:
+    """Azure OpenAI should require api_version parameter."""
+    pytest.importorskip("openai", reason="openai not installed")
+    with pytest.raises(InvalidArgumentError, match="api_version must be specified"):
+        OpenAIEmbeddingFunction(
+            api_key="test_key",
+            api_type="azure",
+            api_base="https://example.openai.azure.com",
+            deployment_id="my-deployment",
+            # Missing api_version should raise
+        )
+
+
+def test_azure_requires_api_base() -> None:
+    """Azure OpenAI should require api_base parameter."""
+    pytest.importorskip("openai", reason="openai not installed")
+    with pytest.raises(InvalidArgumentError, match="api_base must be specified"):
+        OpenAIEmbeddingFunction(
+            api_key="test_key",
+            api_type="azure",
+            api_version="2023-05-15",
+            deployment_id="my-deployment",
+            # Missing api_base should raise
+        )


### PR DESCRIPTION
Problem and motivation: Azure OpenAI requires api_version, deployment_id, and api_base. Missing values fail at runtime, so these tests lock in that validation. Context: chroma-core/chroma#1770.

Summary of changes:
- add tests for missing deployment_id, api_version, and api_base
- assert InvalidArgumentError is raised when required values are absent

Testing:
```bash
python -m pytest chromadb/test/ef/test_openai_ef.py -v
```

Impact and risks: no backward compatibility changes, only adds tests. Docs or comments: not needed. CI: not run locally. Reviewer focus: test expectations and error messages.
