### PR TITLE
fix: replace deprecated asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/chromadb/telemetry/opentelemetry/__init__.py
+++ b/chromadb/telemetry/opentelemetry/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import asyncio
 import os
 from functools import wraps
@@ -125,7 +126,7 @@ def trace_method(
     """A decorator that traces a method."""
 
     def decorator(f: T) -> T:
-        if asyncio.iscoroutinefunction(f):
+        if inspect.iscoroutinefunction(f):
 
             @wraps(f)
             async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Fixes #6729.

 was deprecated in Python 3.12 and will be removed in Python 3.16. On Python 3.14, every ChromaDB initialization produces a DeprecationWarning.

## Fix

One-line change in :



Added  at the top of the file.

 is the recommended replacement per the Python 3.12 deprecation notice. It has been available since Python 3.4, so no backwards compatibility concerns.

Tested on Python 3.14 where the warning was originally reported.