### PR TITLE
Replace panic with error variant in metadata document parsing

### DIFF
--- a/rust/log/src/sqlite_log.rs
+++ b/rust/log/src/sqlite_log.rs
@@ -29,7 +29,7 @@ pub enum SqlitePullLogsError {
     InvalidMetadata(#[from] serde_json::Error),
     #[error("Failed to parse document from metadata: unexpected type")]
     InvalidDocumentType,
-    #[error("Method {0} is not implemented")],
+    #[error("Method {0} is not implemented")]
     NotImplemented(String),
 }
 
@@ -40,7 +40,7 @@ impl ChromaError for SqlitePullLogsError {
             SqlitePullLogsError::InvalidEncoding(_) => ErrorCodes::InvalidArgument,
             SqlitePullLogsError::InvalidEmbedding(_) => ErrorCodes::InvalidArgument,
             SqlitePullLogsError::InvalidMetadata(_) => ErrorCodes::InvalidArgument,
-            SqlitePullLogsError::InvalidDocumentType(_) => ErrorCodes::InvalidArgument,
+            SqlitePullLogsError::InvalidDocumentType => ErrorCodes::InvalidArgument,
             SqlitePullLogsError::NotImplemented(_) => ErrorCodes::Internal,
         }
     }


### PR DESCRIPTION
## Description of changes
- Improvements & Bug fixes
  - Replace panic with `InvalidDocumentType` error variant in `SqlitePullLogsError` when `chroma:document` has an unexpected type during log reads

## Test plan
- [ ] Tests pass locally with `cargo test` for rust

## Migration plan
None required. This is a non-breaking change that converts a panic into a proper error.

## Observability plan
No new instrumentation needed. The error propagates through existing error handling paths.

## Documentation Changes
No documentation changes required.