### PR TITLE
Revert "[CHORE]  Tighten down k8s resources in test."

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.78
+version: 0.1.77
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/values.dev.yaml
+++ b/k8s/distributed-chroma/values.dev.yaml
@@ -9,9 +9,9 @@ sysdb:
     kubernetes-namespace: chroma
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
     requests:
-      cpu: 100m
+      cpu: 200m
 
 rustFrontendService:
   # We have to specify the command, because the Dockerfile uses the CLI since its shared with
@@ -24,9 +24,9 @@ rustFrontendService:
       value: 'value: "1"'
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
     requests:
-      cpu: 100m
+      cpu: 200m
 
 queryService:
   env:
@@ -35,9 +35,9 @@ queryService:
   jemallocConfig: "prof:true,prof_active:true,lg_prof_sample:19"
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
     requests:
-      cpu: 100m
+      cpu: 200m
 
 compactionService:
   env:
@@ -62,14 +62,14 @@ garbageCollector:
   jemallocConfig: "prof:true,prof_active:true,lg_prof_sample:19"
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
     requests:
-      cpu: 100m
+      cpu: 200m
 
 rustSysdbService:
   replicaCount: 1
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
     requests:
-      cpu: 100m
+      cpu: 200m

--- a/k8s/test/grafana.yaml
+++ b/k8s/test/grafana.yaml
@@ -63,11 +63,6 @@ spec:
       containers:
         - name: grafana
           image: grafana/grafana-oss:11.1.4
-          resources:
-            requests:
-              cpu: "50m"
-            limits:
-              cpu: "50m"
           ports:
             - containerPort: 3000
               name: http-port

--- a/k8s/test/jaeger.yaml
+++ b/k8s/test/jaeger.yaml
@@ -38,10 +38,8 @@ spec:
               name: http-port
           resources:
             requests:
-              cpu: "50m"
               memory: "512Mi"
             limits:
-              cpu: "50m"
               memory: "2Gi"
 
           volumeMounts:

--- a/k8s/test/minio.yaml
+++ b/k8s/test/minio.yaml
@@ -20,11 +20,6 @@ spec:
       containers:
         - name: minio
           image: minio/minio:latest
-          resources:
-            requests:
-              cpu: "100m"
-            limits:
-              cpu: "100m"
           args:
             - server
             - /storage

--- a/k8s/test/otel-collector.yaml
+++ b/k8s/test/otel-collector.yaml
@@ -57,11 +57,6 @@ spec:
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector:0.107.0
-          resources:
-            requests:
-              cpu: "50m"
-            limits:
-              cpu: "50m"
           ports:
             - containerPort: 4317
               name: grpc-port

--- a/k8s/test/postgres.yaml
+++ b/k8s/test/postgres.yaml
@@ -16,11 +16,6 @@ spec:
       containers:
         - name: postgres
           image: chroma-postgres
-          resources:
-            requests:
-              cpu: "100m"
-            limits:
-              cpu: "100m"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"

--- a/k8s/test/postgres2.yaml
+++ b/k8s/test/postgres2.yaml
@@ -16,11 +16,6 @@ spec:
       containers:
         - name: postgres
           image: chroma-postgres
-          resources:
-            requests:
-              cpu: "100m"
-            limits:
-              cpu: "100m"
           env:
             - name: POSTGRES_MULTIPLE_DATABASES
               value: "sysdb,log"

--- a/k8s/test/prometheus.yaml
+++ b/k8s/test/prometheus.yaml
@@ -31,11 +31,6 @@ spec:
       containers:
         - name: prometheus
           image: prom/prometheus:v2.53.2
-          resources:
-            requests:
-              cpu: "50m"
-            limits:
-              cpu: "50m"
           ports:
             - containerPort: 9090
               name: http-port

--- a/k8s/test/spanner.yaml
+++ b/k8s/test/spanner.yaml
@@ -17,11 +17,6 @@ spec:
       containers:
         - name: spanner
           image: gcr.io/cloud-spanner-emulator/emulator:1.5.45
-          resources:
-            requests:
-              cpu: "100m"
-            limits:
-              cpu: "100m"
           ports:
             - containerPort: 9010
               name: grpc


### PR DESCRIPTION
Reverts chroma-core/chroma#6509

This caused a flake on main.  Not sure why it didn't trip on pre-merge CI.