### PR TITLE
[CHORE] Disable stall protection for reads.

### DIFF
--- a/rust/garbage_collector/src/config.rs
+++ b/rust/garbage_collector/src/config.rs
@@ -186,6 +186,8 @@ mod tests {
                 if let S3CredentialsConfig::Minio = storage_config.credentials {
                     assert_eq!(storage_config.connect_timeout_ms, 5000);
                     assert_eq!(storage_config.request_timeout_ms, 30000);
+                    assert!(!storage_config.stall_download_enabled);
+                    assert!(storage_config.stall_upload_enabled);
                     assert_eq!(storage_config.upload_part_size_bytes, 536870912);
                     assert_eq!(storage_config.download_part_size_bytes, 8388608);
                 } else {

--- a/rust/storage/src/config.rs
+++ b/rust/storage/src/config.rs
@@ -96,6 +96,10 @@ pub struct S3StorageConfig {
     pub request_retry_count: u32,
     #[serde(default = "S3StorageConfig::default_stall_protection_ms")]
     pub stall_protection_ms: u64,
+    #[serde(default = "S3StorageConfig::default_stall_download_enabled")]
+    pub stall_download_enabled: bool,
+    #[serde(default = "S3StorageConfig::default_stall_upload_enabled")]
+    pub stall_upload_enabled: bool,
     #[serde(default = "S3StorageConfig::default_upload_part_size_bytes")]
     pub upload_part_size_bytes: usize,
     #[serde(default = "S3StorageConfig::default_download_part_size_bytes")]
@@ -128,6 +132,14 @@ impl S3StorageConfig {
         5000
     }
 
+    fn default_stall_download_enabled() -> bool {
+        false
+    }
+
+    fn default_stall_upload_enabled() -> bool {
+        true
+    }
+
     fn default_upload_part_size_bytes() -> usize {
         5 * 1024 * 1024
     }
@@ -147,6 +159,8 @@ impl Default for S3StorageConfig {
             request_timeout_ms: S3StorageConfig::default_request_timeout_ms(),
             request_retry_count: S3StorageConfig::default_request_retry_count(),
             stall_protection_ms: S3StorageConfig::default_stall_protection_ms(),
+            stall_download_enabled: S3StorageConfig::default_stall_download_enabled(),
+            stall_upload_enabled: S3StorageConfig::default_stall_upload_enabled(),
             upload_part_size_bytes: S3StorageConfig::default_upload_part_size_bytes(),
             download_part_size_bytes: S3StorageConfig::default_download_part_size_bytes(),
         }

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -1186,8 +1186,8 @@ impl Configurable<StorageConfig> for S3Storage {
                     .build();
 
                 let stalled_config = StalledStreamProtectionConfig::enabled()
-                    .download_enabled(false)
-                    .upload_enabled(true)
+                    .download_enabled(s3_config.stall_download_enabled)
+                    .upload_enabled(s3_config.stall_upload_enabled)
                     .grace_period(Duration::from_millis(s3_config.stall_protection_ms))
                     .build();
 

--- a/rust/storage/src/s3.rs
+++ b/rust/storage/src/s3.rs
@@ -1186,6 +1186,7 @@ impl Configurable<StorageConfig> for S3Storage {
                     .build();
 
                 let stalled_config = StalledStreamProtectionConfig::enabled()
+                    .download_enabled(false)
                     .upload_enabled(true)
                     .grace_period(Duration::from_millis(s3_config.stall_protection_ms))
                     .build();

--- a/rust/worker/tests/config_from_default_path.rs
+++ b/rust/worker/tests/config_from_default_path.rs
@@ -38,6 +38,8 @@ fn test_config_from_default_path() {
                             credentials: Minio
                             connect_timeout_ms: 5000
                             request_timeout_ms: 1000
+                            stall_download_enabled: true
+                            stall_upload_enabled: false
                             upload_part_size_bytes: 8388608
                             download_part_size_bytes: 8388608
                         rate_limiting_policy:
@@ -231,6 +233,8 @@ fn test_config_from_default_path() {
         match config.query_service.storage {
             chroma_storage::config::StorageConfig::AdmissionControlledS3(config) => {
                 assert_eq!(config.s3_config.bucket, "chroma");
+                assert!(config.s3_config.stall_download_enabled);
+                assert!(!config.s3_config.stall_upload_enabled);
                 match config.rate_limiting_policy {
                     chroma_storage::config::RateLimitingConfig::CountBasedPolicy(config) => {
                         assert_eq!(config.max_concurrent_requests, 15);
@@ -245,6 +249,8 @@ fn test_config_from_default_path() {
         match config.compaction_service.storage {
             chroma_storage::config::StorageConfig::AdmissionControlledS3(config) => {
                 assert_eq!(config.s3_config.bucket, "chroma");
+                assert!(!config.s3_config.stall_download_enabled);
+                assert!(config.s3_config.stall_upload_enabled);
                 match config.rate_limiting_policy {
                     chroma_storage::config::RateLimitingConfig::CountBasedPolicy(config) => {
                         assert_eq!(config.max_concurrent_requests, 15);


### PR DESCRIPTION
## Description of changes

We have other timeouts and retries.  Turn off the stall protection.

## Test plan

CI

## Migration plan

N/A

## Observability plan

Watch stalls not happen on read.

## Documentation Changes

N/A
