### PR TITLE
[ENH] Add maxscore option in schema

### DIFF
--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1721,7 +1721,16 @@ class VectorIndexConfig(BaseModel):
 class SparseVectorIndexConfig(BaseModel):
     """Configuration for sparse vector index."""
 
-    model_config = {"arbitrary_types_allowed": True, "extra": "forbid"}
+    model_config = {"arbitrary_types_allowed": True}
+
+    _validate_extra_fields = _create_extra_fields_validator(
+        [
+            "embedding_function",
+            "source_key",
+            "bm25",
+            "algorithm",
+        ]
+    )
 
     # TODO(Sanket): Change this to the appropriate sparse ef and use a default here.
     embedding_function: Optional[Any] = None

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -1726,7 +1726,16 @@ class VectorIndexConfig(BaseModel):
 class SparseVectorIndexConfig(BaseModel):
     """Configuration for sparse vector index."""
 
-    model_config = {"arbitrary_types_allowed": True, "extra": "forbid"}
+    model_config = {"arbitrary_types_allowed": True}
+
+    _validate_extra_fields = _create_extra_fields_validator(
+        [
+            "embedding_function",
+            "source_key",
+            "bm25",
+            "algorithm",
+        ]
+    )
 
     # TODO(Sanket): Change this to the appropriate sparse ef and use a default here.
     embedding_function: Optional[Any] = None

--- a/chromadb/test/api/test_schema.py
+++ b/chromadb/test/api/test_schema.py
@@ -1876,9 +1876,7 @@ class TestNewSchema:
         schema.create_index(config=fts_config, key="#document")
 
         # Test 3: Cannot disable all indexes globally (no config, no key)
-        with pytest.raises(
-            ValueError, match="Cannot disable all indexes"
-        ):
+        with pytest.raises(ValueError, match="Cannot disable all indexes"):
             schema.delete_index()
 
         # Test 4: Cannot enable all indexes globally
@@ -2790,12 +2788,14 @@ class TestNewSchema:
 
     def test_cmek_invalid_deserialization(self) -> None:
         """Test that invalid CMEK data raises a warning and sets cmek to None."""
-        with pytest.raises(ValueError, match="Unsupported or missing CMEK provider in data"):
-            Schema.deserialize_from_json(
-                {"defaults": {}, "keys": {}, "cmek": {}}
-            )
+        with pytest.raises(
+            ValueError, match="Unsupported or missing CMEK provider in data"
+        ):
+            Schema.deserialize_from_json({"defaults": {}, "keys": {}, "cmek": {}})
 
-        with pytest.raises(ValueError, match="Unsupported or missing CMEK provider in data"):
+        with pytest.raises(
+            ValueError, match="Unsupported or missing CMEK provider in data"
+        ):
             Schema.deserialize_from_json(
                 {
                     "defaults": {},
@@ -2803,6 +2803,7 @@ class TestNewSchema:
                     "cmek": {"invalid_provider": "some-resource"},
                 }
             )
+
 
 def test_sparse_vector_cannot_be_created_globally() -> None:
     """Test that sparse vector index cannot be created globally (without a key)."""
@@ -2964,15 +2965,11 @@ def test_delete_index_rejects_special_keys() -> None:
         schema.delete_index(config=string_config, key=Key.DOCUMENT)
 
     # Test that Key.EMBEDDING is rejected
-    with pytest.raises(
-        ValueError, match="Cannot modify #embedding"
-    ):
+    with pytest.raises(ValueError, match="Cannot modify #embedding"):
         schema.delete_index(config=string_config, key=Key.EMBEDDING)
 
     # Test that string "#embedding" is also rejected (for consistency)
-    with pytest.raises(
-        ValueError, match="Cannot modify #embedding"
-    ):
+    with pytest.raises(ValueError, match="Cannot modify #embedding"):
         schema.delete_index(config=string_config, key="#embedding")
 
     # Test that any other key starting with # is rejected (second check)
@@ -3156,7 +3153,11 @@ def test_config_classes_reject_invalid_fields() -> None:
 
     error_msg = str(exc_info.value)
     assert "key" in error_msg.lower()
