### PR TITLE
fix config roundtrip test failing for simple_ef

### DIFF
--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -52,11 +52,11 @@ class TestEmbeddingFunctionSchemas:
                 f"{ef_name} requires arguments that we cannot provide without external deps: {e}"
             )
 
-        # Mock __call__ to avoid needing to actually generate embeddings
-        mock_call = MagicMock(return_value=mock_embeddings(["test"]))
-        mock_common_deps.setattr(ef_instance, "__call__", mock_call)
-
-        # Get the config from the real instance
+        # Get the config from the real instance. We do not mock __call__
+        # because Python only looks up dunder methods on the class, so
+        # setting it on the instance would not intercept anything anyway;
+        # get_config() does not invoke the embedding function, so a real
+        # instance is safe here.
         config = ef_instance.get_config()
 
         # Test recreation from config


### PR DESCRIPTION
The `test_embedding_function_config_roundtrip` test was failing for `simple_ef` (and potentially other embedding functions) because it used `create_autospec` with `__new__` mocking. This caused `get_config()` to return a `MagicMock` object instead of an actual dict, so the roundtrip comparison always failed — two different MagicMock instances aren't equal.

Switched to using the `_create_ef_instance` helper that's already used by the other tests in this same file. This creates real instances with mocked external deps, so `get_config()` returns real config dicts that can be properly compared after a `build_from_config` roundtrip.

Fixes #6029