### PR TITLE
[ENH]: delete_collection_versions in MCMR

### DIFF
--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -537,6 +537,7 @@ message MarkVersionForDeletionResponse {
 message DeleteCollectionVersionRequest {
   int64 epoch_id = 1;
   repeated VersionListForCollection versions = 2;
+  optional string database_name = 3;
 }
 
 message DeleteCollectionVersionResponse {

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -895,6 +895,7 @@ impl GarbageCollectorOrchestrator {
                         collection_id: collection_id.to_string(),
                         versions,
                     },
+                    database_name: self.database_name.clone(),
                 },
                 ctx.receiver(),
                 self.context.task_cancellation_token.clone(),

--- a/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
+++ b/rust/garbage_collector/src/operators/delete_versions_at_sysdb.rs
@@ -26,6 +26,7 @@ pub struct DeleteVersionsAtSysDbInput {
     pub epoch_id: i64,
     pub sysdb_client: SysDb,
     pub versions_to_delete: VersionListForCollection,
+    pub database_name: chroma_types::DatabaseName,
 }
 
 #[derive(Debug)]
@@ -149,7 +150,10 @@ impl Operator<DeleteVersionsAtSysDbInput, DeleteVersionsAtSysDbOutput>
             );
 
             match sysdb
-                .delete_collection_version(vec![input.versions_to_delete.clone()])
+                .delete_collection_version(
+                    vec![input.versions_to_delete.clone()],
+                    input.database_name.clone(),
+                )
                 .await
             {
                 Ok(results) => {
@@ -191,7 +195,7 @@ mod tests {
     use super::*;
     use chroma_storage::local::LocalStorage;
     use chroma_sysdb::TestSysDb;
-    use chroma_types::chroma_proto;
+    use chroma_types::{chroma_proto, DatabaseName};
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -218,6 +222,7 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {
@@ -249,6 +254,7 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {
@@ -390,6 +396,7 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {
@@ -460,6 +467,7 @@ mod tests {
             versions_to_delete: versions_to_delete.clone(),
             sysdb_client: sysdb,
             epoch_id: 123,
+            database_name: DatabaseName::new("test_db").expect("valid db name"),
         };
 
         let operator = DeleteVersionsAtSysDbOperator {

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -640,11 +640,45 @@ impl SysDb for SysdbService {
 
     async fn delete_collection_version(
         &self,
-        _request: Request<DeleteCollectionVersionRequest>,
+        request: Request<DeleteCollectionVersionRequest>,
     ) -> Result<Response<DeleteCollectionVersionResponse>, Status> {
-        Err(Status::unimplemented(
-            "delete_collection_version is not supported",
-        ))
+        let proto_req = request.into_inner();
+        let database_name = proto_req
+            .database_name
+            .ok_or_else(|| Status::invalid_argument("database_name is required"))
+            .and_then(|name| {
+                DatabaseName::new(name).ok_or_else(|| {
+                    Status::invalid_argument("database_name must be at least 3 characters")
+                })
+            })?;
+
+        let mut collection_id_to_success = std::collections::HashMap::new();
+        for version_list in &proto_req.versions {
+            let collection_id_str = version_list.collection_id.clone();
+            let success = match self
+                .update_version_file_single_collection(
+                    version_list,
+                    &database_name,
+                    VersionFileOperation::DeleteVersions,
+                )
+                .await
+            {
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::error!(
+                        collection_id = %collection_id_str,
+                        error = ?e,
+                        "Failed to delete versions for collection"
+                    );
+                    false
+                }
+            };
+            collection_id_to_success.insert(collection_id_str, success);
+        }
+
+        Ok(Response::new(DeleteCollectionVersionResponse {
+            collection_id_to_success,
+        }))
     }
 
     async fn batch_get_collection_version_file_paths(
@@ -1090,6 +1124,39 @@ impl SysdbService {
                         )));
                     }
                 }
+                VersionFileOperation::DeleteVersions => {
+                    // First check which versions actually exist
+                    let existing_versions: HashSet<i64> = version_history.versions
+                        .iter()
+                        .map(|v| v.version)
+                        .collect();
+
+                    // Find any requested versions that don't exist
+                    let missing: Vec<i64> = target_versions
+                        .iter()
+                        .filter(|v| !existing_versions.contains(v))
+                        .copied()
+                        .collect();
+
+                    if !missing.is_empty() {
+                        return Err(SysDbError::Internal(format!(
+                            "Versions not found in version file: {:?}", missing
+                        )));
+                    }
+
+                    // Now remove the versions
+                    version_history
+                        .versions
+                        .retain(|v| !target_versions.contains(&v.version));
+
+                    // Ensure at least one version remains unless collection is soft-deleted
+                    // Don't have access to soft deleted status here
+                    if version_history.versions.is_empty() && !collection.name.starts_with("_deleted_") {
+                        return Err(SysDbError::Internal(
+                            "Cannot delete all versions for non-deleted collection".to_string()
+                        ));
+                    }
+                }
             }
 
             // Calculate oldest version timestamp and active version count
@@ -1210,18 +1277,21 @@ impl SysdbService {
 #[derive(Debug, Clone, Copy)]
 enum VersionFileOperation {
     MarkForDeletion,
+    DeleteVersions,
 }
 
 impl VersionFileOperation {
     fn name(&self) -> &'static str {
         match self {
             VersionFileOperation::MarkForDeletion => "mark_version_for_deletion",
+            VersionFileOperation::DeleteVersions => "delete_collection_version",
         }
     }
 
     fn version_file_type(&self) -> VersionFileType {
         match self {
             VersionFileOperation::MarkForDeletion => VersionFileType::GarbageCollectionMark,
+            VersionFileOperation::DeleteVersions => VersionFileType::GarbageCollectionDelete,
         }
     }
 }

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -713,10 +713,13 @@ impl SysDb {
     pub async fn delete_collection_version(
         &mut self,
         versions: Vec<VersionListForCollection>,
+        database_name: DatabaseName,
     ) -> Result<HashMap<String, bool>, DeleteCollectionVersionError> {
         match self {
             SysDb::Grpc(client) => {
-                let response = client.delete_collection_version(versions).await?;
+                let response = client
+                    .delete_collection_version(versions, database_name)
+                    .await?;
                 Ok(response)
             }
             SysDb::Test(client) => Ok(client.delete_collection_version(versions).await),
@@ -2098,13 +2101,23 @@ impl GrpcSysDb {
     async fn delete_collection_version(
         &mut self,
         versions: Vec<chroma_proto::VersionListForCollection>,
+        database_name: DatabaseName,
     ) -> Result<HashMap<String, bool>, DeleteCollectionVersionError> {
         let req = chroma_proto::DeleteCollectionVersionRequest {
             epoch_id: 0, // TODO: Pass this through
             versions,
+            database_name: Some(database_name.as_ref().to_string()),
         };
 
-        let res = self.client.delete_collection_version(req).await?;
+        let res = self
+            .client(&database_name)
+            .map_err(|e| {
+                DeleteCollectionVersionError::FailedToDeleteVersion(tonic::Status::internal(
+                    e.to_string(),
+                ))
+            })?
+            .delete_collection_version(req)
+            .await?;
         Ok(res.into_inner().collection_id_to_success)
     }
 


### PR DESCRIPTION
## Description of changes

This change implements delete_collection_version in rust sysdb.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_