### PR TITLE
fix: remove src from published files to resolve Next.js build crash

### DIFF
--- a/clients/new-js/packages/ai-embeddings/google-gemini/package.json
+++ b/clients/new-js/packages/ai-embeddings/google-gemini/package.json
@@ -20,7 +20,6 @@
     }
   },
   "files": [
-    "src",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
## Description of changes

Fixes #6475 

This PR resolves a build crash in strict environments (like Next.js 16+ Turbopack) caused by raw testing files being published to the npm registry. 

- **Improvements & Bug fixes**
  - Removed `"src"` from the `"files"` array in `package.json` for `@chroma-core/google-gemini`.
  - Only the `"dist"` directory is now published, preventing the `Missing module type` Turbopack compilation error triggered by `src/index.test.ts`.

## Test plan

This is strictly a build configuration change and does not affect the core logic of the client. 

- [ ] Tests pass locally with `yarn test` for js
- **Custom Validation:** Verified that `main`, `types`, and `exports` all point to the `dist/` directory, meaning the raw `src/` directory is not required in the published npm artifact.

## Migration plan

None required. This is purely a packaging fix to prevent test files from being shipped to end users. It is fully backwards compatible.

## Observability plan

N/A

## Documentation Changes

N/A