### PR TITLE
[ENH] JS - get collection by ID

### DIFF
--- a/clients/new-js/packages/chromadb/src/chroma-client.ts
+++ b/clients/new-js/packages/chromadb/src/chroma-client.ts
@@ -14,7 +14,7 @@ import {
   ChecklistResponse,
 } from "./api";
 import { CollectionMetadata, UserIdentity } from "./types";
-import { Collection, CollectionImpl } from "./collection";
+import { Collection, CollectionHandle, CollectionImpl } from "./collection";
 import { EmbeddingFunction, getEmbeddingFunction } from "./embedding-function";
 import { chromaFetch } from "./chroma-fetch";
 import * as process from "node:process";
@@ -535,6 +535,33 @@ export class ChromaClient {
       embeddingFunction: resolvedEmbeddingFunction,
       id: data.id,
       schema: serverSchema,
+    });
+  }
+
+  /**
+   * Returns a lightweight collection handle for the given collection ID.
+   * The handle supports operations that don't require an embedding function
+   * or schema (e.g., add with pre-computed embeddings, get, delete, count, search).
+   * Operations that require an embedding function will throw a clear error
+   * directing you to use {@link getCollection} instead.
+   * @param id - The collection ID
+   * @returns A Collection handle for the given ID
+   * @throws ChromaValueError if tenant or database are not set on the client
+   */
+  public collection(id: string): Collection {
+    if (!this._tenant || !this._database) {
+      throw new ChromaValueError(
+        "tenant and database must be set on the client before calling collection(). " +
+          "Provide them in the ChromaClient constructor or use getCollection() instead.",
+      );
+    }
+
+    return new CollectionHandle({
+      chromaClient: this,
+      apiClient: this.apiClient,
+      id,
+      tenant: this._tenant,
+      database: this._database,
     });
   }
 

--- a/clients/new-js/packages/chromadb/src/collection.ts
+++ b/clients/new-js/packages/chromadb/src/collection.ts
@@ -1155,3 +1155,144 @@ export class CollectionImpl implements Collection {
     return data;
   }
 }
+
+/**
+ * Arguments for creating a CollectionHandle instance.
+ */
+export interface CollectionHandleArgs {
+  /** ChromaDB client instance */
+  chromaClient: ChromaClient;
+  /** HTTP API client */
+  apiClient: ReturnType<typeof createClient>;
+  /** Collection ID */
+  id: string;
+  /** Tenant name */
+  tenant: string;
+  /** Database name */
+  database: string;
+}
+
+const HANDLE_EMBEDDING_ERROR =
+  "This operation requires an embedding function, which is not available on " +
+  "a collection obtained via client.collection(id). Provide pre-computed " +
+  "embeddings directly, or use client.getCollection() to get a full " +
+  "collection with embedding support.";
+
+const HANDLE_NOT_SUPPORTED_ERROR =
+  "is not supported on a collection obtained via client.collection(id). " +
+  "Use client.getCollection() to get a full collection instance.";
+
+/**
+ * A lightweight collection handle that holds only the collection ID and
+ * client context. Supports operations that don't require an embedding
+ * function or schema. Obtained via {@link ChromaClient.collection}.
+ */
+export class CollectionHandle extends CollectionImpl {
+  constructor({ chromaClient, apiClient, id, tenant, database }: CollectionHandleArgs) {
+    super({
+      chromaClient,
+      apiClient,
+      id,
+      tenant,
+      database,
+      name: "",
+      configuration: {},
+    });
+  }
+
+  public override async add(args: {
+    ids: string[];
+    embeddings?: number[][];
+    metadatas?: Metadata[];
+    documents?: string[];
+    uris?: string[];
+  }): Promise<void> {
+    if (!args.embeddings) {
+      throw new ChromaValueError(HANDLE_EMBEDDING_ERROR);
+    }
+    return super.add(args);
+  }
+
+  public override async update(args: {
+    ids: string[];
+    embeddings?: number[][];
+    metadatas?: Metadata[];
+    documents?: string[];
+    uris?: string[];
+  }): Promise<void> {
+    if (!args.embeddings && args.documents) {
+      throw new ChromaValueError(HANDLE_EMBEDDING_ERROR);
+    }
+    return super.update(args);
+  }
+
+  public override async upsert(args: {
+    ids: string[];
+    embeddings?: number[][];
+    metadatas?: Metadata[];
+    documents?: string[];
+    uris?: string[];
+  }): Promise<void> {
+    if (!args.embeddings) {
+      throw new ChromaValueError(HANDLE_EMBEDDING_ERROR);
+    }
+    return super.upsert(args);
+  }
+
+  public override async query<TMeta extends Metadata = Metadata>(args: {
+    queryEmbeddings?: number[][];
+    queryTexts?: string[];
+    queryURIs?: string[];
+    ids?: string[];
+    nResults?: number;
+    where?: Where;
+    whereDocument?: WhereDocument;
+    include?: Include[];
+  }): Promise<QueryResult<TMeta>> {
+    if (!args.queryEmbeddings) {
+      throw new ChromaValueError(HANDLE_EMBEDDING_ERROR);
+    }
+    return super.query(args);
+  }
+
+  public override async search(
+    searches: SearchLike | SearchLike[],
+    options?: { readLevel?: ReadLevel },
+  ): Promise<SearchResult> {
+    const items = Array.isArray(searches) ? searches : [searches];
+    for (const search of items) {
+      const payload = toSearch(search).toPayload();
+      if (this.hasStringKnnQuery(payload.rank)) {
+        throw new ChromaValueError(HANDLE_EMBEDDING_ERROR);
+      }
+    }
+    return super.search(searches, options);
+  }
+
+  public override async modify(_args: {
+    name?: string;
+    metadata?: CollectionMetadata;
+    configuration?: UpdateCollectionConfiguration;
+  }): Promise<void> {
+    throw new ChromaValueError(`modify() ${HANDLE_NOT_SUPPORTED_ERROR}`);
+  }
+
+  public override async fork(_args: { name: string }): Promise<Collection> {
+    throw new ChromaValueError(`fork() ${HANDLE_NOT_SUPPORTED_ERROR}`);
+  }
+
+  private hasStringKnnQuery(obj: unknown): boolean {
+    if (!obj || typeof obj !== "object") return false;
+    if (Array.isArray(obj)) {
+      return obj.some((item) => this.hasStringKnnQuery(item));
+    }
+    const record = obj as Record<string, unknown>;
+    if ("$knn" in record && isPlainObject(record.$knn)) {
+      const knn = record.$knn as Record<string, unknown>;
+      if (typeof knn.query === "string") return true;
+    }
+    return Object.values(record).some((value) =>
+      this.hasStringKnnQuery(value),
+    );
+  }
+}

