### PR TITLE
[BUG] Reject NaN/Infinity in base64-encoded embeddings

### DIFF
--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1329,19 +1329,14 @@ fn validate_embeddings(embeddings: &[Vec<f32>]) -> Result<(), ValidationError> {
         return Err(ValidationError::new("embedding_minimum_dimensions")
             .with_message("Each embedding must have at least 1 dimension".into()));
     }
-    if embeddings
-        .iter()
-        .any(|e| e.iter().any(|&v| !v.is_finite()))
-    {
+    if embeddings.iter().any(|e| e.iter().any(|&v| !v.is_finite())) {
         return Err(ValidationError::new("embedding_non_finite")
             .with_message("Embeddings must not contain NaN or Infinity values".into()));
     }
     Ok(())
 }
 
-fn validate_update_embeddings(
-    embeddings: &[Option<Vec<f32>>],
-) -> Result<(), ValidationError> {
+fn validate_update_embeddings(embeddings: &[Option<Vec<f32>>]) -> Result<(), ValidationError> {
     for e in embeddings.iter().flatten() {
         if e.is_empty() {
             return Err(ValidationError::new("embedding_minimum_dimensions")
@@ -1349,9 +1344,7 @@ fn validate_update_embeddings(
         }
         if e.iter().any(|&v| !v.is_finite()) {
             return Err(ValidationError::new("embedding_non_finite")
-                .with_message(
-                    "Embeddings must not contain NaN or Infinity values".into(),
-                ));
+                .with_message("Embeddings must not contain NaN or Infinity values".into()));
         }
     }
     Ok(())

--- a/rust/types/src/api_types.rs
+++ b/rust/types/src/api_types.rs
@@ -1329,6 +1329,31 @@ fn validate_embeddings(embeddings: &[Vec<f32>]) -> Result<(), ValidationError> {
         return Err(ValidationError::new("embedding_minimum_dimensions")
             .with_message("Each embedding must have at least 1 dimension".into()));
     }
+    if embeddings
+        .iter()
+        .any(|e| e.iter().any(|&v| !v.is_finite()))
+    {
+        return Err(ValidationError::new("embedding_non_finite")
+            .with_message("Embeddings must not contain NaN or Infinity values".into()));
+    }
+    Ok(())
+}
+
+fn validate_update_embeddings(
+    embeddings: &[Option<Vec<f32>>],
+) -> Result<(), ValidationError> {
+    for e in embeddings.iter().flatten() {
+        if e.is_empty() {
+            return Err(ValidationError::new("embedding_minimum_dimensions")
+                .with_message("Each embedding must have at least 1 dimension".into()));
+        }
+        if e.iter().any(|&v| !v.is_finite()) {
+            return Err(ValidationError::new("embedding_non_finite")
+                .with_message(
+                    "Embeddings must not contain NaN or Infinity values".into(),
+                ));
+        }
+    }
     Ok(())
 }
 
@@ -1385,6 +1410,7 @@ pub struct UpdateCollectionRecordsRequest {
     pub database_name: String,
     pub collection_id: CollectionUuid,
     pub ids: Vec<String>,
+    #[validate(custom(function = "validate_update_embeddings"))]
     pub embeddings: Option<Vec<Option<Vec<f32>>>>,
     pub documents: Option<Vec<Option<String>>>,
     pub uris: Option<Vec<Option<String>>>,
@@ -2751,6 +2777,66 @@ mod test {
         );
 
         // Should fail because sparse vector is not sorted
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_request_rejects_nan_embedding() {
+        let result = AddCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            CollectionUuid(uuid::Uuid::new_v4()),
+            vec!["id1".to_string()],
+            vec![vec![1.0, f32::NAN, 3.0]],
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_request_rejects_infinity_embedding() {
+        let result = AddCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            CollectionUuid(uuid::Uuid::new_v4()),
+            vec!["id1".to_string()],
+            vec![vec![1.0, f32::INFINITY]],
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_request_rejects_nan_embedding() {
+        let result = UpdateCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            CollectionUuid(uuid::Uuid::new_v4()),
+            vec!["id1".to_string()],
+            Some(vec![Some(vec![1.0, f32::NAN])]),
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_upsert_request_rejects_nan_embedding() {
+        let result = UpsertCollectionRecordsRequest::try_new(
+            "tenant".to_string(),
+            "database".to_string(),
+            CollectionUuid(uuid::Uuid::new_v4()),
+            vec!["id1".to_string()],
+            vec![vec![f32::NEG_INFINITY, 2.0]],
+            None,
+            None,
+            None,
+        );
         assert!(result.is_err());
     }
 }

--- a/rust/types/src/base64_decode.rs
+++ b/rust/types/src/base64_decode.rs
@@ -299,10 +299,7 @@ mod tests {
         bytes.extend_from_slice(&1.0f32.to_le_bytes());
         bytes.extend_from_slice(&f32::NAN.to_le_bytes());
         bytes.extend_from_slice(&3.0f32.to_le_bytes());
-        let base64_str = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &bytes,
-        );
+        let base64_str = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &bytes);
         let result = decode_base64_embedding(&base64_str);
         assert!(matches!(
             result,
@@ -317,7 +314,9 @@ mod tests {
     fn embeddings_strategy() -> impl Strategy<Value = Vec<Vec<f32>>> {
         proptest::collection::vec(
             proptest::collection::vec(
-                proptest::num::f32::NORMAL | proptest::num::f32::SUBNORMAL | proptest::num::f32::ZERO,
+                proptest::num::f32::NORMAL
+                    | proptest::num::f32::SUBNORMAL
+                    | proptest::num::f32::ZERO,
                 0..10,
             ),
             0..5,

--- a/rust/types/src/base64_decode.rs
+++ b/rust/types/src/base64_decode.rs
@@ -11,6 +11,8 @@ pub enum Base64DecodeError {
     InvalidByteLength { byte_length: usize },
     #[error("Failed to convert embedding {embedding_index} to byte array")]
     EmbeddingConversionFailed { embedding_index: usize },
+    #[error("Non-finite float value at embedding index {embedding_index}: {value}")]
+    NonFiniteFloatValue { embedding_index: usize, value: f32 },
 }
 
 impl ChromaError for Base64DecodeError {
@@ -106,7 +108,14 @@ pub fn decode_base64_embedding(base64_str: &String) -> Result<Vec<f32>, Base64De
             .try_into()
             .map_err(|_| Base64DecodeError::EmbeddingConversionFailed { embedding_index })?;
         // handles little endian encoding
-        floats.push(f32::from_le_bytes(float_bytes));
+        let f = f32::from_le_bytes(float_bytes);
+        if !f.is_finite() {
+            return Err(Base64DecodeError::NonFiniteFloatValue {
+                embedding_index,
+                value: f,
+            });
+        }
+        floats.push(f);
     }
 
     Ok(floats)
@@ -245,9 +254,74 @@ mod tests {
         general_purpose::STANDARD.encode(&bytes)
     }
 
+    #[test]
+    fn test_nan_base64_rejected() {
+        let nan_base64 = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            f32::NAN.to_le_bytes(),
+        );
+        let result = decode_base64_embedding(&nan_base64);
+        assert!(matches!(
+            result,
+            Err(Base64DecodeError::NonFiniteFloatValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_infinity_base64_rejected() {
+        let inf_base64 = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            f32::INFINITY.to_le_bytes(),
+        );
+        let result = decode_base64_embedding(&inf_base64);
+        assert!(matches!(
+            result,
+            Err(Base64DecodeError::NonFiniteFloatValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_neg_infinity_base64_rejected() {
+        let neg_inf_base64 = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            f32::NEG_INFINITY.to_le_bytes(),
+        );
+        let result = decode_base64_embedding(&neg_inf_base64);
+        assert!(matches!(
+            result,
+            Err(Base64DecodeError::NonFiniteFloatValue { .. })
+        ));
+    }
+
+    #[test]
+    fn test_nan_in_multi_embedding_rejected() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+        bytes.extend_from_slice(&f32::NAN.to_le_bytes());
+        bytes.extend_from_slice(&3.0f32.to_le_bytes());
+        let base64_str = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            &bytes,
+        );
+        let result = decode_base64_embedding(&base64_str);
+        assert!(matches!(
+            result,
+            Err(Base64DecodeError::NonFiniteFloatValue {
+                embedding_index: 1,
+                ..
+            })
+        ));
+    }
+
     #[cfg(feature = "testing")]
     fn embeddings_strategy() -> impl Strategy<Value = Vec<Vec<f32>>> {
-        any::<Vec<Vec<f32>>>()
+        proptest::collection::vec(
+            proptest::collection::vec(
+                proptest::num::f32::NORMAL | proptest::num::f32::SUBNORMAL | proptest::num::f32::ZERO,
+                0..10,
+            ),
+            0..5,
+        )
     }
 
     #[cfg(feature = "testing")]

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -499,6 +499,9 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for UpdateMetadataValue {
                 Ok(UpdateMetadataValue::Int(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::FloatValue(value)) => {
+                if !value.is_finite() {
+                    return Err(UpdateMetadataValueConversionError::InvalidValue);
+                }
                 Ok(UpdateMetadataValue::Float(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::StringValue(value)) => {
@@ -518,6 +521,9 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for UpdateMetadataValue {
                 Ok(UpdateMetadataValue::IntArray(value.values.clone()))
             }
             Some(chroma_proto::update_metadata_value::Value::DoubleListValue(value)) => {
+                if value.values.iter().any(|v| !v.is_finite()) {
+                    return Err(UpdateMetadataValueConversionError::InvalidValue);
+                }
                 Ok(UpdateMetadataValue::FloatArray(value.values.clone()))
             }
             Some(chroma_proto::update_metadata_value::Value::StringListValue(value)) => {
@@ -1054,6 +1060,9 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for MetadataValue {
                 Ok(MetadataValue::Int(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::FloatValue(value)) => {
+                if !value.is_finite() {
+                    return Err(MetadataValueConversionError::InvalidValue);
+                }
                 Ok(MetadataValue::Float(*value))
             }
             Some(chroma_proto::update_metadata_value::Value::StringValue(value)) => {
@@ -1073,6 +1082,9 @@ impl TryFrom<&chroma_proto::UpdateMetadataValue> for MetadataValue {
                 Ok(MetadataValue::IntArray(value.values.clone()))
             }
             Some(chroma_proto::update_metadata_value::Value::DoubleListValue(value)) => {
+                if value.values.iter().any(|v| !v.is_finite()) {
+                    return Err(MetadataValueConversionError::InvalidValue);
+                }
                 Ok(MetadataValue::FloatArray(value.values.clone()))
             }
             Some(chroma_proto::update_metadata_value::Value::StringListValue(value)) => {
@@ -3036,5 +3048,71 @@ mod tests {
                 children: vec![foo.clone(), baz.clone(), foo.clone()]
             })
         );
+    }
+
+    #[test]
+    fn test_reject_nan_metadata_float_via_grpc() {
+        for bad_value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let proto = chroma_proto::UpdateMetadataValue {
+                value: Some(chroma_proto::update_metadata_value::Value::FloatValue(
+                    bad_value,
+                )),
+            };
+
+            let result = UpdateMetadataValue::try_from(&proto);
+            assert!(
+                result.is_err(),
+                "should reject {bad_value} in UpdateMetadataValue"
+            );
+
+            let result = MetadataValue::try_from(&proto);
+            assert!(
+                result.is_err(),
+                "should reject {bad_value} in MetadataValue"
+            );
+        }
+
+        // Valid floats should still work.
+        let proto = chroma_proto::UpdateMetadataValue {
+            value: Some(chroma_proto::update_metadata_value::Value::FloatValue(1.5)),
+        };
+        assert!(UpdateMetadataValue::try_from(&proto).is_ok());
+        assert!(MetadataValue::try_from(&proto).is_ok());
+    }
+
+    #[test]
+    fn test_reject_nan_metadata_float_array_via_grpc() {
+        for bad_value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let proto = chroma_proto::UpdateMetadataValue {
+                value: Some(chroma_proto::update_metadata_value::Value::DoubleListValue(
+                    chroma_proto::DoubleListValue {
+                        values: vec![1.0, bad_value, 3.0],
+                    },
+                )),
+            };
+
+            let result = UpdateMetadataValue::try_from(&proto);
+            assert!(
+                result.is_err(),
+                "should reject {bad_value} in UpdateMetadataValue float array"
+            );
+
+            let result = MetadataValue::try_from(&proto);
+            assert!(
+                result.is_err(),
+                "should reject {bad_value} in MetadataValue float array"
+            );
+        }
+
+        // Valid float arrays should still work.
+        let proto = chroma_proto::UpdateMetadataValue {
+            value: Some(chroma_proto::update_metadata_value::Value::DoubleListValue(
+                chroma_proto::DoubleListValue {
+                    values: vec![1.0, 2.0, 3.0],
+                },
+            )),
+        };
+        assert!(UpdateMetadataValue::try_from(&proto).is_ok());
+        assert!(MetadataValue::try_from(&proto).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- **Security fix**: base64-encoded embeddings could inject NaN/Infinity values that permanently corrupt HNSW indexes. A single unauthenticated POST request with a crafted base64 embedding causes all queries touching the poisoned vector to return NaN distances (IEEE 754 propagation). The corruption persists across restarts.
- Adds `is_finite()` validation in `decode_base64_embedding()` to reject non-finite floats at the decode boundary
- Adds defense-in-depth `is_finite()` check in `validate_embeddings()` covering both JSON and base64 paths
- Adds missing embedding validation to `UpdateCollectionRecordsRequest` (previously had none)
- Affects both single-node and distributed deployments (shared `chroma-types` crate, same frontend server)

## Test plan

- [x] New unit tests for NaN, Infinity, -Infinity rejection in base64 decode (4 tests)
- [x] New unit tests for validation rejection across add, update, upsert request types (4 tests)
- [x] Updated proptest strategy to generate only finite floats
- [x] Full `cargo test -p chroma-types` passes (289 tests)