### PR TITLE
fix: Add IS_PERSISTENT=TRUE to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       # Read more about deployments: https://docs.trychroma.com/deployment
       - chroma-data:/data
     environment:
+      - IS_PERSISTENT=TRUE
       - CHROMA_OPEN_TELEMETRY__ENDPOINT=${CHROMA_OPEN_TELEMETRY__ENDPOINT}
       - CHROMA_OPEN_TELEMETRY__SERVICE_NAME=${CHROMA_OPEN_TELEMETRY__SERVICE_NAME}
       - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}


### PR DESCRIPTION
## Problem

The docker-compose.yml mounts a volume at /data but doesn't set IS_PERSISTENT=TRUE. This causes silent data loss when users run ChromaDB with Docker and the container restarts, even though they have a bind mount configured.

The chromadb config defaults is_persistent to False, so without explicitly setting IS_PERSISTENT=TRUE, data is not actually persisted to the volume.

## Solution

Add IS_PERSISTENT=TRUE to the environment section of docker-compose.yml.

## Changes

- Added IS_PERSISTENT=TRUE environment variable to docker-compose.yml

## Verification

This aligns with other docker-compose examples in the repo (docker-compose.server.example.yml, examples/server_side_embeddings/huggingface/docker-compose.yml) which already include this setting.

Fixes #6654

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.