### PR TITLE
[DOC] Fix link to Rust documentation

### DIFF
--- a/docs/mintlify/docs/overview/getting-started.mdx
+++ b/docs/mintlify/docs/overview/getting-started.mdx
@@ -407,7 +407,7 @@ summary.
 </Tab>
 <Tab title="Rust" icon="rust">
 
-Our Rust docs are hosted on [docs.rs](docs.rs/chroma/latest/chroma/)!
+Our Rust docs are hosted on [docs.rs](https://docs.rs/chroma/latest/chroma/)!
 
 ## Install Manually
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Fixed broken docs.rs link in getting-started.mdx (missing https://)

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
