### PR TITLE
[ENH]: Support Where filter DSL in collection.delete()

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -29,6 +29,7 @@ from chromadb.execution.expression.plan import Search
 
 if TYPE_CHECKING:
     from chromadb.api import AsyncServerAPI  # noqa: F401
+    from chromadb.execution.expression.operator import Where as WhereExpression
 
 
 class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
@@ -512,7 +513,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
     async def delete(
         self,
         ids: Optional[IDs] = None,
-        where: Optional[Where] = None,
+        where: Optional[Union[Where, "WhereExpression"]] = None,
         where_document: Optional[WhereDocument] = None,
         limit: Optional[int] = None,
     ) -> DeleteResult:
@@ -520,8 +521,11 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
 
         Args:
             ids: The ids of the embeddings to delete
-            where: A Where type dict used to filter the delection by. E.g. `{"$and": [{"color" : "red"}, {"price": {"$gte": 4.20}}]}`. Optional.
-            where_document: A WhereDocument type dict used to filter the deletion by the document content. E.g. `{"$contains": "hello"}`. Optional.
+            where: Metadata filter. Accepts a dict or a Where DSL expression
+                (e.g. ``Key("field") == value``). DSL expressions can include
+                ``Key.DOCUMENT`` conditions, which replace ``where_document``.
+            where_document: Document content filter. Cannot be used together
+                with a Where DSL expression.
             limit: Maximum number of records to delete. Can only be used with where or where_document filters.
 
         Returns:
@@ -530,6 +534,7 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
         Raises:
             ValueError: If you don't provide either ids, where, or where_document
             ValueError: If limit is specified without a where or where_document clause.
