### PR TITLE
fix: handle numpy array in embedding truthiness check

### DIFF
--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -836,7 +836,7 @@ class CollectionCommon(Generic[ClientT]):
         if key == EMBEDDING_KEY:
             # Use the collection's main embedding function
             embedding = self._embed(input=[query_text], is_query=True)
-            if not embedding or len(embedding) != 1:
+            if embedding is None or len(embedding) != 1:
                 raise ValueError(
                     "Embedding function returned unexpected number of embeddings"
                 )
@@ -910,7 +910,7 @@ class CollectionCommon(Generic[ClientT]):
                         # Fallback if embed_query doesn't exist
                         embeddings = embedding_func([query_text])
 
-                    if not embeddings or len(embeddings) != 1:
+                    if embeddings is None or len(embeddings) != 1:
                         raise ValueError(
                             "Embedding function returned unexpected number of embeddings"
                         )


### PR DESCRIPTION
## Summary

Fixes #6681

`CollectionCommon._embed_knn_string_queries()` uses `if not embedding` (line 839) and `if not embeddings` (line 913) to check for missing embeddings. When an embedding function returns a numpy array (common with cloud/API-based embedding providers), this raises:

```
ValueError: The truth value of an array with more than one element is ambiguous.
```

This is because numpy arrays with more than one element do not support Python's truthiness protocol — `bool(np.array([1, 2]))` raises the above error.

## Fix

Replace `if not embedding` with `if embedding is None` on both lines. This correctly handles:
- `None` return (embedding function failed) — caught
- Empty list `[]` — caught by `len(...) != 1`  
- Numpy array — no longer triggers ambiguous truth value error
- Normal list — works as before

## Test plan

- [x] Verified the two affected lines in `chromadb/api/models/CollectionCommon.py`
- [x] Confirmed no other instances of `if not embedding` in the codebase
- [ ] Existing test suite passes (change is minimal and safe — only affects None-checking logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)