### PR TITLE
fix(types): correct type annotations in embedding_functions.py

### DIFF
--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -1,5 +1,6 @@
-from typing import Dict, Any, Type, Set
+from typing import Any, Callable, Dict, Optional, Set, Type, TypeVar, Union
 from chromadb.api.types import (
+    Embeddable,
     EmbeddingFunction,
     DefaultEmbeddingFunction,
     SparseEmbeddingFunction,
@@ -139,7 +140,7 @@ def get_builtins() -> Set[str]:
 
 
 # Dictionary of supported embedding functions
-known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignore
+known_embedding_functions: Dict[str, Type[EmbeddingFunction[Embeddable]]] = {
     "cohere": CohereEmbeddingFunction,
     "openai": OpenAIEmbeddingFunction,
     "huggingface": HuggingFaceEmbeddingFunction,
@@ -170,7 +171,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "perplexity": PerplexityEmbeddingFunction,
 }
 
-sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  # type: ignore
+sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction[Embeddable]]] = {
     "huggingface_sparse": HuggingFaceSparseEmbeddingFunction,
     "fastembed_sparse": FastembedSparseEmbeddingFunction,
     "bm25": Bm25EmbeddingFunction,
@@ -179,7 +180,12 @@ sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  
 }
 
 
-def register_embedding_function(ef_class=None):  # type: ignore
+_EF = TypeVar("_EF", bound=Type[EmbeddingFunction[Embeddable]])
+
+
+def register_embedding_function(
+    ef_class: Optional[_EF] = None,
+) -> Union[_EF, Callable[[_EF], _EF]]:
     """Register a custom embedding function.
 
     Can be used as a decorator:
@@ -195,7 +201,7 @@ def register_embedding_function(ef_class=None):  # type: ignore
         ef_class: The embedding function class to register.
     """
 
-    def _register(cls):  # type: ignore
+    def _register(cls: _EF) -> _EF:
         try:
             name = cls.name()
             known_embedding_functions[name] = cls
@@ -205,13 +211,18 @@ def register_embedding_function(ef_class=None):  # type: ignore
 
     # If called with a class, register it immediately
     if ef_class is not None:
-        return _register(ef_class)  # type: ignore
+        return _register(ef_class)
 
     # If called without arguments, return a decorator
     return _register
 
 
-def register_sparse_embedding_function(ef_class=None):  # type: ignore
+_SEF = TypeVar("_SEF", bound=Type[SparseEmbeddingFunction[Embeddable]])
+
+
+def register_sparse_embedding_function(
+    ef_class: Optional[_SEF] = None,
+) -> Union[_SEF, Callable[[_SEF], _SEF]]:
     """Register a custom sparse embedding function.
 
     Can be used as a decorator:
@@ -221,7 +232,7 @@ def register_sparse_embedding_function(ef_class=None):  # type: ignore
             def name(cls): return "my_sparse_embedding"
     """
 
-    def _register(cls):  # type: ignore
+    def _register(cls: _SEF) -> _SEF:
         try:
             name = cls.name()
             sparse_known_embedding_functions[name] = cls
@@ -230,13 +241,13 @@ def register_sparse_embedding_function(ef_class=None):  # type: ignore
         return cls  # Return the class unchanged
 
     if ef_class is not None:
-        return _register(ef_class)  # type: ignore
+        return _register(ef_class)
 
     return _register
 
 
 # Function to convert config to embedding function
-def config_to_embedding_function(config: Dict[str, Any]) -> EmbeddingFunction:  # type: ignore
+def config_to_embedding_function(config: Dict[str, Any]) -> EmbeddingFunction[Embeddable]:
     """Convert a config dictionary to an embedding function.
 
     Args:

--- a/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
+++ b/chromadb/utils/embedding_functions/onnx_mini_lm_l6_v2.py
@@ -89,7 +89,7 @@ class ONNXMiniLM_L6_V2(EmbeddingFunction[Documents]):
 
     # Borrowed from https://gist.github.com/yanqd0/c13ed29e29432e3cf3e7c38467f42f51
     # Download with tqdm to preserve the sentence-transformers experience
-    @retry(  # type: ignore
+    @retry(
         reraise=True,
         stop=stop_after_attempt(3),
         wait=wait_random(min=1, max=3),


### PR DESCRIPTION
Fixes #1169\n\nReplaces `# type: ignore` comments with proper type annotations in `chromadb/utils/embedding_functions.py` so mypy passes cleanly.