### PR TITLE
[BLD] Disable test-bench on each PR

### DIFF
--- a/.github/workflows/_rust-tests.yml
+++ b/.github/workflows/_rust-tests.yml
@@ -2,6 +2,14 @@ name: Rust tests
 
 on:
   workflow_call:
+    inputs:
+      # PR workflow passes false to save runner time; release keeps benches enabled.
+      # If benchmarks prove useful for regression detection, add a scheduled workflow
+      # (e.g. nightly) that calls this reusable workflow with run_rust_benchmarks: true.
+      run_rust_benchmarks:
+        description: Whether to run the cargo bench matrix jobs
+        type: boolean
+        default: true
 
 jobs:
   test:
@@ -108,6 +116,7 @@ jobs:
         with:
           artifact-name: "rust-integration-test-${{ matrix.nextest_profile }}-${{ matrix.partition }}"
   test-benches:
+    if: inputs.run_rust_benchmarks
     strategy:
       matrix:
         platform: [blacksmith-16vcpu-ubuntu-2404]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -179,6 +179,9 @@ jobs:
     if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
+    with:
+      # Benches are off on PRs; see _rust-tests.yml for a note on running them on a schedule.
+      run_rust_benchmarks: false
 
   rust-feature-tests:
     name: Rust feature tests


### PR DESCRIPTION
# Description of changes

Skip Rust test-benches on PRs via run_rust_benchmarks: false in pr.yml; reusable workflow defaults to true so release/other callers still run benches. Comments mention optional nightly if we want bench signal without PR cost.

# Test plan

PR: Rust workflow runs, test-benches skipped. Release (or any caller without the flag): benches still run.