### PR TITLE
[BLD] Dark launch a shared tilt cluster

### DIFF
--- a/.github/workflows/_cluster-tests.yml
+++ b/.github/workflows/_cluster-tests.yml
@@ -1,0 +1,60 @@
+## Reusable shared-cluster workflow for CI.
+## See docs/ci/cluster-tests.md for rollout strategy and mappings.
+name: Shared cluster tests
+
+on:
+  workflow_call:
+    inputs:
+      enabled:
+        description: 'Whether to run the shared-cluster tests in this invocation'
+        required: false
+        default: true
+        type: boolean
+      rust_enabled:
+        description: 'Enable Rust shared-cluster integration tests'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  rust-shared-cluster:
+    if: ${{ inputs.enabled && inputs.rust_enabled }}
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    name: Rust shared-cluster integration
+    # OIDC token auth for AWS
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_MIN_STACK_SIZE: 8388608
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Set up Docker
+        uses: ./.github/actions/docker
+        with:
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Tilt services
+        uses: ./.github/actions/tilt
+
+      - name: Build CLI
+        run: cargo build --bin chroma
+
+      - name: Run Rust k8s integration tests (shared cluster)
+        run: bin/rust-k8s-integration-partitions.sh
+
+      - name: Save service logs to artifact
+        if: always()
+        uses: ./.github/actions/export-tilt-logs
+        with:
+          artifact-name: "rust-shared-cluster-integration"
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,10 @@ jobs:
       tests-to-run: ${{ steps.determine-tests.outputs.tests-to-run }}
       # Helm version check
       helm-version-changed: ${{ steps.helm-version.outputs.version_changed }}
+
+      # Shared-cluster (vcluster) flags
+      shared-cluster-enabled: ${{ steps.shared-cluster-flags.outputs.shared-cluster-enabled }}
+      shared-cluster-needed: ${{ steps.shared-cluster-flags.outputs.shared-cluster-needed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -92,6 +96,32 @@ jobs:
           FILTER_GO: ${{ steps.filter.outputs.go }}
           FILTER_CI_INFRA: ${{ steps.filter.outputs.ci-infra }}
         run: bin/ci/determine-tests-to-run.sh
+
+      - name: Compute shared-cluster flags
+        id: shared-cluster-flags
+        run: |
+          ALLOWLIST='${{ vars.SHARED_CLUSTER_ALLOWLIST }}'
+          ACTOR='${{ github.actor }}'
+          SHARED_CLUSTER_ENABLED=false
+          SHARED_CLUSTER_NEEDED=false
+
+          TESTS_TO_RUN='${{ steps.determine-tests.outputs.tests-to-run }}'
+
+          case ",$ALLOWLIST," in
+            *,"$ACTOR",*)
+              SHARED_CLUSTER_ENABLED=true
+              ;;
+          esac
+
+
+          if [[ "$TESTS_TO_RUN" == *"rust"* || \
+                "$TESTS_TO_RUN" == *"go"* || \
+                "$TESTS_TO_RUN" == *"python"* ]]; then
+            SHARED_CLUSTER_NEEDED=true
+          fi
+
+          echo "shared-cluster-enabled=$SHARED_CLUSTER_ENABLED" >> $GITHUB_OUTPUT
+          echo "shared-cluster-needed=$SHARED_CLUSTER_NEEDED" >> $GITHUB_OUTPUT
 
       - name: Check Helm version change
         id: helm-version
@@ -179,6 +209,50 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
+
+  vcluster-create-teardown:
+    name: vcluster (create + teardown)
+    needs: change-detection
+    if: >
+      needs.change-detection.outputs.shared-cluster-enabled == 'true' &&
+      needs.change-detection.outputs.shared-cluster-needed == 'true'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Install vCluster CLI
+        uses: loft-sh/setup-vcluster@v0.0.1
+
+      - name: Login to vCluster Platform
+        env:
+          PLATFORM_URL: ${{ vars.VCLUSTER_PLATFORM_URL }}
+          ACCESS_KEY: ${{ secrets.VCLUSTER_ACCESS_KEY }}
+        run: vcluster platform login $PLATFORM_URL --access-key $ACCESS_KEY
+
+      - name: Create PR vcluster
+        id: create
+        env:
+          VCLUSTER_NAME: "repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}"
+        run: |
+          echo "Creating vcluster: $VCLUSTER_NAME"
+
+          vcluster create $VCLUSTER_NAME \
+            --project default \
+            --driver platform \
+            --template vcluster-pro-template
+
+          echo "name=$VCLUSTER_NAME" >> $GITHUB_OUTPUT
+
+      - name: Verify vcluster (kubectl get nodes)
+        run: kubectl get nodes
+
+      - name: Delete PR vcluster
+        if: always()
+        env:
+          VCLUSTER_NAME: ${{ steps.create.outputs.name }}
+        run: |
+          if [ -n "$VCLUSTER_NAME" ]; then
+            echo "Deleting vcluster: $VCLUSTER_NAME"
+            vcluster delete $VCLUSTER_NAME --project default --driver platform
+          fi
 
   rust-feature-tests:
     name: Rust feature tests

--- a/bin/rust-k8s-integration-partitions.sh
+++ b/bin/rust-k8s-integration-partitions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the Rust k8s integration nextest profiles with the same partitioning
+# strategy used in the existing GitHub Actions matrix.
+#
+# Profiles:
+# - ci_k8s_integration      (partition_method=hash)
+# - ci_k8s_integration_slow (partition_method=count)
+#
+# Partitions:
+# - 1/2 and 2/2 for each profile.
+
+profiles=("ci_k8s_integration" "ci_k8s_integration_slow")
+
+for profile in "${profiles[@]}"; do
+  case "$profile" in
+    ci_k8s_integration)
+      partition_method="hash"
+      ;;
+    ci_k8s_integration_slow)
+      partition_method="count"
+      ;;
+    *)
+      echo "Unknown profile: ${profile}" >&2
+      exit 1
+      ;;
+  esac
+
+  for partition in 1 2; do
+    echo "Running profile=${profile} partition=${partition_method}:${partition}/2"
+    cargo nextest run \
+      --profile "${profile}" \
+      --partition "${partition_method}:${partition}/2" \
+      --no-tests warn
+  done
+done
+

