### PR TITLE
[ENH] Skip record load when only id is requested

### DIFF
--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -940,6 +940,23 @@ impl RecordSegmentReader<'_> {
             .await
     }
 
+    /// Get the user id for a given offset id using the lightweight id_to_user_id blockfile.
+    /// This avoids loading the full DataRecord (embedding, metadata, document).
+    pub async fn get_user_id_for_offset_id(
+        &self,
+        offset_id: u32,
+    ) -> Result<Option<&str>, Box<dyn ChromaError>> {
+        self.id_to_user_id.get("", offset_id).await
+    }
+
+    /// Bulk prefetch for the id_to_user_id blockfile.
+    /// This is the lightweight alternative to load_id_to_data when only user IDs are needed.
+    pub async fn load_id_to_user_id(&self, keys: impl Iterator<Item = u32>) {
+        self.id_to_user_id
+            .load_data_for_keys(keys.map(|k| ("".to_string(), k)))
+            .await
+    }
+
     pub async fn get_total_logical_size_bytes(&self) -> Result<u64, Box<dyn ChromaError>> {
         self.id_to_data
             .get_range_stream(""..="", ..)

--- a/rust/segment/src/blockfile_record.rs
+++ b/rust/segment/src/blockfile_record.rs
@@ -942,11 +942,16 @@ impl RecordSegmentReader<'_> {
 
     /// Get the user id for a given offset id using the lightweight id_to_user_id blockfile.
     /// This avoids loading the full DataRecord (embedding, metadata, document).
+    /// Returns an error if the offset id is not found.
     pub async fn get_user_id_for_offset_id(
         &self,
         offset_id: u32,
-    ) -> Result<Option<&str>, Box<dyn ChromaError>> {
-        self.id_to_user_id.get("", offset_id).await
+    ) -> Result<&str, Box<dyn ChromaError>> {
+        self.id_to_user_id.get("", offset_id).await?.ok_or_else(|| {
+            Box::new(RecordSegmentReaderCreationError::DataRecordNotFound(
+                offset_id,
+            )) as Box<dyn ChromaError>
+        })
     }
 
     /// Bulk prefetch for the id_to_user_id blockfile.

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -106,6 +106,10 @@ pub enum LogMaterializerError {
     EmbeddingMaterialization,
     #[error("Error reading record segment {0}")]
     RecordSegment(#[from] Box<dyn ChromaError>),
+    #[error("Log index {0} out of bounds when resolving user ID")]
+    LogIndexOutOfBounds(usize),
+    #[error("Record segment reader required but not available")]
+    RecordSegmentReaderRequired,
 }
 
 impl ChromaError for LogMaterializerError {
@@ -114,6 +118,8 @@ impl ChromaError for LogMaterializerError {
             LogMaterializerError::MetadataMaterialization(e) => e.code(),
             LogMaterializerError::EmbeddingMaterialization => ErrorCodes::Internal,
             LogMaterializerError::RecordSegment(e) => e.code(),
+            LogMaterializerError::LogIndexOutOfBounds(_) => ErrorCodes::Internal,
+            LogMaterializerError::RecordSegmentReaderRequired => ErrorCodes::Internal,
         }
     }
 }
@@ -270,18 +276,21 @@ impl<'log_data> BorrowedMaterializedLogRecord<'log_data> {
         record_segment_reader: Option<&RecordSegmentReader<'_>>,
     ) -> Result<String, LogMaterializerError> {
         if let Some(id) = self.materialized_log_record.user_id_at_log_index {
-            return Ok(self.logs.get(id).unwrap().record.id.clone());
+            return Ok(self
+                .logs
+                .get(id)
+                .ok_or(LogMaterializerError::LogIndexOutOfBounds(id))?
+                .record
+                .id
+                .clone());
         }
 
-        // SAFETY: If user_id_at_log_index is None, the record must exist in the segment
-        // and the reader must be available. Returns empty string if invariant is violated.
         match record_segment_reader {
             Some(reader) => Ok(reader
                 .get_user_id_for_offset_id(self.materialized_log_record.offset_id)
                 .await?
-                .unwrap_or_default()
                 .to_string()),
-            None => Ok(String::new()),
+            None => Err(LogMaterializerError::RecordSegmentReaderRequired),
         }
     }
 

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -262,6 +262,27 @@ impl<'log_data> BorrowedMaterializedLogRecord<'log_data> {
         }
     }
 
+    /// Get the user id for this record without hydrating the full data record.
+    /// When the user id is available in the log, it is returned directly (no I/O).
+    /// Otherwise, it falls back to the lightweight id_to_user_id blockfile lookup.
+    pub async fn get_user_id(
+        &self,
+        record_segment_reader: Option<&RecordSegmentReader<'_>>,
+    ) -> Result<String, LogMaterializerError> {
+        if let Some(id) = self.materialized_log_record.user_id_at_log_index {
+            return Ok(self.logs.get(id).unwrap().record.id.clone());
+        }
+
+        match record_segment_reader {
+            Some(reader) => Ok(reader
+                .get_user_id_for_offset_id(self.materialized_log_record.offset_id)
+                .await?
+                .expect("Expected user id for offset id in segment")
+                .to_string()),
+            None => panic!("Expected at least one source of user id"),
+        }
+    }
+
     /// Reads any record segment data that this log record may reference and returns a hydrated version of this record.
     /// The record segment reader passed here **must be over the same set of blockfiles** as the reader that was originally passed to `materialize_logs()`. If the two readers are different, the behavior is undefined.
     pub async fn hydrate<'segment_data>(

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -273,13 +273,15 @@ impl<'log_data> BorrowedMaterializedLogRecord<'log_data> {
             return Ok(self.logs.get(id).unwrap().record.id.clone());
         }
 
