### PR TITLE
[CLN]: Remove ListDeadJobs endpoint

### DIFF
--- a/idl/chromadb/proto/compactor.proto
+++ b/idl/chromadb/proto/compactor.proto
@@ -26,14 +26,6 @@ message RebuildResponse {
   // Empty
 }
 
-message ListDeadJobsRequest {
-  // Empty
-}
-
-message ListDeadJobsResponse {
-  CollectionIds ids = 1;
-}
-
 message ListInProgressJobsRequest {
   // Empty
 }
@@ -60,7 +52,6 @@ message GetCollectionAssignmentResponse {
 service Compactor {
   rpc Compact(CompactRequest) returns (CompactResponse) {}
   rpc Rebuild(RebuildRequest) returns (RebuildResponse) {}
-  rpc ListDeadJobs(ListDeadJobsRequest) returns (ListDeadJobsResponse) {}
   rpc ListInProgressJobs(ListInProgressJobsRequest) returns (ListInProgressJobsResponse) {}
   rpc GetCollectionAssignment(GetCollectionAssignmentRequest) returns (GetCollectionAssignmentResponse) {}
 }

--- a/rust/worker/src/compactor/compaction_client.rs
+++ b/rust/worker/src/compactor/compaction_client.rs
@@ -1,7 +1,6 @@
 use chroma_types::chroma_proto::{
     compactor_client::CompactorClient, CollectionIds, CompactRequest,
-    GetCollectionAssignmentRequest, ListDeadJobsRequest, ListInProgressJobsRequest, RebuildRequest,
-    SegmentScope,
+    GetCollectionAssignmentRequest, ListInProgressJobsRequest, RebuildRequest, SegmentScope,
 };
 use clap::{Parser, Subcommand};
 use std::io::Write;
@@ -49,8 +48,6 @@ pub enum CompactionCommand {
         #[arg(long = "segment", value_parser = ["metadata", "vector"])]
         segment_scopes: Vec<String>,
     },
-    /// List all dead jobs (collections with failed compactions)
-    ListDeadJobs,
     /// List all in-progress compaction jobs
     ListInProgressJobs,
     /// Get collection assignment info (which node would handle a collection)
@@ -105,27 +102,6 @@ impl CompactionClient {
                     .await;
                 if let Err(status) = response {
                     return Err(CompactionClientError::Compactor(status.to_string()));
-                }
-            }
-            CompactionCommand::ListDeadJobs => {
-                let mut client = self.grpc_client().await?;
-                let response = client
-                    .list_dead_jobs(ListDeadJobsRequest {})
-                    .await
-                    .map_err(|e| CompactionClientError::Compactor(e.to_string()))?;
-
-                let dead_jobs = response.into_inner();
-                if let Some(ids) = dead_jobs.ids {
-                    writeln!(w, "Dead jobs (collections with failed compactions):")?;
-                    if ids.ids.is_empty() {
-                        writeln!(w, "  None")?;
-                    } else {
-                        for id in ids.ids {
-                            writeln!(w, "  {}", id)?;
-                        }
-                    }
-                } else {
-                    writeln!(w, "No dead jobs response didn't contain an ids field")?;
                 }
             }
             CompactionCommand::ListInProgressJobs => {

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -4,7 +4,7 @@ use super::OneOffCompactMessage;
 use super::RebuildMessage;
 use crate::compactor::types::{
     GetCollectionAssignmentMessage, GetCollectionAssignmentResponse, InProgressJobEntry,
-    ListDeadJobsMessage, ListInProgressJobsMessage, ScheduledCompactMessage,
+    ListInProgressJobsMessage, ScheduledCompactMessage,
 };
 use crate::config::CompactionServiceConfig;
 use crate::execution::operators::fragment_fetch::FragmentFetcher;
@@ -866,24 +866,6 @@ impl Handler<RegisterOnReadySignal> for CompactionManager {
             }
         } else {
             self.on_next_memberlist_signal = Some(message.on_ready_tx);
-        }
-    }
-}
-
-#[async_trait]
-impl Handler<ListDeadJobsMessage> for CompactionManager {
-    type Result = ();
-
-    async fn handle(
-        &mut self,
-        message: ListDeadJobsMessage,
-        _ctx: &ComponentContext<CompactionManager>,
-    ) {
-        // Dead jobs are now tracked in sysdb via compaction_failure_count, not in memory
-        // Return empty list as this endpoint is deprecated
-        // TODO(tanujnay112): remove this endpoint
-        if let Err(e) = message.response_tx.send(Vec::new()) {
-            tracing::warn!("Failed to send dead jobs response: {:?}", e);
         }
     }
 }