--- a/clients/new-js/packages/chromadb/src/index.ts
+++ b/clients/new-js/packages/chromadb/src/index.ts
@@ -6,7 +6,7 @@
 // Apply Deno compatibility patch
 import "./deno";
 
-export { Collection } from "./collection";
+export { Collection, CollectionHandle } from "./collection";
 export { withChroma } from "./next";
 export * from "./types";
 export * from "./admin-client";

--- a/clients/new-js/packages/chromadb/test/collection.handle.test.ts
+++ b/clients/new-js/packages/chromadb/test/collection.handle.test.ts
@@ -1,0 +1,223 @@
+import { expect, test, beforeEach, describe } from "@jest/globals";
+import { ChromaClient, ChromaValueError, Search } from "../src";
+import { EMBEDDINGS, IDS, METADATAS } from "./utils/data";
+
+describe("collection handle", () => {
+  const client = new ChromaClient({
+    path: process.env.DEFAULT_CHROMA_INSTANCE_URL,
+  });
+
+  let collectionId: string;
+
+  beforeEach(async () => {
+    await client.reset();
+    const collection = await client.createCollection({ name: "test" });
+    collectionId = collection.id;
+  });
+
+  test("it should return a collection synchronously", () => {
+    const handle = client.collection(collectionId);
+    expect(handle).toBeDefined();
+    expect(handle.id).toBe(collectionId);
+  });
+
+  test("it should add records with pre-computed embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+      metadatas: METADATAS,
+    });
+    const count = await handle.count();
+    expect(count).toBe(3);
+  });
+
+  test("it should get records", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+      metadatas: METADATAS,
+    });
+    const res = await handle.get({ ids: ["test1"] });
+    expect(res.ids).toEqual(["test1"]);
+  });
+
+  test("it should delete records", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    await handle.delete({ ids: ["test1"] });
+    const count = await handle.count();
+    expect(count).toBe(2);
+  });
+
+  test("it should count records", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    const count = await handle.count();
+    expect(count).toBe(3);
+  });
+
+  test("it should peek records", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    const res = await handle.peek({ limit: 2 });
+    expect(res.ids).toHaveLength(2);
+  });
+
+  test("it should query with pre-computed embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    const results = await handle.query({
+      queryEmbeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
+      nResults: 2,
+    });
+    expect(results.ids[0]).toHaveLength(2);
+  });
+
+  // Search is not implemented in the local test server
+  test.skip("it should search with pre-computed embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    const results = await handle.search(
+      new Search()
+        .rank({ $knn: { query: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] } })
+        .limit(2),
+    );
+    expect(results).toBeDefined();
+  });
+
+  test("it should update records with pre-computed embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    await handle.update({
+      ids: ["test1"],
+      embeddings: [[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]],
+    });
+    const res = await handle.get({
+      ids: ["test1"],
+      include: ["embeddings"],
+    });
+    expect(res.embeddings?.[0]).toEqual([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  });
+
+  test("it should upsert records with pre-computed embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await handle.upsert({
+      ids: ["new1"],
+      embeddings: [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]],
+    });
+    const count = await handle.count();
+    expect(count).toBe(1);
+  });
+
+  test("it should error on add without embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await expect(
+      handle.add({
+        ids: ["test1"],
+        documents: ["This is a test"],
+      }),
+    ).rejects.toThrow(ChromaValueError);
+    await expect(
+      handle.add({
+        ids: ["test1"],
+        documents: ["This is a test"],
+      }),
+    ).rejects.toThrow(/client\.getCollection\(\)/);
+  });
+
+  test("it should error on upsert without embeddings", async () => {
+    const handle = client.collection(collectionId);
+    await expect(
+      handle.upsert({
+        ids: ["test1"],
+        documents: ["This is a test"],
+      }),
+    ).rejects.toThrow(ChromaValueError);
+  });
+
+  test("it should error on query without queryEmbeddings", async () => {
+    const handle = client.collection(collectionId);
+    await expect(
+      handle.query({
+        queryTexts: ["test"],
+      }),
+    ).rejects.toThrow(ChromaValueError);
+    await expect(
+      handle.query({
+        queryTexts: ["test"],
+      }),
+    ).rejects.toThrow(/client\.getCollection\(\)/);
+  });
+
+  test("it should error on search with string knn query", async () => {
+    const handle = client.collection(collectionId);
+    await expect(
+      handle.search(
+        new Search()
+          .rank({ $knn: { query: "a text query" } })
+          .limit(2),
+      ),
+    ).rejects.toThrow(ChromaValueError);
+    await expect(
+      handle.search(
+        new Search()
+          .rank({ $knn: { query: "a text query" } })
+          .limit(2),
+      ),
+    ).rejects.toThrow(/client\.getCollection\(\)/);
+  });
+
+  test("it should error on modify", async () => {
+    const handle = client.collection(collectionId);
+    await expect(
+      handle.modify({ name: "new_name" }),
+    ).rejects.toThrow(ChromaValueError);
+    await expect(
+      handle.modify({ name: "new_name" }),
+    ).rejects.toThrow(/modify\(\)/);
+  });
+
+  test("it should error on fork", async () => {
+    const handle = client.collection(collectionId);
+    await expect(
+      handle.fork({ name: "forked" }),
+    ).rejects.toThrow(ChromaValueError);
+    await expect(
+      handle.fork({ name: "forked" }),
+    ).rejects.toThrow(/fork\(\)/);
+  });
+
+  test("it should allow update with only metadata (no documents or embeddings)", async () => {
+    const handle = client.collection(collectionId);
+    await handle.add({
+      ids: IDS,
+      embeddings: EMBEDDINGS,
+    });
+    await handle.update({
+      ids: ["test1"],
+      metadatas: [{ updated: true }],
+    });
+    const res = await handle.get({ ids: ["test1"] });
+    expect(res.metadatas?.[0]).toEqual({ updated: true });
+  });
+});


