### PR TITLE
test(js): make async error assertions more idiomatic

### DIFF
--- a/clients/js/packages/chromadb-core/test/add.collections.test.ts
+++ b/clients/js/packages/chromadb-core/test/add.collections.test.ts
@@ -107,13 +107,9 @@ describe("add collections", () => {
         embeddingFunction: embedder,
       });
 
-      try {
-        await embedder.generate(DOCUMENTS);
-      } catch (e: any) {
-        expect(e.message).toMatch(
-          "This model does not support specifying dimensions.",
-        );
-      }
+      await expect(embedder.generate(DOCUMENTS)).rejects.toThrow(
+        "This model does not support specifying dimensions.",
+      );
     });
   }
 
@@ -180,9 +176,9 @@ describe("add collections", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.add({ ids: IDS, embeddings: EMBEDDINGS });
-    }).rejects.toThrow(ChromaNotFoundError);
+    await expect(
+      collection.add({ ids: IDS, embeddings: EMBEDDINGS }),
+    ).rejects.toThrow(ChromaNotFoundError);
   });
 
   test("It should return an error when inserting duplicate IDs in the same batch", async () => {
@@ -190,11 +186,9 @@ describe("add collections", () => {
     const ids = IDS.concat(["test1"]);
     const embeddings = EMBEDDINGS.concat([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]);
     const metadatas = METADATAS.concat([{ test: "test1", float_value: 0.1 }]);
-    try {
-      await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("duplicates");
-    }
+    await expect(
+      collection.add({ ids, embeddings, metadatas }),
+    ).rejects.toThrow(/duplicates/);
   });
 
   test("should error on empty embedding", async () => {
@@ -202,10 +196,8 @@ describe("add collections", () => {
     const ids = ["id1"];
     const embeddings = [[]];
     const metadatas = [{ test: "test1", float_value: 0.1 }];
-    try {
-      await collection.add({ ids, embeddings, metadatas });
-    } catch (e: any) {
-      expect(e.message).toMatch("got empty embedding at pos");
-    }
+    await expect(
+      collection.add({ ids, embeddings, metadatas }),
+    ).rejects.toThrow(/got empty embedding at pos/);
   });
 });

--- a/clients/js/packages/chromadb-core/test/admin.test.ts
+++ b/clients/js/packages/chromadb-core/test/admin.test.ts
@@ -120,16 +120,11 @@ describe("AdminClient", () => {
     await adminClient.createDatabase({ name: dbName, tenantName: tenantName });
 
     // Attempt to create it again, should fail
-    try {
-      await adminClient.createDatabase({
+    await expect(
+      adminClient.createDatabase({
         name: dbName,
         tenantName: tenantName,
-      });
-      // If it reaches here, the test failed because no error was thrown
-      expect(true).toBe(false);
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      expect(error).toBeInstanceOf(ChromaUniqueError);
-    }
+      }),
+    ).rejects.toBeInstanceOf(ChromaUniqueError);
   });
 });

--- a/clients/js/packages/chromadb-core/test/delete.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/delete.collection.test.ts
@@ -38,8 +38,8 @@ describe("delete collection", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.delete({ where: { test: "test1" } });
-    }).rejects.toThrow(ChromaNotFoundError);
+    await expect(
+      collection.delete({ where: { test: "test1" } }),
+    ).rejects.toThrow(ChromaNotFoundError);
   });
 });

--- a/clients/js/packages/chromadb-core/test/get.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/get.collection.test.ts
@@ -44,18 +44,17 @@ describe("get collections", () => {
       embeddings: EMBEDDINGS,
       metadatas: METADATAS,
     });
-    try {
-      await collection.get({
-        where: {
-          //@ts-ignore supposed to fail
-          test: { $contains: "hello" },
-        },
-      });
-    } catch (error: any) {
-      expect(error).toBeDefined();
-      expect(error).toBeInstanceOf(InvalidArgumentError);
-      expect(error.message).toMatchInlineSnapshot(`"Invalid where clause"`);
-    }
+    const invalidWhereQuery = collection.get({
+      where: {
+        //@ts-ignore supposed to fail
+        test: { $contains: "hello" },
+      },
+    });
+
+    await expect(invalidWhereQuery).rejects.toThrow(InvalidArgumentError);
+    await expect(invalidWhereQuery).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Invalid where clause"`,
+    );
   });
 
   test("it should get embedding with matching documents", async () => {
@@ -105,18 +104,17 @@ describe("get collections", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.get({ ids: IDS });
-    }).rejects.toThrow(ChromaNotFoundError);
+    await expect(collection.get({ ids: IDS })).rejects.toThrow(
+      ChromaNotFoundError,
+    );
   });
 
   test("it should throw an error if the collection does not exist", async () => {
     await expect(
-      async () =>
-        await client.getCollection({
-          name: "test",
-          embeddingFunction: new DefaultEmbeddingFunction(),
-        }),
+      client.getCollection({
+        name: "test",
+        embeddingFunction: new DefaultEmbeddingFunction(),
+      }),
     ).rejects.toThrow(Error);
   });
 });

