### PR TITLE
[ENH] Return created Tenant/Database from create endpoints

### DIFF
--- a/chromadb/api/__init__.py
+++ b/chromadb/api/__init__.py
@@ -547,11 +547,14 @@ class ClientAPI(BaseAPI, ABC):
 
 class AdminAPI(ABC):
     @abstractmethod
-    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         """Create a new database. Raises an error if the database already exists.
 
         Args:
             database: The name of the database to create.
+
+        Returns:
+            The created Database.
 
         """
         pass
@@ -594,11 +597,14 @@ class AdminAPI(ABC):
         pass
 
     @abstractmethod
-    def create_tenant(self, name: str) -> None:
+    def create_tenant(self, name: str) -> Tenant:
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
             tenant: The name of the tenant to create.
+
+        Returns:
+            The created Tenant.
 
         """
         pass

--- a/chromadb/api/async_api.py
+++ b/chromadb/api/async_api.py
@@ -499,11 +499,14 @@ class AsyncClientAPI(AsyncBaseAPI, ABC):
 
 class AsyncAdminAPI(ABC):
     @abstractmethod
-    async def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+    async def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         """Create a new database. Raises an error if the database already exists.
 
         Args:
             database: The name of the database to create.
+
+        Returns:
+            The created Database.
 
         """
         pass
@@ -546,11 +549,14 @@ class AsyncAdminAPI(ABC):
         pass
 
     @abstractmethod
-    async def create_tenant(self, name: str) -> None:
+    async def create_tenant(self, name: str) -> Tenant:
         """Create a new tenant. Raises an error if the tenant already exists.
 
         Args:
             tenant: The name of the tenant to create.
+
+        Returns:
+            The created Tenant.
 
         """
         pass

--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -488,7 +488,7 @@ class AsyncAdminClient(SharedSystemClient, AsyncAdminAPI):
         self._server = self._system.instance(AsyncServerAPI)
 
     @override
-    async def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+    async def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         return await self._server.create_database(name=name, tenant=tenant)
 
     @override
@@ -511,7 +511,7 @@ class AsyncAdminClient(SharedSystemClient, AsyncAdminAPI):
         )
 
     @override
-    async def create_tenant(self, name: str) -> None:
+    async def create_tenant(self, name: str) -> Tenant:
         return await self._server.create_tenant(name=name)
 
     @override

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -180,11 +180,14 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         self,
         name: str,
         tenant: str = DEFAULT_TENANT,
-    ) -> None:
-        await self._make_request(
+    ) -> Database:
+        response = await self._make_request(
             "post",
             f"/tenants/{tenant}/databases",
             json={"name": name},
+        )
+        return Database(
+            id=response["id"], name=response["name"], tenant=response["tenant"]
         )
 
     @trace_method("AsyncFastAPI.get_database", OpenTelemetryGranularity.OPERATION)
@@ -242,12 +245,13 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
 
     @trace_method("AsyncFastAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
     @override
-    async def create_tenant(self, name: str) -> None:
-        await self._make_request(
+    async def create_tenant(self, name: str) -> Tenant:
+        resp_json = await self._make_request(
             "post",
             "/tenants",
             json={"name": name},
         )
+        return Tenant(name=resp_json["name"])
 
     @trace_method("AsyncFastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)
     @override

--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -186,6 +186,9 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             f"/tenants/{tenant}/databases",
             json={"name": name},
         )
+        # Fallback for older servers that return empty body
+        if not response or not isinstance(response, dict):
+            return await self.get_database(name=name, tenant=tenant)
         return Database(
             id=response["id"], name=response["name"], tenant=response["tenant"]
         )
@@ -251,6 +254,9 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
             "/tenants",
             json={"name": name},
         )
+        # Fallback for older servers that return empty body
+        if not resp_json or not isinstance(resp_json, dict):
+            return Tenant(name=name)
         return Tenant(name=resp_json["name"])
 
     @trace_method("AsyncFastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -631,12 +631,15 @@ class AdminClient(SharedSystemClient, AdminAPI):
         self._server = self._system.instance(ServerAPI)
 
     @override
-    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
         """Create a database in a tenant.
 
         Args:
             name: Database name.
             tenant: Tenant that owns the database.
+
+        Returns:
+            The created Database.
         """
         return self._server.create_database(name=name, tenant=tenant)
 
@@ -673,7 +676,7 @@ class AdminClient(SharedSystemClient, AdminAPI):
         return self._server.list_databases(limit, offset, tenant=tenant)
 
     @override
-    def create_tenant(self, name: str) -> None:
+    def create_tenant(self, name: str) -> Tenant:
         return self._server.create_tenant(name=name)
 
     @override

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -153,6 +153,9 @@ class FastAPI(BaseHTTPClient, ServerAPI):
             f"/tenants/{tenant}/databases",
             json={"name": name},
         )
+        # Fallback for older servers that return empty body
+        if not resp_json or not isinstance(resp_json, dict):
+            return self.get_database(name=name, tenant=tenant)
         return Database(
             id=resp_json["id"], name=resp_json["name"], tenant=resp_json["tenant"]
         )
@@ -216,6 +219,9 @@ class FastAPI(BaseHTTPClient, ServerAPI):
     @override
     def create_tenant(self, name: str) -> Tenant:
         resp_json = self._make_request("post", "/tenants", json={"name": name})
+        # Fallback for older servers that return empty body
+        if not resp_json or not isinstance(resp_json, dict):
+            return Tenant(name=name)
         return Tenant(name=resp_json["name"])
 
     @trace_method("FastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)

--- a/chromadb/api/fastapi.py
+++ b/chromadb/api/fastapi.py
@@ -146,12 +146,15 @@ class FastAPI(BaseHTTPClient, ServerAPI):
         self,
         name: str,
         tenant: str = DEFAULT_TENANT,
-    ) -> None:
+    ) -> Database:
         """Creates a database"""
-        self._make_request(
+        resp_json = self._make_request(
             "post",
             f"/tenants/{tenant}/databases",
             json={"name": name},
+        )
+        return Database(
+            id=resp_json["id"], name=resp_json["name"], tenant=resp_json["tenant"]
         )
 
     # Migrated to rust in distributed.
@@ -211,8 +214,9 @@ class FastAPI(BaseHTTPClient, ServerAPI):
 
     @trace_method("FastAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
     @override
-    def create_tenant(self, name: str) -> None:
-        self._make_request("post", "/tenants", json={"name": name})
+    def create_tenant(self, name: str) -> Tenant:
+        resp_json = self._make_request("post", "/tenants", json={"name": name})
+        return Tenant(name=resp_json["name"])
 
     @trace_method("FastAPI.get_tenant", OpenTelemetryGranularity.OPERATION)
     @override

--- a/chromadb/api/rust.py
+++ b/chromadb/api/rust.py
@@ -133,8 +133,14 @@ class RustBindingsAPI(ServerAPI):
     # ////////////////////////////// Admin API //////////////////////////////
 
     @override
-    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
-        return self.bindings.create_database(name, tenant)
+    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
+        self.bindings.create_database(name, tenant)
+        database = self.bindings.get_database(name, tenant)
+        return {
+            "id": database.id,
+            "name": database.name,
+            "tenant": database.tenant,
+        }
 
     @override
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
@@ -167,8 +173,9 @@ class RustBindingsAPI(ServerAPI):
         ]
 
     @override
-    def create_tenant(self, name: str) -> None:
-        return self.bindings.create_tenant(name)
+    def create_tenant(self, name: str) -> Tenant:
+        self.bindings.create_tenant(name)
+        return Tenant(name=name)
 
     @override
     def get_tenant(self, name: str) -> Tenant:

--- a/chromadb/api/segment.py
+++ b/chromadb/api/segment.py
@@ -154,7 +154,7 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI.create_database", OpenTelemetryGranularity.OPERATION)
     @override
-    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> None:
+    def create_database(self, name: str, tenant: str = DEFAULT_TENANT) -> t.Database:
         if len(name) < 3:
             raise ValueError("Database name must be at least 3 characters long")
 
@@ -164,7 +164,7 @@ class SegmentAPI(ServerAPI):
             name=name,
         )
 
-        self._sysdb.create_database(
+        return self._sysdb.create_database(
             id=uuid4(),
             name=name,
             tenant=tenant,
@@ -192,11 +192,11 @@ class SegmentAPI(ServerAPI):
 
     @trace_method("SegmentAPI.create_tenant", OpenTelemetryGranularity.OPERATION)
     @override
-    def create_tenant(self, name: str) -> None:
+    def create_tenant(self, name: str) -> t.Tenant:
         if len(name) < 3:
             raise ValueError("Tenant name must be at least 3 characters long")
 
-        self._sysdb.create_tenant(
+        return self._sysdb.create_tenant(
             name=name,
         )
 

--- a/chromadb/db/mixins/sysdb.py
+++ b/chromadb/db/mixins/sysdb.py
@@ -68,7 +68,7 @@ class SqlSysDB(SqlDB, SysDB):
     @override
     def create_database(
         self, id: UUID, name: str, tenant: str = DEFAULT_TENANT
-    ) -> None:
+    ) -> Database:
         with self.tx() as cur:
             # Get the tenant id for the tenant name and then insert the database with the id, name and tenant id
             databases = Table("databases")
@@ -93,6 +93,7 @@ class SqlSysDB(SqlDB, SysDB):
                 raise UniqueConstraintError(
                     f"Database {name} already exists for tenant {tenant}"
                 ) from e
+        return Database(id=id, name=name, tenant=tenant)
 
     @override
     def get_database(self, name: str, tenant: str = DEFAULT_TENANT) -> Database:
@@ -183,7 +184,7 @@ class SqlSysDB(SqlDB, SysDB):
             ]
 
     @override
-    def create_tenant(self, name: str) -> None:
+    def create_tenant(self, name: str) -> Tenant:
         with self.tx() as cur:
             tenants = Table("tenants")
             insert_tenant = (
@@ -197,6 +198,7 @@ class SqlSysDB(SqlDB, SysDB):
                 cur.execute(sql, params)
             except self.unique_constraint_error() as e:
                 raise UniqueConstraintError(f"Tenant {name} already exists") from e
+        return Tenant(name=name)
 
     @override
     def get_tenant(self, name: str) -> Tenant:

--- a/chromadb/db/system.py
+++ b/chromadb/db/system.py
@@ -27,9 +27,9 @@ class SysDB(Component):
     @abstractmethod
     def create_database(
         self, id: UUID, name: str, tenant: str = DEFAULT_TENANT
-    ) -> None:
+    ) -> Database:
         """Create a new database in the System database. Raises an Error if the Database
