### PR TITLE
[ENH]: Code impl for Block with more efficient estimated_size() function

### DIFF
--- a/rust/blockstore/Cargo.toml
+++ b/rust/blockstore/Cargo.toml
@@ -33,6 +33,7 @@ chroma-storage = { workspace = true }
 chroma-cache = { workspace = true }
 chroma-types = { workspace = true }
 chroma-tracing = { workspace = true }
+bincode = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/rust/cache/src/foyer.rs
+++ b/rust/cache/src/foyer.rs
@@ -17,6 +17,9 @@ use std::time::Duration;
 
 pub const MIB: usize = 1024 * 1024;
 
+// Re-export foyer's Code trait and CodeError for blockstore usage
+pub use foyer::{Code, CodeError};
+
 const fn default_capacity() -> usize {
     1048576
 }


### PR DESCRIPTION
## Description of changes

foyer had a blanket Code implementation for types that were Serialize + Deserialize. Its estimated_size() function operates by serializing its input and then wastefully finding the size of that. This change explicitly implements Code for Block to avoid this inefficiency.

- Improvements & Bug fixes
  - Foyer insertions should be faster now. It calls estimated_size() on the admission control path while further up the callstack chroma blockstorage potentially holds a NAC permit.
- New functionality
  - N/A

## Test plan
Tests have been added to the affected file to ensure that the new Code trait is interoperable with Blocks serialized via the old trait.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

See test plan.

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
