### PR TITLE
[BUG] Update deprecated Google Gemini model defaults in JS SDK

### DIFF
--- a/clients/js/packages/chromadb-core/src/embeddings/GoogleGeminiEmbeddingFunction.ts
+++ b/clients/js/packages/chromadb-core/src/embeddings/GoogleGeminiEmbeddingFunction.ts
@@ -22,7 +22,7 @@ export class GoogleGenerativeAiEmbeddingFunction implements IEmbeddingFunction {
 
   constructor({
     googleApiKey,
-    model = "embedding-001",
+    model = "gemini-embedding-001",
     taskType = "RETRIEVAL_DOCUMENT",
     apiKeyEnvVar = "GOOGLE_API_KEY",
   }: {

--- a/clients/js/packages/chromadb-core/test/embeddings/ef_schema.test.ts
+++ b/clients/js/packages/chromadb-core/test/embeddings/ef_schema.test.ts
@@ -118,13 +118,13 @@ const EMBEDDING_FUNCTION_CONFIGS: Record<string, any> = {
   google_generative_ai: {
     args: {
       googleApiKey: "dummy_key",
-      model: "embedding-001",
+      model: "gemini-embedding-001",
       taskType: "RETRIEVAL_DOCUMENT",
       apiKeyEnvVar: "GOOGLE_API_KEY",
     },
     config: {
       api_key_env_var: "GOOGLE_API_KEY",
-      model_name: "embedding-001",
+      model_name: "gemini-embedding-001",
     },
   },
   huggingface_server: {

--- a/clients/new-js/packages/ai-embeddings/google-gemini/README.md
+++ b/clients/new-js/packages/ai-embeddings/google-gemini/README.md
@@ -17,7 +17,7 @@ import { GoogleGeminiEmbeddingFunction } from '@chroma-core/google-gemini';
 // Initialize the embedder
 const embedder = new GoogleGeminiEmbeddingFunction({
   apiKey: 'your-api-key', // Or set GEMINI_API_KEY env var
-  modelName: 'text-embedding-004', // Optional, defaults to latest model
+  modelName: 'gemini-embedding-001', // Optional, defaults to latest model
   taskType: 'RETRIEVAL_DOCUMENT', // Optional
 });
 
@@ -64,7 +64,7 @@ Get your API key from the [Google AI Studio](https://aistudio.google.com/app/api
 
 ## Supported Models
 
-- `text-embedding-004` (latest)
-- `embedding-001`
+- `gemini-embedding-001` (latest)
+- `text-embedding-004` (deprecated)
 
 Check the [Google AI documentation](https://ai.google.dev/models/gemini) for the most up-to-date list of available embedding models.

--- a/clients/new-js/packages/ai-embeddings/google-gemini/src/index.test.ts
+++ b/clients/new-js/packages/ai-embeddings/google-gemini/src/index.test.ts
@@ -12,10 +12,10 @@ describe("GoogleGeminiEmbeddingFunction", () => {
   } else {
     it(defaultParametersTest, () => {
       const embedder = new GoogleGeminiEmbeddingFunction();
-      expect(embedder.name).toBe("google-generative-ai");
+      expect(embedder.name).toBe("google-gemini");
 
       const config = embedder.getConfig();
-      expect(config.model_name).toBe("text-embedding-004");
+      expect(config.model_name).toBe("gemini-embedding-001");
       expect(config.api_key_env_var).toBe("GEMINI_API_KEY");
       expect(config.task_type).toBeUndefined();
     });


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Update the default embedding model name from deprecated models to `gemini-embedding-001` in the JS SDK packages, aligning them with the Python SDK (which was already updated).
  - Fix incorrect test expectations in the new JS SDK google-gemini package (`name` field and default `model_name`).
  - Update the google-gemini README to reference the current model instead of deprecated ones.

### Details

Google deprecated `embedding-001` and `text-embedding-004` in favor of `gemini-embedding-001` ([deprecation notice](https://ai.google.dev/gemini-api/docs/deprecations#embedding-models)). The Python SDK was already updated, but the JS SDK still referenced the old models in several places:

| File | Before | After |
|------|--------|-------|
| `clients/js/packages/chromadb-core/src/embeddings/GoogleGeminiEmbeddingFunction.ts` | `embedding-001` | `gemini-embedding-001` |
| `clients/js/packages/chromadb-core/test/embeddings/ef_schema.test.ts` | `embedding-001` | `gemini-embedding-001` |
| `clients/new-js/packages/ai-embeddings/google-gemini/src/index.test.ts` | Expected name `google-generative-ai`, model `text-embedding-004` | Expected name `google-gemini`, model `gemini-embedding-001` |
| `clients/new-js/packages/ai-embeddings/google-gemini/README.md` | `text-embedding-004` as latest | `gemini-embedding-001` as latest |

The test file `index.test.ts` in the new JS SDK also had two incorrect expectations:
1. `embedder.name` was expected to be `"google-generative-ai"` but the actual source code defines `NAME = "google-gemini"`
2. `config.model_name` was expected to be `"text-embedding-004"` but the actual default is `"gemini-embedding-001"`

Fixes #6012

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust
- The test expectations have been corrected to match actual source code behavior
- No runtime behavior changes for users who explicitly specify a model name

## Migration plan

Users relying on the old default model name `embedding-001` in the old JS SDK (`chromadb-core` `GoogleGenerativeAiEmbeddingFunction`) will now default to `gemini-embedding-001`. Since `embedding-001` is deprecated by Google, this is a necessary update. Users who explicitly pass a model name are unaffected.

## Observability plan

N/A - no new instrumentation needed.

## Documentation Changes

Updated the `@chroma-core/google-gemini` README to reflect the correct current model name (`gemini-embedding-001`) and mark `text-embedding-004` as deprecated.