### PR TITLE
[ENH]: ListInProgressJobs endpoint for compactor

### DIFF
--- a/idl/chromadb/proto/compactor.proto
+++ b/idl/chromadb/proto/compactor.proto
@@ -34,8 +34,23 @@ message ListDeadJobsResponse {
   CollectionIds ids = 1;
 }
 
+message ListInProgressJobsRequest {
+  // Empty
+}
+
+message InProgressJobInfo {
+  string job_id = 1;
+  string database_name = 2;
+  int64 expires_at_epoch_secs = 3;
+}
+
+message ListInProgressJobsResponse {
+  repeated InProgressJobInfo jobs = 1;
+}
+
 service Compactor {
   rpc Compact(CompactRequest) returns (CompactResponse) {}
   rpc Rebuild(RebuildRequest) returns (RebuildResponse) {}
   rpc ListDeadJobs(ListDeadJobsRequest) returns (ListDeadJobsResponse) {}
+  rpc ListInProgressJobs(ListInProgressJobsRequest) returns (ListInProgressJobsResponse) {}
 }

--- a/rust/worker/src/compactor/compaction_client.rs
+++ b/rust/worker/src/compactor/compaction_client.rs
@@ -1,6 +1,6 @@
 use chroma_types::chroma_proto::{
     compactor_client::CompactorClient, CollectionIds, CompactRequest, ListDeadJobsRequest,
-    RebuildRequest, SegmentScope,
+    ListInProgressJobsRequest, RebuildRequest, SegmentScope,
 };
 use clap::{Parser, Subcommand};
 use thiserror::Error;
@@ -47,6 +47,8 @@ pub enum CompactionCommand {
     },
     /// List all dead jobs (collections with failed compactions)
     ListDeadJobs,
+    /// List all in-progress compaction jobs
+    ListInProgressJobs,
 }
 
 impl CompactionClient {
@@ -114,6 +116,26 @@ impl CompactionClient {
                     }
                 } else {
                     println!("No dead jobs response didn't contain an ids field");
+                }
+            }
+            CompactionCommand::ListInProgressJobs => {
+                let mut client = self.grpc_client().await?;
+                let response = client
+                    .list_in_progress_jobs(ListInProgressJobsRequest {})
+                    .await
+                    .map_err(|e| CompactionClientError::Compactor(e.to_string()))?;
+
+                let jobs = response.into_inner().jobs;
+                println!("In-progress compaction jobs:");
+                if jobs.is_empty() {
+                    println!("  None");
+                } else {
+                    for job in jobs {
+                        println!(
+                            "  job_id={} database={} expires_at_epoch_secs={}",
+                            job.job_id, job.database_name, job.expires_at_epoch_secs
+                        );
+                    }
                 }
             }
         };

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -2,7 +2,9 @@ use super::scheduler::Scheduler;
 use super::scheduler_policy::LasCompactionTimeSchedulerPolicy;
 use super::OneOffCompactMessage;
 use super::RebuildMessage;
-use crate::compactor::types::{ListDeadJobsMessage, ScheduledCompactMessage};
+use crate::compactor::types::{
+    InProgressJobEntry, ListDeadJobsMessage, ListInProgressJobsMessage, ScheduledCompactMessage,
+};
 use crate::config::CompactionServiceConfig;
 use crate::execution::operators::purge_dirty_log::PurgeDirtyLog;
 use crate::execution::operators::purge_dirty_log::PurgeDirtyLogError;
