### PR TITLE
[DNC]  On failure of tilt, use tilt dump engine.

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -7,7 +7,7 @@ runs:
       uses: ./.github/actions/tilt-setup-prebuild
     - name: Start Tilt
       shell: bash
-      run: tilt ci
+      run: tilt ci || tilt dump engine
     - name: Forward ports
       shell: bash
       run: |


### PR DESCRIPTION
## Description of changes

`tilt dump engine` should give us the ability to inspect a failed `tilt ci`.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Watch CI

## Documentation Changes

N/A
