### PR TITLE
fix: increase recursion limit for chroma-segment crate

### DIFF
--- a/rust/segment/src/lib.rs
+++ b/rust/segment/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 pub mod blockfile_metadata;
 pub mod blockfile_record;
 pub mod bloom_filter;


### PR DESCRIPTION
## Summary
Fixes #6687.
**Root cause:** The Rust compiler hits the default recursion limit (128) when computing the layout of blockfile_metadata::from_segment(), causing the build to fail with "queries overflow the depth limit".
**Fix:** Added #![recursion_limit = "256"] to the chroma-segment crate root to allow the compiler to complete the layout computation.
## Changes
- rust/segment/src/lib.rs: Added #![recursion_limit = "256"]
## Testing
- Verified fix addresses reported build failure
- Change is minimal and follows Rust conventions for complex type hierarchies

Made with [Cursor](https://cursor.com)