### PR TITLE
fix: handle string query in Knn with Cloud embeddings

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -836,7 +836,7 @@ class CollectionCommon(Generic[ClientT]):
         if key == EMBEDDING_KEY:
             # Use the collection's main embedding function
             embedding = self._embed(input=[query_text], is_query=True)
-            if not embedding or len(embedding) != 1:
+            if embedding is None or len(embedding) != 1:
                 raise ValueError(
                     "Embedding function returned unexpected number of embeddings"
                 )
@@ -910,7 +910,7 @@ class CollectionCommon(Generic[ClientT]):
                         # Fallback if embed_query doesn't exist
                         embeddings = embedding_func([query_text])
 
-                    if not embeddings or len(embeddings) != 1:
+                    if embeddings is None or len(embeddings) != 1:
                         raise ValueError(
                             "Embedding function returned unexpected number of embeddings"
                         )


### PR DESCRIPTION
Fixes #6681

## Problem
Cloud embedding functions (ChromaCloudQwenEmbeddingFunction, ChromaCloudSpladeEmbeddingFunction) return numpy arrays instead of Python lists. The check `if not embedding` fails for numpy arrays because "the truth value of an array with more than one element is ambiguous."

## Solution
Changed `if not embedding` to `if embedding is None` in two locations in `_embed_knn_string_queries`:
- Line 839: main embedding field handling
- Line 913: metadata field with sparse embedding handling

## Verification
Tested that the fix works with both list and numpy array embeddings:
- Lists continue to work as before
- Numpy arrays now work correctly instead of raising ValueError
- Edge cases (None, empty list) are still properly handled