### PR TITLE
[ENH]: mark_version_to_gc in MCMR

### DIFF
--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -527,6 +527,7 @@ message ListCollectionsToGcResponse {
 message MarkVersionForDeletionRequest {
   int64 epoch_id = 1;
   repeated VersionListForCollection versions = 2;
+  optional string database_name = 3;
 }
 
 message MarkVersionForDeletionResponse {

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -392,7 +392,7 @@ impl GarbageCollectorOrchestrator {
             .collect::<Result<Vec<_>, _>>()?;
 
         self.sysdb_client
-            .mark_version_for_deletion(0, versions_to_mark)
+            .mark_version_for_deletion(0, versions_to_mark, self.database_name.clone())
             .await
             .map_err(|err| GarbageCollectorError::SysDbMethodFailed(err.to_string()))?;
 

--- a/rust/rust-sysdb/src/backend.rs
+++ b/rust/rust-sysdb/src/backend.rs
@@ -372,6 +372,30 @@ impl Backend {
         }
     }
 
+    /// CAS update of version_file_name in collection_compaction_cursors.
+    /// Returns true if the update succeeded (rows affected > 0), false if CAS failed.
+    pub async fn update_version_related_fields(
+        &self,
+        collection_id: &str,
+        old_version_file_name: &str,
+        new_version_file_name: &str,
+        oldest_version_ts: Option<i64>,
+        num_active_versions: i32,
+    ) -> Result<bool, SysDbError> {
+        match self {
+            Backend::Spanner(s) => {
+                s.update_version_related_fields(
+                    collection_id,
+                    old_version_file_name,
+                    new_version_file_name,
+                    oldest_version_ts,
+                    num_active_versions,
+                )
+                .await
+            }
+        }
+    }
+
     /// Reset the database state by deleting all data and recreating default entities.
     pub async fn reset(&self) -> Result<(), SysDbError> {
         match self {

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -47,7 +47,7 @@ use chroma_types::chroma_proto::{
     UpdateSegmentRequest, UpdateSegmentResponse,
 };
 use chroma_types::{Collection, CollectionUuid, DatabaseName};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use tokio::{
     select,
@@ -598,14 +598,44 @@ impl SysDb for SysdbService {
 
         Ok(Response::new(proto_resp))
     }
-
     async fn mark_version_for_deletion(
         &self,
-        _request: Request<MarkVersionForDeletionRequest>,
+        request: Request<MarkVersionForDeletionRequest>,
     ) -> Result<Response<MarkVersionForDeletionResponse>, Status> {
-        Err(Status::unimplemented(
-            "mark_version_for_deletion is not supported",
-        ))
+        let proto_req = request.into_inner();
+        let database_name = proto_req
+            .database_name
+            .as_ref()
+            .and_then(DatabaseName::new)
+            .ok_or_else(|| Status::invalid_argument("valid database_name is required"))?;
+
+        let mut collection_id_to_success = HashMap::new();
+        for version_list in &proto_req.versions {
+            let collection_id_str = version_list.collection_id.clone();
+            let success = match self
+                .update_version_file_single_collection(
+                    version_list,
+                    &database_name,
+                    VersionFileOperation::MarkForDeletion,
+                )
+                .await
+            {
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::error!(
+                        collection_id = %collection_id_str,
+                        error = ?e,
+                        "Failed to mark versions for deletion after retries"
+                    );
+                    false
+                }
+            };
+            collection_id_to_success.insert(collection_id_str, success);
+        }
+
+        Ok(Response::new(MarkVersionForDeletionResponse {
+            collection_id_to_success,
+        }))
     }
 
     async fn delete_collection_version(
@@ -974,7 +1004,225 @@ impl SysdbService {
                 tracing::error!("Failed to upload version file: {}", e);
                 e
             })?;
+
         Ok((version_file_pb, new_version_file_path))
+    }
+
+    /// Update a single collection's version file using a CAS retry loop.
+    async fn update_version_file_single_collection(
+        &self,
+        version_list: &chroma_types::chroma_proto::VersionListForCollection,
+        database_name: &DatabaseName,
+        operation: VersionFileOperation,
+    ) -> Result<(), SysDbError> {
+        let collection_id =
+            CollectionUuid(crate::types::validate_uuid(&version_list.collection_id)?);
+
+        // Validate that versions list is not empty
+        if version_list.versions.is_empty() {
+            return Err(SysDbError::InvalidArgument(
+                "versions list cannot be empty".to_string(),
+            ));
+        }
+
+        let target_versions: std::collections::HashSet<i64> =
+            version_list.versions.iter().copied().collect();
+
+        let backoff = ConstantBuilder::default()
+            .with_delay(std::time::Duration::from_millis(100))
+            .with_max_times(10);
+
+        (|| async {
+            // 1. Get collection to obtain current version_file_path
+            let get_req = internal::GetCollectionsRequest::for_collection(
+                collection_id,
+                database_name.clone(),
+                true,
+            );
+            let backend = get_req.assign(&self.backends);
+            let collection_response = get_req.run(backend.clone()).await?;
+            let collection = collection_response
+                .collections
+                .first()
+                .ok_or_else(|| {
+                    SysDbError::NotFound(format!("Collection {} not found", collection_id))
+                })?
+                .clone();
+
+            let old_version_file_path = collection.version_file_path.clone().unwrap_or_default();
+
+            // 2. Fetch the existing version file from storage
+            let version_file_manager =
+                VersionFileManager::new(self.local_region_object_storage.clone());
+            let mut version_file = version_file_manager.fetch(&collection).await.map_err(|e| {
+                tracing::error!(
+                    collection_id = %collection_id,
+                    error = ?e,
+                    "Failed to fetch version file for {}",
+                    operation.name()
+                );
+                SysDbError::Internal(format!("Failed to fetch version file: {}", e))
+            })?;
+
+            // 3. Apply the operation to the version file
+            let version_history = version_file
+                .version_history
+                .as_mut()
+                .ok_or_else(|| SysDbError::Internal("Version history not found".to_string()))?;
+
+            match operation {
+                VersionFileOperation::MarkForDeletion => {
+                    let mut versions_found = 0;
+                    for version_info in version_history.versions.iter_mut() {
+                        if target_versions.contains(&version_info.version) {
+                            version_info.marked_for_deletion = true;
+                            versions_found += 1;
+                        }
+                    }
+                    if versions_found != target_versions.len() {
+                        let found_versions: HashSet<i64> = version_history.versions
+                            .iter()
+                            .filter_map(|v| target_versions.contains(&v.version).then_some(v.version))
+                            .collect();
+                        let missing: Vec<i64> = target_versions.difference(&found_versions).copied().collect();
+                        return Err(SysDbError::Internal(format!(
+                            "Versions not found in version file: {:?}", missing
+                        )));
+                    }
+                }
+            }
+
+            // Calculate oldest version timestamp and active version count
+            // Find the oldest timestamp among all non-deleted versions
+            let oldest_version_ts = version_history
+                .versions
+                .iter()
+                .filter(|v| !v.marked_for_deletion)
+                .map(|v| v.created_at_secs)
+                .min();
+            let num_active_versions = version_history
+                .versions
+                .iter()
+                .filter(|v| !v.marked_for_deletion)
+                .count() as i32;
+
+            tracing::debug!(
+                collection_id = %collection_id,
+                oldest_version_ts = ?oldest_version_ts,
+                num_active_versions = num_active_versions,
+                total_versions = version_history.versions.len(),
+                "Calculated version metadata for update"
+            );
+
+            let new_version_file_path = version_file_manager.generate_file_path(
+                &collection,
+                collection.version as i64,
+                operation.version_file_type(),
+            );
+
+            // 4. Upload the new version file
+            version_file_manager
+                .upload(
+                    &new_version_file_path,
+                    &version_file,
+                    &collection,
+                    collection.version as i64,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        collection_id = %collection_id,
+                        error = ?e,
+                        "Failed to upload {} version file",
+                        operation.name()
+                    );
+                    SysDbError::Internal(format!(
+                        "Failed to upload {} version file: {}",
+                        operation.name(),
+                        e
+                    ))
+                })?;
+
+            // 5. CAS update version_file_name and related fields in the DB
+            tracing::debug!(
+                collection_id = %collection_id,
+                old_version_file_path = %old_version_file_path,
+                new_version_file_path = %new_version_file_path,
+                "Calling update_version_related_fields"
+            );
+
+            let updated = backend
+                .update_version_related_fields(
+                    &collection_id.0.to_string(),
+                    &old_version_file_path,
+                    &new_version_file_path,
+                    oldest_version_ts,
+                    num_active_versions,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        collection_id = %collection_id,
+                        error = ?e,
+                        "Failed to update version related fields"
+                    );
+                    e
+                })?;
+
+            tracing::debug!(
+                collection_id = %collection_id,
+                updated = updated,
+                "Database update completed"
+            );
+
+            if !updated {
+                tracing::info!(
+                    collection_id = %collection_id,
+                    "CAS failed for {}, retrying",
+                    operation.name()
+                );
+                // TODO: delete the orphaned version file from storage
+                tracing::error!(
+                    collection_id = %collection_id,
+                    orphaned_file_path = %new_version_file_path,
+                    operation = %operation.name(),
+                    "Orphaned version file created due to CAS failure - manual cleanup may be required"
+                );
+                return Err(SysDbError::CollectionEntryIsStale);
+            }
+
+            tracing::info!(
+                collection_id = %collection_id,
+                versions = ?version_list.versions,
+                new_version_file_path = %new_version_file_path,
+                "Successfully completed {}",
+                operation.name()
+            );
+
+            Ok(())
+        })
+        .retry(backoff)
+        .when(|e: &SysDbError| matches!(e, SysDbError::CollectionEntryIsStale))
+        .await
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum VersionFileOperation {
+    MarkForDeletion,
+}
+
+impl VersionFileOperation {
+    fn name(&self) -> &'static str {
+        match self {
+            VersionFileOperation::MarkForDeletion => "mark_version_for_deletion",
+        }
+    }
+
+    fn version_file_type(&self) -> VersionFileType {
+        match self {
+            VersionFileOperation::MarkForDeletion => VersionFileType::GarbageCollectionMark,
+        }
     }
 }
 

