### PR TITLE
[CHORE](deps): pin usearch to 2.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7069,7 +7069,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10354,9 +10354,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usearch"
-version = "2.24.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09657b7d3d88992d7475be6f345d3cb3b388d13c152dbd4742e0b955e3a2b632"
+checksum = "0a03c05af8d678ec19f014c734ab667c20ea54128b4f9a1472cb470246a9b341"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ fastbloom = { version = "0.17.0", features = ["serde"] }
 validator = { version = "0.19", features = ["derive"] }
 rust-embed = { version = "8.5.0", features = ["include-exclude", "debug-embed"] }
 hnswlib = { version = "0.8.2", git = "https://github.com/chroma-core/hnswlib.git", branch = "master" }
-usearch = "2.23"
+usearch = "=2.23"
 faer = { version = "0.24.0", default-features = false, features = ["std", "rand"] }
 reqwest = { version = "0.13", features = ["rustls", "http2", "query"], default-features = false }
 random-port = "0.1.1"


### PR DESCRIPTION
## Description of changes

Pin usearch to an exact 2.23 release instead of the 2.23
semver range so dependency resolution does not float to 2.24.

Refresh Cargo.lock to match the exact version selection.

## Test plan

CI

## Migration plan

N/A

## Observability plan

CI

## Documentation Changes

N/A

Co-authored-by: AI