-    assert "extra" in error_msg.lower() or "permitted" in error_msg.lower()
+    assert (
+        "extra" in error_msg.lower()
+        or "permitted" in error_msg.lower()
+        or "not a valid field" in error_msg.lower()
+    )
 
     # Test VectorIndexConfig rejects invalid fields
     with pytest.raises((ValueError, ValidationError)) as exc_info:

--- a/clients/new-js/packages/chromadb/src/api/types.gen.ts
+++ b/clients/new-js/packages/chromadb/src/api/types.gen.ts
@@ -593,6 +593,14 @@ export type SpannIndexConfig = {
 };
 
 /**
+ * Sparse vector index algorithm.
+ *
+ * Controls which posting list format and query engine are used for
+ * sparse vector search within a collection.
+ */
+export type SparseIndexAlgorithm = 'wand' | 'max_score';
+
+/**
  * Represents a sparse vector using parallel arrays for indices and values.
  *
  * On deserialization: accepts both old format `{"indices": [...], "values": [...]}`
@@ -616,6 +624,13 @@ export type SparseVector = {
 };
 
 export type SparseVectorIndexConfig = {
+    /**
+     * Sparse index algorithm (cloud-only, tenant-gated).
+     * Omitted from JSON when set to the default (Wand) so that old
+     * servers/clients that do not know about this field can still
+     * deserialize the schema.
+     */
+    algorithm?: SparseIndexAlgorithm;
     /**
      * Whether this embedding is BM25
      */

--- a/go/pkg/sysdb/coordinator/model/collection_configuration.go
+++ b/go/pkg/sysdb/coordinator/model/collection_configuration.go
@@ -243,6 +243,7 @@ type SparseVectorIndexConfig struct {
 	EmbeddingFunction *EmbeddingFunctionConfiguration `json:"embedding_function,omitempty"`
 	SourceKey         *string                         `json:"source_key,omitempty"`
 	Bm25              *bool                           `json:"bm25,omitempty"`
+	Algorithm         *string                         `json:"algorithm,omitempty"`
 }
 
 type ValueTypes struct {

--- a/rust/chroma/examples/collection_search.rs
+++ b/rust/chroma/examples/collection_search.rs
@@ -231,6 +231,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             embedding_function: None,
             source_key: None,
             bm25: Some(true), // Enable BM25 mode for this sparse index
+            algorithm: Default::default(),
         }
         .into(),
     )?;

--- a/rust/chroma/src/types.rs
+++ b/rust/chroma/src/types.rs
@@ -86,6 +86,7 @@ pub use chroma_types::SetOperator;
 pub use chroma_types::Space;
 pub use chroma_types::SpannConfiguration;
 pub use chroma_types::SpannIndexConfig;
+pub use chroma_types::SparseIndexAlgorithm;
 pub use chroma_types::SparseVector;
 pub use chroma_types::SparseVectorIndexConfig;
 pub use chroma_types::SparseVectorIndexType;

--- a/rust/frontend/sample_configs/distributed.yaml
+++ b/rust/frontend/sample_configs/distributed.yaml
@@ -85,4 +85,5 @@ tenants_to_migrate_immediately:
 - "default_tenant"
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
+tenants_with_maxscore_enabled: []
 enable_log_scouting: true

--- a/rust/frontend/sample_configs/distributed2.yaml
+++ b/rust/frontend/sample_configs/distributed2.yaml
@@ -75,4 +75,5 @@ tenants_to_migrate_immediately:
 - "default_tenant"
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
+tenants_with_maxscore_enabled: []
 enable_log_scouting: true

--- a/rust/frontend/sample_configs/distributed_mcmr.yaml
+++ b/rust/frontend/sample_configs/distributed_mcmr.yaml
@@ -75,4 +75,5 @@ tenants_to_migrate_immediately:
 - "default_tenant"
 tenants_to_migrate_immediately_threshold: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 tenants_with_quantization_enabled: []
+tenants_with_maxscore_enabled: []
 enable_log_scouting: true

