### PR TITLE
[CHORE]: Make S3 read error more descriptive

### DIFF
--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -348,7 +348,7 @@ impl S3Storage {
         let mut reader = output.body.into_async_read();
 
         reader.read_exact(&mut buf).await.map_err(|e| {
-            tracing::error!("Error reading from S3: {}", e);
+            tracing::error!("Error reading from S3: {:?}", e);
             StorageError::Generic {
                 source: Arc::new(e),
             }


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Make the S3 read error message in `get_with_e_tag` more descriptive
- New functionality
  - ...

## Test plan

N/A

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
