### PR TITLE
[BUG](sysdb): include inner errors in FlushCompactionError display

### DIFF
--- a/rust/sysdb/src/sysdb.rs
+++ b/rust/sysdb/src/sysdb.rs
@@ -2549,21 +2549,21 @@ impl ChromaError for GetLastCompactionTimeError {
 
 #[derive(Error, Debug)]
 pub enum FlushCompactionError {
-    #[error("Failed to flush compaction")]
+    #[error("Failed to flush compaction: {0}")]
     FailedToFlushCompaction(#[from] tonic::Status),
-    #[error("Failed to convert segment flush info")]
+    #[error("Failed to convert segment flush info: {0}")]
     SegmentFlushInfoConversionError(#[from] SegmentFlushInfoConversionError),
-    #[error("Failed to convert collection flush info")]
+    #[error("Failed to convert collection flush info: {0}")]
     CollectionFlushInfoConversionError(#[from] CollectionFlushInfoConversionError),
-    #[error("Failed to convert flush compaction response")]
+    #[error("Failed to convert flush compaction response: {0}")]
     FlushCompactionResponseConversionError(#[from] FlushCompactionResponseConversionError),
     #[error("Collection not found in sysdb")]
     CollectionNotFound,
     #[error("Segment not found in sysdb")]
     SegmentNotFound,
-    #[error("Failed to serialize schema")]
+    #[error("Failed to serialize schema: {0}")]
     Schema(#[from] SchemaError),
-    #[error("Failed to get client for database")]
+    #[error("Failed to get client for database: {0}")]
     ClientResolutionError(#[from] ClientResolutionError),
 }
 


### PR DESCRIPTION
## Description of changes

Add {0} format specifiers to #[error(...)] attributes on
FlushCompactionError variants that wrap inner error types. Previously
these variants discarded the inner error message when displayed,
making debugging difficult. Now the root cause propagates through
the error chain.

## Test plan

CI.

## Migration plan

N/A

## Observability plan

I saw a failure in CI that this would help debug.  Watch CI.

## Documentation Changes

N/A

Co-authored-by: AI
