### PR TITLE
[BLD] Build images before matrix runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -152,10 +152,33 @@ jobs:
           header: helm-chart-version-info
           delete: true
 
+  # Build Docker images once and warm the Blacksmith sticky disk cache.
+  # Downstream jobs that need Docker images (test-integration,
+  # test-mcmr-integration, test-cluster-rust-frontend) will clone this
+  # snapshot and get all BuildKit layers cached — avoiding ~6 min of
+  # redundant cargo compilation per job (~20 jobs × 6 min → 1 × 6 min).
+  build-images:
+    name: Build Docker images (warm sticky disk)
+    needs: change-detection
+    if: |
+      contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust') ||
+      contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Blacksmith builder
+        uses: useblacksmith/setup-docker-builder@v1
+      - name: Build all CI images (warms BuildKit cache on sticky disk)
+        run: docker buildx bake -f .github/actions/tilt-setup-prebuild/docker-bake.hcl
+
   python-tests:
     name: Python tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
+    needs: [change-detection, build-images]
+    if: |
+      always() &&
+      !failure() && !cancelled() &&
+      contains(fromJson(needs.change-detection.outputs.tests-to-run), 'python')
     uses: ./.github/workflows/_python-tests.yml
     secrets: inherit
     with:
@@ -175,8 +198,11 @@ jobs:
 
   rust-tests:
     name: Rust tests
-    needs: change-detection
-    if: contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
+    needs: [change-detection, build-images]
+    if: |
+      always() &&
+      !failure() && !cancelled() &&
+      contains(fromJson(needs.change-detection.outputs.tests-to-run), 'rust')
     uses: ./.github/workflows/_rust-tests.yml
     secrets: inherit
     with:
@@ -248,6 +274,7 @@ jobs:
   all-required-pr-checks-passed:
     if: always()
     needs:
+      - build-images
       - python-tests
       - python-vulnerability-scan
       - javascript-client-tests
@@ -264,12 +291,13 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-spanner-migrations,check-helm-version-bump,delete-helm-comment
+          allowed-skips: build-images,python-tests,python-vulnerability-scan,javascript-client-tests,rust-tests,rust-feature-tests,go-tests,check-spanner-migrations,check-helm-version-bump,delete-helm-comment
 
   notify-slack-on-failure:
     name: Notify Slack on Test Failure
     if: github.ref == 'refs/heads/main' && failure()
     needs:
+      - build-images
       - python-tests
       - python-vulnerability-scan
       - javascript-client-tests


### PR DESCRIPTION
## Description of changes

Adds a `build-images` job to `pr.yml` that runs `docker buildx bake`
once before `rust-tests` and `python-tests`. The Blacksmith sticky
disk commits the warm BuildKit cache so all ~20 downstream jobs clone
it instead of each independently compiling Rust (~6 min × 20 → 6 min
× 1).

- Improvements & Bug fixes
  - ~114 CPU-minutes saved per PR from eliminated redundant cargo
    builds
  - No change to wall-clock time for any individual test job
- New functionality
  - `build-images` job gated on rust/python change detection
  - `rust-tests` and `python-tests` use `needs: build-images` with
    `!failure() && !cancelled()` so they still run if the job is
    skipped

## Test plan

- [ ] Open a PR touching `rust/` and confirm `build-images` runs
      before `rust-tests` and `python-tests`
- [ ] Check downstream bake logs show all layers cached (CACHED in
      every step)
- [ ] Open a go-only PR and confirm `build-images` is skipped and
      `go-tests` still runs unblocked
- [ ] Verify `all-required-pr-checks-passed` still passes in all
      three cases (rust, python, go-only)

## Observability plan

Compare Blacksmith normalized minutes for `rust-tests` and
`python-tests` before/after over 1 week. Expect ~95% reduction in
Docker build time across matrix jobs.
