### PR TITLE
[TST] Fix test_cross_version_persist

### DIFF
--- a/chromadb/test/property/test_cross_version_persist.py
+++ b/chromadb/test/property/test_cross_version_persist.py
@@ -38,7 +38,7 @@ BASELINE_VERSIONS = ["0.4.1", "0.5.3"]
 version_re = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
 # Some modules do not work across versions, since we upgrade our support for them, and should be explicitly reimported in the subprocess
-VERSIONED_MODULES = ["pydantic", "numpy", "tokenizers"]
+VERSIONED_MODULES = ["pydantic", "pydantic_settings", "numpy", "tokenizers"]
 
 
 def versions() -> List[str]:


### PR DESCRIPTION
In Chroma 1.5.4, we dropped support for pydantic v1 and chromadb.Settings now uses pydantic_settings.
In test_cross_version_persist, we import old versions of chromadb. We needed to download a new version of pydantic_settings that's compatible with these old versions of chromadb.

Itai is the GOAT