### PR TITLE
[TST] Make pytest use importlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ required-version = "23.3.0"                 # Black will refuse to run if it's n
 target-version = ['py39', 'py310', 'py311']
 
 [tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]
 pythonpath = ["."]
 asyncio_mode = "auto"
 


### PR DESCRIPTION
Locally, tests have issues because we have two files with the same name.

https://github.com/chroma-core/chroma/issues/6031

* [api/test_schema.py](https://github.com/chroma-core/chroma/blob/85026a2c76efeb2200984b7561f4eaf105328764/chromadb/test/api/test_schema.py)
* [property/test_schema.py](https://github.com/chroma-core/chroma/blob/85026a2c76efeb2200984b7561f4eaf105328764/chromadb/test/property/test_schema.py)

Rather than renaming these files, we should make pytest use `importlib` as recommended by their docs.

https://docs.pytest.org/en/stable/explanation/goodpractices.html

> For historical reasons, pytest defaults to the prepend import mode instead of the importlib import mode we recommend for new projects. The reason lies in the way the prepend mode works:

