### PR TITLE
[ENH] Add maxscore lazy cursor

### DIFF
--- a/rust/blockstore/src/arrow/block/types.rs
+++ b/rust/blockstore/src/arrow/block/types.rs
@@ -333,6 +333,47 @@ impl Block {
         }
     }
 
+    /// Get the raw serialized bytes for a given key, skipping deserialization.
+    /// Returns `None` if the key is not found or the value type does not
+    /// support raw byte access.
+    pub fn get_raw<'me, K: ArrowReadableKey<'me>, V: ArrowReadableValue<'me>>(
+        &'me self,
+        prefix: &str,
+        key: K,
+    ) -> Option<&'me [u8]> {
+        match self.binary_search_by::<K, _>(|(p, k)| {
+            p.cmp(prefix).then_with(|| {
+                k.partial_cmp(&key)
+                    .expect("Array values should be comparable.")
+            })
+        }) {
+            Ok(index) => V::get_raw_bytes(self.data.column(2), index),
+            Err(_) => None,
+        }
+    }
+
+    /// Get raw serialized bytes for all entries under a prefix, skipping
+    /// deserialization. Entries whose value type returns `None` from
+    /// `get_raw_bytes` are excluded.
+    pub fn get_prefix_raw<'me, K: ArrowReadableKey<'me>, V: ArrowReadableValue<'me>>(
+        &'me self,
+        prefix: &str,
+    ) -> Vec<(K, &'me [u8])> {
+        let offset = self.find_smallest_index_of_prefix::<K>(prefix);
+        if offset >= self.len() {
+            return Vec::new();
+        }
+        let cap = self.find_smallest_index_of_next_prefix::<K>(prefix);
+        let length = cap - offset;
+
+        let keys = K::get_range(self.data.column(1), offset, length);
+        let col = self.data.column(2);
+        keys.into_iter()
+            .enumerate()
+            .filter_map(|(i, k)| V::get_raw_bytes(col, offset + i).map(|bytes| (k, bytes)))
+            .collect()
+    }
+
     /// Get all the values for a given prefix & key range in the block
     ///
     /// The prefix and key of the returning value must be contained by the prefix range and key range respectively

--- a/rust/blockstore/src/arrow/block/value/sparse_posting_block_value.rs
+++ b/rust/blockstore/src/arrow/block/value/sparse_posting_block_value.rs
@@ -107,6 +107,11 @@ impl ArrowReadableValue<'_> for SparsePostingBlock {
             .collect()
     }
 
+    fn get_raw_bytes(array: &Arc<dyn Array>, index: usize) -> Option<&[u8]> {
+        let arr = array.as_any().downcast_ref::<BinaryArray>()?;
+        Some(arr.value(index))
+    }
+
     fn add_to_delta<K: ArrowWriteableKey>(
         prefix: &str,
         key: K,

--- a/rust/blockstore/src/arrow/blockfile.rs
+++ b/rust/blockstore/src/arrow/blockfile.rs
@@ -564,6 +564,30 @@ impl<'me, K: ArrowReadableKey<'me> + Into<KeyWrapper>, V: ArrowReadableValue<'me
         self.load_blocks(&target_block_ids).await;
     }
 
+    /// Synchronous raw-byte lookup in already-loaded blocks only.
+    /// Returns `None` if the block is not cached, the key is absent,
+    /// or the value type does not support `get_raw_bytes`.
+    pub(crate) fn get_raw_from_cache(&self, prefix: &str, key: K) -> Option<&[u8]> {
+        let search_key = CompositeKey::new(prefix.to_string(), key.clone());
+        let target_block_id = self.root.sparse_index.get_target_block_id(&search_key);
+        let guard = self.loaded_blocks.read();
+        let block: &Block = guard.get(&target_block_id)?;
+        // Safety: the Block is heap-allocated (Box<Block>) and is never
+        // removed from loaded_blocks. The returned &[u8] points into
+        // Arrow buffers owned by the Block. Same lifetime-extension
+        // argument used in get_block's transmute.
+        let block: &'me Block = unsafe { transmute::<&Block, &Block>(block) };
+        block.get_raw::<K, V>(prefix, key)
+    }
+
+    /// Number of Arrow blocks whose key range overlaps this prefix.
+    pub(crate) fn count_blocks_for_prefix(&self, prefix: &str) -> usize {
+        self.root
+            .sparse_index
+            .get_block_ids_range(prefix..=prefix)
+            .len()
+    }
+
     pub(crate) async fn get(
         &'me self,
         prefix: &str,

--- a/rust/blockstore/src/arrow/types.rs
+++ b/rust/blockstore/src/arrow/types.rs
@@ -72,4 +72,14 @@ pub trait ArrowReadableValue<'referred_data>: Sized {
         value: Self,
         storage: &mut BlockStorage,
     );
+
+    /// For types stored as binary blobs, return the raw serialized bytes
+    /// at `index` without deserialization. Types that don't support raw
+    /// access inherit the default `None`.
+    fn get_raw_bytes(
+        _array: &'referred_data Arc<dyn Array>,
+        _index: usize,
+    ) -> Option<&'referred_data [u8]> {
+        None
+    }
 }

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -169,6 +169,30 @@ impl<
             BlockfileReader::ArrowBlockfileReader(reader) => reader.rank(prefix, key).await,
         }
     }
+
+    /// Synchronous raw-byte lookup in already-loaded blocks.
+    /// Returns `None` for `MemoryBlockfileReader` (no Arrow blocks),
+    /// or if the block is not cached / key is absent / value type
+    /// does not support raw access.
+    pub fn get_raw_from_cache(&self, prefix: &str, key: K) -> Option<&[u8]> {
+        match self {
+            BlockfileReader::MemoryBlockfileReader(_) => None,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.get_raw_from_cache(prefix, key)
+            }
+        }
+    }
+
+    /// Number of Arrow blocks whose key range overlaps this prefix.
+    /// Returns `0` for `MemoryBlockfileReader`.
+    pub fn count_blocks_for_prefix(&self, prefix: &str) -> usize {
+        match self {
+            BlockfileReader::MemoryBlockfileReader(_) => 0,
+            BlockfileReader::ArrowBlockfileReader(reader) => {
+                reader.count_blocks_for_prefix(prefix)
+            }
+        }
+    }
 }
 
 impl<

--- a/rust/blockstore/src/types/reader.rs
+++ b/rust/blockstore/src/types/reader.rs
@@ -177,9 +177,7 @@ impl<
     pub fn get_raw_from_cache(&self, prefix: &str, key: K) -> Option<&[u8]> {
         match self {
             BlockfileReader::MemoryBlockfileReader(_) => None,
-            BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.get_raw_from_cache(prefix, key)
-            }
+            BlockfileReader::ArrowBlockfileReader(reader) => reader.get_raw_from_cache(prefix, key),
         }
     }
 
@@ -188,9 +186,7 @@ impl<
     pub fn count_blocks_for_prefix(&self, prefix: &str) -> usize {
         match self {
             BlockfileReader::MemoryBlockfileReader(_) => 0,
-            BlockfileReader::ArrowBlockfileReader(reader) => {
-                reader.count_blocks_for_prefix(prefix)
-            }
+            BlockfileReader::ArrowBlockfileReader(reader) => reader.count_blocks_for_prefix(prefix),
         }
     }
 }

--- a/rust/index/src/sparse/cursor.rs
+++ b/rust/index/src/sparse/cursor.rs
@@ -50,15 +50,15 @@ pub struct PostingCursor<'view> {
 impl<'view> PostingCursor<'view> {
     // ── Constructors ────────────────────────────────────────────────
 
-    /// Create an eager cursor from fully deserialized posting blocks.
-    pub fn from_blocks(blocks: Vec<SparsePostingBlock>) -> Self {
-        let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.header.max_offset).collect();
-        let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.header.max_weight).collect();
+    fn new_with_source(
+        source: CursorSource<'view>,
+        dir_max_offsets: Vec<u32>,
+        dir_max_weights: Vec<f32>,
+    ) -> Self {
         let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
-        let block_count = blocks.len();
-
+        let block_count = dir_max_offsets.len();
         PostingCursor {
-            source: CursorSource::Eager { blocks },
+            source,
             dir_max_offsets,
             dir_max_weights,
             dim_max,
@@ -72,6 +72,17 @@ impl<'view> PostingCursor<'view> {
             lookup_offset_buf: Vec::new(),
             lookup_buf_block_idx: usize::MAX,
         }
+    }
+
+    /// Create an eager cursor from fully deserialized posting blocks.
+    pub fn from_blocks(blocks: Vec<SparsePostingBlock>) -> Self {
+        let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.header.max_offset).collect();
+        let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.header.max_weight).collect();
+        Self::new_with_source(
+            CursorSource::Eager { blocks },
+            dir_max_offsets,
+            dir_max_weights,
+        )
     }
 
     /// Create a view cursor from raw serialized byte slices already in
@@ -83,24 +94,11 @@ impl<'view> PostingCursor<'view> {
     ) -> Self {
         debug_assert_eq!(raw_blocks.len(), dir_max_offsets.len());
         debug_assert_eq!(raw_blocks.len(), dir_max_weights.len());
-        let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
-        let block_count = raw_blocks.len();
-
-        PostingCursor {
-            source: CursorSource::View { raw_blocks },
+        Self::new_with_source(
+            CursorSource::View { raw_blocks },
             dir_max_offsets,
             dir_max_weights,
-            dim_max,
-            block_count,
-            block_idx: 0,
-            pos: 0,
-            offset_buf: Vec::new(),
-            value_buf: Vec::new(),
-            buf_block_idx: usize::MAX,
-            drain_buf_block_idx: usize::MAX,
-            lookup_offset_buf: Vec::new(),
-            lookup_buf_block_idx: usize::MAX,
-        }
+        )
     }
 
     /// Create a lazy cursor with unloaded data blocks. The directory
@@ -108,26 +106,14 @@ impl<'view> PostingCursor<'view> {
     /// are populated via [`populate_from_cache`] / [`populate_all_from_cache`].
     pub fn open_lazy(dir_max_offsets: Vec<u32>, dir_max_weights: Vec<f32>) -> Self {
         debug_assert_eq!(dir_max_offsets.len(), dir_max_weights.len());
-        let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
         let block_count = dir_max_offsets.len();
-
-        PostingCursor {
-            source: CursorSource::Lazy {
+        Self::new_with_source(
+            CursorSource::Lazy {
                 raw_blocks: vec![None; block_count],
             },
             dir_max_offsets,
             dir_max_weights,
-            dim_max,
-            block_count,
-            block_idx: 0,
-            pos: 0,
-            offset_buf: Vec::new(),
-            value_buf: Vec::new(),
-            buf_block_idx: usize::MAX,
-            drain_buf_block_idx: usize::MAX,
-            lookup_offset_buf: Vec::new(),
-            lookup_buf_block_idx: usize::MAX,
-        }
+        )
     }
 
     // ── Lazy population ──────────────────────────────────────────────
@@ -196,6 +182,17 @@ impl<'view> PostingCursor<'view> {
 
     // ── Internal: buffer management ──────────────────────────────────
 
+    /// Get the raw serialized bytes for a block by index. Returns `None`
+    /// for Eager sources (caller handles those separately) or for Lazy
+    /// blocks that haven't been populated yet.
+    fn get_raw_block(&self, idx: usize) -> Option<&'view [u8]> {
+        match &self.source {
+            CursorSource::Eager { .. } => None,
+            CursorSource::View { raw_blocks } => Some(raw_blocks[idx]),
+            CursorSource::Lazy { raw_blocks } => raw_blocks[idx],
+        }
+    }
+
     /// Ensure `offset_buf` and `value_buf` contain the fully decompressed
     /// data for block `idx`. If drain already decompressed offsets for
     /// this block, only values are decompressed. Returns `false` if the
@@ -204,33 +201,20 @@ impl<'view> PostingCursor<'view> {
         if self.buf_block_idx == idx {
             return true;
         }
-        match &self.source {
-            CursorSource::Eager { .. } => true,
-            CursorSource::View { raw_blocks } => {
-                let raw = raw_blocks[idx];
-                let hdr = SparsePostingBlock::peek_header(raw);
-                if self.drain_buf_block_idx != idx {
-                    SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.offset_buf);
-                }
-                SparsePostingBlock::decompress_values_into(raw, &hdr, &mut self.value_buf);
-                self.buf_block_idx = idx;
-                self.drain_buf_block_idx = idx;
-                true
-            }
-            CursorSource::Lazy { raw_blocks } => {
-                let Some(raw) = raw_blocks[idx] else {
-                    return false;
-                };
-                let hdr = SparsePostingBlock::peek_header(raw);
-                if self.drain_buf_block_idx != idx {
-                    SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.offset_buf);
-                }
-                SparsePostingBlock::decompress_values_into(raw, &hdr, &mut self.value_buf);
-                self.buf_block_idx = idx;
-                self.drain_buf_block_idx = idx;
-                true
-            }
+        if matches!(self.source, CursorSource::Eager { .. }) {
+            return true;
         }
+        let Some(raw) = self.get_raw_block(idx) else {
+            return false;
+        };
+        let hdr = SparsePostingBlock::peek_header(raw).expect("valid block header");
+        if self.drain_buf_block_idx != idx {
+            SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.offset_buf);
+        }
+        SparsePostingBlock::decompress_values_into(raw, &hdr, &mut self.value_buf);
+        self.buf_block_idx = idx;
+        self.drain_buf_block_idx = idx;
+        true
     }
 
     /// Ensure `lookup_offset_buf` contains offsets for block `idx`.
@@ -240,25 +224,16 @@ impl<'view> PostingCursor<'view> {
         if self.lookup_buf_block_idx == idx {
             return true;
         }
-        match &self.source {
-            CursorSource::Eager { .. } => true,
-            CursorSource::View { raw_blocks } => {
-                let raw = raw_blocks[idx];
-                let hdr = SparsePostingBlock::peek_header(raw);
-                SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.lookup_offset_buf);
-                self.lookup_buf_block_idx = idx;
-                true
-            }
-            CursorSource::Lazy { raw_blocks } => {
-                let Some(raw) = raw_blocks[idx] else {
-                    return false;
-                };
-                let hdr = SparsePostingBlock::peek_header(raw);
-                SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.lookup_offset_buf);
-                self.lookup_buf_block_idx = idx;
-                true
-            }
+        if matches!(self.source, CursorSource::Eager { .. }) {
+            return true;
         }
+        let Some(raw) = self.get_raw_block(idx) else {
+            return false;
+        };
+        let hdr = SparsePostingBlock::peek_header(raw).expect("valid block header");
+        SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.lookup_offset_buf);
+        self.lookup_buf_block_idx = idx;
+        true
     }
 
     // ── Public API ──────────────────────────────────────────────────
