### PR TITLE
[ENH]: Preallocate during pull log parsing

### DIFF
--- a/rust/log/src/grpc_log.rs
+++ b/rust/log/src/grpc_log.rs
@@ -353,7 +353,7 @@ impl GrpcLog {
         match response {
             Ok(response) => {
                 let logs = response.into_inner().records;
-                let mut result = Vec::new();
+                let mut result = Vec::with_capacity(logs.len());
                 for log_record_proto in logs {
                     let log_record = log_record_proto.try_into();
                     match log_record {

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -1196,13 +1196,13 @@ impl TryFrom<chroma_proto::UpdateMetadata> for UpdateMetadata {
     type Error = UpdateMetadataValueConversionError;
 
     fn try_from(proto_metadata: chroma_proto::UpdateMetadata) -> Result<Self, Self::Error> {
-        let mut metadata = UpdateMetadata::new();
-        for (key, value) in proto_metadata.metadata.iter() {
-            let value = match value.try_into() {
+        let mut metadata = UpdateMetadata::with_capacity(proto_metadata.metadata.len());
+        for (key, value) in proto_metadata.metadata.into_iter() {
+            let value = match (&value).try_into() {
                 Ok(value) => value,
                 Err(_) => return Err(UpdateMetadataValueConversionError::InvalidValue),
             };
-            metadata.insert(key.clone(), value);
+            metadata.insert(key, value);
         }
         Ok(metadata)
     }
@@ -1210,13 +1210,12 @@ impl TryFrom<chroma_proto::UpdateMetadata> for UpdateMetadata {
 
 impl From<UpdateMetadata> for chroma_proto::UpdateMetadata {
     fn from(metadata: UpdateMetadata) -> Self {
-        let mut metadata = metadata;
         let mut proto_metadata = chroma_proto::UpdateMetadata {
-            metadata: HashMap::new(),
+            metadata: HashMap::with_capacity(metadata.len()),
         };
-        for (key, value) in metadata.drain() {
+        for (key, value) in metadata.into_iter() {
             let proto_value = value.into();
-            proto_metadata.metadata.insert(key.clone(), proto_value);
+            proto_metadata.metadata.insert(key, proto_value);
         }
         proto_metadata
     }


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Preallocate metadata HashMap when parsing a proto LogRecord into an UpdateMetadata HashMap.
 - Preallocate result vector of read()
- New functionality
  - N/A

## Test plan

N/A

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
