### PR TITLE
[ENH] Default fallback for delete response

### DIFF
--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -191,7 +191,7 @@ export type DeleteCollectionRecordsPayload = RawWhereFields & {
 };
 
 export type DeleteCollectionRecordsResponse = {
-    deleted: number;
+    deleted?: number;
 };
 
 export type DeleteCollectionResponse = {

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1626,6 +1626,7 @@ impl DeleteCollectionRecordsRequest {
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct DeleteCollectionRecordsResponse {
+    #[serde(default)]
     pub deleted: u32,
 }
 


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Add default fallback for delete response deserialization so that the rust client is backward compatible to old server impl
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
