### PR TITLE
fix: replace ValueError/TypeError with InvalidArgumentError in API layer

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from uuid import UUID
 from overrides import override
 
+from chromadb.errors import InvalidArgumentError
 from chromadb.auth import UserIdentity
 from chromadb.auth.utils import maybe_set_tenant_and_database
 from chromadb.api import AsyncAdminAPI, AsyncClientAPI, AsyncServerAPI
@@ -135,21 +136,21 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         try:
             await self._admin_client.get_tenant(name=tenant)
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
         # Propagate ChromaErrors
         except ChromaError as e:
             raise e
         except Exception:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Could not connect to tenant {tenant}. Are you sure it exists?"
             )
 
         try:
             await self._admin_client.get_database(name=database, tenant=tenant)
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
 

--- a/chromadb/api/client.py
+++ b/chromadb/api/client.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from overrides import override
 import httpx
+from chromadb.errors import InvalidArgumentError
 from chromadb.api import AdminAPI, ClientAPI, ServerAPI
 from chromadb.api.collection_configuration import (
     CreateCollectionConfiguration,
@@ -133,14 +134,14 @@ class Client(SharedSystemClient, ClientAPI):
         try:
             return self._server.get_user_identity()
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
         # Propagate ChromaErrors
         except ChromaError as e:
             raise e
         except Exception as e:
-            raise ValueError(str(e))
+            raise InvalidArgumentError(str(e))
 
     # region BaseAPI Methods
     # Note - we could do this in less verbose ways, but they break type checking
@@ -600,21 +601,21 @@ class Client(SharedSystemClient, ClientAPI):
         try:
             self._admin_client.get_tenant(name=tenant)
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
         # Propagate ChromaErrors
         except ChromaError as e:
             raise e
         except Exception:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Could not connect to tenant {tenant}. Are you sure it exists?"
             )
 
         try:
             self._admin_client.get_database(name=database, tenant=tenant)
         except httpx.ConnectError:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Could not connect to a Chroma server. Are you sure it is running?"
             )
 

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
 import chromadb.errors as errors
+from chromadb.errors import InvalidArgumentError
 from chromadb.base_types import (
     Metadata,
     UpdateMetadata,
@@ -227,7 +228,7 @@ def normalize_embeddings(
         return None
 
     if len(target) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected Embeddings to be non-empty list or numpy array, got {target}"
         )
 
@@ -248,7 +249,7 @@ def normalize_embeddings(
             ):
                 return [np.array(row, dtype=np.float32) for row in target]
 
-    raise ValueError(
+    raise InvalidArgumentError(
         f"Expected embeddings to be a list of floats or ints, a list of lists, a numpy array, or a list of numpy arrays, got {target}"
     )
 
@@ -451,7 +452,7 @@ def _validate_record_set_length_consistency(record_set: BaseRecordSet) -> None:
     lengths = [len(lst) for lst in record_set.values() if lst is not None]  # type: ignore[arg-type]
 
     if not lengths:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"At least one of one of {', '.join(record_set.keys())} must be provided"
         )
 
@@ -462,7 +463,7 @@ def _validate_record_set_length_consistency(record_set: BaseRecordSet) -> None:
     ]
 
     if zero_lengths:
-        raise ValueError(f"Non-empty lists are required for {zero_lengths}")
+        raise InvalidArgumentError(f"Non-empty lists are required for {zero_lengths}")
 
     if len(set(lengths)) > 1:
         error_str = ", ".join(
@@ -470,7 +471,7 @@ def _validate_record_set_length_consistency(record_set: BaseRecordSet) -> None:
             for key, lst in record_set.items()
             if lst is not None  # type: ignore[arg-type]
         )
-        raise ValueError(f"Unequal lengths for fields: {error_str}")
+        raise InvalidArgumentError(f"Unequal lengths for fields: {error_str}")
 
 
 def validate_record_set_for_embedding(
@@ -480,7 +481,7 @@ def validate_record_set_for_embedding(
     Validates that the Record is ready to be embedded, i.e. that it contains exactly one of the embeddable fields.
     """
     if record_set["embeddings"] is not None:
-        raise ValueError("Attempting to embed a record that already has embeddings.")
+        raise InvalidArgumentError("Attempting to embed a record that already has embeddings.")
     if embeddable_fields is None:
         embeddable_fields = get_default_embeddable_record_set_fields()
     validate_record_set_contains_one(record_set, embeddable_fields)
@@ -495,7 +496,7 @@ def validate_record_set_contains_any(
     _validate_record_set_contains(record_set, contains_any)
 
     if not any(record_set[field] is not None for field in contains_any):  # type: ignore[literal-required]
-        raise ValueError(f"At least one of {', '.join(contains_any)} must be provided")
+        raise InvalidArgumentError(f"At least one of {', '.join(contains_any)} must be provided")
 
 
 def validate_record_set_contains_one(
@@ -506,7 +507,7 @@ def validate_record_set_contains_one(
     """
     _validate_record_set_contains(record_set, contains_one)
     if sum(record_set[field] is not None for field in contains_one) != 1:  # type: ignore[literal-required]
-        raise ValueError(f"Exactly one of {', '.join(contains_one)} must be provided")
+        raise InvalidArgumentError(f"Exactly one of {', '.join(contains_one)} must be provided")
 
 
 def _validate_record_set_contains(
@@ -516,7 +517,7 @@ def _validate_record_set_contains(
     Validates that all fields in contains are valid fields of the Record.
     """
     if any(field not in record_set for field in contains):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Invalid field in contains: {', '.join(contains)}, available fields: {', '.join(record_set.keys())}"
         )
 
@@ -988,7 +989,7 @@ def validate_embedding_function(
     protocol_signature = signature(EmbeddingFunction.__call__).parameters.keys()
 
     if not function_signature == protocol_signature:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected EmbeddingFunction.__call__ to have the following signature: {protocol_signature}, got {function_signature}\n"
             "Please see https://docs.trychroma.com/guides/embeddings for details of the EmbeddingFunction interface.\n"
             "Please note the recent change to the EmbeddingFunction interface: https://docs.trychroma.com/deployment/migration#migration-to-0.4.16---november-7,-2023 \n"
@@ -1002,14 +1003,14 @@ class DataLoader(Protocol[L]):
 def validate_ids(ids: IDs) -> IDs:
     """Validates ids to ensure it is a list of strings"""
     if not isinstance(ids, list):
-        raise ValueError(f"Expected IDs to be a list, got {type(ids).__name__} as IDs")
+        raise InvalidArgumentError(f"Expected IDs to be a list, got {type(ids).__name__} as IDs")
     if len(ids) == 0:
-        raise ValueError(f"Expected IDs to be a non-empty list, got {len(ids)} IDs")
+        raise InvalidArgumentError(f"Expected IDs to be a non-empty list, got {len(ids)} IDs")
     seen = set()
     dups = set()
     for id_ in ids:
         if not isinstance(id_, str):
-            raise ValueError(f"Expected ID to be a str, got {id_}")
+            raise InvalidArgumentError(f"Expected ID to be a str, got {id_}")
         if id_ in seen:
             dups.add(id_)
         else:
@@ -1038,7 +1039,7 @@ def validate_ids(ids: IDs) -> IDs:
 def _validate_metadata_list_value(key: str, value: list) -> None:
     """Validates a list metadata value: must be non-empty and homogeneously typed."""
     if len(value) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected metadata list value for key '{key}' to be non-empty"
         )
     first_type = type(value[0])
@@ -1048,7 +1049,7 @@ def _validate_metadata_list_value(key: str, value: list) -> None:
     for item in value:
         item_type = bool if isinstance(item, bool) else type(item)
         if item_type is not first_type or item_type not in (str, int, float, bool):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected metadata list value for key '{key}' to contain only str, int, float, or bool "
                 f"and all elements must be the same type, got {value}"
             )
@@ -1057,22 +1058,22 @@ def _validate_metadata_list_value(key: str, value: list) -> None:
 def validate_metadata(metadata: Metadata) -> Metadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats, bools, SparseVectors, or lists thereof"""
     if not isinstance(metadata, dict) and metadata is not None:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected metadata to be a dict or None, got {type(metadata).__name__} as metadata"
         )
     if metadata is None:
         return metadata
     if len(metadata) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected metadata to be a non-empty dict, got {len(metadata)} metadata attributes"
         )
     for key, value in metadata.items():
         if key == META_KEY_CHROMA_DOCUMENT:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected metadata to not contain the reserved key {META_KEY_CHROMA_DOCUMENT}"
             )
         if not isinstance(key, str):
-            raise TypeError(
+            raise InvalidArgumentError(
                 f"Expected metadata key to be a str, got {key} which is a {type(key).__name__}"
             )
         # Check if value is a SparseVector (validation happens in __post_init__)
@@ -1084,7 +1085,7 @@ def validate_metadata(metadata: Metadata) -> Metadata:
         elif not isinstance(value, bool) and not isinstance(
             value, (str, int, float, type(None))
         ):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected metadata value to be a str, int, float, bool, SparseVector, list, or None, got {value} which is a {type(value).__name__}"
             )
     return metadata
@@ -1093,16 +1094,16 @@ def validate_metadata(metadata: Metadata) -> Metadata:
 def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
     """Validates metadata to ensure it is a dictionary of strings to strings, ints, floats, bools, SparseVectors, or lists thereof"""
     if not isinstance(metadata, dict) and metadata is not None:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected metadata to be a dict or None, got {type(metadata)}"
         )
     if metadata is None:
         return metadata
     if len(metadata) == 0:
-        raise ValueError(f"Expected metadata to be a non-empty dict, got {metadata}")
+        raise InvalidArgumentError(f"Expected metadata to be a non-empty dict, got {metadata}")
     for key, value in metadata.items():
         if not isinstance(key, str):
-            raise ValueError(f"Expected metadata key to be a str, got {key}")
+            raise InvalidArgumentError(f"Expected metadata key to be a str, got {key}")
         # Check if value is a SparseVector (validation happens in __post_init__)
         if isinstance(value, SparseVector):
             pass  # Already validated in SparseVector.__post_init__
@@ -1112,7 +1113,7 @@ def validate_update_metadata(metadata: UpdateMetadata) -> UpdateMetadata:
         elif not isinstance(value, bool) and not isinstance(
             value, (str, int, float, type(None))
         ):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected metadata value to be a str, int, float, bool, SparseVector, list, or None, got {value}"
             )
     return metadata
@@ -1165,7 +1166,7 @@ def deserialize_metadata(
 def validate_metadatas(metadatas: Metadatas) -> Metadatas:
     """Validates metadatas to ensure it is a list of dictionaries of strings to strings, ints, floats or bools"""
     if not isinstance(metadatas, list):
-        raise ValueError(f"Expected metadatas to be a list, got {metadatas}")
+        raise InvalidArgumentError(f"Expected metadatas to be a list, got {metadatas}")
     for metadata in metadatas:
         validate_metadata(metadata)
     return metadatas
@@ -1177,17 +1178,17 @@ def validate_where(where: Where) -> None:
     or in the case of $and and $or, a list of where expressions
     """
     if not isinstance(where, dict):
-        raise ValueError(f"Expected where to be a dict, got {where}")
+        raise InvalidArgumentError(f"Expected where to be a dict, got {where}")
     if len(where) != 1:
-        raise ValueError(f"Expected where to have exactly one operator, got {where}")
+        raise InvalidArgumentError(f"Expected where to have exactly one operator, got {where}")
     for key, value in where.items():
         if not isinstance(key, str):
-            raise ValueError(f"Expected where key to be a str, got {key}")
+            raise InvalidArgumentError(f"Expected where key to be a str, got {key}")
         # $contains and $not_contains are only valid as operators within a
         # field expression (e.g. {"field": {"$contains": val}}), not as
         # top-level where keys.
         if key in ("$contains", "$not_contains"):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected where key to be a metadata field name or a logical "
                 f"operator ($and, $or), got {key}"
             )
@@ -1198,16 +1199,16 @@ def validate_where(where: Where) -> None:
             and key != "$nin"
             and not isinstance(value, (str, int, float, dict))
         ):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected where value to be a str, int, float, or operator expression, got {value}"
             )
         if key == "$and" or key == "$or":
             if not isinstance(value, list):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Expected where value for $and or $or to be a list of where expressions, got {value}"
                 )
             if len(value) <= 1:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Expected where value for $and or $or to be a list with at least two where expressions, got {value}"
                 )
             for where_expression in value:
@@ -1216,7 +1217,7 @@ def validate_where(where: Where) -> None:
         if isinstance(value, dict):
             # Ensure there is only one operator
             if len(value) != 1:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Expected operator expression to have exactly one operator, got {value}"
                 )
 
@@ -1224,22 +1225,22 @@ def validate_where(where: Where) -> None:
                 # Only numbers can be compared with gt, gte, lt, lte
                 if operator in ["$gt", "$gte", "$lt", "$lte"]:
                     if not isinstance(operand, (int, float)):
-                        raise ValueError(
+                        raise InvalidArgumentError(
                             f"Expected operand value to be an int or a float for operator {operator}, got {operand}"
                         )
                 if operator in ["$in", "$nin"]:
                     if not isinstance(operand, list):
-                        raise ValueError(
+                        raise InvalidArgumentError(
                             f"Expected operand value to be an list for operator {operator}, got {operand}"
                         )
                 # $contains/$not_contains: scalar operand (checks if array field contains value)
                 if operator in ["$contains", "$not_contains"]:
                     if key == "#document" and not isinstance(operand, str):
-                        raise ValueError(
+                        raise InvalidArgumentError(
                             f"Expected operand value to be a str for operator {operator} on #document, got {operand}"
                         )
                     if not isinstance(operand, (str, int, float, bool)):
-                        raise ValueError(
+                        raise InvalidArgumentError(
                             f"Expected operand value to be a str, int, float, or bool for operator {operator}, got {operand}"
                         )
                 if operator not in [
@@ -1254,20 +1255,20 @@ def validate_where(where: Where) -> None:
                     "$contains",
                     "$not_contains",
                 ]:
-                    raise ValueError(
+                    raise InvalidArgumentError(
                         f"Expected where operator to be one of $gt, $gte, $lt, $lte, $ne, $eq, $in, $nin, "
                         f"$contains, $not_contains, got {operator}"
                     )
 
                 if not isinstance(operand, (str, int, float, bool, list)):
-                    raise ValueError(
+                    raise InvalidArgumentError(
                         f"Expected where operand value to be a str, int, float, bool, or list of those type, got {operand}"
                     )
                 if isinstance(operand, list) and (
                     len(operand) == 0
                     or not all(isinstance(x, type(operand[0])) for x in operand)
                 ):
-                    raise ValueError(
+                    raise InvalidArgumentError(
                         f"Expected where operand value to be a non-empty list, and all values to be of the same type "
                         f"got {operand}"
                     )
@@ -1279,11 +1280,11 @@ def validate_where_document(where_document: WhereDocument) -> None:
     a list of where_document expressions
     """
     if not isinstance(where_document, dict):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected where document to be a dictionary, got {where_document}"
         )
     if len(where_document) != 1:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected where document to have exactly one operator, got {where_document}"
         )
     for operator, operand in where_document.items():
