### PR TITLE
[ENH]: Precompute data chunk len()

### DIFF
--- a/rust/types/src/data_chunk.rs
+++ b/rust/types/src/data_chunk.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 pub struct Chunk<T> {
     data: Arc<[T]>,
     visibility: Arc<[bool]>,
+    visible_count: usize,
 }
 
 impl<T> Clone for Chunk<T> {
@@ -11,6 +12,7 @@ impl<T> Clone for Chunk<T> {
         Chunk {
             data: self.data.clone(),
             visibility: self.visibility.clone(),
+            visible_count: self.visible_count,
         }
     }
 }
@@ -21,6 +23,7 @@ impl<T> Chunk<T> {
         Chunk {
             data,
             visibility: vec![true; len].into(),
+            visible_count: len,
         }
     }
 
@@ -31,7 +34,7 @@ impl<T> Chunk<T> {
 
     /// Returns the number of visible elements in the data chunk
     pub fn len(&self) -> usize {
-        self.visibility.iter().filter(|&v| *v).count()
+        self.visible_count
     }
 
     /// Returns whether the chunk has zero visible elements.
@@ -75,6 +78,7 @@ impl<T> Chunk<T> {
     /// # Arguments
     /// * `visibility` - A vector of boolean values indicating the visibility of the elements
     pub fn set_visibility(&mut self, visibility: Vec<bool>) {
+        self.visible_count = visibility.iter().filter(|&v| *v).count();
         self.visibility = visibility.into();
     }
 


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
    - `DataChunk.len()` used to count the number of `visibility[i] = True` values to compute the length(). This is inefficient to compute on every invocation. The metadata log reader has a loop that invokes that invokes this `len()` function for every fetched log record. This appears to continue to take up > 40% of CPU on stack traces during gets on a high number of log records. This change precomputes this length value to fix this perf issue.
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_