### PR TITLE
[ENH] Ordered sparse vector writer

### DIFF
--- a/rust/index/src/sparse/writer.rs
+++ b/rust/index/src/sparse/writer.rs
@@ -4,6 +4,7 @@ use chroma_blockstore::{BlockfileFlusher, BlockfileWriter};
 use chroma_error::{ChromaError, ErrorCodes};
 use dashmap::DashMap;
 use thiserror::Error;
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::sparse::{
@@ -106,96 +107,127 @@ impl<'me> SparseWriter<'me> {
             .collect::<Vec<_>>();
         encoded_dimensions.push((DIMENSION_PREFIX.to_string(), u32::MAX));
         encoded_dimensions.sort_unstable();
+        tracing::trace!(
+            num_dimensions = encoded_dimensions.len(),
+            "Collected and sorted delta dimensions"
+        );
 
         let mut block_maxes = HashMap::with_capacity(encoded_dimensions.len());
-        let mut dimension_maxes = match self.old_reader.as_ref() {
-            Some(reader) => reader.get_dimension_max().await?,
-            None => HashMap::new(),
-        };
-
-        for (encoded_dimension, dimension_id) in &encoded_dimensions {
-            if encoded_dimension == DIMENSION_PREFIX {
-                continue;
-            }
-
-            let Some((_, offset_updates)) = self.delta.remove(dimension_id) else {
-                continue;
-            };
-            let mut offset_update_vec = offset_updates.into_iter().collect::<Vec<_>>();
-            offset_update_vec.sort_unstable_by_key(|(offset, _)| *offset);
-
-            let mut offset_values = match self.old_reader.as_ref() {
-                Some(reader) => reader.get_offset_values(encoded_dimension).await?.collect(),
-                None => HashMap::new(),
-            };
-
-            for (offset, update) in offset_update_vec {
-                match update {
-                    Some(value) => {
-                        self.offset_value_writer
-                            .set(encoded_dimension, offset, value)
-                            .await?;
-                        offset_values.insert(offset, value);
-                    }
-                    None => {
-                        self.offset_value_writer
-                            .delete::<_, f32>(encoded_dimension, offset)
-                            .await?;
-                        offset_values.remove(&offset);
-                    }
-                }
-            }
-
-            if offset_values.is_empty() {
-                dimension_maxes.remove(dimension_id);
-            } else {
-                let mut block_max =
-                    Vec::with_capacity(offset_values.len() / self.block_size as usize);
-                let mut dimension_max = f32::MIN;
-                let mut offset_value_vec = offset_values.into_iter().collect::<Vec<_>>();
-                offset_value_vec.sort_unstable_by_key(|(offset, _)| *offset);
-
-                for block in offset_value_vec.chunks(self.block_size as usize) {
-                    let (max_offset, max_value) = block.iter().fold(
-                        (u32::MIN, f32::MIN),
-                        |(max_offset, max_value), (offset, value)| {
-                            (max_offset.max(*offset), max_value.max(*value))
-                        },
-                    );
-                    block_max.push((max_offset + 1, max_value));
-                    dimension_max = dimension_max.max(max_value);
-                }
-
-                block_maxes.insert(*dimension_id, block_max);
-                dimension_maxes.insert(*dimension_id, dimension_max);
+        let mut dimension_maxes = async {
+            match self.old_reader.as_ref() {
+                Some(reader) => reader.get_dimension_max().await,
+                None => Ok(HashMap::new()),
             }
         }
+        .instrument(tracing::trace_span!("Load old dimension maxes"))
+        .await?;
 
-        for (encoded_dimension, dimension_id) in encoded_dimensions {
-            if encoded_dimension == DIMENSION_PREFIX {
-                let mut dimension_max_vec = dimension_maxes.drain().collect::<Vec<_>>();
-                dimension_max_vec.sort_unstable_by_key(|(dimension_id, _)| *dimension_id);
-                for (dimension_max_id, value) in dimension_max_vec {
+        async {
+            for (encoded_dimension, dimension_id) in &encoded_dimensions {
+                if encoded_dimension == DIMENSION_PREFIX {
+                    continue;
+                }
+
+                let Some((_, offset_updates)) = self.delta.remove(dimension_id) else {
+                    continue;
+                };
+                let mut offset_update_vec = offset_updates.into_iter().collect::<Vec<_>>();
+                offset_update_vec.sort_unstable_by_key(|(offset, _)| *offset);
+
+                let mut offset_values = match self.old_reader.as_ref() {
+                    Some(reader) => reader.get_offset_values(encoded_dimension).await?.collect(),
+                    None => HashMap::new(),
+                };
+
+                for (offset, update) in offset_update_vec {
+                    match update {
+                        Some(value) => {
+                            self.offset_value_writer
+                                .set(encoded_dimension, offset, value)
+                                .await?;
+                            offset_values.insert(offset, value);
+                        }
+                        None => {
+                            self.offset_value_writer
+                                .delete::<_, f32>(encoded_dimension, offset)
+                                .await?;
+                            offset_values.remove(&offset);
+                        }
+                    }
+                }
+
+                if offset_values.is_empty() {
+                    dimension_maxes.remove(dimension_id);
+                } else {
+                    let mut block_max =
+                        Vec::with_capacity(offset_values.len() / self.block_size as usize);
+                    let mut dimension_max = f32::MIN;
+                    let mut offset_value_vec = offset_values.into_iter().collect::<Vec<_>>();
+                    offset_value_vec.sort_unstable_by_key(|(offset, _)| *offset);
+
+                    for block in offset_value_vec.chunks(self.block_size as usize) {
+                        let (max_offset, max_value) = block.iter().fold(
+                            (u32::MIN, f32::MIN),
+                            |(max_offset, max_value), (offset, value)| {
+                                (max_offset.max(*offset), max_value.max(*value))
+                            },
+                        );
+                        block_max.push((max_offset + 1, max_value));
+                        dimension_max = dimension_max.max(max_value);
+                    }
+
+                    block_maxes.insert(*dimension_id, block_max);
+                    dimension_maxes.insert(*dimension_id, dimension_max);
+                }
+            }
+            Ok::<_, SparseWriterError>(())
+        }
+        .instrument(tracing::trace_span!(
+            "Write offset values and compute block maxes"
+        ))
+        .await?;
+
+        async {
+            for (encoded_dimension, dimension_id) in encoded_dimensions {
+                if encoded_dimension == DIMENSION_PREFIX {
+                    let mut dimension_max_vec = dimension_maxes.drain().collect::<Vec<_>>();
+                    dimension_max_vec.sort_unstable_by_key(|(dimension_id, _)| *dimension_id);
+                    for (dimension_max_id, value) in dimension_max_vec {
+                        self.max_writer
+                            .set(DIMENSION_PREFIX, dimension_max_id, value)
+                            .await?;
+                    }
+                    continue;
+                }
+
+                let Some(block_max) = block_maxes.remove(&dimension_id) else {
+                    continue;
+                };
+                for (offset, value) in block_max {
                     self.max_writer
-                        .set(DIMENSION_PREFIX, dimension_max_id, value)
+                        .set(&encoded_dimension, offset, value)
                         .await?;
                 }
-                continue;
             }
-
-            let Some(block_max) = block_maxes.remove(&dimension_id) else {
-                continue;
-            };
-            for (offset, value) in block_max {
-                self.max_writer
-                    .set(&encoded_dimension, offset, value)
-                    .await?;
-            }
+            Ok::<_, SparseWriterError>(())
         }
+        .instrument(tracing::trace_span!("Write max blockfile"))
+        .await?;
+
+        let max_flusher = self
+            .max_writer
+            .commit::<u32, f32>()
+            .instrument(tracing::trace_span!("Commit max blockfile"))
+            .await?;
+        let offset_value_flusher = self
+            .offset_value_writer
+            .commit::<u32, f32>()
+            .instrument(tracing::trace_span!("Commit offset-value blockfile"))
+            .await?;
 
         Ok(SparseFlusher {
-            max_flusher: self.max_writer.commit::<u32, f32>().await?,
-            offset_value_flusher: self.offset_value_writer.commit::<u32, f32>().await?,
+            max_flusher,
+            offset_value_flusher,
         })
     }
 }

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -403,7 +403,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                 .map_err(|e| MetadataSegmentError::BlockfileOpenError(*e))?;
             let max_writer = {
                 let mut options =
-                    BlockfileWriterOptions::new(max_prefix.to_string()).fork(max_uuid);
+                    BlockfileWriterOptions::new(max_prefix.to_string()).ordered_mutations();
                 if let Some(cmek) = &cmek {
                     options = options.with_cmek(cmek.clone());
                 }
@@ -425,7 +425,8 @@ impl<'me> MetadataSegmentWriter<'me> {
                 .map_err(|e| MetadataSegmentError::BlockfileOpenError(*e))?;
             let offset_value_writer = {
                 let mut options = BlockfileWriterOptions::new(offset_value_prefix.to_string())
-                    .fork(offset_value_uuid);
+                    .fork(offset_value_uuid)
+                    .ordered_mutations();
                 if let Some(cmek) = &cmek {
                     options = options.with_cmek(cmek.clone());
                 }
@@ -442,7 +443,8 @@ impl<'me> MetadataSegmentWriter<'me> {
             ))
         } else {
             let max_writer = {
-                let mut options = BlockfileWriterOptions::new(prefix_path.clone());
+                let mut options =
+                    BlockfileWriterOptions::new(prefix_path.clone()).ordered_mutations();
                 if let Some(cmek) = &cmek {
                     options = options.with_cmek(cmek.clone());
                 }
@@ -452,7 +454,8 @@ impl<'me> MetadataSegmentWriter<'me> {
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
             let offset_value_writer = {
-                let mut options = BlockfileWriterOptions::new(prefix_path.clone());
+                let mut options =
+                    BlockfileWriterOptions::new(prefix_path.clone()).ordered_mutations();
                 if let Some(cmek) = &cmek {
                     options = options.with_cmek(cmek.clone());
                 }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Replace `Arc<Mutex<HashMap<_, _>>>` in sparse vector writer with `Arc<DashMap<_, _>>`
  - Refactor the commit step to use ordered block file writer.
  - Create max block file from scratch every time to avoid aggressive point delete
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
