### PR TITLE
[ENH](sysdb): Skip get_collections req logging

### DIFF
--- a/rust/rust-sysdb/src/spanner.rs
+++ b/rust/rust-sysdb/src/spanner.rs
@@ -810,7 +810,20 @@ impl SpannerBackend {
     /// - `limit` and `offset`: Pagination
     ///
     /// Returns a list of matching collections.
-    #[instrument(skip(self, req), level = "info")]
+    #[instrument(
+        skip(self, req),
+        fields(
+            tenant_id = ?req.filter.tenant_id,
+            database_name = ?req.filter.database_name,
+            topology_name = ?req.filter.topology_name,
+            collection_name = ?req.filter.name,
+            ids_count = ?req.filter.ids.as_ref().map(Vec::len),
+            include_soft_deleted = req.filter.include_soft_deleted,
+            limit = ?req.filter.limit,
+            offset = ?req.filter.offset
+        ),
+        level = "info"
+    )]
     pub async fn get_collections(
         &self,
         req: GetCollectionsRequest,


### PR DESCRIPTION
## Description of changes

Exclude the request payload from the tracing span for
get_collections.  Remove spammy log line.

This keeps request details out of logs, which bloats space.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Improve it.

## Documentation Changes

N/A

Co-authored-by: AI