--- a/rust/frontend/src/config.rs
+++ b/rust/frontend/src/config.rs
@@ -77,6 +77,8 @@ pub struct FrontendConfig {
     pub min_records_for_invocation: u64,
     #[serde(default = "Default::default")]
     pub tenants_with_quantization_enabled: Vec<String>,
+    #[serde(default = "Default::default")]
+    pub tenants_with_maxscore_enabled: Vec<String>,
     #[serde(default = "default_enable_log_scouting")]
     pub enable_log_scouting: bool,
 }
@@ -101,6 +103,7 @@ impl FrontendConfig {
             enable_schema: default_enable_schema(),
             min_records_for_invocation: default_min_records_for_invocation(),
             tenants_with_quantization_enabled: vec![],
+            tenants_with_maxscore_enabled: vec![],
             enable_log_scouting: false,
         }
     }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -45,11 +45,11 @@ use chroma_types::{
     ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, Operation, OperationRecord,
     Quantization, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse, Schema,
     SchemaError, SearchRequest, SearchResponse, Segment, SegmentScope, SegmentType, SegmentUuid,
-    UpdateCollectionError, UpdateCollectionRecordsError, UpdateCollectionRecordsRequest,
-    UpdateCollectionRecordsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
-    UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse, UpsertCollectionRecordsError,
-    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, VectorIndexConfiguration,
-    Where,
+    SparseIndexAlgorithm, UpdateCollectionError, UpdateCollectionRecordsError,
+    UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse, UpdateCollectionRequest,
+    UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse,
+    UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
+    VectorIndexConfiguration, Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
@@ -85,6 +85,7 @@ pub struct ServiceBasedFrontend {
     retries_builder: ExponentialBuilder,
     min_records_for_invocation: u64,
     tenants_with_quantization_enabled: Vec<String>,
+    tenants_with_maxscore_enabled: Vec<String>,
     enable_log_scouting: bool,
 }
 
@@ -101,6 +102,7 @@ impl ServiceBasedFrontend {
         enable_schema: bool,
         min_records_for_invocation: u64,
         tenants_with_quantization_enabled: Vec<String>,
+        tenants_with_maxscore_enabled: Vec<String>,
         enable_log_scouting: bool,
     ) -> Self {
         let meter = global::meter("chroma");
@@ -149,6 +151,7 @@ impl ServiceBasedFrontend {
             retries_builder,
             min_records_for_invocation,
             tenants_with_quantization_enabled,
+            tenants_with_maxscore_enabled,
             enable_log_scouting,
         }
     }
@@ -638,6 +641,14 @@ impl ServiceBasedFrontend {
             .any(|t| t == "*" || t == tenant_id)
     }
 
+    /// Check if MaxScore sparse index should be enabled for the given tenant.
+    /// Returns true if the list contains "*" (all tenants) or the exact tenant_id.
+    fn should_enable_maxscore_for_tenant(&self, tenant_id: &str) -> bool {
+        self.tenants_with_maxscore_enabled
+            .iter()
+            .any(|t| t == "*" || t == tenant_id)
+    }
+
     pub fn get_default_knn_index(&self) -> KnnIndex {
         self.default_knn_index
     }
@@ -1063,6 +1074,13 @@ impl ServiceBasedFrontend {
         if let Some(ref mut schema) = reconciled_schema {
             if self.should_enable_quantization_for_tenant(&tenant_id) {
                 schema.quantize(Quantization::FourBitRabitQWithUSearch);
+            }
+        }
+
+        // Enable MaxScore sparse index for tenants in the config list
+        if let Some(ref mut schema) = reconciled_schema {
+            if self.should_enable_maxscore_for_tenant(&tenant_id) {
+                schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
             }
         }
 
@@ -2741,6 +2759,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             config.enable_schema,
             config.min_records_for_invocation,
             config.tenants_with_quantization_enabled.clone(),
+            config.tenants_with_maxscore_enabled.clone(),
             config.enable_log_scouting,
         ))
     }

