### PR TITLE
build: enforce absolute imports with flake8-tidy-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,9 @@ repos:
         args:
           - "--extend-ignore=E203,E501,E503"
           - "--max-line-length=88"
+          - "--ban-relative-imports=true"
+        additional_dependencies:
+          - flake8-tidy-imports>=4.10.0
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Summary
- add `flake8-tidy-imports` to the flake8 pre-commit hook
- enable `--ban-relative-imports=true` so new relative imports are rejected
- replace the one existing relative import in `chromadb/utils/embedding_functions/schemas/registry.py` with an absolute import

## Validation
- `python3 -m flake8 chromadb/utils/embedding_functions/schemas/registry.py --extend-ignore=E203,E501,E503 --max-line-length=88 --ban-relative-imports=true`
- scanned the repo for `from .` / `from ..` imports (no remaining matches)

Fixes #2334
