### PR TITLE
[BUG] Disable recursive balance in quantized spann

### DIFF
--- a/rust/index/src/spann/quantized_spann.rs
+++ b/rust/index/src/spann/quantized_spann.rs
@@ -398,10 +398,10 @@ impl<I: VectorIndex> QuantizedSpannIndexWriter<I> {
             return Ok(());
         }
 
-        for cluster_id in self.register(id, embedding, &rng_cluster_ids)? {
-            Box::pin(self.balance(cluster_id)).await?;
-        }
-
+        // TODO(sicheng): We should recursively balance here. We are not doing this right now because
+        // some data distribution will cause aggressive recursion. We need to address the root cause
+        // and then enable recursive balancing
+        self.register(id, embedding, &rng_cluster_ids)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Disabling recursive balancing in the quantized spann implementation for now after reassign. Some data distribution cause it to aggressively recurse. This is a temporary remedy until we properly identify the root cause.
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
