### PR TITLE
[CHORE](ci): remove chromadb-client references from JS release workflows

### DIFF
--- a/.github/workflows/release-dev-javascript-client.yml
+++ b/.github/workflows/release-dev-javascript-client.yml
@@ -67,7 +67,7 @@ jobs:
           echo "DEV_TAG=${DEV_TAG}" >> "$GITHUB_ENV"
 
           # Update each package's version with dev tag
-          for PKG_DIR in packages/chromadb packages/chromadb-client; do
+          for PKG_DIR in packages/chromadb; do
             PKG_PATH="./${PKG_DIR}/package.json"
             # Get current version
             CURRENT_VERSION=$(node -p "require('${PKG_PATH}').version")
@@ -92,10 +92,6 @@ jobs:
           PACKAGE_NAME=$(jq -r '.name' $CHROMADB_PKG)
           jq --arg org "$ORG_NAME" --arg name "$PACKAGE_NAME" '.name = "\($org)/\($name)"' $CHROMADB_PKG > tmp.$$.json && mv tmp.$$.json $CHROMADB_PKG
 
-          # Update chromadb-client package
-          CLIENT_PKG="./packages/chromadb-client/package.json"
-          PACKAGE_NAME=$(jq -r '.name' $CLIENT_PKG)
-          jq --arg org "$ORG_NAME" --arg name "$PACKAGE_NAME" '.name = "\($org)/\($name)"' $CLIENT_PKG > tmp.$$.json && mv tmp.$$.json $CLIENT_PKG
         working-directory: ./clients/js/
 
       - name: Publish dev packages

--- a/.github/workflows/release-javascript-client.yml
+++ b/.github/workflows/release-javascript-client.yml
@@ -78,10 +78,6 @@ jobs:
         PACKAGE_NAME=$(jq -r '.name' $CHROMADB_PKG)
         jq --arg org "$ORG_NAME" --arg name "$PACKAGE_NAME" '.name = "\($org)/\($name)"' $CHROMADB_PKG > tmp.$$.json && mv tmp.$$.json $CHROMADB_PKG
 
-        # Update chromadb-client package
-        CLIENT_PKG="./packages/chromadb-client/package.json"
-        PACKAGE_NAME=$(jq -r '.name' $CLIENT_PKG)
-        jq --arg org "$ORG_NAME" --arg name "$PACKAGE_NAME" '.name = "\($org)/\($name)"' $CLIENT_PKG > tmp.$$.json && mv tmp.$$.json $CLIENT_PKG
       working-directory: ./clients/js/
     - name: Publish packages
       run: pnpm publish -r --access public --no-git-checks


### PR DESCRIPTION
## Description of changes

Remove chromadb-client package handling from both the dev and production
JavaScript client release workflows:
- Narrow dev version tagging loop to only packages/chromadb
- Remove org-scoped name rewriting for chromadb-client in both workflows

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