--- a/rust/frontend/src/impls/service_based_frontend.rs
+++ b/rust/frontend/src/impls/service_based_frontend.rs
@@ -45,11 +45,11 @@ use chroma_types::{
     ListDatabasesError, ListDatabasesRequest, ListDatabasesResponse, Operation, OperationRecord,
     Quantization, QueryError, QueryRequest, QueryResponse, ResetError, ResetResponse, Schema,
     SchemaError, SearchRequest, SearchResponse, Segment, SegmentScope, SegmentType, SegmentUuid,
-    UpdateCollectionError, UpdateCollectionRecordsError, UpdateCollectionRecordsRequest,
-    UpdateCollectionRecordsResponse, UpdateCollectionRequest, UpdateCollectionResponse,
-    UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse, UpsertCollectionRecordsError,
-    UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse, VectorIndexConfiguration,
-    Where,
+    SparseIndexAlgorithm, UpdateCollectionError, UpdateCollectionRecordsError,
+    UpdateCollectionRecordsRequest, UpdateCollectionRecordsResponse, UpdateCollectionRequest,
+    UpdateCollectionResponse, UpdateTenantError, UpdateTenantRequest, UpdateTenantResponse,
+    UpsertCollectionRecordsError, UpsertCollectionRecordsRequest, UpsertCollectionRecordsResponse,
+    VectorIndexConfiguration, Where,
 };
 use opentelemetry::global;
 use opentelemetry::metrics::Counter;
@@ -85,6 +85,7 @@ pub struct ServiceBasedFrontend {
     retries_builder: ExponentialBuilder,
     min_records_for_invocation: u64,
     tenants_with_quantization_enabled: Vec<String>,
+    tenants_with_maxscore_enabled: Vec<String>,
     enable_log_scouting: bool,
 }
 
@@ -101,6 +102,7 @@ impl ServiceBasedFrontend {
         enable_schema: bool,
         min_records_for_invocation: u64,
         tenants_with_quantization_enabled: Vec<String>,
+        tenants_with_maxscore_enabled: Vec<String>,
         enable_log_scouting: bool,
     ) -> Self {
         let meter = global::meter("chroma");
@@ -149,6 +151,7 @@ impl ServiceBasedFrontend {
             retries_builder,
             min_records_for_invocation,
             tenants_with_quantization_enabled,
+            tenants_with_maxscore_enabled,
             enable_log_scouting,
         }
     }
@@ -790,6 +793,14 @@ impl ServiceBasedFrontend {
             .any(|t| t == "*" || t == tenant_id)
     }
 
+    /// Check if MaxScore sparse index should be enabled for the given tenant.
+    /// Returns true if the list contains "*" (all tenants) or the exact tenant_id.
+    fn should_enable_maxscore_for_tenant(&self, tenant_id: &str) -> bool {
+        self.tenants_with_maxscore_enabled
+            .iter()
+            .any(|t| t == "*" || t == tenant_id)
+    }
+
     pub fn get_default_knn_index(&self) -> KnnIndex {
         self.default_knn_index
     }
@@ -1215,6 +1226,13 @@ impl ServiceBasedFrontend {
         if let Some(ref mut schema) = reconciled_schema {
             if self.should_enable_quantization_for_tenant(&tenant_id) {
                 schema.quantize(Quantization::FourBitRabitQWithUSearch);
+            }
+        }
+
+        // Enable MaxScore sparse index for tenants in the config list
+        if let Some(ref mut schema) = reconciled_schema {
+            if self.should_enable_maxscore_for_tenant(&tenant_id) {
+                schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
             }
         }
 
@@ -2893,6 +2911,7 @@ impl Configurable<(FrontendConfig, System)> for ServiceBasedFrontend {
             config.enable_schema,
             config.min_records_for_invocation,
             config.tenants_with_quantization_enabled.clone(),
+            config.tenants_with_maxscore_enabled.clone(),
             config.enable_log_scouting,
         ))
     }

--- a/rust/python_bindings/src/bindings.rs
+++ b/rust/python_bindings/src/bindings.rs
@@ -131,6 +131,7 @@ impl Bindings {
             enable_schema,
             min_records_for_invocation: default_min_records_for_invocation(),
             tenants_with_quantization_enabled: vec![],
+            tenants_with_maxscore_enabled: vec![],
             enable_log_scouting: false,
         };
 

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -423,6 +423,37 @@ impl Schema {
         defaults_enabled || key_enabled
     }
 
