### PR TITLE
[ENH] Truncate repr of test record set types for readable hypothesis output

### DIFF
--- a/chromadb/test/property/invariants.py
+++ b/chromadb/test/property/invariants.py
@@ -78,16 +78,16 @@ def wrap_all(record_set: RecordSet) -> NormalizedRecordSet:
             "embeddings must be a list of lists, a list of numpy arrays, a list of numbers, or None"
         )
 
-    return {
-        "ids": wrap(record_set["ids"]),
-        "documents": wrap(record_set["documents"])
+    return NormalizedRecordSet(
+        ids=wrap(record_set["ids"]),
+        documents=wrap(record_set["documents"])
         if record_set["documents"] is not None
         else None,
-        "metadatas": wrap(record_set["metadatas"])
+        metadatas=wrap(record_set["metadatas"])
         if record_set["metadatas"] is not None
         else None,
-        "embeddings": embedding_list,
-    }
+        embeddings=embedding_list,
+    )
 
 
 def check_metadata(

--- a/chromadb/test/property/test_add.py
+++ b/chromadb/test/property/test_add.py
@@ -204,13 +204,13 @@ def create_large_recordset(
     metadatas = [{"some_key": f"{i}"} for i in range(size)]
     documents = [f"Document {i}" for i in range(size)]
     embeddings = [[1, 2, 3] for _ in range(size)]
-    record_set: Dict[str, List[Any]] = {
-        "ids": ids,
-        "embeddings": cast(Embeddings, embeddings),
-        "metadatas": metadatas,
-        "documents": documents,
-    }
-    return cast(strategies.RecordSet, record_set)
+    record_set = strategies.RecordSet(
+        ids=ids,
+        embeddings=cast(Embeddings, embeddings),
+        metadatas=metadatas,
+        documents=documents,
+    )
+    return record_set
 
 
 @given(collection=collection_st, should_compact=st.booleans())

--- a/chromadb/test/property/test_embeddings.py
+++ b/chromadb/test/property/test_embeddings.py
@@ -138,18 +138,20 @@ class EmbeddingStateMachineBase(RuleBasedStateMachine):
             # Partially apply the non-duplicative records to the state
             new_ids = list(set(normalized_record_set["ids"]).difference(intersection))
             indices = [normalized_record_set["ids"].index(id) for id in new_ids]
-            filtered_record_set: strategies.NormalizedRecordSet = {
-                "ids": [normalized_record_set["ids"][i] for i in indices],
-                "metadatas": [normalized_record_set["metadatas"][i] for i in indices]
-                if normalized_record_set["metadatas"]
-                else None,
-                "documents": [normalized_record_set["documents"][i] for i in indices]
-                if normalized_record_set["documents"]
-                else None,
-                "embeddings": [normalized_record_set["embeddings"][i] for i in indices]
-                if normalized_record_set["embeddings"]
-                else None,
-            }
+            filtered_record_set: strategies.NormalizedRecordSet = (
+                strategies.NormalizedRecordSet(
+                    ids=[normalized_record_set["ids"][i] for i in indices],
+                    metadatas=[normalized_record_set["metadatas"][i] for i in indices]
+                    if normalized_record_set["metadatas"]
+                    else None,
+                    documents=[normalized_record_set["documents"][i] for i in indices]
+                    if normalized_record_set["documents"]
+                    else None,
+                    embeddings=[normalized_record_set["embeddings"][i] for i in indices]
+                    if normalized_record_set["embeddings"]
+                    else None,
+                )
+            )
             self.collection.add(**normalized_record_set)  # type: ignore[arg-type]
             self._upsert_embeddings(cast(strategies.RecordSet, filtered_record_set))
             return multiple(*filtered_record_set["ids"])

--- a/chromadb/test/test_multithreaded.py
+++ b/chromadb/test/test_multithreaded.py
@@ -26,12 +26,12 @@ def generate_record_set(N: int, D: int) -> RecordSet:
     embeddings = np.random.rand(N, D).tolist()
 
     # Create a normalized record set to compare against
-    normalized_record_set: RecordSet = {
-        "ids": ids,
-        "embeddings": embeddings,  # type: ignore
-        "metadatas": metadatas,  # type: ignore
-        "documents": documents,
-    }
+    normalized_record_set: RecordSet = RecordSet(
+        ids=ids,
+        embeddings=embeddings,  # type: ignore
+        metadatas=metadatas,  # type: ignore
+        documents=documents,
+    )
 
     return normalized_record_set
 


### PR DESCRIPTION
## Description of changes

Introduce `_TruncatedReprDict` base class that caps repr() at 1000
characters, preventing hypothesis from producing overwhelming error
messages when tests fail with large record sets.

RecordSet, NormalizedRecordSet, and StateMachineRecordSet now inherit
from `_TruncatedReprDict` instead of TypedDict, and all construction
sites are updated from dict literal syntax to constructor calls.

## Test plan

I expect to see CI not give pages of vectors when there's a flake.

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