--- a/clients/js/packages/chromadb-core/test/offline.test.ts
+++ b/clients/js/packages/chromadb-core/test/offline.test.ts
@@ -4,13 +4,14 @@ import { ChromaConnectionError } from "../src/Errors";
 
 test("it fails with a nice error when offline", async () => {
   const chroma = new ChromaClient({ path: "http://example.invalid" });
-  try {
-    await chroma.createCollection({ name: "test" });
-    throw new Error("Should have thrown an error.");
-  } catch (e) {
-    expect(e).toBeInstanceOf(ChromaConnectionError);
-    expect((e as Error).message).toMatchInlineSnapshot(
-      `"Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable."`,
-    );
-  }
+  const createCollectionRequest = chroma.createCollection({ name: "test" });
+
+  await expect(createCollectionRequest).rejects.toBeInstanceOf(
+    ChromaConnectionError,
+  );
+
+  await expect(createCollectionRequest).rejects.toMatchObject({
+    message:
+      "Failed to connect to chromadb. Make sure your server is running and try again. If you are running from a browser, make sure that your chromadb instance is configured to allow requests from the current origin using the CHROMA_SERVER_CORS_ALLOW_ORIGINS environment variable.",
+  });
 });

--- a/clients/js/packages/chromadb-core/test/peek.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/peek.collection.test.ts
@@ -27,8 +27,6 @@ describe("peek records", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.peek({});
-    }).rejects.toThrow(ChromaNotFoundError);
+    await expect(collection.peek({})).rejects.toThrow(ChromaNotFoundError);
   });
 });

--- a/clients/js/packages/chromadb-core/test/query.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/query.collection.test.ts
@@ -226,9 +226,9 @@ describe("query records", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.query({ queryEmbeddings: [1, 2, 3] });
-    }).rejects.toThrow(ChromaNotFoundError);
+    await expect(
+      collection.query({ queryEmbeddings: [1, 2, 3] }),
+    ).rejects.toThrow(ChromaNotFoundError);
   });
 
   test("it should query a collection with specific IDs", async () => {
@@ -464,13 +464,13 @@ describe("id filtering", () => {
     }
 
     const deletedId = idsToDelete[0];
-    await expect(async () => {
-      await collection.query({
+    await expect(
+      collection.query({
         queryEmbeddings: queryEmbedding,
         ids: deletedId,
         nResults: 1,
         include: [IncludeEnum.Metadatas],
-      });
-    }).rejects.toThrow();
+      }),
+    ).rejects.toThrow();
   });
 });

--- a/clients/js/packages/chromadb-core/test/update.collection.test.ts
+++ b/clients/js/packages/chromadb-core/test/update.collection.test.ts
@@ -61,14 +61,14 @@ describe("update records", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.update({
+    await expect(
+      collection.update({
         ids: ["test1"],
         embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
         metadatas: [{ test: "meta1" }],
         documents: ["doc1"],
-      });
-    }).rejects.toThrow(ChromaNotFoundError);
+      }),
+    ).rejects.toThrow(ChromaNotFoundError);
   });
 
   test("should support updating records without a document or an embedding", async () => {

--- a/clients/js/packages/chromadb-core/test/upsert.collections.test.ts
+++ b/clients/js/packages/chromadb-core/test/upsert.collections.test.ts
@@ -42,13 +42,13 @@ describe("upsert records", () => {
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });
-    await expect(async () => {
-      await collection.upsert({
+    await expect(
+      collection.upsert({
         ids: ["test1"],
         embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 11]],
         metadatas: [{ test: "meta1" }],
         documents: ["doc1"],
-      });
-    }).rejects.toThrow(ChromaNotFoundError);
+      }),
+    ).rejects.toThrow(ChromaNotFoundError);
   });
 });


### PR DESCRIPTION
## Summary
This PR takes a focused first pass on #2801 by converting async error tests in `chromadb-core` to more idiomatic Jest patterns.

### What changed
- Replaced `try/catch`-style async failure assertions with `await expect(promise).rejects...` in:
  - `add.collections.test.ts`
  - `admin.test.ts`
  - `get.collection.test.ts`
  - `offline.test.ts`
- Replaced `await expect(async () => await ...)` wrappers with direct promise assertions across:
  - `add.collections.test.ts`
  - `delete.collection.test.ts`
  - `get.collection.test.ts`
  - `peek.collection.test.ts`
  - `query.collection.test.ts`
  - `update.collection.test.ts`
  - `upsert.collections.test.ts`

This reduces false-positive risk in tests and aligns with Jest's recommended `rejects` style.

## Verification
- Formatting: `prettier --write` on all edited test files ✅
- Test run in this environment is currently blocked by missing native `bcrypt` binding from dependency install script restrictions (`pnpm approve-builds`), so full Jest verification is deferred to CI.

Ref #2801
