### PR TITLE
[BUG] Fix sysdb OTEL metrics service name

### DIFF
--- a/go/shared/otel/main.go
+++ b/go/shared/otel/main.go
@@ -136,13 +136,8 @@ func InitTracing(ctx context.Context, config *TracingConfig) (err error) {
 		return
 	}
 
-	// Create resource with service name; merge with default so our service name
-	// overrides any from environment (OTEL_SERVICE_NAME, etc.) for both traces and metrics.
-	res, err := resource.Merge(resource.Default(),
-		resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String(config.Service)))
-	if err != nil {
-		return fmt.Errorf("failed to merge resource: %w", err)
-	}
+	// Create resource with service name that will be used for both traces and metrics.
+	res := resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String(config.Service))
 
 	// Create a new tracer provider with a batch span processor and the OTLP exporter.
 	tp := sdktrace.NewTracerProvider(

--- a/k8s/distributed-chroma/values.yaml
+++ b/k8s/distributed-chroma/values.yaml
@@ -20,7 +20,7 @@ sysdb:
   replicaCount: 1
   env:
     - name: OPTL_TRACING_ENDPOINT
-      value: 'value: "jaeger.chroma.svc.cluster.local:4317"'
+      value: 'value: "otel-collector.chroma.svc.cluster.local:4317"'
   resources:
     limits:
       cpu: '2000m'

--- a/k8s/distributed-chroma/values2.yaml
+++ b/k8s/distributed-chroma/values2.yaml
@@ -20,7 +20,7 @@ sysdb:
   replicaCount: 1
   env:
     - name: OPTL_TRACING_ENDPOINT
-      value: 'value: "jaeger.chroma.svc.cluster.local:4317"'
+      value: 'value: "otel-collector.chroma.svc.cluster.local:4317"'
   resources:
     limits:
       cpu: '2000m'


### PR DESCRIPTION
## Description of changes

Currently sysdb metrics are not associated with any otel service. This PR fixes the OTEL initialization so that the service name is specified for the OTEL metrics. Additionally, it updates our default chart overrides so that sysdb sends both traces and metrics to otel-collector. That way otel-collector will route traces to jaeger and it will route metrics to prometheus.

## Test plan

TODO

## Migration plan

TODO

## Observability plan

Verify exported sysdb metrics appear associated with the correct service

## Documentation Changes

TODO
