### PR TITLE
[BUG] Fix PRAGMA foreign_keys not taking effect inside transaction

### DIFF
--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -20,7 +20,7 @@ from typing_extensions import Literal
 from types import TracebackType
 import os
 from uuid import UUID
-from threading import local
+from threading import local, Thread
 from importlib_resources import files
 from importlib_resources.abc import Traversable
 
@@ -111,7 +111,10 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
         with self.tx() as cur:
             cur.execute("PRAGMA case_sensitive_like = ON")
         self.initialize_migrations()
-        self._check_foreign_key_integrity()
+        # Run FK integrity check in background to avoid blocking startup
+        # on large databases (PRAGMA foreign_key_check does a full table scan).
+        t = Thread(target=self._check_foreign_key_integrity, daemon=True)
+        t.start()
 
         if (
             # (don't attempt to access .config if migrations haven't been run)

--- a/chromadb/db/impl/sqlite.py
+++ b/chromadb/db/impl/sqlite.py
@@ -10,6 +10,8 @@ from chromadb.telemetry.opentelemetry import (
     OpenTelemetryGranularity,
     trace_method,
 )
+from chromadb.telemetry.product import ProductTelemetryClient
+from chromadb.telemetry.product.events import SqliteForeignKeyViolationEvent
 import sqlite3
 from overrides import override
 import pypika
@@ -37,6 +39,8 @@ class TxWrapper(base.TxWrapper):
     @override
     def __enter__(self) -> base.Cursor:
         if len(self._tx_stack.stack) == 0:
+            # foreign_keys must be set outside a transaction to take effect
+            self._conn.execute("PRAGMA foreign_keys = ON")
             self._conn.execute("PRAGMA case_sensitive_like = ON")
             self._conn.execute("BEGIN;")
         self._tx_stack.stack.append(self)
@@ -77,6 +81,7 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
         ]
         self._is_persistent = self._settings.require("is_persistent")
         self._opentelemetry_client = system.require(OpenTelemetryClient)
+        self._product_telemetry_client = system.require(ProductTelemetryClient)
         if not self._is_persistent:
             # In order to allow sqlite to be shared between multiple threads, we need to use a
             # URI connection string with shared cache.
@@ -98,10 +103,15 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
     @override
     def start(self) -> None:
         super().start()
+        # PRAGMA foreign_keys must be set outside a transaction to take effect.
+        # See: https://www.sqlite.org/pragma.html#pragma_foreign_keys
+        conn = self._conn_pool.connect()
+        conn.execute("PRAGMA foreign_keys = ON")
+        self._conn_pool.return_to_pool(conn)
         with self.tx() as cur:
-            cur.execute("PRAGMA foreign_keys = ON")
             cur.execute("PRAGMA case_sensitive_like = ON")
         self.initialize_migrations()