@@ -1295,27 +1296,27 @@ def validate_where_document(where_document: WhereDocument) -> None:
             "$and",
             "$or",
         ]:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected where document operator to be one of $contains, $not_contains, $regex, $not_regex, $and, $or, got {operator}"
             )
         if operator == "$and" or operator == "$or":
             if not isinstance(operand, list):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Expected document value for $and or $or to be a list of where document expressions, got {operand}"
                 )
             if len(operand) <= 1:
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"Expected document value for $and or $or to be a list with at least two where document expressions, got {operand}"
                 )
             for where_document_expression in operand:
                 validate_where_document(where_document_expression)
         # Value is $contains/$not_contains/$regex/$not_regex operator
         elif not isinstance(operand, str):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected where document operand value for operator {operator} to be a str, got {operand}"
             )
         elif len(operand) == 0:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected where document operand value for operator {operator} to be a non-empty str"
             )
 
@@ -1325,20 +1326,20 @@ def validate_include(include: Include, dissalowed: Optional[Include] = None) -> 
     to control if distances is allowed"""
 
     if not isinstance(include, list):
-        raise ValueError(f"Expected include to be a list, got {include}")
+        raise InvalidArgumentError(f"Expected include to be a list, got {include}")
     for item in include:
         if not isinstance(item, str):
-            raise ValueError(f"Expected include item to be a str, got {item}")
+            raise InvalidArgumentError(f"Expected include item to be a str, got {item}")
 
         # Get the valid items from the Literal type inside the List
         valid_items = get_args(get_args(Include)[0])
         if item not in valid_items:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected include item to be one of {', '.join(valid_items)}, got {item}"
             )
 
         if dissalowed is not None and any(item == e for e in dissalowed):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Include item cannot be one of {', '.join(dissalowed)}, got {item}"
             )
 
@@ -1347,11 +1348,11 @@ def validate_n_results(n_results: int) -> int:
     """Validates n_results to ensure it is a positive Integer. Since hnswlib does not allow n_results to be negative."""
     # Check Number of requested results
     if not isinstance(n_results, int):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected requested number of results to be a int, got {n_results}"
         )
     if n_results <= 0:
-        raise TypeError(
+        raise InvalidArgumentError(
             f"Number of requested results {n_results}, cannot be negative, or zero."
         )
     return n_results
@@ -1360,25 +1361,25 @@ def validate_n_results(n_results: int) -> int:
 def validate_embeddings(embeddings: Embeddings) -> Embeddings:
     """Validates embeddings to ensure it is a list of numpy arrays of ints, or floats"""
     if not isinstance(embeddings, (list, np.ndarray)):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected embeddings to be a list, got {type(embeddings).__name__}"
         )
     if len(embeddings) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected embeddings to be a list with at least one item, got {len(embeddings)} embeddings"
         )
     if not all([isinstance(e, np.ndarray) for e in embeddings]):
-        raise ValueError(
+        raise InvalidArgumentError(
             "Expected each embedding in the embeddings to be a numpy array, got "
             f"{list(set([type(e).__name__ for e in embeddings]))}"
         )
     for i, embedding in enumerate(embeddings):
         if embedding.ndim == 0:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected a 1-dimensional array, got a 0-dimensional array {embedding}"
             )
         if embedding.size == 0:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected each embedding in the embeddings to be a 1-dimensional numpy array with at least 1 int/float value. Got a 1-dimensional numpy array with no values at pos {i}"
             )
 
@@ -1389,7 +1390,7 @@ def validate_embeddings(embeddings: Embeddings) -> Embeddings:
             np.int32,
             np.int64,
         ]:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Expected each value in the embedding to be a int or float, got an embedding with "
                 f"{embedding.dtype} - {embedding}"
             )
@@ -1410,16 +1411,16 @@ def validate_sparse_vectors(vectors: SparseVectors) -> SparseVectors:
     This function only validates the list structure and instance types.
     """
     if not isinstance(vectors, list):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected sparse vectors to be a list, got {type(vectors).__name__}"
         )
     if len(vectors) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected sparse vectors to be a non-empty list, got {len(vectors)} sparse vectors"
         )
     for i, vector in enumerate(vectors):
         if not isinstance(vector, SparseVector):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Expected SparseVector instance at position {i}, got {type(vector).__name__}"
             )
     return vectors