--- a/rust/rust-sysdb/src/types.rs
+++ b/rust/rust-sysdb/src/types.rs
@@ -489,6 +489,21 @@ impl TryFrom<chroma_proto::GetCollectionsRequest> for GetCollectionsRequest {
     }
 }
 
+impl GetCollectionsRequest {
+    pub fn for_collection(
+        collection_id: CollectionUuid,
+        database_name: DatabaseName,
+        include_soft_deleted: bool,
+    ) -> Self {
+        Self {
+            filter: CollectionFilter::default()
+                .ids(vec![collection_id])
+                .database_name(database_name)
+                .include_soft_deleted(include_soft_deleted),
+        }
+    }
+}
+
 /// Internal request for getting a collection with its segments.
 #[derive(Debug, Clone)]
 pub struct GetCollectionWithSegmentsRequest {

--- a/rust/segment/src/version_file.rs
+++ b/rust/segment/src/version_file.rs
@@ -258,10 +258,8 @@ impl VersionFileManager {
         };
 
         if version_history.versions.is_empty() {
-            tracing::error!("version history is empty");
-            return Err(VersionFileError::ValidationFailed(
-                "version history is empty".to_string(),
-            ));
+            tracing::warn!("version history is empty");
+            return Ok(());
         }
 
         let versions = &version_history.versions;
@@ -789,7 +787,7 @@ mod tests {
             VersionFileType::Compaction,
         );
 
-        let res = manager
+        let reupload_result = manager
             .upload(
                 &modified_path,
                 &version_file,
@@ -797,7 +795,7 @@ mod tests {
                 modified_version_id,
             )
             .await;
-        assert!(res.is_ok());
+        assert!(reupload_result.is_ok(), "Reupload should succeed");
 
         // Validate that the path follows the new Go-style format: {version_id:06d}_{uuid}_flush
         // We'll check that the path contains the expected components

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -684,9 +684,13 @@ impl SysDb {
         &mut self,
         epoch_id: i64,
         versions: Vec<VersionListForCollection>,
+        database_name: DatabaseName,
     ) -> Result<HashMap<String, bool>, MarkVersionForDeletionError> {
         match self {
-            SysDb::Grpc(grpc) => grpc.mark_version_for_deletion(epoch_id, versions).await,
+            SysDb::Grpc(grpc) => {
+                grpc.mark_version_for_deletion(epoch_id, versions, database_name)
+                    .await
+            }
             SysDb::Test(test) => {
                 let versions_clone = versions.clone();
                 test.mark_version_for_deletion(epoch_id, versions_clone)
@@ -2069,10 +2073,25 @@ impl GrpcSysDb {
         &mut self,
         epoch_id: i64,
         versions: Vec<chroma_proto::VersionListForCollection>,
+        database_name: DatabaseName,
     ) -> Result<HashMap<String, bool>, MarkVersionForDeletionError> {
-        let req = chroma_proto::MarkVersionForDeletionRequest { epoch_id, versions };
+        let database_name_str = Some(database_name.as_ref().to_string());
 
-        let res = self.client.mark_version_for_deletion(req).await?;
+        let req = chroma_proto::MarkVersionForDeletionRequest {
+            epoch_id,
+            versions,
+            database_name: database_name_str,
+        };
+
+        let res = self
+            .client(&database_name)
+            .map_err(|e| {
+                MarkVersionForDeletionError::FailedToMarkVersion(tonic::Status::internal(
+                    e.to_string(),
+                ))
+            })?
+            .mark_version_for_deletion(req)
+            .await?;
         Ok(res.into_inner().collection_id_to_success)
     }
 

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -927,15 +927,26 @@ impl Handler<GetCollectionAssignmentMessage> for CompactionManager {
         message: GetCollectionAssignmentMessage,
         _ctx: &ComponentContext<CompactionManager>,
     ) {
+        // Get the current memberlist from scheduler
+        let memberlist = self.scheduler.get_memberlist();
+        let mut member_ids: Vec<String> = memberlist
+            .iter()
+            .map(|member| member.member_id.clone())
+            .collect();
+
+        // Sort memberlist for consistent output
+        member_ids.sort();
+
+        // Get the assignment policy from scheduler
         let assignment_policy = self.scheduler.get_assignment_policy();
 
+        // Set the members in the assignment policy
+        assignment_policy.set_members(member_ids.clone());
+
+        // Determine which node this collection would be assigned to
         let assigned_node = assignment_policy
             .assign_one(&message.collection_id.0.to_string())
             .unwrap_or_else(|_| "no_assignment".to_string());
-
-        let mut member_ids = assignment_policy.get_members();
-
-        member_ids.sort();
 
         let response = GetCollectionAssignmentResponse {
             assigned_node,

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 
 use chroma_config::assignment::assignment_policy::AssignmentPolicy;
 use chroma_log::{CollectionInfo, CollectionRecord, Log};
-use chroma_memberlist::memberlist_provider::Memberlist;
+use chroma_memberlist::memberlist_provider::{Member, Memberlist};
 use chroma_sysdb::{DatabaseOrTopology, GetCollectionsOptions, SysDb};
 use chroma_types::{CollectionUuid, DatabaseName, JobId, TopologyName};
 use figment::providers::Env;
@@ -522,6 +522,10 @@ impl Scheduler {
 
     pub(crate) fn has_memberlist(&self) -> bool {
         self.memberlist.is_some()
+    }
+
+    pub(crate) fn get_memberlist(&self) -> Vec<Member> {
+        self.memberlist.as_ref().cloned().unwrap_or_default()
     }
 
     pub(crate) fn get_assignment_policy(&mut self) -> &mut Box<dyn AssignmentPolicy> {


### PR DESCRIPTION
## Description of changes

This PR implements `mark_version_for_deletion` for rust sysdb to support MCMR GC.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_