### PR TITLE
fix: provide actionable VC++ guidance for Windows DLL import failure

### DIFF
--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -48,14 +48,23 @@ from chromadb.api.types import (
 # TODO(hammadb): Unify imports across types vs root __init__.py
 from chromadb.types import Database, Tenant, Collection as CollectionModel
 from chromadb.execution.expression.plan import Search
-import chromadb_rust_bindings
-
 
 from typing import Optional, Sequence, List, Dict, Any, Tuple
 from overrides import override
 from uuid import UUID
 import json
 import platform
+
+try:
+    import chromadb_rust_bindings
+except ImportError as exc:
+    if platform.system() == "Windows" and "DLL load failed" in str(exc):
+        raise ImportError(
+            "Failed to import chromadb_rust_bindings. On Windows this usually means "
+            "the Microsoft Visual C++ Redistributable is missing. Install it from "
+            "https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist and retry."
+        ) from exc
+    raise
 
 if platform.system() != "Windows":
     import resource

--- a/chromadb/cli/cli.py
+++ b/chromadb/cli/cli.py
@@ -1,7 +1,18 @@
+import platform
 import re
 import sys
 
-import chromadb_rust_bindings
+try:
+    import chromadb_rust_bindings
+except ImportError as exc:
+    if platform.system() == "Windows" and "DLL load failed" in str(exc):
+        raise ImportError(
+            "Failed to import chromadb_rust_bindings. On Windows this usually means "
+            "the Microsoft Visual C++ Redistributable is missing. Install it from "
+            "https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist and retry."
+        ) from exc
+    raise
+
 import requests
 from packaging.version import parse
 
@@ -26,8 +37,10 @@ def update():
         response.raise_for_status()
         releases = response.json()
 
-        version_pattern = re.compile(r'^\d+\.\d+\.\d+$')
-        numeric_releases = [r["tag_name"] for r in releases if version_pattern.fullmatch(r["tag_name"])]
+        version_pattern = re.compile(r"^\d+\.\d+\.\d+$")
+        numeric_releases = [
+            r["tag_name"] for r in releases if version_pattern.fullmatch(r["tag_name"])
+        ]
 
         if not numeric_releases:
             print("Couldn't fetch the latest Chroma version")
@@ -39,7 +52,8 @@ def update():
             return
 
         print(
-            f"A new version of Chroma is available!\nIf you're using pip, run 'pip install --upgrade chromadb' to upgrade to version {latest}")
+            f"A new version of Chroma is available!\nIf you're using pip, run 'pip install --upgrade chromadb' to upgrade to version {latest}"
+        )
 
     except Exception as e:
         print("Couldn't fetch the latest Chroma version")


### PR DESCRIPTION
## Summary
When chromadb_rust_bindings fails to load on Windows due to missing Visual C++ runtime, users get a generic "DLL load failed" ImportError. This PR catches that case and raises a clearer error with a link to install the Microsoft Visual C++ Redistributable.

## Root Cause
The Rust bindings depend on the VC++ runtime on Windows. When it is missing, Python raises a generic ImportError that does not guide users toward the fix.

## Fix
- Wrap `import chromadb_rust_bindings` in try/except in chromadb/api/rust.py and chromadb/cli/cli.py
- On Windows, when the ImportError message contains "DLL load failed", raise a clearer ImportError with the official VC++ Redistributable install URL
- Re-raise unchanged for all other import failures (non-Windows or different error types)

Fixes #6589