### PR DESCRIPTION
Adds a new synchronous `client.collection(id)` method that returns a lightweight collection handle by ID, without making any network requests or resolving embedding functions.

This is useful when you already know the collection ID and want to perform operations with pre-computed embeddings — no need to pay the cost of `getCollection()` which fetches metadata, configuration, schema, and resolves embedding functions from the server.

```ts
// Zero overhead — no network call, no async
const col = client.collection("abc-123");

await col.add({ ids: ["1", "2"], embeddings: [[1, 2, 3], [4, 5, 6]] });
await col.get({ ids: ["1"] });
await col.delete({ ids: ["1"] });
await col.count();
await col.query({ queryEmbeddings: [[1, 2, 3]], nResults: 5 });
```

### Design

A new `CollectionHandle` class extends `CollectionImpl` and overrides methods that depend on an embedding function or schema to throw clear, actionable errors:

| Method | Behavior |
|--------|----------|
| `add`, `upsert` | Works with `embeddings` provided; throws if only `documents` given |
| `update` | Works with `embeddings` or metadata-only updates; throws if `documents` given without `embeddings` |
| `query` | Works with `queryEmbeddings`; throws if only `queryTexts` given |
| `search` | Works with vector `$knn` queries; throws if string `$knn` query detected |
| `modify`, `fork` | Always throws — these require full collection state |
| `count`, `get`, `peek`, `delete`, `getIndexingStatus`, `forkCount` | Work as-is with no restrictions |

Error messages direct users to either provide pre-computed embeddings or use `getCollection()`:

```
This operation requires an embedding function, which is not available on a collection
obtained via client.collection(id). Provide pre-computed embeddings directly, or use
client.getCollection() to get a full collection with embedding support.
```

The return type is `Collection`, so handles are fully interchangeable with collections obtained via `getCollection()`.

### Changes

- **`src/collection.ts`** — Added `CollectionHandle` class extending `CollectionImpl` with guarded overrides
- **`src/chroma-client.ts`** — Added `collection(id: string): Collection` method on `ChromaClient`
- **`src/index.ts`** — Exported `CollectionHandle`
- **`test/collection.handle.test.ts`** — 17 tests covering all supported operations and error cases