### PR TITLE
[ENH] Add built-in MockEmbeddingFunction and MockSparseEmbeddingFunction

### DIFF
--- a/chromadb/test/ef/test_mock_ef.py
+++ b/chromadb/test/ef/test_mock_ef.py
@@ -1,0 +1,151 @@
+import numpy as np
+
+from chromadb.utils.embedding_functions.mock_embedding_function import (
+    MockEmbeddingFunction,
+)
+from chromadb.utils.embedding_functions.mock_sparse_embedding_function import (
+    MockSparseEmbeddingFunction,
+)
+
+
+# --- MockEmbeddingFunction tests ---
+
+
+def test_mock_ef_generates_correct_dimension() -> None:
+    ef = MockEmbeddingFunction(dim=128)
+    embeddings = ef(["hello"])
+    assert len(embeddings) == 1
+    assert embeddings[0].shape == (128,)
+
+
+def test_mock_ef_default_dimension() -> None:
+    ef = MockEmbeddingFunction()
+    embeddings = ef(["hello"])
+    assert embeddings[0].shape == (256,)
+
+
+def test_mock_ef_deterministic() -> None:
+    ef = MockEmbeddingFunction(dim=64)
+    a = ef(["hello world"])
+    b = ef(["hello world"])
+    assert np.array_equal(a[0], b[0])
+
+
+def test_mock_ef_different_inputs_produce_different_outputs() -> None:
+    ef = MockEmbeddingFunction(dim=64)
+    a = ef(["hello"])
+    b = ef(["world"])
+    assert not np.array_equal(a[0], b[0])
+
+
+def test_mock_ef_multiple_inputs() -> None:
+    ef = MockEmbeddingFunction(dim=32)
+    embeddings = ef(["a", "b", "c"])
+    assert len(embeddings) == 3
+    for emb in embeddings:
+        assert emb.shape == (32,)
+
+
+def test_mock_ef_seed_changes_output() -> None:
+    ef1 = MockEmbeddingFunction(dim=64, seed="seed1")
+    ef2 = MockEmbeddingFunction(dim=64, seed="seed2")
+    a = ef1(["hello"])
+    b = ef2(["hello"])
+    assert not np.array_equal(a[0], b[0])
+
+
+def test_mock_ef_config_roundtrip() -> None:
+    ef = MockEmbeddingFunction(dim=128, seed="test")
+    config = ef.get_config()
+    restored = MockEmbeddingFunction.build_from_config(config)
+    assert restored._dim == 128
+    assert restored._seed == "test"
+
+    original = ef(["test"])
+    rebuilt = restored(["test"])
+    assert np.array_equal(original[0], rebuilt[0])
+
+
+def test_mock_ef_name() -> None:
+    assert MockEmbeddingFunction.name() == "mock"
+
+
+def test_mock_ef_dtype() -> None:
+    ef = MockEmbeddingFunction(dim=16, dtype=np.float64)
+    embeddings = ef(["hello"])
+    assert embeddings[0].dtype == np.float64
+
+
+# --- MockSparseEmbeddingFunction tests ---
+
+
+def test_mock_sparse_ef_generates_sparse_vectors() -> None:
+    ef = MockSparseEmbeddingFunction()
+    vectors = ef(["hello"])
+    assert len(vectors) == 1
+    assert len(vectors[0].indices) > 0
+    assert len(vectors[0].indices) == len(vectors[0].values)
+
+
+def test_mock_sparse_ef_deterministic() -> None:
+    ef = MockSparseEmbeddingFunction()
+    a = ef(["hello world"])
+    b = ef(["hello world"])
+    assert a[0].indices == b[0].indices
+    assert a[0].values == b[0].values
+
+
+def test_mock_sparse_ef_different_inputs() -> None:
+    ef = MockSparseEmbeddingFunction()
+    a = ef(["hello"])
+    b = ef(["world"])
+    assert a[0].indices != b[0].indices
+
+
+def test_mock_sparse_ef_multiple_inputs() -> None:
+    ef = MockSparseEmbeddingFunction()
+    vectors = ef(["a", "b", "c"])
+    assert len(vectors) == 3
+
+
+def test_mock_sparse_ef_indices_sorted() -> None:
+    ef = MockSparseEmbeddingFunction()
+    vectors = ef(["test sorting"])
+    indices = vectors[0].indices
+    assert indices == sorted(indices)
+    # Strictly ascending (no duplicates)
+    for i in range(1, len(indices)):
+        assert indices[i] > indices[i - 1]
+
+
+def test_mock_sparse_ef_indices_within_vocab() -> None:
+    ef = MockSparseEmbeddingFunction(vocab_size=100)
+    vectors = ef(["hello world"])
+    for idx in vectors[0].indices:
+        assert 0 <= idx < 100
+
+
+def test_mock_sparse_ef_seed_changes_output() -> None:
+    ef1 = MockSparseEmbeddingFunction(seed="s1")
+    ef2 = MockSparseEmbeddingFunction(seed="s2")
+    a = ef1(["hello"])
+    b = ef2(["hello"])
+    assert a[0].indices != b[0].indices
+
+
+def test_mock_sparse_ef_config_roundtrip() -> None:
+    ef = MockSparseEmbeddingFunction(vocab_size=500, nnz=10, seed="test")
+    config = ef.get_config()
+    restored = MockSparseEmbeddingFunction.build_from_config(config)
+    assert restored._vocab_size == 500
+    assert restored._nnz == 10
+    assert restored._seed == "test"
+
+    original = ef(["test"])
+    rebuilt = restored(["test"])
+    assert original[0].indices == rebuilt[0].indices
+    assert original[0].values == rebuilt[0].values
+
+
+def test_mock_sparse_ef_name() -> None:
+    assert MockSparseEmbeddingFunction.name() == "mock_sparse"

