### PR TITLE
[ENH] Thread topology name through purge-dirty pipeline

### DIFF
--- a/idl/chromadb/proto/logservice.proto
+++ b/idl/chromadb/proto/logservice.proto
@@ -107,6 +107,7 @@ message UpdateCollectionLogOffsetResponse {
 
 message PurgeDirtyForCollectionRequest {
   repeated string collection_ids = 1;
+  string topology_name = 5;
 }
 
 message PurgeDirtyForCollectionResponse {

--- a/rust/log/src/log.rs
+++ b/rust/log/src/log.rs
@@ -6,7 +6,7 @@ use chroma_error::ChromaError;
 use chroma_memberlist::client_manager::ClientAssignmentError;
 use chroma_types::{
     Cmek, CollectionUuid, DatabaseName, ForkCollectionError, ForkLogsResponse, LogRecord,
-    OperationRecord, ResetError, ResetResponse,
+    OperationRecord, ResetError, ResetResponse, TopologyName,
 };
 use std::fmt::Debug;
 
@@ -216,7 +216,7 @@ impl Log {
     #[tracing::instrument(skip(self), err(Display))]
     pub async fn purge_dirty_for_collection(
         &mut self,
-        collection_ids: Vec<CollectionUuid>,
+        collection_ids: Vec<(CollectionUuid, Option<TopologyName>)>,
     ) -> Result<(), Box<dyn ChromaError>> {
         match self {
             Log::Sqlite(_) => unimplemented!("not implemented for sqlite"),

--- a/rust/worker/src/execution/operators/purge_dirty_log.rs
+++ b/rust/worker/src/execution/operators/purge_dirty_log.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use chroma_log::Log;
 use chroma_system::{Operator, OperatorType};
-use chroma_types::CollectionUuid;
+use chroma_types::{CollectionUuid, TopologyName};
 use thiserror::Error;
 use tokio::time::{error::Elapsed, timeout};
 
@@ -29,7 +29,7 @@ pub struct PurgeDirtyLog {
 
 #[derive(Clone, Debug)]
 pub struct PurgeDirtyLogInput {
-    pub collection_uuids: Vec<CollectionUuid>,
+    pub collection_uuids: Vec<(CollectionUuid, Option<TopologyName>)>,
 }
 
 pub type PurgeDirtyLogOutput = ();
@@ -70,6 +70,7 @@ impl Operator<PurgeDirtyLogInput, PurgeDirtyLogOutput> for PurgeDirtyLog {
                 .purge_dirty_for_collection(input.collection_uuids.clone()),
         )
         .await??;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description of changes

Pass topology_name alongside collection IDs when purging dirty log
entries so the log service can scope purges to the correct topology.

- Add topology_name field to PurgeDirtyForCollectionRequest proto
- Change purge_dirty_for_collection to accept (CollectionUuid,
  Option<TopologyName>) pairs and group requests by topology
- Convert Scheduler.deleted_collections from HashSet to HashMap to
  track each deleted collection's topology name
- Update PurgeDirtyLogInput to carry topology information

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