--- a/docs/ci/cluster-tests.md
+++ b/docs/ci/cluster-tests.md
@@ -1,0 +1,55 @@
+### Cluster tests and shared cluster plan
+
+This document tracks how our current Tilt-based cluster tests map to the planned shared-cluster workflow.
+
+#### Current Tilt-dependent jobs
+
+- **Rust k8s integration**:
+  - **Workflow**: `.github/workflows/_rust-tests.yml`
+  - **Job**: `test-integration`
+  - **Command**: `cargo nextest run --profile ci_k8s_integration|ci_k8s_integration_slow --partition …`
+- **Rust MCMR integration**:
+  - **Workflow**: `.github/workflows/_rust-tests.yml`
+  - **Job**: `test-mcmr-integration`
+  - **Command**: `cargo nextest run --profile mcmr_k8s_integration --test-threads 1`
+- **Go cluster tests**:
+  - **Workflow**: `.github/workflows/_go-tests.yml`
+  - **Job**: `cluster-test`
+  - **Command**: `bin/cluster-test.sh bash -c 'cd go && make test'`
+- **Python cluster tests (rust frontend)**:
+  - **Workflow**: `.github/workflows/_python-tests.yml`
+  - **Job**: `test-cluster-rust-frontend`
+  - **Command**: `bin/cluster-test.sh bash -c 'python -m pytest "${{ matrix.test-glob }}" …'`
+
+#### Planned shared-cluster workflow mapping
+
+Once the reusable shared-cluster workflow
+(`.github/workflows/_cluster-tests.yml`) is introduced, the intent is:
+
+- **Rust k8s integration** (`test-integration`)
+  - **Shared phase**: `rust_integration`
+- **Rust MCMR integration** (`test-mcmr-integration`)
+  - **Shared phase**: `rust_mcmr`
+- **Go cluster tests** (`cluster-test`)
+  - **Shared phase**: `go_cluster`
+- **Python cluster tests (rust frontend)** (`test-cluster-rust-frontend`)
+  - **Shared phase**: `python_cluster_frontend`
+
+This mapping allows us to compare “old job vs. new phase” behavior and
+gradually roll traffic over.
+
+#### Allowlist for shared-cluster usage
+
+We use a simple allowlist to control who exercises the shared-cluster workflow
+once it is wired in:
+
+- **User allowlist**: `SHARED_CLUSTER_ALLOWLIST`
+  - **Source**: GitHub Actions variable `vars.SHARED_CLUSTER_ALLOWLIST`.
+  - **Format**: comma-separated list of GitHub usernames, for example:
+    - `alice,bob,charlie`
+  - **Intended usage**:
+    - In early phases, only PRs authored by users in this list will run the shared-cluster workflow.
+    - When the allowlist is empty or unset, no PRs will use the shared-cluster workflow (legacy cluster jobs only).
+
+The shared-cluster workflow will read this allowlist via inputs or environment and will be introduced in a later phase. For now, this document and the allowlist definition provide the groundwork and guardrails for the rollout.
+


### PR DESCRIPTION
- Allow some users to opt into a shared tilt cluster which will try to
  run all the cluster tests in a shared cluster.
- We will roll this out by username see
  `docs/ci/cluster-tests.md` for more details.

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
