### PR TITLE
fix: use installed package metadata for version endpoint

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -57,6 +57,7 @@ from chromadb.execution.expression.operator import (
 )
 from pathlib import Path
 import os
+from importlib.metadata import PackageNotFoundError, version as metadata_version
 
 # Re-export types from chromadb.types
 __all__ = [
@@ -108,7 +109,17 @@ logger = logging.getLogger(__name__)
 
 __settings = Settings()
 
-__version__ = "1.5.5"
+_STATIC_VERSION = "1.5.5"
+
+
+def _resolve_version() -> str:
+    try:
+        return metadata_version("chromadb")
+    except PackageNotFoundError:
+        return _STATIC_VERSION
+
+
+__version__ = _resolve_version()
 
 
 # Workaround to deal with Colab's old sqlite3 version

--- a/chromadb/test/test_version.py
+++ b/chromadb/test/test_version.py
@@ -1,0 +1,14 @@
+import chromadb
+
+
+def test_resolve_version_uses_installed_distribution_version(monkeypatch):
+    monkeypatch.setattr(chromadb, "metadata_version", lambda _: "1.2.3.dev15")
+    assert chromadb._resolve_version() == "1.2.3.dev15"
+
+
+def test_resolve_version_falls_back_when_distribution_metadata_missing(monkeypatch):
+    def _raise_package_not_found(_: str) -> str:
+        raise chromadb.PackageNotFoundError
+
+    monkeypatch.setattr(chromadb, "metadata_version", _raise_package_not_found)
+    assert chromadb._resolve_version() == chromadb._STATIC_VERSION


### PR DESCRIPTION
## Summary
Fix `/version` for dev Docker images by resolving `chromadb` version from installed package metadata instead of relying only on the source constant.

## What changed
- In `chromadb/__init__.py`, added `_resolve_version()`:
  - first tries `importlib.metadata.version("chromadb")`
  - falls back to `_STATIC_VERSION` when package metadata is unavailable
- Set `__version__ = _resolve_version()`.
- Added tests in `chromadb/test/test_version.py` for both metadata and fallback paths.

## Why
Issue #1341 reports that dev Docker images can return an older stable version from `/version`. In the container, source code is copied over the installed package path, so reading only the hardcoded source version can be stale. Reading the installed distribution metadata fixes this while keeping a safe fallback.

## Validation
- `python3 -m compileall -q chromadb/__init__.py chromadb/test/test_version.py`
- `pytest` is not available in this local environment, so I could not run the new test file here.

Fixes #1341