+    /// Check if any sparse index is configured to use MaxScore.
+    pub fn is_maxscore_enabled(&self) -> bool {
+        let check = |sv: &SparseVectorValueType| -> bool {
+            sv.sparse_vector_index.as_ref().is_some_and(|idx| {
+                idx.enabled && matches!(idx.config.algorithm, SparseIndexAlgorithm::MaxScore)
+            })
+        };
+        self.defaults.sparse_vector.as_ref().is_some_and(check)
+            || self
+                .keys
+                .values()
+                .any(|vt| vt.sparse_vector.as_ref().is_some_and(check))
+    }
+
+    /// Set the sparse index algorithm on all sparse index configs
+    /// (defaults and every key-specific config).
+    pub fn set_sparse_algorithm(&mut self, algorithm: SparseIndexAlgorithm) {
+        if let Some(sv) = &mut self.defaults.sparse_vector {
+            if let Some(idx) = &mut sv.sparse_vector_index {
+                idx.config.algorithm = algorithm.clone();
+            }
+        }
+        for vt in self.keys.values_mut() {
+            if let Some(sv) = &mut vt.sparse_vector {
+                if let Some(idx) = &mut sv.sparse_vector_index {
+                    idx.config.algorithm = algorithm.clone();
+                }
+            }
+        }
+    }
+
     pub fn is_fts_enabled(&self) -> bool {
         // Check key-specific override first, then fall back to global defaults
         self.keys
@@ -488,6 +519,7 @@ impl Default for Schema {
                         embedding_function: None,
                         source_key: None,
                         bm25: None,
+                        algorithm: SparseIndexAlgorithm::Wand,
                     },
                 }),
             }),
@@ -861,6 +893,7 @@ impl Schema {
                         embedding_function: Some(EmbeddingFunctionConfiguration::Unknown),
                         source_key: None,
                         bm25: Some(false),
+                        algorithm: SparseIndexAlgorithm::Wand,
                     },
                 }),
             }),
@@ -1668,6 +1701,11 @@ impl Schema {
                 .or(default.embedding_function.clone()),
             source_key: user.source_key.clone().or(default.source_key.clone()),
             bm25: user.bm25.or(default.bm25),
+            algorithm: if !is_default_sparse_algorithm(&user.algorithm) {
+                user.algorithm.clone()
+            } else {
+                default.algorithm.clone()
+            },
         }
     }
 
@@ -2992,6 +3030,23 @@ impl SpannIndexConfig {
     }
 }
 
+/// Sparse vector index algorithm.
+///
+/// Controls which posting list format and query engine are used for
+/// sparse vector search within a collection.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum SparseIndexAlgorithm {
+    #[default]
+    Wand,
+    MaxScore,
+}
+
+fn is_default_sparse_algorithm(v: &SparseIndexAlgorithm) -> bool {
+    matches!(v, SparseIndexAlgorithm::Wand)
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields)]
@@ -3005,6 +3060,12 @@ pub struct SparseVectorIndexConfig {
     /// Whether this embedding is BM25
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bm25: Option<bool>,
+    /// Sparse index algorithm (cloud-only, tenant-gated).
+    /// Omitted from JSON when set to the default (Wand) so that old
+    /// servers/clients that do not know about this field can still
+    /// deserialize the schema.
+    #[serde(default, skip_serializing_if = "is_default_sparse_algorithm")]
+    pub algorithm: SparseIndexAlgorithm,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -3616,6 +3677,7 @@ mod tests {
                             embedding_function: Some(EmbeddingFunctionConfiguration::Legacy),
                             source_key: None,
                             bm25: None,
+                            algorithm: SparseIndexAlgorithm::Wand,
                         },
                     }),
                 }),
@@ -4004,12 +4066,14 @@ mod tests {
             embedding_function: Some(EmbeddingFunctionConfiguration::Legacy),
             source_key: Some("default_sparse_key".to_string()),
             bm25: None,
+            algorithm: SparseIndexAlgorithm::Wand,
         };
 
         let user_config = SparseVectorIndexConfig {
             embedding_function: None,                        // Will use default
             source_key: Some("user_sparse_key".to_string()), // Override
             bm25: None,
+            algorithm: SparseIndexAlgorithm::Wand,
         };
 
         let result = Schema::merge_sparse_vector_index_config(&default_config, &user_config);
