### PR TITLE
fix: Knn string query ValueError with Cloud embedding functions

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -836,7 +836,7 @@ class CollectionCommon(Generic[ClientT]):
         if key == EMBEDDING_KEY:
             # Use the collection's main embedding function
             embedding = self._embed(input=[query_text], is_query=True)
-            if not embedding or len(embedding) != 1:
+            if embedding is None or len(embedding) != 1:
                 raise ValueError(
                     "Embedding function returned unexpected number of embeddings"
                 )
@@ -910,7 +910,7 @@ class CollectionCommon(Generic[ClientT]):
                         # Fallback if embed_query doesn't exist
                         embeddings = embedding_func([query_text])
 
-                    if not embeddings or len(embeddings) != 1:
+                    if embeddings is None or len(embeddings) != 1:
                         raise ValueError(
                             "Embedding function returned unexpected number of embeddings"
                         )


### PR DESCRIPTION
Fixes #6681

**Problem:**
In \`CollectionCommon._embed_knn_string_queries\`, the check \`if not embedding\` fails when the embedding function returns a numpy array, because \`not numpy_array\` raises \`ValueError: The truth value of an array with more than one element is ambiguous.\`

This affects Cloud embedding functions (ChromaCloudQwenEmbeddingFunction, ChromaCloudSpladeEmbeddingFunction) which return numpy arrays, while the default local embedding function returns plain lists.

**Fix:**
Replace \`if not embedding\` with \`if embedding is None\` at two locations:
- Line 839: main embedding field check
- Line 913: sparse embedding field check

This correctly handles both list and numpy array return types from embedding functions.

**Testing:**
The fix was verified to handle numpy arrays without raising the ambiguous truth value error, while maintaining the same validation behavior for None values and empty results.