### PR TITLE
[TST] Fix async client test for Python 3.14

### DIFF
--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -60,6 +60,17 @@ def http_api_factory(
                 yield cast(HttpAPIFactory, factory)
 
 
+@pytest.fixture()
+def http_api(http_api_factory: HttpAPIFactory) -> Generator[ClientAPI, None, None]:
+    if os.environ.get("CHROMA_SERVER_HTTP_PORT") is not None:
+        port = int(os.environ.get("CHROMA_SERVER_HTTP_PORT"))  # type: ignore
+        client = http_api_factory(port=port)
+    else:
+        client = http_api_factory()
+    yield client
+    client.clear_system_cache()
+
+
 def test_ephemeral_client(ephemeral_api: ClientAPI) -> None:
     settings = ephemeral_api.get_settings()
     assert settings.is_persistent is False


### PR DESCRIPTION
This test is broken in Python 3.14
https://docs.python.org/3/library/asyncio-policy.html?utm_source=chatgpt.com

> Changed in version 3.14: The get_event_loop() method of the default asyncio policy now raises a RuntimeError if there is no set event loop.

I just made it use the same pattern used here:

https://github.com/chroma-core/chroma/blob/1c1c7fc489dbb937dcc751616bd79b360f8ba1eb/chromadb/utils/async_to_sync.py#L18-L23