@@ -4021,6 +4085,86 @@ mod tests {
             result.embedding_function,
             Some(EmbeddingFunctionConfiguration::Legacy)
         );
+    }
+
+    #[test]
+    fn test_sparse_algorithm_serde_roundtrip() {
+        // Old schema JSON without algorithm field -> defaults to Wand
+        let json_no_algorithm = r#"{
+            "embedding_function": null,
+            "source_key": null,
+            "bm25": null
+        }"#;
+        let config: SparseVectorIndexConfig = serde_json::from_str(json_no_algorithm).unwrap();
+        assert_eq!(config.algorithm, SparseIndexAlgorithm::Wand);
+
+        // Serialize with Wand -> algorithm field absent from JSON
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(
+            !serialized.contains("algorithm"),
+            "Wand (default) must not appear in JSON: {serialized}"
+        );
+
+        // Deserialize with "algorithm": "max_score" -> MaxScore
+        let json_maxscore = r#"{
+            "embedding_function": null,
+            "source_key": null,
+            "bm25": null,
+            "algorithm": "max_score"
+        }"#;
+        let config: SparseVectorIndexConfig = serde_json::from_str(json_maxscore).unwrap();
+        assert_eq!(config.algorithm, SparseIndexAlgorithm::MaxScore);
+
+        // Serialize with MaxScore -> algorithm field present in JSON
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(
+            serialized.contains(r#""algorithm":"max_score""#),
+            "MaxScore must appear in JSON: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_is_maxscore_enabled() {
+        // Default schema -> Wand -> false
+        let schema = Schema::default();
+        assert!(!schema.is_maxscore_enabled());
+
+        // Schema with sparse enabled but Wand algorithm -> false
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        schema
+            .keys
+            .entry("sparse_key".to_string())
+            .or_default()
+            .sparse_vector = Some(SparseVectorValueType {
+            sparse_vector_index: Some(SparseVectorIndexType {
+                enabled: true,
+                config: SparseVectorIndexConfig {
+                    embedding_function: None,
+                    source_key: None,
+                    bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
+                },
+            }),
+        });
+        assert!(!schema.is_maxscore_enabled());
+
+        // Set algorithm to MaxScore -> true
+        schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
+        assert!(schema.is_maxscore_enabled());
+
+        // Disabled index with MaxScore -> false
+        schema
+            .keys
+            .get_mut("sparse_key")
+            .unwrap()
+            .sparse_vector
+            .as_mut()
+            .unwrap()
+            .sparse_vector_index
+            .as_mut()
+            .unwrap()
+            .enabled = false;
+        assert!(!schema.is_maxscore_enabled());
     }
 
     #[test]
@@ -5869,6 +6013,7 @@ mod tests {
                 embedding_function: None,
                 source_key: None,
                 bm25: None,
+                algorithm: SparseIndexAlgorithm::Wand,
             }),
         );
         assert!(result.is_err());
@@ -5885,6 +6030,7 @@ mod tests {
                     embedding_function: None,
                     source_key: None,
                     bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
                 }),
             )
             .expect("first sparse should succeed")
@@ -5894,6 +6040,7 @@ mod tests {
                     embedding_function: None,
                     source_key: None,
                     bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
                 }),
             );
         assert!(result.is_err());
@@ -5962,6 +6109,7 @@ mod tests {
                     embedding_function: None,
                     source_key: None,
                     bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
                 }),
             )
             .expect("create should succeed")
@@ -5971,6 +6119,7 @@ mod tests {
                     embedding_function: None,
                     source_key: None,
                     bm25: None,
+                    algorithm: SparseIndexAlgorithm::Wand,
                 }),
             );
         assert!(result.is_err());
@@ -6796,6 +6945,7 @@ mod tests {
                         embedding_function,
                         source_key,
                         bm25,
+                        algorithm: SparseIndexAlgorithm::Wand,
                     }
                 })
         }

