### PR TITLE
fix(test): handle missing event loop in async_client test fixture

### DIFF
--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -47,7 +47,12 @@ def http_api_factory(
             with patch("chromadb.api.async_client.AsyncClient.get_user_identity"):
 
                 def factory(*args: Any, **kwargs: Any) -> Any:
-                    cls = asyncio.get_event_loop().run_until_complete(
+                    try:
+                        loop = asyncio.get_event_loop()
+                    except RuntimeError:
+                        loop = asyncio.new_event_loop()
+                        asyncio.set_event_loop(loop)
+                    cls = loop.run_until_complete(
                         chromadb.AsyncHttpClient(*args, **kwargs)
                     )
                     return cls

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -47,15 +47,22 @@ def http_api_factory(
             with patch("chromadb.api.async_client.AsyncClient.get_user_identity"):
 
                 def factory(*args: Any, **kwargs: Any) -> Any:
+                    created_loop = False
                     try:
                         loop = asyncio.get_event_loop()
                     except RuntimeError:
                         loop = asyncio.new_event_loop()
                         asyncio.set_event_loop(loop)
-                    cls = loop.run_until_complete(
-                        chromadb.AsyncHttpClient(*args, **kwargs)
-                    )
-                    return cls
+                        created_loop = True
+                    try:
+                        cls = loop.run_until_complete(
+                            chromadb.AsyncHttpClient(*args, **kwargs)
+                        )
+                        return cls
+                    finally:
+                        if created_loop:
+                            loop.close()
+                            asyncio.set_event_loop(None)
 
                 yield cast(HttpAPIFactory, factory)
 

--- a/chromadb/test/test_client.py
+++ b/chromadb/test/test_client.py
@@ -61,6 +61,14 @@ def http_api_factory(
                         return cls
                     finally:
                         if created_loop:
+                            # Cancel all pending tasks before closing the loop
+                            pending = asyncio.all_tasks(loop)
+                            if pending:
+                                for task in pending:
+                                    task.cancel()
+                                loop.run_until_complete(
+                                    asyncio.gather(*pending, return_exceptions=True)
+                                )
                             loop.close()
                             asyncio.set_event_loop(None)
 


### PR DESCRIPTION
Fixes #6659

**Problem:**
Tests using the `async_client` parameter fail with `RuntimeError: There is no current event loop in thread 'MainThread'` on Python 3.10+.

`asyncio.get_event_loop()` no longer creates a new event loop automatically when one doesn't exist. This affects:
- `test_http_client[async_client]`
- `test_http_client_with_inconsistent_host_settings[async_client]`
- `test_http_client_with_inconsistent_port_settings[async_client]`

**Fix:**
Catch `RuntimeError` and create a new event loop with `asyncio.new_event_loop()`, following the same pattern used in `chromadb/utils/async_to_sync.py`.

**Testing:**
All three failing test cases now pass:
- `test_http_client[async_client]` ✓
- `test_http_client_with_inconsistent_host_settings[async_client]` ✓
- `test_http_client_with_inconsistent_port_settings[async_client]` ✓

---
*This PR was created by ClawOSS, an autonomous codebase helper.*