### PR TITLE
[ENH] Re-export read level for rust client

### DIFF
--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -182,7 +182,7 @@ impl ChromaCollection {
     /// # Example
     ///
     /// ```
-    /// use chroma_types::plan::ReadLevel;
+    /// use chroma::types::ReadLevel;
     ///
     /// # async fn example(collection: &chroma::ChromaCollection) -> Result<(), Box<dyn std::error::Error>> {
     /// // Skip WAL for faster count (may miss recent writes)
@@ -576,7 +576,7 @@ impl ChromaCollection {
     /// # Example
     ///
     /// ```
-    /// use chroma_types::plan::{SearchPayload, ReadLevel};
+    /// use chroma::types::{SearchPayload, ReadLevel};
     ///
     /// # async fn example(collection: &chroma::ChromaCollection) -> Result<(), Box<dyn std::error::Error>> {
     /// let search = SearchPayload::default().limit(Some(10), 0);

--- a/rust/chroma/src/types.rs
+++ b/rust/chroma/src/types.rs
@@ -13,6 +13,7 @@ pub use chroma_types::operator::QueryVector;
 pub use chroma_types::operator::Rank;
 pub use chroma_types::operator::RankExpr;
 pub use chroma_types::operator::Select;
+pub use chroma_types::plan::ReadLevel;
 pub use chroma_types::plan::SearchPayload;
 pub use chroma_types::regex::hir::ChromaHir;
 pub use chroma_types::regex::ChromaRegex;


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - Re-export read level for rust client
- New functionality
  - N/A

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
