### PR TITLE
[DOC] Update docs branding to "open-source data infrastructure for AI"

### DIFF
--- a/docs/mintlify/AGENTS.md
+++ b/docs/mintlify/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to coding agents when working in this documentation 
 
 ## Structure
 
-This is a Mintlify documentation site for Chroma (the open-source AI application database).
+This is a Mintlify documentation site for Chroma (the open-source data infrastructure for AI).
 
 - `docs.json` - Main configuration file defining navigation, theme, and site settings
 - `docs/` - Core documentation (getting started, collections, querying, embeddings, CLI)

--- a/docs/mintlify/README.md
+++ b/docs/mintlify/README.md
@@ -1,6 +1,6 @@
 # Chroma Documentation
 
-This is the official documentation for [Chroma](https://www.trychroma.com), the open-source AI application database.
+This is the official documentation for [Chroma](https://www.trychroma.com), the open-source data infrastructure for AI.
 
 Documentation is built with [Mintlify](https://mintlify.com) and deployed at [mint-docs.trychroma.com](https://mint-docs.trychroma.com).
 

--- a/docs/mintlify/docs/overview/oss.mdx
+++ b/docs/mintlify/docs/overview/oss.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Open Source"
-description: "Chroma is the open-source AI application database. Contribute to the project or learn about telemetry and privacy."
+description: "Chroma is the open-source data infrastructure for AI. Contribute to the project or learn about telemetry and privacy."
 ---
 import { Callout } from '/snippets/callout.mdx';
 


### PR DESCRIPTION
## Summary
- Updates Chroma's identity phrase from "the open-source AI application database" to "the open-source data infrastructure for AI" across 3 docs files: `AGENTS.md`, `README.md`, and `oss.mdx`
- Aligns docs with the updated branding already live on trychroma.com

## Test plan
- [x] `grep -r "AI application database" docs/mintlify/` returns 0 results
- [x] New phrase appears in AGENTS.md, README.md, oss.mdx, introduction.mdx, and getting-started.mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)