### PR TITLE
[PERF] Add hnsw:initial_capacity to reduce memory from HNSW index resizing

### DIFF
--- a/chromadb/segment/impl/vector/hnsw_params.py
+++ b/chromadb/segment/impl/vector/hnsw_params.py
@@ -14,6 +14,7 @@ param_validators: Dict[str, Validator] = {
     "hnsw:M": lambda p: isinstance(p, int),
     "hnsw:num_threads": lambda p: isinstance(p, int),
     "hnsw:resize_factor": lambda p: isinstance(p, (int, float)),
+    "hnsw:initial_capacity": lambda p: isinstance(p, int) and p > 0,
 }
 
 # Extra params used for persistent hnsw
@@ -50,6 +51,7 @@ class HnswParams(Params):
     M: int
     num_threads: int
     resize_factor: float
+    initial_capacity: int
 
     def __init__(self, metadata: Metadata):
         metadata = metadata or {}
@@ -61,6 +63,7 @@ class HnswParams(Params):
             metadata.get("hnsw:num_threads", multiprocessing.cpu_count())
         )
         self.resize_factor = float(metadata.get("hnsw:resize_factor", 1.2))
+        self.initial_capacity = int(metadata.get("hnsw:initial_capacity", 1000))
 
     @staticmethod
     def extract(metadata: Metadata) -> Metadata:

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -209,7 +209,7 @@ class LocalHnswSegment(VectorReader):
             space=self._params.space, dim=dimensionality
         )  # possible options are l2, cosine or ip
         index.init_index(
-            max_elements=DEFAULT_CAPACITY,
+            max_elements=self._params.initial_capacity,
             ef_construction=self._params.construction_ef,
             M=self._params.M,
         )
@@ -238,7 +238,7 @@ class LocalHnswSegment(VectorReader):
             new_size = int(
                 (self._total_elements_added + n) * self._params.resize_factor
             )
-            index.resize_index(max(new_size, DEFAULT_CAPACITY))
+            index.resize_index(max(new_size, self._params.initial_capacity))
 
     @trace_method("LocalHnswSegment._apply_batch", OpenTelemetryGranularity.ALL)
     def _apply_batch(self, batch: Batch) -> None:

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -9,7 +9,6 @@ from chromadb.db.impl.sqlite import SqliteDB
 from chromadb.segment.impl.vector.batch import Batch
 from chromadb.segment.impl.vector.hnsw_params import PersistentHnswParams
 from chromadb.segment.impl.vector.local_hnsw import (
-    DEFAULT_CAPACITY,
     LocalHnswSegment,
 )
 from chromadb.segment.impl.vector.brute_force_index import BruteForceIndex
@@ -214,13 +213,13 @@ class PersistentLocalHnswSegment(LocalHnswSegment):
                             )
                         )
                         * self._params.resize_factor,
-                        DEFAULT_CAPACITY,
+                        self._params.initial_capacity,
                     )
                 ),
             )
         else:
             index.init_index(
-                max_elements=DEFAULT_CAPACITY,
+                max_elements=self._params.initial_capacity,
                 ef_construction=self._params.construction_ef,
                 M=self._params.M,
                 is_persistent_index=True,

--- a/chromadb/test/property/strategies.py
+++ b/chromadb/test/property/strategies.py
@@ -494,6 +494,8 @@ def metadata_with_hnsw_strategy(draw: st.DrawFn) -> Optional[CollectionMetadata]
     if draw(st.booleans()):
         metadata["hnsw:resize_factor"] = draw(st.floats(min_value=1.0, max_value=5.0))
     if draw(st.booleans()):
+        metadata["hnsw:initial_capacity"] = draw(st.integers(min_value=1, max_value=100000))
+    if draw(st.booleans()):
         metadata["hnsw:sync_threshold"] = draw(
             st.integers(min_value=2, max_value=10000)
         )

--- a/chromadb/test/property/test_schema.py
+++ b/chromadb/test/property/test_schema.py
@@ -25,6 +25,7 @@ HNSW_METADATA_TO_CONFIG: Dict[str, str] = {
     "hnsw:M": "max_neighbors",
     "hnsw:sync_threshold": "sync_threshold",
     "hnsw:resize_factor": "resize_factor",
+    "hnsw:initial_capacity": "initial_capacity",
 }
 
 HNSW_FIELDS = [
@@ -34,6 +35,7 @@ HNSW_FIELDS = [
     "max_neighbors",
     "sync_threshold",
     "resize_factor",
+    "initial_capacity",
 ]
 
 HNSW_DEFAULTS: Dict[str, Any] = {
@@ -43,6 +45,7 @@ HNSW_DEFAULTS: Dict[str, Any] = {
     "max_neighbors": 16,
     "sync_threshold": 1000,
     "resize_factor": 1.2,
+    "initial_capacity": 1000,
 }
 
 SPANN_FIELDS = [


### PR DESCRIPTION
## Summary

- Adds a new `hnsw:initial_capacity` metadata parameter that controls the initial `max_elements` for the HNSW index
- Replaces all hardcoded `DEFAULT_CAPACITY` references in index initialization and resize logic with the user-configurable value
- Default value (1000) preserves existing behavior — no breaking changes

## Problem

When adding many vectors to a collection incrementally, the HNSW index starts at `DEFAULT_CAPACITY=1000` and grows by `resize_factor=1.2x` each time capacity is exceeded:

```
1000 → 1200 → 1440 → 1728 → 2074 → 2489 → 2987  (6 resizes for ~3000 vectors)
```

Each `resize_index()` call in hnswlib allocates a **new contiguous buffer** and frees the old one. However, memory allocators (glibc and jemalloc) typically **do not return these large freed buffers to the OS**. The old buffers remain mapped in the process address space, causing RSS to grow far beyond actual data requirements.

In our production environment, we observed **50GB+ RSS for 54MB of vector data** (2786 vectors, 1024-dim embeddings). Analysis of `/proc/PID/smaps` revealed a descending pattern of anonymous memory mappings (7GB, 6GB, 5GB, 4GB...) — each one a ghost of a previous resize operation.

## Solution

Allow users to pre-size the index to avoid unnecessary resizes:

```python
collection = client.get_or_create_collection(
    name="my_collection",
    metadata={"hnsw:initial_capacity": 5000}  # match expected dataset size
)
```

This follows the existing pattern of `hnsw:*` metadata parameters (`hnsw:resize_factor`, `hnsw:batch_size`, etc.).

### Changes

| File | Change |
|------|--------|
| `hnsw_params.py` | Add `initial_capacity` field + validator |
| `local_hnsw.py` | Use `self._params.initial_capacity` instead of `DEFAULT_CAPACITY` |
| `local_persistent_hnsw.py` | Same — both `init_index` and `load_index` paths |
| `test/property/strategies.py` | Add `hnsw:initial_capacity` to property-based test strategies |
| `test/property/test_schema.py` | Add to schema mapping and defaults |

## Test plan

- [ ] Existing tests pass (no behavior change with default value 1000)
- [ ] Property-based tests now exercise `hnsw:initial_capacity` with random values
- [ ] Manual verification: creating a collection with `hnsw:initial_capacity=5000` and adding 3000 vectors results in 0 resize operations (vs 6 previously)

🤖 Generated with [Claude Code](https://claude.com/claude-code)