### PR TITLE
[ENH](wal3): handle AlreadyExists alongside Precondition errors

### DIFF
--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -343,7 +343,8 @@ impl<FP: FragmentPointer, U: FragmentUploader<FP>> FragmentPublisher for BatchMa
                 .await
             {
                 Ok(e_tag) => return Ok(e_tag),
-                Err(StorageError::Precondition { path: _, source: _ }) => {
+                Err(StorageError::AlreadyExists { path: _, source: _ })
+                | Err(StorageError::Precondition { path: _, source: _ }) => {
                     return Err(Error::LogContentionFailure);
                 }
                 Err(e) => {
@@ -410,7 +411,8 @@ pub async fn upload_parquet(
             Err(err @ StorageError::PermissionDenied { .. }) => {
                 return Err(Error::StorageError(Arc::new(err)));
             }
-            Err(StorageError::Precondition { path: _, source: _ }) => {
+            Err(StorageError::AlreadyExists { path: _, source: _ })
+            | Err(StorageError::Precondition { path: _, source: _ }) => {
                 return Err(Error::LogContentionFailure);
             }
             Err(err) => {

--- a/rust/wal3/src/interfaces/s3/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/s3/manifest_manager.rs
@@ -401,7 +401,7 @@ impl ManifestManager {
         let payload = serde_json::to_string(&initial)
             .map_err(|e| Error::CorruptManifest(format!("could not encode JSON manifest: {e:?}")))?
             .into_bytes();
-        storage
+        match storage
             .put_bytes(
                 &crate::manifest::manifest_path(prefix),
                 payload,
@@ -410,8 +410,13 @@ impl ManifestManager {
                     .with_mode(PutMode::IfNotExist),
             )
             .await
-            .map_err(Arc::new)?;
-        Ok(())
+        {
+            Ok(_) => Ok(()),
+            Err(StorageError::AlreadyExists { .. } | StorageError::Precondition { .. }) => {
+                Err(Error::AlreadyInitialized)
+            }
+            Err(err) => Err(Arc::new(err).into()),
+        }
     }
 
     /// Validate the e_tag against the manifest on object storage.
@@ -479,7 +484,8 @@ impl ManifestManager {
                     // because it "crashes" the log and reinitializes.
                     return Err(Error::LogContentionFailure);
                 }
-                Err(StorageError::Precondition { path: _, source: _ }) => {
+                Err(StorageError::AlreadyExists { path: _, source: _ })
+                | Err(StorageError::Precondition { path: _, source: _ }) => {
                     // NOTE(rescrv):  This is "durable" because it's a manifest failure.  See the
                     // comment in the Error enum for why this makes sense.
                     return Err(Error::LogContentionDurable);
@@ -725,7 +731,8 @@ impl ManifestPublisher<(FragmentSeqNo, LogPosition)> for ManifestManager {
                 Ok(_) => {
                     return Ok(snapshot.to_pointer());
                 }
-                Err(StorageError::Precondition { path: _, source: _ }) => {
+                Err(StorageError::AlreadyExists { path: _, source: _ })
+                | Err(StorageError::Precondition { path: _, source: _ }) => {
                     // NOTE(rescrv):  This is something of a lie.  We know that someone put the
                     // file before us, and we know the setsum of the file is embedded in the path.
                     // Because the setsum is only calculable if you have the file and we assume


### PR DESCRIPTION
## Description of changes

Some storage backends return StorageError::AlreadyExists instead of
StorageError::Precondition when a conditional put (IfNotExist) fails.
Handle both error variants at every contention point:

- batch_manager: treat AlreadyExists as LogContentionFailure
- manifest_manager initialize: return AlreadyInitialized error
- manifest_manager put: treat AlreadyExists as LogContentionDurable
- manifest_manager publish: treat AlreadyExists as contention

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
