### PR TITLE
[BUG](gc): handle known dispatcher shutdown panic in tests

### DIFF
--- a/rust/garbage_collector/src/garbage_collector_component.rs
+++ b/rust/garbage_collector/src/garbage_collector_component.rs
@@ -768,7 +768,9 @@ mod tests {
         assert!(is_known_runtime_drop_join_error(
             "Cannot drop a runtime in a context where blocking is not allowed"
         ));
-        assert!(!is_known_runtime_drop_join_error("panic: dispatcher task failed"));
+        assert!(!is_known_runtime_drop_join_error(
+            "panic: dispatcher task failed"
+        ));
     }
 
     async fn wait_for_new_version(


### PR DESCRIPTION
## Description of changes

The dispatcher join in GC integration tests can fail with a "Cannot drop
a runtime in a context where blocking is not allowed" panic during
teardown. This is a benign race condition in the test harness, not a
real bug in garbage collection logic.

Add is_known_runtime_drop_join_error helper to detect this specific
panic message, and use it in run_garbage_collection to warn-and-continue
rather than propagating the panic. Include a unit test for the helper.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