--- a/rust/worker/src/compactor/compaction_server.rs
+++ b/rust/worker/src/compactor/compaction_server.rs
@@ -3,9 +3,9 @@ use chroma_jemalloc_pprof_server::spawn_pprof_server;
 use chroma_system::ComponentHandle;
 use chroma_types::chroma_proto::{
     compactor_server::{Compactor, CompactorServer},
-    CollectionIds, CompactRequest, CompactResponse, GetCollectionAssignmentRequest,
-    GetCollectionAssignmentResponse, InProgressJobInfo, ListDeadJobsRequest, ListDeadJobsResponse,
-    ListInProgressJobsRequest, ListInProgressJobsResponse, RebuildRequest, RebuildResponse,
+    CompactRequest, CompactResponse, GetCollectionAssignmentRequest,
+    GetCollectionAssignmentResponse, InProgressJobInfo, ListInProgressJobsRequest,
+    ListInProgressJobsResponse, RebuildRequest, RebuildResponse,
 };
 use std::str::FromStr;
 use tokio::{
@@ -16,8 +16,8 @@ use tonic::{transport::Server, Request, Response, Status};
 use tracing::trace_span;
 
 use crate::compactor::{
-    GetCollectionAssignmentMessage, ListDeadJobsMessage, ListInProgressJobsMessage,
-    OneOffCompactMessage, RegisterOnReadySignal,
+    GetCollectionAssignmentMessage, ListInProgressJobsMessage, OneOffCompactMessage,
+    RegisterOnReadySignal,
 };
 
 use super::{CompactionManager, RebuildMessage};
@@ -121,29 +121,6 @@ impl Compactor for CompactionServer {
             .map_err(|e| Status::internal(e.to_string()))?;
 
         Ok(Response::new(RebuildResponse {}))
-    }
-
-    async fn list_dead_jobs(
-        &self,
-        _request: Request<ListDeadJobsRequest>,
-    ) -> Result<Response<ListDeadJobsResponse>, Status> {
-        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
-
-        self.manager
-            .receiver()
-            .send(ListDeadJobsMessage { response_tx }, None)
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
-
-        let dead_jobs = response_rx
-            .await
-            .map_err(|e| Status::internal(format!("Failed to receive response: {}", e)))?;
-
-        Ok(Response::new(ListDeadJobsResponse {
-            ids: Some(CollectionIds {
-                ids: dead_jobs.iter().map(ToString::to_string).collect(),
-            }),
-        }))
     }
 
     async fn list_in_progress_jobs(

--- a/rust/worker/src/compactor/types.rs
+++ b/rust/worker/src/compactor/types.rs
@@ -25,11 +25,6 @@ pub struct RebuildMessage {
 }
 
 #[derive(Debug)]
-pub struct ListDeadJobsMessage {
-    pub response_tx: oneshot::Sender<Vec<JobId>>,
-}
-
-#[derive(Debug)]
 pub struct InProgressJobEntry {
     pub job_id: JobId,
     pub database_name: String,


### PR DESCRIPTION
## Description of changes

Compactors don't maintain an in-memory DLQ anymore. Remove the ListDeadJobs endpoint to reflect this

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_