### PR TITLE
[ENH] replace live cloud tests with k8s integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,10 +2,7 @@
 against-tilt = { max-threads = 1 }
 
 [profile.default]
-default-filter = "not test(/test_k8s_integration_/) and not test(/test_k8s_mcmr_integration_/) and not test(/test_long_running_/) and not test(/test_live_cloud_/) and not test(/test_gcs_/)"
-
-[profile.live_cloud]
-default-filter = "test(/test_live_cloud_/)"
+default-filter = "not test(/test_k8s_integration_/) and not test(/test_k8s_mcmr_integration_/) and not test(/test_long_running_/) and not test(/test_gcs_/)"
 
 [profile.storage_gcs]
 default-filter = "test(/test_gcs_/)"

--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -42,24 +42,6 @@ jobs:
       - name: Test
         run: cargo nextest run --profile ci_long_running
 
-  test-live-cloud:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    env:
-      CARGO_TERM_COLOR: always
-      RUST_BACKTRACE: 1
-      RUST_MIN_STACK_SIZE: 8388608
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup
-        uses: ./.github/actions/rust
-        with:
-          github-token: ${{ github.token }}
-      - name: Test
-        run: cargo nextest run --profile live_cloud
-        env:
-          CHROMA_CLOUD_API_KEY: ${{ secrets.TEST_CHROMA_CLOUD_API_KEY }}
-
   test-storage-gcs:
     runs-on: blacksmith-8vcpu-ubuntu-2404
     env:

