### PR TITLE
[BUG]  Tests for garbage collector panic on zero-attached function.

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -1150,6 +1150,7 @@ mod tests {
             collection_soft_delete_grace_period: Duration::from_secs(1),
             attached_function_soft_delete_grace_period: Duration::from_secs(1),
             max_collections_to_gc: 100,
+            max_attached_functions_to_gc_per_run: 100,
             min_versions_to_keep: 2,
             filter_min_versions_if_alive: None,
             gc_interval_mins: 10,


### PR DESCRIPTION
## Description of changes

Bug:
```
2026-03-09T23:29:08.107131Z ERROR test_k8s_integration_gc_v2_and_database_hard_delete: garbage_collector_library::garbage_collector_component: Failed to get attached functions to garbage collect: Failed to get attached functions to gc: status: 'Internal error', self: "rpc error: code = InvalidArgument desc = limit must be greater than 0", metadata: {"content-type": "application/grpc"}
```

Fix is to not Default::default it.

Test didn't fail locally, but did in CI.  Seems to be the fix, but I have no evidence.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A