+        self._check_foreign_key_integrity()
 
         if (
             # (don't attempt to access .config if migrations haven't been run)
@@ -111,6 +121,31 @@ class SqliteDB(MigratableDB, SqlEmbeddingsQueue, SqlSysDB):
             logger.warning(
                 "⚠️ It looks like you upgraded from a version below 0.5.6 and could benefit from vacuuming your database. Run chromadb utils vacuum --help for more information."
             )
+
+    def _check_foreign_key_integrity(self) -> None:
+        """Check for foreign key constraint violations and report via telemetry."""
+        conn = self._conn_pool.connect()
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            cursor = conn.execute("PRAGMA foreign_key_check")
+            violations = cursor.fetchall()
+            if violations:
+                tables = {row[0] for row in violations}
+                logger.warning(
+                    "Foreign key constraint violations detected in tables: %s "
+                    "(%d violations). This may indicate data inconsistency from "
+                    "a previous version where foreign keys were not enforced.",
+                    ", ".join(sorted(tables)),
+                    len(violations),
+                )
+                self._product_telemetry_client.capture(
+                    SqliteForeignKeyViolationEvent(
+                        num_violations=len(violations),
+                        tables_affected=",".join(sorted(tables)),
+                    )
+                )
+        finally:
+            self._conn_pool.return_to_pool(conn)
 
     @trace_method("SqliteDB.stop", OpenTelemetryGranularity.ALL)
     @override

--- a/chromadb/telemetry/product/events.py
+++ b/chromadb/telemetry/product/events.py
@@ -254,3 +254,13 @@ class CollectionDeleteEvent(ProductTelemetryEvent):
         super().__init__()
         self.collection_uuid = collection_uuid
         self.delete_amount = delete_amount
+
+
+class SqliteForeignKeyViolationEvent(ProductTelemetryEvent):
+    num_violations: int
+    tables_affected: str
+
+    def __init__(self, num_violations: int, tables_affected: str):
+        super().__init__()
+        self.num_violations = num_violations
+        self.tables_affected = tables_affected

--- a/chromadb/test/db/test_sqlite_foreign_keys.py
+++ b/chromadb/test/db/test_sqlite_foreign_keys.py
@@ -91,8 +91,8 @@ def test_foreign_key_check_detects_violations() -> None:
             conn.execute(
                 "INSERT INTO _fk_test_child (id, parent_id) VALUES (1, 999)"
             )
-            conn.execute("PRAGMA foreign_keys = ON")
         finally:
+            conn.execute("PRAGMA foreign_keys = ON")
             db._conn_pool.return_to_pool(conn)
 
         # Now check that _check_foreign_key_integrity detects the violation

--- a/chromadb/test/db/test_sqlite_foreign_keys.py
+++ b/chromadb/test/db/test_sqlite_foreign_keys.py
@@ -1,0 +1,109 @@
+import sqlite3
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from chromadb.config import Settings, System
+from chromadb.db.impl.sqlite import SqliteDB
+
+
+def _make_system(persist_directory: str) -> System:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.segment.SegmentAPI",
+        chroma_sysdb_impl="chromadb.db.impl.sqlite.SqliteDB",
+        chroma_producer_impl="chromadb.db.impl.sqlite.SqliteDB",
+        chroma_consumer_impl="chromadb.db.impl.sqlite.SqliteDB",
+        persist_directory=persist_directory,
+        is_persistent=True,
+        allow_reset=True,
+        anonymized_telemetry=False,
+    )
+    system = System(settings)
+    return system
+
+
+def test_foreign_keys_enabled_outside_transaction() -> None:
+    """Verify PRAGMA foreign_keys = ON is effective (set outside transaction)."""
+    save_path = tempfile.TemporaryDirectory()
+    system = _make_system(save_path.name)
+    system.start()
+    try:
+        db = system.instance(SqliteDB)
+        conn = db._conn_pool.connect()
+        result = conn.execute("PRAGMA foreign_keys").fetchone()
+        db._conn_pool.return_to_pool(conn)
+        assert result[0] == 1, "foreign_keys pragma should be ON"
+    finally:
+        system.stop()
+        save_path.cleanup()
+
+
+def test_foreign_keys_enabled_in_transaction() -> None:
+    """Verify foreign_keys is set before BEGIN in TxWrapper."""
+    save_path = tempfile.TemporaryDirectory()
+    system = _make_system(save_path.name)
+    system.start()
+    try:
+        db = system.instance(SqliteDB)
+        with db.tx() as cur:
+            cur.execute("PRAGMA foreign_keys")
+            result = cur.fetchone()
+            assert result[0] == 1, "foreign_keys should be ON inside transaction"
+    finally:
+        system.stop()
+        save_path.cleanup()
+
+
+def test_foreign_key_check_no_violations() -> None:
+    """Verify _check_foreign_key_integrity runs without error on clean DB."""
+    save_path = tempfile.TemporaryDirectory()
+    system = _make_system(save_path.name)
+    system.start()
+    try:
+        db = system.instance(SqliteDB)
+        # Should not raise
+        db._check_foreign_key_integrity()
+    finally:
+        system.stop()
+        save_path.cleanup()
+
+
+def test_foreign_key_check_detects_violations() -> None:
+    """Verify telemetry is sent when FK violations exist."""
+    save_path = tempfile.TemporaryDirectory()
+    system = _make_system(save_path.name)
+    system.start()
+    try:
+        db = system.instance(SqliteDB)
+
+        # Introduce a FK violation by inserting orphaned data directly
+        conn = db._conn_pool.connect()
+        # Temporarily disable FK enforcement to insert bad data
+        conn.execute("PRAGMA foreign_keys = OFF")
+        try:
+            # Find a table with a foreign key constraint
+            cursor = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND sql LIKE '%REFERENCES%'"
+            )
+            fk_tables = cursor.fetchall()
+
+            if not fk_tables:
+                # No FK constraints in schema, skip violation test
+                db._conn_pool.return_to_pool(conn)
+                return
+
+            # Re-enable FK for the check
+            conn.execute("PRAGMA foreign_keys = ON")
+        finally:
+            db._conn_pool.return_to_pool(conn)
+
+        # The actual violation detection is tested via the telemetry capture mock
+        with patch.object(db._product_telemetry_client, "capture") as mock_capture:
+            db._check_foreign_key_integrity()
+            # On a clean DB there should be no violations, so capture should not be called
+            # This validates the code path runs without error
+            if not mock_capture.called:
+                pass  # Expected: no violations on clean DB
+
+    finally:
+        system.stop()
+        save_path.cleanup()