-        already exists."""
+        already exists. Returns the created Database."""
         pass
 
     @abstractmethod
@@ -54,9 +54,9 @@ class SysDB(Component):
         pass
 
     @abstractmethod
-    def create_tenant(self, name: str) -> None:
+    def create_tenant(self, name: str) -> Tenant:
         """Create a new tenant in the System database. The name must be unique.
-        Raises an Error if the Tenant already exists."""
+        Raises an Error if the Tenant already exists. Returns the created Tenant."""
         pass
 
     @abstractmethod

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -568,10 +568,10 @@ class FastAPI(Server):
         self,
         request: Request,
         tenant: str,
-    ) -> None:
+    ) -> Database:
         def process_create_database(
             tenant: str, headers: Headers, raw_body: bytes
-        ) -> None:
+        ) -> Database:
             db = validate_model(CreateDatabase, orjson.loads(raw_body))
 
             # NOTE(rescrv, iron will auth):  Implemented.
@@ -648,8 +648,8 @@ class FastAPI(Server):
     async def create_tenant(
         self,
         request: Request,
-    ) -> None:
-        def process_create_tenant(request: Request, raw_body: bytes) -> None:
+    ) -> Tenant:
+        def process_create_tenant(request: Request, raw_body: bytes) -> Tenant:
             tenant = validate_model(CreateTenant, orjson.loads(raw_body))
 
             # NOTE(rescrv, iron will auth):  Implemented.
@@ -1634,10 +1634,10 @@ class FastAPI(Server):
         self,
         request: Request,
         tenant: str = DEFAULT_TENANT,
-    ) -> None:
+    ) -> Database:
         def process_create_database(
             tenant: str, headers: Headers, raw_body: bytes
-        ) -> None:
+        ) -> Database:
             db = validate_model(CreateDatabase, orjson.loads(raw_body))
 
             (
@@ -1704,8 +1704,8 @@ class FastAPI(Server):
     async def create_tenant_v1(
         self,
         request: Request,
-    ) -> None:
-        def process_create_tenant(request: Request, raw_body: bytes) -> None:
+    ) -> Tenant:
+        def process_create_tenant(request: Request, raw_body: bytes) -> Tenant:
             tenant = validate_model(CreateTenant, orjson.loads(raw_body))
 
             # NOTE(rescrv, iron will auth):  v1

--- a/chromadb/server/fastapi/__init__.py
+++ b/chromadb/server/fastapi/__init__.py
@@ -587,7 +587,7 @@ class FastAPI(Server):
 
             return self._api.create_database(db.name, tenant)
 
-        await to_thread.run_sync(
+        return await to_thread.run_sync(
             process_create_database,
             tenant,
             request.headers,
@@ -663,7 +663,7 @@ class FastAPI(Server):
 
             return self._api.create_tenant(tenant.name)
 
-        await to_thread.run_sync(
+        return await to_thread.run_sync(
             process_create_tenant,
             request,
             await request.body(),
@@ -1658,7 +1658,7 @@ class FastAPI(Server):
 
             return self._api.create_database(db.name, tenant)
 
-        await to_thread.run_sync(
+        return await to_thread.run_sync(
             process_create_database,
             tenant,
             request.headers,
@@ -1721,7 +1721,7 @@ class FastAPI(Server):
 
             return self._api.create_tenant(tenant.name)
 
-        await to_thread.run_sync(
+        return await to_thread.run_sync(
             process_create_tenant,
             request,
             await request.body(),


### PR DESCRIPTION
## Summary

Creating a tenant or database via the HTTP API currently returns `null` in the response body, making it impossible for clients to confirm the created resource or retrieve its ID without a follow-up GET request.

Fixes #3286

## Changes

Changed `create_tenant()` and `create_database()` return types from `None` to `Tenant`/`Database` across the full stack:

- **SysDB layer**: `SqlSysDB.create_database()` returns `Database(id, name, tenant)`, `create_tenant()` returns `Tenant(name)`
- **Abstract interfaces**: `SysDB`, `AdminAPI`, `AsyncAdminAPI` updated
- **API implementations**: `SegmentAPI`, `RustBindingsAPI` propagate the result
- **HTTP clients**: `FastAPI`, `AsyncFastAPI` client implementations parse the response
- **Server handlers**: v1 and v2 handlers now return the created object

Response format matches existing `get_tenant()` / `get_database()`:
```json
// POST /api/v1/tenants
{"name": "my_tenant"}

// POST /api/v1/databases
{"id": "...", "name": "my_database", "tenant": "my_tenant"}
```

## Test plan

- Existing tests continue to pass (return value was previously discarded)
- `create_tenant()` returns `Tenant` with the created name
- `create_database()` returns `Database` with id, name, and tenant