### PR TITLE
[ENH]: Add a gauge metric in sysdb to track compaction_failure_count

### DIFF
--- a/go/pkg/sysdb/coordinator/dlq_metrics.go
+++ b/go/pkg/sysdb/coordinator/dlq_metrics.go
@@ -1,0 +1,71 @@
+package coordinator
+
+import (
+	"context"
+
+	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dao"
+	"github.com/chroma-core/chroma/go/shared/otel"
+	"github.com/pingcap/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+)
+
+// StartDLQMetrics registers a callback that reports the current state of
+// the compaction DLQ. It queries the read replica to minimize
+// overhead on the primary database.
+func StartDLQMetrics(ctx context.Context) {
+	log.Info("Starting compaction DLQ metrics")
+
+	// Create an observable gauge to track the current state
+	gauge, err := otel.Meter.Int64ObservableGauge(
+		"compaction_dlq_size",
+		metric.WithDescription("Current number of collections in compaction DLQ by failure count"),
+		metric.WithUnit("{collections}"),
+	)
+	if err != nil {
+		log.Error("Failed to create compaction_dlq_size gauge", zap.Error(err))
+		return
+	}
+
+	metaDomain := dao.NewMetaDomain()
+
+	// Register callback to report current state
+	registration, err := otel.Meter.RegisterCallback(
+		func(callbackCtx context.Context, observer metric.Observer) error {
+			collectionDb := metaDomain.CollectionDb(callbackCtx)
+			failureCounts, err := collectionDb.GetDLQFailureCounts()
+			if err != nil {
+				log.Error("Failed to get compaction DLQ size", zap.Error(err))
+				return err
+			}
+
+			// Report current count for each failure level
+			for failureCount, count := range failureCounts {
+				observer.ObserveInt64(gauge, count,
+					metric.WithAttributes(
+						attribute.Int("failure_count", int(failureCount)),
+					),
+				)
+			}
+
+			log.Debug("Reported compaction DLQ state", zap.Any("failure_counts", failureCounts))
+			return nil
+		},
+		gauge,
+	)
+	if err != nil {
+		log.Error("Failed to register metrics callback", zap.Error(err))
+		return
+	}
+
+	// Wait for context cancellation
+	<-ctx.Done()
+
+	// Unregister callback on shutdown
+	if err := registration.Unregister(); err != nil {
+		log.Error("Failed to unregister metrics callback", zap.Error(err))
+	}
+
+	log.Info("Stopped compaction DLQ metrics")
+}

--- a/go/pkg/sysdb/grpc/server.go
+++ b/go/pkg/sysdb/grpc/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/chroma-core/chroma/go/pkg/leader"
 	"github.com/chroma-core/chroma/go/pkg/memberlist_manager"
 	"github.com/chroma-core/chroma/go/pkg/proto/coordinatorpb"
-	"github.com/chroma-core/chroma/go/pkg/sysdb/coordinator"
+	coordinatorpkg "github.com/chroma-core/chroma/go/pkg/sysdb/coordinator"
 	"github.com/chroma-core/chroma/go/pkg/sysdb/metastore/db/dbcore"
 	s3metastore "github.com/chroma-core/chroma/go/pkg/sysdb/metastore/s3"
 	"github.com/chroma-core/chroma/go/pkg/utils"
@@ -77,7 +77,7 @@ type Config struct {
 // convenient for end-to-end property based testing.
 type Server struct {
 	coordinatorpb.UnimplementedSysDBServer
-	coordinator  coordinator.Coordinator
+	coordinator  coordinatorpkg.Coordinator
 	grpcServer   grpcutils.GrpcServer
 	healthServer *health.Server
 }
@@ -151,7 +151,7 @@ func NewWithGrpcProvider(config Config, provider grpcutils.GrpcProvider) (*Serve
 		return nil, err
 	}
 
-	coordinator, err := coordinator.NewCoordinator(ctx, coordinator.CoordinatorConfig{
+	coordinator, err := coordinatorpkg.NewCoordinator(ctx, coordinatorpkg.CoordinatorConfig{
 		ObjectStore:                 s3MetaStore,
 		VersionFileEnabled:          config.VersionFileEnabled,
 		HeapServiceEnabled:          config.HeapServiceEnabled,
@@ -168,11 +168,19 @@ func NewWithGrpcProvider(config Config, provider grpcutils.GrpcProvider) (*Serve
 		// Start leader election for memberlist management
 		go leader.AcquireLeaderLock(context.Background(), func(leaderCtx context.Context) {
 			log.Info("Acquired leadership for memberlist management")
+
+			// Start DLQ metrics while leader is active
+			metricCtx, cancel := context.WithCancel(leaderCtx)
+			defer cancel()
+			go coordinatorpkg.StartDLQMetrics(metricCtx)
+			log.Info("Started DLQ metrics goroutine")
+
 			if err := StartMemberListManagers(leaderCtx, config); err != nil {
 				log.Error("Failed to start memberlist manager", zap.Error(err))
 			}
 			log.Info("Released leadership for memberlist management")
 		})
+
 		log.Info("Starting GRPC server")
 		s.grpcServer, err = provider.StartGrpcServer("coordinator", config.GrpcConfig, func(registrar grpc.ServiceRegistrar) {
 			coordinatorpb.RegisterSysDBServer(registrar, s)

--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -729,3 +729,32 @@ func (s *collectionDb) IncrementCompactionFailureCount(collectionID string) erro
 	}
 	return nil
 }
+
+// GetDLQFailureCounts returns a map of compaction_failure_count to the number of collections with that count.
+// This uses the read replica to minimize overhead on the primary database.
+func (s *collectionDb) GetDLQFailureCounts() (map[int32]int64, error) {
+	type result struct {
+		CompactionFailureCount int32 `gorm:"column:compaction_failure_count"`
+		Count                  int64 `gorm:"column:count"`
+	}
+
+	var results []result
+	err := s.read_db.Model(&dbmodel.Collection{}).
+		Select("compaction_failure_count, COUNT(*) as count").
+		Where("compaction_failure_count > 0").
+		Group("compaction_failure_count").
+		Find(&results).Error
+
+	if err != nil {
+		log.Error("GetCompactionDLQSize failed", zap.Error(err))
+		return nil, err
+	}
+
+	// Convert to map for easier access
+	countMap := make(map[int32]int64)
+	for _, r := range results {
+		countMap[r.CompactionFailureCount] = r.Count
+	}
+
+	return countMap, nil
+}

--- a/go/pkg/sysdb/metastore/db/dao/collection_test.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection_test.go
@@ -727,6 +727,70 @@ func (suite *CollectionDbTestSuite) TestCollectionDb_CompactionFailureCount() {
 	suite.NoError(err)
 }
 
+func (suite *CollectionDbTestSuite) TestCollectionDb_GetDLQFailureCounts() {
+	dim := int32(128)
+
+	// Create collections with different compaction_failure_count values
+	// Collection 1: failure count = 0 (should NOT be in DLQ)
+	collection1 := daotest.NewTestCollection(
+		suite.tenantName,
+		suite.databaseId,
+		"test_dlq_size_1",
+		daotest.WithDimension(dim),
+		daotest.WithCompactionFailureCount(0),
+	)
+	collectionID1, err := CreateTestCollection(suite.db, collection1)
+	suite.NoError(err)
+
+	// Collection 2: failure count = 1 (should be in DLQ)
+	collection2 := daotest.NewTestCollection(
+		suite.tenantName,
+		suite.databaseId,
+		"test_dlq_size_2",
+		daotest.WithDimension(dim),
+		daotest.WithCompactionFailureCount(1),
+	)
+	collectionID2, err := CreateTestCollection(suite.db, collection2)
+	suite.NoError(err)
+
+	// Collection 3: failure count = 5 (should be in DLQ)
+	collection3 := daotest.NewTestCollection(
+		suite.tenantName,
+		suite.databaseId,
+		"test_dlq_size_3",
+		daotest.WithDimension(dim),
+		daotest.WithCompactionFailureCount(5),
+	)
+	collectionID3, err := CreateTestCollection(suite.db, collection3)
+	suite.NoError(err)
+
+	// Get DLQ size - should have 1 collection with failure_count=1 and 1 with failure_count=5
+	dlqSize, err := suite.collectionDb.GetDLQFailureCounts()
+	suite.NoError(err)
+	suite.Equal(2, len(dlqSize))      // 2 different failure counts
+	suite.Equal(int64(1), dlqSize[1]) // 1 collection with failure_count=1
+	suite.Equal(int64(1), dlqSize[5]) // 1 collection with failure_count=5
+
+	// Increment failure count on collection 1, now it should be in DLQ with failure_count=1
+	err = suite.collectionDb.IncrementCompactionFailureCount(collectionID1)
+	suite.NoError(err)
+
+	// DLQ size should now have 2 collections with failure_count=1 and 1 with failure_count=5
+	dlqSize, err = suite.collectionDb.GetDLQFailureCounts()
+	suite.NoError(err)
+	suite.Equal(2, len(dlqSize))      // Still 2 different failure counts
+	suite.Equal(int64(2), dlqSize[1]) // 2 collections with failure_count=1
+	suite.Equal(int64(1), dlqSize[5]) // 1 collection with failure_count=5
+
+	// Clean up
+	err = CleanUpTestCollection(suite.db, collectionID1)
+	suite.NoError(err)
+	err = CleanUpTestCollection(suite.db, collectionID2)
+	suite.NoError(err)
+	err = CleanUpTestCollection(suite.db, collectionID3)
+	suite.NoError(err)
+}
+
 func TestCollectionDbTestSuiteSuite(t *testing.T) {
 	testSuite := new(CollectionDbTestSuite)
 	suite.Run(t, testSuite)

--- a/go/pkg/sysdb/metastore/db/dbmodel/collection.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/collection.go
@@ -75,4 +75,5 @@ type ICollectionDb interface {
 	BatchGetCollectionVersionFilePaths(collectionIDs []string) (map[string]string, error)
 	BatchGetCollectionSoftDeleteStatus(collectionIDs []string) (map[string]bool, error)
 	IncrementCompactionFailureCount(collectionID string) error
+	GetDLQFailureCounts() (map[int32]int64, error)
 }

--- a/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
+++ b/go/pkg/sysdb/metastore/db/dbmodel/mocks/ICollectionDb.go
@@ -344,6 +344,36 @@ func (_m *ICollectionDb) IncrementCompactionFailureCount(collectionID string) er
 	return r0
 }
 
+// GetDLQFailureCounts provides a mock function with no fields
+func (_m *ICollectionDb) GetDLQFailureCounts() (map[int32]int64, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDLQFailureCounts")
+	}
+
+	var r0 map[int32]int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (map[int32]int64, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() map[int32]int64); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[int32]int64)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Insert provides a mock function with given fields: in
 func (_m *ICollectionDb) Insert(in *dbmodel.Collection) error {
 	ret := _m.Called(in)


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Added a gauge metric to track DLQ members, attributed by the value of compaction_failure_count.
    - This is periodically updated via a goroutine that is launched on the sysdb leader. This goroutine does a `COUNT GROUP BY compaction_failure_count` query on all collections where `compaction_failure_count > 0`.
- New functionality
    - ^, possible to view this metric via prometheus/otel

## Test plan

Manual testing locally

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_