### PR TITLE
[CHORE] Fix a test that hogs memory.

### DIFF
--- a/chromadb/test/stress/test_many_collections.py
+++ b/chromadb/test/stress/test_many_collections.py
@@ -21,7 +21,8 @@ def test_many_collections(client: ServerAPI) -> None:
         # point is to test the file handle limit
         return
 
-    num_collections = 10000
+    # NOTE(rescrv): 10k collections blows memory, 7.5k gives 25% headroom
+    num_collections = 7500
     collections: List[Collection] = []
     for i in range(num_collections):
         new_collection = client.create_collection(


### PR DESCRIPTION
## Description of changes

We're getting OOMs on chromadb/test/stress/test_many_collections.py.

I've checked going back to October and this is not a recent regression,
as the test uses 30GiB+ of memory every time.  Relieve pressure on the
test by making it 3/4 what it was.

## Test plan

- [X] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

Watch CI for stability

## Documentation Changes

N/A
