### PR TITLE
[ENH]: Fix log gc db name threading

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -266,6 +266,9 @@ impl GarbageCollectorOrchestrator {
             .get_collections(GetCollectionsOptions {
                 collection_ids: Some(soft_deleted_collections_to_gc),
                 include_soft_deleted: true,
+                database_or_topology: Some(DatabaseOrTopology::Database(
+                    self.database_name.clone(),
+                )),
                 ..Default::default()
             })
             .await
@@ -316,37 +319,6 @@ impl GarbageCollectorOrchestrator {
         self.version_files = output.version_files;
         self.graph = Some(output.graph.clone());
 
-        let collection_ids = self.version_files.keys().cloned().collect::<Vec<_>>();
-        let collections = self
-            .sysdb_client
-            .get_collections(GetCollectionsOptions {
-                collection_ids: Some(collection_ids),
-                include_soft_deleted: true,
-                database_or_topology: Some(DatabaseOrTopology::Database(
-                    self.database_name.clone(),
-                )),
-                ..Default::default()
-            })
-            .await
-            .map_err(|e| GarbageCollectorError::SysDbMethodFailed(e.to_string()))?;
-
-        // TODO: This doesn't make sense, it'll all be the same databasename
-        let mut database_names = HashMap::new();
-        for collection in collections {
-            match DatabaseName::new(collection.database.clone()) {
-                Some(database_name) => {
-                    database_names.insert(collection.collection_id, database_name);
-                }
-                None => {
-                    tracing::error!(
-                        "Collection {} has invalid database name '{}', skipping GC",
-                        collection.collection_id,
-                        collection.database
-                    );
-                }
-            }
-        }
-
         let task = wrap(
             Box::new(ComputeVersionsToDeleteOperator {}),
             ComputeVersionsToDeleteInput {
@@ -354,7 +326,6 @@ impl GarbageCollectorOrchestrator {
                 soft_deleted_collections: self.soft_deleted_collections_to_gc.clone(),
                 cutoff_time: self.version_absolute_cutoff_time,
                 min_versions_to_keep: self.min_versions_to_keep,
-                database_names,
             },
             ctx.receiver(),
             self.context.task_cancellation_token.clone(),
@@ -390,7 +361,7 @@ impl GarbageCollectorOrchestrator {
         let versions_to_mark = output
             .versions
             .iter()
-            .map(|(collection_id, (_database_name, versions))| {
+            .map(|(collection_id, versions)| {
                 let version_file = self
                     .version_files
                     .get(collection_id)
@@ -434,7 +405,7 @@ impl GarbageCollectorOrchestrator {
         let version_files = self.version_files.clone();
 
         let mut stream = futures::stream::iter(output.versions.into_iter().flat_map(
-            |(collection_id, (_database_name, versions))| {
+            |(collection_id, versions)| {
                 versions
                     .keys()
                     .map(|version| (collection_id, *version))
@@ -507,7 +478,7 @@ impl GarbageCollectorOrchestrator {
             ),
         )?;
 
-        for (collection_id, (database_name, versions)) in &versions_to_delete.versions {
+        for (collection_id, versions) in &versions_to_delete.versions {
             let Some(&min_version_to_keep) = versions
                 .iter()
                 .filter_map(|(version, action)| {
@@ -552,10 +523,7 @@ impl GarbageCollectorOrchestrator {
             collections_to_garbage_collect.insert(
                 *collection_id,
                 // The minimum offset to keep is one after the minimum compaction offset
-                (
-                    database_name.clone(),
-                    LogPosition::from_offset(min_compaction_log_offset) + 1u64,
-                ),
+                LogPosition::from_offset(min_compaction_log_offset) + 1u64,
             );
         }
 
@@ -571,6 +539,7 @@ impl GarbageCollectorOrchestrator {
             DeleteUnusedLogsInput {
                 collections_to_destroy,
                 collections_to_garbage_collect,
+                database_name: Some(self.database_name.clone()),
             },
             ctx.receiver(),
             self.context.task_cancellation_token.clone(),
@@ -604,7 +573,6 @@ impl GarbageCollectorOrchestrator {
                 "Expected versions_to_delete_output to contain collection {}",
                 output.collection_id
             )))?
-            .1
             .get(&output.version)
             .ok_or(GarbageCollectorError::InvariantViolation(format!(
                 "Expected versions_to_delete_output to contain version {} for collection {}",
@@ -857,7 +825,7 @@ impl GarbageCollectorOrchestrator {
         let versions_to_delete = versions_to_delete
             .versions
             .iter()
-            .filter_map(|(collection_id, (_database_name, versions))| {
+            .filter_map(|(collection_id, versions)| {
                 let versions = versions
                     .iter()
                     .filter_map(|(version, action)| {

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -10,7 +10,7 @@ use chroma_system::{
     wrap, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
     OrchestratorContext, TaskResult,
 };
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionUuid, DatabaseName};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::oneshot::Sender;
 use tracing::{Level, Span};
@@ -22,6 +22,7 @@ pub struct HardDeleteLogOnlyGarbageCollectorOrchestrator {
     logs: Log,
     result_channel: Option<Sender<Result<GarbageCollectorResponse, GarbageCollectorError>>>,
     collection_to_destroy: CollectionUuid,
+    database_name: Option<DatabaseName>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -31,6 +32,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
         storage: Storage,
         logs: Log,
         collection_to_destroy: CollectionUuid,
+        database_name: Option<DatabaseName>,
     ) -> Self {
         Self {
             context: OrchestratorContext::new(dispatcher),
@@ -38,6 +40,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
             logs,
             result_channel: None,
             collection_to_destroy,
+            database_name,
         }
     }
 }
@@ -100,6 +103,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
             DeleteUnusedLogsInput {
                 collections_to_destroy,
                 collections_to_garbage_collect,
+                database_name: self.database_name.clone(),
             },
             ctx.receiver(),
             self.context.task_cancellation_token.clone(),
@@ -199,6 +203,7 @@ mod tests {
             storage.clone(),
             logs.clone(),
             collection_to_destroy,
+            None,
         );
 
         // Verify the orchestrator is properly initialized
@@ -241,6 +246,7 @@ mod tests {
             storage.clone(),
             logs.clone(),
             collection_to_destroy,
+            None,
         );
 
         // Verify the orchestrator stores correct collection UUID for destruction

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -2,7 +2,7 @@ use crate::types::{VersionGraph, VersionStatus};
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_system::{Operator, OperatorType};
-use chroma_types::{CollectionUuid, DatabaseName};
+use chroma_types::CollectionUuid;
 use chrono::{DateTime, Utc};
 use petgraph::visit::Topo;
 use std::collections::{HashMap, HashSet};
@@ -17,7 +17,6 @@ pub struct ComputeVersionsToDeleteInput {
     pub soft_deleted_collections: HashSet<CollectionUuid>,
     pub cutoff_time: DateTime<Utc>,
     pub min_versions_to_keep: u32,
-    pub database_names: HashMap<CollectionUuid, DatabaseName>,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -28,7 +27,7 @@ pub enum CollectionVersionAction {
 
 #[derive(Debug, Clone)]
 pub struct ComputeVersionsToDeleteOutput {
-    pub versions: HashMap<CollectionUuid, (DatabaseName, HashMap<i64, CollectionVersionAction>)>,
+    pub versions: HashMap<CollectionUuid, HashMap<i64, CollectionVersionAction>>,
 }
 
 #[derive(Error, Debug)]
@@ -121,8 +120,7 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
         Ok(ComputeVersionsToDeleteOutput {
             versions: versions_by_collection
                 .into_iter()
-                .filter_map(|(collection_id, versions)| {
-                    let database_name = input.database_names.get(&collection_id)?.clone();
+                .map(|(collection_id, versions)| {
                     let versions: HashMap<_, _> = versions
                         .into_iter()
                         .map(|(version, _, mode)| (version, mode))
@@ -148,7 +146,7 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
                         );
                     }
 
-                    Some((collection_id, (database_name, versions)))
+                    (collection_id, versions)
                 })
                 .collect(),
         })
@@ -208,16 +206,11 @@ mod tests {
         graph.add_edge(v2, v3, ());
         graph.add_edge(v3, v4, ());
 
-        let database_name = DatabaseName::new("test_db").unwrap();
-        let mut database_names = HashMap::new();
-        database_names.insert(collection_id, database_name);
-
         let input = ComputeVersionsToDeleteInput {
             graph,
             cutoff_time: now - Duration::hours(6),
             min_versions_to_keep: 1,
             soft_deleted_collections: HashSet::new(),
-            database_names,
         };
 
         let mut result = ComputeVersionsToDeleteOperator {}
@@ -227,7 +220,7 @@ mod tests {
 
         // v0 is always kept, and the most recent version (v4) is kept. v3 is not eligible for deletion because it is after the cutoff time. So v1 and v2 are marked for deletion.
         assert_eq!(result.versions.len(), 1);
-        let (_database_name, versions) = result.versions.remove(&collection_id).unwrap();
+        let versions = result.versions.remove(&collection_id).unwrap();
         let mut versions = versions.into_iter().collect::<Vec<_>>();
         versions.sort_by_key(|(version, _)| *version);
         assert_eq!(
@@ -326,17 +319,11 @@ mod tests {
         // C was forked from B
         graph.add_edge(b_v2, c_v0, ());
 
-        let mut database_names = HashMap::new();
-        database_names.insert(a_collection_id, DatabaseName::new("test_db").unwrap());
-        database_names.insert(b_collection_id, DatabaseName::new("test_db").unwrap());
-        database_names.insert(c_collection_id, DatabaseName::new("test_db").unwrap());
-
         let input = ComputeVersionsToDeleteInput {
             graph,
             cutoff_time: now - Duration::hours(6),
             min_versions_to_keep: 1,
             soft_deleted_collections: HashSet::new(),
-            database_names,
         };
 
         let mut result = ComputeVersionsToDeleteOperator {}
@@ -345,7 +332,7 @@ mod tests {
             .unwrap();
 
         // For collection A: v0 is always kept, and the most recent version (v4) is kept. v3 is not eligible for deletion because it is after the cutoff time. So v1 and v2 are marked for deletion.
-        let (_database_name, a_versions) = result.versions.remove(&a_collection_id).unwrap();
+        let a_versions = result.versions.remove(&a_collection_id).unwrap();
         let mut a_versions = a_versions.into_iter().collect::<Vec<_>>();
         a_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(
@@ -360,7 +347,7 @@ mod tests {
         );
 
         // For collection B: v0 is always kept, and the most recent version (v2) is kept. So v1 is marked for deletion.
-        let (_database_name, b_versions) = result.versions.remove(&b_collection_id).unwrap();
+        let b_versions = result.versions.remove(&b_collection_id).unwrap();
         let mut b_versions = b_versions.into_iter().collect::<Vec<_>>();
         b_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(
@@ -373,7 +360,7 @@ mod tests {
         );
 
         // For collection C: v0 is always kept.
-        let (_database_name, c_versions) = result.versions.remove(&c_collection_id).unwrap();
+        let c_versions = result.versions.remove(&c_collection_id).unwrap();
         let mut c_versions = c_versions.into_iter().collect::<Vec<_>>();
         c_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(c_versions, vec![(0, CollectionVersionAction::Keep)]);
@@ -463,17 +450,11 @@ mod tests {
         // C was forked from B
         graph.add_edge(b_v2, c_v0, ());
 
-        let mut database_names = HashMap::new();
-        database_names.insert(a_collection_id, DatabaseName::new("test_db").unwrap());
-        database_names.insert(b_collection_id, DatabaseName::new("test_db").unwrap());
-        database_names.insert(c_collection_id, DatabaseName::new("test_db").unwrap());
-
         let input = ComputeVersionsToDeleteInput {
             graph,
             cutoff_time: now - Duration::hours(6),
             min_versions_to_keep: 1,
             soft_deleted_collections: HashSet::from([b_collection_id]), // B was soft deleted
-            database_names,
         };
 
         let mut result = ComputeVersionsToDeleteOperator {}
@@ -482,7 +463,7 @@ mod tests {
             .unwrap();
 
         // For collection A: v0 is always kept, and the most recent version (v4) is kept. v3 is not eligible for deletion because it is after the cutoff time. So v1 and v2 are marked for deletion.
-        let (_database_name, a_versions) = result.versions.remove(&a_collection_id).unwrap();
+        let a_versions = result.versions.remove(&a_collection_id).unwrap();
         let mut a_versions = a_versions.into_iter().collect::<Vec<_>>();
         a_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(
@@ -497,7 +478,7 @@ mod tests {
         );
 
         // Collection B was soft deleted, so all versions are marked for deletion.
-        let (_database_name, b_versions) = result.versions.remove(&b_collection_id).unwrap();
+        let b_versions = result.versions.remove(&b_collection_id).unwrap();
         let mut b_versions = b_versions.into_iter().collect::<Vec<_>>();
         b_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(
@@ -510,223 +491,9 @@ mod tests {
         );
 
         // For collection C: v0 is always kept.
-        let (_database_name, c_versions) = result.versions.remove(&c_collection_id).unwrap();
+        let c_versions = result.versions.remove(&c_collection_id).unwrap();
         let mut c_versions = c_versions.into_iter().collect::<Vec<_>>();
         c_versions.sort_by_key(|(version, _)| *version);
         assert_eq!(c_versions, vec![(0, CollectionVersionAction::Keep)]);
-    }
-
-    /// Collections missing from database_names are filtered out of the output entirely.
-    #[tokio::test]
-    #[traced_test]
-    async fn collection_missing_from_database_names_is_filtered_out() {
-        let now = Utc::now();
-
-        let collection_with_db = CollectionUuid::new();
-        let collection_without_db = CollectionUuid::new();
-
-        let mut graph = VersionGraph::new();
-        let v0_with = graph.add_node(VersionGraphNode {
-            collection_id: collection_with_db,
-            version: 0,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(48)),
-            },
-        });
-        let v1_with = graph.add_node(VersionGraphNode {
-            collection_id: collection_with_db,
-            version: 1,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(24)),
-            },
-        });
-        graph.add_edge(v0_with, v1_with, ());
-
-        let v0_without = graph.add_node(VersionGraphNode {
-            collection_id: collection_without_db,
-            version: 0,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(48)),
-            },
-        });
-        let v1_without = graph.add_node(VersionGraphNode {
-            collection_id: collection_without_db,
-            version: 1,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(24)),
-            },
-        });
-        graph.add_edge(v0_without, v1_without, ());
-
-        let mut database_names = HashMap::new();
-        database_names.insert(collection_with_db, DatabaseName::new("test_db").unwrap());
-        // Deliberately not inserting collection_without_db.
-
-        let input = ComputeVersionsToDeleteInput {
-            graph,
-            cutoff_time: now - Duration::hours(6),
-            min_versions_to_keep: 1,
-            soft_deleted_collections: HashSet::new(),
-            database_names,
-        };
-
-        let result = ComputeVersionsToDeleteOperator {}
-            .run(&input)
-            .await
-            .unwrap();
-
-        // Only collection_with_db should be in output; collection_without_db is filtered.
-        assert_eq!(result.versions.len(), 1);
-        assert!(result.versions.contains_key(&collection_with_db));
-        assert!(!result.versions.contains_key(&collection_without_db));
-    }
-
-    /// Verify database name in input is propagated correctly to output.
-    #[tokio::test]
-    #[traced_test]
-    async fn database_name_propagated_to_output() {
-        let now = Utc::now();
-        let collection_id = CollectionUuid::new();
-        let expected_db_name = DatabaseName::new("my_special_database").unwrap();
-
-        let mut graph = VersionGraph::new();
-        let v0 = graph.add_node(VersionGraphNode {
-            collection_id,
-            version: 0,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(48)),
-            },
-        });
-        let v1 = graph.add_node(VersionGraphNode {
-            collection_id,
-            version: 1,
-            status: VersionStatus::Alive { created_at: now },
-        });
-        graph.add_edge(v0, v1, ());
-
-        let mut database_names = HashMap::new();
-        database_names.insert(collection_id, expected_db_name.clone());
-
-        let input = ComputeVersionsToDeleteInput {
-            graph,
-            cutoff_time: now - Duration::hours(6),
-            min_versions_to_keep: 1,
-            soft_deleted_collections: HashSet::new(),
-            database_names,
-        };
-
-        let result = ComputeVersionsToDeleteOperator {}
-            .run(&input)
-            .await
-            .unwrap();
-
-        let (actual_db_name, _versions) = result.versions.get(&collection_id).unwrap();
-        assert_eq!(*actual_db_name, expected_db_name);
-    }
-
-    /// Empty database_names results in an empty output, even with collections in graph.
-    #[tokio::test]
-    #[traced_test]
-    async fn empty_database_names_produces_empty_output() {
-        let now = Utc::now();
-        let collection_id = CollectionUuid::new();
-
-        let mut graph = VersionGraph::new();
-        let v0 = graph.add_node(VersionGraphNode {
-            collection_id,
-            version: 0,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(48)),
-            },
-        });
-        let v1 = graph.add_node(VersionGraphNode {
-            collection_id,
-            version: 1,
-            status: VersionStatus::Alive { created_at: now },
-        });
-        graph.add_edge(v0, v1, ());
-
-        let database_names = HashMap::new();
-
-        let input = ComputeVersionsToDeleteInput {
-            graph,
-            cutoff_time: now - Duration::hours(6),
-            min_versions_to_keep: 1,
-            soft_deleted_collections: HashSet::new(),
-            database_names,
-        };
-
-        let result = ComputeVersionsToDeleteOperator {}
-            .run(&input)
-            .await
-            .unwrap();
-
-        assert!(result.versions.is_empty());
-    }
-
-    /// Different collections can have different database names.
-    #[tokio::test]
-    #[traced_test]
-    async fn different_database_names_for_different_collections() {
-        let now = Utc::now();
-
-        let collection_a = CollectionUuid::new();
-        let collection_b = CollectionUuid::new();
-        let db_name_a = DatabaseName::new("database_alpha").unwrap();
-        let db_name_b = DatabaseName::new("database_beta").unwrap();
-
-        let mut graph = VersionGraph::new();
-        let a_v0 = graph.add_node(VersionGraphNode {
-            collection_id: collection_a,
-            version: 0,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(48)),
-            },
-        });
-        let a_v1 = graph.add_node(VersionGraphNode {
-            collection_id: collection_a,
-            version: 1,
-            status: VersionStatus::Alive { created_at: now },
-        });
-        graph.add_edge(a_v0, a_v1, ());
-
-        let b_v0 = graph.add_node(VersionGraphNode {
-            collection_id: collection_b,
-            version: 0,
-            status: VersionStatus::Alive {
-                created_at: (now - Duration::hours(48)),
-            },
-        });
-        let b_v1 = graph.add_node(VersionGraphNode {
-            collection_id: collection_b,
-            version: 1,
-            status: VersionStatus::Alive { created_at: now },
-        });
-        graph.add_edge(b_v0, b_v1, ());
-
-        let mut database_names = HashMap::new();
-        database_names.insert(collection_a, db_name_a.clone());
-        database_names.insert(collection_b, db_name_b.clone());
-
-        let input = ComputeVersionsToDeleteInput {
-            graph,
-            cutoff_time: now - Duration::hours(6),
-            min_versions_to_keep: 1,
-            soft_deleted_collections: HashSet::new(),
-            database_names,
-        };
-
-        let result = ComputeVersionsToDeleteOperator {}
-            .run(&input)
-            .await
-            .unwrap();
-
-        assert_eq!(result.versions.len(), 2);
-
-        let (actual_db_a, _) = result.versions.get(&collection_a).unwrap();
-        assert_eq!(*actual_db_a, db_name_a);
-
-        let (actual_db_b, _) = result.versions.get(&collection_b).unwrap();
-        assert_eq!(*actual_db_b, db_name_b);
     }
 }

--- a/rust/garbage_collector/src/operators/delete_unused_logs.rs
+++ b/rust/garbage_collector/src/operators/delete_unused_logs.rs
@@ -32,7 +32,8 @@ pub struct DeleteUnusedLogsOperator {
 #[derive(Clone, Debug)]
 pub struct DeleteUnusedLogsInput {
     pub collections_to_destroy: HashSet<CollectionUuid>,
-    pub collections_to_garbage_collect: HashMap<CollectionUuid, (DatabaseName, LogPosition)>,
+    pub collections_to_garbage_collect: HashMap<CollectionUuid, LogPosition>,
+    pub database_name: Option<DatabaseName>,
 }
 
 pub type DeleteUnusedLogsOutput = ();
@@ -75,11 +76,9 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
         let storage_arc = Arc::new(self.storage.clone());
         if !input.collections_to_garbage_collect.is_empty() {
             let mut log_gc_futures = Vec::with_capacity(input.collections_to_garbage_collect.len());
-            for (collection_id, (database_name, minimum_log_offset_to_keep)) in
-                &input.collections_to_garbage_collect
+            for (collection_id, minimum_log_offset_to_keep) in &input.collections_to_garbage_collect
             {
                 let collection_id = *collection_id;
-                let database_name = database_name.clone();
                 let storage_clone = storage_arc.clone();
                 let mut logs = self.logs.clone();
                 log_gc_futures.push(async move {
@@ -144,7 +143,7 @@ impl Operator<DeleteUnusedLogsInput, DeleteUnusedLogsOutput> for DeleteUnusedLog
                             }
                         };
                     }
-                    if let Err(err) = logs.garbage_collect_phase2(database_name, collection_id).await {
+                    if let Err(err) = logs.garbage_collect_phase2(input.database_name.clone(), collection_id).await {
                         tracing::error!("Unable to garbage collect log for collection [{collection_id}]: {err}");
                         return Err(DeleteUnusedLogsError::Gc(err));
                     };

--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -709,7 +709,7 @@ impl GrpcLog {
 
     pub async fn garbage_collect_phase2(
         &mut self,
-        database_name: DatabaseName,
+        database_name: Option<DatabaseName>,
         collection_id: CollectionUuid,
     ) -> Result<(), GarbageCollectError> {
         let mut client = self
@@ -727,7 +727,7 @@ impl GrpcLog {
                         collection_id.to_string(),
                     ),
                 ),
-                database_name: database_name.into_string(),
+                database_name: database_name.map(|db| db.into_string()).unwrap_or_default(),
             })
             .await?;
         Ok(())

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -352,7 +352,7 @@ impl Log {
 
     pub async fn garbage_collect_phase2(
         &mut self,
-        database_name: DatabaseName,
+        database_name: Option<DatabaseName>,
         collection_id: CollectionUuid,
     ) -> Result<(), GarbageCollectError> {
         match self {


### PR DESCRIPTION
## Description of changes

This PR updates the database name plumbing logic in the GC DeleteUnusedLogs operator. Since the collection batches are partitioned by fork tree, which doesn't span databases there is no reason for each batch element to plumb its own database name. This diff simplifies said plumbing by associating a single database name with each GC batch. 

This diff also adjusts the manual GC path to fetch a database name from sysdb for a requested GC of a particular collection id before kicking off the GC.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_