### PR TITLE
[ENH]: Compaction endpoint to return where a collection would be assigned

### DIFF
--- a/idl/chromadb/proto/compactor.proto
+++ b/idl/chromadb/proto/compactor.proto
@@ -48,9 +48,19 @@ message ListInProgressJobsResponse {
   repeated InProgressJobInfo jobs = 1;
 }
 
+message GetCollectionAssignmentRequest {
+  string collection_id = 1;
+}
+
+message GetCollectionAssignmentResponse {
+  string assigned_node = 1;
+  repeated string memberlist = 2;
+}
+
 service Compactor {
   rpc Compact(CompactRequest) returns (CompactResponse) {}
   rpc Rebuild(RebuildRequest) returns (RebuildResponse) {}
   rpc ListDeadJobs(ListDeadJobsRequest) returns (ListDeadJobsResponse) {}
   rpc ListInProgressJobs(ListInProgressJobsRequest) returns (ListInProgressJobsResponse) {}
+  rpc GetCollectionAssignment(GetCollectionAssignmentRequest) returns (GetCollectionAssignmentResponse) {}
 }

--- a/rust/worker/src/compactor/compaction_client.rs
+++ b/rust/worker/src/compactor/compaction_client.rs
@@ -1,8 +1,10 @@
 use chroma_types::chroma_proto::{
-    compactor_client::CompactorClient, CollectionIds, CompactRequest, ListDeadJobsRequest,
-    ListInProgressJobsRequest, RebuildRequest, SegmentScope,
+    compactor_client::CompactorClient, CollectionIds, CompactRequest,
+    GetCollectionAssignmentRequest, ListDeadJobsRequest, ListInProgressJobsRequest, RebuildRequest,
+    SegmentScope,
 };
 use clap::{Parser, Subcommand};
+use std::io::Write;
 use thiserror::Error;
 use tonic::transport::Channel;
 use uuid::Uuid;
