### PR TITLE
[BUG] Fix qwen EF return type

### DIFF
--- a/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
+++ b/chromadb/utils/embedding_functions/chroma_cloud_qwen_embedding_function.py
@@ -98,7 +98,7 @@ class ChromaCloudQwenEmbeddingFunction(EmbeddingFunction[Documents]):
 
         embeddings: List[List[float]] = response["embeddings"]
 
-        return np.array(embeddings, dtype=np.float32)
+        return [np.array(embedding, dtype=np.float32) for embedding in embeddings]
 
     def __call__(self, input: Documents) -> Embeddings:
         """


### PR DESCRIPTION
closes https://github.com/chroma-core/chroma/issues/6681

```
qwen_ef = ChromaCloudQwenEmbeddingFunction(
    model=ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B,
    task="retrieval_document",
)
schema = Schema()
schema.create_index(config=VectorIndexConfig(embedding_function=qwen_ef))
col = client.create_collection(name=COLLECTION, schema=schema)

search = (
    Search()
    .rank(Knn(query="this is a test")) # note that query is a string
)
results = col.search(search)
```

When running this code, the user gets the following error:

```
 File "/Users/kylediaz/R/chroma/chroma/chromadb/api/models/CollectionCommon.py", line 963, in _embed_rank_string_queries
    return self._embed_knn_string_queries(rank)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/kylediaz/R/chroma/chroma/chromadb/api/models/CollectionCommon.py", line 839, in _embed_knn_string_queries
    if not embedding or len(embedding) != 1:
           ^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Chroma EFs should return a `List[Embedding]`. This error occurred because the Qwen EF returns a 2d numpy array instead of a python list.

When using Knn + schema + string query, it hits a code path that makes a hard assumption that the embedding is a `List[Embedding]`. Since it's not a list -- it's a numpy array -- it errors.

This is breaking behavior because it changes the output of this EF, but I feel it is necessary. The output of this EF should conform to the type annotation/our EF standard.

https://github.com/chroma-core/chroma/pull/2803 we're using lists of python or numpy vectors, not 2d numpy arrays. the alternative option here to extend our API to allow 2d np arrays to -- this way the qwen EF doesn't have to have a breaking change.