### PR TITLE
[CHORE] Set query service replica count to 1 in dev values

### DIFF
--- a/k8s/distributed-chroma/Chart.yaml
+++ b/k8s/distributed-chroma/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: distributed-chroma
 description: A helm chart for distributed Chroma
 type: application
-version: 0.1.78
+version: 0.1.79
 appVersion: "0.4.24"
 keywords:
   - chroma

--- a/k8s/distributed-chroma/values2.dev.yaml
+++ b/k8s/distributed-chroma/values2.dev.yaml
@@ -38,6 +38,7 @@ queryService:
       cpu: 200m
     requests:
       cpu: 200m
+  replicaCount: 1
 
 compactionService:
   env:


### PR DESCRIPTION
## Description of changes

Explicitly set replicaCount for queryService in the dev Helm values
to ensure a consistent single-replica deployment in dev environments.

This is so that mcmr will pack into a tighter cluster.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Watch CI flake less.

## Documentation Changes

N/A

Co-authored-by: AI
