### PR TITLE
[DOC] fix TS run chroma command

### DIFF
--- a/docs/mintlify/docs/overview/getting-started.mdx
+++ b/docs/mintlify/docs/overview/getting-started.mdx
@@ -282,13 +282,24 @@ summary.
   <Step title="Create a Chroma Client">
     Run the Chroma backend:
 
-    ```bash Terminal CLI
-    chroma run --path ./getting-started
+    <CodeGroup>
+    ```bash npm
+    npx chroma run --path ./getting-started
     ```
-    ```bash Terminal Docker
+    ```bash pnpm
+    pnpm exec chroma run --path ./getting-started
+    ```
+    ```bash bun
+    bunx chroma run --path ./getting-started
+    ```
+    ```bash yarn
+    yarn chroma run --path ./getting-started
+    ```
+    ```bash docker
     docker pull chromadb/chroma
     docker run -p 8000:8000 chromadb/chroma
     ```
+    </CodeGroup>
 
     Then create a client which connects to it:
 


### PR DESCRIPTION
![Screenshot 2026-02-11 at 12.32.18 PM.png](https://app.graphite.com/user-attachments/assets/12e8209b-9ba9-4a7c-bce3-4405da46204e.png)

Users are confused when they try to run only `chroma run` after installing. This command does not work because the chroma command was not added to the PATH. Without installing locally, you need to use `npx`, `pnpm exec`, etc.