@@ -819,6 +821,36 @@ impl Handler<ListDeadJobsMessage> for CompactionManager {
         // TODO(tanujnay112): remove this endpoint
         if let Err(e) = message.response_tx.send(Vec::new()) {
             tracing::warn!("Failed to send dead jobs response: {:?}", e);
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<ListInProgressJobsMessage> for CompactionManager {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: ListInProgressJobsMessage,
+        _ctx: &ComponentContext<CompactionManager>,
+    ) {
+        let entries = self
+            .scheduler
+            .get_in_progress_jobs()
+            .into_iter()
+            .map(|(job_id, job)| InProgressJobEntry {
+                job_id,
+                database_name: job.database_name.as_ref().to_string(),
+                expires_at_epoch_secs: job
+                    .expires_at
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0),
+            })
+            .collect();
+
+        if let Err(e) = message.response_tx.send(entries) {
+            tracing::warn!("Failed to send in-progress jobs response: {:?}", e);
         }
     }
 }

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -3,8 +3,9 @@ use chroma_jemalloc_pprof_server::spawn_pprof_server;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     compactor_server::{Compactor, CompactorServer},
-    CollectionIds, CompactRequest, CompactResponse, ListDeadJobsRequest, ListDeadJobsResponse,
-    RebuildRequest, RebuildResponse,
+    CollectionIds, CompactRequest, CompactResponse, InProgressJobInfo, ListDeadJobsRequest,
+    ListDeadJobsResponse, ListInProgressJobsRequest, ListInProgressJobsResponse, RebuildRequest,
+    RebuildResponse,
 };
 use tokio::{
     signal::unix::{signal, SignalKind},
@@ -13,7 +14,9 @@ use tokio::{
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::trace_span;
 
-use crate::compactor::{ListDeadJobsMessage, OneOffCompactMessage, RegisterOnReadySignal};
+use crate::compactor::{
+    ListDeadJobsMessage, ListInProgressJobsMessage, OneOffCompactMessage, RegisterOnReadySignal,
+};
 
 use super::{CompactionManager, RebuildMessage};
 
@@ -138,6 +141,34 @@ impl Compactor for CompactionServer {
             ids: Some(CollectionIds {
                 ids: dead_jobs.iter().map(ToString::to_string).collect(),
             }),
+        }))
+    }
+
+    async fn list_in_progress_jobs(
+        &self,
+        _request: Request<ListInProgressJobsRequest>,
+    ) -> Result<Response<ListInProgressJobsResponse>, Status> {
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        self.manager
+            .receiver()
+            .send(ListInProgressJobsMessage { response_tx }, None)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let in_progress_jobs = response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?;
+
+        Ok(Response::new(ListInProgressJobsResponse {
+            jobs: in_progress_jobs
+                .into_iter()
+                .map(|entry| InProgressJobInfo {
+                    job_id: entry.job_id.to_string(),
+                    database_name: entry.database_name,
+                    expires_at_epoch_secs: entry.expires_at_epoch_secs,
+                })
+                .collect(),
         }))
     }
 }

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -39,9 +39,9 @@ impl SchedulerMetrics {
     }
 }
 
-struct InProgressJob {
-    expires_at: SystemTime,
-    database_name: DatabaseName,
+pub(crate) struct InProgressJob {
+    pub(crate) expires_at: SystemTime,
+    pub(crate) database_name: DatabaseName,
 }
 
 impl InProgressJob {
@@ -505,6 +505,13 @@ impl Scheduler {
 
     pub(crate) fn get_jobs(&self) -> impl Iterator<Item = &CompactionJob> {
         self.job_queue.iter()
+    }
+
+    pub(crate) fn get_in_progress_jobs(&self) -> Vec<(JobId, &InProgressJob)> {
+        self.in_progress_jobs
+            .iter()
+            .map(|(id, job)| (*id, job))
+            .collect()
     }
 
     pub(crate) fn set_memberlist(&mut self, memberlist: Memberlist) {

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -28,3 +28,15 @@ pub struct RebuildMessage {
 pub struct ListDeadJobsMessage {
     pub response_tx: oneshot::Sender<Vec<JobId>>,
 }
+
+#[derive(Debug)]
+pub struct InProgressJobEntry {
+    pub job_id: JobId,
+    pub database_name: String,
+    pub expires_at_epoch_secs: i64,
+}
+
+#[derive(Debug)]
+pub struct ListInProgressJobsMessage {
+    pub response_tx: oneshot::Sender<Vec<InProgressJobEntry>>,
+}


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
    - Adds a ListInProgressJobs RPC endpoint that returns the list of in progress jobs (collection ids) within the compaction's scheduler along with its expiration time and database name.
- New functionality
    - This endpoint can be accessed by the compaction client by doing `compaction_client --url \<compactor-url> list-in-progress-jobs`

## Test plan

Manual testing

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_