### PR TITLE
[BUG](log-service): return not-found when requested log entries have been purged

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -2188,6 +2188,9 @@ impl LogServer {
                     )
                 })?,
         };
+        if !fragments.is_empty() && fragments[0].start.offset() > req.start_from_offset {
+            return Err(Status::not_found("Some entries have been purged"));
+        }
         let storage_prefix = collection_id.storage_prefix_for_log();
         let absolute_offsets = topology_name.is_none();
         let proto_fragments = fragments


### PR DESCRIPTION
## Description of changes

Detect when the first available fragment starts after the requested
start_from_offset, indicating that earlier entries were garbage
collected. Return a NOT_FOUND status with a descriptive message instead
of silently returning fragments beginning at a later offset, which
could cause data inconsistency for callers expecting contiguous entries.

## Test plan

I was able to locally observe the HoleInLog case.
I haven't repro'd since this patch.

+ CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
