### PR TITLE
fix: resolve maturin strip vs include-debuginfo conflict for local dev builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,9 @@ packages = ["chromadb"]
 chromadb = ["*.yml"]
 
 [tool.maturin]
-strip = true
+# strip = false to avoid conflict with maturin dev's automatic --include-debuginfo
+# (maturin develop includes debug info by default; --strip cannot be used with --include-debuginfo)
+strip = false
 features = ["pyo3/extension-module"]
 manifest-path = "rust/python_bindings/Cargo.toml"
 python-packages = ["chromadb"]


### PR DESCRIPTION
## Summary
Fixes maturin build failure when running `maturin dev` locally. The error `--include-debuginfo cannot be used with --strip` occurs because maturin develop automatically includes debug info for local development, while `strip=true` in pyproject.toml causes maturin to pass `--strip`—these flags are mutually exclusive.

## Root Cause
- `[tool.maturin] strip = true` in pyproject.toml causes maturin to pass `--strip` to rustc
- `maturin develop` (and `maturin dev`) automatically includes debug info (.pdb, .dSYM, .dwp) for local development
- Maturin explicitly rejects the combination: "Cannot be used with --strip"

## Fix
Set `strip = false` in pyproject.toml. This allows `maturin dev` to succeed. Release wheels will be slightly larger but local development will work. CI/release builds can override with `maturin build --strip` if needed.

Fixes #6536
