### PR TITLE
[TST] Mark function tests as cluster only

### DIFF
--- a/chromadb/test/distributed/test_statistics_wrapper.py
+++ b/chromadb/test/distributed/test_statistics_wrapper.py
@@ -11,6 +11,7 @@ import pytest
 from chromadb.api.client import Client as ClientCreator
 from chromadb.base_types import SparseVector
 from chromadb.config import System
+from chromadb.test.conftest import skip_if_not_cluster
 from chromadb.test.utils.wait_for_version_increase import (
     get_collection_version,
     wait_for_version_increase,
@@ -21,6 +22,8 @@ from chromadb.utils.statistics import (
     get_statistics,
     get_statistics_fn_name,
 )
+
+pytestmark = [skip_if_not_cluster()]
 
 
 def test_statistics_wrapper(basic_http_client: System) -> None:

--- a/chromadb/test/distributed/test_task_api.py
+++ b/chromadb/test/distributed/test_task_api.py
@@ -14,11 +14,14 @@ from chromadb.api.functions import (
 )
 from chromadb.config import System
 from chromadb.errors import ChromaError, NotFoundError
+from chromadb.test.conftest import skip_if_not_cluster
 from chromadb.test.utils.wait_for_version_increase import (
     get_collection_version,
     wait_for_version_increase,
 )
 from time import sleep
+
+pytestmark = [skip_if_not_cluster()]
 
 
 def test_count_function_attach_and_detach(basic_http_client: System) -> None:


### PR DESCRIPTION
These tests only work with distributed Chroma, but they seem to run even when I have `CHROMA_RUST_BINDINGS_TEST_ONLY=1`.

In the CI, it passes because we run pytest with `--ignore-glob 'chromadb/test/distributed/*'`. Locally, this test only passes if you have `tilt up` running.