### PR TITLE
fix(docker): add curl to runner stage for HEALTHCHECK support

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -75,7 +75,7 @@ ENV RUST_BACKTRACE=${ADDRESS_SANITIZER:+'full'}${ADDRESS_SANITIZER:-'0'}
 RUN if [ "$ADDRESS_SANITIZER" = "1" ]; then apt-get update \
   && apt-get install -y build-essential llvm; \
   fi
-RUN apt-get update && apt-get install -y dumb-init libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y dumb-init libssl-dev ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 FROM runner AS cli
 


### PR DESCRIPTION
Fixes #6855

Adds `curl` to the `debian:stable-slim` runner stage so the docker-compose healthcheck (which uses `curl` to probe `/api/v2/heartbeat`) can execute successfully. Without `curl` installed, the container healthcheck fails immediately on startup.

**Root cause:** The `runner` base image (`debian:stable-slim`) does not include `curl` by default. The docker-compose healthcheck command references `curl` but it was never installed in the runner stage.

**Fix:** Added `curl` to the existing `apt-get install` line in the runner stage alongside `dumb-init`, `libssl-dev`, and `ca-certificates`.