### PR TITLE
[CHORE] compute ready_uncompacted only for compaction-eligible collections

### DIFF
--- a/rust/log-service/src/lib.rs
+++ b/rust/log-service/src/lib.rs
@@ -1541,25 +1541,17 @@ impl LogServer {
                 }
             }
         };
-        let s3_rollups = {
-            self.need_to_compact_s3
-                .lock()
-                .values()
-                .copied()
-                .collect::<Vec<_>>()
-        };
-        for rollup in &s3_rollups {
-            record_rollup_metrics(rollup);
+        {
+            let s3_rollups = self.need_to_compact_s3.lock();
+            for rollup in s3_rollups.values() {
+                record_rollup_metrics(rollup);
+            }
         }
-        let repl_rollups = {
-            self.need_to_compact_repl
-                .lock()
-                .values()
-                .copied()
-                .collect::<Vec<_>>()
-        };
-        for rollup in &repl_rollups {
-            record_rollup_metrics(rollup);
+        {
+            let repl_rollups = self.need_to_compact_repl.lock();
+            for rollup in repl_rollups.values() {
+                record_rollup_metrics(rollup);
+            }
         }
         self.metrics
             .log_likely_needs_purge_dirty


### PR DESCRIPTION
## Description of changes

Move the log_ready_uncompacted_records_count metric from
get_all_collections_to_compact (where it summed over all selected
rollups) into the rollup tick loop, gating it behind should_compact.
This ensures the metric reflects only records that actually meet the
compaction threshold, providing an accurate signal for monitoring.

Add suggested_compaction_threshold (default 250) to LogServerConfig
to parameterize the compaction eligibility check.

The real problem is that the `*ready*` variant may go to zero while
the `*total*` variant goes to something reasonable.  Move the ready
variant to be adjacent to the total variant so they rollup similarly.

As an extra:  We need to have _one_ threshold, so the
suggested_compaction_threshold was added.

## Test plan

CI -> Staging

## Migration plan

N/A

## Observability plan

Should be improved.

## Documentation Changes

N/A

Co-authored-by: AI