@@ -1428,11 +1429,11 @@ def validate_sparse_vectors(vectors: SparseVectors) -> SparseVectors:
 def validate_documents(documents: Documents, nullable: bool = False) -> None:
     """Validates documents to ensure it is a list of strings"""
     if not isinstance(documents, list):
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected documents to be a list, got {type(documents).__name__}"
         )
     if len(documents) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected documents to be a non-empty list, got {len(documents)} documents"
         )
     for document in documents:
@@ -1440,20 +1441,20 @@ def validate_documents(documents: Documents, nullable: bool = False) -> None:
         if document is None and nullable:
             continue
         if not is_document(document):
-            raise ValueError(f"Expected document to be a str, got {document}")
+            raise InvalidArgumentError(f"Expected document to be a str, got {document}")
 
 
 def validate_images(images: Images) -> None:
     """Validates images to ensure it is a list of numpy arrays"""
     if not isinstance(images, list):
-        raise ValueError(f"Expected images to be a list, got {type(images).__name__}")
+        raise InvalidArgumentError(f"Expected images to be a list, got {type(images).__name__}")
     if len(images) == 0:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected images to be a non-empty list, got {len(images)} images"
         )
     for image in images:
         if not is_image(image):
-            raise ValueError(f"Expected image to be a numpy array, got {image}")
+            raise InvalidArgumentError(f"Expected image to be a numpy array, got {image}")
 
 
 def validate_batch(
@@ -1467,7 +1468,7 @@ def validate_batch(
     limits: Dict[str, Any],
 ) -> None:
     if len(batch[0]) > limits["max_batch_size"]:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Batch size {len(batch[0])} exceeds maximum batch size {limits['max_batch_size']}"
         )
 
