### PR TITLE
[ENH][worker]  Re-add the fetch_log_concurrency semaphore.

### DIFF
--- a/rust/worker/src/execution/operators/fetch_log.rs
+++ b/rust/worker/src/execution/operators/fetch_log.rs
@@ -185,7 +185,12 @@ impl FetchLogOperator {
             .collect();
 
         let fetched = fragment_fetcher
-            .fetch_records(&pointers, self.start_log_offset_id, limit_offset)
+            .fetch_records(
+                &pointers,
+                self.start_log_offset_id,
+                limit_offset,
+                self.fetch_log_concurrency,
+            )
             .await?;
 
         Ok(Chunk::new(fetched.into()))

--- a/rust/worker/src/execution/operators/fragment_fetch.rs
+++ b/rust/worker/src/execution/operators/fragment_fetch.rs
@@ -153,13 +153,15 @@ impl FragmentFetcher {
     /// Fetch and decode log records from a set of fragment pointers.
     ///
     /// Records are filtered to the half-open range [start_offset, limit_offset)
-    /// and returned sorted by log_offset.
+    /// and returned sorted by log_offset. At most `max_concurrency` fragment
+    /// fetches are in flight at any given time.
     #[tracing::instrument(skip(self, pointers), fields(num_fragments = pointers.len()))]
     pub async fn fetch_records(
         &self,
         pointers: &[FragmentPointer],
         start_offset: u64,
         limit_offset: u64,
+        max_concurrency: usize,
     ) -> Result<Vec<LogRecord>, FragmentFetchError> {
         if pointers.is_empty() {
             if start_offset < limit_offset {
@@ -170,11 +172,16 @@ impl FragmentFetcher {
             }
             return Ok(Vec::new());
         }
+        let sema = Arc::new(tokio::sync::Semaphore::new(max_concurrency));
         let futures: Vec<_> = pointers
             .iter()
-            .map(|pointer| async move {
-                self.fetch_fragment(pointer, start_offset, limit_offset)
-                    .await
+            .map(|pointer| {
+                let sema = Arc::clone(&sema);
+                async move {
+                    let _permit = sema.acquire().await;
+                    self.fetch_fragment(pointer, start_offset, limit_offset)
+                        .await
+                }
             })
             .collect();
         let results = try_join_all(futures).await?;
@@ -423,7 +430,7 @@ mod tests {
         let (_tmp, storage) = chroma_storage::test_storage();
         let fetcher = FragmentFetcher::new_for_test(storage);
         let err = fetcher
-            .fetch_records(&[], 5, 10)
+            .fetch_records(&[], 5, 10, 10)
             .await
             .expect_err("empty pointers with start < limit should be a hole");
         match err {
@@ -440,7 +447,7 @@ mod tests {
         let (_tmp, storage) = chroma_storage::test_storage();
         let fetcher = FragmentFetcher::new_for_test(storage);
         let records = fetcher
-            .fetch_records(&[], 5, 5)
+            .fetch_records(&[], 5, 5, 10)
             .await
             .expect("empty pointers with start == limit should succeed");
         assert!(records.is_empty(), "should return no records");


### PR DESCRIPTION
## Description of changes

This adds a default-10 semaphore to the fragment_fetch path.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