--- a/chromadb/utils/embedding_functions/__init__.py
+++ b/chromadb/utils/embedding_functions/__init__.py
@@ -95,6 +95,12 @@ from chromadb.utils.embedding_functions.chroma_bm25_embedding_function import (
 from chromadb.utils.embedding_functions.perplexity_embedding_function import (
     PerplexityEmbeddingFunction,
 )
+from chromadb.utils.embedding_functions.mock_embedding_function import (
+    MockEmbeddingFunction,
+)
+from chromadb.utils.embedding_functions.mock_sparse_embedding_function import (
+    MockSparseEmbeddingFunction,
+)
 
 
 # Get all the class names for backward compatibility
@@ -132,7 +138,9 @@ _all_classes: Set[str] = {
     "ChromaCloudQwenEmbeddingFunction",
     "ChromaCloudSpladeEmbeddingFunction",
     "ChromaBm25EmbeddingFunction",
-    "PerplexityEmbeddingFunction"
+    "PerplexityEmbeddingFunction",
+    "MockEmbeddingFunction",
+    "MockSparseEmbeddingFunction",
 }
 
 
@@ -171,6 +179,7 @@ known_embedding_functions: Dict[str, Type[EmbeddingFunction]] = {  # type: ignor
     "together_ai": TogetherAIEmbeddingFunction,
     "chroma-cloud-qwen": ChromaCloudQwenEmbeddingFunction,
     "perplexity": PerplexityEmbeddingFunction,
+    "mock": MockEmbeddingFunction,
 }
 
 sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  # type: ignore
@@ -179,6 +188,7 @@ sparse_known_embedding_functions: Dict[str, Type[SparseEmbeddingFunction]] = {  
     "bm25": Bm25EmbeddingFunction,
     "chroma-cloud-splade": ChromaCloudSpladeEmbeddingFunction,
     "chroma_bm25": ChromaBm25EmbeddingFunction,
+    "mock_sparse": MockSparseEmbeddingFunction,
 }
 
 
@@ -301,6 +311,8 @@ __all__ = [
     "ChromaCloudSpladeEmbeddingFunction",
     "ChromaBm25EmbeddingFunction",
     "PerplexityEmbeddingFunction",
+    "MockEmbeddingFunction",
+    "MockSparseEmbeddingFunction",
     "register_embedding_function",
     "config_to_embedding_function",
     "known_embedding_functions",

--- a/chromadb/utils/embedding_functions/mock_embedding_function.py
+++ b/chromadb/utils/embedding_functions/mock_embedding_function.py
@@ -1,0 +1,83 @@
+import hashlib
+from typing import Dict, Any, List, Optional
+
+import numpy as np
+
+from chromadb.api.types import (
+    Documents,
+    Embeddings,
+    EmbeddingFunction,
+)
+from chromadb.utils.embedding_functions import register_embedding_function
+
+
+@register_embedding_function
+class MockEmbeddingFunction(EmbeddingFunction[Documents]):
+    """A deterministic embedding function for testing that requires no external dependencies.
+
+    Generates embeddings by hashing input text with SHA-256, producing reproducible
+    vectors of configurable dimension and dtype. Identical inputs always produce
+    identical embeddings.
+
+    Args:
+        dim: The dimension of generated embeddings. Defaults to 256.
+        dtype: The numpy dtype of generated embeddings. Defaults to np.float32.
+        seed: Optional seed prepended to input text before hashing, allowing
+              different MockEmbeddingFunction instances to produce different
+              embeddings for the same input.
+    """
+
+    def __init__(
+        self,
+        dim: int = 256,
+        dtype: np.dtype = np.float32,
+        seed: Optional[str] = None,
+    ) -> None:
+        self._dim = dim
+        self._dtype = dtype
+        self._seed = seed
+
+    def __call__(self, input: Documents) -> Embeddings:
+        embeddings: Embeddings = []
+        for text in input:
+            hash_input = text if self._seed is None else f"{self._seed}{text}"
+            hash_bytes = hashlib.sha256(hash_input.encode("utf-8")).digest()
+            # Extend hash bytes to fill the desired dimension
+            extended = hash_bytes
+            while len(extended) < self._dim * 4:
+                extended += hashlib.sha256(extended).digest()
+            values = [
+                int.from_bytes(extended[i * 4 : (i + 1) * 4], "little") / (2**32)
+                for i in range(self._dim)
+            ]
+            embeddings.append(np.array(values, dtype=self._dtype))
+        return embeddings
+
+    @staticmethod
+    def name() -> str:
+        return "mock"
+
+    def get_config(self) -> Dict[str, Any]:
+        config: Dict[str, Any] = {
+            "dim": self._dim,
+            "dtype": str(self._dtype),
+        }
+        if self._seed is not None:
+            config["seed"] = self._seed
+        return config
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "MockEmbeddingFunction":
+        return MockEmbeddingFunction(
+            dim=config.get("dim", 256),
+            dtype=np.dtype(config.get("dtype", "float32")),
+            seed=config.get("seed"),
+        )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        if "dim" in config and (not isinstance(config["dim"], int) or config["dim"] <= 0):
+            raise ValueError(f"dim must be a positive integer, got {config['dim']}")
+
+    def default_space(self) -> str:  # type: ignore[override]
+        return "cosine"

--- a/chromadb/utils/embedding_functions/mock_sparse_embedding_function.py
+++ b/chromadb/utils/embedding_functions/mock_sparse_embedding_function.py
@@ -1,0 +1,102 @@
+import hashlib
+from typing import Dict, Any, List, Optional
+
+from chromadb.api.types import (
+    Documents,
+    SparseEmbeddingFunction,
+)
+from chromadb.base_types import SparseVector, SparseVectors
+from chromadb.utils.embedding_functions import register_sparse_embedding_function
+
+
+@register_sparse_embedding_function
+class MockSparseEmbeddingFunction(SparseEmbeddingFunction[Documents]):
+    """A deterministic sparse embedding function for testing that requires no external dependencies.
+
+    Generates sparse vectors by hashing input text with SHA-256. Each input
+    produces a reproducible sparse vector with a configurable number of
+    non-zero entries and vocabulary size.
+
+    Args:
+        vocab_size: The size of the vocabulary (max index value). Defaults to 30000.
+        nnz: The number of non-zero entries per vector. Defaults to 20.
+        seed: Optional seed prepended to input text before hashing.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int = 30000,
+        nnz: int = 20,
+        seed: Optional[str] = None,
+    ) -> None:
+        self._vocab_size = vocab_size
+        self._nnz = nnz
+        self._seed = seed
+
+    def __call__(self, input: Documents) -> SparseVectors:
+        vectors: SparseVectors = []
+        for text in input:
+            hash_input = text if self._seed is None else f"{self._seed}{text}"
+            hash_bytes = hashlib.sha256(hash_input.encode("utf-8")).digest()
+            extended = hash_bytes
+            while len(extended) < self._nnz * 8:
+                extended += hashlib.sha256(extended).digest()
+
+            indices: List[int] = []
+            values: List[float] = []
+            for i in range(self._nnz):
+                idx_bytes = extended[i * 4 : (i + 1) * 4]
+                val_bytes = extended[self._nnz * 4 + i * 4 : self._nnz * 4 + (i + 1) * 4]
+                idx = int.from_bytes(idx_bytes, "little") % self._vocab_size
+                val = int.from_bytes(val_bytes, "little") / (2**32)
+                indices.append(idx)
+                values.append(val)
+
+            # Deduplicate indices, keeping the first occurrence
+            seen: Dict[int, float] = {}
+            for idx, val in zip(indices, values):
+                if idx not in seen:
+                    seen[idx] = val
+
+            sorted_items = sorted(seen.items())
+            vectors.append(
+                SparseVector(
+                    indices=[item[0] for item in sorted_items],
+                    values=[item[1] for item in sorted_items],
+                )
+            )
+        return vectors
+
+    @staticmethod
+    def name() -> str:
+        return "mock_sparse"
+
+    def get_config(self) -> Dict[str, Any]:
+        config: Dict[str, Any] = {
+            "vocab_size": self._vocab_size,
+            "nnz": self._nnz,
+        }
+        if self._seed is not None:
+            config["seed"] = self._seed
+        return config
+
+    @staticmethod
+    def build_from_config(config: Dict[str, Any]) -> "MockSparseEmbeddingFunction":
+        return MockSparseEmbeddingFunction(
+            vocab_size=config.get("vocab_size", 30000),
+            nnz=config.get("nnz", 20),
+            seed=config.get("seed"),
+        )
+
+    @staticmethod
+    def validate_config(config: Dict[str, Any]) -> None:
+        if "vocab_size" in config and (
+            not isinstance(config["vocab_size"], int) or config["vocab_size"] <= 0
+        ):
+            raise ValueError(
+                f"vocab_size must be a positive integer, got {config['vocab_size']}"
+            )
+        if "nnz" in config and (
+            not isinstance(config["nnz"], int) or config["nnz"] <= 0
+        ):
+            raise ValueError(f"nnz must be a positive integer, got {config['nnz']}")


### PR DESCRIPTION
## Summary
- Adds `MockEmbeddingFunction` and `MockSparseEmbeddingFunction` as built-in SDK utilities so users don't need to define their own mock EFs for every test project
- Both are deterministic (SHA-256 hash-based), zero-dependency, and fully implement the EF protocol

Fixes #6598

## Changes
- `chromadb/utils/embedding_functions/mock_embedding_function.py`: Dense mock EF with configurable `dim`, `dtype`, and `seed`
- `chromadb/utils/embedding_functions/mock_sparse_embedding_function.py`: Sparse mock EF with configurable `vocab_size`, `nnz`, and `seed`
- Registered as `"mock"` and `"mock_sparse"` in the embedding function registries
- Added to `__init__.py` imports, `_all_classes`, and `__all__`
- Comprehensive tests in `chromadb/test/ef/test_mock_ef.py`

## Test plan
- 16 unit tests covering:
  - Correct output dimensions/structure
  - Deterministic output (same input → same output)
  - Different inputs produce different outputs
  - Seed isolation between instances
  - Config roundtrip (get_config → build_from_config → identical output)
  - Sparse vector index sorting and vocab bounds
  - Multiple input handling