--- a/rust/chroma/src/client/chroma_http_client.rs
+++ b/rust/chroma/src/client/chroma_http_client.rs
@@ -932,7 +932,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_heartbeat() {
+    async fn test_k8s_integration_heartbeat() {
         with_client(|client| async move {
             let heartbeat = client.heartbeat().await.unwrap();
             assert!(heartbeat.nanosecond_heartbeat > 0);
@@ -942,7 +942,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_auth_identity() {
+    async fn test_k8s_integration_get_auth_identity() {
         with_client(|client| async move {
             let identity = client.get_auth_identity().await.unwrap();
             assert!(!identity.tenant.is_empty());
@@ -1054,7 +1054,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_parses_error() {
+    async fn test_k8s_integration_parses_error() {
         with_client(|mut client| async move {
             let collection = client.new_collection("foo").await;
             let err = client
@@ -1075,7 +1075,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_list_collections() {
+    async fn test_k8s_integration_list_collections() {
         with_client(|mut client| async move {
             let first = client.new_collection("first").await;
             let second = client.new_collection("second").await;
@@ -1102,7 +1102,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_count_collections() {
+    async fn test_k8s_integration_count_collections() {
         with_client(|mut client| async move {
             let initial_count = client.count_collections().await.unwrap();
 
@@ -1119,7 +1119,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_create_collection() {
+    async fn test_k8s_integration_create_collection() {
         with_client(|mut client| async move {
             let schema = Schema::default_with_embedding_function(
                 EmbeddingFunctionConfiguration::Known(EmbeddingFunctionNewConfiguration {
@@ -1140,7 +1140,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_collection() {
+    async fn test_k8s_integration_get_collection() {
         with_client(|mut client| async move {
             let collection = client.new_collection("my_collection").await;
             let name = collection.name().to_string();
@@ -1152,7 +1152,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_delete_collection() {
+    async fn test_k8s_integration_delete_collection() {
         with_client(|client| async move {
             let name = unique_collection_name("to_be_deleted");
 

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -823,7 +823,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_accessor_methods() {
+    async fn test_k8s_integration_accessor_methods() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_accessors").await;
             assert!(!collection.database().is_empty());
@@ -836,7 +836,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_count_empty_collection() {
+    async fn test_k8s_integration_count_empty_collection() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_count_empty").await;
 
@@ -849,7 +849,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_indexing_status() {
+    async fn test_k8s_integration_get_indexing_status() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_indexing_status").await;
 
@@ -883,7 +883,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_add_single_record() {
+    async fn test_k8s_integration_add_single_record() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_add_single").await;
 
@@ -907,7 +907,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_add_multiple_records() {
+    async fn test_k8s_integration_add_multiple_records() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_add_multiple").await;
 
@@ -939,7 +939,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_add_with_metadata() {
+    async fn test_k8s_integration_add_with_metadata() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_add_metadata").await;
 
@@ -966,7 +966,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_add_with_uris() {
+    async fn test_k8s_integration_add_with_uris() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_add_uris").await;
 
@@ -989,7 +989,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_all_records() {
+    async fn test_k8s_integration_get_all_records() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_get_all").await;
 
@@ -1015,7 +1015,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_by_ids() {
+    async fn test_k8s_integration_get_by_ids() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_get_by_ids").await;
 
@@ -1054,7 +1054,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_with_limit_and_offset() {
+    async fn test_k8s_integration_get_with_limit_and_offset() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_get_limit_offset").await;
 
@@ -1092,7 +1092,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_with_where_clause() {
+    async fn test_k8s_integration_get_with_where_clause() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_get_where").await;
 
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_get_with_include_list() {
+    async fn test_k8s_integration_get_with_include_list() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_get_include").await;
 
@@ -1176,7 +1176,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_query_basic() {
+    async fn test_k8s_integration_query_basic() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_query_basic").await;
 
@@ -1214,7 +1214,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_query_with_n_results() {
+    async fn test_k8s_integration_query_with_n_results() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_query_n_results").await;
 
@@ -1255,7 +1255,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_query_with_where_clause() {
+    async fn test_k8s_integration_query_with_where_clause() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_query_where").await;
 
@@ -1303,7 +1303,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_query_multiple_embeddings() {
+    async fn test_k8s_integration_query_multiple_embeddings() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_query_multiple").await;
 
@@ -1342,7 +1342,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_search_with_read_levels() {
+    async fn test_k8s_integration_search_with_read_levels() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_search_read_level").await;
 
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_update_embeddings() {
+    async fn test_k8s_integration_update_embeddings() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_update_embeddings").await;
 
@@ -1449,7 +1449,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_update_documents() {
+    async fn test_k8s_integration_update_documents() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_update_documents").await;
 
@@ -1497,7 +1497,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_update_metadata() {
+    async fn test_k8s_integration_update_metadata() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_update_metadata").await;
 
@@ -1559,7 +1559,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_upsert_insert_new() {
+    async fn test_k8s_integration_upsert_insert_new() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_upsert_insert").await;
 
@@ -1583,7 +1583,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_upsert_update_existing() {
+    async fn test_k8s_integration_upsert_update_existing() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_upsert_update").await;
 
@@ -1618,7 +1618,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_upsert_mixed() {
+    async fn test_k8s_integration_upsert_mixed() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_upsert_mixed").await;
 
@@ -1653,7 +1653,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_delete_by_ids() {
+    async fn test_k8s_integration_delete_by_ids() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_delete_by_ids").await;
 
@@ -1686,7 +1686,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_delete_by_where() {
+    async fn test_k8s_integration_delete_by_where() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_delete_by_where").await;
 
@@ -1725,7 +1725,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_fork_basic() {
+    async fn test_k8s_integration_fork_basic() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_fork_source").await;
 
@@ -1760,7 +1760,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_fork_preserves_data() {
+    async fn test_k8s_integration_fork_preserves_data() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_fork_preserves_source").await;
 
@@ -1798,7 +1798,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_fork_independence() {
+    async fn test_k8s_integration_fork_independence() {
         with_client(|mut client| async move {
             let collection = client.new_collection("test_fork_independence_source").await;
 
@@ -1842,7 +1842,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
-    async fn test_live_cloud_modify() {
+    async fn test_k8s_integration_modify() {
         with_client(|mut client| async move {
             let mut collection = client.new_collection("test_modify").await;
 

--- a/rust/chroma/src/lib.rs
+++ b/rust/chroma/src/lib.rs
@@ -112,35 +112,18 @@ pub use collection::ChromaCollection;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::{ChromaAuthMethod, ChromaHttpClientOptions};
+    use crate::client::ChromaHttpClientOptions;
     use std::collections::HashSet;
     use std::sync::{Arc, LazyLock, Mutex};
     use uuid::Uuid;
 
-    static CHROMA_CLIENT_OPTIONS: LazyLock<ChromaHttpClientOptions> = LazyLock::new(|| {
-        match dotenvy::dotenv() {
-            Ok(_) => {}
-            Err(err) => {
-                if err.not_found() {
-                    tracing::warn!("No .env file found");
-                } else {
-                    panic!("Error loading .env file: {}", err);
-                }
-            }
-        };
-
-        ChromaHttpClientOptions {
-            endpoint: std::env::var("CHROMA_ENDPOINT")
-                .unwrap_or_else(|_| "https://api.trychroma.com".to_string())
-                .parse()
-                .unwrap(),
-            auth_method: ChromaAuthMethod::cloud_api_key(
-                &std::env::var("CHROMA_CLOUD_API_KEY").unwrap(),
-            )
-            .unwrap(),
+    static CHROMA_CLIENT_OPTIONS: LazyLock<ChromaHttpClientOptions> =
+        LazyLock::new(|| ChromaHttpClientOptions {
+            endpoint: "http://localhost:8000".parse().unwrap(),
+            tenant_id: Some("default_tenant".to_string()),
+            database_name: Some("default_database".to_string()),
             ..Default::default()
-        }
-    });
+        });
 
     pub struct TestClient {
         client: ChromaHttpClient,


### PR DESCRIPTION
## Description of changes

Rename all test_live_cloud_* tests to test_k8s_integration_* so they run
under the existing k8s integration nextest profile instead of requiring a
separate live cloud profile and credentials.

- Rename 29 test functions across chroma_http_client.rs and collection.rs
- Remove the live_cloud nextest profile from nextest.toml
- Replace cloud API client config (dotenvy, CHROMA_ENDPOINT,
  CHROMA_CLOUD_API_KEY) with localhost:8000 default tenant/database
- Remove test_live_cloud_ from the default nextest exclusion filter
- Remove test-live-cloud GitHub action.

## Test plan

I ran `cargo test -p chroma` locally.

CI for the rest.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
