### PR TITLE
[BUG](wal3): return correct log contention error variants

### DIFF
--- a/rust/wal3/src/interfaces/batch_manager.rs
+++ b/rust/wal3/src/interfaces/batch_manager.rs
@@ -413,7 +413,10 @@ pub async fn upload_parquet(
             }
             Err(StorageError::AlreadyExists { path: _, source: _ })
             | Err(StorageError::Precondition { path: _, source: _ }) => {
-                return Err(Error::LogContentionFailure);
+                // NOTE(rescrv):  It's gotta be a retry here because there was no write; the data
+                // is safe to retry; percolates as an error to the user otherwise when the requests
+                // are retryable.
+                return Err(Error::LogContentionRetry);
             }
             Err(err) => {
                 tracing::error!(
@@ -447,6 +450,43 @@ mod tests {
     use crate::interfaces::s3::manifest_manager::ManifestManager;
     use crate::interfaces::s3::S3FragmentUploader;
     use crate::{FragmentSeqNo, LogWriterOptions, SnapshotOptions, ThrottleOptions};
+
+    #[tokio::test]
+    async fn test_k8s_integration_upload_parquet_returns_retry_on_already_exists() {
+        let storage = s3_client_for_test_with_new_bucket().await;
+        let prefix = "test-upload-parquet-retry";
+        let options = LogWriterOptions::default();
+        let fragment_identifier = FragmentIdentifier::SeqNo(FragmentSeqNo::from_u64(42));
+        let unprefixed_path = crate::unprefixed_fragment_path(fragment_identifier);
+        let path = format!("{prefix}/{unprefixed_path}");
+        // Pre-populate the path so that IfNotExist triggers AlreadyExists.
+        storage
+            .put_bytes(
+                &path,
+                b"pre-existing data".to_vec(),
+                chroma_storage::PutOptions::default(),
+            )
+            .await
+            .expect("pre-population should succeed");
+        let messages = vec![vec![1, 2, 3]];
+        let result = upload_parquet(
+            &options,
+            &storage,
+            prefix,
+            fragment_identifier,
+            Some(LogPosition::from_offset(1)),
+            messages,
+            None,
+            1_000_000,
+        )
+        .await;
+        let err = result.expect_err("upload_parquet should fail with LogContentionRetry");
+        println!("upload_parquet_returns_retry_on_already_exists: err={err:?}");
+        assert!(
+            matches!(err, Error::LogContentionRetry),
+            "expected LogContentionRetry, got {err:?}"
+        );
+    }
 
     #[tokio::test]
     async fn test_k8s_integration_batches() {

--- a/rust/wal3/src/interfaces/s3/manifest_manager.rs
+++ b/rust/wal3/src/interfaces/s3/manifest_manager.rs
@@ -482,7 +482,10 @@ impl ManifestManager {
                     // without an e_tag we cannot do anything.  The log contention backoff protocol
                     // cares for this case, rather than having to error-handle it separately
                     // because it "crashes" the log and reinitializes.
-                    return Err(Error::LogContentionFailure);
+                    //
+                    // Was: LogContentionFailure.  Changed to LogContentionDurable because the
+                    // manifest post-fragment is durable.
+                    return Err(Error::LogContentionDurable);
                 }
                 Err(StorageError::AlreadyExists { path: _, source: _ })
                 | Err(StorageError::Precondition { path: _, source: _ }) => {


### PR DESCRIPTION
## Description of changes

Return semantically correct LogContention error variants so callers
handle contention appropriately:

- batch_manager: return LogContentionRetry instead of
  LogContentionFailure on storage precondition errors during parquet
  upload, because no data was written and the operation is safe to
  retry.
- manifest_manager: return LogContentionDurable instead of
  LogContentionFailure when missing an e_tag after a manifest update,
  because the post-fragment is already durable. (s3 only; no spanner)

Returning LogContentionFailure in these cases caused retryable requests
to surface as errors to the user.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
