### PR TITLE
[ENH](log-service): separate S3 and repl dirty log roll-ups

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1368,7 +1368,7 @@ impl LogServer {
     }
 
     /// Roll up the S3 dirty log independently of topology roll-ups.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), name = "roll_dirty_log")]
     async fn roll_dirty_log_s3_cycle(&self) -> Result<(), Error> {
         let _guard = self.rolling_up_s3.lock().await;
         match self.roll_dirty_log_s3().await {
@@ -1389,7 +1389,7 @@ impl LogServer {
     }
 
     /// Roll up all topology dirty logs independently of S3 roll-ups.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), name = "roll_dirty_log")]
     async fn roll_dirty_log_repl_cycle(&self) -> Result<(), Error> {
         let _guard = self.rolling_up_repl.lock().await;
         let mut futures = vec![];


### PR DESCRIPTION
## Description of changes

Split the dirty log rolling mechanism into independent S3 and replication
paths so they can run concurrently without blocking each other. Previously
a slow topology roll-up would delay S3 compaction signals and vice versa.

- Split `rolling_up` mutex into `rolling_up_s3` and `rolling_up_repl`
- Split `need_to_compact` into `need_to_compact_s3` (keyed by
  CollectionUuid) and `need_to_compact_repl` (keyed by
  (TopologyName, CollectionUuid))
- Replace monolithic `roll_dirty_log` with `roll_dirty_log_s3_cycle`
  and `roll_dirty_log_repl_cycle` running concurrently via tokio::join
- Extract `should_compact` and `likely_needs_purge_dirty` methods on
  RollupPerCollection to deduplicate compaction selection logic
- Merge backpressure and metrics from both maps after each cycle

## Test plan

chroma-log-service, wal3: local
the rest: CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
