### PR TITLE
[BUG](worker): set suggested compaction threshold

### DIFF
--- a/rust/worker/chroma_config.yaml
+++ b/rust/worker/chroma_config.yaml
@@ -216,6 +216,7 @@ compaction_service:
 log_service:
   num_records_before_backpressure: 100000
   reinsert_threshold: 0
+  suggested_compaction_threshold: 10
   opentelemetry:
     service_name: "rust-log-service"
     endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -215,6 +215,7 @@ compaction_service:
 log_service:
   num_records_before_backpressure: 100000
   reinsert_threshold: 0
+  suggested_compaction_threshold: 10
   opentelemetry:
     service_name: "rust-log-service"
     endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -215,6 +215,7 @@ compaction_service:
 log_service:
   num_records_before_backpressure: 100000
   reinsert_threshold: 0
+  suggested_compaction_threshold: 10
   opentelemetry:
     service_name: "rust-log-service"
     endpoint: "http://otel-collector.chroma.svc.cluster.local:4317"


### PR DESCRIPTION
## Description of changes

Add suggested_compaction_threshold: 10 to the worker
log_service config in the standard, mcmr, and mcmr2 YAMLs
so all config variants carry the same explicit setting.

This is to prevent timing out when waiting for a version
increase in tests that wrote fewer than 250 log records
between compactions.

## Test plan

Watch CI.

## Migration plan

N/A

## Observability plan

Watch CI.

## Documentation Changes

N/A

Co-authored-by: AI
