### PR TITLE
[CHORE]  Set $SERVICE in chroma2 to depend on $SERVICE of chroma.

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -323,9 +323,9 @@ k8s_resource('compaction-service:statefulset:chroma', resource_deps=['sysdb:depl
 k8s_resource('garbage-collector:statefulset:chroma', resource_deps=['k8s_setup', 'minio-deployment'], labels=["chroma"], port_forwards='50055:50055')
 
 # Production Chroma 2
-k8s_resource('postgres:deployment:chroma2', resource_deps=['k8s_setup2'], labels=["infrastructure2", 'postgres:deployment:chroma'], port_forwards='6432:5432')
+k8s_resource('postgres:deployment:chroma2', resource_deps=['k8s_setup2', 'postgres:deployment:chroma'], labels=["infrastructure2"], port_forwards='6432:5432')
 # Jobs are suffixed with the image tag to ensure they are unique. In this context, the image tag is defined in k8s/distributed-chroma/values.yaml.
-k8s_resource('sysdb-migration-latest:job:chroma2', resource_deps=['postgres:deployment:chroma2'], labels=["infrastructure2", 'sysdb-migration-latest:job:chroma'])
+k8s_resource('sysdb-migration-latest:job:chroma2', resource_deps=['postgres:deployment:chroma2', 'sysdb-migration-latest:job:chroma'], labels=["infrastructure2"])
 k8s_resource('rust-log-service:statefulset:chroma2', labels=["chroma2"], port_forwards=['60054:50051', '60052:50052'], resource_deps=['minio-deployment', 'rust-sysdb-migration-latest', 'rust-log-service:statefulset:chroma'])
 k8s_resource('rust-sysdb-migration-latest', resource_deps=['spanner-deployment'], labels=["infrastructure2"])
 k8s_resource('sysdb:deployment:chroma2', resource_deps=['sysdb-migration-latest:job:chroma2', 'sysdb:deployment:chroma'], labels=["chroma2"], port_forwards='60051:50051')


### PR DESCRIPTION
## Description of changes

Service $FOO in chroma and $FOO in chroma2 getting built at the same time seems to confuse tilt.
Add a dependency so that only one builds at a time.

## Test plan

Watch CI and run it a couple times.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
