### PR TITLE
[BUG](ci): Capture chroma2 logs

### DIFF
--- a/bin/get-logs.sh
+++ b/bin/get-logs.sh
@@ -1,41 +1,55 @@
 #!/usr/bin/env bash
 set -e
 
-# Hardcoded namespace
-NAMESPACE=chroma
-echo "Namespace: $NAMESPACE"
-
 # Check if the test-name and version-number are provided as arguments
 if [ -z "$1" ]; then
   echo "Usage: $0 <output-file-path>"
   exit 1  # Exit with code 1 indicating an error
 fi
 
-OUTPUT_FILE_PATH=$(readlink -m $1)
+OUTPUT_FILE_PATH=$(readlink -m "$1")
 TEMP_DIR=$(mktemp -d)
 
 mkdir "$TEMP_DIR/logs"
 mkdir "$TEMP_DIR/traces"
 
+fetch_namespace() {
+  local namespace="$1"
+  local pods
+
+  echo "Namespace: $namespace"
+
+  # Get the list of all pods in the namespace
+  pods=$(kubectl get pods -n "$namespace" -o jsonpath='{.items[*].metadata.name}')
+  echo "Got all the pods in $namespace: $pods"
+
+  # Iterate over each pod and get the logs
+  for pod in $pods; do
+    local output_name
+
+    echo "Getting logs for pod: $pod"
+
+    if [ "$namespace" = "chroma" ]; then
+      output_name="${pod}.txt"
+    else
+      output_name="${namespace}_${pod}.txt"
+    fi
+
+    kubectl logs "$pod" -n "$namespace" --since=0s > "${TEMP_DIR}/logs/${output_name}" || true
+  done
+}
+
 # Create a description of the k8s cluster
 kubectl describe -A all > "${TEMP_DIR}/logs/describe-all.txt" || true
 
-# Get the list of all pods in the namespace
-PODS=$(kubectl get pods -n $NAMESPACE -o jsonpath='{.items[*].metadata.name}')
-echo "Got all the pods: $PODS"
-
-# Iterate over each pod and get the logs
-for POD in $PODS; do
-  echo "Getting logs for pod: $POD"
-  # Save the logs to a file named after the pod and test name
-  kubectl logs $POD -n $NAMESPACE --since=0s > "${TEMP_DIR}/logs/${POD}.txt" || true
-done
+fetch_namespace chroma
+fetch_namespace chroma2
 
 # Get traces from Jaeger for all services
 curl "http://localhost:16686/api/services" | jq -r '.data[]' | while read -r service; do curl "http://localhost:16686/api/traces?limit=100&lookback=1h&maxDuration&minDuration&service=$service" > "$TEMP_DIR/traces/$service.json" || true; done
 
 # Zip all log files
-cd $TEMP_DIR &&zip -r "$OUTPUT_FILE_PATH" . && cd -
+cd "$TEMP_DIR" && zip -r "$OUTPUT_FILE_PATH" . && cd -
 
 # Print confirmation message
 echo "Logs have been zipped to $OUTPUT_FILE_PATH"

--- a/bin/get-logs.sh
+++ b/bin/get-logs.sh
@@ -20,7 +20,7 @@ fetch_namespace() {
   echo "Namespace: $namespace"
 
   # Get the list of all pods in the namespace
-  pods=$(kubectl get pods -n "$namespace" -o jsonpath='{.items[*].metadata.name}')
+  pods=$(kubectl get pods -n "$namespace" -o jsonpath='{.items[*].metadata.name}' || true)
   echo "Got all the pods in $namespace: $pods"
 
   # Iterate over each pod and get the logs


### PR DESCRIPTION
## Description of changes

Fetch pod logs from both the chroma and chroma2 namespaces so the
archive includes the full tilt deployment.

Also factor namespace collection into a helper and quote shell
expansions to avoid path and argument splitting issues.

Bash is fun.

## Test plan

CI.  It's always CI.

## Migration plan

N/A; backwards-compatible output.

## Observability plan

Watch CI for this PR to make sure it uploads artifacts.

## Documentation Changes

N/A

Co-authored-by: AI
