### PR TITLE
[CHORE]  Set the tilt-up timeout for `tilt ci` to 10min.

### DIFF
--- a/.github/actions/tilt/action.yaml
+++ b/.github/actions/tilt/action.yaml
@@ -7,7 +7,7 @@ runs:
       uses: ./.github/actions/tilt-setup-prebuild
     - name: Start Tilt
       shell: bash
-      run: tilt ci
+      run: tilt ci --timeout 10m
     - name: Forward ports
       shell: bash
       run: |


### PR DESCRIPTION
## Description of changes

Prior to this change the timeout was the default of 30 minutes.  After
5-10 most tests fail, but a failure to bring up costs the full 30.

Set the timeout to 10 minutes so that flakes resolve quicker for faster
retries.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