+        // SAFETY: If user_id_at_log_index is None, the record must exist in the segment
+        // and the reader must be available. Returns empty string if invariant is violated.
         match record_segment_reader {
             Some(reader) => Ok(reader
                 .get_user_id_for_offset_id(self.materialized_log_record.offset_id)
                 .await?
-                .expect("Expected user id for offset id in segment")
+                .unwrap_or_default()
                 .to_string()),
-            None => panic!("Expected at least one source of user id"),
+            None => Ok(String::new()),
         }
     }
 

--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -95,17 +95,18 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
 
         let offset_id_set: HashSet<_> = HashSet::from_iter(input.offset_ids.iter().cloned());
 
-        // Always prefetch id_to_user_id (used by get_user_id for all records).
-        // Additionally prefetch id_to_data when full hydration is needed.
+        // Prefetch: when needs_data, load full data records (which contain the user ID);
+        // otherwise, load only the lightweight id_to_user_id mapping.
         if let Some(reader) = &record_segment_reader {
-            reader
-                .load_id_to_user_id(offset_id_set.iter().cloned())
-                .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
-                .await;
             if needs_data {
                 reader
                     .load_id_to_data(offset_id_set.iter().cloned())
                     .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
+                    .await;
+            } else {
+                reader
+                    .load_id_to_user_id(offset_id_set.iter().cloned())
+                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
                     .await;
             }
         }
