### PR TITLE
[BUG](gc): increase queue sizes and add S3 timeouts

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -264,11 +264,13 @@ garbage_collector:
     request_timeout_ms: 60000
   dispatcher_config:
     num_worker_threads: 4
-    dispatcher_queue_size: 100
-    worker_queue_size: 100
+    dispatcher_queue_size: 1000
+    worker_queue_size: 1000
   storage_config:
     s3:
       bucket: "chroma-storage"
+      connect_timeout_ms: 60000
+      request_timeout_ms: 60000 # 1 minute
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -310,11 +310,13 @@ garbage_collector:
     request_timeout_ms: 60000
   dispatcher_config:
     num_worker_threads: 4
-    dispatcher_queue_size: 100
-    worker_queue_size: 100
+    dispatcher_queue_size: 1000
+    worker_queue_size: 1000
   storage_config:
     s3:
       bucket: "chroma-storage"
+      connect_timeout_ms: 60000
+      request_timeout_ms: 60000 # 1 minute
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -311,11 +311,13 @@ garbage_collector:
     request_timeout_ms: 60000
   dispatcher_config:
     num_worker_threads: 4
-    dispatcher_queue_size: 100
-    worker_queue_size: 100
+    dispatcher_queue_size: 1000
+    worker_queue_size: 1000
   storage_config:
     s3:
       bucket: "chroma-storage2"
+      connect_timeout_ms: 60000
+      request_timeout_ms: 60000 # 1 minute
   assignment_policy:
     rendezvous_hashing:
       hasher: Murmur3


### PR DESCRIPTION
## Description of changes

Increase dispatcher and worker queue sizes from 100 to 1000 and add
explicit S3 connect and request timeouts (60s each) to the garbage
collector configuration across all testing configs.

These changes prevent the garbage collector from dropping work under
load due to undersized queues and from timing out on S3 requests
that just happen to take 5+ seconds.  Now they need to take 60+.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
