### PR TITLE
[CHORE]  Add debug logging so we can see what the RLS sees when it throws backpressure warnings

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1437,6 +1437,7 @@ impl LogServer {
             let need_to_compact_s3 = self.need_to_compact_s3.lock();
             for (collection_id, rollup) in need_to_compact_s3.iter() {
                 if rollup.requires_backpressure(self.config.num_records_before_backpressure) {
+                    tracing::info!(collection_id =? collection_id, rollup =? rollup, "requires backpressure");
                     backpressure.push(*collection_id);
                 }
             }
@@ -1445,6 +1446,7 @@ impl LogServer {
             let need_to_compact_repl = self.need_to_compact_repl.lock();
             for ((_, collection_id), rollup) in need_to_compact_repl.iter() {
                 if rollup.requires_backpressure(self.config.num_records_before_backpressure) {
+                    tracing::info!(collection_id =? collection_id, rollup =? rollup, "requires backpressure");
                     backpressure.push(*collection_id);
                 }
             }


### PR DESCRIPTION
## Description of changes

We don't know what leads to a backpressure decision.  Embed it in spans in the moment.

## Test plan

CI

## Migration plan

N/A

## Observability plan

That's the plan.

## Documentation Changes

N/A
