### PR TITLE
fix(telemetry): replace `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`

### DIFF
--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import os
 from functools import wraps
 from enum import Enum
@@ -125,7 +125,7 @@ def trace_method(
     """A decorator that traces a method."""
 
     def decorator(f: T) -> T:
-        if asyncio.iscoroutinefunction(f):
+        if inspect.iscoroutinefunction(f):
 
             @wraps(f)
             async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

Fixes #6729.

`asyncio.iscoroutinefunction()` was deprecated in Python 3.12 ([docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.iscoroutinefunction)) and is scheduled for removal in Python 3.16.

On Python 3.14+, every ChromaDB initialization emits a `DeprecationWarning`:

```
chromadb/telemetry/opentelemetry/__init__.py:128: DeprecationWarning:
asyncio.iscoroutinefunction is deprecated and slated for removal in Python 3.16;
use inspect.iscoroutinefunction() instead
```

## Fix

Replace `asyncio.iscoroutinefunction()` with `inspect.iscoroutinefunction()` which is the stdlib-recommended alternative.

## Testing

- One-line change in `chromadb/telemetry/opentelemetry/__init__.py`
- Verified the file still passes Python import checks