@@ -1564,7 +1565,7 @@ def validate_sparse_embedding_function(
     protocol_signature = signature(SparseEmbeddingFunction.__call__).parameters.keys()
 
     if not function_signature == protocol_signature:
-        raise ValueError(
+        raise InvalidArgumentError(
             f"Expected SparseEmbeddingFunction.__call__ to have the following signature: {protocol_signature}, got {function_signature}\n"
             "Please see https://docs.trychroma.com/guides/embeddings for details of the SparseEmbeddingFunction interface.\n"
         )
@@ -1694,11 +1695,11 @@ class VectorIndexConfig(BaseModel):
         elif isinstance(v, str):
             pass  # Already a string
         else:
-            raise ValueError(f"source_key must be str or Key, got {type(v).__name__}")
+            raise InvalidArgumentError(f"source_key must be str or Key, got {type(v).__name__}")
 
         # Validate: only #document is allowed if key starts with #
         if v.startswith("#") and v != "#document":
-            raise ValueError(
+            raise InvalidArgumentError(
                 "source_key cannot begin with '#'. "
                 "The only valid key starting with '#' is Key.DOCUMENT or '#document'."
             )
@@ -1715,7 +1716,7 @@ class VectorIndexConfig(BaseModel):
             # Use the existing validation function
             validate_embedding_function(v)
             return v
-        raise ValueError("embedding_function must be callable or None")
+        raise InvalidArgumentError("embedding_function must be callable or None")
 
 
 class SparseVectorIndexConfig(BaseModel):
@@ -1744,11 +1745,11 @@ class SparseVectorIndexConfig(BaseModel):
         elif isinstance(v, str):
             pass  # Already a string
         else:
-            raise ValueError(f"source_key must be str or Key, got {type(v).__name__}")
+            raise InvalidArgumentError(f"source_key must be str or Key, got {type(v).__name__}")
 
         # Validate: only #document is allowed if key starts with #
         if v.startswith("#") and v != "#document":
-            raise ValueError(
+            raise InvalidArgumentError(
                 "source_key cannot begin with '#'. "
                 "The only valid key starting with '#' is Key.DOCUMENT or '#document'."
             )
@@ -1765,7 +1766,7 @@ class SparseVectorIndexConfig(BaseModel):
             # Use the sparse vector function validation
             validate_sparse_embedding_function(v)
             return v
-        raise ValueError(
+        raise InvalidArgumentError(
             "embedding_function must be a callable SparseEmbeddingFunction or None"
         )
 
@@ -1954,7 +1955,7 @@ class Cmek:
         if self.provider == CmekProvider.GCP:
             return {"gcp": self.resource}
         # Unreachable with current providers, but future-proof
-        raise ValueError(f"Unknown CMEK provider: {self.provider}")
+        raise InvalidArgumentError(f"Unknown CMEK provider: {self.provider}")
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Cmek":
@@ -1977,11 +1978,11 @@ class Cmek:
         if "gcp" in data:
             resource = data["gcp"]
             if not isinstance(resource, str):
-                raise ValueError(
+                raise InvalidArgumentError(
                     f"CMEK gcp resource must be a string, got: {type(resource)}"
                 )
             return cls.gcp(resource)
-        raise ValueError(f"Unsupported or missing CMEK provider in data: {data}")
+        raise InvalidArgumentError(f"Unsupported or missing CMEK provider in data: {data}")
 
 
 # Index Type Classes
@@ -2111,26 +2112,26 @@ class Schema:
 
         # Disallow config=None and key=None - too dangerous
         if config is None and key is None:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Cannot enable all index types globally. Must specify either config or key."
             )
 
         # Disallow using special internal key #embedding
         if key is not None and key == EMBEDDING_KEY:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Cannot create index on special key '{key}'. This key is managed automatically by the system. Invoke create_index(VectorIndexConfig(...)) without specifying a key to configure the vector index globally."
             )
 
         # Only allow #document with FtsIndexConfig
         if key == DOCUMENT_KEY and not isinstance(config, FtsIndexConfig):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Cannot create index on special key '{key}' with this config. "
                 "Only FtsIndexConfig is allowed for #document."
             )
 
         # Disallow any key starting with # (except #document which allows FTS)
         if key is not None and key.startswith("#") and key != DOCUMENT_KEY:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "key cannot begin with '#'. "
                 "Keys starting with '#' are reserved for system use."
             )
@@ -2144,20 +2145,20 @@ class Schema:
                 return self
             else:
                 # Disallow vector index on any custom key
-                raise ValueError(
+                raise InvalidArgumentError(
                     "Vector index cannot be enabled on specific keys. Use create_index(config=VectorIndexConfig(...)) without specifying a key to configure the vector index globally."
                 )
 
         # FTS index is only allowed on #document key
         if isinstance(config, FtsIndexConfig) and key != DOCUMENT_KEY:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "FTS index can only be enabled on #document key. "
                 "Use create_index(config=FtsIndexConfig(), key='#document')"
             )
 
         # Disallow sparse vector index without a specific key
         if isinstance(config, SparseVectorIndexConfig) and key is None:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Sparse vector index must be created on a specific key. "
                 "Please specify a key using: create_index(config=SparseVectorIndexConfig(...), key='your_key')"
             )
@@ -2165,7 +2166,7 @@ class Schema:
         # TODO: Consider removing this check in the future to allow enabling all indexes for a key
         # Disallow enabling all index types for a key (config=None, key="some_key")
         if config is None and key is not None:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Cannot enable all index types for key '{key}'. Please specify a specific index configuration."
             )
 
