### PR TITLE
[ENH]  Only enrich dirty logs from s3, not repl.

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1432,7 +1432,6 @@ impl LogServer {
             rollups.insert((Some(topology.name.clone()), collection_id), rollup);
         }
         let mut backpressure = vec![];
-        self.enrich_dirty_log(&mut rollups).await?;
         for ((_, collection_id), rollup) in rollups.iter() {
             if rollup.requires_backpressure(self.config.num_records_before_backpressure) {
                 backpressure.push(*collection_id);


### PR DESCRIPTION
## Description of changes

The dirty log on S3 needs to enrich itself to purge markers.  The dirty
log on repl is self-healing and doesn't need to enrich itself.  Remove
the enrichment to make the dirty-log rollup fast.

## Test plan

Local for wal3/chroma-log-service.  CI for the rest.

## Migration plan

N/A

## Observability plan

Watch staging.

## Documentation Changes

N/A