+            ValueError: If both a Where DSL expression and where_document are provided.
         """
         delete_request = self._validate_and_prepare_delete_request(
             ids, where, where_document, limit=limit

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -32,6 +32,7 @@ from chromadb.api.functions import Function
 
 if TYPE_CHECKING:
     from chromadb.api.models.AttachedFunction import AttachedFunction
+    from chromadb.execution.expression.operator import Where as WhereExpression
 
 logger = logging.getLogger(__name__)
 
@@ -537,7 +538,7 @@ class Collection(CollectionCommon["ServerAPI"]):
     def delete(
         self,
         ids: Optional[IDs] = None,
-        where: Optional[Where] = None,
+        where: Optional[Union[Where, "WhereExpression"]] = None,
         where_document: Optional[WhereDocument] = None,
         limit: Optional[int] = None,
     ) -> DeleteResult:
@@ -547,8 +548,11 @@ class Collection(CollectionCommon["ServerAPI"]):
 
         Args:
             ids: Record IDs to delete.
-            where: Metadata filter.
-            where_document: Document content filter.
+            where: Metadata filter. Accepts a dict or a Where DSL expression
+                (e.g. ``Key("field") == value``). DSL expressions can include
+                ``Key.DOCUMENT`` conditions, which replace ``where_document``.
+            where_document: Document content filter. Cannot be used together
+                with a Where DSL expression.
             limit: Maximum number of records to delete. Can only be used with where or where_document filters.
 
         Returns:
@@ -557,6 +561,7 @@ class Collection(CollectionCommon["ServerAPI"]):
         Raises:
             ValueError: If no IDs or filters are provided.
             ValueError: If limit is specified without a where or where_document clause.
+            ValueError: If both a Where DSL expression and where_document are provided.
         """
         delete_request = self._validate_and_prepare_delete_request(
             ids, where, where_document, limit=limit

--- a/chromadb/api/models/CollectionCommon.py
+++ b/chromadb/api/models/CollectionCommon.py
@@ -84,6 +84,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from chromadb.api import ServerAPI, AsyncServerAPI
+    from chromadb.execution.expression.operator import Where as WhereExpression
 
 ClientT = TypeVar("ClientT", "ServerAPI", "AsyncServerAPI")
 
@@ -465,10 +466,23 @@ class CollectionCommon(Generic[ClientT]):
     def _validate_and_prepare_delete_request(
         self,
         ids: Optional[IDs],
-        where: Optional[Where],
+        where: Optional[Union[Where, "WhereExpression"]],
         where_document: Optional[WhereDocument],
         limit: Optional[int] = None,
     ) -> DeleteRequest:
+        # Convert DSL Where expressions to dict format
+        from chromadb.execution.expression.operator import (
+            Where as WhereExpressionCls,
+        )
+
+        if isinstance(where, WhereExpressionCls):
+            if where_document is not None:
+                raise ValueError(
+                    "Cannot use both a Where expression and where_document. "
+                    "Use Key.DOCUMENT within the Where expression instead."
+                )
+            where = where.to_dict()
+
         if ids is None and where is None and where_document is None:
             raise ValueError(
                 "At least one of ids, where, or where_document must be provided"

--- a/chromadb/test/test_api.py
+++ b/chromadb/test/test_api.py
@@ -498,6 +498,90 @@ def test_collection_delete_with_invalid_collection_throws(client):
         collection.delete(ids=["id1"])
 
 
+def test_delete_with_dsl_where(client):
+    client.reset()
+    from chromadb.execution.expression.operator import Key
+
+    collection = client.create_collection(
+        "testspace",
+        metadata={"hnsw:space": "l2"},
+    )
+    collection.add(
+        ids=["id1", "id2", "id3"],
+        embeddings=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        metadatas=[
+            {"category": "a"},
+            {"category": "b"},
+            {"category": "a"},
+        ],
+    )
+    assert collection.count() == 3
+
+    result = collection.delete(where=Key("category") == "a")
+    assert result["deleted"] == 2
+    assert collection.count() == 1
+
+    remaining = collection.get()
+    assert remaining["ids"] == ["id2"]
+
+
+def test_delete_with_dsl_where_document(client):
+    client.reset()
+    from chromadb.execution.expression.operator import Key
+
+    collection = client.create_collection("testspace")
+    collection.add(
+        ids=["id1", "id2", "id3"],
+        embeddings=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        documents=["the quick brown fox", "lazy dog sleeps", "quick fox jumps"],
+    )
+    assert collection.count() == 3
+
+    result = collection.delete(where=Key.DOCUMENT.contains("quick"))
+    assert result["deleted"] == 2
+    assert collection.count() == 1
+
+    remaining = collection.get()
+    assert remaining["ids"] == ["id2"]
+
+
+def test_delete_dsl_where_and_where_document_raises(client):
+    client.reset()
+    from chromadb.execution.expression.operator import Key
+
+    collection = client.create_collection("testspace")
+    collection.add(
+        ids=["id1"],
+        embeddings=[[1, 0, 0]],
+        metadatas=[{"category": "a"}],
+        documents=["hello world"],
+    )
+
+    with pytest.raises(ValueError, match="Cannot use both a Where expression and where_document"):
+        collection.delete(
+            where=Key("category") == "a",
+            where_document={"$contains": "hello"},
+        )
+
+
+def test_delete_with_dict_where_still_works(client):
+    client.reset()
+    collection = client.create_collection(
+        "testspace",
+        metadata={"hnsw:space": "l2"},
+    )
+    collection.add(
+        ids=["id1", "id2"],
+        embeddings=[[1, 0, 0], [0, 1, 0]],
+        metadatas=[{"category": "a"}, {"category": "b"}],
+    )
+    assert collection.count() == 2
+
+    result = collection.delete(where={"category": "a"})
+    assert result["deleted"] == 1
+    assert collection.count() == 1
+
+
 def test_count(client):
     client.reset()
     collection = client.create_collection("testspace")


### PR DESCRIPTION
## Summary

`collection.delete()` now accepts Where DSL expressions (e.g. `Key("category") == "a"`) in addition to dict-style filters. This brings `delete()` in line with the Search API, which already supports both formats.

Fixes #6709

## Changes

- **CollectionCommon.py**: `_validate_and_prepare_delete_request()` detects DSL `Where` objects via `isinstance`, converts to dict with `.to_dict()`, then flows through existing validation. Raises `ValueError` if both a DSL `where` and `where_document` are provided (since DSL can include `Key.DOCUMENT` conditions).
- **Collection.py / AsyncCollection.py**: Updated `delete()` type hints and docstrings to accept `Union[Where, WhereExpression]`.
- **test_api.py**: Four new tests covering DSL metadata filter, DSL `#document` filter, DSL+where_document rejection, and dict-style regression.

## Design decisions

- **No backend changes needed.** `validate_where()` already handles `#document` keys in dict where clauses (line 1237 of `api/types.py`). The conversion from DSL to dict happens in the SDK layer before any API call.
- **Runtime import** of `WhereExpressionCls` inside `_validate_and_prepare_delete_request()` to avoid circular import risk, with `TYPE_CHECKING` import for static analysis.
- **Dict where + where_document is still allowed** (no behavior change for existing users). Only DSL where + where_document is rejected, since the DSL unifies both concepts via `Key.DOCUMENT`.

## Testing

- Unit-tested the conversion pipeline: DSL `to_dict()`, `isinstance` checks, `validate_where()` with `#document` dicts, and the rejection logic.
- Integration tests added to `test_api.py` (will run in CI with the full fixture infrastructure).