@@ -2197,24 +2198,24 @@ class Schema:
 
         # Case 1: Both config and key are None - fail the request
         if config is None and key is None:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "Cannot disable all indexes. Must specify either config or key."
             )
 
         # Disallow using special internal key #embedding
         if key is not None and key == EMBEDDING_KEY:
-            raise ValueError("Cannot modify #embedding. Currently not supported")
+            raise InvalidArgumentError("Cannot modify #embedding. Currently not supported")
 
         # Only allow #document with FtsIndexConfig (to disable FTS)
         if key == DOCUMENT_KEY and not isinstance(config, FtsIndexConfig):
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Cannot delete index on special key '{key}' with this config. "
                 "Only FtsIndexConfig is allowed for #document."
             )
 
         # Disallow any key starting with # (except #document which allows FTS deletion)
         if key is not None and key.startswith("#") and key != DOCUMENT_KEY:
-            raise ValueError(
+            raise InvalidArgumentError(
                 "key cannot begin with '#'. "
                 "Keys starting with '#' are reserved for system use."
             )
@@ -2222,20 +2223,20 @@ class Schema:
         # TODO: Consider removing these checks in the future to allow disabling vector and sparse vector indexes
         # Temporarily disallow deleting vector index (both globally and per-key)
         if isinstance(config, VectorIndexConfig):
-            raise ValueError("Deleting vector index is not currently supported.")
+            raise InvalidArgumentError("Deleting vector index is not currently supported.")
 
         # Temporarily disallow deleting sparse vector index (both globally and per-key)
         if isinstance(config, SparseVectorIndexConfig):
-            raise ValueError("Deleting sparse vector index is not currently supported.")
+            raise InvalidArgumentError("Deleting sparse vector index is not currently supported.")
 
         # FTS deletion is only allowed on #document key
         if isinstance(config, FtsIndexConfig) and key != DOCUMENT_KEY:
-            raise ValueError("Deleting FTS index is only supported on #document key.")
+            raise InvalidArgumentError("Deleting FTS index is only supported on #document key.")
 
         # TODO: Consider removing this check in the future to allow disabling all indexes for a key
         # Disallow disabling all index types for a key (config=None, key="some_key")
         if key is not None and config is None:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"Cannot disable all index types for key '{key}'. Please specify a specific index configuration."
             )
 
@@ -2370,7 +2371,7 @@ class Schema:
             if value_types.sparse_vector is not None:
                 if value_types.sparse_vector.sparse_vector_index is not None:
                     if value_types.sparse_vector.sparse_vector_index.enabled:
-                        raise ValueError(
+                        raise InvalidArgumentError(
                             f"Cannot enable sparse vector index on key '{key}'. "
                             f"A sparse vector index is already enabled on key '{existing_key}'. "
                             f"Only one sparse vector index is allowed per collection."
@@ -2382,7 +2383,7 @@ class Schema:
         since there is no default embedding function. Raises ValueError otherwise.
         """
         if config.source_key is not None and config.embedding_function is None:
-            raise ValueError(
+            raise InvalidArgumentError(
                 f"If source_key is provided then embedding_function must also be provided "
                 f"since there is no default embedding function. Config: {config}"
             )


### PR DESCRIPTION
Replaces 103 user-facing ValueError/TypeError with InvalidArgumentError in the API layer (types.py, client.py, async_client.py) for consistent error handling.
