### PR TITLE
[BLD] Only run rust lint if rust changed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ packages = ["chromadb"]
 chromadb = ["*.yml"]
 
 [tool.maturin]
-strip = false
+strip = true
 features = ["pyo3/extension-module"]
 manifest-path = "rust/python_bindings/Cargo.toml"
 python-packages = ["chromadb"]


### PR DESCRIPTION
the Lint CI job runs no matter what. I noticed that Clippy takes a long time to run (5 min!). We can skip it if there are no rust changes, right?

slow run (5m): https://github.com/chroma-core/chroma/actions/runs/23457796162/job/68251565192?pr=6710
with this fix (48s): https://github.com/chroma-core/chroma/actions/runs/23458393732/job/68253632164?pr=6710