### PR TITLE
[CHORE]  Make rust-sysdb-migration a dep of log-service in mcmr world.

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,7 @@
 update_settings(max_parallel_updates=6)
 
 # *:ci images are defined in .github/actions/tilt/docker-bake.hcl and used for .github/actions/tilt/action.yaml.
+multi_region_enabled = os.environ.get('MULTI_REGION') == 'true'
 
 if config.tilt_subcommand == "ci":
   custom_build(
@@ -330,7 +331,7 @@ k8s_resource(
 k8s_resource('postgres:deployment:chroma', resource_deps=['k8s_setup'], labels=["infrastructure"], port_forwards='5432:5432')
 # Jobs are suffixed with the image tag to ensure they are unique. In this context, the image tag is defined in k8s/distributed-chroma/values.yaml.
 k8s_resource('sysdb-migration-latest:job:chroma', resource_deps=['postgres:deployment:chroma'], labels=["infrastructure"])
-k8s_resource('rust-log-service:statefulset:chroma', labels=["chroma"], port_forwards=['50054:50051', '50052:50052'], resource_deps=['minio-deployment'])
+k8s_resource('rust-log-service:statefulset:chroma', labels=["chroma"], port_forwards=['50054:50051', '50052:50052'], resource_deps=['minio-deployment'] + (['rust-sysdb-migration-latest'] if multi_region_enabled else []))
 k8s_resource('sysdb:deployment:chroma', resource_deps=['sysdb-migration-latest:job:chroma'], labels=["chroma"], port_forwards='50051:50051')
 k8s_resource('rust-sysdb-service:deployment:chroma', resource_deps = ['k8s_setup', 'spanner-deployment', 'rust-sysdb-migration-latest'], labels = ["chroma"], port_forwards = '50056:50051')
 k8s_resource('rust-frontend-service:deployment:chroma', resource_deps=['sysdb:deployment:chroma', 'rust-log-service:statefulset:chroma'], labels=["chroma"], port_forwards='8000:8000')
@@ -343,7 +344,7 @@ k8s_resource('load-service', resource_deps=['k8s_setup'], labels=["infrastructur
 k8s_resource('postgres:deployment:chroma2', resource_deps=['k8s_setup2'], labels=["infrastructure2"], port_forwards='6432:5432')
 # Jobs are suffixed with the image tag to ensure they are unique. In this context, the image tag is defined in k8s/distributed-chroma/values.yaml.
 k8s_resource('sysdb-migration-latest:job:chroma2', resource_deps=['postgres:deployment:chroma2'], labels=["infrastructure2"])
-k8s_resource('rust-log-service:statefulset:chroma2', labels=["chroma2"], port_forwards=['60054:50051', '60052:50052'], resource_deps=['minio-deployment'])
+k8s_resource('rust-log-service:statefulset:chroma2', labels=["chroma2"], port_forwards=['60054:50051', '60052:50052'], resource_deps=['minio-deployment'] + (['rust-sysdb-migration-latest'] if multi_region_enabled else []))
 k8s_resource('rust-sysdb-migration-latest', resource_deps=['spanner-deployment'], labels=["infrastructure2"])
 k8s_resource('sysdb:deployment:chroma2', resource_deps=['sysdb-migration-latest:job:chroma2'], labels=["chroma2"], port_forwards='60051:50051')
 k8s_resource('rust-sysdb-service:deployment:chroma2', resource_deps=['k8s_setup2', 'spanner-deployment', 'rust-sysdb-migration-latest'], labels=["chroma2"], port_forwards='60056:50051')


### PR DESCRIPTION
## Description of changes

If MULTI_REGION=true is set, the rust-sysdb-migration (and spanner too)
can fail to come up before the log service.  Fix that by conditionally
adding the migration to the resources required by the log service.

## Test plan

CI + local tilt up

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
