### PR TITLE
[ENH]: batch_get_collection_version_file_paths for MCMR

### DIFF
--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -544,6 +544,7 @@ message DeleteCollectionVersionResponse {
 
 message BatchGetCollectionVersionFilePathsRequest {
   repeated string collection_ids = 1;
+  optional string database_name = 2;
 }
 
 message BatchGetCollectionVersionFilePathsResponse {

--- a/rust/garbage_collector/src/operators/get_version_file_paths.rs
+++ b/rust/garbage_collector/src/operators/get_version_file_paths.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use chroma_error::ChromaError;
 use chroma_sysdb::SysDb;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::{BatchGetCollectionVersionFilePathsError, CollectionUuid};
+use chroma_types::{BatchGetCollectionVersionFilePathsError, CollectionUuid, DatabaseName};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -10,13 +10,19 @@ use thiserror::Error;
 pub struct GetVersionFilePathsInput {
     collection_ids: Vec<CollectionUuid>,
     sysdb: SysDb,
+    database_name: DatabaseName,
 }
 
 impl GetVersionFilePathsInput {
-    pub fn new(collection_ids: Vec<CollectionUuid>, sysdb: SysDb) -> Self {
+    pub fn new(
+        collection_ids: Vec<CollectionUuid>,
+        sysdb: SysDb,
+        database_name: DatabaseName,
+    ) -> Self {
         Self {
             collection_ids,
             sysdb,
+            database_name,
         }
     }
 }
@@ -62,7 +68,10 @@ impl Operator<GetVersionFilePathsInput, GetVersionFilePathsOutput> for GetVersio
         let paths = input
             .sysdb
             .clone()
-            .batch_get_collection_version_file_paths(input.collection_ids.clone())
+            .batch_get_collection_version_file_paths(
+                input.collection_ids.clone(),
+                Some(input.database_name.clone()),
+            )
             .await?;
 
         Ok(GetVersionFilePathsOutput(paths))

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -567,10 +567,11 @@ impl SysDb {
     pub async fn batch_get_collection_version_file_paths(
         &mut self,
         collection_ids: Vec<CollectionUuid>,
+        database_name: Option<DatabaseName>,
     ) -> Result<HashMap<CollectionUuid, String>, BatchGetCollectionVersionFilePathsError> {
         match self {
             SysDb::Grpc(grpc) => {
-                grpc.batch_get_collection_version_file_paths(collection_ids)
+                grpc.batch_get_collection_version_file_paths(collection_ids, database_name)
                     .await
             }
             SysDb::Sqlite(_) => todo!(),
@@ -1825,15 +1826,20 @@ impl GrpcSysDb {
     async fn batch_get_collection_version_file_paths(
         &mut self,
         collection_ids: Vec<CollectionUuid>,
+        database_name: Option<DatabaseName>,
     ) -> Result<HashMap<CollectionUuid, String>, BatchGetCollectionVersionFilePathsError> {
-        let res = self
-            .client
+        let mut client = match &database_name {
+            Some(db_name) => self.client(db_name)?,
+            None => self.client.clone(),
+        };
+        let res = client
             .batch_get_collection_version_file_paths(
                 chroma_proto::BatchGetCollectionVersionFilePathsRequest {
                     collection_ids: collection_ids
                         .into_iter()
                         .map(|id| id.0.to_string())
                         .collect(),
+                    database_name: database_name.map(|d| d.into_string()),
                 },
             )
             .await?;

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -127,6 +127,8 @@ pub enum BatchGetCollectionVersionFilePathsError {
     Grpc(#[from] Status),
     #[error("Could not parse UUID from string {1}: {0}")]
     Uuid(uuid::Error, String),
+    #[error("Client resolution error: {0}")]
+    ClientResolution(#[from] ClientResolutionError),
 }
 
 impl ChromaError for BatchGetCollectionVersionFilePathsError {
@@ -134,6 +136,7 @@ impl ChromaError for BatchGetCollectionVersionFilePathsError {
         match self {
             BatchGetCollectionVersionFilePathsError::Grpc(status) => status.code().into(),
             BatchGetCollectionVersionFilePathsError::Uuid(_, _) => ErrorCodes::InvalidArgument,
+            BatchGetCollectionVersionFilePathsError::ClientResolution(e) => e.code(),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

This change adds the `batch_get_collection_version_file_paths` endpoint in rust sysdb for garbage collection.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_