### PR TITLE
[BLD] Add flake8 rule to ban relative imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,9 @@ repos:
         args:
           - "--extend-ignore=E203,E501,E503"
           - "--max-line-length=88"
+          - "--ban-relative-imports=true"
+        additional_dependencies:
+          - flake8-tidy-imports==4.10.0
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.0"

--- a/chromadb/utils/embedding_functions/schemas/registry.py
+++ b/chromadb/utils/embedding_functions/schemas/registry.py
@@ -8,7 +8,7 @@ It can be used to get information about available schemas and their versions.
 from typing import Dict, List, Set
 import os
 import json
-from .schema_utils import SCHEMAS_DIR
+from chromadb.utils.embedding_functions.schemas.schema_utils import SCHEMAS_DIR
 
 
 def get_available_schemas() -> List[str]:


### PR DESCRIPTION
## Summary

Closes #2334

- Adds  plugin to the pre-commit flake8 hook with 
- Converts the single existing relative import in  to absolute

## Details

The project already uses absolute imports everywhere (1900+ files) with only 1 exception. This PR:

1. Fixes that one relative import:  → 
2. Adds  as an  to the flake8 pre-commit hook
3. Adds the  flag to flake8 args

Any future relative imports will now be caught by CI.

## Test Plan

- [x] Verified no other relative imports exist in the codebase
- [x] Confirmed the absolute import path resolves correctly
- [ ] Pre-commit hook catches new relative imports