### PR TITLE
[ENH] add tracing spans to log fetch path

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2171,7 +2171,7 @@ impl LogServer {
             Some(fragments) => fragments,
             None => log_reader
                 .scan(from, limits)
-                .instrument(tracing::info_span!("log_reader::scan", %collection_id))
+                .instrument(tracing::info_span!("log_reader::scan", %collection_id, start_offset = req.start_from_offset))
                 .await
                 .map_err(|err| {
                     Status::new(

--- a/rust/worker/src/execution/operators/fetch_log.rs
+++ b/rust/worker/src/execution/operators/fetch_log.rs
@@ -166,7 +166,7 @@ impl FetchLogOperator {
                 self.start_log_offset_id,
             )
             .instrument(
-                tracing::info_span!("scout_log_fragments", collection_id = %self.collection_uuid),
+                tracing::info_span!("scout_log_fragments", collection_id = %self.collection_uuid, start_log_offset = self.start_log_offset_id),
             )
             .await?;
 

--- a/rust/worker/src/execution/operators/fragment_fetch.rs
+++ b/rust/worker/src/execution/operators/fragment_fetch.rs
@@ -155,7 +155,7 @@ impl FragmentFetcher {
     /// Records are filtered to the half-open range [start_offset, limit_offset)
     /// and returned sorted by log_offset.  At most `max_concurrency` fragment
     /// fetches are in flight at any given time.
-    #[tracing::instrument(skip(self, pointers))]
+    #[tracing::instrument(skip(self, pointers), fields(num_fragments = pointers.len()))]
     pub async fn fetch_records(
         &self,
         pointers: &[FragmentPointer],


### PR DESCRIPTION
## Description of changes

Instrument the log-fetching hot path with tracing info spans to improve
observability during debugging and performance analysis:

- log-service: span make_log_reader, manifest_with_head_check, and
  log_reader::scan in ScoutLogFragments RPC handler
- fetch_log: span the scout_log_fragments call
- fragment_fetch: instrument fetch_records and fetch_fragment methods

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
