### PR TITLE
[ENH]: Make tasks tenant-aware

### DIFF
--- a/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
+++ b/rust/garbage_collector/src/construct_version_graph_orchestrator.rs
@@ -21,8 +21,8 @@ use chroma_error::{ChromaError, ErrorCodes};
 use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_system::{
-    wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
-    OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
+    wrap_with_token, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler,
+    Orchestrator, OrchestratorContext, PanicError, TaskError, TaskMessage, TaskResult,
 };
 use chroma_types::{chroma_proto::CollectionVersionFile, CollectionUuid};
 use chrono::DateTime;
@@ -71,7 +71,7 @@ impl ConstructVersionGraphOrchestrator {
         lineage_file_path: Option<String>,
     ) -> Self {
         Self {
-            context: OrchestratorContext::new(dispatcher),
+            context: OrchestratorContext::new(dispatcher, ""),
             storage,
             sysdb,
             result_channel: None,
@@ -175,7 +175,7 @@ impl Orchestrator for ConstructVersionGraphOrchestrator {
         );
 
         let mut tasks = vec![(
-            wrap(
+            wrap_with_token(
                 Box::new(FetchVersionFileOperator {}),
                 FetchVersionFileInput::new(self.version_file_path.clone(), self.storage.clone()),
                 ctx.receiver(),
@@ -186,7 +186,7 @@ impl Orchestrator for ConstructVersionGraphOrchestrator {
 
         if let Some(lineage_file_path) = &self.lineage_file_path {
             tasks.push((
-                wrap(
+                wrap_with_token(
                     Box::new(FetchLineageFileOperator {}),
                     FetchLineageFileInput::new(self.storage.clone(), lineage_file_path.clone()),
                     ctx.receiver(),
@@ -454,7 +454,7 @@ impl Handler<TaskResult<FetchLineageFileOutput, FetchLineageFileError>>
 
         if !collection_ids_to_fetch_version_files.is_empty() {
             self.num_pending_tasks += 1;
-            let list_files_at_versions_task = wrap(
+            let list_files_at_versions_task = wrap_with_token(
                 Box::new(GetVersionFilePathsOperator {}),
                 GetVersionFilePathsInput::new(
                     collection_ids_to_fetch_version_files.into_iter().collect(),
@@ -503,7 +503,7 @@ impl Handler<TaskResult<GetVersionFilePathsOutput, GetVersionFilePathsError>>
 
         for path in output.0.values() {
             let version_file = FetchVersionFileInput::new(path.clone(), self.storage.clone());
-            let fetch_version_file_task = wrap(
+            let fetch_version_file_task = wrap_with_token(
                 Box::new(FetchVersionFileOperator {}),
                 version_file,
                 ctx.receiver(),

--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -16,8 +16,8 @@ use chroma_memberlist::memberlist_provider::Memberlist;
 use chroma_storage::Storage;
 use chroma_sysdb::{CollectionToGcInfo, GetCollectionsToGcError, SysDb, SysDbConfig};
 use chroma_system::{
-    wrap, Component, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator, System,
-    TaskResult,
+    wrap_with_token, Component, ComponentContext, ComponentHandle, Dispatcher, Handler,
+    Orchestrator, System, TaskResult,
 };
 use chroma_types::CollectionUuid;
 use chrono::{DateTime, Utc};
@@ -303,7 +303,7 @@ impl GarbageCollector {
             tracing::error!("Uninitialized dispatcher for garbage collector");
             return;
         };
-        let truncate_dirty_log_task = wrap(
+        let truncate_dirty_log_task = wrap_with_token(
             Box::new(TruncateDirtyLogOperator {
                 storage: self.storage.clone(),
                 logs: self.logs.clone(),

--- a/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
+++ b/rust/garbage_collector/src/garbage_collector_orchestrator_v2.rs
@@ -31,7 +31,7 @@ use chroma_log::Log;
 use chroma_storage::Storage;
 use chroma_sysdb::{GetCollectionsOptions, SysDb};
 use chroma_system::{
-    wrap, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler,
+    wrap_with_token, ChannelError, ComponentContext, ComponentHandle, Dispatcher, Handler,
     OneshotMessageReceiver, Orchestrator, OrchestratorContext, PanicError, System, TaskError,
     TaskMessage, TaskResult,
 };
@@ -111,7 +111,7 @@ impl GarbageCollectorOrchestrator {
             version_absolute_cutoff_time,
             collection_soft_delete_absolute_cutoff_time,
             sysdb_client,
-            context: OrchestratorContext::new(dispatcher),
+            context: OrchestratorContext::new(dispatcher, ""),
             system,
             storage,
             logs,
@@ -341,7 +341,7 @@ impl GarbageCollectorOrchestrator {
             }
         }
 
-        let task = wrap(
+        let task = wrap_with_token(
             Box::new(ComputeVersionsToDeleteOperator {}),
             ComputeVersionsToDeleteInput {
                 graph: output.graph,
@@ -424,7 +424,7 @@ impl GarbageCollectorOrchestrator {
         // Now, list files for each version
         let root_manager = self.root_manager.clone();
         let dispatcher = self.dispatcher();
-        let task_cancellation_token = self.context.task_cancellation_token.clone();
+        let cancellation_token = self.context.task_cancellation_token.clone();
         let version_files = self.version_files.clone();
 
         let mut stream = futures::stream::iter(output.versions.into_iter().flat_map(
@@ -437,7 +437,7 @@ impl GarbageCollectorOrchestrator {
         ))
         .map(|(collection_id, version)| {
             let root_manager = root_manager.clone();
-            let task_cancellation_token = task_cancellation_token.clone();
+            let cancellation_token = cancellation_token.clone();
             let mut dispatcher = dispatcher.clone();
             let version_file = version_files.get(&collection_id).cloned();
 
@@ -449,11 +449,11 @@ impl GarbageCollectorOrchestrator {
                 let tx: OneshotMessageReceiver<
                     TaskResult<ListFilesAtVersionOutput, ListFilesAtVersionError>,
                 > = tx;
-                let task: TaskMessage = wrap(
+                let task: TaskMessage = wrap_with_token(
                     Box::new(ListFilesAtVersionsOperator {}),
                     ListFilesAtVersionInput::new(root_manager, version_file, version),
                     Box::new(tx),
-                    task_cancellation_token,
+                    cancellation_token,
                 );
 
                 dispatcher
@@ -553,7 +553,7 @@ impl GarbageCollectorOrchestrator {
             );
         }
 
-        let task = wrap(
+        let task = wrap_with_token(
             Box::new(DeleteUnusedLogsOperator {
                 enabled: self.enable_log_gc,
                 mode: self.cleanup_mode,
@@ -798,7 +798,7 @@ impl GarbageCollectorOrchestrator {
         let database_name = collection_info.database_name.clone();
         self.database_name = Some(database_name.clone());
 
-        let task = wrap(
+        let task = wrap_with_token(
             Box::new(DeleteUnusedFilesOperator::new(
                 self.storage.clone(),
                 self.cleanup_mode,
@@ -909,7 +909,7 @@ impl GarbageCollectorOrchestrator {
                 ),
             )?;
 
-            let delete_versions_task = wrap(
+            let delete_versions_task = wrap_with_token(
                 Box::new(DeleteVersionsAtSysDbOperator {
                     storage: self.storage.clone(),
                 }),

--- a/rust/garbage_collector/src/log_only_orchestrator.rs
+++ b/rust/garbage_collector/src/log_only_orchestrator.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use chroma_log::Log;
 use chroma_storage::Storage;
 use chroma_system::{
-    wrap, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
+    wrap_with_token, ComponentContext, ComponentHandle, Dispatcher, Handler, Orchestrator,
     OrchestratorContext, TaskResult,
 };
 use chroma_types::CollectionUuid;
@@ -33,7 +33,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
         collection_to_destroy: CollectionUuid,
     ) -> Self {
         Self {
-            context: OrchestratorContext::new(dispatcher),
+            context: OrchestratorContext::new(dispatcher, ""),
             storage,
             logs,
             result_channel: None,
@@ -89,7 +89,7 @@ impl HardDeleteLogOnlyGarbageCollectorOrchestrator {
         let collections_to_destroy =
             HashSet::from_iter(vec![self.collection_to_destroy].into_iter());
         let collections_to_garbage_collect = HashMap::new();
-        let task = wrap(
+        let task = wrap_with_token(
             Box::new(DeleteUnusedLogsOperator {
                 enabled: true,
                 mode: CleanupMode::DeleteV2,

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -225,7 +225,7 @@ impl Dispatcher {
         self.metrics.task_enqueued_total.add(1, &task_kv);
         match task.get_type() {
             OperatorType::IO => {
-                let child_span = trace_span!(parent: Span::current(), "IO task execution", name = task.get_name(), task_type = "io");
+                let child_span = trace_span!(parent: Span::current(), "IO task execution", name = task.get_name(), task_type = "io", tenant = task.get_executor_info().tenant.as_ref());
                 // This spin loop:
                 // - reads a witness from active_io_tasks.
                 // - aborts the task if witness is zero.
@@ -275,7 +275,7 @@ impl Dispatcher {
             OperatorType::Other => {
                 // If a worker is waiting for a task, send it to the worker in FIFO order.
                 // Otherwise, add it to the task queue.
-                let span = trace_span!(parent: Span::current(), "Other task execution", name = task.get_name(), task_type = "other");
+                let span = trace_span!(parent: Span::current(), "Other task execution", name = task.get_name(), task_type = "other", tenant = task.get_executor_info().tenant.as_ref());
                 match self.waiters.pop() {
                     Some(channel) => match channel.reply_to.send(task, Some(span)).await {
                         Ok(_) => {
@@ -604,7 +604,7 @@ mod tests {
                 .map(char::from)
                 .collect();
             println!("Scheduling mock io operator with filename {}", filename);
-            let task = wrap(
+            let task = wrap_with_token(
                 Box::new(MockIoOperator {}),
                 filename,
                 ctx.receiver(),
@@ -665,7 +665,7 @@ mod tests {
 
         async fn handle(&mut self, _message: (), ctx: &ComponentContext<MockDispatchUser>) {
             println!("Scheduling mock cpu operator with input {}", 42.0);
-            let task = wrap(
+            let task = wrap_with_token(
                 Box::new(MockOperator {}),
                 42.0,
                 ctx.receiver(),

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -1,8 +1,11 @@
-use crate::{utils::duration_ms, utils::PanicError, ReceiverForMessage};
+use crate::{
+    execution::orchestrator::OrchestratorContext, utils::duration_ms, utils::PanicError,
+    ReceiverForMessage,
+};
 use async_trait::async_trait;
 use chroma_error::{ChromaError, ErrorCodes};
 use futures::FutureExt;
-use std::{any::type_name, fmt::Debug, panic::AssertUnwindSafe};
+use std::{any::type_name, borrow::Cow, fmt::Debug, panic::AssertUnwindSafe};
 use std::{sync::LazyLock, time::Instant};
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
@@ -134,6 +137,7 @@ where
     started_at: Option<Instant>,
     operator_name: &'static str,
     operator_type: OperatorType,
+    tenant: Cow<'static, str>,
 }
 
 struct TaskMetrics {
@@ -299,6 +303,11 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TaskExecutorInfo {
+    pub tenant: Cow<'static, str>,
+}
+
 /// A message type used by the dispatcher to send tasks to worker threads.
 pub type TaskMessage = Box<dyn TaskWrapper>;
 
@@ -313,6 +322,7 @@ pub trait TaskWrapper: Send + Debug {
     fn get_type(&self) -> OperatorType;
     fn created_at(&self) -> Instant;
     async fn abort(&mut self);
+    fn get_executor_info(&self) -> TaskExecutorInfo;
 }
 
 /// Implement the TaskWrapper trait for every Task. This allows us to
@@ -363,6 +373,12 @@ where
         self.created_at
     }
 
+    fn get_executor_info(&self) -> TaskExecutorInfo {
+        TaskExecutorInfo {
+            tenant: self.tenant.clone(),
+        }
+    }
+
     async fn abort(&mut self) {
         self.task_state = TaskState::Aborted;
         if let Err(err) = self
@@ -391,12 +407,12 @@ where
     }
 }
 
-/// Wrap an operator and its input into a task message.
-pub fn wrap<Input, Output, Error>(
+fn wrap_internal<Input, Output, Error>(
     operator: Box<dyn Operator<Input, Output, Error = Error>>,
     input: Input,
     reply_channel: Box<dyn ReceiverForMessage<TaskResult<Output, Error>>>,
     cancellation_token: CancellationToken,
+    tenant: Cow<'static, str>,
 ) -> TaskMessage
 where
     Error: ChromaError + Debug + Send + 'static,
@@ -422,7 +438,51 @@ where
         started_at: None,
         operator_name,
         operator_type,
+        tenant,
     })
+}
+
+/// Wrap an operator and its input into a task message.
+pub fn wrap<Input, Output, Error>(
+    operator: Box<dyn Operator<Input, Output, Error = Error>>,
+    input: Input,
+    reply_channel: Box<dyn ReceiverForMessage<TaskResult<Output, Error>>>,
+    context: &OrchestratorContext,
+) -> TaskMessage
+where
+    Error: ChromaError + Debug + Send + 'static,
+    Input: Send + Sync + Debug + 'static,
+    Output: Send + Sync + Debug + 'static,
+{
+    wrap_internal(
+        operator,
+        input,
+        reply_channel,
+        context.task_cancellation_token.clone(),
+        context.tenant.clone(),
+    )
+}
+
+/// Wrap an operator and its input into a task message using a raw CancellationToken.
+/// Use this for non-orchestrator callers where an OrchestratorContext is not available.
+pub fn wrap_with_token<Input, Output, Error>(
+    operator: Box<dyn Operator<Input, Output, Error = Error>>,
+    input: Input,
+    reply_channel: Box<dyn ReceiverForMessage<TaskResult<Output, Error>>>,
+    cancellation_token: CancellationToken,
+) -> TaskMessage
+where
+    Error: ChromaError + Debug + Send + 'static,
+    Input: Send + Sync + Debug + 'static,
+    Output: Send + Sync + Debug + 'static,
+{
+    wrap_internal(
+        operator,
+        input,
+        reply_channel,
+        cancellation_token,
+        Cow::Borrowed(""),
+    )
 }
 
 #[cfg(test)]
@@ -471,7 +531,7 @@ mod tests {
         }
 
         async fn on_start(&mut self, ctx: &ComponentContext<Self>) {
-            let task = wrap(
+            let task = wrap_with_token(
                 Box::new(MockOperator {}),
                 (),
                 ctx.receiver(),

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use chroma_error::ChromaError;
 use core::fmt::Debug;
 use std::any::type_name;
+use std::borrow::Cow;
 use std::sync::LazyLock;
 use std::time::Instant;
 use tokio::sync::oneshot::{self, error::RecvError, Sender};
@@ -59,13 +60,19 @@ pub struct OrchestratorContext {
 
     // Used to cancel all spawned tasks.
     pub task_cancellation_token: CancellationToken,
+
+    pub tenant: Cow<'static, str>,
 }
 
 impl OrchestratorContext {
-    pub fn new(dispatcher: ComponentHandle<Dispatcher>) -> Self {
+    pub fn new(
+        dispatcher: ComponentHandle<Dispatcher>,
+        tenant: impl Into<Cow<'static, str>>,
+    ) -> Self {
         Self {
             dispatcher,
             task_cancellation_token: CancellationToken::new(),
+            tenant: tenant.into(),
         }
     }
 }
@@ -317,7 +324,7 @@ impl<O: Orchestrator> Component for O {
 mod tests {
     use super::*;
     use crate::{
-        execution::operator::{wrap, Operator, TaskResult},
+        execution::operator::{wrap, wrap_with_token, Operator, TaskResult},
         types::Handler,
         DispatcherConfig, ReceiverForMessage,
     };
@@ -399,12 +406,7 @@ mod tests {
             let mut tasks = Vec::new();
             for _ in 0..self.num_tasks {
                 let operator = SleepingOperator {};
-                let task = wrap(
-                    Box::new(operator),
-                    (),
-                    ctx.receiver(),
-                    self.context.task_cancellation_token.clone(),
-                );
+                let task = wrap(Box::new(operator), (), ctx.receiver(), &self.context);
                 tasks.push((task, None));
             }
             tasks
@@ -479,7 +481,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<TaskResult<(), TestError>>(2);
         let test_receiver: Box<dyn ReceiverForMessage<TaskResult<(), TestError>>> =
             Box::new(TestReceiver { sender: tx });
-        let task = wrap(
+        let task = wrap_with_token(
             Box::new(SimpleOperator {}),
             (),
             test_receiver,

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -32,7 +32,8 @@ use chroma_segment::spann_provider::SpannProvider;
 use chroma_storage::Storage;
 use chroma_sysdb::SysDb;
 use chroma_system::{
-    wrap, Component, ComponentContext, ComponentHandle, Dispatcher, Handler, System, TaskResult,
+    wrap_with_token, Component, ComponentContext, ComponentHandle, Dispatcher, Handler, System,
+    TaskResult,
 };
 use chroma_types::{CollectionUuid, JobId};
 use futures::stream::FuturesUnordered;
@@ -279,16 +280,16 @@ impl CompactionManager {
         let purge_dirty_log_input = PurgeDirtyLogInput {
             collection_uuids: deleted_collection_uuids.clone(),
         };
-        let purge_dirty_log_task = wrap(
+        let Some(mut dispatcher) = self.context.dispatcher.clone() else {
+            tracing::error!("Unable to create background task to purge dirty log: Dispatcher is not set for compaction manager");
+            return;
+        };
+        let purge_dirty_log_task = wrap_with_token(
             Box::new(purge_dirty_log),
             purge_dirty_log_input,
             ctx.receiver(),
             ctx.cancellation_token.clone(),
         );
-        let Some(mut dispatcher) = self.context.dispatcher.clone() else {
-            tracing::error!("Unable to create background task to purge dirty log: Dispatcher is not set for compaction manager");
-            return;
-        };
         if let Err(err) = dispatcher
             .send(purge_dirty_log_task, Some(Span::current()))
             .await
@@ -315,16 +316,16 @@ impl CompactionManager {
         let repair_log_offsets_input = RepairLogOffsetsInput {
             log_offsets_to_repair,
         };
-        let repair_log_offsets_task = wrap(
+        let Some(mut dispatcher) = self.context.dispatcher.clone() else {
+            tracing::error!("Unable to create background task to repair log offsets: Dispatcher is not set for compaction manager");
+            return;
+        };
+        let repair_log_offsets_task = wrap_with_token(
             Box::new(repair_log_offsets),
             repair_log_offsets_input,
             ctx.receiver(),
             ctx.cancellation_token.clone(),
         );
-        let Some(mut dispatcher) = self.context.dispatcher.clone() else {
-            tracing::error!("Unable to create background task to repair log offsets: Dispatcher is not set for compaction manager");
-            return;
-        };
         if let Err(err) = dispatcher
             .send(repair_log_offsets_task, Some(Span::current()))
             .await

--- a/rust/worker/src/execution/orchestration/apply_logs_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/apply_logs_orchestrator.rs
@@ -231,10 +231,7 @@ impl ApplyLogsOrchestrator {
                 operator,
                 input,
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             );
             tasks_to_run.push((task, Some(span)));
         }
@@ -266,10 +263,7 @@ impl ApplyLogsOrchestrator {
                 operator,
                 input,
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             );
             tasks_to_run.push((task, Some(span)));
         }
@@ -297,10 +291,7 @@ impl ApplyLogsOrchestrator {
                 operator,
                 input,
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             );
             tasks_to_run.push((task, Some(span)));
         }
@@ -320,10 +311,7 @@ impl ApplyLogsOrchestrator {
             operator,
             input,
             ctx.receiver(),
-            self.context
-                .orchestrator_context
-                .task_cancellation_token
-                .clone(),
+            &self.context.orchestrator_context,
         );
         let res = self.dispatcher().send(task, Some(span)).await;
         self.ok_or_terminate(res, ctx).await;
@@ -341,10 +329,7 @@ impl ApplyLogsOrchestrator {
             operator,
             input,
             ctx.receiver(),
-            self.context
-                .orchestrator_context
-                .task_cancellation_token
-                .clone(),
+            &self.context.orchestrator_context,
         );
         let res = self.dispatcher().send(task, Some(span)).await;
         self.ok_or_terminate(res, ctx).await;

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -220,7 +220,10 @@ impl AttachedFunctionOrchestrator {
         data_fetch_records: Vec<MaterializeLogOutput>,
         is_for_backfill: bool,
     ) -> Self {
-        let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
+        let orchestrator_context = OrchestratorContext::new(
+            dispatcher.clone(),
+            input_collection_info.collection.tenant.clone(),
+        );
 
         AttachedFunctionOrchestrator {
             input_collection_info,
@@ -409,10 +412,7 @@ impl AttachedFunctionOrchestrator {
                 operator,
                 input,
                 ctx.receiver(),
-                self.output_context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.output_context.orchestrator_context,
             );
             self.send(task, ctx, Some(Span::current())).await;
         }
@@ -445,12 +445,7 @@ impl Orchestrator for AttachedFunctionOrchestrator {
         let input = GetAttachedFunctionInput {
             collection_id: collection_info.collection_id,
         };
-        let task = wrap(
-            operator,
-            input,
-            ctx.receiver(),
-            self.context().task_cancellation_token.clone(),
-        );
+        let task = wrap(operator, input, ctx.receiver(), self.context());
         vec![(task, Some(Span::current()))]
     }
 
@@ -577,12 +572,7 @@ impl Handler<TaskResult<GetAttachedFunctionOutput, GetAttachedFunctionOperatorEr
                     database_name,
                 ));
                 let input = ();
-                let task = wrap(
-                    operator,
-                    input,
-                    ctx.receiver(),
-                    self.context().task_cancellation_token.clone(),
-                );
+                let task = wrap(operator, input, ctx.receiver(), self.context());
                 let res = self.dispatcher().send(task, None).await;
                 self.ok_or_terminate(res, ctx).await;
             }
@@ -843,12 +833,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
             is_for_backfill: self.is_for_backfill,
         };
 
-        let task = wrap(
-            operator,
-            input,
-            ctx.receiver(),
-            self.context().task_cancellation_token.clone(),
-        );
+        let task = wrap(operator, input, ctx.receiver(), self.context());
         let res = self.dispatcher().send(task, None).await;
         self.ok_or_terminate(res, ctx).await;
     }

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -15,8 +15,8 @@ use chroma_segment::{
 };
 use chroma_sysdb::SysDb;
 use chroma_system::{
-    wrap, ComponentHandle, Dispatcher, Orchestrator, OrchestratorContext, PanicError, System,
-    TaskError,
+    wrap_with_token, ComponentHandle, Dispatcher, Orchestrator, OrchestratorContext, PanicError,
+    System, TaskError,
 };
 use chroma_types::{Collection, CollectionUuid, JobId, Schema, SegmentFlushInfo, SegmentUuid};
 use opentelemetry::metrics::Counter;
@@ -148,7 +148,10 @@ pub struct CompactionContext {
 
 impl Clone for CompactionContext {
     fn clone(&self) -> Self {
-        let orchestrator_context = OrchestratorContext::new(self.dispatcher.clone());
+        let orchestrator_context = OrchestratorContext::new(
+            self.dispatcher.clone(),
+            self.orchestrator_context.tenant.clone(),
+        );
         Self {
             collection_info: self.collection_info.clone(),
             log: self.log.clone(),
@@ -183,7 +186,10 @@ impl CompactionContext {
     /// Create an empty output context for attached function orchestrator
     /// This creates a new context with an empty collection_info OnceCell
     fn clone_for_new_collection(&self) -> Self {
-        let orchestrator_context = OrchestratorContext::new(self.dispatcher.clone());
+        let orchestrator_context = OrchestratorContext::new(
+            self.dispatcher.clone(),
+            self.orchestrator_context.tenant.clone(),
+        );
         Self {
             collection_info: OnceCell::new(), // Start empty for output context
             log: self.log.clone(),
@@ -307,7 +313,7 @@ impl CompactionContext {
         is_function_disabled: bool,
         fragment_fetcher: Option<Arc<FragmentFetcher>>,
     ) -> Self {
-        let orchestrator_context = OrchestratorContext::new(dispatcher.clone());
+        let orchestrator_context = OrchestratorContext::new(dispatcher.clone(), "");
         CompactionContext {
             collection_info: OnceCell::new(),
             is_rebuild,
@@ -600,7 +606,7 @@ impl CompactionContext {
         let (receiver, rx) = chroma_system::OneshotMessageReceiver::new();
 
         // Wrap the operator as a task
-        let task = wrap(
+        let task = wrap_with_token(
             operator,
             input,
             Box::new(receiver),

--- a/rust/worker/src/execution/orchestration/count.rs
+++ b/rust/worker/src/execution/orchestration/count.rs
@@ -93,7 +93,10 @@ impl CountOrchestrator {
         fetch_log: FetchLogOperator,
         read_level: ReadLevel,
     ) -> Self {
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         Self {
             context,
             blockfile_provider,
@@ -138,7 +141,7 @@ impl Orchestrator for CountOrchestrator {
                         empty_logs,
                     ),
                     ctx.receiver(),
-                    self.context.task_cancellation_token.clone(),
+                    &self.context,
                 );
                 tasks.push((task, Some(Span::current())));
             }
@@ -147,7 +150,7 @@ impl Orchestrator for CountOrchestrator {
                     Box::new(self.fetch_log.clone()),
                     (),
                     ctx.receiver(),
-                    self.context.task_cancellation_token.clone(),
+                    &self.context,
                 );
                 tasks.push((fetch_log_task, Some(Span::current())));
             }
@@ -191,7 +194,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for CountOrchestrator {
                 output,
             ),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         self.send(task, ctx, Some(Span::current())).await;
     }

--- a/rust/worker/src/execution/orchestration/get.rs
+++ b/rust/worker/src/execution/orchestration/get.rs
@@ -156,7 +156,10 @@ impl GetOrchestrator {
         limit: Limit,
         projection: Projection,
     ) -> Self {
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         Self {
             context,
             queue,
@@ -198,7 +201,7 @@ impl Orchestrator for GetOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         // Prefetch task is detached from the orchestrator
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch record segment", segment_id = %self.collection_and_segments.record_segment.id);
@@ -213,7 +216,7 @@ impl Orchestrator for GetOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch metadata segment", segment_id = %self.collection_and_segments.metadata_segment.id);
         Span::current().add_link(prefetch_span.context().span().span_context().clone());
@@ -224,7 +227,7 @@ impl Orchestrator for GetOrchestrator {
             Box::new(self.fetch_log.clone()),
             (),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         tasks.push((fetch_log_task, Some(Span::current())));
 
@@ -282,7 +285,7 @@ impl Handler<TaskResult<FetchLogOutput, FetchLogError>> for GetOrchestrator {
                 record_segment: self.collection_and_segments.record_segment.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         self.send(task, ctx, Some(Span::current())).await;
     }
@@ -315,7 +318,7 @@ impl Handler<TaskResult<FilterOutput, FilterError>> for GetOrchestrator {
                 compact_offset_ids: output.compact_offset_ids,
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         self.send(task, ctx, Some(Span::current())).await;
     }
@@ -350,7 +353,7 @@ impl Handler<TaskResult<LimitOutput, LimitError>> for GetOrchestrator {
             Box::new(self.projection.clone()),
             input,
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         self.send(task, ctx, Some(Span::current())).await;
     }

--- a/rust/worker/src/execution/orchestration/knn.rs
+++ b/rust/worker/src/execution/orchestration/knn.rs
@@ -137,7 +137,10 @@ impl KnnOrchestrator {
         } else {
             Vec::new()
         };
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         Self {
             context,
             blockfile_provider,
@@ -159,7 +162,7 @@ impl KnnOrchestrator {
                     batch_measures: self.batch_distances.drain(..).collect(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             self.send(task, ctx, Some(Span::current())).await;
         }
@@ -195,7 +198,7 @@ impl Orchestrator for KnnOrchestrator {
                 distance_function: self.knn_filter_output.distance_function.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         tasks.push((knn_log_task, Some(Span::current())));
 
@@ -212,7 +215,7 @@ impl Orchestrator for KnnOrchestrator {
                     distance_function: self.knn_filter_output.distance_function.clone(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             tasks.push((knn_segment_task, Some(Span::current())));
         }

--- a/rust/worker/src/execution/orchestration/knn_filter.rs
+++ b/rust/worker/src/execution/orchestration/knn_filter.rs
@@ -216,7 +216,10 @@ impl KnnFilterOrchestrator {
         filter: Filter,
         read_level: ReadLevel,
     ) -> Self {
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         Self {
             context,
             blockfile_provider,
@@ -245,7 +248,7 @@ impl KnnFilterOrchestrator {
                 record_segment: self.collection_and_segments.record_segment.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         )
     }
 }
@@ -276,7 +279,7 @@ impl Orchestrator for KnnFilterOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         // Prefetch task is detached from the orchestrator
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch spann segment", segment_id = %self.collection_and_segments.vector_segment.id);
@@ -291,7 +294,7 @@ impl Orchestrator for KnnFilterOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         // Prefetch task is detached from the orchestrator
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch record segment", segment_id = %self.collection_and_segments.record_segment.id);
@@ -306,7 +309,7 @@ impl Orchestrator for KnnFilterOrchestrator {
                 self.blockfile_provider.clone(),
             ),
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         let prefetch_span = tracing::info_span!(parent: None, "Prefetch metadata segment", segment_id = %self.collection_and_segments.metadata_segment.id);
         Span::current().add_link(prefetch_span.context().span().span_context().clone());
@@ -329,7 +332,7 @@ impl Orchestrator for KnnFilterOrchestrator {
                     Box::new(self.fetch_log.clone()),
                     (),
                     ctx.receiver(),
-                    self.context.task_cancellation_token.clone(),
+                    &self.context,
                 );
                 tasks.push((fetch_log_task, Some(Span::current())));
             }

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -281,10 +281,7 @@ impl Orchestrator for LogFetchOrchestrator {
                 }),
                 (),
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             ),
             Some(Span::current()),
         )]
@@ -347,10 +344,7 @@ impl LogFetchOrchestrator {
             operator,
             input,
             ctx.receiver(),
-            self.context
-                .orchestrator_context
-                .task_cancellation_token
-                .clone(),
+            &self.context.orchestrator_context,
         );
         self.send(task, ctx, Some(Span::current())).await;
     }
@@ -407,10 +401,7 @@ impl LogFetchOrchestrator {
                 operator,
                 input,
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             );
             self.send(task, ctx, Some(Span::current())).await;
         }
@@ -464,10 +455,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     record_segment_reader: record_reader.clone(),
                 },
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             )
         } else {
             let database_name = match chroma_types::DatabaseName::new(collection.database.clone()) {
@@ -497,10 +485,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                 }),
                 (),
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             )
         };
 
@@ -697,10 +682,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                 Box::new(PrefetchSegmentOperator::new()),
                 PrefetchSegmentInput::new(segment, self.context.blockfile_provider.clone()),
                 ctx.receiver(),
-                self.context
-                    .orchestrator_context
-                    .task_cancellation_token
-                    .clone(),
+                &self.context.orchestrator_context,
             );
 
             // Prefetch task is detached from the orchestrator

--- a/rust/worker/src/execution/orchestration/projection.rs
+++ b/rust/worker/src/execution/orchestration/projection.rs
@@ -104,6 +104,7 @@ where
 }
 
 impl ProjectionOrchestrator {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         dispatcher: ComponentHandle<Dispatcher>,
         queue: usize,
@@ -112,8 +113,9 @@ impl ProjectionOrchestrator {
         record_segment: Segment,
         record_distances: Vec<RecordMeasure>,
         knn_projection: KnnProjection,
+        tenant: String,
     ) -> Self {
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(dispatcher, tenant);
         Self {
             context,
             blockfile_provider,
@@ -153,7 +155,7 @@ impl Orchestrator for ProjectionOrchestrator {
                 record_distances: self.record_distances.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
 
         vec![(projection_task, Some(Span::current()))]

--- a/rust/worker/src/execution/orchestration/quantized_spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/quantized_spann_knn.rs
@@ -66,9 +66,10 @@ impl QuantizedSpannKnnOrchestrator {
         knn_filter_output: KnnFilterOutput,
         knn: Knn,
     ) -> Self {
+        let tenant = collection_and_segments.collection.tenant.clone();
         Self {
             collection_and_segments,
-            context: OrchestratorContext::new(dispatcher),
+            context: OrchestratorContext::new(dispatcher, tenant),
             knn,
             knn_filter_output,
             queue,
@@ -93,7 +94,7 @@ impl QuantizedSpannKnnOrchestrator {
                     batch_measures: std::mem::take(&mut self.log_and_bruteforce_results),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             self.send(task, ctx, Some(Span::current())).await;
         }
@@ -130,7 +131,7 @@ impl Orchestrator for QuantizedSpannKnnOrchestrator {
                 distance_function: self.knn_filter_output.distance_function.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         tasks.push((knn_log_task, Some(Span::current())));
 
@@ -151,7 +152,7 @@ impl Orchestrator for QuantizedSpannKnnOrchestrator {
                 }),
                 (),
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             tasks.push((load_center_task, Some(Span::current())));
         }
@@ -222,7 +223,7 @@ impl Handler<TaskResult<QuantizedSpannLoadCenterOutput, QuantizedSpannLoadCenter
                 reader: output.reader,
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         self.send(center_search_task, ctx, Some(Span::current()))
             .await;
@@ -267,7 +268,7 @@ impl Handler<TaskResult<QuantizedSpannCenterSearchOutput, QuantizedSpannCenterSe
                 Box::new(load_cluster_operator.clone()),
                 QuantizedSpannLoadClusterInput { cluster_id },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             self.send(load_cluster_task, ctx, Some(Span::current()))
                 .await;
@@ -321,7 +322,7 @@ impl Handler<TaskResult<QuantizedSpannLoadClusterOutput, QuantizedSpannLoadClust
                 global_versions: output.global_versions,
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         self.send(bf_task, ctx, Some(Span::current())).await;
     }

--- a/rust/worker/src/execution/orchestration/rank.rs
+++ b/rust/worker/src/execution/orchestration/rank.rs
@@ -163,7 +163,10 @@ impl RankOrchestrator {
         select: Select,
         collection_and_segments: CollectionAndSegments,
     ) -> Self {
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         Self {
             context,
             blockfile_provider,
@@ -190,7 +193,7 @@ impl RankOrchestrator {
                 record_segment: self.collection_and_segments.record_segment.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
 
         self.send(task, ctx, Some(Span::current())).await;
@@ -237,7 +240,7 @@ impl Orchestrator for RankOrchestrator {
                     knn_results: self.knn_results.clone(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             ),
             None => wrap(
                 Box::new(self.limit.clone()),
@@ -253,7 +256,7 @@ impl Orchestrator for RankOrchestrator {
                         .clone(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             ),
         };
         vec![(task, Some(Span::current()))]
@@ -331,7 +334,7 @@ impl Handler<TaskResult<RankOutput, RankError>> for RankOrchestrator {
                     record_segment: self.collection_and_segments.record_segment.clone(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
 
             self.send(task, ctx, Some(Span::current())).await;

--- a/rust/worker/src/execution/orchestration/register_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/register_orchestrator.rs
@@ -216,10 +216,7 @@ impl Orchestrator for RegisterOrchestrator {
                         self.context.log.clone(),
                     ),
                     ctx.receiver(),
-                    self.context
-                        .orchestrator_context
-                        .task_cancellation_token
-                        .clone(),
+                    &self.context.orchestrator_context,
                 ),
                 Some(Span::current()),
             )]
@@ -294,10 +291,7 @@ impl Orchestrator for RegisterOrchestrator {
                             .clone(),
                     ),
                     ctx.receiver(),
-                    self.context
-                        .orchestrator_context
-                        .task_cancellation_token
-                        .clone(),
+                    &self.context.orchestrator_context,
                 ),
                 Some(Span::current()),
             )]

--- a/rust/worker/src/execution/orchestration/spann_knn.rs
+++ b/rust/worker/src/execution/orchestration/spann_knn.rs
@@ -86,7 +86,10 @@ impl SpannKnnOrchestrator {
             } else {
                 query.clone()
             };
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         let blockfile_provider = spann_provider.blockfile_provider.clone();
         Self {
             context,
@@ -125,7 +128,7 @@ impl SpannKnnOrchestrator {
                     batch_measures: batch_distances,
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             self.send(task, ctx, Some(Span::current())).await;
         }
@@ -161,7 +164,7 @@ impl Orchestrator for SpannKnnOrchestrator {
                 distance_function: self.knn_filter_output.distance_function.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         tasks.push((knn_log_task, Some(Span::current())));
         let reader_res = Box::pin(SpannSegmentReader::from_segment(
@@ -190,7 +193,7 @@ impl Orchestrator for SpannKnnOrchestrator {
                         k: self.k,
                     },
                     ctx.receiver(),
-                    self.context.task_cancellation_token.clone(),
+                    &self.context,
                 );
                 tasks.push((head_search_task, Some(Span::current())));
             }
@@ -272,7 +275,7 @@ impl Handler<TaskResult<SpannCentersSearchOutput, SpannCentersSearchError>>
                     head_id: head_id as u32,
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
 
             self.send(fetch_pl_task, ctx, Some(Span::current())).await;
@@ -308,7 +311,7 @@ impl Handler<TaskResult<SpannFetchPlOutput, SpannFetchPlError>> for SpannKnnOrch
                 query: self.normalized_query_emb.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
 
         self.send(bf_pl_task, ctx, Some(Span::current())).await;

--- a/rust/worker/src/execution/orchestration/sparse_knn.rs
+++ b/rust/worker/src/execution/orchestration/sparse_knn.rs
@@ -113,7 +113,10 @@ impl SparseKnnOrchestrator {
         key: String,
         limit: u32,
     ) -> Self {
-        let context = OrchestratorContext::new(dispatcher);
+        let context = OrchestratorContext::new(
+            dispatcher,
+            collection_and_segments.collection.tenant.clone(),
+        );
         Self {
             context,
             blockfile_provider,
@@ -147,7 +150,7 @@ impl SparseKnnOrchestrator {
                 record_segment: self.collection_and_segments.record_segment.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
 
         let sparse_index_knn_task = wrap(
@@ -166,7 +169,7 @@ impl SparseKnnOrchestrator {
                 metadata_segment: self.collection_and_segments.metadata_segment.clone(),
             },
             ctx.receiver(),
-            self.context.task_cancellation_token.clone(),
+            &self.context,
         );
         vec![sparse_log_knn_task, sparse_index_knn_task]
     }
@@ -179,7 +182,7 @@ impl SparseKnnOrchestrator {
                     batch_measures: self.batch_measures.drain(..).collect(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             self.send(task, ctx, Some(Span::current())).await;
         }
@@ -238,7 +241,7 @@ impl Orchestrator for SparseKnnOrchestrator {
                     record_segment: self.collection_and_segments.record_segment.clone(),
                 },
                 ctx.receiver(),
-                self.context.task_cancellation_token.clone(),
+                &self.context,
             );
             vec![(idf_task, Some(Span::current()))]
         } else {

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -488,6 +488,7 @@ impl WorkerServer {
                             collection_and_segments.record_segment.clone(),
                             record_distances,
                             knn_projection,
+                            collection_and_segments.collection.tenant.clone(),
                         );
                         projection_orchestrator
                             .run(system)
@@ -546,6 +547,7 @@ impl WorkerServer {
                             collection_and_segments.record_segment.clone(),
                             record_distances,
                             knn_projection,
+                            collection_and_segments.collection.tenant.clone(),
                         );
                         projection_orchestrator
                             .run(system)


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - Threads a Tenant into dispatcher Tasks by having the Task wrapper constructor take in an OrchestratorContext. In some call-sites (compaction and GC) this OrchestratorContext didn't have a tenant readily available so more work will be done to enable that.
- New functionality
  - ...

## Test plan

TBD...
- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
