### PR TITLE
[BUG] Add clear error message for empty embedding lists

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -243,6 +243,11 @@ def normalize_embeddings(
         elif isinstance(target[0], np.ndarray):
             return cast(Embeddings, target)
         elif isinstance(target[0], list):
+            if len(target[0]) == 0:
+                raise ValueError(
+                    "Expected each embedding in the embeddings to be a non-empty list, "
+                    "got an empty list at pos 0"
+                )
             if isinstance(target[0][0], (int, float)) and not isinstance(
                 target[0][0], bool
             ):

--- a/chromadb/test/api/test_types.py
+++ b/chromadb/test/api/test_types.py
@@ -103,3 +103,17 @@ def test_embedding_function_results_format_when_response_is_invalid() -> None:
         from chromadb.api.types import normalize_embeddings
 
         normalize_embeddings(result)
+
+
+def test_normalize_embeddings_empty_list_raises_value_error() -> None:
+    from chromadb.api.types import normalize_embeddings
+
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_embeddings([])
+
+
+def test_normalize_embeddings_empty_inner_list_raises_value_error() -> None:
+    from chromadb.api.types import normalize_embeddings
+
+    with pytest.raises(ValueError, match="non-empty list"):
+        normalize_embeddings([[]])


### PR DESCRIPTION
## Summary
- When users provide an empty embedding like `[[]]`, `normalize_embeddings()` crashes with an unhelpful `IndexError: list index out of range` at the `target[0][0]` access
- This adds an explicit check for empty inner lists before accessing the first element, raising a descriptive `ValueError` instead

Fixes #5047

## Changes
- Added empty inner list check in `normalize_embeddings()` before `target[0][0]` access
- Added two test cases for empty embedding validation (`[]` and `[[]]`)

## Test plan
- New unit tests in `chromadb/test/api/test_types.py`:
  - `test_normalize_embeddings_empty_list_raises_value_error`
  - `test_normalize_embeddings_empty_inner_list_raises_value_error`
- Existing tests remain passing (no behavioral change for valid inputs)