### PR TITLE
[ENH]Add ClientFactory for CompactorClient

### DIFF
--- a/rust/memberlist/src/client_manager.rs
+++ b/rust/memberlist/src/client_manager.rs
@@ -7,8 +7,8 @@ use chroma_error::ChromaError;
 use chroma_system::{Component, ComponentContext, Handler};
 use chroma_tracing::GrpcClientTraceService;
 use chroma_types::chroma_proto::{
-    heap_tender_service_client::HeapTenderServiceClient, log_service_client::LogServiceClient,
-    query_executor_client::QueryExecutorClient,
+    compactor_client::CompactorClient, heap_tender_service_client::HeapTenderServiceClient,
+    log_service_client::LogServiceClient, query_executor_client::QueryExecutorClient,
 };
 use parking_lot::RwLock;
 use std::{
@@ -497,6 +497,17 @@ impl ClientFactory
 {
     fn new_from_channel(channel: GrpcClientTraceService<Channel>) -> Self {
         HeapTenderServiceClient::new(channel)
+    }
+    fn max_decoding_message_size(self, max_size: usize) -> Self {
+        self.max_decoding_message_size(max_size)
+    }
+}
+
+impl ClientFactory
+    for CompactorClient<chroma_tracing::GrpcClientTraceService<tonic::transport::Channel>>
+{
+    fn new_from_channel(channel: GrpcClientTraceService<Channel>) -> Self {
+        CompactorClient::new(channel)
     }
     fn max_decoding_message_size(self, max_size: usize) -> Self {
         self.max_decoding_message_size(max_size)


### PR DESCRIPTION
Adds a ClientFactory implementation for the compactor gRPC client so
compaction nodes discovered via the memberlist can be used with
ClientAssigner and ClientManager.

Changes:

* Implement ClientFactory for
  `CompactorClient<GrpcClientTraceService<Channel>>` in
  `rust/memberlist/src/client_manager.rs`, matching the existing pattern
  used for `LogServiceClient`, `QueryExecutorClient`, and
  `HeapTenderServiceClient`.
* `new_from_channel` wraps the channel with
  `CompactorClient::new(channel)`; `max_decoding_message_size` delegates
  to the tonic client’s builder.

Now, external callers (e.g. ops service) can construct
`ClientAssigner<CompactorClient<...>>` and use it with `ClientManager`
and a memberlist provider (e.g. `CustomResourceMemberlistProvider`) to
talk to compaction-service nodes by node name or assignment key (e.g.
collection ID), in the same way as the log service client.

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
