### PR TITLE
[DOC] Fix missing word in manage-collections documentation

### DIFF
--- a/docs/mintlify/docs/collections/manage-collections.mdx
+++ b/docs/mintlify/docs/collections/manage-collections.mdx
@@ -160,7 +160,7 @@ collection.add(
 
 ### Collection Metadata
 
-When creating collections, you can pass the optional `metadata` argument to add a mapping of metadata key-value pairs to your collections. This can be useful for adding general about the collection like creation time, description of the data stored in the collection, and more.
+When creating collections, you can pass the optional `metadata` argument to add a mapping of metadata key-value pairs to your collections. This can be useful for adding general information about the collection like creation time, description of the data stored in the collection, and more.
 
 <CodeGroup>
 ```python Python


### PR DESCRIPTION
Add missing word "information" in the Collection Metadata section.

https://claude.ai/code/session_01HuqswcccMfZpNeSrNXh6p4

## Description of changes

_Summarize the changes made by this PR._

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