--- a/rust/types/src/collection_schema.rs
+++ b/rust/types/src/collection_schema.rs
@@ -3044,7 +3044,7 @@ pub enum SparseIndexAlgorithm {
 }
 
 fn is_default_sparse_algorithm(v: &SparseIndexAlgorithm) -> bool {
-    matches!(v, SparseIndexAlgorithm::Wand)
+    v == &SparseIndexAlgorithm::default()
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/rust/types/src/segment.rs
+++ b/rust/types/src/segment.rs
@@ -23,6 +23,7 @@ pub const U32_METADATA: &str = "u32_metadata";
 
 pub const SPARSE_MAX: &str = "sparse_max";
 pub const SPARSE_OFFSET_VALUE: &str = "sparse_offset_value";
+pub const SPARSE_POSTING: &str = "sparse_posting";
 
 pub const HNSW_PATH: &str = "hnsw_path";
 pub const VERSION_MAP_PATH: &str = "version_map_path";


### PR DESCRIPTION
## Description of changes
*This is PR 6 in the MaxScore stack. It adds the schema configuration and frontend tenant gating needed to conditionally enable the MaxScore sparse index algorithm on a per-tenant basis. This PR has zero runtime impact — nothing reads the new field yet. The segment wiring and orchestrator routing will follow in subsequent PRs.*
- **`SparseIndexAlgorithm` enum** (`collection_schema.rs`): `Wand` (default) | `MaxScore`. Uses `#[serde(default, skip_serializing_if)]` so the field is omitted from JSON when set to the default (`Wand`) — old servers and clients that use `deny_unknown_fields` will never encounter it unless the feature is actively enabled.
- **`algorithm` field on `SparseVectorIndexConfig`**: Added with backward-compatible serde attributes. Updated `merge_sparse_vector_index_config()` to merge the new field (user's non-default value wins).
- **Schema helpers**: `Schema::is_maxscore_enabled()` checks if any enabled sparse index uses `MaxScore`. `Schema::set_sparse_algorithm()` sets the algorithm on all sparse index configs (defaults + key-specific).
- **Frontend gating**: `tenants_with_maxscore_enabled: Vec<String>` config field (same pattern as `tenants_with_quantization_enabled`). `should_enable_maxscore_for_tenant()` check with wildcard (`"*"`) support. In `create_collection()`, injects `MaxScore` algorithm into the schema for enabled tenants.
- **Client backward compatibility**:
  - **Python**: Changed `SparseVectorIndexConfig` from `extra: "forbid"` to `_create_extra_fields_validator` with `"algorithm"` in the allowlist (same pattern as `SpannIndexConfig` for `quantize`). Old unknown fields still rejected.
  - **Go**: Added `Algorithm *string` with `json:"algorithm,omitempty"` to prevent silent data loss on re-marshal.
  - **Rust client**: Re-exported `SparseIndexAlgorithm` from `chroma::types`.
  - **JS**: Already tolerant of unknown fields — no changes needed.
- **Segment constant**: `SPARSE_POSTING` file path key for the new blockfile format (used by the segment wiring PR).
## Test plan
- `test_sparse_algorithm_serde_roundtrip`: Old JSON without `algorithm` deserializes to `Wand`; `Wand` is omitted from serialized output; `"max_score"` round-trips correctly.
- `test_is_maxscore_enabled`: Returns `true` only when sparse index is both `enabled: true` and `algorithm: MaxScore`; returns `false` for disabled indexes or `Wand` algorithm.
- All 66 existing schema unit tests + 5 doc-tests pass (no regressions).
- Manually verified against a live Tilt server with all three clients:
  - New Python/Rust/JS clients correctly read collections with `"algorithm": "max_score"` in the schema.
  - Old Python client fails on `get_collection` with `extra_forbidden` (expected).
  - Old Rust client fails on both `get_collection` and `list_collections` with `deny_unknown_fields` (expected).
  - Confirms deploy-first-then-enable deployment order.
## Migration plan
No migration needed. The feature is inert until `tenants_with_maxscore_enabled` is configured. Deployment order: deploy all servers with the new field support first, then enable the config for specific tenants. Only newly-created collections for those tenants get `algorithm: "max_score"` in their schema. Existing collections are never modified.
## Observability plan
No new instrumentation. The existing `create_collection` tracing captures the full schema including the new field.
## Documentation Changes
No user-facing API changes. Internal Rust doc comments included on the new enum and helper methods.