### PR TITLE
[ENH]: Cache rust git submodules in mounted volume

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -47,6 +47,7 @@ ENV EXCLUDED_PACKAGES="chromadb_rust_bindings chromadb-js-bindings chroma-benchm
 # Once Rust supports AVX512, the target-features will be updated to use AVX512.
 RUN --mount=type=cache,sharing=locked,target=/chroma/target/ \
   --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry/ \
+  --mount=type=cache,sharing=locked,target=/usr/local/cargo/git/ \
   if [ "$ENABLE_AVX512" = "1" ]; then \
   export CXXFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \
   export CFLAGS="-mavx512f -mavx512dq -mavx512bw -mavx512vl" && \


### PR DESCRIPTION
## Description of changes

This change speeds up incremental builds by caching git submodules.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
