### PR TITLE
fix(js): make collection.delete() args parameter optional

### DIFF
--- a/clients/new-js/packages/chromadb/src/collection.ts
+++ b/clients/new-js/packages/chromadb/src/collection.ts
@@ -202,7 +202,7 @@ export interface Collection {
    * Deletes records from the collection based on filters.
    * @param args - Deletion criteria
    */
-  delete(args: {
+  delete(args?: {
     /** Specific record IDs to delete */
     ids?: string[];
     /** Metadata-based filtering for deletion */
@@ -1100,7 +1100,7 @@ export class CollectionImpl implements Collection {
     ids?: string[];
     where?: Where;
     whereDocument?: WhereDocument;
-  }): Promise<void> {
+  } = {}): Promise<void> {
     this.validateDelete(ids, where, whereDocument);
 
     await RecordService.collectionDelete({

--- a/clients/new-js/packages/chromadb/test/delete.collection.test.ts
+++ b/clients/new-js/packages/chromadb/test/delete.collection.test.ts
@@ -34,6 +34,20 @@ describe("delete collection", () => {
     );
   });
 
+  test("it should delete all documents when called with no arguments", async () => {
+    const collection = await client.createCollection({ name: "test" });
+    await collection.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+      metadatas: METADATAS,
+    });
+    let count = await collection.count();
+    expect(count).toBe(3);
+    await collection.delete();
+    count = await collection.count();
+    expect(count).toBe(0);
+  });
+
   test("should error on non existing collection", async () => {
     const collection = await client.createCollection({ name: "test" });
     await client.deleteCollection({ name: "test" });


### PR DESCRIPTION
## Summary
- Fixes #5845 — TypeScript `collection.delete()` requires an `args` parameter even though all its properties are optional
- The docs show `delete()` as callable with no arguments, but the interface and implementation require the object to be passed
- Fix: make `args` optional in the interface (`args?:`) and add `= {}` default in the implementation
- The legacy client (`clients/js`) already does this correctly — this aligns the new client to match

## Files changed
- `clients/new-js/packages/chromadb/src/collection.ts` — made `args` optional in both the `Collection` interface (line 205) and `CollectionImpl.delete` implementation (line 1103)
- `clients/new-js/packages/chromadb/test/delete.collection.test.ts` — added test for `collection.delete()` with no arguments, verifying all documents are deleted

## Test plan
- [x] New test: `"it should delete all documents when called with no arguments"` — adds 3 documents, calls `collection.delete()` with no args, verifies count is 0
- [x] Existing `delete` tests unaffected (they pass args as before)
- [x] `validateDelete` already handles all params being undefined