### PR TITLE
fix(docker): Add IS_PERSISTENT=TRUE to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       # Read more about deployments: https://docs.trychroma.com/deployment
       - chroma-data:/data
     environment:
+      - IS_PERSISTENT=TRUE
       - CHROMA_OPEN_TELEMETRY__ENDPOINT=${CHROMA_OPEN_TELEMETRY__ENDPOINT}
       - CHROMA_OPEN_TELEMETRY__SERVICE_NAME=${CHROMA_OPEN_TELEMETRY__SERVICE_NAME}
       - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}


### PR DESCRIPTION
## Description of changes

The docker-compose.yml mounts a volume at /data for persistence, but doesn't set IS_PERSISTENT=TRUE. This causes silent data loss when users deploy with docker-compose and expect data to persist across container restarts (Issue #6654).

- Bug fix: Added IS_PERSISTENT=TRUE to the environment section

## Test plan

- Verified that IS_PERSISTENT=TRUE is correctly parsed by the Settings class
- The existing volume mount at /data will now actually be used for persistence

## Migration plan

No migration needed. This only affects new deployments using docker-compose.yml.

## Documentation Changes

None required - the docker-compose.yml comment already mentions persistence.

Fixes #6654