### PR TITLE
[TST] Add python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.12", "3.14"]
         test-globs: ["chromadb/test/property/test_collections.py",
                    "chromadb/test/property/test_add.py",
                    "chromadb/test/property/test_filtering.py",
@@ -20,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - uses: useblacksmith/setup-docker-builder@v1
       - uses: ./.github/actions/tilt
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -152,6 +152,7 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
+      python_versions: '["3.9", "3.14"]'
       property_testing_preset: 'normal'
 
   python-vulnerability-scan:

--- a/.github/workflows/release-chromadb.yml
+++ b/.github/workflows/release-chromadb.yml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
-      python_versions: '["3.9", "3.10", "3.11", "3.12"]'
+      python_versions: '["3.9", "3.10", "3.11", "3.12", "3.14"]'
       property_testing_preset: 'normal'
 
   python-tests-windows:


### PR DESCRIPTION
TODO: figure out of other versions can be removed to reduce cost

I expect this to fail because tests break on 3.14. There are stacked PRs that fix the issues.