### PR TITLE
[BUG](tracing): install rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,7 @@ dependencies = [
  "opentelemetry 0.27.1",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ usearch = "=2.23"
 faer = { version = "0.24.0", default-features = false, features = ["std", "rand"] }
 reqwest = { version = "0.13", features = ["rustls", "http2", "query"], default-features = false }
 random-port = "0.1.1"
+rustls = { version = "0.23.37", features = ["aws-lc-rs"] }
 ndarray = { version = "0.16.1", features = ["approx"] }
 humantime = { version = "2.2.0" }
 petgraph = { version = "0.8.1" }

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -25,6 +25,7 @@ axum = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 tokio = { workspace = true }
+rustls = { workspace = true }
 
 chroma-system = { workspace = true }
 

--- a/rust/tracing/src/init_tracer.rs
+++ b/rust/tracing/src/init_tracer.rs
@@ -17,6 +17,12 @@ use std::sync::OnceLock;
 
 static TOKIO_METRICS_INSTRUMENTS: OnceLock<TokioMetricsInstruments> = OnceLock::new();
 
+fn install_rustls_crypto_provider() {
+    // Multiple dependencies enable different rustls backends in this workspace.
+    // Install one explicitly before any TLS client config is built.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
 #[allow(dead_code)]
 struct TokioMetricsInstruments {
     active_tasks_gauge: opentelemetry::metrics::ObservableGauge<u64>,
@@ -124,6 +130,8 @@ pub fn init_otel_layer(
     service_name: &String,
     otel_endpoint: &String,
 ) -> Box<dyn Layer<Registry> + Send + Sync> {
+    install_rustls_crypto_provider();
+
     tracing::info!(
         "Registering jaeger subscriber for {} at endpoint {}",
         service_name,


### PR DESCRIPTION
## Description of changes

Install the aws-lc-rs provider before building the OTLP TLS
config.

This makes the rustls backend choice explicit in the tracing
crate and adds the workspace dependency needed to access it.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
