### PR TITLE
[ENH]: MCMR batch_get_collection_soft_delete_status

### DIFF
--- a/idl/chromadb/proto/coordinator.proto
+++ b/idl/chromadb/proto/coordinator.proto
@@ -555,6 +555,7 @@ message BatchGetCollectionVersionFilePathsResponse {
 
 message BatchGetCollectionSoftDeleteStatusRequest {
   repeated string collection_ids = 1;
+  optional string database_name = 2;
 }
 
 message BatchGetCollectionSoftDeleteStatusResponse {

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -1335,7 +1335,7 @@ mod tests {
 
         // Double check that the collection is still soft deleted
         let statuses = sysdb
-            .batch_get_collection_soft_delete_status(vec![collection_id])
+            .batch_get_collection_soft_delete_status(None, vec![collection_id])
             .await
             .unwrap();
         assert_eq!(

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -244,15 +244,26 @@ impl GarbageCollectorOrchestrator {
     ) -> Result<HashSet<CollectionUuid>, GarbageCollectorError> {
         let soft_delete_statuses = self
             .sysdb_client
-            .batch_get_collection_soft_delete_status(all_collection_ids.clone())
+            .batch_get_collection_soft_delete_status(
+                Some(self.database_name.clone()),
+                all_collection_ids.clone(),
+            )
             .await
             .map_err(|e| GarbageCollectorError::SysDbMethodFailed(e.to_string()))?;
 
         let all_collection_ids: HashSet<CollectionUuid> = all_collection_ids.into_iter().collect();
 
+        tracing::trace!("Soft delete statuses: {:?}", soft_delete_statuses);
+
         let soft_deleted_collections_to_gc = soft_delete_statuses
             .iter()
             .filter_map(|(collection_id, status)| {
+                tracing::trace!(
+                    collection_id = %collection_id,
+                    is_soft_deleted = status,
+                    in_all_collection_ids = all_collection_ids.contains(collection_id),
+                    "Collection soft delete status"
+                );
                 if *status && all_collection_ids.contains(collection_id) {
                     Some(*collection_id)
                 } else {
@@ -265,10 +276,10 @@ impl GarbageCollectorOrchestrator {
             .sysdb_client
             .get_collections(GetCollectionsOptions {
                 collection_ids: Some(soft_deleted_collections_to_gc),
-                include_soft_deleted: true,
                 database_or_topology: Some(DatabaseOrTopology::Database(
                     self.database_name.clone(),
                 )),
+                include_soft_deleted: true,
                 ..Default::default()
             })
             .await
@@ -277,6 +288,12 @@ impl GarbageCollectorOrchestrator {
         let mut eligible_ids = HashSet::new();
         let cutoff_time: SystemTime = self.collection_soft_delete_absolute_cutoff_time.into();
         for collection in collections {
+            tracing::debug!(
+                "Collection {} was updated at {:?}, cutoff time is {:?}",
+                collection.collection_id,
+                collection.updated_at,
+                cutoff_time
+            );
             if collection.updated_at < cutoff_time {
                 eligible_ids.insert(collection.collection_id);
             } else {

--- a/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
+++ b/rust/garbage_collector/src/operators/compute_versions_to_delete_from_graph.rs
@@ -96,6 +96,12 @@ impl Operator<ComputeVersionsToDeleteInput, ComputeVersionsToDeleteOutput>
                 .skip(input.min_versions_to_keep as usize)
             {
                 if *created_at < input.cutoff_time {
+                    tracing::debug!(
+                        version = *version,
+                        created_at = %created_at,
+                        cutoff_time = %input.cutoff_time,
+                        "Deleting version before cutoff time"
+                    );
                     *mode = CollectionVersionAction::Delete;
                 } else {
                     tracing::debug!(

--- a/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
+++ b/rust/garbage_collector/tests/proptest_helpers/garbage_collector_under_test.rs
@@ -379,7 +379,7 @@ impl StateMachineTest for GarbageCollectorUnderTest {
             let storage = state.storage.clone();
 
             async move {
-                let collection_statuses = sysdb.batch_get_collection_soft_delete_status(ref_state.collection_status.keys().cloned().collect()).await.unwrap();
+                let collection_statuses = sysdb.batch_get_collection_soft_delete_status(None, ref_state.collection_status.keys().cloned().collect()).await.unwrap();
                 for (collection_id, status) in ref_state.collection_status.iter() {
                     match status {
                         CollectionStatus::Deleted => {

--- a/rust/rust-sysdb/src/backend.rs
+++ b/rust/rust-sysdb/src/backend.rs
@@ -383,7 +383,7 @@ impl Backend {
         }
     }
 
-    /// CAS update of version_file_name in collection_compaction_cursors.
+    /// CAS update of version_file_name and related fields in collections table.
     /// Returns true if the update succeeded (rows affected > 0), false if CAS failed.
     pub async fn update_version_related_fields(
         &self,

--- a/rust/rust-sysdb/src/server.rs
+++ b/rust/rust-sysdb/src/server.rs
@@ -726,11 +726,34 @@ impl SysDb for SysdbService {
 
     async fn batch_get_collection_soft_delete_status(
         &self,
-        _request: Request<BatchGetCollectionSoftDeleteStatusRequest>,
+        request: Request<BatchGetCollectionSoftDeleteStatusRequest>,
     ) -> Result<Response<BatchGetCollectionSoftDeleteStatusResponse>, Status> {
-        Err(Status::unimplemented(
-            "batch_get_collection_soft_delete_status is not supported",
-        ))
+        tracing::debug!("batch_get_collection_soft_delete_status: called");
+        let proto_req = request.into_inner();
+        let internal_req: internal::GetCollectionsRequest = proto_req
+            .try_into()
+            .map_err(|e: SysDbError| Status::from(e))?;
+
+        let backend = internal_req.assign(&self.backends);
+        let internal_resp = internal_req.run(backend).await?;
+
+        let mut collection_id_to_is_soft_deleted = std::collections::HashMap::new();
+        for collection in &internal_resp.collections {
+            let is_deleted = internal_resp
+                .soft_deleted_ids
+                .contains(&collection.collection_id);
+            collection_id_to_is_soft_deleted
+                .insert(collection.collection_id.0.to_string(), is_deleted);
+        }
+
+        tracing::debug!(
+            "BatchGetCollectionSoftDeleteStatusResponse: {} entries",
+            collection_id_to_is_soft_deleted.len()
+        );
+
+        Ok(Response::new(BatchGetCollectionSoftDeleteStatusResponse {
+            collection_id_to_is_soft_deleted,
+        }))
     }
 
     async fn cleanup_expired_partial_attached_functions(
@@ -3032,5 +3055,88 @@ mod tests {
         // (even though chroma_types::Collection doesn't expose is_deleted field)
         // because the proto structure is different. The main test is that
         // soft delete works and the collection is not found when trying to get it.
+    }
+
+    #[tokio::test]
+    async fn test_k8s_integration_mcmr_batch_get_collection_soft_delete_status() {
+        let Some(backend): Option<SpannerBackend> = setup_test_backend().await else {
+            panic!("Skipping test: Spanner emulator not reachable. Is Tilt running?");
+        };
+
+        let (service, _temp_dir) = setup_test_service(backend.clone()).await;
+        let (tenant_id, database_name) = setup_tenant_and_database(&backend).await;
+
+        // Create two collections
+        let active_collection_id = CollectionUuid(Uuid::new_v4());
+        let deleted_collection_id = CollectionUuid(Uuid::new_v4());
+
+        for (cid, name) in [
+            (active_collection_id, "active_collection"),
+            (deleted_collection_id, "deleted_collection"),
+        ] {
+            let req = CreateCollectionRequest {
+                id: cid,
+                tenant_id: tenant_id.clone(),
+                database_name: database_name.clone(),
+                name: name.to_string(),
+                dimension: Some(128),
+                metadata: Some(HashMap::new()),
+                segments: vec![Segment {
+                    id: SegmentUuid(Uuid::new_v4()),
+                    r#type: SegmentType::BlockfileMetadata,
+                    scope: SegmentScope::METADATA,
+                    collection: cid,
+                    file_path: HashMap::new(),
+                    metadata: None,
+                }],
+                index_schema: Schema::default(),
+                get_or_create: false,
+            };
+            let backend_for_create = req.assign(&service.backends);
+            req.run(backend_for_create).await.unwrap();
+        }
+
+        // Soft-delete one collection
+        let delete_req = chroma_types::chroma_proto::DeleteCollectionRequest {
+            tenant: tenant_id.clone(),
+            database: database_name.as_ref().to_string(),
+            id: deleted_collection_id.0.to_string(),
+            segment_ids: vec![],
+        };
+        service
+            .delete_collection(Request::new(delete_req))
+            .await
+            .expect("Failed to soft-delete collection");
+
+        // Call batch_get_collection_soft_delete_status via the gRPC handler
+        let status_req = BatchGetCollectionSoftDeleteStatusRequest {
+            collection_ids: vec![
+                active_collection_id.0.to_string(),
+                deleted_collection_id.0.to_string(),
+            ],
+            database_name: Some(database_name.as_ref().to_string()),
+        };
+        let response = service
+            .batch_get_collection_soft_delete_status(Request::new(status_req))
+            .await
+            .expect("Failed to get soft delete status");
+
+        let statuses = response.into_inner().collection_id_to_is_soft_deleted;
+
+        // Active collection should be false
+        assert_eq!(
+            statuses.get(&active_collection_id.0.to_string()),
+            Some(&false),
+            "Active collection should not be soft deleted"
+        );
+
+        // Deleted collection should be true
+        assert_eq!(
+            statuses.get(&deleted_collection_id.0.to_string()),
+            Some(&true),
+            "Soft-deleted collection should be marked as deleted"
+        );
+
+        assert_eq!(statuses.len(), 2, "Should have exactly 2 entries");
     }
 }

--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -867,11 +867,12 @@ impl SpannerBackend {
             (Some(limit), Some(offset)) => format!("LIMIT {} OFFSET {}", limit, offset),
             (Some(limit), None) => format!("LIMIT {}", limit),
             (None, None) => String::new(),
-            (None, Some(_)) => {
+            (None, Some(offset)) if offset > 0 => {
                 return Err(SysDbError::InvalidArgument(
                     "offset requires limit to be specified".to_string(),
                 ));
             }
+            (None, Some(_)) => String::new(),
         };
 
         let query = format!(
@@ -904,7 +905,8 @@ impl SpannerBackend {
                 ccc.last_compaction_time_secs,
                 ccc.version_file_name,
                 ccc.compaction_failure_count,
-                ccc.index_schema
+                ccc.index_schema,
+                c.is_deleted
             FROM filtered_collections fc
             JOIN collections c ON c.collection_id = fc.collection_id
             LEFT JOIN collection_metadata cm ON cm.collection_id = c.collection_id
@@ -933,6 +935,8 @@ impl SpannerBackend {
             stmt.add_param("database_name", &database_name.as_ref());
         }
 
+        tracing::debug!("Get collection query is: {}", query);
+
         let mut tx = self.client.single().await?;
         let mut result_set = tx
             .query(stmt)
@@ -960,14 +964,35 @@ impl SpannerBackend {
 
         // Convert each group of rows to a Collection, preserving the query order
         let mut collections = Vec::new();
+        let mut soft_deleted_ids = std::collections::HashSet::new();
         for collection_id in collection_order {
             if let Some(rows) = rows_by_collection.remove(&collection_id) {
+                let is_deleted: bool = rows[0]
+                    .column_by_name("is_deleted")
+                    .map_err(SysDbError::FailedToReadColumn)?;
+                tracing::debug!(
+                    "Collection {} has is_deleted: {}",
+                    collection_id,
+                    is_deleted
+                );
                 let collection = Collection::try_from(SpannerRows { rows })?;
+                if is_deleted {
+                    tracing::debug!(
+                        "Adding collection {} to soft_deleted_ids",
+                        collection.collection_id
+                    );
+                    soft_deleted_ids.insert(collection.collection_id);
+                }
                 collections.push(collection);
             }
         }
 
-        Ok(GetCollectionsResponse { collections })
+        tracing::debug!("Final soft_deleted_ids: {:?}", soft_deleted_ids);
+
+        Ok(GetCollectionsResponse {
+            collections,
+            soft_deleted_ids,
+        })
     }
 
     /// Count collections for a tenant, optionally filtered by database.
@@ -1661,6 +1686,9 @@ impl SpannerBackend {
             "#,
         );
 
+        tracing::debug!("list_collections_to_gc query: {}", query);
+        tracing::debug!("list_collections_to_gc params: {:?}", req);
+
         let mut stmt = Statement::new(&query);
         stmt.add_param("region", &region.to_string());
 
@@ -1713,6 +1741,7 @@ impl SpannerBackend {
                 database_name,
             });
         }
+        tracing::debug!("Got {} collections", collections.len());
 
         Ok(ListCollectionsToGcResponse { collections })
     }

--- a/rust/rust-sysdb/src/types.rs
+++ b/rust/rust-sysdb/src/types.rs
@@ -389,20 +389,23 @@ impl TryFrom<chroma_proto::GetCollectionsRequest> for GetCollectionsRequest {
 
         // Collect all IDs from both `id` and `ids_filter`
         let mut all_ids: Vec<CollectionUuid> = Vec::new();
+        let mut has_id_filter = false;
 
         if let Some(id_str) = req.id {
+            has_id_filter = true;
             let id = CollectionUuid(validate_uuid(&id_str)?);
             all_ids.push(id);
         }
 
         if let Some(ids_filter) = req.ids_filter {
+            has_id_filter = true;
             for id_str in ids_filter.ids {
                 let id = CollectionUuid(validate_uuid(&id_str)?);
                 all_ids.push(id);
             }
         }
 
-        if !all_ids.is_empty() {
+        if has_id_filter {
             filter = filter.ids(all_ids);
         }
 
@@ -458,12 +461,6 @@ impl TryFrom<chroma_proto::GetCollectionsRequest> for GetCollectionsRequest {
             filter = filter.limit(limit);
         }
         if let Some(offset) = req.offset {
-            if offset < 0 {
-                return Err(SysDbError::InvalidArgument(format!(
-                    "offset must be non-negative, got {}",
-                    offset
-                )));
-            }
             if offset > 0 {
                 if req.limit.is_none() {
                     return Err(SysDbError::InvalidArgument(
@@ -735,6 +732,7 @@ impl Assignable for GetCollectionsRequest {
         }
         // Fall back to default if no database filter
         // TODO(Sanket): Make database name mandatory in the filter.
+        tracing::warn!("No database filter provided, using default backend");
         Backend::Spanner(factory.one_spanner().clone())
     }
 }
@@ -1152,7 +1150,7 @@ impl TryFrom<SpannerRows> for Collection {
             }
         }
 
-        // Parse schema JSON (index_schema is NOT NULL, so parsing should succeed)
+        // Parse schema JSON (use default schema if no compaction cursor exists)
         let parsed_schema: Schema =
             serde_json::from_str(&schema_json).map_err(SysDbError::InvalidSchemaJson)?;
 
@@ -1425,6 +1423,8 @@ impl TryFrom<CreateCollectionResponse> for chroma_proto::CreateCollectionRespons
 #[derive(Debug, Clone)]
 pub struct GetCollectionsResponse {
     pub collections: Vec<Collection>,
+    /// Collection IDs that are soft-deleted (only populated when include_soft_deleted is true)
+    pub soft_deleted_ids: std::collections::HashSet<CollectionUuid>,
 }
 
 impl TryFrom<GetCollectionsResponse> for chroma_proto::GetCollectionsResponse {
@@ -1607,6 +1607,37 @@ impl TryFrom<FlushCompactionResponse> for chroma_proto::FlushCollectionCompactio
             collection_version: r.collection_version,
             last_compaction_time: r.last_compaction_time,
         })
+    }
+}
+
+impl TryFrom<chroma_proto::BatchGetCollectionSoftDeleteStatusRequest> for GetCollectionsRequest {
+    type Error = SysDbError;
+
+    fn try_from(
+        req: chroma_proto::BatchGetCollectionSoftDeleteStatusRequest,
+    ) -> Result<Self, Self::Error> {
+        let mut ids = Vec::new();
+        for id_str in req.collection_ids {
+            ids.push(CollectionUuid(validate_uuid(&id_str)?));
+        }
+
+        let mut filter = CollectionFilter::default()
+            .ids(ids)
+            .include_soft_deleted(true);
+
+        if let Some(db_str) = req.database_name {
+            if !db_str.is_empty() {
+                let database_name = DatabaseName::new(&db_str).ok_or_else(|| {
+                    SysDbError::InvalidArgument(format!(
+                        "database name must be at least 3 characters, got '{}'",
+                        db_str
+                    ))
+                })?;
+                filter = filter.database_name(database_name);
+            }
+        }
+
+        Ok(GetCollectionsRequest { filter })
     }
 }
 

--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -584,11 +584,12 @@ impl SysDb {
 
     pub async fn batch_get_collection_soft_delete_status(
         &mut self,
+        database_name: Option<DatabaseName>,
         collection_ids: Vec<CollectionUuid>,
     ) -> Result<HashMap<CollectionUuid, bool>, BatchGetCollectionSoftDeleteStatusError> {
         match self {
             SysDb::Grpc(grpc) => {
-                grpc.batch_get_collection_soft_delete_status(collection_ids)
+                grpc.batch_get_collection_soft_delete_status(database_name, collection_ids)
                     .await
             }
             SysDb::Sqlite(_) => todo!(),
@@ -1872,26 +1873,36 @@ impl GrpcSysDb {
 
     async fn batch_get_collection_soft_delete_status(
         &mut self,
+        database_name: Option<DatabaseName>,
         collection_ids: Vec<CollectionUuid>,
     ) -> Result<HashMap<CollectionUuid, bool>, BatchGetCollectionSoftDeleteStatusError> {
-        let res = self
-            .client
+        let mut client = match &database_name {
+            Some(db_name) => self.client(db_name)?,
+            None => self.client.clone(),
+        };
+        let res = client
             .batch_get_collection_soft_delete_status(
                 chroma_proto::BatchGetCollectionSoftDeleteStatusRequest {
                     collection_ids: collection_ids
                         .into_iter()
                         .map(|id| id.0.to_string())
                         .collect(),
+                    database_name: database_name.map(|d| d.into_string()),
                 },
             )
             .await?;
         let collection_id_to_status = res.into_inner().collection_id_to_is_soft_deleted;
+        tracing::debug!(
+            "BatchGetCollectionSoftDeleteStatusResponse: {} entries",
+            collection_id_to_status.len()
+        );
         let mut result = HashMap::new();
         for (key, value) in collection_id_to_status {
             let collection_id = CollectionUuid(
                 Uuid::try_parse(&key)
                     .map_err(|err| BatchGetCollectionSoftDeleteStatusError::Uuid(err, key))?,
             );
+            tracing::debug!("Collection {} is soft deleted: {}", collection_id, value);
             result.insert(collection_id, value);
         }
         Ok(result)
@@ -2116,6 +2127,11 @@ impl GrpcSysDb {
             versions,
             database_name: Some(database_name.as_ref().to_string()),
         };
+        tracing::trace!(
+            "delete_collection_version request: epoch_id={}, versions={:?}",
+            req.epoch_id,
+            req.versions,
+        );
 
         let res = self
             .client(&database_name)

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -147,6 +147,8 @@ pub enum BatchGetCollectionSoftDeleteStatusError {
     Grpc(#[from] Status),
     #[error("Could not parse UUID from string {1}: {0}")]
     Uuid(uuid::Error, String),
+    #[error("Client resolution error: {0}")]
+    ClientResolution(#[from] ClientResolutionError),
 }
 
 impl ChromaError for BatchGetCollectionSoftDeleteStatusError {
@@ -154,6 +156,7 @@ impl ChromaError for BatchGetCollectionSoftDeleteStatusError {
         match self {
             BatchGetCollectionSoftDeleteStatusError::Grpc(status) => status.code().into(),
             BatchGetCollectionSoftDeleteStatusError::Uuid(_, _) => ErrorCodes::InvalidArgument,
+            BatchGetCollectionSoftDeleteStatusError::ClientResolution(e) => e.code(),
         }
     }
 }

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -295,10 +295,16 @@ garbage_collector:
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
   max_collections_to_gc: 1000
   gc_interval_mins: 1
+  enable_log_gc_for_tenant: ["default_tenant"]
   disallow_collections: []
   default_mode: "deletev2"
   sysdb_config:
     host: "sysdb.chroma"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
+  mcmr_sysdb_config:
+    host: "rust-sysdb-service.chroma"
     port: 50051
     connect_timeout_ms: 60000
     request_timeout_ms: 60000

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -286,6 +286,7 @@ log_service:
             project: "local-project"
             instance: "test-instance"
             database: "local-logdb-database"
+
 garbage_collector:
   service_name: "garbage-collector"
   otel_endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"
@@ -295,10 +296,16 @@ garbage_collector:
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
   max_collections_to_gc: 1000
   gc_interval_mins: 1
+  enable_log_gc_for_tenant: ["default_tenant"]
   disallow_collections: []
   default_mode: "deletev2"
   sysdb_config:
     host: "sysdb.chroma2"
+    port: 50051
+    connect_timeout_ms: 60000
+    request_timeout_ms: 60000
+  mcmr_sysdb_config:
+    host: "rust-sysdb-service.chroma2"
     port: 50051
     connect_timeout_ms: 60000
     request_timeout_ms: 60000


### PR DESCRIPTION
## Description of changes

Implements the `batch_get_collection_soft_delete_status` endpoint for rust sysdb and adds a few debugging messages I found helpful when testing end to end GC functionality on MCMR.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

Unit tests are added in spanner.rs

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_