@@ -131,74 +132,76 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
             .iter()
             .map(|offset_id| {
                 async {
-                    // Resolve user ID (shared across both paths)
-                    let id = match offset_id_to_log_record.get(offset_id) {
-                        Some(log) => log
-                            .get_user_id(record_segment_reader.as_ref())
-                            .await
-                            .map_err(ProjectionError::LogMaterializer)?,
-                        None => match &record_segment_reader {
-                            Some(reader) => reader
-                                .get_user_id_for_offset_id(*offset_id)
-                                .await?
-                                .to_string(),
-                            None => return Err(ProjectionError::RecordSegmentUninitialized),
-                        },
-                    };
+                    if needs_data {
+                        // Full hydration path: get ID and data from hydrated record
+                        let (id, document, embedding, metadata) =
+                            match offset_id_to_log_record.get(offset_id) {
+                                Some(log) => {
+                                    let log = log
+                                        .hydrate(record_segment_reader.as_ref())
+                                        .await
+                                        .map_err(ProjectionError::LogMaterializer)?;
+                                    (
+                                        log.get_user_id().to_string(),
+                                        log.merged_document_ref()
+                                            .filter(|_| self.document)
+                                            .map(str::to_string),
+                                        self.embedding
+                                            .then_some(log.merged_embeddings_ref().to_vec()),
+                                        self.metadata
+                                            .then_some(log.merged_metadata())
+                                            .filter(|metadata| !metadata.is_empty()),
+                                    )
+                                }
+                                None => {
+                                    let reader = record_segment_reader
+                                        .as_ref()
+                                        .ok_or(ProjectionError::RecordSegmentUninitialized)?;
+                                    let record =
+                                        reader.get_data_for_offset_id(*offset_id).await?.ok_or(
+                                            ProjectionError::RecordSegmentPhantomRecord(*offset_id),
+                                        )?;
+                                    (
+                                        record.id.to_string(),
+                                        record
+                                            .document
+                                            .filter(|_| self.document)
+                                            .map(str::to_string),
+                                        self.embedding.then_some(record.embedding.to_vec()),
+                                        record.metadata.filter(|_| self.metadata),
+                                    )
+                                }
+                            };
 
-                    if !needs_data {
-                        return Ok(ProjectionRecord {
+                        Ok(ProjectionRecord {
+                            id,
+                            document,
+                            embedding,
+                            metadata,
+                        })
+                    } else {
+                        // Lightweight path: resolve user ID only via id_to_user_id blockfile
+                        let id = match offset_id_to_log_record.get(offset_id) {
+                            Some(log) => log
+                                .get_user_id(record_segment_reader.as_ref())
+                                .await
+                                .map_err(ProjectionError::LogMaterializer)?,
+                            None => match &record_segment_reader {
+                                Some(reader) => reader
+                                    .get_user_id_for_offset_id(*offset_id)
+                                    .await?
+                                    .to_string(),
+                                None => return Err(ProjectionError::RecordSegmentUninitialized),
+                            },
+                        };
+
+                        Ok(ProjectionRecord {
                             id,
                             document: None,
                             embedding: None,
                             metadata: None,
-                        });
+                        })
                     }
-
-                    // Hydrate data fields
-                    let (document, embedding, metadata) =
-                        match offset_id_to_log_record.get(offset_id) {
-                            Some(log) => {
-                                let log = log
-                                    .hydrate(record_segment_reader.as_ref())
-                                    .await
-                                    .map_err(ProjectionError::LogMaterializer)?;
-                                (
-                                    log.merged_document_ref()
-                                        .filter(|_| self.document)
-                                        .map(str::to_string),
-                                    self.embedding
-                                        .then_some(log.merged_embeddings_ref().to_vec()),
-                                    self.metadata
-                                        .then_some(log.merged_metadata())
-                                        .filter(|metadata| !metadata.is_empty()),
-                                )
-                            }
-                            None => {
-                                let reader = record_segment_reader
-                                    .as_ref()
-                                    .ok_or(ProjectionError::RecordSegmentUninitialized)?;
-                                let record =
-                                    reader.get_data_for_offset_id(*offset_id).await?.ok_or(
-                                        ProjectionError::RecordSegmentPhantomRecord(*offset_id),
-                                    )?;
-                                (
-                                    record
-                                        .document
-                                        .filter(|_| self.document)
-                                        .map(str::to_string),
-                                    self.embedding.then_some(record.embedding.to_vec()),
-                                    record.metadata.filter(|_| self.metadata),
-                                )
-                            }
-                        };
-
-                    Ok(ProjectionRecord {
-                        id,
-                        document,
-                        embedding,
-                        metadata,
-                    })
                 }
                 .instrument(current_span.clone())
             })

--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -95,18 +95,17 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
 
         let offset_id_set: HashSet<_> = HashSet::from_iter(input.offset_ids.iter().cloned());
 
-        // Conditionally prefetch: load full data records when needed,
-        // otherwise just prefetch the lightweight id_to_user_id mapping.
+        // Always prefetch id_to_user_id (used by get_user_id for all records).
+        // Additionally prefetch id_to_data when full hydration is needed.
         if let Some(reader) = &record_segment_reader {
+            reader
+                .load_id_to_user_id(offset_id_set.iter().cloned())
+                .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
+                .await;
             if needs_data {
                 reader
                     .load_id_to_data(offset_id_set.iter().cloned())
                     .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
-                    .await;
-            } else {
-                reader
-                    .load_id_to_user_id(offset_id_set.iter().cloned())
-                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
                     .await;
             }
         }
@@ -132,83 +131,74 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
             .iter()
             .map(|offset_id| {
                 async {
-                    if needs_data {
-                        // Full hydration path: load complete data records
-                        let record = match offset_id_to_log_record.get(offset_id) {
-                            // The offset id is in the log
+                    // Resolve user ID (shared across both paths)
+                    let id = match offset_id_to_log_record.get(offset_id) {
+                        Some(log) => log
+                            .get_user_id(record_segment_reader.as_ref())
+                            .await
+                            .map_err(ProjectionError::LogMaterializer)?,
+                        None => match &record_segment_reader {
+                            Some(reader) => reader
+                                .get_user_id_for_offset_id(*offset_id)
+                                .await?
+                                .to_string(),
+                            None => return Err(ProjectionError::RecordSegmentUninitialized),
+                        },
+                    };
+
+                    if !needs_data {
+                        return Ok(ProjectionRecord {
+                            id,
+                            document: None,
+                            embedding: None,
+                            metadata: None,
+                        });
+                    }
+
+                    // Hydrate data fields
+                    let (document, embedding, metadata) =
+                        match offset_id_to_log_record.get(offset_id) {
                             Some(log) => {
                                 let log = log
                                     .hydrate(record_segment_reader.as_ref())
                                     .await
                                     .map_err(ProjectionError::LogMaterializer)?;
-
-                                ProjectionRecord {
-                                    id: log.get_user_id().to_string(),
-                                    document: log
-                                        .merged_document_ref()
+                                (
+                                    log.merged_document_ref()
                                         .filter(|_| self.document)
                                         .map(str::to_string),
-                                    embedding: self
-                                        .embedding
+                                    self.embedding
                                         .then_some(log.merged_embeddings_ref().to_vec()),
-                                    metadata: self
-                                        .metadata
+                                    self.metadata
                                         .then_some(log.merged_metadata())
                                         .filter(|metadata| !metadata.is_empty()),
-                                }
+                                )
                             }
-                            // The offset id is in the record segment
                             None => {
-                                if let Some(reader) = &record_segment_reader {
-                                    let record =
-                                        reader.get_data_for_offset_id(*offset_id).await?.ok_or(
-                                            ProjectionError::RecordSegmentPhantomRecord(*offset_id),
-                                        )?;
-                                    ProjectionRecord {
-                                        id: record.id.to_string(),
-                                        document: record
-                                            .document
-                                            .filter(|_| self.document)
-                                            .map(str::to_string),
-                                        embedding: self
-                                            .embedding
-                                            .then_some(record.embedding.to_vec()),
-                                        metadata: record.metadata.filter(|_| self.metadata),
-                                    }
-                                } else {
-                                    return Err(ProjectionError::RecordSegmentUninitialized);
-                                }
+                                let reader = record_segment_reader
+                                    .as_ref()
+                                    .ok_or(ProjectionError::RecordSegmentUninitialized)?;
+                                let record =
+                                    reader.get_data_for_offset_id(*offset_id).await?.ok_or(
+                                        ProjectionError::RecordSegmentPhantomRecord(*offset_id),
+                                    )?;
+                                (
+                                    record
+                                        .document
+                                        .filter(|_| self.document)
+                                        .map(str::to_string),
+                                    self.embedding.then_some(record.embedding.to_vec()),
+                                    record.metadata.filter(|_| self.metadata),
+                                )
                             }
                         };
-                        Ok::<_, ProjectionError>(record)
-                    } else {
-                        // Lightweight path: only resolve user ID, skip full data hydration
-                        let id = match offset_id_to_log_record.get(offset_id) {
-                            Some(log) => log
-                                .get_user_id(record_segment_reader.as_ref())
-                                .await
-                                .map_err(ProjectionError::LogMaterializer)?,
-                            None => {
-                                if let Some(reader) = &record_segment_reader {
-                                    reader
-                                        .get_user_id_for_offset_id(*offset_id)
-                                        .await?
-                                        .ok_or(ProjectionError::RecordSegmentPhantomRecord(
-                                            *offset_id,
-                                        ))?
-                                        .to_string()
-                                } else {
-                                    return Err(ProjectionError::RecordSegmentUninitialized);
-                                }
-                            }
-                        };
-                        Ok(ProjectionRecord {
-                            id,
-                            document: None,
-                            embedding: None,
-                            metadata: None,
-                        })
-                    }
+
+                    Ok(ProjectionRecord {
+                        id,
+                        document,
+                        embedding,
+                        metadata,
+                    })
                 }
                 .instrument(current_span.clone())
             })

--- a/rust/worker/src/execution/operators/projection.rs
+++ b/rust/worker/src/execution/operators/projection.rs
@@ -73,9 +73,12 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
             return Ok(ProjectionOutput { records: vec![] });
         }
 
+        let needs_data = self.document || self.embedding || self.metadata;
+
         tracing::trace!(
-            "Running projection on {} offset ids",
-            input.offset_ids.len()
+            "Running projection on {} offset ids (needs_data={})",
+            input.offset_ids.len(),
+            needs_data,
         );
         let record_segment_reader = match Box::pin(RecordSegmentReader::from_segment(
             &input.record_segment,
@@ -90,11 +93,27 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
             Err(e) => Err(*e),
         }?;
 
+        let offset_id_set: HashSet<_> = HashSet::from_iter(input.offset_ids.iter().cloned());
+
+        // Conditionally prefetch: load full data records when needed,
+        // otherwise just prefetch the lightweight id_to_user_id mapping.
+        if let Some(reader) = &record_segment_reader {
+            if needs_data {
+                reader
+                    .load_id_to_data(offset_id_set.iter().cloned())
+                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
+                    .await;
+            } else {
+                reader
+                    .load_id_to_user_id(offset_id_set.iter().cloned())
+                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
+                    .await;
+            }
+        }
+
         let materialized_logs = materialize_logs(&record_segment_reader, input.logs.clone(), None)
             .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
             .await?;
-
-        let offset_id_set: HashSet<_> = HashSet::from_iter(input.offset_ids.iter().cloned());
 
         // Create a hash map that maps an offset id to the corresponding log
         // It contains all records from the logs that should be present in the final result
@@ -113,51 +132,83 @@ impl Operator<ProjectionInput, ProjectionOutput> for Projection {
             .iter()
             .map(|offset_id| {
                 async {
-                    let record = match offset_id_to_log_record.get(offset_id) {
-                        // The offset id is in the log
-                        Some(log) => {
-                            let log = log
-                                .hydrate(record_segment_reader.as_ref())
-                                .await
-                                .map_err(ProjectionError::LogMaterializer)?;
+                    if needs_data {
+                        // Full hydration path: load complete data records
+                        let record = match offset_id_to_log_record.get(offset_id) {
+                            // The offset id is in the log
+                            Some(log) => {
+                                let log = log
+                                    .hydrate(record_segment_reader.as_ref())
+                                    .await
+                                    .map_err(ProjectionError::LogMaterializer)?;
 
-                            ProjectionRecord {
-                                id: log.get_user_id().to_string(),
-                                document: log
-                                    .merged_document_ref()
-                                    .filter(|_| self.document)
-                                    .map(str::to_string),
-                                embedding: self
-                                    .embedding
-                                    .then_some(log.merged_embeddings_ref().to_vec()),
-                                metadata: self
-                                    .metadata
-                                    .then_some(log.merged_metadata())
-                                    .filter(|metadata| !metadata.is_empty()),
-                            }
-                        }
-                        // The offset id is in the record segment
-                        None => {
-                            if let Some(reader) = &record_segment_reader {
-                                let record =
-                                    reader.get_data_for_offset_id(*offset_id).await?.ok_or(
-                                        ProjectionError::RecordSegmentPhantomRecord(*offset_id),
-                                    )?;
                                 ProjectionRecord {
-                                    id: record.id.to_string(),
-                                    document: record
-                                        .document
+                                    id: log.get_user_id().to_string(),
+                                    document: log
+                                        .merged_document_ref()
                                         .filter(|_| self.document)
                                         .map(str::to_string),
-                                    embedding: self.embedding.then_some(record.embedding.to_vec()),
-                                    metadata: record.metadata.filter(|_| self.metadata),
+                                    embedding: self
+                                        .embedding
+                                        .then_some(log.merged_embeddings_ref().to_vec()),
+                                    metadata: self
+                                        .metadata
+                                        .then_some(log.merged_metadata())
+                                        .filter(|metadata| !metadata.is_empty()),
                                 }
-                            } else {
-                                return Err(ProjectionError::RecordSegmentUninitialized);
                             }
-                        }
-                    };
-                    Ok::<_, ProjectionError>(record)
+                            // The offset id is in the record segment
+                            None => {
+                                if let Some(reader) = &record_segment_reader {
+                                    let record =
+                                        reader.get_data_for_offset_id(*offset_id).await?.ok_or(
+                                            ProjectionError::RecordSegmentPhantomRecord(*offset_id),
+                                        )?;
+                                    ProjectionRecord {
+                                        id: record.id.to_string(),
+                                        document: record
+                                            .document
+                                            .filter(|_| self.document)
+                                            .map(str::to_string),
+                                        embedding: self
+                                            .embedding
+                                            .then_some(record.embedding.to_vec()),
+                                        metadata: record.metadata.filter(|_| self.metadata),
+                                    }
+                                } else {
+                                    return Err(ProjectionError::RecordSegmentUninitialized);
+                                }
+                            }
+                        };
+                        Ok::<_, ProjectionError>(record)
+                    } else {
+                        // Lightweight path: only resolve user ID, skip full data hydration
+                        let id = match offset_id_to_log_record.get(offset_id) {
+                            Some(log) => log
+                                .get_user_id(record_segment_reader.as_ref())
+                                .await
+                                .map_err(ProjectionError::LogMaterializer)?,
+                            None => {
+                                if let Some(reader) = &record_segment_reader {
+                                    reader
+                                        .get_user_id_for_offset_id(*offset_id)
+                                        .await?
+                                        .ok_or(ProjectionError::RecordSegmentPhantomRecord(
+                                            *offset_id,
+                                        ))?
+                                        .to_string()
+                                } else {
+                                    return Err(ProjectionError::RecordSegmentUninitialized);
+                                }
+                            }
+                        };
+                        Ok(ProjectionRecord {
+                            id,
+                            document: None,
+                            embedding: None,
+                            metadata: None,
+                        })
+                    }
                 }
                 .instrument(current_span.clone())
             })

--- a/rust/worker/src/execution/operators/select.rs
+++ b/rust/worker/src/execution/operators/select.rs
@@ -113,17 +113,18 @@ impl Operator<SelectInput, SelectOutput> for Select {
             .map(|record| record.offset_id)
             .collect::<HashSet<_>>();
 
-        // Always prefetch id_to_user_id (used by get_user_id for all records).
-        // Additionally prefetch id_to_data when full hydration is needed.
+        // Prefetch: when needs_data, load full data records (which contain the user ID);
+        // otherwise, load only the lightweight id_to_user_id mapping.
         if let Some(reader) = &record_segment_reader {
-            reader
-                .load_id_to_user_id(offset_id_set.iter().cloned())
-                .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
-                .await;
             if needs_data {
                 reader
                     .load_id_to_data(offset_id_set.iter().cloned())
                     .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
+                    .await;
+            } else {
+                reader
+                    .load_id_to_user_id(offset_id_set.iter().cloned())
+                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
                     .await;
             }
         }
@@ -146,24 +147,9 @@ impl Operator<SelectInput, SelectOutput> for Select {
             .records
             .iter()
             .map(|record| async {
-                // Resolve user ID (shared across both paths)
-                let id = match offset_id_to_log_record.get(&record.offset_id) {
-                    Some(log) => log
-                        .get_user_id(record_segment_reader.as_ref())
-                        .await
-                        .map_err(SelectError::LogMaterializer)?,
-                    None => match &record_segment_reader {
-                        Some(reader) => reader
-                            .get_user_id_for_offset_id(record.offset_id)
-                            .await?
-                            .to_string(),
-                        None => return Err(SelectError::RecordSegmentUninitialized),
-                    },
-                };
-
-                // Conditionally hydrate data fields
-                let (document, embedding, metadata) = if needs_data {
-                    let (doc, emb, mut full_metadata) = match offset_id_to_log_record
+                if needs_data {
+                    // Full hydration path: get ID and data from hydrated record
+                    let (id, document, embedding, mut full_metadata) = match offset_id_to_log_record
                         .get(&record.offset_id)
                     {
                         Some(log) => {
@@ -172,6 +158,7 @@ impl Operator<SelectInput, SelectOutput> for Select {
                                 .await
                                 .map_err(SelectError::LogMaterializer)?;
                             (
+                                log.get_user_id().to_string(),
                                 select_document
                                     .then(|| log.merged_document_ref().map(str::to_string))
                                     .flatten(),
@@ -188,6 +175,7 @@ impl Operator<SelectInput, SelectOutput> for Select {
                                 .await?
                                 .ok_or(SelectError::RecordSegmentPhantomRecord(record.offset_id))?;
                             (
+                                data.id.to_string(),
                                 select_document
                                     .then(|| data.document.map(|s| s.to_string()))
                                     .flatten(),
@@ -201,23 +189,41 @@ impl Operator<SelectInput, SelectOutput> for Select {
                         full_metadata.retain(|key, _| metadata_fields_to_select.contains(key));
                     }
 
-                    let metadata = if full_metadata.is_empty() {
-                        None
-                    } else {
-                        Some(full_metadata)
-                    };
-                    (doc, emb, metadata)
+                    Ok(SearchRecord {
+                        id,
+                        document,
+                        embedding,
+                        metadata: if full_metadata.is_empty() {
+                            None
+                        } else {
+                            Some(full_metadata)
+                        },
+                        score: select_score.then_some(record.measure),
+                    })
                 } else {
-                    (None, None, None)
-                };
+                    // Lightweight path: resolve user ID only via id_to_user_id blockfile
+                    let id = match offset_id_to_log_record.get(&record.offset_id) {
+                        Some(log) => log
+                            .get_user_id(record_segment_reader.as_ref())
+                            .await
+                            .map_err(SelectError::LogMaterializer)?,
+                        None => match &record_segment_reader {
+                            Some(reader) => reader
+                                .get_user_id_for_offset_id(record.offset_id)
+                                .await?
+                                .to_string(),
+                            None => return Err(SelectError::RecordSegmentUninitialized),
+                        },
+                    };
 
-                Ok(SearchRecord {
-                    id,
-                    document,
-                    embedding,
-                    metadata,
-                    score: select_score.then_some(record.measure),
-                })
+                    Ok(SearchRecord {
+                        id,
+                        document: None,
+                        embedding: None,
+                        metadata: None,
+                        score: select_score.then_some(record.measure),
+                    })
+                }
             })
             .collect::<Vec<_>>();
 

--- a/rust/worker/src/execution/operators/select.rs
+++ b/rust/worker/src/execution/operators/select.rs
@@ -113,18 +113,17 @@ impl Operator<SelectInput, SelectOutput> for Select {
             .map(|record| record.offset_id)
             .collect::<HashSet<_>>();
 
-        // Conditionally prefetch: only load full data records when needed,
-        // otherwise just prefetch the lightweight id_to_user_id mapping.
+        // Always prefetch id_to_user_id (used by get_user_id for all records).
+        // Additionally prefetch id_to_data when full hydration is needed.
         if let Some(reader) = &record_segment_reader {
+            reader
+                .load_id_to_user_id(offset_id_set.iter().cloned())
+                .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
+                .await;
             if needs_data {
                 reader
                     .load_id_to_data(offset_id_set.iter().cloned())
                     .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
-                    .await;
-            } else {
-                reader
-                    .load_id_to_user_id(offset_id_set.iter().cloned())
-                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
                     .await;
             }
         }
@@ -147,103 +146,78 @@ impl Operator<SelectInput, SelectOutput> for Select {
             .records
             .iter()
             .map(|record| async {
-                if needs_data {
-                    // Full hydration path: load complete data records
-                    let (id, document, embedding, mut full_metadata) =
-                        match offset_id_to_log_record.get(&record.offset_id) {
-                            // The offset id is in the log
-                            Some(log) => {
-                                let log = log
-                                    .hydrate(record_segment_reader.as_ref())
-                                    .await
-                                    .map_err(SelectError::LogMaterializer)?;
+                // Resolve user ID (shared across both paths)
+                let id = match offset_id_to_log_record.get(&record.offset_id) {
+                    Some(log) => log
+                        .get_user_id(record_segment_reader.as_ref())
+                        .await
+                        .map_err(SelectError::LogMaterializer)?,
+                    None => match &record_segment_reader {
+                        Some(reader) => reader
+                            .get_user_id_for_offset_id(record.offset_id)
+                            .await?
+                            .to_string(),
+                        None => return Err(SelectError::RecordSegmentUninitialized),
+                    },
+                };
 
-                                (
-                                    log.get_user_id().to_string(),
-                                    select_document
-                                        .then(|| log.merged_document_ref().map(str::to_string))
-                                        .flatten(),
-                                    select_embedding.then(|| log.merged_embeddings_ref().to_vec()),
-                                    log.merged_metadata(),
-                                )
-                            }
-                            // The offset id is in the record segment
-                            None => {
-                                if let Some(reader) = &record_segment_reader {
-                                    let data = reader
-                                        .get_data_for_offset_id(record.offset_id)
-                                        .await?
-                                        .ok_or(SelectError::RecordSegmentPhantomRecord(
-                                            record.offset_id,
-                                        ))?;
-
-                                    (
-                                        data.id.to_string(),
-                                        select_document
-                                            .then(|| data.document.map(|s| s.to_string()))
-                                            .flatten(),
-                                        select_embedding.then(|| data.embedding.to_vec()),
-                                        data.metadata.unwrap_or_default(),
-                                    )
-                                } else {
-                                    return Err(SelectError::RecordSegmentUninitialized);
-                                }
-                            }
-                        };
+                // Conditionally hydrate data fields
+                let (document, embedding, metadata) = if needs_data {
+                    let (doc, emb, mut full_metadata) = match offset_id_to_log_record
+                        .get(&record.offset_id)
+                    {
+                        Some(log) => {
+                            let log = log
+                                .hydrate(record_segment_reader.as_ref())
+                                .await
+                                .map_err(SelectError::LogMaterializer)?;
+                            (
+                                select_document
+                                    .then(|| log.merged_document_ref().map(str::to_string))
+                                    .flatten(),
+                                select_embedding.then(|| log.merged_embeddings_ref().to_vec()),
+                                log.merged_metadata(),
+                            )
+                        }
+                        None => {
+                            let reader = record_segment_reader
+                                .as_ref()
+                                .ok_or(SelectError::RecordSegmentUninitialized)?;
+                            let data = reader
+                                .get_data_for_offset_id(record.offset_id)
+                                .await?
+                                .ok_or(SelectError::RecordSegmentPhantomRecord(record.offset_id))?;
+                            (
+                                select_document
+                                    .then(|| data.document.map(|s| s.to_string()))
+                                    .flatten(),
+                                select_embedding.then(|| data.embedding.to_vec()),
+                                data.metadata.unwrap_or_default(),
+                            )
+                        }
+                    };
 
                     if !select_all_metadata {
                         full_metadata.retain(|key, _| metadata_fields_to_select.contains(key));
                     }
 
-                    Ok(SearchRecord {
-                        id,
-                        document: if select_document { document } else { None },
-                        embedding: if select_embedding { embedding } else { None },
-                        metadata: if full_metadata.is_empty() {
-                            None
-                        } else {
-                            Some(full_metadata)
-                        },
-                        score: if select_score {
-                            Some(record.measure)
-                        } else {
-                            None
-                        },
-                    })
-                } else {
-                    // Lightweight path: only resolve user ID, skip full data hydration
-                    let id = match offset_id_to_log_record.get(&record.offset_id) {
-                        Some(log) => log
-                            .get_user_id(record_segment_reader.as_ref())
-                            .await
-                            .map_err(SelectError::LogMaterializer)?,
-                        None => {
-                            if let Some(reader) = &record_segment_reader {
-                                reader
-                                    .get_user_id_for_offset_id(record.offset_id)
-                                    .await?
-                                    .ok_or(SelectError::RecordSegmentPhantomRecord(
-                                        record.offset_id,
-                                    ))?
-                                    .to_string()
-                            } else {
-                                return Err(SelectError::RecordSegmentUninitialized);
-                            }
-                        }
+                    let metadata = if full_metadata.is_empty() {
+                        None
+                    } else {
+                        Some(full_metadata)
                     };
+                    (doc, emb, metadata)
+                } else {
+                    (None, None, None)
+                };
 
-                    Ok(SearchRecord {
-                        id,
-                        document: None,
-                        embedding: None,
-                        metadata: None,
-                        score: if select_score {
-                            Some(record.measure)
-                        } else {
-                            None
-                        },
-                    })
-                }
+                Ok(SearchRecord {
+                    id,
+                    document,
+                    embedding,
+                    metadata,
+                    score: select_score.then_some(record.measure),
+                })
             })
             .collect::<Vec<_>>();
 

--- a/rust/worker/src/execution/operators/select.rs
+++ b/rust/worker/src/execution/operators/select.rs
@@ -83,34 +83,6 @@ impl Operator<SelectInput, SelectOutput> for Select {
             Err(e) => Err(*e),
         }?;
 
-        let offset_id_set = input
-            .records
-            .iter()
-            .map(|record| record.offset_id)
-            .collect::<HashSet<_>>();
-
-        // Load data for offset ids
-        if let Some(reader) = &record_segment_reader {
-            reader
-                .load_id_to_data(offset_id_set.iter().cloned())
-                .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
-                .await;
-        }
-
-        let materialized_logs = materialize_logs(&record_segment_reader, input.logs.clone(), None)
-            .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
-            .await?;
-
-        // Create a hash map that maps an offset id to the corresponding log
-        let offset_id_to_log_record = materialized_logs
-            .iter()
-            .flat_map(|log| {
-                offset_id_set
-                    .contains(&log.get_offset_id())
-                    .then_some((log.get_offset_id(), log))
-            })
-            .collect::<HashMap<_, _>>();
-
         // Determine which keys to select
         let select_document = self.keys.contains(&Key::Document);
         let select_embedding = self.keys.contains(&Key::Embedding);
@@ -132,77 +104,153 @@ impl Operator<SelectInput, SelectOutput> for Select {
             })
             .collect::<HashSet<_>>();
 
+        let select_metadata = select_all_metadata || !metadata_fields_to_select.is_empty();
+        let needs_data = select_document || select_embedding || select_metadata;
+
+        let offset_id_set = input
+            .records
+            .iter()
+            .map(|record| record.offset_id)
+            .collect::<HashSet<_>>();
+
+        // Conditionally prefetch: only load full data records when needed,
+        // otherwise just prefetch the lightweight id_to_user_id mapping.
+        if let Some(reader) = &record_segment_reader {
+            if needs_data {
+                reader
+                    .load_id_to_data(offset_id_set.iter().cloned())
+                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to data", num_ids = offset_id_set.len()))
+                    .await;
+            } else {
+                reader
+                    .load_id_to_user_id(offset_id_set.iter().cloned())
+                    .instrument(tracing::trace_span!(parent: Span::current(), "Load ID to user ID", num_ids = offset_id_set.len()))
+                    .await;
+            }
+        }
+
+        let materialized_logs = materialize_logs(&record_segment_reader, input.logs.clone(), None)
+            .instrument(tracing::trace_span!(parent: Span::current(), "Materialize logs"))
+            .await?;
+
+        // Create a hash map that maps an offset id to the corresponding log
+        let offset_id_to_log_record = materialized_logs
+            .iter()
+            .flat_map(|log| {
+                offset_id_set
+                    .contains(&log.get_offset_id())
+                    .then_some((log.get_offset_id(), log))
+            })
+            .collect::<HashMap<_, _>>();
+
         let futures = input
             .records
             .iter()
             .map(|record| async {
-                let (id, document, embedding, mut full_metadata) = match offset_id_to_log_record
-                    .get(&record.offset_id)
-                {
-                    // The offset id is in the log
-                    Some(log) => {
-                        let log = log
-                            .hydrate(record_segment_reader.as_ref())
-                            .await
-                            .map_err(SelectError::LogMaterializer)?;
+                if needs_data {
+                    // Full hydration path: load complete data records
+                    let (id, document, embedding, mut full_metadata) =
+                        match offset_id_to_log_record.get(&record.offset_id) {
+                            // The offset id is in the log
+                            Some(log) => {
+                                let log = log
+                                    .hydrate(record_segment_reader.as_ref())
+                                    .await
+                                    .map_err(SelectError::LogMaterializer)?;
 
-                        (
-                            log.get_user_id().to_string(),
-                            select_document
-                                .then(|| log.merged_document_ref().map(str::to_string))
-                                .flatten(),
-                            select_embedding.then(|| log.merged_embeddings_ref().to_vec()),
-                            log.merged_metadata(),
-                        )
+                                (
+                                    log.get_user_id().to_string(),
+                                    select_document
+                                        .then(|| log.merged_document_ref().map(str::to_string))
+                                        .flatten(),
+                                    select_embedding.then(|| log.merged_embeddings_ref().to_vec()),
+                                    log.merged_metadata(),
+                                )
+                            }
+                            // The offset id is in the record segment
+                            None => {
+                                if let Some(reader) = &record_segment_reader {
+                                    let data = reader
+                                        .get_data_for_offset_id(record.offset_id)
+                                        .await?
+                                        .ok_or(SelectError::RecordSegmentPhantomRecord(
+                                            record.offset_id,
+                                        ))?;
+
+                                    (
+                                        data.id.to_string(),
+                                        select_document
+                                            .then(|| data.document.map(|s| s.to_string()))
+                                            .flatten(),
+                                        select_embedding.then(|| data.embedding.to_vec()),
+                                        data.metadata.unwrap_or_default(),
+                                    )
+                                } else {
+                                    return Err(SelectError::RecordSegmentUninitialized);
+                                }
+                            }
+                        };
+
+                    if !select_all_metadata {
+                        full_metadata.retain(|key, _| metadata_fields_to_select.contains(key));
                     }
-                    // The offset id is in the record segment
-                    None => {
-                        if let Some(reader) = &record_segment_reader {
-                            let record = reader
-                                .get_data_for_offset_id(record.offset_id)
-                                .await?
-                                .ok_or(SelectError::RecordSegmentPhantomRecord(record.offset_id))?;
 
-                            (
-                                record.id.to_string(),
-                                select_document
-                                    .then(|| record.document.map(|s| s.to_string()))
-                                    .flatten(),
-                                select_embedding.then(|| record.embedding.to_vec()),
-                                record.metadata.unwrap_or_default(),
-                            )
+                    Ok(SearchRecord {
+                        id,
+                        document: if select_document { document } else { None },
+                        embedding: if select_embedding { embedding } else { None },
+                        metadata: if full_metadata.is_empty() {
+                            None
                         } else {
-                            return Err(SelectError::RecordSegmentUninitialized);
+                            Some(full_metadata)
+                        },
+                        score: if select_score {
+                            Some(record.measure)
+                        } else {
+                            None
+                        },
+                    })
+                } else {
+                    // Lightweight path: only resolve user ID, skip full data hydration
+                    let id = match offset_id_to_log_record.get(&record.offset_id) {
+                        Some(log) => log
+                            .get_user_id(record_segment_reader.as_ref())
+                            .await
+                            .map_err(SelectError::LogMaterializer)?,
+                        None => {
+                            if let Some(reader) = &record_segment_reader {
+                                reader
+                                    .get_user_id_for_offset_id(record.offset_id)
+                                    .await?
+                                    .ok_or(SelectError::RecordSegmentPhantomRecord(
+                                        record.offset_id,
+                                    ))?
+                                    .to_string()
+                            } else {
+                                return Err(SelectError::RecordSegmentUninitialized);
+                            }
                         }
-                    }
-                };
+                    };
 
-                if !select_all_metadata {
-                    full_metadata.retain(|key, _| metadata_fields_to_select.contains(key));
+                    Ok(SearchRecord {
+                        id,
+                        document: None,
+                        embedding: None,
+                        metadata: None,
+                        score: if select_score {
+                            Some(record.measure)
+                        } else {
+                            None
+                        },
+                    })
                 }
-
-                Ok(SearchRecord {
-                    id,
-                    document: if select_document { document } else { None },
-                    embedding: if select_embedding { embedding } else { None },
-                    metadata: if full_metadata.is_empty() {
-                        None
-                    } else {
-                        Some(full_metadata)
-                    },
-                    score: if select_score {
-                        Some(record.measure)
-                    } else {
-                        None
-                    },
-                })
             })
             .collect::<Vec<_>>();
 
         let records = stream::iter(futures)
             .buffered(32)
             .try_collect()
-            .instrument(tracing::trace_span!(parent: Span::current(), "Hydrate records", num_records = input.records.len()))
+            .instrument(tracing::trace_span!(parent: Span::current(), "Select records", num_records = input.records.len()))
             .await?;
 
         Ok(SearchPayloadResult { records })
@@ -303,6 +351,133 @@ mod tests {
             assert!(record.metadata.is_some());
             assert!(record.score.is_some());
         }
+    }
+
+    /// Test the lightweight path (no data hydration) when records come from the log.
+    /// Log records 11-15 are new (not in segment), so user_id_at_log_index is set.
+    #[tokio::test]
+    async fn test_select_score_only_with_log_records() {
+        let mut test_segment = TestDistributedSegment::new().await;
+        test_segment
+            .populate_with_generator(10, upsert_generator)
+            .await;
+
+        // Offset IDs 11-15 are new log records (not in segment).
+        // Offset IDs 1, 5 are in the segment only.
+        let records = vec![
+            RecordMeasure {
+                offset_id: 11,
+                measure: 0.95,
+            },
+            RecordMeasure {
+                offset_id: 13,
+                measure: 0.85,
+            },
+            RecordMeasure {
+                offset_id: 1,
+                measure: 0.6,
+            },
+            RecordMeasure {
+                offset_id: 5,
+                measure: 0.4,
+            },
+        ];
+
+        let input = SelectInput {
+            records,
+            logs: upsert_generator.generate_chunk(11..=15),
+            blockfile_provider: test_segment.blockfile_provider.clone(),
+            record_segment: test_segment.record_segment.clone(),
+        };
+
+        let mut keys = HashSet::new();
+        keys.insert(Key::Score);
+
+        let select_operator = Select { keys };
+
+        let output = select_operator
+            .run(&input)
+            .await
+            .expect("Select should succeed");
+
+        assert_eq!(output.records.len(), 4);
+
+        // Log records: user id resolved from log chunk without hydration
+        assert_eq!(output.records[0].id, "id_11");
+        assert_eq!(output.records[0].score, Some(0.95));
+        assert!(output.records[0].document.is_none());
+        assert!(output.records[0].embedding.is_none());
+        assert!(output.records[0].metadata.is_none());
+
+        assert_eq!(output.records[1].id, "id_13");
+        assert_eq!(output.records[1].score, Some(0.85));
+
+        // Segment-only records: user id resolved from id_to_user_id blockfile
+        assert_eq!(output.records[2].id, "id_1");
+        assert_eq!(output.records[2].score, Some(0.6));
+        assert!(output.records[2].document.is_none());
+
+        assert_eq!(output.records[3].id, "id_5");
+        assert_eq!(output.records[3].score, Some(0.4));
+    }
+
+    /// Test the lightweight path when log records update existing segment records.
+    /// In this case, user_id_at_log_index is set on the materialized log record
+    /// and offset_id_exists_in_segment is true, but we should still avoid hydration.
+    #[tokio::test]
+    async fn test_select_score_only_with_log_updating_segment() {
+        let mut test_segment = TestDistributedSegment::new().await;
+        test_segment
+            .populate_with_generator(10, upsert_generator)
+            .await;
+
+        // Logs 8-12: offsets 8-10 update existing segment records, 11-12 are new.
+        let records = vec![
+            RecordMeasure {
+                offset_id: 8,
+                measure: 0.9,
+            },
+            RecordMeasure {
+                offset_id: 11,
+                measure: 0.7,
+            },
+            RecordMeasure {
+                offset_id: 3,
+                measure: 0.5,
+            },
+        ];
+
+        let input = SelectInput {
+            records,
+            logs: upsert_generator.generate_chunk(8..=12),
+            blockfile_provider: test_segment.blockfile_provider.clone(),
+            record_segment: test_segment.record_segment.clone(),
+        };
+
+        let mut keys = HashSet::new();
+        keys.insert(Key::Score);
+
+        let select_operator = Select { keys };
+
+        let output = select_operator
+            .run(&input)
+            .await
+            .expect("Select should succeed");
+
+        assert_eq!(output.records.len(), 3);
+
+        // offset 8: in segment AND in log (upsert updates it), user_id from log
+        assert_eq!(output.records[0].id, "id_8");
+        assert_eq!(output.records[0].score, Some(0.9));
+        assert!(output.records[0].document.is_none());
+
+        // offset 11: new log record only
+        assert_eq!(output.records[1].id, "id_11");
+        assert_eq!(output.records[1].score, Some(0.7));
+
+        // offset 3: segment-only, not in log, resolved from id_to_user_id blockfile
+        assert_eq!(output.records[2].id, "id_3");
+        assert_eq!(output.records[2].score, Some(0.5));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Update `Select` and `Projection` operator so that if only user id is requested as output, skip loading the record data
- New functionality
  - Re-introduce `get_user_id_for_offset_id` and `load_id_to_user_id` in record segment reader
  - Introduce `get_user_id` on materialized log

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
