### PR TITLE
[CLN] Make telemetry a no-op and remove posthog as a dependency

### DIFF
--- a/chromadb/telemetry/product/posthog.py
+++ b/chromadb/telemetry/product/posthog.py
@@ -1,61 +1,11 @@
-import posthog
-import logging
-import sys
-from typing import Any, Dict, Set
-from chromadb.config import System
 from chromadb.telemetry.product import (
     ProductTelemetryClient,
     ProductTelemetryEvent,
 )
 from overrides import override
 
-logger = logging.getLogger(__name__)
-
-POSTHOG_EVENT_SETTINGS = {"$process_person_profile": False}
-
 
 class Posthog(ProductTelemetryClient):
-    def __init__(self, system: System):
-        if not system.settings.anonymized_telemetry or "pytest" in sys.modules:
-            posthog.disabled = True
-        else:
-            logger.info(
-                "Anonymized telemetry enabled. See \
-                    https://docs.trychroma.com/telemetry for more information."
-            )
-
-        posthog.project_api_key = "phc_YeUxaojbKk5KPi8hNlx1bBKHzuZ4FDtl67kH1blv8Bh"
-        posthog_logger = logging.getLogger("posthog")
-        # Silence posthog's logging
-        posthog_logger.disabled = True
-
-        self.batched_events: Dict[str, ProductTelemetryEvent] = {}
-        self.seen_event_types: Set[Any] = set()
-
-        super().__init__(system)
-
     @override
     def capture(self, event: ProductTelemetryEvent) -> None:
-        if event.max_batch_size == 1 or event.batch_key not in self.seen_event_types:
-            self.seen_event_types.add(event.batch_key)
-            self._direct_capture(event)
-            return
-        batch_key = event.batch_key
-        if batch_key not in self.batched_events:
-            self.batched_events[batch_key] = event
-            return
-        batched_event = self.batched_events[batch_key].batch(event)
-        self.batched_events[batch_key] = batched_event
-        if batched_event.batch_size >= batched_event.max_batch_size:
-            self._direct_capture(batched_event)
-            del self.batched_events[batch_key]
-
-    def _direct_capture(self, event: ProductTelemetryEvent) -> None:
-        try:
-            posthog.capture(
-                self.user_id,
-                event.name,
-                {**event.properties, **POSTHOG_EVENT_SETTINGS, **self.context},
-            )
-        except Exception as e:
-            logger.error(f"Failed to send telemetry event {event.name}: {e}")
+        pass

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
   'opentelemetry-exporter-otlp-proto-grpc>=1.2.0',
   'opentelemetry-sdk>=1.2.0',
   'overrides >= 7.3.1',
-  'posthog >= 2.4.0, < 6.0.0',
   'pydantic>=2.0',
   'pydantic-settings >= 2.0',
   'typing_extensions >= 4.5.0',

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -5,7 +5,6 @@ opentelemetry-exporter-otlp-proto-grpc>=1.2.0
 opentelemetry-sdk>=1.2.0
 orjson>=3.9.12
 overrides >= 7.3.1
-posthog>=2.4.0,<6.0.0
 pybase64>=1.4.1
 pydantic>=2.0
 pydantic-settings>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "Chroma."
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = ["Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent"]
-dependencies = ['build >= 1.0.3', 'pydantic >= 2.0', 'pydantic-settings >= 2.0', 'pybase64>=1.4.1', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'posthog >= 2.4.0, < 6.0.0', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
+dependencies = ['build >= 1.0.3', 'pydantic >= 2.0', 'pydantic-settings >= 2.0', 'pybase64>=1.4.1', 'uvicorn[standard] >= 0.18.3', 'numpy >= 1.22.5', 'typing_extensions >= 4.5.0', 'onnxruntime >= 1.14.1', 'opentelemetry-api>=1.2.0', 'opentelemetry-exporter-otlp-proto-grpc>=1.2.0', 'opentelemetry-sdk>=1.2.0', 'tokenizers >= 0.13.2', 'pypika >= 0.48.9', 'tqdm >= 4.65.0', 'overrides >= 7.3.1', 'importlib-resources', 'graphlib_backport >= 1.0.3; python_version < "3.9"', 'grpcio >= 1.58.0', 'bcrypt >= 4.0.1', 'typer >= 0.9.0', 'kubernetes>=28.1.0', 'tenacity>=8.2.3', 'PyYAML>=6.0.0', 'mmh3>=4.0.1', 'orjson>=3.9.12', 'httpx>=0.27.0', 'rich>=10.11.0', 'jsonschema>=4.19.0']
 
 [project.optional-dependencies]
 dev = ['chroma-hnswlib==0.7.6', 'fastapi>=0.115.9', 'opentelemetry-instrumentation-fastapi>=0.41b0']

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ opentelemetry-exporter-otlp-proto-grpc>=1.24.0
 opentelemetry-sdk>=1.24.0
 orjson>=3.9.12
 overrides>=7.3.1
-posthog>=2.4.0,<6.0.0
 pybase64>=1.4.1
 pydantic>=2.0
 pydantic-settings>=2.0


### PR DESCRIPTION
https://github.com/chroma-core/chroma/issues/6469

We do not collect telemetry anymore. This removes posthog as a dependency and makes the product telemetry impl a no-op.

I want to say on our docs that [we do not collect telemetry](https://docs.trychroma.com/docs/overview/oss#telemetry), and I feel removing this instrumentation is a prerequisite.

I'm keeping Posthog telemetry class because it is referenced in the config file as the telemetry impl. This breaks backwards compatibility tests.