### PR TITLE
[BUG] Quantize as a string field in schema

### DIFF
--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -164,7 +164,7 @@ type SpannIndexConfig struct {
 	EfSearch              *int     `json:"ef_search,omitempty"`
 	MaxNeighbors          *int     `json:"max_neighbors,omitempty"`
 	CenterDriftThreshold  *float64 `json:"center_drift_threshold,omitempty"`
-	Quantize              bool     `json:"quantize,omitempty"`
+	Quantize              string   `json:"quantize,omitempty"`
 }
 
 type VectorIndexType struct {


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - `quantize` is a string field on spann config, not bool
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