@@ -315,7 +290,7 @@ impl<'view> PostingCursor<'view> {
 
             while self.pos < offsets.len() {
                 let off = offsets[self.pos];
-                if passes_mask(off, mask) {
+                if mask.contains(off) {
                     return Some((off, values[self.pos]));
                 }
                 self.pos += 1;
@@ -374,7 +349,7 @@ impl<'view> PostingCursor<'view> {
                     CursorSource::Lazy { raw_blocks } => raw_blocks[bi]?,
                     CursorSource::Eager { .. } => unreachable!(),
                 };
-                let hdr = SparsePostingBlock::peek_header(raw);
+                let hdr = SparsePostingBlock::peek_header(raw).expect("valid block header");
                 Some(SparsePostingBlock::read_value_at(raw, &hdr, idx))
             }
             Err(_) => None,
@@ -496,7 +471,7 @@ impl<'view> PostingCursor<'view> {
                         if doc > window_end {
                             return;
                         }
-                        if passes_mask(doc, mask) {
+                        if mask.contains(doc) {
                             let idx = (doc - window_start) as usize;
                             bitmap[idx >> 6] |= 1u64 << (idx & 63);
                             accum[idx] += vals[self.pos] * query_weight;
@@ -504,49 +479,13 @@ impl<'view> PostingCursor<'view> {
                         self.pos += 1;
                     }
                 }
-                CursorSource::View { raw_blocks } => {
-                    let raw = raw_blocks[self.block_idx];
-                    let hdr = SparsePostingBlock::peek_header(raw);
-                    if self.drain_buf_block_idx != self.block_idx {
-                        SparsePostingBlock::decompress_offsets_into(
-                            raw,
-                            &hdr,
-                            &mut self.offset_buf,
-                        );
-                        self.drain_buf_block_idx = self.block_idx;
-                        self.buf_block_idx = usize::MAX;
-                    }
-                    let wb = SparsePostingBlock::raw_weight_bytes(raw, &hdr);
-
-                    if self
-                        .offset_buf
-                        .get(self.pos)
-                        .is_some_and(|&o| o < window_start)
-                    {
-                        self.pos = self.offset_buf.partition_point(|&o| o < window_start);
-                    }
-                    while self.pos < self.offset_buf.len() {
-                        let doc = self.offset_buf[self.pos];
-                        if doc > window_end {
-                            return;
-                        }
-                        if passes_mask(doc, mask) {
-                            let idx = (doc - window_start) as usize;
-                            bitmap[idx >> 6] |= 1u64 << (idx & 63);
-                            let bp = self.pos * 2;
-                            let w = f16::from_le_bytes([wb[bp], wb[bp + 1]]).to_f32();
-                            accum[idx] += w * query_weight;
-                        }
-                        self.pos += 1;
-                    }
-                }
-                CursorSource::Lazy { raw_blocks } => {
-                    let Some(raw) = raw_blocks[self.block_idx] else {
+                _ => {
+                    let Some(raw) = self.get_raw_block(self.block_idx) else {
                         self.block_idx += 1;
                         self.pos = 0;
                         continue;
                     };
-                    let hdr = SparsePostingBlock::peek_header(raw);
+                    let hdr = SparsePostingBlock::peek_header(raw).expect("valid block header");
                     if self.drain_buf_block_idx != self.block_idx {
                         SparsePostingBlock::decompress_offsets_into(
                             raw,
@@ -570,7 +509,7 @@ impl<'view> PostingCursor<'view> {
                         if doc > window_end {
                             return;
                         }
-                        if passes_mask(doc, mask) {
+                        if mask.contains(doc) {
                             let idx = (doc - window_start) as usize;
                             bitmap[idx >> 6] |= 1u64 << (idx & 63);
                             let bp = self.pos * 2;
@@ -644,58 +583,13 @@ impl<'view> PostingCursor<'view> {
                         self.pos = 0;
                     }
                 }
-                CursorSource::View { raw_blocks } => {
-                    let raw = raw_blocks[self.block_idx];
-                    let hdr = SparsePostingBlock::peek_header(raw);
-                    if self.drain_buf_block_idx != self.block_idx {
-                        SparsePostingBlock::decompress_offsets_into(
-                            raw,
-                            &hdr,
-                            &mut self.offset_buf,
-                        );
-                        self.drain_buf_block_idx = self.block_idx;
-                        self.buf_block_idx = usize::MAX;
-                    }
-                    let wb = SparsePostingBlock::raw_weight_bytes(raw, &hdr);
-
-                    if self
-                        .offset_buf
-                        .get(self.pos)
-                        .is_some_and(|&o| o < window_start)
-                    {
-                        self.pos = self.offset_buf.partition_point(|&o| o < window_start);
-                    }
-
-                    while self.pos < self.offset_buf.len() && ci < cand_docs.len() {
-                        let doc = self.offset_buf[self.pos];
-                        if doc > window_end {
-                            return;
-                        }
-                        let cand = cand_docs[ci];
-                        if doc < cand {
-                            self.pos += 1;
-                        } else if doc > cand {
-                            ci += 1;
-                        } else {
-                            let bp = self.pos * 2;
-                            let w = f16::from_le_bytes([wb[bp], wb[bp + 1]]).to_f32();
-                            cand_scores[ci] += query_weight * w;
-                            self.pos += 1;
-                            ci += 1;
-                        }
-                    }
-                    if self.pos >= self.offset_buf.len() {
-                        self.block_idx += 1;
-                        self.pos = 0;
-                    }
-                }
-                CursorSource::Lazy { raw_blocks } => {
-                    let Some(raw) = raw_blocks[self.block_idx] else {
+                _ => {
+                    let Some(raw) = self.get_raw_block(self.block_idx) else {
                         self.block_idx += 1;
                         self.pos = 0;
                         continue;
                     };
-                    let hdr = SparsePostingBlock::peek_header(raw);
+                    let hdr = SparsePostingBlock::peek_header(raw).expect("valid block header");
                     if self.drain_buf_block_idx != self.block_idx {
                         SparsePostingBlock::decompress_offsets_into(
                             raw,
@@ -740,12 +634,5 @@ impl<'view> PostingCursor<'view> {
                 }
             }
         }
-    }
-}
-
-fn passes_mask(offset: u32, mask: &SignedRoaringBitmap) -> bool {
-    match mask {
-        SignedRoaringBitmap::Include(rbm) => rbm.contains(offset),
-        SignedRoaringBitmap::Exclude(rbm) => !rbm.contains(offset),
     }
 }

--- a/rust/index/src/sparse/cursor.rs
+++ b/rust/index/src/sparse/cursor.rs
@@ -1,0 +1,751 @@
+use chroma_blockstore::BlockfileReader;
+use chroma_types::{SignedRoaringBitmap, SparsePostingBlock};
+use half::f16;
+
+enum CursorSource<'view> {
+    /// All blocks are fully deserialized in memory.
+    Eager { blocks: Vec<SparsePostingBlock> },
+    /// Raw serialized byte slices borrowed from the Arrow block cache.
+    /// Decompressed on-the-fly into reusable buffers.
+    View { raw_blocks: Vec<&'view [u8]> },
+    /// Similar to View but blocks start as `None` and are populated via
+    /// `populate_from_cache` / `populate_all_from_cache`.
+    Lazy {
+        raw_blocks: Vec<Option<&'view [u8]>>,
+    },
+}
+
+/// A cursor over a single dimension's posting list. Three backing modes
+/// (`Eager`, `View`, `Lazy`) share the same traversal/accumulation logic
+/// but differ in how they obtain raw block data.
+///
+/// View and Lazy cursors use fused f16 weight reads in hot paths
+/// (`drain_essential`, `score_candidates`) — only offsets are
+/// decompressed, and individual f16 weights are converted to f32 on
+/// demand, avoiding wasteful bulk conversion for entries outside the
+/// window or excluded by the mask.
+pub struct PostingCursor<'view> {
+    source: CursorSource<'view>,
+    pub(crate) dir_max_offsets: Vec<u32>,
+    pub(crate) dir_max_weights: Vec<f32>,
+    dim_max: f32,
+    block_count: usize,
+    block_idx: usize,
+    pos: usize,
+    // Forward scan buffers (offsets + values, fully decompressed)
+    offset_buf: Vec<u32>,
+    value_buf: Vec<f32>,
+    buf_block_idx: usize,
+    // Drain/score offset-only buffer tracking. drain_essential and
+    // score_candidates decompress offsets into offset_buf but read raw
+    // f16 weights directly from the block bytes. When this index
+    // matches the current block, offset_buf already contains offsets
+    // but value_buf is stale — buf_block_idx is set to usize::MAX.
+    drain_buf_block_idx: usize,
+    // Point-lookup buffer (offsets only, separate from forward scan)
+    lookup_offset_buf: Vec<u32>,
+    lookup_buf_block_idx: usize,
+}
+
+impl<'view> PostingCursor<'view> {
+    // ── Constructors ────────────────────────────────────────────────
+
+    /// Create an eager cursor from fully deserialized posting blocks.
+    pub fn from_blocks(blocks: Vec<SparsePostingBlock>) -> Self {
+        let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.header.max_offset).collect();
+        let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.header.max_weight).collect();
+        let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
+        let block_count = blocks.len();
+
+        PostingCursor {
+            source: CursorSource::Eager { blocks },
+            dir_max_offsets,
+            dir_max_weights,
+            dim_max,
+            block_count,
+            block_idx: 0,
+            pos: 0,
+            offset_buf: Vec::new(),
+            value_buf: Vec::new(),
+            buf_block_idx: usize::MAX,
+            drain_buf_block_idx: usize::MAX,
+            lookup_offset_buf: Vec::new(),
+            lookup_buf_block_idx: usize::MAX,
+        }
+    }
+
+    /// Create a view cursor from raw serialized byte slices already in
+    /// the Arrow block cache, plus the pre-loaded directory metadata.
+    pub fn open(
+        raw_blocks: Vec<&'view [u8]>,
+        dir_max_offsets: Vec<u32>,
+        dir_max_weights: Vec<f32>,
+    ) -> Self {
+        debug_assert_eq!(raw_blocks.len(), dir_max_offsets.len());
+        debug_assert_eq!(raw_blocks.len(), dir_max_weights.len());
+        let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
+        let block_count = raw_blocks.len();
+
+        PostingCursor {
+            source: CursorSource::View { raw_blocks },
+            dir_max_offsets,
+            dir_max_weights,
+            dim_max,
+            block_count,
+            block_idx: 0,
+            pos: 0,
+            offset_buf: Vec::new(),
+            value_buf: Vec::new(),
+            buf_block_idx: usize::MAX,
+            drain_buf_block_idx: usize::MAX,
+            lookup_offset_buf: Vec::new(),
+            lookup_buf_block_idx: usize::MAX,
+        }
+    }
+
+    /// Create a lazy cursor with unloaded data blocks. The directory
+    /// metadata must have been pre-loaded. Blocks start as `None` and
+    /// are populated via [`populate_from_cache`] / [`populate_all_from_cache`].
+    pub fn open_lazy(dir_max_offsets: Vec<u32>, dir_max_weights: Vec<f32>) -> Self {
+        debug_assert_eq!(dir_max_offsets.len(), dir_max_weights.len());
+        let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
+        let block_count = dir_max_offsets.len();
+
+        PostingCursor {
+            source: CursorSource::Lazy {
+                raw_blocks: vec![None; block_count],
+            },
+            dir_max_offsets,
+            dir_max_weights,
+            dim_max,
+            block_count,
+            block_idx: 0,
+            pos: 0,
+            offset_buf: Vec::new(),
+            value_buf: Vec::new(),
+            buf_block_idx: usize::MAX,
+            drain_buf_block_idx: usize::MAX,
+            lookup_offset_buf: Vec::new(),
+            lookup_buf_block_idx: usize::MAX,
+        }
+    }
+
+    // ── Lazy population ──────────────────────────────────────────────
+
+    /// Whether this is a lazy cursor with potentially unloaded blocks.
+    pub fn is_lazy(&self) -> bool {
+        matches!(self.source, CursorSource::Lazy { .. })
+    }
+
+    /// Check whether a specific posting block has been loaded.
+    pub fn is_block_loaded(&self, idx: usize) -> bool {
+        match &self.source {
+            CursorSource::Lazy { raw_blocks } => {
+                idx < raw_blocks.len() && raw_blocks[idx].is_some()
+            }
+            _ => true,
+        }
+    }
+
+    /// Populate specific lazy blocks from the reader's cache. Returns
+    /// the number of blocks successfully loaded.
+    pub fn populate_from_cache(
+        &mut self,
+        reader: &'view BlockfileReader<'view, u32, SparsePostingBlock>,
+        encoded_dim: &str,
+        block_indices: &[usize],
+    ) -> usize {
+        let CursorSource::Lazy { raw_blocks } = &mut self.source else {
+            return 0;
+        };
+        let mut loaded = 0;
+        for &idx in block_indices {
+            if idx >= raw_blocks.len() || raw_blocks[idx].is_some() {
+                continue;
+            }
+            if let Some(bytes) = reader.get_raw_from_cache(encoded_dim, idx as u32) {
+                raw_blocks[idx] = Some(bytes);
+                loaded += 1;
+            }
+        }
+        loaded
+    }
+
+    /// Populate all unloaded blocks from the reader's cache. Returns
+    /// the number of blocks successfully loaded.
+    pub fn populate_all_from_cache(
+        &mut self,
+        reader: &'view BlockfileReader<'view, u32, SparsePostingBlock>,
+        encoded_dim: &str,
+    ) -> usize {
+        let CursorSource::Lazy { raw_blocks } = &mut self.source else {
+            return 0;
+        };
+        let mut loaded = 0;
+        for (idx, slot) in raw_blocks.iter_mut().enumerate().take(self.block_count) {
+            if slot.is_some() {
+                continue;
+            }
+            if let Some(bytes) = reader.get_raw_from_cache(encoded_dim, idx as u32) {
+                *slot = Some(bytes);
+                loaded += 1;
+            }
+        }
+        loaded
+    }
+
+    // ── Internal: buffer management ──────────────────────────────────
+
+    /// Ensure `offset_buf` and `value_buf` contain the fully decompressed
+    /// data for block `idx`. If drain already decompressed offsets for
+    /// this block, only values are decompressed. Returns `false` if the
+    /// block is unavailable (lazy not populated).
+    fn ensure_forward_block(&mut self, idx: usize) -> bool {
+        if self.buf_block_idx == idx {
+            return true;
+        }
+        match &self.source {
+            CursorSource::Eager { .. } => true,
+            CursorSource::View { raw_blocks } => {
+                let raw = raw_blocks[idx];
+                let hdr = SparsePostingBlock::peek_header(raw);
+                if self.drain_buf_block_idx != idx {
+                    SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.offset_buf);
+                }
+                SparsePostingBlock::decompress_values_into(raw, &hdr, &mut self.value_buf);
+                self.buf_block_idx = idx;
+                self.drain_buf_block_idx = idx;
+                true
+            }
+            CursorSource::Lazy { raw_blocks } => {
+                let Some(raw) = raw_blocks[idx] else {
+                    return false;
+                };
+                let hdr = SparsePostingBlock::peek_header(raw);
+                if self.drain_buf_block_idx != idx {
+                    SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.offset_buf);
+                }
+                SparsePostingBlock::decompress_values_into(raw, &hdr, &mut self.value_buf);
+                self.buf_block_idx = idx;
+                self.drain_buf_block_idx = idx;
+                true
+            }
+        }
+    }
+
+    /// Ensure `lookup_offset_buf` contains offsets for block `idx`.
+    /// Only decompresses offsets — values are read on demand via
+    /// `SparsePostingBlock::read_value_at`.
+    fn ensure_lookup_offsets(&mut self, idx: usize) -> bool {
+        if self.lookup_buf_block_idx == idx {
+            return true;
+        }
+        match &self.source {
+            CursorSource::Eager { .. } => true,
+            CursorSource::View { raw_blocks } => {
+                let raw = raw_blocks[idx];
+                let hdr = SparsePostingBlock::peek_header(raw);
+                SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.lookup_offset_buf);
+                self.lookup_buf_block_idx = idx;
+                true
+            }
+            CursorSource::Lazy { raw_blocks } => {
+                let Some(raw) = raw_blocks[idx] else {
+                    return false;
+                };
+                let hdr = SparsePostingBlock::peek_header(raw);
+                SparsePostingBlock::decompress_offsets_into(raw, &hdr, &mut self.lookup_offset_buf);
+                self.lookup_buf_block_idx = idx;
+                true
+            }
+        }
+    }
+
+    // ── Public API ──────────────────────────────────────────────────
+
+    pub fn block_count(&self) -> usize {
+        self.block_count
+    }
+
+    pub fn current(&mut self) -> Option<(u32, f32)> {
+        if self.block_idx >= self.block_count {
+            return None;
+        }
+        if !self.ensure_forward_block(self.block_idx) {
+            return None;
+        }
+        let (offsets, values) = match &mut self.source {
+            CursorSource::Eager { blocks } => blocks[self.block_idx].decode(),
+            CursorSource::View { .. } | CursorSource::Lazy { .. } => {
+                (&self.offset_buf[..], &self.value_buf[..])
+            }
+        };
+        if self.pos < offsets.len() {
+            Some((offsets[self.pos], values[self.pos]))
+        } else {
+            None
+        }
+    }
+
+    pub fn advance(&mut self, target: u32, mask: &SignedRoaringBitmap) -> Option<(u32, f32)> {
+        while self.block_idx < self.block_count {
+            if self.dir_max_offsets[self.block_idx] < target {
+                self.block_idx += 1;
+                self.pos = 0;
+                continue;
+            }
+
+            if !self.ensure_forward_block(self.block_idx) {
+                self.block_idx += 1;
+                self.pos = 0;
+                continue;
+            }
+
+            let (offsets, values) = match &mut self.source {
+                CursorSource::Eager { blocks } => blocks[self.block_idx].decode(),
+                CursorSource::View { .. } | CursorSource::Lazy { .. } => {
+                    (&self.offset_buf[..], &self.value_buf[..])
+                }
+            };
+
+            if self.pos == 0 || offsets.get(self.pos).is_some_and(|&o| o < target) {
+                let start = self.pos;
+                self.pos = start + offsets[start..].partition_point(|&o| o < target);
+            }
+
+            while self.pos < offsets.len() {
+                let off = offsets[self.pos];
+                if passes_mask(off, mask) {
+                    return Some((off, values[self.pos]));
+                }
+                self.pos += 1;
+            }
+
+            self.block_idx += 1;
+            self.pos = 0;
+        }
+        None
+    }
+
+    /// Point lookup for a single doc_id.
+    ///
+    /// Fast path: reuses the forward buffer if the target block is already
+    /// loaded there. View/Lazy slow path: decompresses only offsets, then
+    /// reads a single f16 weight on hit via `read_value_at`.
+    pub fn get_value(&mut self, doc_id: u32) -> Option<f32> {
+        let bi = self
+            .dir_max_offsets
+            .partition_point(|&max_off| max_off < doc_id);
+        if bi >= self.block_count {
+            return None;
+        }
+
+        // Fast path: forward buffer already has this block fully decompressed
+        if self.buf_block_idx == bi {
+            return match self.offset_buf.binary_search(&doc_id) {
+                Ok(idx) => Some(self.value_buf[idx]),
+                Err(_) => None,
+            };
+        }
+
+        if let CursorSource::Eager { blocks } = &mut self.source {
+            let (offsets, values) = blocks[bi].decode();
+            if offsets.is_empty() || doc_id < offsets[0] {
+                return None;
+            }
+            return match offsets.binary_search(&doc_id) {
+                Ok(idx) => Some(values[idx]),
+                Err(_) => None,
+            };
+        }
+
+        // View/Lazy path: decompress offsets only, read single value on hit
+        if !self.ensure_lookup_offsets(bi) {
+            return None;
+        }
+        let offsets = &self.lookup_offset_buf;
+        if offsets.is_empty() || doc_id < offsets[0] {
+            return None;
+        }
+        match offsets.binary_search(&doc_id) {
+            Ok(idx) => {
+                let raw = match &self.source {
+                    CursorSource::View { raw_blocks } => raw_blocks[bi],
+                    CursorSource::Lazy { raw_blocks } => raw_blocks[bi]?,
+                    CursorSource::Eager { .. } => unreachable!(),
+                };
+                let hdr = SparsePostingBlock::peek_header(raw);
+                Some(SparsePostingBlock::read_value_at(raw, &hdr, idx))
+            }
+            Err(_) => None,
+        }
+    }
+
+    pub fn current_block_max(&self) -> f32 {
+        self.dir_max_weights
+            .get(self.block_idx)
+            .copied()
+            .unwrap_or(0.0)
+    }
+
+    pub fn dimension_max(&self) -> f32 {
+        self.dim_max
+    }
+
+    /// Return the MAX block-level weight across all blocks overlapping
+    /// [window_start, window_end].
+    pub fn window_upper_bound(&self, window_start: u32, window_end: u32) -> f32 {
+        let bi_start = self
+            .dir_max_offsets
+            .partition_point(|&max| max < window_start);
+        let mut max_w = 0.0f32;
+        for bi in bi_start..self.block_count {
+            max_w = max_w.max(self.dir_max_weights[bi]);
+            if self.dir_max_offsets[bi] >= window_end {
+                break;
+            }
+        }
+        max_w
+    }
+
+    /// O(1) sequential advance to the next entry. Handles block
+    /// transitions and eagerly decompresses the next block for pipeline
+    /// locality.
+    pub fn next(&mut self) {
+        if self.block_idx >= self.block_count {
+            return;
+        }
+        self.pos += 1;
+        let len = match &self.source {
+            CursorSource::Eager { blocks } => blocks[self.block_idx].len(),
+            CursorSource::View { .. } | CursorSource::Lazy { .. } => self.offset_buf.len(),
+        };
+        if self.pos >= len {
+            self.block_idx += 1;
+            self.pos = 0;
+            if self.block_idx < self.block_count {
+                self.ensure_forward_block(self.block_idx);
+            }
+        }
+    }
+
+    pub fn current_block_end(&self) -> Option<u32> {
+        self.dir_max_offsets.get(self.block_idx).copied()
+    }
+
+    /// Batch-drain every posting entry in `[window_start, window_end]`
+    /// from this *essential* term into a shared window accumulator.
+    ///
+    /// # How it fits into the query pipeline
+    ///
+    /// The BlockMaxMaxScore algorithm partitions query terms into
+    /// *essential* (high-contribution) and *non-essential* (low) for each
+    /// doc-id window. Essential terms are drained first so that every
+    /// candidate document gets at least a partial score. Non-essential
+    /// terms are then scored only against those candidates via
+    /// [`score_candidates`].
+    ///
+    /// # Fused f16 reads (View/Lazy)
+    ///
+    /// For View and Lazy sources, only offsets are decompressed into
+    /// `offset_buf`. Weights are read as raw f16 bytes per-entry and
+    /// converted to f32 on the fly, avoiding bulk f16→f32 conversion
+    /// for entries outside the window or excluded by the mask.
+    ///
+    /// # Arguments
+    ///
+    /// * `accum` — flat `f32` array of length ≥ `WINDOW_WIDTH`. Slot
+    ///   `accum[(doc - window_start)]` accumulates the running dot-product
+    ///   contribution for that document across all essential terms.
+    /// * `bitmap` — parallel `u64` bit-array. Bit `(doc - window_start)`
+    ///   is set for every document touched, enabling the caller to
+    ///   enumerate candidates without scanning the full window.
+    /// * `mask` — include/exclude filter applied per document.
+    ///
+    /// # Cursor state
+    ///
+    /// On return the cursor is positioned just past `window_end` (or
+    /// exhausted). The caller advances `window_start` and calls this
+    /// method again for the next window — the cursor resumes where it
+    /// left off.
+    pub fn drain_essential(
+        &mut self,
+        window_start: u32,
+        window_end: u32,
+        query_weight: f32,
+        accum: &mut [f32],
+        bitmap: &mut [u64],
+        mask: &SignedRoaringBitmap,
+    ) {
+        while self.block_idx < self.block_count {
+            if self.dir_max_offsets[self.block_idx] < window_start {
+                self.block_idx += 1;
+                self.pos = 0;
+                continue;
+            }
+
+            match &mut self.source {
+                CursorSource::Eager { blocks } => {
+                    let (offsets, vals) = blocks[self.block_idx].decode();
+
+                    if offsets.get(self.pos).is_some_and(|&o| o < window_start) {
+                        self.pos = offsets.partition_point(|&o| o < window_start);
+                    }
+                    while self.pos < offsets.len() {
+                        let doc = offsets[self.pos];
+                        if doc > window_end {
+                            return;
+                        }
+                        if passes_mask(doc, mask) {
+                            let idx = (doc - window_start) as usize;
+                            bitmap[idx >> 6] |= 1u64 << (idx & 63);
+                            accum[idx] += vals[self.pos] * query_weight;
+                        }
+                        self.pos += 1;
+                    }
+                }
+                CursorSource::View { raw_blocks } => {
+                    let raw = raw_blocks[self.block_idx];
+                    let hdr = SparsePostingBlock::peek_header(raw);
+                    if self.drain_buf_block_idx != self.block_idx {
+                        SparsePostingBlock::decompress_offsets_into(
+                            raw,
+                            &hdr,
+                            &mut self.offset_buf,
+                        );
+                        self.drain_buf_block_idx = self.block_idx;
+                        self.buf_block_idx = usize::MAX;
+                    }
+                    let wb = SparsePostingBlock::raw_weight_bytes(raw, &hdr);
+
+                    if self
+                        .offset_buf
+                        .get(self.pos)
+                        .is_some_and(|&o| o < window_start)
+                    {
+                        self.pos = self.offset_buf.partition_point(|&o| o < window_start);
+                    }
+                    while self.pos < self.offset_buf.len() {
+                        let doc = self.offset_buf[self.pos];
+                        if doc > window_end {
+                            return;
+                        }
+                        if passes_mask(doc, mask) {
+                            let idx = (doc - window_start) as usize;
+                            bitmap[idx >> 6] |= 1u64 << (idx & 63);
+                            let bp = self.pos * 2;
+                            let w = f16::from_le_bytes([wb[bp], wb[bp + 1]]).to_f32();
+                            accum[idx] += w * query_weight;
+                        }
+                        self.pos += 1;
+                    }
+                }
+                CursorSource::Lazy { raw_blocks } => {
+                    let Some(raw) = raw_blocks[self.block_idx] else {
+                        self.block_idx += 1;
+                        self.pos = 0;
+                        continue;
+                    };
+                    let hdr = SparsePostingBlock::peek_header(raw);
+                    if self.drain_buf_block_idx != self.block_idx {
+                        SparsePostingBlock::decompress_offsets_into(
+                            raw,
+                            &hdr,
+                            &mut self.offset_buf,
+                        );
+                        self.drain_buf_block_idx = self.block_idx;
+                        self.buf_block_idx = usize::MAX;
+                    }
+                    let wb = SparsePostingBlock::raw_weight_bytes(raw, &hdr);
+
+                    if self
+                        .offset_buf
+                        .get(self.pos)
+                        .is_some_and(|&o| o < window_start)
+                    {
+                        self.pos = self.offset_buf.partition_point(|&o| o < window_start);
+                    }
+                    while self.pos < self.offset_buf.len() {
+                        let doc = self.offset_buf[self.pos];
+                        if doc > window_end {
+                            return;
+                        }
+                        if passes_mask(doc, mask) {
+                            let idx = (doc - window_start) as usize;
+                            bitmap[idx >> 6] |= 1u64 << (idx & 63);
+                            let bp = self.pos * 2;
+                            let w = f16::from_le_bytes([wb[bp], wb[bp + 1]]).to_f32();
+                            accum[idx] += w * query_weight;
+                        }
+                        self.pos += 1;
+                    }
+                }
+            }
+
+            self.block_idx += 1;
+            self.pos = 0;
+        }
+    }
+
+    /// Merge-join this (non-essential) cursor against sorted candidates,
+    /// accumulating matched scores into `cand_scores`.
+    ///
+    /// For View/Lazy sources, this is fused: only offsets are decompressed
+    /// and f16 weights are read from raw bytes at matched positions only.
+    pub fn score_candidates(
+        &mut self,
+        window_start: u32,
+        window_end: u32,
+        query_weight: f32,
+        cand_docs: &[u32],
+        cand_scores: &mut [f32],
+    ) {
+        if cand_docs.is_empty() {
+            return;
+        }
+
+        let mut ci = 0;
+
+        while self.block_idx < self.block_count && ci < cand_docs.len() {
+            if self.dir_max_offsets[self.block_idx] < window_start
+                || self.dir_max_offsets[self.block_idx] < cand_docs[ci]
+            {
+                self.block_idx += 1;
+                self.pos = 0;
+                continue;
+            }
+
+            match &mut self.source {
+                CursorSource::Eager { blocks } => {
+                    let (offsets, values) = blocks[self.block_idx].decode();
+
+                    if offsets.get(self.pos).is_some_and(|&o| o < window_start) {
+                        self.pos = offsets.partition_point(|&o| o < window_start);
+                    }
+
+                    while self.pos < offsets.len() && ci < cand_docs.len() {
+                        let doc = offsets[self.pos];
+                        if doc > window_end {
+                            return;
+                        }
+                        let cand = cand_docs[ci];
+                        if doc < cand {
+                            self.pos += 1;
+                        } else if doc > cand {
+                            ci += 1;
+                        } else {
+                            cand_scores[ci] += query_weight * values[self.pos];
+                            self.pos += 1;
+                            ci += 1;
+                        }
+                    }
+                    if self.pos >= offsets.len() {
+                        self.block_idx += 1;
+                        self.pos = 0;
+                    }
+                }
+                CursorSource::View { raw_blocks } => {
+                    let raw = raw_blocks[self.block_idx];
+                    let hdr = SparsePostingBlock::peek_header(raw);
+                    if self.drain_buf_block_idx != self.block_idx {
+                        SparsePostingBlock::decompress_offsets_into(
+                            raw,
+                            &hdr,
+                            &mut self.offset_buf,
+                        );
+                        self.drain_buf_block_idx = self.block_idx;
+                        self.buf_block_idx = usize::MAX;
+                    }
+                    let wb = SparsePostingBlock::raw_weight_bytes(raw, &hdr);
+
+                    if self
+                        .offset_buf
+                        .get(self.pos)
+                        .is_some_and(|&o| o < window_start)
+                    {
+                        self.pos = self.offset_buf.partition_point(|&o| o < window_start);
+                    }
+
+                    while self.pos < self.offset_buf.len() && ci < cand_docs.len() {
+                        let doc = self.offset_buf[self.pos];
+                        if doc > window_end {
+                            return;
+                        }
+                        let cand = cand_docs[ci];
+                        if doc < cand {
+                            self.pos += 1;
+                        } else if doc > cand {
+                            ci += 1;
+                        } else {
+                            let bp = self.pos * 2;
+                            let w = f16::from_le_bytes([wb[bp], wb[bp + 1]]).to_f32();
+                            cand_scores[ci] += query_weight * w;
+                            self.pos += 1;
+                            ci += 1;
+                        }
+                    }
+                    if self.pos >= self.offset_buf.len() {
+                        self.block_idx += 1;
+                        self.pos = 0;
+                    }
+                }
+                CursorSource::Lazy { raw_blocks } => {
+                    let Some(raw) = raw_blocks[self.block_idx] else {
+                        self.block_idx += 1;
+                        self.pos = 0;
+                        continue;
+                    };
+                    let hdr = SparsePostingBlock::peek_header(raw);
+                    if self.drain_buf_block_idx != self.block_idx {
+                        SparsePostingBlock::decompress_offsets_into(
+                            raw,
+                            &hdr,
+                            &mut self.offset_buf,
+                        );
+                        self.drain_buf_block_idx = self.block_idx;
+                        self.buf_block_idx = usize::MAX;
+                    }
+                    let wb = SparsePostingBlock::raw_weight_bytes(raw, &hdr);
+
+                    if self
+                        .offset_buf
+                        .get(self.pos)
+                        .is_some_and(|&o| o < window_start)
+                    {
+                        self.pos = self.offset_buf.partition_point(|&o| o < window_start);
+                    }
+
+                    while self.pos < self.offset_buf.len() && ci < cand_docs.len() {
+                        let doc = self.offset_buf[self.pos];
+                        if doc > window_end {
+                            return;
+                        }
+                        let cand = cand_docs[ci];
+                        if doc < cand {
+                            self.pos += 1;
+                        } else if doc > cand {
+                            ci += 1;
+                        } else {
+                            let bp = self.pos * 2;
+                            let w = f16::from_le_bytes([wb[bp], wb[bp + 1]]).to_f32();
+                            cand_scores[ci] += query_weight * w;
+                            self.pos += 1;
+                            ci += 1;
+                        }
+                    }
+                    if self.pos >= self.offset_buf.len() {
+                        self.block_idx += 1;
+                        self.pos = 0;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn passes_mask(offset: u32, mask: &SignedRoaringBitmap) -> bool {
+    match mask {
+        SignedRoaringBitmap::Include(rbm) => rbm.contains(offset),
+        SignedRoaringBitmap::Exclude(rbm) => !rbm.contains(offset),
+    }
+}

--- a/rust/index/src/sparse/cursor.rs
+++ b/rust/index/src/sparse/cursor.rs
@@ -9,7 +9,7 @@ enum CursorSource<'view> {
     /// Decompressed on-the-fly into reusable buffers.
     View { raw_blocks: Vec<&'view [u8]> },
     /// Similar to View but blocks start as `None` and are populated via
-    /// `populate_from_cache` / `populate_all_from_cache`.
+    /// `populate_from_cache`.
     Lazy {
         raw_blocks: Vec<Option<&'view [u8]>>,
     },
@@ -103,7 +103,7 @@ impl<'view> PostingCursor<'view> {
 
     /// Create a lazy cursor with unloaded data blocks. The directory
     /// metadata must have been pre-loaded. Blocks start as `None` and
-    /// are populated via [`populate_from_cache`] / [`populate_all_from_cache`].
+    /// are populated via [`populate_from_cache`].
     pub fn open_lazy(dir_max_offsets: Vec<u32>, dir_max_weights: Vec<f32>) -> Self {
         debug_assert_eq!(dir_max_offsets.len(), dir_max_weights.len());
         let block_count = dir_max_offsets.len();
@@ -157,27 +157,36 @@ impl<'view> PostingCursor<'view> {
         loaded
     }
 
-    /// Populate all unloaded blocks from the reader's cache. Returns
-    /// the number of blocks successfully loaded.
-    pub fn populate_all_from_cache(
-        &mut self,
-        reader: &'view BlockfileReader<'view, u32, SparsePostingBlock>,
-        encoded_dim: &str,
-    ) -> usize {
-        let CursorSource::Lazy { raw_blocks } = &mut self.source else {
-            return 0;
-        };
-        let mut loaded = 0;
-        for (idx, slot) in raw_blocks.iter_mut().enumerate().take(self.block_count) {
-            if slot.is_some() {
+    /// Append indices of unloaded blocks overlapping [window_start, window_end]
+    /// to `out`. Walks forward from the current scan position; blocks before
+    /// the cursor's current block are not revisited (they were either already
+    /// processed or intentionally skipped).
+    pub fn collect_overlapping_blocks(
+        &self,
+        window_start: u32,
+        window_end: u32,
+        out: &mut Vec<usize>,
+    ) {
+        if !self.is_lazy() {
+            return;
+        }
+        for bi in self.block_idx..self.block_count {
+            if self.is_block_loaded(bi) {
                 continue;
             }
-            if let Some(bytes) = reader.get_raw_from_cache(encoded_dim, idx as u32) {
-                *slot = Some(bytes);
-                loaded += 1;
+            let block_start = if bi == 0 {
+                0
+            } else {
+                self.dir_max_offsets[bi - 1] + 1
+            };
+            if block_start > window_end {
+                break;
             }
+            if self.dir_max_offsets[bi] < window_start {
+                continue;
+            }
+            out.push(bi);
         }
-        loaded
     }
 
     // ── Internal: buffer management ──────────────────────────────────

--- a/rust/index/src/sparse/cursor.rs
+++ b/rust/index/src/sparse/cursor.rs
@@ -242,6 +242,8 @@ impl<'view> PostingCursor<'view> {
         self.block_count
     }
 
+    /// Returns `None` when the cursor is exhausted or positioned at an
+    /// unloaded lazy block (intentional — lazy cursors skip such blocks).
     pub fn current(&mut self) -> Option<(u32, f32)> {
         if self.block_idx >= self.block_count {
             return None;
@@ -302,7 +304,7 @@ impl<'view> PostingCursor<'view> {
         None
     }
 
-    /// Point lookup for a single doc_id.
+    /// Point lookup for a single doc_id. Currently used only in tests.
     ///
     /// Fast path: reuses the forward buffer if the target block is already
     /// loaded there. View/Lazy slow path: decompresses only offsets, then
@@ -539,6 +541,8 @@ impl<'view> PostingCursor<'view> {
         cand_docs: &[u32],
         cand_scores: &mut [f32],
     ) {
+        // No candidates survived the essential-term drain for this window,
+        // so there is nothing to merge-join against.
         if cand_docs.is_empty() {
             return;
         }

--- a/rust/index/src/sparse/maxscore.md
+++ b/rust/index/src/sparse/maxscore.md
@@ -76,7 +76,65 @@ contribution combined can't promote a zero-score document above the threshold.
 
 Each essential term's cursor walks its blocks within the window, writing
 `accum[doc - window_start] += query_weight × value` into a flat 4096-slot
-accumulator array. A companion 64-word bitmap tracks which slots were touched.
+accumulator array. A companion 64-word bitmap (`[u64; 64]`, one bit per
+slot) tracks which slots were touched.
+
+**Why a bitmap?** After draining, we need to collect the touched slots
+into sorted candidate arrays and later reset only those slots to zero.
+Scanning the bitmap is more efficient than a full scan of the window —
+the bitmap (`[u64; 64]`) makes both operations proportional to the number
+of candidates rather than the window width.
+
+```text
+  window_start = 8192        window_end = 12287
+  ┌─────────────────────────────────────────────────────────────────┐
+  │                   accum[0..4095]  (f32 × 4096)                  │
+  │  [0.0] [0.0] [0.72] [0.0] [0.0] [1.05] [0.0] [0.0] [0.31] ...│
+  └───┬──────┬─────┬──────┬─────┬──────┬─────┬──────┬─────┬────────┘
+      │      │     │      │     │      │     │      │     │
+      0      1     2      3     4      5     6      7     8  ← slot index
+                                                              (doc = slot + 8192)
+  ┌──────────────────────────────────────────────────────┐
+  │              bitmap[0]  (u64, bits 0..63)             │
+  │  ...0 0 1 0 0 1 0 0 1 0 0 ...                        │
+  │        ↑     ↑       ↑                                │
+  │      bit 8  bit 5  bit 2                              │
+  └──────────────────────────────────────────────────────┘
+
+  drain_essential (term "cat", qw=1.0):
+    cursor has doc 8194 (val 0.36) → slot 2: accum[2] += 1.0 × 0.36
+                                              bitmap[0] |= (1 << 2)
+    cursor has doc 8197 (val 0.53) → slot 5: accum[5] += 1.0 × 0.53
+                                              bitmap[0] |= (1 << 5)
+
+  drain_essential (term "food", qw=0.5):
+    cursor has doc 8194 (val 0.72) → slot 2: accum[2] += 0.5 × 0.72  (now 0.72)
+    cursor has doc 8200 (val 0.62) → slot 8: accum[8] += 0.5 × 0.62
+                                              bitmap[0] |= (1 << 8)
+
+  candidate extraction (bitmap walk):
+    word 0 = ...101000100₂
+    trailing_zeros() → bit 2 → cand_docs=[8194], cand_scores=[0.72]
+    clear bit, trailing_zeros() → bit 5 → cand_docs=[8194,8197], ...
+    clear bit, trailing_zeros() → bit 8 → cand_docs=[8194,8197,8200], ...
+    word 0 = 0 → next word ...
+
+  selective reset:
+    same walk zeros accum[2], accum[5], accum[8]; clears bitmap words
+```
+
+- **Candidate extraction**: iterate 64 words; for each non-zero `u64`,
+  `trailing_zeros()` pops set bits in constant time, yielding only the
+  occupied slots in doc-id order.
+- **Selective reset**: after the window is scored, the same set-bit walk
+  zeros only the touched `accum` entries and clears the bitmap words,
+  avoiding a full 4096-entry `memset`.
+
+When the window is densely filled (many essential terms, dense posting
+lists) the bitmap scan approaches a linear sweep — no worse than brute
+force. When it's sparsely filled (common for high-dimensional SPLADE
+vectors where each term covers a small fraction of documents) the
+savings are significant.
 
 This is a pure sequential scan — no random access, very cache-friendly.
 
@@ -119,3 +177,141 @@ and sort descending by score.
 | Budget pruning | Candidates are eliminated *before* scoring weak terms |
 | Block-max upper bounds | Entire blocks are skipped when their max is too low |
 | Bitmap-guided cleanup | Only touched slots are zeroed per window |
+
+---
+
+## Worked Example
+
+A small end-to-end trace showing every step. We search for
+`query = {cat: 1.0, food: 0.5, cute: 0.3}` with `k = 2`.
+
+### Index contents
+
+```text
+doc 0: {cat: 0.9, cute: 0.4}
+doc 1: {food: 0.8}
+doc 2: {cat: 0.5, food: 0.6, cute: 0.7}
+doc 3: {cat: 0.2, cute: 0.1}
+doc 4: {food: 0.3}
+```
+
+Posting lists (one block each, all fit in a single window):
+
+```text
+dim "cat":   [(0, 0.9), (2, 0.5), (3, 0.2)]   dim_max = 0.9
+dim "food":  [(1, 0.8), (2, 0.6), (4, 0.3)]   dim_max = 0.8
+dim "cute":  [(0, 0.4), (2, 0.7), (3, 0.1)]   dim_max = 0.7
+```
+
+### Step 0 — Setup
+
+Open cursors. Compute `max_score = query_weight × dim_max`:
+
+```text
+term   qw    dim_max   max_score
+cute   0.3   0.7       0.21
+food   0.5   0.8       0.40
+cat    1.0   0.9       0.90
+```
+
+Sort ascending by max_score: `[cute=0.21, food=0.40, cat=0.90]`.
+Heap is empty, `threshold = -∞`.
+
+### Window [0, 4095] — the only window needed
+
+#### Step 1 — Partition
+
+All blocks fall in this window, so `window_score = max_score` for each
+term. Prefix sums:
+
+```text
+         cute    food    cat
+score    0.21    0.40    0.90
+prefix   0.21    0.61    1.51
+                  ↑
+            threshold = -∞, so prefix ≥ threshold immediately at cute
+```
+
+Threshold is `-∞`, so every prefix sum ≥ threshold — the split is at
+index 0. **All three terms are essential** (this is typical for the first
+window before any candidates enter the heap).
+
+#### Step 2 — Phase 1: Drain essential terms
+
+Process each essential term, accumulating into `accum[]`:
+
+```text
+drain cute (qw=0.3):
+  doc 0, val 0.4 → slot 0: accum[0] += 0.3 × 0.4 = 0.12    bitmap set bit 0
+  doc 2, val 0.7 → slot 2: accum[2] += 0.3 × 0.7 = 0.21    bitmap set bit 2
+  doc 3, val 0.1 → slot 3: accum[3] += 0.3 × 0.1 = 0.03    bitmap set bit 3
+
+drain food (qw=0.5):
+  doc 1, val 0.8 → slot 1: accum[1] += 0.5 × 0.8 = 0.40    bitmap set bit 1
+  doc 2, val 0.6 → slot 2: accum[2] += 0.5 × 0.6 = 0.30    (now 0.51)
+  doc 4, val 0.3 → slot 4: accum[4] += 0.5 × 0.3 = 0.15    bitmap set bit 4
+
+drain cat (qw=1.0):
+  doc 0, val 0.9 → slot 0: accum[0] += 1.0 × 0.9 = 0.90    (now 1.02)
+  doc 2, val 0.5 → slot 2: accum[2] += 1.0 × 0.5 = 0.50    (now 1.01)
+  doc 3, val 0.2 → slot 3: accum[3] += 1.0 × 0.2 = 0.20    (now 0.23)
+```
+
+Accumulator state:
+
+```text
+slot:   0      1      2      3      4
+accum:  1.02   0.40   1.01   0.23   0.15
+bitmap: 1      1      1      1      1     (bits 0-4 set)
+```
+
+#### Candidate extraction (bitmap walk)
+
+Walk set bits → build sorted candidate arrays:
+
+```text
+cand_docs   = [0,    1,    2,    3,    4   ]
+cand_scores = [1.02, 0.40, 1.01, 0.23, 0.15]
+```
+
+#### Step 3 — Phase 2: Non-essential merge-join
+
+No non-essential terms this window (all were essential), so this phase
+is skipped.
+
+#### Step 4 — Phase 3: Heap extraction (k=2)
+
+Walk candidates, pushing into the min-heap:
+
+```text
+doc 0, score 1.02 → heap [1.02]               (heap not full)
+doc 1, score 0.40 → heap [0.40, 1.02]         (heap full, threshold = 0.40)
+doc 2, score 1.01 → 1.01 > 0.40 → push, pop min
+                     heap [1.01, 1.02]         (threshold = 1.01)
+doc 3, score 0.23 → 0.23 < 1.01 → skip
+doc 4, score 0.15 → 0.15 < 1.01 → skip
+```
+
+#### Reset
+
+Bitmap walk zeros `accum[0..4]`, clears bitmap. Ready for next window
+(none remain).
+
+### Final result
+
+Drain heap, sort descending:
+
+```text
+rank 1: doc 0, score 1.02
+rank 2: doc 2, score 1.01
+```
+
+Verify by brute force:
+
+```text
+doc 0: 1.0×0.9 + 0.3×0.4           = 1.02  ✓
+doc 1: 0.5×0.8                       = 0.40
+doc 2: 1.0×0.5 + 0.5×0.6 + 0.3×0.7 = 1.01  ✓
+doc 3: 1.0×0.2 + 0.3×0.1           = 0.23
+doc 4: 0.5×0.3                       = 0.15
+```

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -495,7 +495,7 @@ impl<'me> MaxScoreReader<'me> {
         let mut metas: Vec<TermMeta> = Vec::new();
         for (idx, &(_, query_weight)) in collected.iter().enumerate() {
             let encoded_dim = encoded_dims[idx].clone();
-            let Some(dir) = self.get_directory(&encoded_dim).await? else {
+            let Some((dir, _part_count)) = self.get_directory(&encoded_dim).await? else {
                 continue;
             };
             if dir.num_blocks() == 0 {

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -8,6 +8,7 @@ use chroma_types::{
 };
 use dashmap::DashMap;
 use futures::StreamExt;
+use std::iter;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -341,243 +342,7 @@ impl<'me> MaxScoreWriter<'me> {
     }
 }
 
-// ── PostingCursor ───────────────────────────────────────────────────
-
-/// Eager cursor backed by fully decompressed `SparsePostingBlock`s.
-pub struct PostingCursor {
-    blocks: Vec<SparsePostingBlock>,
-    dir_max_offsets: Vec<u32>,
-    pub(crate) dir_max_weights: Vec<f32>,
-    dim_max: f32,
-    block_count: usize,
-    block_idx: usize,
-    pos: usize,
-}
-
-impl PostingCursor {
-    pub fn from_blocks(blocks: Vec<SparsePostingBlock>) -> Self {
-        let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.header.max_offset).collect();
-        let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.header.max_weight).collect();
-        let dim_max = dir_max_weights.iter().copied().fold(0.0f32, f32::max);
-        let block_count = blocks.len();
-
-        PostingCursor {
-            blocks,
-            dir_max_offsets,
-            dir_max_weights,
-            dim_max,
-            block_count,
-            block_idx: 0,
-            pos: 0,
-        }
-    }
-
-    pub fn block_count(&self) -> usize {
-        self.block_count
-    }
-
-    pub fn current(&mut self) -> Option<(u32, f32)> {
-        if self.block_idx >= self.block_count {
-            return None;
-        }
-        let (offsets, values) = self.blocks[self.block_idx].decode();
-        if self.pos < offsets.len() {
-            Some((offsets[self.pos], values[self.pos]))
-        } else {
-            None
-        }
-    }
-
-    pub fn advance(&mut self, target: u32, mask: &SignedRoaringBitmap) -> Option<(u32, f32)> {
-        while self.block_idx < self.block_count {
-            if self.dir_max_offsets[self.block_idx] < target {
-                self.block_idx += 1;
-                self.pos = 0;
-                continue;
-            }
-
-            let (offsets, values) = self.blocks[self.block_idx].decode();
-
-            if self.pos == 0 || offsets.get(self.pos).is_some_and(|&o| o < target) {
-                let start = self.pos;
-                self.pos = start + offsets[start..].partition_point(|&o| o < target);
-            }
-
-            while self.pos < offsets.len() {
-                let off = offsets[self.pos];
-                if mask.contains(off) {
-                    return Some((off, values[self.pos]));
-                }
-                self.pos += 1;
-            }
-
-            self.block_idx += 1;
-            self.pos = 0;
-        }
-        None
-    }
-
-    pub fn get_value(&mut self, doc_id: u32) -> Option<f32> {
-        let bi = self
-            .dir_max_offsets
-            .partition_point(|&max_off| max_off < doc_id);
-        if bi >= self.block_count {
-            return None;
-        }
-
-        let (offsets, values) = self.blocks[bi].decode();
-        if offsets.is_empty() || doc_id < offsets[0] {
-            return None;
-        }
-        match offsets.binary_search(&doc_id) {
-            Ok(idx) => Some(values[idx]),
-            Err(_) => None,
-        }
-    }
-
-    pub fn current_block_max(&self) -> f32 {
-        self.dir_max_weights
-            .get(self.block_idx)
-            .copied()
-            .unwrap_or(0.0)
-    }
-
-    pub fn dimension_max(&self) -> f32 {
-        self.dim_max
-    }
-
-    /// Return the MAX block-level weight across all blocks overlapping
-    /// [window_start, window_end].
-    pub fn window_upper_bound(&self, window_start: u32, window_end: u32) -> f32 {
-        let bi_start = self
-            .dir_max_offsets
-            .partition_point(|&max| max < window_start);
-        let mut max_w = 0.0f32;
-        for bi in bi_start..self.block_count {
-            max_w = max_w.max(self.dir_max_weights[bi]);
-            if self.dir_max_offsets[bi] >= window_end {
-                break;
-            }
-        }
-        max_w
-    }
-
-    pub fn next(&mut self) {
-        if self.block_idx >= self.block_count {
-            return;
-        }
-        self.pos += 1;
-        let len = self.blocks[self.block_idx].len();
-        if self.pos >= len {
-            self.block_idx += 1;
-            self.pos = 0;
-        }
-    }
-
-    pub fn current_block_end(&self) -> Option<u32> {
-        self.dir_max_offsets.get(self.block_idx).copied()
-    }
-
-    /// Batch-drain all entries in [window_start, window_end] into a flat
-    /// accumulator array. Each doc's score is accumulated as
-    /// `accum[(doc - window_start)] += query_weight * value`.
-    ///
-    /// The bitmap tracks touched slots for efficient enumeration.
-    pub fn drain_essential(
-        &mut self,
-        window_start: u32,
-        window_end: u32,
-        query_weight: f32,
-        accum: &mut [f32],
-        bitmap: &mut [u64],
-        mask: &SignedRoaringBitmap,
-    ) {
-        while self.block_idx < self.block_count {
-            if self.dir_max_offsets[self.block_idx] < window_start {
-                self.block_idx += 1;
-                self.pos = 0;
-                continue;
-            }
-
-            let (offsets, vals) = self.blocks[self.block_idx].decode();
-
-            if offsets.get(self.pos).is_some_and(|&o| o < window_start) {
-                self.pos = offsets.partition_point(|&o| o < window_start);
-            }
-            while self.pos < offsets.len() {
-                let doc = offsets[self.pos];
-                if doc > window_end {
-                    return;
-                }
-                if mask.contains(doc) {
-                    let idx = (doc - window_start) as usize;
-                    // Set bit `idx` in packed bitmap (word = idx/64, bit = idx%64)
-                    // to track touched slots for efficient enumeration later.
-                    bitmap[idx >> 6] |= 1u64 << (idx & 63);
-                    accum[idx] += vals[self.pos] * query_weight;
-                }
-                self.pos += 1;
-            }
-
-            self.block_idx += 1;
-            self.pos = 0;
-        }
-    }
-
-    /// Merge-join this (non-essential) cursor against sorted candidates,
-    /// accumulating matched scores into `cand_scores`.
-    pub fn score_candidates(
-        &mut self,
-        window_start: u32,
-        window_end: u32,
-        query_weight: f32,
-        cand_docs: &[u32],
-        cand_scores: &mut [f32],
-    ) {
-        if cand_docs.is_empty() {
-            return;
-        }
-
-        let mut ci = 0;
-
-        while self.block_idx < self.block_count && ci < cand_docs.len() {
-            if self.dir_max_offsets[self.block_idx] < window_start
-                || self.dir_max_offsets[self.block_idx] < cand_docs[ci]
-            {
-                self.block_idx += 1;
-                self.pos = 0;
-                continue;
-            }
-
-            let (offsets, values) = self.blocks[self.block_idx].decode();
-
-            if offsets.get(self.pos).is_some_and(|&o| o < window_start) {
-                self.pos = offsets.partition_point(|&o| o < window_start);
-            }
-
-            while self.pos < offsets.len() && ci < cand_docs.len() {
-                let doc = offsets[self.pos];
-                if doc > window_end {
-                    return;
-                }
-                let cand = cand_docs[ci];
-                if doc < cand {
-                    self.pos += 1;
-                } else if doc > cand {
-                    ci += 1;
-                } else {
-                    cand_scores[ci] += query_weight * values[self.pos];
-                    self.pos += 1;
-                    ci += 1;
-                }
-            }
-            if self.pos >= offsets.len() {
-                self.block_idx += 1;
-                self.pos = 0;
-            }
-        }
-    }
-}
+pub use super::cursor::PostingCursor;
 
 // ── MaxScoreReader ───────────────────────────────────────────────
 
@@ -674,7 +439,7 @@ impl<'me> MaxScoreReader<'me> {
     pub async fn open_cursor(
         &'me self,
         encoded_dim: &str,
-    ) -> Result<Option<PostingCursor>, MaxScoreError> {
+    ) -> Result<Option<PostingCursor<'me>>, MaxScoreError> {
         let blocks = self.get_posting_blocks(encoded_dim).await?;
         if blocks.is_empty() {
             return Ok(None);
@@ -682,10 +447,16 @@ impl<'me> MaxScoreReader<'me> {
         Ok(Some(PostingCursor::from_blocks(blocks)))
     }
 
-    /// BlockMaxMaxScore query with window accumulator.
+    /// BlockMaxMaxScore query using the 3-batch I/O pipeline.
     ///
-    /// Eager-only: all posting blocks are loaded up front. Lazy I/O and
-    /// 3-batch pipeline are added in PR #3.
+    /// 1. **Batch 1 — directories**: load directory blocks for every
+    ///    query dimension in parallel, parse metadata.
+    /// 2. **Batch 2 — essential data**: small dims (≤2 Arrow blocks)
+    ///    get View cursors immediately; large dims get Lazy cursors
+    ///    whose blocks are loaded and populated in bulk.
+    /// 3. **Batch 3 — non-essential data**: after the threshold
+    ///    stabilizes, load remaining blocks for non-essential terms,
+    ///    pruning blocks that can't beat the threshold.
     pub async fn query(
         &'me self,
         query_vector: impl IntoIterator<Item = (u32, f32)>,
@@ -699,31 +470,94 @@ impl<'me> MaxScoreReader<'me> {
         let collected: Vec<(u32, f32)> = query_vector.into_iter().collect();
         let encoded_dims: Vec<String> = collected.iter().map(|(d, _)| encode_u32(*d)).collect();
 
-        // Open cursors for all query dimensions concurrently, preserving
-        // insertion order so that cursor_results[i] corresponds to
-        // collected[i]'s query weight. (`buffered` yields in submission
-        // order; `buffer_unordered` would yield in completion order,
-        // mismatching cursors with query weights.)
-        let cursor_results: Vec<Result<Option<PostingCursor>, MaxScoreError>> =
-            futures::stream::iter(encoded_dims.iter().map(|enc| self.open_cursor(enc)))
-                .buffered(encoded_dims.len())
-                .collect()
-                .await;
+        // ── Batch 1: load directory parts for all query dims ────────
+        let dir_prefixes: Vec<String> = encoded_dims
+            .iter()
+            .map(|d| format!("{}{}", DIRECTORY_PREFIX, d))
+            .collect();
+        self.posting_reader
+            .load_blocks_for_prefixes(dir_prefixes.iter().map(|s| s.as_str()))
+            .await;
 
-        let mut terms: Vec<TermState> = Vec::new();
-        for (idx, result) in cursor_results.into_iter().enumerate() {
-            let Some(mut cursor) = result? else {
+        struct TermMeta {
+            encoded_dim: String,
+            dir_max_offsets: Vec<u32>,
+            dir_max_weights: Vec<f32>,
+            query_weight: f32,
+            max_score: f32,
+        }
+
+        let mut metas: Vec<TermMeta> = Vec::new();
+        for (idx, &(_, query_weight)) in collected.iter().enumerate() {
+            let encoded_dim = encoded_dims[idx].clone();
+            let Some(dir) = self.get_directory(&encoded_dim).await? else {
                 continue;
             };
-            let query_weight = collected[idx].1;
-            cursor.advance(0, &mask);
-            let max_score = query_weight * cursor.dimension_max();
-            terms.push(TermState {
-                cursor,
+            if dir.num_blocks() == 0 {
+                continue;
+            }
+            let max_score = query_weight * dir.dim_max_weight();
+            metas.push(TermMeta {
+                encoded_dim,
+                dir_max_offsets: dir.max_offsets().to_vec(),
+                dir_max_weights: dir.max_weights().to_vec(),
                 query_weight,
                 max_score,
-                window_score: max_score,
             });
+        }
+
+        if metas.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // ── Build cursors ──────────────────────────────────────────
+        // Small dimensions (≤2 Arrow blocks) use the eager View path;
+        // large dimensions use Lazy cursors populated in Batch 2.
+        let mut terms: Vec<TermState<'me>> = Vec::new();
+        for meta in metas {
+            let block_count = self
+                .posting_reader
+                .count_blocks_for_prefix(&meta.encoded_dim);
+
+            if block_count <= 2 {
+                self.posting_reader
+                    .load_blocks_for_prefixes(iter::once(meta.encoded_dim.as_str()))
+                    .await;
+                let n = meta.dir_max_offsets.len();
+                let raw_blocks: Vec<&[u8]> = (0..n)
+                    .filter_map(|seq| {
+                        self.posting_reader
+                            .get_raw_from_cache(&meta.encoded_dim, seq as u32)
+                    })
+                    .collect();
+
+                let mut cursor = if raw_blocks.len() == n {
+                    PostingCursor::open(raw_blocks, meta.dir_max_offsets, meta.dir_max_weights)
+                } else {
+                    let blocks = self.get_posting_blocks(&meta.encoded_dim).await?;
+                    if blocks.is_empty() {
+                        continue;
+                    }
+                    PostingCursor::from_blocks(blocks)
+                };
+                cursor.advance(0, &mask);
+                terms.push(TermState {
+                    cursor,
+                    encoded_dim: meta.encoded_dim,
+                    query_weight: meta.query_weight,
+                    max_score: meta.max_score,
+                    window_score: meta.max_score,
+                });
+            } else {
+                let cursor = PostingCursor::open_lazy(meta.dir_max_offsets, meta.dir_max_weights);
+                terms.push(TermState {
+                    cursor,
+                    encoded_dim: meta.encoded_dim,
+                    query_weight: meta.query_weight,
+                    max_score: meta.max_score,
+                    window_score: meta.max_score,
+                });
+            }
         }
 
         if terms.is_empty() {
@@ -732,6 +566,39 @@ impl<'me> MaxScoreReader<'me> {
 
         terms.sort_by(|a, b| a.max_score.total_cmp(&b.max_score));
 
+        // ── Batch 2: load all blocks for essential terms ───────────
+        // At threshold=MIN all terms are essential. Load their posting
+        // blocks so the first windows can run without blocking.
+        let essential_idx = 0usize;
+        {
+            let mut keys_to_load: Vec<(String, u32)> = Vec::new();
+            for t in terms[essential_idx..].iter() {
+                if t.cursor.is_lazy() {
+                    for bk in 0..t.cursor.block_count() as u32 {
+                        keys_to_load.push((t.encoded_dim.clone(), bk));
+                    }
+                }
+            }
+            if !keys_to_load.is_empty() {
+                self.posting_reader.load_data_for_keys(keys_to_load).await;
+                for t in terms[essential_idx..].iter_mut() {
+                    if t.cursor.is_lazy() {
+                        let dim = t.encoded_dim.clone();
+                        t.cursor.populate_all_from_cache(&self.posting_reader, &dim);
+                    }
+                }
+            }
+        }
+
+        for t in terms.iter_mut() {
+            if t.cursor.is_lazy() {
+                t.cursor.advance(0, &mask);
+            }
+        }
+
+        let mut non_essential_loaded = false;
+
+        // ── Window loop ────────────────────────────────────────────
         let k_usize = k as usize;
         let mut heap = TopKHeap::new(k_usize);
         let mut threshold = heap.threshold();
@@ -754,9 +621,6 @@ impl<'me> MaxScoreReader<'me> {
         while window_start <= max_doc_id {
             let window_end = (window_start + WINDOW_WIDTH - 1).min(max_doc_id);
 
-            // Per-window re-partition: compute each term's window-local
-            // upper bound, re-sort, and find the essential/non-essential
-            // split.
             for t in terms.iter_mut() {
                 t.window_score =
                     t.query_weight * t.cursor.window_upper_bound(window_start, window_end);
@@ -775,7 +639,6 @@ impl<'me> MaxScoreReader<'me> {
                 }
             }
 
-            // Phase 1: batch-drain essential terms into accumulator
             for term in terms[essential_idx..].iter_mut() {
                 term.cursor.drain_essential(
                     window_start,
@@ -787,7 +650,6 @@ impl<'me> MaxScoreReader<'me> {
                 );
             }
 
-            // Scan bitmap → sorted cand_docs + contiguous cand_scores
             cand_docs.clear();
             cand_scores.clear();
             for (word_idx, &word) in bitmap.iter().enumerate().take(BITMAP_WORDS) {
@@ -809,7 +671,34 @@ impl<'me> MaxScoreReader<'me> {
                 continue;
             }
 
-            // Phase 2: non-essential merge-join with budget pruning
+            // ── Batch 3: lazy-load non-essential blocks (once) ────
+            if !non_essential_loaded && essential_idx > 0 {
+                non_essential_loaded = true;
+                let mut ne_keys: Vec<(String, u32)> = Vec::new();
+                for t in terms.iter() {
+                    if !t.cursor.is_lazy() {
+                        continue;
+                    }
+                    for bi in 0..t.cursor.block_count() {
+                        if t.cursor.is_block_loaded(bi) {
+                            continue;
+                        }
+                        if t.query_weight * t.cursor.dir_max_weights[bi] > threshold {
+                            ne_keys.push((t.encoded_dim.clone(), bi as u32));
+                        }
+                    }
+                }
+                if !ne_keys.is_empty() {
+                    self.posting_reader.load_data_for_keys(ne_keys).await;
+                    for t in terms.iter_mut() {
+                        if t.cursor.is_lazy() {
+                            let dim = t.encoded_dim.clone();
+                            t.cursor.populate_all_from_cache(&self.posting_reader, &dim);
+                        }
+                    }
+                }
+            }
+
             if essential_idx > 0 {
                 let mut remaining_budget: f32 =
                     terms[..essential_idx].iter().map(|t| t.window_score).sum();
@@ -840,12 +729,10 @@ impl<'me> MaxScoreReader<'me> {
                 }
             }
 
-            // Phase 3: extract to heap and reset accumulator
             for (ci, &doc) in cand_docs.iter().enumerate() {
                 threshold = heap.push(cand_scores[ci], doc);
             }
 
-            // Zero accum slots + clear bitmap using the bitmap itself
             for (word_idx, word) in bitmap.iter_mut().enumerate().take(BITMAP_WORDS) {
                 let mut bits = *word;
                 while bits != 0 {
@@ -866,8 +753,9 @@ impl<'me> MaxScoreReader<'me> {
     }
 }
 
-struct TermState {
-    cursor: PostingCursor,
+struct TermState<'a> {
+    cursor: PostingCursor<'a>,
+    encoded_dim: String,
     query_weight: f32,
     max_score: f32,
     window_score: f32,

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -571,38 +571,6 @@ impl<'me> MaxScoreReader<'me> {
 
         terms.sort_by(|a, b| a.max_score.total_cmp(&b.max_score));
 
-        // ── Batch 2: load all blocks for essential terms ───────────
-        // At threshold=MIN all terms are essential. Load their posting
-        // blocks so the first windows can run without blocking.
-        let essential_idx = 0usize;
-        {
-            let mut keys_to_load: Vec<(String, u32)> = Vec::new();
-            for t in terms[essential_idx..].iter() {
-                if t.cursor.is_lazy() {
-                    for bk in 0..t.cursor.block_count() as u32 {
-                        keys_to_load.push((t.encoded_dim.clone(), bk));
-                    }
-                }
-            }
-            if !keys_to_load.is_empty() {
-                self.posting_reader.load_data_for_keys(keys_to_load).await;
-                for t in terms[essential_idx..].iter_mut() {
-                    if t.cursor.is_lazy() {
-                        let dim = t.encoded_dim.clone();
-                        t.cursor.populate_all_from_cache(&self.posting_reader, &dim);
-                    }
-                }
-            }
-        }
-
-        for t in terms.iter_mut() {
-            if t.cursor.is_lazy() {
-                t.cursor.advance(0, &mask);
-            }
-        }
-
-        let mut non_essential_loaded = false;
-
         // ── Window loop ────────────────────────────────────────────
         let k_usize = k as usize;
         let mut heap = TopKHeap::new(k_usize);
@@ -622,6 +590,9 @@ impl<'me> MaxScoreReader<'me> {
             .unwrap_or(0);
 
         let mut window_start = 0u32;
+        let mut keys_to_load: Vec<(String, u32)> = Vec::new();
+        let mut keys_per_term: Vec<Vec<usize>> = (0..terms.len()).map(|_| Vec::new()).collect();
+        let mut overlapping: Vec<usize> = Vec::new();
 
         while window_start <= max_doc_id {
             let window_end = (window_start + WINDOW_WIDTH - 1).min(max_doc_id);
@@ -640,6 +611,53 @@ impl<'me> MaxScoreReader<'me> {
                     if prefix >= threshold {
                         essential_idx = i;
                         break;
+                    }
+                }
+            }
+
+            // ── Pre-Phase-1: load blocks overlapping this window ───
+            // Each posting block (~131K offsets) typically spans many
+            // windows, so most iterations find zero new blocks to load.
+            // Essential terms load unconditionally; non-essential terms
+            // are gated by a partial-score-aware bound.
+            {
+                let essential_budget: f32 =
+                    terms[essential_idx..].iter().map(|t| t.window_score).sum();
+                let block_load_floor = threshold - essential_budget;
+
+                keys_to_load.clear();
+                for v in keys_per_term.iter_mut() {
+                    v.clear();
+                }
+
+                for (ti, t) in terms.iter().enumerate() {
+                    overlapping.clear();
+                    t.cursor
+                        .collect_overlapping_blocks(window_start, window_end, &mut overlapping);
+                    let is_essential = ti >= essential_idx;
+                    for &bi in &overlapping {
+                        if !is_essential
+                            && t.query_weight * t.cursor.dir_max_weights[bi] <= block_load_floor
+                        {
+                            continue;
+                        }
+                        keys_to_load.push((t.encoded_dim.clone(), bi as u32));
+                        keys_per_term[ti].push(bi);
+                    }
+                }
+
+                if !keys_to_load.is_empty() {
+                    self.posting_reader
+                        .load_data_for_keys(keys_to_load.drain(..))
+                        .await;
+                    for (ti, indices) in keys_per_term.iter().enumerate() {
+                        if indices.is_empty() {
+                            continue;
+                        }
+                        let dim = terms[ti].encoded_dim.clone();
+                        terms[ti]
+                            .cursor
+                            .populate_from_cache(&self.posting_reader, &dim, indices);
                     }
                 }
             }
@@ -668,40 +686,14 @@ impl<'me> MaxScoreReader<'me> {
                 }
             }
 
+            // No essential term touched any doc in this window. Skip
+            // Phase 2, heap update, and accumulator reset.
             if cand_docs.is_empty() {
                 window_start = window_end.wrapping_add(1);
                 if window_start == 0 {
                     break;
                 }
                 continue;
-            }
-
-            // ── Batch 3: lazy-load non-essential blocks (once) ────
-            if !non_essential_loaded && essential_idx > 0 {
-                non_essential_loaded = true;
-                let mut ne_keys: Vec<(String, u32)> = Vec::new();
-                for t in terms.iter() {
-                    if !t.cursor.is_lazy() {
-                        continue;
-                    }
-                    for bi in 0..t.cursor.block_count() {
-                        if t.cursor.is_block_loaded(bi) {
-                            continue;
-                        }
-                        if t.query_weight * t.cursor.dir_max_weights[bi] > threshold {
-                            ne_keys.push((t.encoded_dim.clone(), bi as u32));
-                        }
-                    }
-                }
-                if !ne_keys.is_empty() {
-                    self.posting_reader.load_data_for_keys(ne_keys).await;
-                    for t in terms.iter_mut() {
-                        if t.cursor.is_lazy() {
-                            let dim = t.encoded_dim.clone();
-                            t.cursor.populate_all_from_cache(&self.posting_reader, &dim);
-                        }
-                    }
-                }
             }
 
             if essential_idx > 0 {
@@ -713,6 +705,8 @@ impl<'me> MaxScoreReader<'me> {
                         let cutoff = threshold - remaining_budget;
                         filter_competitive(&mut cand_docs, &mut cand_scores, cutoff);
                     }
+                    // All candidates pruned by budget filter; no point
+                    // scoring further non-essential terms.
                     if cand_docs.is_empty() {
                         break;
                     }

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -7,7 +7,7 @@ use chroma_types::{
     DIRECTORY_PREFIX, MAX_BLOCK_ENTRIES,
 };
 use dashmap::DashMap;
-use futures::StreamExt;
+
 use std::iter;
 use thiserror::Error;
 use uuid::Uuid;
@@ -17,6 +17,11 @@ use crate::sparse::types::{decode_u32, encode_u32, Score, TopKHeap};
 const DEFAULT_BLOCK_SIZE: u32 = 1024;
 
 pub const SPARSE_POSTING_BLOCK_SIZE_BYTES: usize = 1024 * 1024;
+
+/// Dimensions with at most this many Arrow blocks use a View cursor
+/// (loaded eagerly into cache). Larger dimensions use Lazy cursors
+/// whose blocks are loaded on demand in Batch 2/3.
+const MAX_VIEW_BLOCKS: usize = 2;
 
 #[derive(Debug, Error)]
 pub enum MaxScoreError {
@@ -519,7 +524,7 @@ impl<'me> MaxScoreReader<'me> {
                 .posting_reader
                 .count_blocks_for_prefix(&meta.encoded_dim);
 
-            if block_count <= 2 {
+            if block_count <= MAX_VIEW_BLOCKS {
                 self.posting_reader
                     .load_blocks_for_prefixes(iter::once(meta.encoded_dim.as_str()))
                     .await;

--- a/rust/index/src/sparse/mod.rs
+++ b/rust/index/src/sparse/mod.rs
@@ -1,3 +1,4 @@
+pub mod cursor;
 pub mod maxscore;
 pub mod reader;
 pub mod types;

--- a/rust/index/tests/maxscore/main.rs
+++ b/rust/index/tests/maxscore/main.rs
@@ -14,3 +14,5 @@ mod ms_11_vectorized_scoring;
 mod ms_12_cursor_view;
 mod ms_13_cursor_lazy;
 mod ms_14_three_batch_pipeline;
+mod ms_15_multi_window;
+mod ms_16_lazy_partial_load;

--- a/rust/index/tests/maxscore/main.rs
+++ b/rust/index/tests/maxscore/main.rs
@@ -11,3 +11,6 @@ mod ms_08_edge_cases;
 mod ms_09_recall;
 mod ms_10_incremental_query;
 mod ms_11_vectorized_scoring;
+mod ms_12_cursor_view;
+mod ms_13_cursor_lazy;
+mod ms_14_three_batch_pipeline;

--- a/rust/index/tests/maxscore/ms_12_cursor_view.rs
+++ b/rust/index/tests/maxscore/ms_12_cursor_view.rs
@@ -23,9 +23,10 @@ fn make_view_cursor(entries_per_block: &[&[(u32, f32)]]) -> (Vec<Vec<u8>>, Posti
     let raw_refs: Vec<&[u8]> = raw_bytes.iter().map(|v| v.as_slice()).collect();
     let cursor = PostingCursor::open(raw_refs, dir_max_offsets, dir_max_weights);
 
-    // Safety: we return owned raw_bytes alongside the cursor so the
-    // references remain valid. The caller must keep raw_bytes alive.
-    let cursor: PostingCursor<'static> = unsafe { std::mem::transmute(cursor) };
+    // SAFETY: The cursor borrows from raw_bytes which is returned alongside
+    // it. The caller must keep raw_bytes alive for the cursor's lifetime.
+    let cursor: PostingCursor<'static> =
+        unsafe { std::mem::transmute::<PostingCursor<'_>, PostingCursor<'static>>(cursor) };
     (raw_bytes, cursor)
 }
 

--- a/rust/index/tests/maxscore/ms_12_cursor_view.rs
+++ b/rust/index/tests/maxscore/ms_12_cursor_view.rs
@@ -1,0 +1,145 @@
+use crate::common;
+use chroma_index::sparse::maxscore::PostingCursor;
+use chroma_types::{SignedRoaringBitmap, SparsePostingBlock};
+
+fn all_mask() -> SignedRoaringBitmap {
+    SignedRoaringBitmap::Exclude(Default::default())
+}
+
+/// Build a view cursor from entry slices. Returns the owned raw bytes
+/// (must stay alive) and the cursor. Values go through f16 quantization,
+/// so use approximate comparisons.
+fn make_view_cursor(entries_per_block: &[&[(u32, f32)]]) -> (Vec<Vec<u8>>, PostingCursor<'static>) {
+    let blocks: Vec<SparsePostingBlock> = entries_per_block
+        .iter()
+        .map(|e| SparsePostingBlock::from_sorted_entries(e).unwrap())
+        .collect();
+
+    let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.max_offset).collect();
+    let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.max_weight).collect();
+
+    let raw_bytes: Vec<Vec<u8>> = blocks.iter().map(|b| b.serialize()).collect();
+
+    let raw_refs: Vec<&[u8]> = raw_bytes.iter().map(|v| v.as_slice()).collect();
+    let cursor = PostingCursor::open(raw_refs, dir_max_offsets, dir_max_weights);
+
+    // Safety: we return owned raw_bytes alongside the cursor so the
+    // references remain valid. The caller must keep raw_bytes alive.
+    let cursor: PostingCursor<'static> = unsafe { std::mem::transmute(cursor) };
+    (raw_bytes, cursor)
+}
+
+fn assert_opt_approx(a: Option<(u32, f32)>, b: Option<(u32, f32)>, tol: f32) {
+    match (a, b) {
+        (Some((ao, av)), Some((bo, bv))) => {
+            assert_eq!(ao, bo, "offset mismatch");
+            common::assert_approx(av, bv, tol);
+        }
+        (None, None) => {}
+        _ => panic!("mismatch: {a:?} vs {b:?}"),
+    }
+}
+
+#[test]
+fn view_cursor_advance_matches_eager() {
+    let entries = &[(0u32, 0.1f32), (5, 0.2), (10, 0.3), (20, 0.4)];
+
+    let block = SparsePostingBlock::from_sorted_entries(entries).unwrap();
+    let mut eager = PostingCursor::from_blocks(vec![block]);
+
+    let (_raw, mut view) = make_view_cursor(&[entries]);
+
+    let mask = all_mask();
+
+    for target in [0, 5, 7, 10, 15, 20, 25] {
+        let e = eager.advance(target, &mask);
+        let v = view.advance(target, &mask);
+        assert_opt_approx(v, e, 1e-3);
+        if e.is_some() {
+            eager.next();
+            view.next();
+        }
+    }
+}
+
+#[test]
+fn view_cursor_multi_block_advance() {
+    let b1_entries: &[(u32, f32)] = &[(0, 0.1), (5, 0.2)];
+    let b2_entries: &[(u32, f32)] = &[(10, 0.3), (15, 0.4)];
+
+    let (_raw, mut cursor) = make_view_cursor(&[b1_entries, b2_entries]);
+    let mask = all_mask();
+
+    assert_opt_approx(cursor.advance(0, &mask), Some((0, 0.1)), 1e-3);
+    cursor.next();
+    assert_opt_approx(cursor.advance(10, &mask), Some((10, 0.3)), 1e-3);
+}
+
+#[test]
+fn view_cursor_drain_essential() {
+    let entries: &[(u32, f32)] = &[(0, 0.5), (1, 0.25), (2, 0.75)];
+    let (_raw, mut cursor) = make_view_cursor(&[entries]);
+    let mask = all_mask();
+
+    let mut accum = vec![0.0f32; 4096];
+    let mut bitmap = [0u64; 64];
+
+    cursor.drain_essential(0, 2, 2.0, &mut accum, &mut bitmap, &mask);
+
+    common::assert_approx(accum[0], 0.5 * 2.0, 1e-3);
+    common::assert_approx(accum[1], 0.25 * 2.0, 1e-3);
+    common::assert_approx(accum[2], 0.75 * 2.0, 1e-3);
+    assert!(bitmap[0] & 0b111 == 0b111);
+}
+
+#[test]
+fn view_cursor_score_candidates() {
+    let entries: &[(u32, f32)] = &[(0, 0.5), (1, 0.25), (2, 0.75), (5, 0.1)];
+    let (_raw, mut cursor) = make_view_cursor(&[entries]);
+
+    let cand_docs = vec![0, 2, 5];
+    let mut cand_scores = vec![0.0; 3];
+    cursor.score_candidates(0, 10, 1.0, &cand_docs, &mut cand_scores);
+
+    common::assert_approx(cand_scores[0], 0.5, 1e-3);
+    common::assert_approx(cand_scores[1], 0.75, 1e-3);
+    common::assert_approx(cand_scores[2], 0.1, 1e-3);
+}
+
+#[test]
+fn view_cursor_get_value() {
+    let b1: &[(u32, f32)] = &[(0, 0.1), (5, 0.2)];
+    let b2: &[(u32, f32)] = &[(10, 0.3), (15, 0.4)];
+    let (_raw, mut cursor) = make_view_cursor(&[b1, b2]);
+
+    common::assert_approx(cursor.get_value(0).unwrap(), 0.1, 1e-3);
+    common::assert_approx(cursor.get_value(5).unwrap(), 0.2, 1e-3);
+    common::assert_approx(cursor.get_value(10).unwrap(), 0.3, 1e-3);
+    common::assert_approx(cursor.get_value(15).unwrap(), 0.4, 1e-3);
+    assert_eq!(cursor.get_value(7), None);
+    assert_eq!(cursor.get_value(100), None);
+}
+
+#[test]
+fn view_cursor_window_upper_bound() {
+    let b1: &[(u32, f32)] = &[(0, 0.1), (5, 0.9)];
+    let b2: &[(u32, f32)] = &[(10, 0.3), (15, 0.4)];
+    let (_raw, cursor) = make_view_cursor(&[b1, b2]);
+
+    assert_eq!(cursor.window_upper_bound(0, 5), 0.9);
+    assert_eq!(cursor.window_upper_bound(10, 15), 0.4);
+    let ub = cursor.window_upper_bound(0, 15);
+    assert!(ub >= 0.9);
+}
+
+#[test]
+fn view_cursor_current() {
+    let entries: &[(u32, f32)] = &[(3, 0.5), (7, 0.9)];
+    let (_raw, mut cursor) = make_view_cursor(&[entries]);
+
+    assert_opt_approx(cursor.current(), Some((3, 0.5)), 1e-3);
+    cursor.next();
+    assert_opt_approx(cursor.current(), Some((7, 0.9)), 1e-3);
+    cursor.next();
+    assert_eq!(cursor.current(), None);
+}

--- a/rust/index/tests/maxscore/ms_12_cursor_view.rs
+++ b/rust/index/tests/maxscore/ms_12_cursor_view.rs
@@ -15,8 +15,8 @@ fn make_view_cursor(entries_per_block: &[&[(u32, f32)]]) -> (Vec<Vec<u8>>, Posti
         .map(|e| SparsePostingBlock::from_sorted_entries(e).unwrap())
         .collect();
 
-    let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.max_offset).collect();
-    let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.max_weight).collect();
+    let dir_max_offsets: Vec<u32> = blocks.iter().map(|b| b.header.max_offset).collect();
+    let dir_max_weights: Vec<f32> = blocks.iter().map(|b| b.header.max_weight).collect();
 
     let raw_bytes: Vec<Vec<u8>> = blocks.iter().map(|b| b.serialize()).collect();
 

--- a/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
+++ b/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
@@ -1,0 +1,136 @@
+use crate::common;
+use chroma_index::sparse::maxscore::PostingCursor;
+use chroma_index::sparse::types::encode_u32;
+use chroma_types::{DirectoryBlock, SignedRoaringBitmap, SparsePostingBlock};
+
+fn all_mask() -> SignedRoaringBitmap {
+    SignedRoaringBitmap::Exclude(Default::default())
+}
+
+#[tokio::test]
+async fn lazy_cursor_advance_matches_eager() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.5f32)]),
+        (5, vec![(1, 0.3)]),
+        (10, vec![(1, 0.9)]),
+        (20, vec![(1, 0.1)]),
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors).await;
+    let encoded_dim = encode_u32(1);
+
+    let dir_block: SparsePostingBlock = reader
+        .posting_reader()
+        .get(&encoded_dim, u32::MAX)
+        .await
+        .unwrap()
+        .unwrap();
+    let dir = DirectoryBlock::from_block(dir_block).unwrap();
+    let (dir_max_offsets, dir_max_weights) = dir.entries();
+
+    // Load data blocks into cache
+    reader
+        .posting_reader()
+        .load_blocks_for_prefixes([encoded_dim.as_str()])
+        .await;
+
+    let mut lazy_cursor =
+        PostingCursor::open_lazy(dir_max_offsets.clone(), dir_max_weights.clone());
+    lazy_cursor.populate_all_from_cache(reader.posting_reader(), &encoded_dim);
+
+    let blocks = reader.get_posting_blocks(&encoded_dim).await.unwrap();
+    let mut eager_cursor = PostingCursor::from_blocks(blocks);
+
+    let mask = all_mask();
+    for target in [0, 5, 7, 10, 15, 20, 25] {
+        let e = eager_cursor.advance(target, &mask);
+        let l = lazy_cursor.advance(target, &mask);
+        match (e, l) {
+            (Some((eo, ev)), Some((lo, lv))) => {
+                assert_eq!(eo, lo, "advance({target}) offset mismatch");
+                common::assert_approx(lv, ev, 1e-3);
+            }
+            (None, None) => {}
+            _ => panic!("advance({target}) mismatch: eager={e:?} lazy={l:?}"),
+        }
+        if e.is_some() {
+            eager_cursor.next();
+            lazy_cursor.next();
+        }
+    }
+}
+
+#[tokio::test]
+async fn lazy_cursor_get_value() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.1f32)]),
+        (5, vec![(1, 0.2)]),
+        (10, vec![(1, 0.3)]),
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors).await;
+    let encoded_dim = encode_u32(1);
+
+    let dir_block: SparsePostingBlock = reader
+        .posting_reader()
+        .get(&encoded_dim, u32::MAX)
+        .await
+        .unwrap()
+        .unwrap();
+    let dir = DirectoryBlock::from_block(dir_block).unwrap();
+    let (offsets, weights) = dir.entries();
+
+    reader
+        .posting_reader()
+        .load_blocks_for_prefixes([encoded_dim.as_str()])
+        .await;
+
+    let mut cursor = PostingCursor::open_lazy(offsets, weights);
+    cursor.populate_all_from_cache(reader.posting_reader(), &encoded_dim);
+
+    common::assert_approx(cursor.get_value(0).unwrap(), 0.1, 1e-3);
+    common::assert_approx(cursor.get_value(5).unwrap(), 0.2, 1e-3);
+    common::assert_approx(cursor.get_value(10).unwrap(), 0.3, 1e-3);
+    assert_eq!(cursor.get_value(7), None);
+    assert_eq!(cursor.get_value(99), None);
+}
+
+#[tokio::test]
+async fn lazy_cursor_drain_essential() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.5f32)]),
+        (1, vec![(1, 0.25)]),
+        (2, vec![(1, 0.75)]),
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors).await;
+    let encoded_dim = encode_u32(1);
+
+    let dir_block: SparsePostingBlock = reader
+        .posting_reader()
+        .get(&encoded_dim, u32::MAX)
+        .await
+        .unwrap()
+        .unwrap();
+    let dir = DirectoryBlock::from_block(dir_block).unwrap();
+    let (offsets, weights) = dir.entries();
+
+    reader
+        .posting_reader()
+        .load_blocks_for_prefixes([encoded_dim.as_str()])
+        .await;
+
+    let mut cursor = PostingCursor::open_lazy(offsets, weights);
+    cursor.populate_all_from_cache(reader.posting_reader(), &encoded_dim);
+
+    let mask = all_mask();
+    let mut accum = vec![0.0f32; 4096];
+    let mut bitmap = [0u64; 64];
+
+    cursor.drain_essential(0, 2, 2.0, &mut accum, &mut bitmap, &mask);
+
+    common::assert_approx(accum[0], 0.5 * 2.0, 1e-3);
+    common::assert_approx(accum[1], 0.25 * 2.0, 1e-3);
+    common::assert_approx(accum[2], 0.75 * 2.0, 1e-3);
+    assert!(bitmap[0] & 0b111 == 0b111);
+}

--- a/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
+++ b/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
@@ -35,7 +35,8 @@ async fn lazy_cursor_advance_matches_eager() {
 
     let mut lazy_cursor =
         PostingCursor::open_lazy(dir_max_offsets.clone(), dir_max_weights.clone());
-    lazy_cursor.populate_all_from_cache(reader.posting_reader(), &encoded_dim);
+    let all_indices: Vec<usize> = (0..dir_max_offsets.len()).collect();
+    lazy_cursor.populate_from_cache(reader.posting_reader(), &encoded_dim, &all_indices);
 
     let blocks = reader.get_posting_blocks(&encoded_dim).await.unwrap();
     let mut eager_cursor = PostingCursor::from_blocks(blocks);
@@ -83,8 +84,9 @@ async fn lazy_cursor_get_value() {
         .load_blocks_for_prefixes([encoded_dim.as_str()])
         .await;
 
-    let mut cursor = PostingCursor::open_lazy(offsets, weights);
-    cursor.populate_all_from_cache(reader.posting_reader(), &encoded_dim);
+    let mut cursor = PostingCursor::open_lazy(offsets.clone(), weights);
+    let all_indices: Vec<usize> = (0..offsets.len()).collect();
+    cursor.populate_from_cache(reader.posting_reader(), &encoded_dim, &all_indices);
 
     common::assert_approx(cursor.get_value(0).unwrap(), 0.1, 1e-3);
     common::assert_approx(cursor.get_value(5).unwrap(), 0.2, 1e-3);
@@ -117,8 +119,9 @@ async fn lazy_cursor_drain_essential() {
         .load_blocks_for_prefixes([encoded_dim.as_str()])
         .await;
 
-    let mut cursor = PostingCursor::open_lazy(offsets, weights);
-    cursor.populate_all_from_cache(reader.posting_reader(), &encoded_dim);
+    let mut cursor = PostingCursor::open_lazy(offsets.clone(), weights);
+    let all_indices: Vec<usize> = (0..offsets.len()).collect();
+    cursor.populate_from_cache(reader.posting_reader(), &encoded_dim, &all_indices);
 
     let mask = all_mask();
     let mut accum = vec![0.0f32; 4096];

--- a/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
+++ b/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
@@ -1,7 +1,7 @@
 use crate::common;
 use chroma_index::sparse::maxscore::PostingCursor;
 use chroma_index::sparse::types::encode_u32;
-use chroma_types::{DirectoryBlock, SignedRoaringBitmap, SparsePostingBlock};
+use chroma_types::SignedRoaringBitmap;
 
 fn all_mask() -> SignedRoaringBitmap {
     SignedRoaringBitmap::Exclude(Default::default())
@@ -19,14 +19,13 @@ async fn lazy_cursor_advance_matches_eager() {
     let (_tmp, _prov, reader) = common::build_index(vectors).await;
     let encoded_dim = encode_u32(1);
 
-    let dir_block: SparsePostingBlock = reader
-        .posting_reader()
-        .get(&encoded_dim, u32::MAX)
+    let dir = reader
+        .get_directory(&encoded_dim)
         .await
         .unwrap()
-        .unwrap();
-    let dir = DirectoryBlock::from_block(dir_block).unwrap();
-    let (dir_max_offsets, dir_max_weights) = dir.entries();
+        .expect("directory should exist");
+    let dir_max_offsets = dir.max_offsets().to_vec();
+    let dir_max_weights = dir.max_weights().to_vec();
 
     // Load data blocks into cache
     reader
@@ -71,14 +70,13 @@ async fn lazy_cursor_get_value() {
     let (_tmp, _prov, reader) = common::build_index(vectors).await;
     let encoded_dim = encode_u32(1);
 
-    let dir_block: SparsePostingBlock = reader
-        .posting_reader()
-        .get(&encoded_dim, u32::MAX)
+    let dir = reader
+        .get_directory(&encoded_dim)
         .await
         .unwrap()
-        .unwrap();
-    let dir = DirectoryBlock::from_block(dir_block).unwrap();
-    let (offsets, weights) = dir.entries();
+        .expect("directory should exist");
+    let offsets = dir.max_offsets().to_vec();
+    let weights = dir.max_weights().to_vec();
 
     reader
         .posting_reader()
@@ -106,14 +104,13 @@ async fn lazy_cursor_drain_essential() {
     let (_tmp, _prov, reader) = common::build_index(vectors).await;
     let encoded_dim = encode_u32(1);
 
-    let dir_block: SparsePostingBlock = reader
-        .posting_reader()
-        .get(&encoded_dim, u32::MAX)
+    let dir = reader
+        .get_directory(&encoded_dim)
         .await
         .unwrap()
-        .unwrap();
-    let dir = DirectoryBlock::from_block(dir_block).unwrap();
-    let (offsets, weights) = dir.entries();
+        .expect("directory should exist");
+    let offsets = dir.max_offsets().to_vec();
+    let weights = dir.max_weights().to_vec();
 
     reader
         .posting_reader()

--- a/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
+++ b/rust/index/tests/maxscore/ms_13_cursor_lazy.rs
@@ -19,7 +19,7 @@ async fn lazy_cursor_advance_matches_eager() {
     let (_tmp, _prov, reader) = common::build_index(vectors).await;
     let encoded_dim = encode_u32(1);
 
-    let dir = reader
+    let (dir, _) = reader
         .get_directory(&encoded_dim)
         .await
         .unwrap()
@@ -70,7 +70,7 @@ async fn lazy_cursor_get_value() {
     let (_tmp, _prov, reader) = common::build_index(vectors).await;
     let encoded_dim = encode_u32(1);
 
-    let dir = reader
+    let (dir, _) = reader
         .get_directory(&encoded_dim)
         .await
         .unwrap()
@@ -104,7 +104,7 @@ async fn lazy_cursor_drain_essential() {
     let (_tmp, _prov, reader) = common::build_index(vectors).await;
     let encoded_dim = encode_u32(1);
 
-    let dir = reader
+    let (dir, _) = reader
         .get_directory(&encoded_dim)
         .await
         .unwrap()

--- a/rust/index/tests/maxscore/ms_14_three_batch_pipeline.rs
+++ b/rust/index/tests/maxscore/ms_14_three_batch_pipeline.rs
@@ -1,0 +1,147 @@
+use crate::common;
+use chroma_types::SignedRoaringBitmap;
+
+fn all_mask() -> SignedRoaringBitmap {
+    SignedRoaringBitmap::Exclude(Default::default())
+}
+
+#[tokio::test]
+async fn three_batch_basic_correctness() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.5f32), (2, 0.3)]),
+        (1, vec![(1, 0.1), (2, 0.9)]),
+        (2, vec![(1, 0.8), (3, 0.4)]),
+        (3, vec![(2, 0.7), (3, 0.2)]),
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 1.0f32), (2, 0.5)];
+
+    let results = reader.query(query.clone(), 2, all_mask()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, 2, &all_mask());
+
+    assert_eq!(results.len(), brute.len());
+    for (r, b) in results.iter().zip(brute.iter()) {
+        assert_eq!(r.offset, b.0, "offset mismatch");
+        common::assert_approx(r.score, b.1, 0.02);
+    }
+}
+
+#[tokio::test]
+async fn three_batch_single_dimension() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.9f32)]),
+        (1, vec![(1, 0.1)]),
+        (2, vec![(1, 0.5)]),
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 1.0f32)];
+
+    let results = reader.query(query.clone(), 3, all_mask()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, 3, &all_mask());
+
+    assert_eq!(results.len(), brute.len());
+    for (r, b) in results.iter().zip(brute.iter()) {
+        assert_eq!(r.offset, b.0);
+        common::assert_approx(r.score, b.1, 0.02);
+    }
+}
+
+#[tokio::test]
+async fn three_batch_k_larger_than_results() {
+    let vectors = vec![(0u32, vec![(1u32, 0.5f32)]), (1, vec![(1, 0.3)])];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 1.0f32)];
+
+    let results = reader.query(query.clone(), 100, all_mask()).await.unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].offset, 0);
+    assert_eq!(results[1].offset, 1);
+}
+
+#[tokio::test]
+async fn three_batch_empty_query() {
+    let vectors = vec![(0u32, vec![(1u32, 0.5f32)])];
+    let (_tmp, _prov, reader) = common::build_index(vectors).await;
+
+    let results = reader
+        .query(Vec::<(u32, f32)>::new(), 10, all_mask())
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn three_batch_k_zero() {
+    let vectors = vec![(0u32, vec![(1u32, 0.5f32)])];
+    let (_tmp, _prov, reader) = common::build_index(vectors).await;
+
+    let results = reader
+        .query(vec![(1u32, 1.0f32)], 0, all_mask())
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn three_batch_no_matching_dimension() {
+    let vectors = vec![(0u32, vec![(1u32, 0.5f32)]), (1, vec![(2, 0.3)])];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors).await;
+    let query = vec![(999u32, 1.0f32)];
+
+    let results = reader.query(query, 10, all_mask()).await.unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn three_batch_with_mask() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.9f32)]),
+        (1, vec![(1, 0.1)]),
+        (2, vec![(1, 0.5)]),
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 1.0f32)];
+
+    let mut rbm = roaring::RoaringBitmap::new();
+    rbm.insert(0);
+    rbm.insert(2);
+    let mask = SignedRoaringBitmap::Include(rbm);
+
+    let results = reader.query(query.clone(), 10, mask.clone()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, 10, &mask);
+
+    assert_eq!(results.len(), brute.len());
+    for (r, b) in results.iter().zip(brute.iter()) {
+        assert_eq!(r.offset, b.0);
+        common::assert_approx(r.score, b.1, 0.02);
+    }
+}
+
+#[tokio::test]
+async fn three_batch_multi_block_per_dim() {
+    let mut vectors = Vec::new();
+    for i in 0..200u32 {
+        vectors.push((
+            i,
+            vec![(1u32, 0.01 * (i as f32 + 1.0)), (2, 0.005 * i as f32)],
+        ));
+    }
+
+    let (_tmp, _prov, reader) =
+        common::build_index_with_block_size(vectors.clone(), Some(32)).await;
+    let query = vec![(1u32, 1.0f32), (2, 0.5)];
+
+    let results = reader.query(query.clone(), 5, all_mask()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, 5, &all_mask());
+
+    assert_eq!(results.len(), brute.len());
+    for (r, b) in results.iter().zip(brute.iter()) {
+        assert_eq!(r.offset, b.0, "offset mismatch at rank");
+        common::assert_approx(r.score, b.1, 0.05);
+    }
+}

--- a/rust/index/tests/maxscore/ms_15_multi_window.rs
+++ b/rust/index/tests/maxscore/ms_15_multi_window.rs
@@ -1,0 +1,96 @@
+use crate::common;
+use chroma_types::SignedRoaringBitmap;
+
+fn all_mask() -> SignedRoaringBitmap {
+    SignedRoaringBitmap::Exclude(Default::default())
+}
+
+/// Documents spanning the 4096-entry window boundary.
+/// Verifies that the window loop, accumulator reset, and bitmap
+/// zeroing work correctly when documents cross window boundaries.
+#[tokio::test]
+async fn multi_window_boundary_docs() {
+    // Place documents at window edges: end of window 0, start of window 1,
+    // and further into window 1.
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.9f32), (2, 0.1)]),
+        (4094, vec![(1, 0.8), (2, 0.2)]),
+        (4095, vec![(1, 0.7), (2, 0.3)]), // last slot of window 0
+        (4096, vec![(1, 0.6), (2, 0.4)]), // first slot of window 1
+        (4097, vec![(1, 0.5), (2, 0.5)]),
+        (8191, vec![(1, 0.4), (2, 0.6)]), // last slot of window 1
+        (8192, vec![(1, 0.3), (2, 0.7)]), // first slot of window 2
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 1.0f32), (2, 1.0)];
+    let k = 5;
+
+    let results = reader.query(query.clone(), k, all_mask()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, k as usize, &all_mask());
+
+    assert_eq!(results.len(), brute.len());
+    let offsets: Vec<u32> = results.iter().map(|r| r.offset).collect();
+    let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
+    let recall = common::tie_aware_recall(&offsets, &scores, &brute, 5e-3);
+    assert!(
+        recall >= 1.0,
+        "multi-window recall {recall} < 1.0, maxscore={offsets:?}, brute={brute:?}"
+    );
+}
+
+/// Spread many documents across several windows and verify correctness
+/// against brute force with multiple query dimensions.
+#[tokio::test]
+async fn multi_window_many_docs_across_windows() {
+    // 30 documents spread across 3 windows (offsets 0..12288 with stride 410).
+    // Two query dimensions with different weights to exercise the
+    // essential/non-essential partition across window boundaries.
+    let vectors: Vec<(u32, Vec<(u32, f32)>)> = (0..30)
+        .map(|i| {
+            let offset = i * 410; // spreads across windows 0, 1, 2
+            let w1 = 0.01 * ((i * 7 + 3) % 100) as f32;
+            let w2 = 0.01 * ((i * 13 + 11) % 100) as f32;
+            (offset, vec![(1u32, w1), (2, w2)])
+        })
+        .collect();
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 2.0f32), (2, 0.5)];
+    let k = 10;
+
+    let results = reader.query(query.clone(), k, all_mask()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, k as usize, &all_mask());
+
+    assert_eq!(results.len(), brute.len());
+    let offsets: Vec<u32> = results.iter().map(|r| r.offset).collect();
+    let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
+    let recall = common::tie_aware_recall(&offsets, &scores, &brute, 5e-3);
+    assert!(
+        recall >= 1.0,
+        "multi-window many-docs recall {recall} < 1.0, maxscore={offsets:?}, brute={brute:?}"
+    );
+}
+
+/// Single document in window 0, single document in window 1. Verifies
+/// that the accumulator is properly reset between windows.
+#[tokio::test]
+async fn multi_window_accumulator_reset() {
+    let vectors = vec![
+        (0u32, vec![(1u32, 0.5f32)]),
+        (5000, vec![(1, 0.9)]), // window 1 (offset >= 4096)
+    ];
+
+    let (_tmp, _prov, reader) = common::build_index(vectors.clone()).await;
+    let query = vec![(1u32, 1.0f32)];
+
+    let results = reader.query(query.clone(), 2, all_mask()).await.unwrap();
+    let brute = common::brute_force_topk(&vectors, &query, 2, &all_mask());
+
+    assert_eq!(results.len(), 2);
+    // doc 5000 should rank first (score 0.9 > 0.5)
+    assert_eq!(results[0].offset, brute[0].0);
+    assert_eq!(results[1].offset, brute[1].0);
+    common::assert_approx(results[0].score, brute[0].1, 5e-3);
+    common::assert_approx(results[1].score, brute[1].1, 5e-3);
+}

--- a/rust/index/tests/maxscore/ms_16_lazy_partial_load.rs
+++ b/rust/index/tests/maxscore/ms_16_lazy_partial_load.rs
@@ -1,0 +1,196 @@
+use crate::common;
+use chroma_index::sparse::maxscore::PostingCursor;
+use chroma_index::sparse::types::encode_u32;
+use chroma_types::SignedRoaringBitmap;
+
+fn all_mask() -> SignedRoaringBitmap {
+    SignedRoaringBitmap::Exclude(Default::default())
+}
+
+/// Lazy cursor with only some blocks loaded. Unloaded blocks should
+/// be transparently skipped during advance.
+#[tokio::test]
+async fn lazy_partial_load_advance_skips_unloaded() {
+    // Use small block_size to force multiple blocks per dimension.
+    // With block_size=2, offsets [0,1,2,3,4,5] produce 3 blocks:
+    //   block 0: [0, 1], block 1: [2, 3], block 2: [4, 5]
+    let vectors: Vec<(u32, Vec<(u32, f32)>)> = (0..6)
+        .map(|i| (i, vec![(1u32, 0.1 * (i as f32 + 1.0))]))
+        .collect();
+
+    let (_tmp, _prov, reader) = common::build_index_with_block_size(vectors, Some(2)).await;
+    let encoded_dim = encode_u32(1);
+
+    let dir = reader
+        .get_directory(&encoded_dim)
+        .await
+        .unwrap()
+        .expect("directory should exist");
+    let dir_max_offsets = dir.max_offsets().to_vec();
+    let dir_max_weights = dir.max_weights().to_vec();
+
+    assert_eq!(dir_max_offsets.len(), 3, "expected 3 blocks");
+
+    // Load only block 0 and block 2, leave block 1 unloaded.
+    reader
+        .posting_reader()
+        .load_blocks_for_prefixes([encoded_dim.as_str()])
+        .await;
+
+    let mut cursor = PostingCursor::open_lazy(dir_max_offsets.clone(), dir_max_weights.clone());
+    // Only populate blocks 0 and 2
+    cursor.populate_from_cache(reader.posting_reader(), &encoded_dim, &[0, 2]);
+
+    let mask = all_mask();
+
+    // advance(0) should find doc 0 in block 0
+    let r = cursor.advance(0, &mask);
+    assert_eq!(r.map(|(o, _)| o), Some(0));
+    cursor.next();
+
+    // advance(1) should find doc 1 in block 0
+    let r = cursor.advance(1, &mask);
+    assert_eq!(r.map(|(o, _)| o), Some(1));
+    cursor.next();
+
+    // advance(2) should skip block 1 (unloaded) and find doc 4 in block 2
+    let r = cursor.advance(2, &mask);
+    assert_eq!(r.map(|(o, _)| o), Some(4));
+    cursor.next();
+
+    // advance(5) should find doc 5 in block 2
+    let r = cursor.advance(5, &mask);
+    assert_eq!(r.map(|(o, _)| o), Some(5));
+    cursor.next();
+
+    // Exhausted
+    let r = cursor.advance(6, &mask);
+    assert_eq!(r, None);
+}
+
+/// Lazy cursor with partially loaded blocks used with drain_essential.
+/// Entries from unloaded blocks should not appear in the accumulator.
+#[tokio::test]
+async fn lazy_partial_load_drain_skips_unloaded() {
+    let vectors: Vec<(u32, Vec<(u32, f32)>)> = (0..6)
+        .map(|i| (i, vec![(1u32, 0.1 * (i as f32 + 1.0))]))
+        .collect();
+
+    let (_tmp, _prov, reader) = common::build_index_with_block_size(vectors, Some(2)).await;
+    let encoded_dim = encode_u32(1);
+
+    let dir = reader
+        .get_directory(&encoded_dim)
+        .await
+        .unwrap()
+        .expect("directory should exist");
+    let dir_max_offsets = dir.max_offsets().to_vec();
+    let dir_max_weights = dir.max_weights().to_vec();
+
+    reader
+        .posting_reader()
+        .load_blocks_for_prefixes([encoded_dim.as_str()])
+        .await;
+
+    let mut cursor = PostingCursor::open_lazy(dir_max_offsets, dir_max_weights);
+    // Only populate block 0 and block 2 (skip block 1 with offsets [2,3])
+    cursor.populate_from_cache(reader.posting_reader(), &encoded_dim, &[0, 2]);
+
+    let mask = all_mask();
+    let mut accum = vec![0.0f32; 4096];
+    let mut bitmap = [0u64; 64];
+
+    cursor.drain_essential(0, 5, 1.0, &mut accum, &mut bitmap, &mask);
+
+    // Block 0 entries (offsets 0, 1) should be accumulated
+    assert!(accum[0] > 0.0, "offset 0 should be in accum");
+    assert!(accum[1] > 0.0, "offset 1 should be in accum");
+
+    // Block 1 entries (offsets 2, 3) should NOT be accumulated (block unloaded)
+    assert_eq!(
+        accum[2], 0.0,
+        "offset 2 should NOT be in accum (block unloaded)"
+    );
+    assert_eq!(
+        accum[3], 0.0,
+        "offset 3 should NOT be in accum (block unloaded)"
+    );
+
+    // Block 2 entries (offsets 4, 5) should be accumulated
+    assert!(accum[4] > 0.0, "offset 4 should be in accum");
+    assert!(accum[5] > 0.0, "offset 5 should be in accum");
+
+    // Bitmap should reflect only the loaded entries
+    let touched_bits = bitmap[0];
+    assert!(touched_bits & (1 << 0) != 0, "bit 0 set");
+    assert!(touched_bits & (1 << 1) != 0, "bit 1 set");
+    assert!(touched_bits & (1 << 2) == 0, "bit 2 not set");
+    assert!(touched_bits & (1 << 3) == 0, "bit 3 not set");
+    assert!(touched_bits & (1 << 4) != 0, "bit 4 set");
+    assert!(touched_bits & (1 << 5) != 0, "bit 5 set");
+}
+
+/// Lazy cursor with partially loaded blocks used with score_candidates.
+/// Candidates matching unloaded blocks should not get scores.
+#[tokio::test]
+async fn lazy_partial_load_score_candidates_skips_unloaded() {
+    let vectors: Vec<(u32, Vec<(u32, f32)>)> = (0..6)
+        .map(|i| (i, vec![(1u32, 0.1 * (i as f32 + 1.0))]))
+        .collect();
+
+    let (_tmp, _prov, reader) = common::build_index_with_block_size(vectors, Some(2)).await;
+    let encoded_dim = encode_u32(1);
+
+    let dir = reader
+        .get_directory(&encoded_dim)
+        .await
+        .unwrap()
+        .expect("directory should exist");
+    let dir_max_offsets = dir.max_offsets().to_vec();
+    let dir_max_weights = dir.max_weights().to_vec();
+
+    reader
+        .posting_reader()
+        .load_blocks_for_prefixes([encoded_dim.as_str()])
+        .await;
+
+    let mut cursor = PostingCursor::open_lazy(dir_max_offsets, dir_max_weights);
+    // Only populate block 0 and block 2
+    cursor.populate_from_cache(reader.posting_reader(), &encoded_dim, &[0, 2]);
+
+    // Candidates from all three blocks
+    let cand_docs = vec![0u32, 1, 2, 3, 4, 5];
+    let mut cand_scores = vec![0.0f32; 6];
+
+    cursor.score_candidates(0, 5, 1.0, &cand_docs, &mut cand_scores);
+
+    // Candidates from loaded blocks get scores
+    assert!(
+        cand_scores[0] > 0.0,
+        "doc 0 should be scored (block 0 loaded)"
+    );
+    assert!(
+        cand_scores[1] > 0.0,
+        "doc 1 should be scored (block 0 loaded)"
+    );
+
+    // Candidates from unloaded block 1 get no scores
+    assert_eq!(
+        cand_scores[2], 0.0,
+        "doc 2 should not be scored (block 1 unloaded)"
+    );
+    assert_eq!(
+        cand_scores[3], 0.0,
+        "doc 3 should not be scored (block 1 unloaded)"
+    );
+
+    // Candidates from loaded block 2 get scores
+    assert!(
+        cand_scores[4] > 0.0,
+        "doc 4 should be scored (block 2 loaded)"
+    );
+    assert!(
+        cand_scores[5] > 0.0,
+        "doc 5 should be scored (block 2 loaded)"
+    );
+}

--- a/rust/index/tests/maxscore/ms_16_lazy_partial_load.rs
+++ b/rust/index/tests/maxscore/ms_16_lazy_partial_load.rs
@@ -21,7 +21,7 @@ async fn lazy_partial_load_advance_skips_unloaded() {
     let (_tmp, _prov, reader) = common::build_index_with_block_size(vectors, Some(2)).await;
     let encoded_dim = encode_u32(1);
 
-    let dir = reader
+    let (dir, _) = reader
         .get_directory(&encoded_dim)
         .await
         .unwrap()
@@ -79,7 +79,7 @@ async fn lazy_partial_load_drain_skips_unloaded() {
     let (_tmp, _prov, reader) = common::build_index_with_block_size(vectors, Some(2)).await;
     let encoded_dim = encode_u32(1);
 
-    let dir = reader
+    let (dir, _) = reader
         .get_directory(&encoded_dim)
         .await
         .unwrap()
@@ -141,7 +141,7 @@ async fn lazy_partial_load_score_candidates_skips_unloaded() {
     let (_tmp, _prov, reader) = common::build_index_with_block_size(vectors, Some(2)).await;
     let encoded_dim = encode_u32(1);
 
-    let dir = reader
+    let (dir, _) = reader
         .get_directory(&encoded_dim)
         .await
         .unwrap()


### PR DESCRIPTION
## Description of changes
This is PR #3 of the BlockMaxMaxScore series, stacked on `hammad/maxscore_writer_reader`. It replaces the eager-only cursor with a tri-modal cursor and rewrites the query pipeline to use a 3-batch I/O strategy for reduced latency.
- New functionality
  - **Tri-modal `PostingCursor`** (`cursor.rs`): Replaces the eager-only cursor from PR #2 with three source modes:
    - **Eager** — fully deserialized `SparsePostingBlock`s (unchanged from PR #2).
    - **View** — borrows raw `&[u8]` slices from the Arrow block cache. Offsets are decompressed into a reusable buffer; f16 weights are read directly from raw bytes on the fly (fused reads, no bulk conversion).
    - **Lazy** — blocks start as `None`, populated on demand via `populate_from_cache` / `populate_all_from_cache`. Same fused f16 read path as View once populated.
  - **Blockstore raw access APIs**: `get_raw_from_cache` (synchronous cache-only raw byte lookup), `count_blocks_for_prefix`, `Block::get_raw` / `Block::get_prefix_raw`, and `ArrowReadableValue::get_raw_bytes` trait method.
  - **3-batch I/O pipeline** in `query()`:
    - **Batch 1**: Load directory blocks for all query dimensions in parallel.
    - **Batch 2**: Small dimensions (≤2 Arrow blocks) get View cursors; large dimensions get Lazy cursors with essential blocks loaded in bulk.
    - **Batch 3**: After the threshold stabilizes, load remaining non-essential blocks with pruning — blocks where `query_weight × max_weight ≤ threshold` are skipped entirely.
## Test plan
- `ms_12_cursor_view` — View cursor vs Eager equivalence: advance, drain_essential, score_candidates, get_value, window_upper_bound, current.
- `ms_13_cursor_lazy` — Lazy cursor via real blockfile I/O: advance, get_value, drain_essential.
- `ms_14_three_batch_pipeline` — End-to-end 3-batch query: basic correctness, single dim, k > results, empty query, k=0, missing dim, masks, multi-block per dim.
- `ms_15_multi_window` — Documents spanning 4096-entry window boundaries: boundary transitions, accumulator reset, many-docs-across-windows recall.
- `ms_16_lazy_partial_load` — Lazy cursor with partially loaded blocks: advance skips unloaded, drain_essential skips unloaded, score_candidates skips unloaded.
- [x] Tests pass locally with `cargo test`
## Migration plan
No migration needed. This changes the internal query execution strategy but does not alter blockfile formats or segment layouts.
## Observability plan
No new instrumentation in this PR. Block-skip counters and batch timing will be added alongside segment integration.
## Documentation Changes
No user-facing API changes. Internal design is documented in `rust/index/src/sparse/maxscore.md`.