### PR TITLE
[BLD] Better triggers for CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - main
-      - '**'
+      - "**"
 
 # Cancel any in-progress workflows when a new commit is pushed to the PR.
 concurrency:
@@ -16,8 +16,6 @@ jobs:
     name: Detect changes and determine tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
-      # Component changes
-      docs-only: ${{ steps.determine-tests.outputs.docs-only }}
       helm-changes: ${{ steps.filter.outputs.helm-changes }}
       # Test flags as a JSON array
       tests-to-run: ${{ steps.determine-tests.outputs.tests-to-run }}
@@ -32,59 +30,68 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          predicate-quantifier: 'every'
+          predicate-quantifier: "some"
           filters: |
-            # documentation changes
-            docs:
-              - 'docs/**'
-              - '**/*.md'
-              - 'sample_apps/**'
-              - 'examples/**'
-            # Outside docs
-            outside-docs:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!sample_apps/**'
-              - '!examples/**'
             # Helm chart changes
             helm-changes:
               - 'k8s/distributed-chroma/**'
             # JavaScript client changes
             js-client:
               - 'clients/js/**'
-            # Outside JS client
-            outside-js-client:
-              - '!clients/js/**'
+              # Rust paths: JS client runs integration tests against the Rust server
+              - 'rust/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'idl/**'
+              # Go paths: chorma backend is partially go
+              - 'go/**'
+            # Rust and related - run rust when any of these change
+            rust:
+              - 'rust/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'idl/**'
+              # Go paths: Go and Rust services talk to each other
+              - 'go/**'
+            # Python and related
+            python:
+              - 'chromadb/**'
+              - 'clients/python/**'
+              - 'requirements.txt'
+              - 'requirements_dev.txt'
+              - 'pyproject.toml'
+              - 'idl/**'
+              # Rust paths: Rust changes can affect Python bindings and client
+              - 'rust/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              # Go paths: chorma backend is partially go
+              - 'go/**'
+            # Go
+            go:
+              - 'go/**'
+              # Rust paths: Rust and Go services talk to each other
+              - 'rust/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'idl/**'
+            # CI/CD and core infra - run all tests when these change
+            ci-infra:
+              - '.github/**'
+              - '**/Dockerfile*'
+              - 'bin/**'
+              - '**/docker-compose*.yml'
+              - 'Makefile'
 
       - name: Determine tests to run
         id: determine-tests
-        run: |
-          # Initialize an empty array
-          TESTS_TO_RUN="[]"
-
-          # If changes are docs-only (changes in docs but not outside docs)
-          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.outside-docs }}" == "false" ]]; then
-            echo "Only documentation changes detected, skipping all tests"
-            echo "docs-only=true" >> $GITHUB_OUTPUT
-            echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "docs-only=false" >> $GITHUB_OUTPUT
-          fi
-
-          # Check for JS-only changes (changes in JS but not outside JS)
-          if [[ "${{ steps.filter.outputs.js-client }}" == "true" && "${{ steps.filter.outputs.outside-js-client }}" == "false" ]]; then
-            echo "JavaScript-only changes detected"
-            TESTS_TO_RUN='["js-client"]'
-            echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # If we get here, we need to run all tests (core changes)
-          echo "Core changes detected, running all tests"
-          TESTS_TO_RUN='["python", "rust", "js-client", "go"]'
-          echo "tests-to-run=${TESTS_TO_RUN}" >> $GITHUB_OUTPUT
+        env:
+          FILTER_JS_CLIENT: ${{ steps.filter.outputs.js-client }}
+          FILTER_RUST: ${{ steps.filter.outputs.rust }}
+          FILTER_PYTHON: ${{ steps.filter.outputs.python }}
+          FILTER_GO: ${{ steps.filter.outputs.go }}
+          FILTER_CI_INFRA: ${{ steps.filter.outputs.ci-infra }}
+        run: bin/ci/determine-tests-to-run.sh
 
       - name: Check Helm version change
         id: helm-version
@@ -152,7 +159,7 @@ jobs:
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
-      property_testing_preset: 'normal'
+      property_testing_preset: "normal"
 
   python-vulnerability-scan:
     name: Python vulnerability scan
@@ -238,38 +245,38 @@ jobs:
   all-required-pr-checks-passed:
     if: always()
     needs:
-    - python-tests
-    - python-vulnerability-scan
-    - javascript-client-tests
-    - rust-tests
-    - rust-feature-tests
-    - go-tests
-    - check-spanner-migrations
-    - lint
-    - check-helm-version-bump
-    - delete-helm-comment
+      - python-tests
+      - python-vulnerability-scan
+      - javascript-client-tests
+      - rust-tests
+      - rust-feature-tests
+      - go-tests
+      - check-spanner-migrations
+      - lint
+      - check-helm-version-bump
+      - delete-helm-comment
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
-        allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-spanner-migrations,check-helm-version-bump,delete-helm-comment
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-spanner-migrations,check-helm-version-bump,delete-helm-comment
 
   notify-slack-on-failure:
     name: Notify Slack on Test Failure
     if: github.ref == 'refs/heads/main' && failure()
     needs:
-    - python-tests
-    - python-vulnerability-scan
-    - javascript-client-tests
-    - rust-tests
-    - rust-feature-tests
-    - go-tests
-    - check-spanner-migrations
-    - lint
-    - check-helm-version-bump
-    - delete-helm-comment
+      - python-tests
+      - python-vulnerability-scan
+      - javascript-client-tests
+      - rust-tests
+      - rust-feature-tests
+      - go-tests
+      - check-spanner-migrations
+      - lint
+      - check-helm-version-bump
+      - delete-helm-comment
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Notify Slack

--- a/bin/ci/determine-tests-to-run.sh
+++ b/bin/ci/determine-tests-to-run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Determines which test suites to run based on changed paths.
+# Uses a whitelist approach: run a suite only when its paths change.
+# Reads filter outputs from env vars (set by the calling workflow).
+# Writes tests-to-run to GITHUB_OUTPUT.
+#
+# Env vars (from dorny/paths-filter):
+#   FILTER_JS_CLIENT, FILTER_RUST, FILTER_PYTHON, FILTER_GO
+#   FILTER_CI_INFRA - when true, run all tests (safety override)
+
+set -euo pipefail
+
+# Whitelist: run each suite when its path filter matches (see pr.yml for which paths trigger which).
+TESTS_TO_RUN=()
+[[ "${FILTER_RUST:-false}" == "true" ]] && TESTS_TO_RUN+=("rust")
+[[ "${FILTER_PYTHON:-false}" == "true" ]] && TESTS_TO_RUN+=("python")
+[[ "${FILTER_GO:-false}" == "true" ]] && TESTS_TO_RUN+=("go")
+[[ "${FILTER_JS_CLIENT:-false}" == "true" ]] && TESTS_TO_RUN+=("js-client")
+
+# Deduplicate (e.g. rust paths are in python and js-client filters too)
+UNIQUE=()
+for s in "${TESTS_TO_RUN[@]}"; do
+  if [[ " ${UNIQUE[*]} " != *" $s "* ]]; then
+    UNIQUE+=("$s")
+  fi
+done
+TESTS_TO_RUN=("${UNIQUE[@]}")
+
+# If CI/infra changed, run all tests (safety override)
+if [[ "${FILTER_CI_INFRA:-false}" == "true" ]]; then
+  echo "CI/infra paths changed, running all tests"
+  TESTS_TO_RUN=("python" "rust" "js-client" "go")
+elif [[ ${#TESTS_TO_RUN[@]} -eq 0 ]]; then
+  echo "No path filters matched, skipping tests"
+  echo "tests-to-run=[]" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Output as JSON array
+printf -v joined '"%s",' "${TESTS_TO_RUN[@]}"
+echo "tests-to-run=[${joined%,}]" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description of changes

This PR refactors the CI workflow to use a path-based test selection system.

- Improvements & Bug fixes
    - Replaced the previous docs-only detection logic with a comprehensive path-based filtering system
    - Changed path filter predicate from "every" to "some" for more accurate change detection
    - Moved test determination logic from inline YAML to a dedicated shell script (`bin/ci/determine-tests-to-run.sh`)
    - Added cross-component dependencies (e.g., Rust changes trigger Python tests due to bindings, Go and Rust tests run together due to service communication)
- New functionality
    - Added safety override that runs all tests when CI/infrastructure files are modified
    - Created comprehensive path mappings for each language/component with their dependencies