### PR TITLE
Fix typos and malformed error message

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -187,7 +187,7 @@ def EphemeralClient(
         settings = Settings()
     settings.is_persistent = False
 
-    # Make sure paramaters are the correct types -- users can pass anything.
+    # Make sure parameters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 
@@ -219,7 +219,7 @@ def PersistentClient(
     settings.persist_directory = str(path)
     settings.is_persistent = True
 
-    # Make sure paramaters are the correct types -- users can pass anything.
+    # Make sure parameters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 
@@ -248,7 +248,7 @@ def RustClient(
     settings.is_persistent = path is not None
     settings.persist_directory = path or ""
 
-    # Make sure paramaters are the correct types -- users can pass anything.
+    # Make sure parameters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 
@@ -414,7 +414,7 @@ def CloudClient(
     if settings is None:
         settings = Settings()
 
-    # Make sure paramaters are the correct types -- users can pass anything.
+    # Make sure parameters are the correct types -- users can pass anything.
     tenant = tenant or os.environ.get("CHROMA_TENANT")
     if tenant is not None:
         tenant = str(tenant)
@@ -453,7 +453,7 @@ def Client(
     database: The database to use for this client. Defaults to the default database.
     """
 
-    # Make sure paramaters are the correct types -- users can pass anything.
+    # Make sure parameters are the correct types -- users can pass anything.
     tenant = str(tenant)
     database = str(database)
 

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -790,8 +790,8 @@ class CollectionCommon(Generic[ClientT]):
             return schema_embedding_function(input=input)
         if self._embedding_function is None:
             raise ValueError(
-                "You must provide an embedding function to compute embeddings."
-                "https://docs.trychroma.com/guides/embeddings"
+                "You must provide an embedding function to compute embeddings. "
+                "See https://docs.trychroma.com/guides/embeddings"
             )
         if is_query:
             return self._embedding_function.embed_query(input=input)


### PR DESCRIPTION
## Summary
- Fixed 5 instances of "paramaters" → "parameters" typo in `chromadb/__init__.py`
- Fixed missing space in error message in `chromadb/api/models/CollectionCommon.py` where string concatenation produced `"...embeddings.https://..."` instead of a properly spaced message

## Test plan
- [ ] Verify no other instances of the "paramaters" typo exist
- [ ] Confirm the error message reads correctly when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)