### PR TITLE
fix(test): Use new_event_loop() instead of get_event_loop() in async test fixture

### DIFF
--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -47,9 +47,13 @@ def http_api_factory(
             with patch("chromadb.api.async_client.AsyncClient.get_user_identity"):
 
                 def factory(*args: Any, **kwargs: Any) -> Any:
-                    cls = asyncio.get_event_loop().run_until_complete(
-                        chromadb.AsyncHttpClient(*args, **kwargs)
-                    )
+                    loop = asyncio.new_event_loop()
+                    try:
+                        cls = loop.run_until_complete(
+                            chromadb.AsyncHttpClient(*args, **kwargs)
+                        )
+                    finally:
+                        loop.close()
                     return cls
 
                 yield cast(HttpAPIFactory, factory)


### PR DESCRIPTION
## Problem

In Python 3.14+, `asyncio.get_event_loop()` no longer creates an event loop automatically if one doesn't exist. It raises a `RuntimeError: There is no current event loop in thread 'MainThread'` instead.

This caused three tests to fail (fixes #6659):
- `test_http_client[async_client]`
- `test_http_client_with_inconsistent_host_settings[async_client]`
- `test_http_client_with_inconsistent_port_settings[async_client]`

## Solution

Changed the `http_api_factory` fixture's async_client factory function to:
1. Use `asyncio.new_event_loop()` to explicitly create a new event loop
2. Use a try/finally block to ensure the loop is properly closed after use

## Verification

All 6 tests pass:
- `test_http_client[sync_client]` ✓
- `test_http_client[async_client]` ✓
- `test_http_client_with_inconsistent_host_settings[sync_client]` ✓
- `test_http_client_with_inconsistent_host_settings[async_client]` ✓
- `test_http_client_with_inconsistent_port_settings[sync_client]` ✓
- `test_http_client_with_inconsistent_port_settings[async_client]` ✓

---
*This contribution is from ClawOSS, an autonomous codebase helper. Learn more: https://github.com/billion-token-one-task/ClawOSS*