@@ -14,6 +16,8 @@ pub enum CompactionClientError {
     Compactor(String),
     #[error("Unable to connect to compactor: {0}")]
     Connection(#[from] tonic::transport::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 /// Tool to control compaction service
@@ -49,6 +53,12 @@ pub enum CompactionCommand {
     ListDeadJobs,
     /// List all in-progress compaction jobs
     ListInProgressJobs,
+    /// Get collection assignment info (which node would handle a collection)
+    GetCollectionAssignment {
+        /// Collection ID to check assignment for
+        #[arg(short, long)]
+        collection_id: Uuid,
+    },
 }
 
 impl CompactionClient {
@@ -56,7 +66,7 @@ impl CompactionClient {
         Ok(CompactorClient::connect(self.url.clone()).await?)
     }
 
-    pub async fn run(&self) -> Result<(), CompactionClientError> {
+    pub async fn run(&self, w: &mut dyn Write) -> Result<(), CompactionClientError> {
         match &self.command {
             CompactionCommand::Compact { id } => {
                 let mut client = self.grpc_client().await?;
@@ -106,16 +116,16 @@ impl CompactionClient {
 
                 let dead_jobs = response.into_inner();
                 if let Some(ids) = dead_jobs.ids {
-                    println!("Dead jobs (collections with failed compactions):");
+                    writeln!(w, "Dead jobs (collections with failed compactions):")?;
                     if ids.ids.is_empty() {
-                        println!("  None");
+                        writeln!(w, "  None")?;
                     } else {
                         for id in ids.ids {
-                            println!("  {}", id);
+                            writeln!(w, "  {}", id)?;
                         }
                     }
                 } else {
-                    println!("No dead jobs response didn't contain an ids field");
+                    writeln!(w, "No dead jobs response didn't contain an ids field")?;
                 }
             }
             CompactionCommand::ListInProgressJobs => {
@@ -126,15 +136,38 @@ impl CompactionClient {
                     .map_err(|e| CompactionClientError::Compactor(e.to_string()))?;
 
                 let jobs = response.into_inner().jobs;
-                println!("In-progress compaction jobs:");
+                writeln!(w, "In-progress compaction jobs:")?;
                 if jobs.is_empty() {
-                    println!("  None");
+                    writeln!(w, "  None")?;
                 } else {
                     for job in jobs {
-                        println!(
+                        writeln!(
+                            w,
                             "  job_id={} database={} expires_at_epoch_secs={}",
                             job.job_id, job.database_name, job.expires_at_epoch_secs
-                        );
+                        )?;
+                    }
+                }
+            }
+            CompactionCommand::GetCollectionAssignment { collection_id } => {
+                let mut client = self.grpc_client().await?;
+                let response = client
+                    .get_collection_assignment(GetCollectionAssignmentRequest {
+                        collection_id: collection_id.to_string(),
+                    })
+                    .await
+                    .map_err(|e| CompactionClientError::Compactor(e.to_string()))?;
+
+                let assignment = response.into_inner();
+                writeln!(w, "Collection assignment information:")?;
+                writeln!(w, "  Collection ID: {}", collection_id)?;
+                writeln!(w, "  Assigned to node: {}", assignment.assigned_node)?;
+                writeln!(w, "  Current memberlist:")?;
+                if assignment.memberlist.is_empty() {
+                    writeln!(w, "    (empty)")?;
+                } else {
+                    for member in assignment.memberlist {
+                        writeln!(w, "    - {}", member)?;
                     }
                 }
             }

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -3,7 +3,8 @@ use super::scheduler_policy::LasCompactionTimeSchedulerPolicy;
 use super::OneOffCompactMessage;
 use super::RebuildMessage;
 use crate::compactor::types::{
-    InProgressJobEntry, ListDeadJobsMessage, ListInProgressJobsMessage, ScheduledCompactMessage,
+    GetCollectionAssignmentMessage, GetCollectionAssignmentResponse, InProgressJobEntry,
+    ListDeadJobsMessage, ListInProgressJobsMessage, ScheduledCompactMessage,
 };
 use crate::config::CompactionServiceConfig;
 use crate::execution::operators::fragment_fetch::FragmentFetcher;
@@ -903,6 +904,36 @@ impl Handler<ListInProgressJobsMessage> for CompactionManager {
 
         if let Err(e) = message.response_tx.send(entries) {
             tracing::warn!("Failed to send in-progress jobs response: {:?}", e);
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<GetCollectionAssignmentMessage> for CompactionManager {
+    type Result = ();
+
+    async fn handle(
+        &mut self,
+        message: GetCollectionAssignmentMessage,
+        _ctx: &ComponentContext<CompactionManager>,
+    ) {
+        let assignment_policy = self.scheduler.get_assignment_policy();
+
+        let assigned_node = assignment_policy
+            .assign_one(&message.collection_id.0.to_string())
+            .unwrap_or_else(|_| "no_assignment".to_string());
+
+        let mut member_ids = assignment_policy.get_members();
+
+        member_ids.sort();
+
+        let response = GetCollectionAssignmentResponse {
+            assigned_node,
+            memberlist: member_ids,
+        };
+
+        if let Err(e) = message.response_tx.send(response) {
+            tracing::warn!("Failed to send collection assignment response: {:?}", e);
         }
     }
 }

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -3,10 +3,11 @@ use chroma_jemalloc_pprof_server::spawn_pprof_server;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     compactor_server::{Compactor, CompactorServer},
-    CollectionIds, CompactRequest, CompactResponse, InProgressJobInfo, ListDeadJobsRequest,
-    ListDeadJobsResponse, ListInProgressJobsRequest, ListInProgressJobsResponse, RebuildRequest,
-    RebuildResponse,
+    CollectionIds, CompactRequest, CompactResponse, GetCollectionAssignmentRequest,
+    GetCollectionAssignmentResponse, InProgressJobInfo, ListDeadJobsRequest, ListDeadJobsResponse,
+    ListInProgressJobsRequest, ListInProgressJobsResponse, RebuildRequest, RebuildResponse,
 };
+use std::str::FromStr;
 use tokio::{
     signal::unix::{signal, SignalKind},
     sync::oneshot,
@@ -15,7 +16,8 @@ use tonic::{transport::Server, Request, Response, Status};
 use tracing::trace_span;
 
 use crate::compactor::{
-    ListDeadJobsMessage, ListInProgressJobsMessage, OneOffCompactMessage, RegisterOnReadySignal,
+    GetCollectionAssignmentMessage, ListDeadJobsMessage, ListInProgressJobsMessage,
+    OneOffCompactMessage, RegisterOnReadySignal,
 };
 
 use super::{CompactionManager, RebuildMessage};
@@ -169,6 +171,40 @@ impl Compactor for CompactionServer {
                     expires_at_epoch_secs: entry.expires_at_epoch_secs,
                 })
                 .collect(),
+        }))
+    }
+
+    async fn get_collection_assignment(
+        &self,
+        request: Request<GetCollectionAssignmentRequest>,
+    ) -> Result<Response<GetCollectionAssignmentResponse>, Status> {
+        let req = request.into_inner();
+
+        // Parse collection ID
+        let collection_id = chroma_types::CollectionUuid::from_str(&req.collection_id)
+            .map_err(|e| Status::invalid_argument(format!("Invalid collection ID: {}", e)))?;
+
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+
+        self.manager
+            .receiver()
+            .send(
+                GetCollectionAssignmentMessage {
+                    collection_id,
+                    response_tx,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let assignment_info = response_rx
+            .await
+            .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?;
+
+        Ok(Response::new(GetCollectionAssignmentResponse {
+            assigned_node: assignment_info.assigned_node,
+            memberlist: assignment_info.memberlist,
         }))
     }
 }

--- a/rust/worker/src/compactor/scheduler.rs
+++ b/rust/worker/src/compactor/scheduler.rs
@@ -521,6 +521,10 @@ impl Scheduler {
     pub(crate) fn has_memberlist(&self) -> bool {
         self.memberlist.is_some()
     }
+
+    pub(crate) fn get_assignment_policy(&mut self) -> &mut Box<dyn AssignmentPolicy> {
+        &mut self.assignment_policy
+    }
 }
 
 #[cfg(test)]

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -40,3 +40,15 @@ pub struct InProgressJobEntry {
 pub struct ListInProgressJobsMessage {
     pub response_tx: oneshot::Sender<Vec<InProgressJobEntry>>,
 }
+
+#[derive(Debug)]
+pub struct GetCollectionAssignmentMessage {
+    pub collection_id: CollectionUuid,
+    pub response_tx: oneshot::Sender<GetCollectionAssignmentResponse>,
+}
+
+#[derive(Debug)]
+pub struct GetCollectionAssignmentResponse {
+    pub assigned_node: String,
+    pub memberlist: Vec<String>,
+}

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -183,7 +183,7 @@ pub async fn compaction_service_entrypoint() {
 
 pub async fn compaction_client_entrypoint() {
     let client = CompactionClient::parse();
-    if let Err(e) = client.run().await {
+    if let Err(e) = client.run(&mut std::io::stdout()).await {
         eprintln!("{e}");
     }
 }


### PR DESCRIPTION
## Description of changes

- Improvements & Bug fixes
  - N/A
- New functionality
  - `./compaction-client --url http://localhost:50051 get-collection-assignment --collection-id <UUID>` returns where the concerned pod thinks the given collection id would be assigned and also returns what it thinks its memberlist is.

## Test plan

Manual local testing.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
