### PR TITLE
[BUG] Return proper error for non-existent tenant/database in create_collection

### DIFF
--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -242,6 +242,12 @@ class SegmentAPI(ServerAPI):
             metadata=metadata,
         )
 
+        # Validate tenant and database exist before attempting to create collection.
+        # Without this, a non-existent tenant/database causes a misleading
+        # UniqueConstraintError from the DB layer. See #2882.
+        self._sysdb.get_tenant(name=tenant)
+        self._sysdb.get_database(name=database, tenant=tenant)
+
         id = uuid4()
 
         model = CollectionModel(


### PR DESCRIPTION
## Summary

When calling `POST /api/v1/collections?tenant=my_tenant&database=my_database` with a non-existent tenant, the HTTP API returns a misleading 500 error:

```
UniqueConstraintError('Collection <uuid> already exists')
```

The actual issue is that the tenant doesn't exist, not that the collection already exists.

Fixes #2882

## Changes

- Add explicit `get_tenant()` and `get_database()` validation in `SegmentAPI.create_collection()` before the DB insert
- These methods raise proper `NotFoundError` with clear messages (e.g., "Tenant my_tenant not found"), which the FastAPI error handler converts to a 404 response

## Test plan

- Calling `create_collection()` with a non-existent tenant now returns `NotFoundError("Tenant X not found")` instead of `UniqueConstraintError`
- Calling with a non-existent database returns `NotFoundError("Database X not found for tenant Y")`
- `get_or_create_collection()` is also covered since it delegates to `create_collection()`