### PR TITLE
[ENH] Improve timeout debug info for version tracking

### DIFF
--- a/.github/workflows/_python-tests.yml
+++ b/.github/workflows/_python-tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
         test-glob:
-          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
+          - "chromadb/test --ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore-glob 'chromadb/test/distributed/*'"
           - "chromadb/test/property --ignore-glob chromadb/test/property/test_cross_version_persist.py"
           - "chromadb/test/property/test_cross_version_persist.py"
         include:
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python: ${{ fromJson(inputs.python_versions) }}
         test-glob:
-          - "--ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'"
+          - "chromadb/test --ignore-glob 'chromadb/test/property/*' --ignore-glob 'chromadb/test/stress/*' --ignore='chromadb/test/test_cli.py' --ignore-glob 'chromadb/test/distributed/*'"
           - "chromadb/test/property/test_add.py"
           - "chromadb/test/property/test_collections.py"
           - "chromadb/test/property/test_collections_with_database_tenant.py"

--- a/chromadb/test/utils/test_wait_for_version_increase.py
+++ b/chromadb/test/utils/test_wait_for_version_increase.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+
+import chromadb.test.utils.wait_for_version_increase as wait_module
+
+
+class _FakeClient:
+    def __init__(self, collection_id: str = "test-collection-id") -> None:
+        self._collection = SimpleNamespace(id=collection_id)
+
+    def get_collection(self, collection_name: str) -> SimpleNamespace:
+        return self._collection
+
+
+def test_wait_for_version_increase_logs_target_version(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = _FakeClient()
+    versions = iter([5, 5, 6])
+    times = iter([100.0, 101.0, 102.0])
+
+    monkeypatch.setattr(wait_module, "COMPACTION_SLEEP", 10)
+    monkeypatch.setattr(wait_module, "get_collection_version", lambda *_: next(versions))
+    monkeypatch.setattr(wait_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(wait_module.time, "time", lambda: next(times))
+
+    new_version = wait_module.wait_for_version_increase(client, "test-collection", 5)
+
+    assert new_version == 6
+    assert (
+        "[wait_for_version_increase] collection=test-collection "
+        "waiting for version >= 6 (current=5, timeout=10s)"
+    ) in capsys.readouterr().out
+
+
+def test_wait_for_version_increase_timeout_mentions_waited_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient()
+    versions = iter([8, 8])
+    times = iter([200.0, 212.0])
+
+    monkeypatch.setattr(wait_module, "COMPACTION_SLEEP", 10)
+    monkeypatch.setattr(wait_module, "get_collection_version", lambda *_: next(versions))
+    monkeypatch.setattr(wait_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(wait_module.time, "time", lambda: next(times))
+
+    with pytest.raises(
+        TimeoutError,
+        match="waited for version >= 9, last seen version 8",
+    ):
+        wait_module.wait_for_version_increase(client, "test-collection", 8)

--- a/chromadb/test/utils/wait_for_version_increase.py
+++ b/chromadb/test/utils/wait_for_version_increase.py
@@ -17,14 +17,26 @@ def wait_for_version_increase(
     additional_time: int = 0,
 ) -> int:
     timeout = COMPACTION_SLEEP
-    initial_time = time.time() + additional_time
+    deadline = time.time() + timeout + additional_time
+    target_version = initial_version + 1
 
     curr_version = get_collection_version(client, collection_name)
+    if curr_version == initial_version:
+        print(
+            "[wait_for_version_increase] "
+            f"collection={collection_name} "
+            f"waiting for version >= {target_version} "
+            f"(current={curr_version}, timeout={timeout + additional_time}s)"
+        )
     while curr_version == initial_version:
         time.sleep(TIMEOUT_INTERVAL)
-        if time.time() - initial_time > timeout:
+        if time.time() > deadline:
             collection_id = client.get_collection(collection_name).id
-            raise TimeoutError(f"Model was not updated in time for {collection_id}")
+            raise TimeoutError(
+                "Model was not updated in time for "
+                f"{collection_id}; waited for version >= {target_version}, "
+                f"last seen version {curr_version}"
+            )
         curr_version = get_collection_version(client, collection_name)
 
     return curr_version

--- a/rust/segment/src/distributed_spann.rs
+++ b/rust/segment/src/distributed_spann.rs
@@ -33,6 +33,7 @@ use thiserror::Error;
 pub struct SpannSegmentWriter {
     index: SpannIndexWriter,
     pub id: SegmentUuid,
+    collection_version: i32,
 }
 
 impl Debug for SpannSegmentWriter {
@@ -222,6 +223,7 @@ impl SpannSegmentWriter {
         Ok(SpannSegmentWriter {
             index: index_writer,
             id: segment.id,
+            collection_version: collection.version,
         })
     }
 
@@ -335,6 +337,7 @@ impl SpannSegmentWriter {
             Err(e) => Err(Box::new(e)),
             Ok(index_flusher) => Ok(SpannSegmentFlusher {
                 id: self.id,
+                collection_version: self.collection_version,
                 index_flusher,
             }),
         }
@@ -347,6 +350,7 @@ impl SpannSegmentWriter {
 
 pub struct SpannSegmentFlusher {
     pub id: SegmentUuid,
+    collection_version: i32,
     index_flusher: SpannIndexFlusher,
 }
 
@@ -358,7 +362,11 @@ impl Debug for SpannSegmentFlusher {
 
 impl SpannSegmentFlusher {
     pub async fn flush(self) -> Result<HashMap<String, Vec<String>>, Box<dyn ChromaError>> {
-        tracing::info!("Flushing spann segment flusher {}", self.id);
+        tracing::info!(
+            segment_id = %self.id,
+            collection_version = self.collection_version,
+            "Flushing spann segment flusher"
+        );
         let index_flusher_res = Box::pin(self.index_flusher.flush()).await.map_err(|e| {
             tracing::error!("Error flushing spann index segment {}: {:?}", self.id, e);
             SpannSegmentWriterError::SpannSegmentWriterFlushError(e)
@@ -396,8 +404,10 @@ impl SpannSegmentFlusher {
                     )],
                 );
                 tracing::info!(
-                    "Flushed file paths for spann segment flusher {:?}",
-                    index_id_map
+                    segment_id = %self.id,
+                    collection_version = self.collection_version,
+                    flushed_files = ?index_id_map,
+                    "Flushed spann segment flusher"
                 );
                 Ok(index_id_map)
             }
@@ -688,6 +698,7 @@ mod test {
             tenant: "test".to_string(),
             database: "test".to_string(),
             database_id: db_id,
+            version: 7,
             ..Default::default()
         };
         collection.schema = Some(
@@ -751,6 +762,7 @@ mod test {
             .commit()
             .await
             .expect("Error committing spann writer");
+        assert_eq!(flusher.collection_version, collection.version);
         spann_segment.file_path = flusher.flush().await.expect("Error flushing spann writer");
         assert_eq!(spann_segment.file_path.len(), 4);
         assert!(spann_segment.file_path.contains_key("hnsw_path"));


### PR DESCRIPTION
## Description of changes

Add diagnostic context to version-increase waits and segment flushes:

- wait_for_version_increase: log target version, current version, and
  timeout on entry; include waited-for and last-seen versions in
  TimeoutError messages
- SpannSegmentWriter/Flusher: thread collection_version through writer
  and flusher so flush log lines include structured segment_id and
  collection_version fields
- Add unit tests for wait_for_version_increase logging and timeout
  messages
- Fix CI test-glob entries to include explicit chromadb/test path

Co-authored-by: AI

## Test plan

CI

## Migration plan

N/A

## Observability plan

Watch CI for failures and debug from there.

## Documentation Changes

N/A