--- a/chromadb/test/db/test_sqlite_foreign_keys.py
+++ b/chromadb/test/db/test_sqlite_foreign_keys.py
@@ -1,6 +1,5 @@
-import sqlite3
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from chromadb.config import Settings, System
 from chromadb.db.impl.sqlite import SqliteDB
@@ -75,34 +74,36 @@ def test_foreign_key_check_detects_violations() -> None:
     try:
         db = system.instance(SqliteDB)
 
-        # Introduce a FK violation by inserting orphaned data directly
+        # Create a FK violation by inserting orphaned data with FK enforcement off
         conn = db._conn_pool.connect()
-        # Temporarily disable FK enforcement to insert bad data
-        conn.execute("PRAGMA foreign_keys = OFF")
         try:
-            # Find a table with a foreign key constraint
-            cursor = conn.execute(
-                "SELECT sql FROM sqlite_master WHERE type='table' AND sql LIKE '%REFERENCES%'"
+            conn.execute("PRAGMA foreign_keys = OFF")
+            # Create test tables with a foreign key relationship
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS _fk_test_parent (id INTEGER PRIMARY KEY)"
             )
-            fk_tables = cursor.fetchall()
-
-            if not fk_tables:
-                # No FK constraints in schema, skip violation test
-                db._conn_pool.return_to_pool(conn)
-                return
-
-            # Re-enable FK for the check
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS _fk_test_child "
+                "(id INTEGER PRIMARY KEY, parent_id INTEGER "
+                "REFERENCES _fk_test_parent(id))"
+            )
+            # Insert orphan row (parent_id=999 doesn't exist in parent table)
+            conn.execute(
+                "INSERT INTO _fk_test_child (id, parent_id) VALUES (1, 999)"
+            )
             conn.execute("PRAGMA foreign_keys = ON")
         finally:
             db._conn_pool.return_to_pool(conn)
 
-        # The actual violation detection is tested via the telemetry capture mock
+        # Now check that _check_foreign_key_integrity detects the violation
         with patch.object(db._product_telemetry_client, "capture") as mock_capture:
             db._check_foreign_key_integrity()
-            # On a clean DB there should be no violations, so capture should not be called
-            # This validates the code path runs without error
-            if not mock_capture.called:
-                pass  # Expected: no violations on clean DB
+            assert mock_capture.called, (
+                "Telemetry capture should be called when FK violations exist"
+            )
+            event = mock_capture.call_args[0][0]
+            assert event.num_violations >= 1
+            assert "_fk_test_child" in event.tables_affected
 
     finally:
         system.stop()


### PR DESCRIPTION
## Summary

`PRAGMA foreign_keys = ON` in `SqliteDB.start()` was executed inside a transaction (`with self.tx()`), which makes it a no-op per [SQLite documentation](https://www.sqlite.org/pragma.html#pragma_foreign_keys):

> This pragma is a no-op within a transaction; foreign key constraint enforcement may only be enabled or disabled when there is no pending BEGIN or SAVEPOINT.

Fixes #3456

## Changes

- Move `PRAGMA foreign_keys = ON` to execute **before** `BEGIN;` in `TxWrapper.__enter__()`, ensuring every connection on every thread has FK enforcement enabled
- Execute the pragma outside transaction in `SqliteDB.start()` for the initial connection
- Add `_check_foreign_key_integrity()` startup diagnostic that runs `PRAGMA foreign_key_check` and sends a `SqliteForeignKeyViolationEvent` telemetry event if violations are detected
- Add `SqliteForeignKeyViolationEvent` telemetry event class
- Add tests verifying FK pragma is effective both outside and inside transactions

## Test plan

- `test_foreign_keys_enabled_outside_transaction` — verifies pragma is ON on raw connection
- `test_foreign_keys_enabled_in_transaction` — verifies pragma is ON inside `with db.tx()`
- `test_foreign_key_check_no_violations` — verifies integrity check runs without error on clean DB
- `test_foreign_key_check_detects_violations` — verifies telemetry code path