### PR TITLE
[ENH] Add maxscore index to metadata segment

### DIFF
--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -422,7 +422,7 @@ impl<'me> MaxScoreReader<'me> {
     /// overestimates by at most `block_size - 1` on the last block, which
     /// is negligible for the IDF formula.
     pub async fn count_postings(&self, encoded_dim: &str) -> Result<usize, MaxScoreError> {
-        let Some(dir) = self.get_directory(encoded_dim).await? else {
+        let Some((dir, _)) = self.get_directory(encoded_dim).await? else {
             return Ok(0);
         };
         let num_blocks = dir.num_blocks();

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -430,13 +430,27 @@ impl<'me> MaxScoreReader<'me> {
         Ok(parts.len())
     }
 
-    /// Count total posting entries for a dimension.
+    /// Estimate total posting entries for a dimension.
     ///
-    /// Used by the IDF operator to compute document frequency.
-    /// O(n_blocks) — loads all blocks and sums their lengths.
+    /// Used by the IDF operator to compute document frequency. Loads only
+    /// the directory (usually cached) and the first posting block to learn
+    /// the block size, then returns `num_blocks * block_size`. This
+    /// overestimates by at most `block_size - 1` on the last block, which
+    /// is negligible for the IDF formula.
     pub async fn count_postings(&self, encoded_dim: &str) -> Result<usize, MaxScoreError> {
-        let blocks = self.get_posting_blocks(encoded_dim).await?;
-        Ok(blocks.iter().map(|b| b.len()).sum())
+        let Some(dir) = self.get_directory(encoded_dim).await? else {
+            return Ok(0);
+        };
+        let num_blocks = dir.num_blocks();
+        if num_blocks == 0 {
+            return Ok(0);
+        }
+        let first_block = self.posting_reader.get(encoded_dim, 0u32).await?;
+        let block_size = first_block.map(|b| b.len()).unwrap_or(0);
+        if block_size == 0 {
+            return Ok(0);
+        }
+        Ok(num_blocks * block_size)
     }
 
     /// Return all dimension IDs stored in the blockfile.

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -430,6 +430,15 @@ impl<'me> MaxScoreReader<'me> {
         Ok(parts.len())
     }
 
+    /// Count total posting entries for a dimension.
+    ///
+    /// Used by the IDF operator to compute document frequency.
+    /// O(n_blocks) — loads all blocks and sums their lengths.
+    pub async fn count_postings(&self, encoded_dim: &str) -> Result<usize, MaxScoreError> {
+        let blocks = self.get_posting_blocks(encoded_dim).await?;
+        Ok(blocks.iter().map(|b| b.len()).sum())
+    }
+
     /// Return all dimension IDs stored in the blockfile.
     ///
     /// Scans only directory entries (prefix "d"...) which are much fewer

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -414,13 +414,27 @@ impl<'me> MaxScoreReader<'me> {
             .map(|d| (d, part_count)))
     }
 
-    /// Count total posting entries for a dimension.
+    /// Estimate total posting entries for a dimension.
     ///
-    /// Used by the IDF operator to compute document frequency.
-    /// O(n_blocks) — loads all blocks and sums their lengths.
+    /// Used by the IDF operator to compute document frequency. Loads only
+    /// the directory (usually cached) and the first posting block to learn
+    /// the block size, then returns `num_blocks * block_size`. This
+    /// overestimates by at most `block_size - 1` on the last block, which
+    /// is negligible for the IDF formula.
     pub async fn count_postings(&self, encoded_dim: &str) -> Result<usize, MaxScoreError> {
-        let blocks = self.get_posting_blocks(encoded_dim).await?;
-        Ok(blocks.iter().map(|b| b.len()).sum())
+        let Some(dir) = self.get_directory(encoded_dim).await? else {
+            return Ok(0);
+        };
+        let num_blocks = dir.num_blocks();
+        if num_blocks == 0 {
+            return Ok(0);
+        }
+        let first_block = self.posting_reader.get(encoded_dim, 0u32).await?;
+        let block_size = first_block.map(|b| b.len()).unwrap_or(0);
+        if block_size == 0 {
+            return Ok(0);
+        }
+        Ok(num_blocks * block_size)
     }
 
     /// Return all dimension IDs stored in the blockfile.

--- a/rust/index/src/sparse/maxscore.rs
+++ b/rust/index/src/sparse/maxscore.rs
@@ -414,6 +414,15 @@ impl<'me> MaxScoreReader<'me> {
             .map(|d| (d, part_count)))
     }
 
+    /// Count total posting entries for a dimension.
+    ///
+    /// Used by the IDF operator to compute document frequency.
+    /// O(n_blocks) — loads all blocks and sums their lengths.
+    pub async fn count_postings(&self, encoded_dim: &str) -> Result<usize, MaxScoreError> {
+        let blocks = self.get_posting_blocks(encoded_dim).await?;
+        Ok(blocks.iter().map(|b| b.len()).sum())
+    }
+
     /// Return all dimension IDs stored in the blockfile.
     ///
     /// Scans only directory entries (prefix "d"...) which are much fewer

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -15,6 +15,9 @@ use chroma_index::fulltext::types::{
 use chroma_index::metadata::types::{
     MetadataIndexError, MetadataIndexFlusher, MetadataIndexReader, MetadataIndexWriter,
 };
+use chroma_index::sparse::maxscore::{
+    MaxScoreFlusher, MaxScoreReader, MaxScoreWriter, SPARSE_POSTING_BLOCK_SIZE_BYTES,
+};
 use chroma_index::sparse::reader::SparseReader;
 use chroma_index::sparse::types::DEFAULT_BLOCK_SIZE;
 use chroma_index::sparse::writer::SparseFlusher;
@@ -28,6 +31,8 @@ use chroma_types::F32_METADATA;
 use chroma_types::FULL_TEXT_PLS;
 use chroma_types::SPARSE_MAX;
 use chroma_types::SPARSE_OFFSET_VALUE;
+use chroma_types::SPARSE_POSTING;
+use chroma_types::SparsePostingBlock;
 use chroma_types::STRING_METADATA;
 use chroma_types::U32_METADATA;
 use chroma_types::{
@@ -50,6 +55,7 @@ pub struct MetadataSegmentWriterShard<'me> {
     pub(crate) f32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) u32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) sparse_index_writer: Option<SparseWriter<'me>>,
+    pub(crate) maxscore_index_writer: Option<MaxScoreWriter<'me>>,
     pub id: SegmentUuid,
 }
 
@@ -85,6 +91,7 @@ impl<'me> MetadataSegmentWriter<'me> {
         segment: &Segment,
         blockfile_provider: &BlockfileProvider,
         cmek: Option<Cmek>,
+        schema: Option<&Schema>,
     ) -> Result<Self, MetadataSegmentWriterError> {
         let segment_shards = segment
             .get_shards()
@@ -106,6 +113,7 @@ impl<'me> MetadataSegmentWriter<'me> {
                     shard,
                     blockfile_provider,
                     cmek.clone(),
+                    schema,
                 )
             })
             .collect();
@@ -146,6 +154,7 @@ impl<'me> MetadataSegmentWriter<'me> {
             &new_shard_segment,
             blockfile_provider,
             cmek,
+            collection.schema.as_ref(),
         )
         .await?;
 
@@ -299,6 +308,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
         segment: &SegmentShard,
         blockfile_provider: &BlockfileProvider,
         cmek: Option<Cmek>,
+        schema: Option<&Schema>,
     ) -> Result<MetadataSegmentWriterShard<'me>, MetadataSegmentError> {
         if segment.r#type != SegmentType::BlockfileMetadata {
             return Err(MetadataSegmentError::InvalidSegmentType);
@@ -547,11 +557,52 @@ impl<'me> MetadataSegmentWriterShard<'me> {
         let u32_metadata_index_writer =
             MetadataIndexWriter::new_u32(u32_metadata_writer, u32_metadata_index_reader);
 
+        // ── Sparse index writer: 3-way branch ───────────────────────
+        //
+        // 1. SPARSE_POSTING in file_path → fork MaxScore index
+        // 2. SPARSE_MAX in file_path     → fork existing WAND index
+        // 3. Neither (fresh collection)  → check schema to decide
+        let posting_file_path = segment.file_path.get(SPARSE_POSTING);
         let max_file_path = segment.file_path.get(SPARSE_MAX);
         let offset_value_file_path = segment.file_path.get(SPARSE_OFFSET_VALUE);
-        let sparse_index_writer = if let (Some(max_file_path), Some(offset_value_file_path)) =
+
+        let (sparse_index_writer, maxscore_index_writer) = if let Some(posting_file_path) =
+            posting_file_path
+        {
+            // ── Fork path: MaxScore index ──────────────────────────
+            let (posting_prefix, posting_uuid) =
+                Segment::extract_prefix_and_id(posting_file_path).map_err(|_| {
+                    MetadataSegmentError::UuidParseError(posting_file_path.to_string())
+                })?;
+            let posting_reader = blockfile_provider
+                .read::<u32, SparsePostingBlock>(BlockfileReaderOptions::new(
+                    posting_uuid,
+                    posting_prefix.to_string(),
+                ))
+                .await
+                .map_err(|e| MetadataSegmentError::BlockfileOpenError(*e))?;
+            let posting_writer = {
+                let mut options = BlockfileWriterOptions::new(posting_prefix.to_string())
+                    .fork(posting_uuid)
+                    .ordered_mutations()
+                    .max_block_size_bytes(SPARSE_POSTING_BLOCK_SIZE_BYTES);
+                if let Some(cmek) = &cmek {
+                    options = options.with_cmek(cmek.clone());
+                }
+                blockfile_provider
+                    .write::<u32, SparsePostingBlock>(options)
+                    .await
+                    .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
+            };
+            let old_reader = MaxScoreReader::new(posting_reader);
+            (
+                None,
+                Some(MaxScoreWriter::new(posting_writer, Some(old_reader))),
+            )
+        } else if let (Some(max_file_path), Some(offset_value_file_path)) =
             (max_file_path, offset_value_file_path)
         {
+            // ── Fork path: existing WAND index (unchanged) ─────────
             let (max_prefix, max_uuid) = Segment::extract_prefix_and_id(max_file_path)
                 .map_err(|_| MetadataSegmentError::UuidParseError(max_file_path.to_string()))?;
             let max_reader = blockfile_provider
@@ -595,13 +646,32 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     .await
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
-            Some(SparseWriter::new(
-                DEFAULT_BLOCK_SIZE,
-                max_writer,
-                offset_value_writer,
-                Some(SparseReader::new(max_reader, offset_value_reader)),
-            ))
+            (
+                Some(SparseWriter::new(
+                    DEFAULT_BLOCK_SIZE,
+                    max_writer,
+                    offset_value_writer,
+                    Some(SparseReader::new(max_reader, offset_value_reader)),
+                )),
+                None,
+            )
+        } else if schema.is_some_and(|s| s.is_maxscore_enabled()) {
+            // ── Fresh collection: MaxScore index ───────────────────
+            let posting_writer = {
+                let mut options = BlockfileWriterOptions::new(prefix_path.clone())
+                    .ordered_mutations()
+                    .max_block_size_bytes(SPARSE_POSTING_BLOCK_SIZE_BYTES);
+                if let Some(cmek) = &cmek {
+                    options = options.with_cmek(cmek.clone());
+                }
+                blockfile_provider
+                    .write::<u32, SparsePostingBlock>(options)
+                    .await
+                    .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
+            };
+            (None, Some(MaxScoreWriter::new(posting_writer, None)))
         } else {
+            // ── Fresh collection: WAND index (default) ─────────────
             let max_writer = {
                 let mut options =
                     BlockfileWriterOptions::new(prefix_path.clone()).ordered_mutations();
@@ -624,12 +694,15 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     .await
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
-            Some(SparseWriter::new(
-                DEFAULT_BLOCK_SIZE,
-                max_writer,
-                offset_value_writer,
+            (
+                Some(SparseWriter::new(
+                    DEFAULT_BLOCK_SIZE,
+                    max_writer,
+                    offset_value_writer,
+                    None,
+                )),
                 None,
-            ))
+            )
         };
 
         Ok(MetadataSegmentWriterShard {
@@ -639,6 +712,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             f32_metadata_index_writer: Some(f32_metadata_index_writer),
             u32_metadata_index_writer: Some(u32_metadata_index_writer),
             sparse_index_writer,
+            maxscore_index_writer,
             id: segment.id,
         })
     }
@@ -707,12 +781,14 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                 }
             }
             MetadataValue::SparseVector(offset_value) => {
-                match &self.sparse_index_writer {
-                    Some(writer) => {
-                        writer.set(offset_id, offset_value.iter()).await;
-                        Ok(())
-                    }
-                    None => panic!("Invariant violation. sparse index writer should be set for metadata segment"),
+                if let Some(writer) = &self.maxscore_index_writer {
+                    writer.set(offset_id, offset_value.iter()).await;
+                    Ok(())
+                } else if let Some(writer) = &self.sparse_index_writer {
+                    writer.set(offset_id, offset_value.iter()).await;
+                    Ok(())
+                } else {
+                    panic!("Invariant violation. sparse index writer should be set for metadata segment")
                 }
             },
             // Array types: explode the array and index each element separately
@@ -839,12 +915,16 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     None => panic!("Invariant violation. bool metadata index writer should be set for metadata segment"),
                 }
             }
-            MetadataValue::SparseVector(offset_value) => match &self.sparse_index_writer {
-                Some(writer) => {
+            MetadataValue::SparseVector(offset_value) => {
+                if let Some(writer) = &self.maxscore_index_writer {
                     writer.delete(offset_id, offset_value.indices.iter().cloned()).await;
                     Ok(())
+                } else if let Some(writer) = &self.sparse_index_writer {
+                    writer.delete(offset_id, offset_value.indices.iter().cloned()).await;
+                    Ok(())
+                } else {
+                    panic!("Invariant violation. sparse index writer should be set for metadata segment")
                 }
-                    None => panic!("Invariant violation. sparse index writer should be set for metadata segment"),
             },
             // Array types: delete each element from the inverted index
             MetadataValue::StringArray(values) => {
@@ -1333,12 +1413,22 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             None => return Err(Box::new(MetadataSegmentError::NoWriter)),
         };
 
-        let sparse_index_flusher = match self.sparse_index_writer {
-            Some(sparse_index_writer) => match Box::pin(sparse_index_writer.commit()).await {
-                Ok(flusher) => flusher,
+        let (sparse_index_flusher, maxscore_index_flusher) = match (
+            self.sparse_index_writer,
+            self.maxscore_index_writer,
+        ) {
+            (Some(w), None) => match Box::pin(w.commit()).await {
+                Ok(flusher) => (Some(flusher), None),
                 Err(e) => return Err(Box::new(e)),
             },
-            None => return Err(Box::new(MetadataSegmentError::NoWriter)),
+            (None, Some(w)) => match w.commit().await {
+                Ok(flusher) => (None, Some(flusher)),
+                Err(e) => return Err(Box::new(e)),
+            },
+            (None, None) => return Err(Box::new(MetadataSegmentError::NoWriter)),
+            (Some(_), Some(_)) => {
+                unreachable!("both sparse_index_writer and maxscore_index_writer are set")
+            }
         };
 
         Ok(MetadataSegmentFlusherShard {
@@ -1349,6 +1439,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             f32_metadata_index_flusher: f32_metadata_flusher,
             u32_metadata_index_flusher: u32_metadata_flusher,
             sparse_index_flusher,
+            maxscore_index_flusher,
         })
     }
 }
@@ -1385,7 +1476,8 @@ pub struct MetadataSegmentFlusherShard {
     pub(crate) bool_metadata_index_flusher: MetadataIndexFlusher,
     pub(crate) f32_metadata_index_flusher: MetadataIndexFlusher,
     pub(crate) u32_metadata_index_flusher: MetadataIndexFlusher,
-    pub(crate) sparse_index_flusher: SparseFlusher,
+    pub(crate) sparse_index_flusher: Option<SparseFlusher>,
+    pub(crate) maxscore_index_flusher: Option<MaxScoreFlusher>,
 }
 
 impl Debug for MetadataSegmentFlusherShard {
@@ -1467,23 +1559,37 @@ impl MetadataSegmentFlusherShard {
             )],
         );
 
-        let max_id = self.sparse_index_flusher.max_id();
-        let offset_value_id = self.sparse_index_flusher.offset_value_id();
-        match Box::pin(self.sparse_index_flusher.flush()).await {
-            Ok(_) => {}
-            Err(e) => return Err(Box::new(e)),
+        if let Some(sparse_flusher) = self.sparse_index_flusher {
+            let max_id = sparse_flusher.max_id();
+            let offset_value_id = sparse_flusher.offset_value_id();
+            match Box::pin(sparse_flusher.flush()).await {
+                Ok(_) => {}
+                Err(e) => return Err(Box::new(e)),
+            }
+            flushed.insert(
+                SPARSE_MAX.to_string(),
+                vec![ChromaSegmentFlusher::flush_key(&prefix_path, &max_id)],
+            );
+            flushed.insert(
+                SPARSE_OFFSET_VALUE.to_string(),
+                vec![ChromaSegmentFlusher::flush_key(
+                    &prefix_path,
+                    &offset_value_id,
+                )],
+            );
         }
-        flushed.insert(
-            SPARSE_MAX.to_string(),
-            vec![ChromaSegmentFlusher::flush_key(&prefix_path, &max_id)],
-        );
-        flushed.insert(
-            SPARSE_OFFSET_VALUE.to_string(),
-            vec![ChromaSegmentFlusher::flush_key(
-                &prefix_path,
-                &offset_value_id,
-            )],
-        );
+
+        if let Some(maxscore_flusher) = self.maxscore_index_flusher {
+            let posting_id = maxscore_flusher.id();
+            match maxscore_flusher.flush().await {
+                Ok(_) => {}
+                Err(e) => return Err(Box::new(e)),
+            }
+            flushed.insert(
+                SPARSE_POSTING.to_string(),
+                vec![ChromaSegmentFlusher::flush_key(&prefix_path, &posting_id)],
+            );
+        }
 
         Ok(flushed)
     }
@@ -1496,6 +1602,7 @@ pub struct MetadataSegmentReaderShard<'me> {
     pub f32_metadata_index_reader: Option<MetadataIndexReader<'me>>,
     pub u32_metadata_index_reader: Option<MetadataIndexReader<'me>>,
     pub sparse_index_reader: Option<SparseReader<'me>>,
+    pub maxscore_index_reader: Option<MaxScoreReader<'me>>,
 }
 
 impl MetadataSegmentReaderShard<'_> {
@@ -1553,6 +1660,14 @@ impl MetadataSegmentReaderShard<'_> {
             Self::load_index_reader(segment, SPARSE_OFFSET_VALUE, blockfile_provider)
                 .instrument(Span::current());
 
+        let sparse_posting_future =
+            Self::load_index_reader::<u32, SparsePostingBlock>(
+                segment,
+                SPARSE_POSTING,
+                blockfile_provider,
+            )
+            .instrument(Span::current());
+
         let (
             pls_reader,
             string_metadata_reader,
@@ -1561,6 +1676,7 @@ impl MetadataSegmentReaderShard<'_> {
             u32_metadata_reader,
             sparse_max_reader,
             sparse_offset_value_reader,
+            sparse_posting_reader,
         ) = tokio::join!(
             pls_future,
             string_metadata_future,
@@ -1569,6 +1685,7 @@ impl MetadataSegmentReaderShard<'_> {
             u32_metadata_future,
             sparse_max_future,
             sparse_offset_value_future,
+            sparse_posting_future,
         );
 
         // Handle results and create index readers
@@ -1591,17 +1708,22 @@ impl MetadataSegmentReaderShard<'_> {
         let f32_metadata_reader = f32_metadata_reader?;
         let f32_metadata_index_reader = f32_metadata_reader.map(MetadataIndexReader::new_f32);
 
-        let sparse_index_reader =
-            if let (Some(sparse_max_reader), Some(sparse_offset_value_reader)) =
-                (sparse_max_reader?, sparse_offset_value_reader?)
-            {
-                Some(SparseReader::new(
-                    sparse_max_reader,
-                    sparse_offset_value_reader,
-                ))
-            } else {
-                None
-            };
+        let sparse_posting_reader = sparse_posting_reader?;
+        let maxscore_index_reader = sparse_posting_reader.map(MaxScoreReader::new);
+
+        // Only create old WAND reader if MaxScore reader is absent
+        let sparse_index_reader = if maxscore_index_reader.is_some() {
+            None
+        } else if let (Some(sparse_max_reader), Some(sparse_offset_value_reader)) =
+            (sparse_max_reader?, sparse_offset_value_reader?)
+        {
+            Some(SparseReader::new(
+                sparse_max_reader,
+                sparse_offset_value_reader,
+            ))
+        } else {
+            None
+        };
 
         Ok(MetadataSegmentReaderShard {
             full_text_index_reader,
@@ -1610,6 +1732,7 @@ impl MetadataSegmentReaderShard<'_> {
             f32_metadata_index_reader,
             u32_metadata_index_reader,
             sparse_index_reader,
+            maxscore_index_reader,
         })
     }
 }
@@ -1720,6 +1843,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -1878,6 +2002,7 @@ mod test {
             &metadata_segment_shard,
             &blockfile_provider,
             None,
+            None,
         )
         .await
         .expect("Error creating segment writer");
@@ -1985,6 +2110,7 @@ mod test {
             &database_id,
             &metadata_segment_shard,
             &blockfile_provider,
+            None,
             None,
         )
         .await
@@ -2098,6 +2224,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -2259,6 +2386,7 @@ mod test {
             &metadata_segment_shard,
             &blockfile_provider,
             None,
+            None,
         )
         .await
         .expect("Error creating segment writer");
@@ -2407,6 +2535,7 @@ mod test {
                 &metadata_segment_shard,
                 &blockfile_provider,
                 None,
+                None,
             )
             .await
             .expect("Error creating segment writer");
@@ -2539,6 +2668,7 @@ mod test {
             &database_id,
             &metadata_segment_shard,
             &blockfile_provider,
+            None,
             None,
         )
         .await
@@ -2684,6 +2814,7 @@ mod test {
                 &metadata_segment_shard,
                 &blockfile_provider,
                 None,
+                None,
             )
             .await
             .expect("Error creating segment writer");
@@ -2805,6 +2936,7 @@ mod test {
             &database_id,
             &metadata_segment_shard,
             &blockfile_provider,
+            None,
             None,
         )
         .await
@@ -2948,6 +3080,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -3260,6 +3393,7 @@ mod test {
                 &metadata_segment_shard,
                 &blockfile_provider,
                 None,
+                None,
             )
             .await
             .expect("Error creating segment writer");
@@ -3422,6 +3556,7 @@ mod test {
                 &metadata_segment_shard,
                 &blockfile_provider,
                 None,
+                None,
             )
             .await
             .expect("Error creating metadata writer");
@@ -3472,6 +3607,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -3556,6 +3692,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -3676,6 +3813,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -3891,6 +4029,7 @@ mod test {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -47,11 +47,32 @@ use thiserror::Error;
 use tracing::Instrument;
 use tracing::Span;
 
-/// Exactly one of `sparse_index_writer` (WAND) / `maxscore_index_writer`
-/// (MaxScore) is `Some`. For existing collections the choice is determined by
-/// which blockfile keys are present in the segment's file_path
-/// (`SPARSE_MAX` → WAND, `SPARSE_POSTING` → MaxScore). For fresh collections
-/// the schema's `algorithm` field decides.
+/// The sparse vector index writer for a segment shard.
+///
+/// For existing collections the variant is determined by which blockfile
+/// keys are present in the segment's file_path (`SPARSE_MAX` → WAND,
+/// `SPARSE_POSTING` → MaxScore). For fresh collections the schema's
+/// `algorithm` field decides.
+#[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum SparseIndexWriter<'me> {
+    Wand(SparseWriter<'me>),
+    MaxScore(MaxScoreWriter<'me>),
+}
+
+/// The sparse vector index flusher for a segment shard.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum SparseIndexFlusher {
+    Wand(SparseFlusher),
+    MaxScore(MaxScoreFlusher),
+}
+
+/// The sparse vector index reader for a segment shard.
+pub enum SparseIndexReader<'me> {
+    Wand(SparseReader<'me>),
+    MaxScore(MaxScoreReader<'me>),
+}
+
 #[derive(Clone)]
 pub struct MetadataSegmentWriterShard<'me> {
     pub(crate) full_text_index_writer: Option<FullTextIndexWriter>,
@@ -59,8 +80,7 @@ pub struct MetadataSegmentWriterShard<'me> {
     pub(crate) bool_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) f32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
     pub(crate) u32_metadata_index_writer: Option<MetadataIndexWriter<'me>>,
-    pub(crate) sparse_index_writer: Option<SparseWriter<'me>>,
-    pub(crate) maxscore_index_writer: Option<MaxScoreWriter<'me>>,
+    pub(crate) sparse_index_writer: Option<SparseIndexWriter<'me>>,
     pub id: SegmentUuid,
 }
 
@@ -571,9 +591,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
         let max_file_path = segment.file_path.get(SPARSE_MAX);
         let offset_value_file_path = segment.file_path.get(SPARSE_OFFSET_VALUE);
 
-        let (sparse_index_writer, maxscore_index_writer) = if let Some(posting_file_path) =
-            posting_file_path
-        {
+        let sparse_index_writer = if let Some(posting_file_path) = posting_file_path {
             // ── Fork path: MaxScore index ──────────────────────────
             let (posting_prefix, posting_uuid) = Segment::extract_prefix_and_id(posting_file_path)
                 .map_err(|_| MetadataSegmentError::UuidParseError(posting_file_path.to_string()))?;
@@ -598,10 +616,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
             let old_reader = MaxScoreReader::new(posting_reader);
-            (
-                None,
-                Some(MaxScoreWriter::new(posting_writer, Some(old_reader))),
-            )
+            SparseIndexWriter::MaxScore(MaxScoreWriter::new(posting_writer, Some(old_reader)))
         } else if let (Some(max_file_path), Some(offset_value_file_path)) =
             (max_file_path, offset_value_file_path)
         {
@@ -649,15 +664,12 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     .await
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
-            (
-                Some(SparseWriter::new(
-                    DEFAULT_BLOCK_SIZE,
-                    max_writer,
-                    offset_value_writer,
-                    Some(SparseReader::new(max_reader, offset_value_reader)),
-                )),
-                None,
-            )
+            SparseIndexWriter::Wand(SparseWriter::new(
+                DEFAULT_BLOCK_SIZE,
+                max_writer,
+                offset_value_writer,
+                Some(SparseReader::new(max_reader, offset_value_reader)),
+            ))
         } else if schema.is_some_and(|s| s.is_maxscore_enabled()) {
             // ── Fresh collection: MaxScore index ───────────────────
             let posting_writer = {
@@ -672,7 +684,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     .await
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
-            (None, Some(MaxScoreWriter::new(posting_writer, None)))
+            SparseIndexWriter::MaxScore(MaxScoreWriter::new(posting_writer, None))
         } else {
             // ── Fresh collection: WAND index (default) ─────────────
             let max_writer = {
@@ -697,15 +709,12 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     .await
                     .map_err(|e| MetadataSegmentError::BlockfileError(*e))?
             };
-            (
-                Some(SparseWriter::new(
-                    DEFAULT_BLOCK_SIZE,
-                    max_writer,
-                    offset_value_writer,
-                    None,
-                )),
+            SparseIndexWriter::Wand(SparseWriter::new(
+                DEFAULT_BLOCK_SIZE,
+                max_writer,
+                offset_value_writer,
                 None,
-            )
+            ))
         };
 
         Ok(MetadataSegmentWriterShard {
@@ -714,8 +723,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             bool_metadata_index_writer: Some(bool_metadata_index_writer),
             f32_metadata_index_writer: Some(f32_metadata_index_writer),
             u32_metadata_index_writer: Some(u32_metadata_index_writer),
-            sparse_index_writer,
-            maxscore_index_writer,
+            sparse_index_writer: Some(sparse_index_writer),
             id: segment.id,
         })
     }
@@ -783,16 +791,18 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     None => panic!("Invariant violation. bool metadata index writer should be set for metadata segment"),
                 }
             }
-            MetadataValue::SparseVector(offset_value) => {
-                if let Some(writer) = &self.maxscore_index_writer {
-                    writer.set(offset_id, offset_value.iter()).await;
+            MetadataValue::SparseVector(offset_value) => match &self.sparse_index_writer {
+                Some(SparseIndexWriter::MaxScore(w)) => {
+                    w.set(offset_id, offset_value.iter()).await;
                     Ok(())
-                } else if let Some(writer) = &self.sparse_index_writer {
-                    writer.set(offset_id, offset_value.iter()).await;
-                    Ok(())
-                } else {
-                    panic!("Invariant violation. sparse index writer should be set for metadata segment")
                 }
+                Some(SparseIndexWriter::Wand(w)) => {
+                    w.set(offset_id, offset_value.iter()).await;
+                    Ok(())
+                }
+                None => Err(MetadataIndexError::BlockfileError(Box::new(
+                    MetadataSegmentError::NoWriter,
+                ))),
             },
             // Array types: explode the array and index each element separately
             // This enables efficient CONTAINS queries via the inverted index
@@ -918,16 +928,20 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                     None => panic!("Invariant violation. bool metadata index writer should be set for metadata segment"),
                 }
             }
-            MetadataValue::SparseVector(offset_value) => {
-                if let Some(writer) = &self.maxscore_index_writer {
-                    writer.delete(offset_id, offset_value.indices.iter().cloned()).await;
+            MetadataValue::SparseVector(offset_value) => match &self.sparse_index_writer {
+                Some(SparseIndexWriter::MaxScore(w)) => {
+                    w.delete(offset_id, offset_value.indices.iter().cloned())
+                        .await;
                     Ok(())
-                } else if let Some(writer) = &self.sparse_index_writer {
-                    writer.delete(offset_id, offset_value.indices.iter().cloned()).await;
-                    Ok(())
-                } else {
-                    panic!("Invariant violation. sparse index writer should be set for metadata segment")
                 }
+                Some(SparseIndexWriter::Wand(w)) => {
+                    w.delete(offset_id, offset_value.indices.iter().cloned())
+                        .await;
+                    Ok(())
+                }
+                None => Err(MetadataIndexError::BlockfileError(Box::new(
+                    MetadataSegmentError::NoWriter,
+                ))),
             },
             // Array types: delete each element from the inverted index
             MetadataValue::StringArray(values) => {
@@ -1416,21 +1430,17 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             None => return Err(Box::new(MetadataSegmentError::NoWriter)),
         };
 
-        let (sparse_index_flusher, maxscore_index_flusher) =
-            match (self.sparse_index_writer, self.maxscore_index_writer) {
-                (Some(w), None) => match Box::pin(w.commit()).await {
-                    Ok(flusher) => (Some(flusher), None),
-                    Err(e) => return Err(Box::new(e)),
-                },
-                (None, Some(w)) => match w.commit().await {
-                    Ok(flusher) => (None, Some(flusher)),
-                    Err(e) => return Err(Box::new(e)),
-                },
-                (None, None) => return Err(Box::new(MetadataSegmentError::NoWriter)),
-                (Some(_), Some(_)) => {
-                    unreachable!("both sparse_index_writer and maxscore_index_writer are set")
-                }
-            };
+        let sparse_index_flusher = match self.sparse_index_writer {
+            Some(SparseIndexWriter::Wand(w)) => match Box::pin(w.commit()).await {
+                Ok(flusher) => Some(SparseIndexFlusher::Wand(flusher)),
+                Err(e) => return Err(Box::new(e)),
+            },
+            Some(SparseIndexWriter::MaxScore(w)) => match Box::pin(w.commit()).await {
+                Ok(flusher) => Some(SparseIndexFlusher::MaxScore(flusher)),
+                Err(e) => return Err(Box::new(e)),
+            },
+            None => return Err(Box::new(MetadataSegmentError::NoWriter)),
+        };
 
         Ok(MetadataSegmentFlusherShard {
             id: self.id,
@@ -1440,7 +1450,6 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             f32_metadata_index_flusher: f32_metadata_flusher,
             u32_metadata_index_flusher: u32_metadata_flusher,
             sparse_index_flusher,
-            maxscore_index_flusher,
         })
     }
 }
@@ -1477,8 +1486,7 @@ pub struct MetadataSegmentFlusherShard {
     pub(crate) bool_metadata_index_flusher: MetadataIndexFlusher,
     pub(crate) f32_metadata_index_flusher: MetadataIndexFlusher,
     pub(crate) u32_metadata_index_flusher: MetadataIndexFlusher,
-    pub(crate) sparse_index_flusher: Option<SparseFlusher>,
-    pub(crate) maxscore_index_flusher: Option<MaxScoreFlusher>,
+    pub(crate) sparse_index_flusher: Option<SparseIndexFlusher>,
 }
 
 impl Debug for MetadataSegmentFlusherShard {
@@ -1560,53 +1568,51 @@ impl MetadataSegmentFlusherShard {
             )],
         );
 
-        if let Some(sparse_flusher) = self.sparse_index_flusher {
-            let max_id = sparse_flusher.max_id();
-            let offset_value_id = sparse_flusher.offset_value_id();
-            match Box::pin(sparse_flusher.flush()).await {
-                Ok(_) => {}
-                Err(e) => return Err(Box::new(e)),
+        match self.sparse_index_flusher {
+            Some(SparseIndexFlusher::Wand(sparse_flusher)) => {
+                let max_id = sparse_flusher.max_id();
+                let offset_value_id = sparse_flusher.offset_value_id();
+                match Box::pin(sparse_flusher.flush()).await {
+                    Ok(_) => {}
+                    Err(e) => return Err(Box::new(e)),
+                }
+                flushed.insert(
+                    SPARSE_MAX.to_string(),
+                    vec![ChromaSegmentFlusher::flush_key(&prefix_path, &max_id)],
+                );
+                flushed.insert(
+                    SPARSE_OFFSET_VALUE.to_string(),
+                    vec![ChromaSegmentFlusher::flush_key(
+                        &prefix_path,
+                        &offset_value_id,
+                    )],
+                );
             }
-            flushed.insert(
-                SPARSE_MAX.to_string(),
-                vec![ChromaSegmentFlusher::flush_key(&prefix_path, &max_id)],
-            );
-            flushed.insert(
-                SPARSE_OFFSET_VALUE.to_string(),
-                vec![ChromaSegmentFlusher::flush_key(
-                    &prefix_path,
-                    &offset_value_id,
-                )],
-            );
-        }
-
-        if let Some(maxscore_flusher) = self.maxscore_index_flusher {
-            let posting_id = maxscore_flusher.id();
-            match maxscore_flusher.flush().await {
-                Ok(_) => {}
-                Err(e) => return Err(Box::new(e)),
+            Some(SparseIndexFlusher::MaxScore(maxscore_flusher)) => {
+                let posting_id = maxscore_flusher.id();
+                match Box::pin(maxscore_flusher.flush()).await {
+                    Ok(_) => {}
+                    Err(e) => return Err(Box::new(e)),
+                }
+                flushed.insert(
+                    SPARSE_POSTING.to_string(),
+                    vec![ChromaSegmentFlusher::flush_key(&prefix_path, &posting_id)],
+                );
             }
-            flushed.insert(
-                SPARSE_POSTING.to_string(),
-                vec![ChromaSegmentFlusher::flush_key(&prefix_path, &posting_id)],
-            );
+            None => {}
         }
 
         Ok(flushed)
     }
 }
 
-/// Exactly one of `sparse_index_reader` (WAND) / `maxscore_index_reader`
-/// (MaxScore) is `Some`, determined by the blockfile keys present in the
-/// segment's file_path.
 pub struct MetadataSegmentReaderShard<'me> {
     pub full_text_index_reader: Option<FullTextIndexReader<'me>>,
     pub string_metadata_index_reader: Option<MetadataIndexReader<'me>>,
     pub bool_metadata_index_reader: Option<MetadataIndexReader<'me>>,
     pub f32_metadata_index_reader: Option<MetadataIndexReader<'me>>,
     pub u32_metadata_index_reader: Option<MetadataIndexReader<'me>>,
-    pub sparse_index_reader: Option<SparseReader<'me>>,
-    pub maxscore_index_reader: Option<MaxScoreReader<'me>>,
+    pub sparse_index_reader: Option<SparseIndexReader<'me>>,
 }
 
 impl MetadataSegmentReaderShard<'_> {
@@ -1712,18 +1718,19 @@ impl MetadataSegmentReaderShard<'_> {
         let f32_metadata_index_reader = f32_metadata_reader.map(MetadataIndexReader::new_f32);
 
         let sparse_posting_reader = sparse_posting_reader?;
-        let maxscore_index_reader = sparse_posting_reader.map(MaxScoreReader::new);
 
-        // Only create old WAND reader if MaxScore reader is absent
-        let sparse_index_reader = if maxscore_index_reader.is_some() {
-            None
+        // MaxScore takes precedence over WAND if both file paths exist.
+        let sparse_index_reader = if let Some(posting_reader) = sparse_posting_reader {
+            Some(SparseIndexReader::MaxScore(MaxScoreReader::new(
+                posting_reader,
+            )))
         } else if let (Some(sparse_max_reader), Some(sparse_offset_value_reader)) =
             (sparse_max_reader?, sparse_offset_value_reader?)
         {
-            Some(SparseReader::new(
+            Some(SparseIndexReader::Wand(SparseReader::new(
                 sparse_max_reader,
                 sparse_offset_value_reader,
-            ))
+            )))
         } else {
             None
         };
@@ -1735,7 +1742,6 @@ impl MetadataSegmentReaderShard<'_> {
             f32_metadata_index_reader,
             u32_metadata_index_reader,
             sparse_index_reader,
-            maxscore_index_reader,
         })
     }
 }
@@ -1744,7 +1750,10 @@ impl MetadataSegmentReaderShard<'_> {
 mod test {
 
     use crate::{
-        blockfile_metadata::{MetadataSegmentReaderShard, MetadataSegmentWriterShard},
+        blockfile_metadata::{
+            MetadataSegmentReaderShard, MetadataSegmentWriterShard, SparseIndexReader,
+            SparseIndexWriter,
+        },
         blockfile_record::{
             RecordSegmentReaderOptions, RecordSegmentReaderShard,
             RecordSegmentReaderShardCreationError, RecordSegmentWriterShard,
@@ -4242,12 +4251,11 @@ mod test {
             .expect("iter1: create writer");
 
             assert!(
-                writer.maxscore_index_writer.is_some(),
+                matches!(
+                    writer.sparse_index_writer,
+                    Some(SparseIndexWriter::MaxScore(_))
+                ),
                 "iter1: should have maxscore writer"
-            );
-            assert!(
-                writer.sparse_index_writer.is_none(),
-                "iter1: should NOT have wand writer"
             );
 
             for offset in 0u32..20 {
@@ -4290,15 +4298,16 @@ mod test {
             .expect("iter1: open reader");
 
             assert!(
-                reader.maxscore_index_reader.is_some(),
+                matches!(
+                    reader.sparse_index_reader,
+                    Some(SparseIndexReader::MaxScore(_))
+                ),
                 "iter1: maxscore reader"
             );
-            assert!(
-                reader.sparse_index_reader.is_none(),
-                "iter1: no wand reader"
-            );
-
-            let ms_reader = reader.maxscore_index_reader.as_ref().unwrap();
+            let Some(SparseIndexReader::MaxScore(ref ms_reader)) = reader.sparse_index_reader
+            else {
+                panic!("iter1: expected MaxScore reader");
+            };
             let dims = ms_reader.get_all_dimension_ids().await.unwrap();
             assert!(!dims.is_empty(), "iter1: should have dimensions");
             assert!(dims.contains(&0), "iter1: dim 0 should exist");
@@ -4310,9 +4319,9 @@ mod test {
                 .values()
                 .filter(|pairs| pairs.iter().any(|(d, _)| *d == 0))
                 .count();
-            assert_eq!(
-                count_dim0, expected_count_dim0,
-                "iter1: count_postings(dim0) mismatch"
+            assert!(
+                count_dim0 >= expected_count_dim0,
+                "iter1: count_postings(dim0) mismatch: got {count_dim0}, expected >= {expected_count_dim0}"
             );
         }
 
@@ -4334,7 +4343,10 @@ mod test {
             .expect("iter2: create writer (fork)");
 
             assert!(
-                writer.maxscore_index_writer.is_some(),
+                matches!(
+                    writer.sparse_index_writer,
+                    Some(SparseIndexWriter::MaxScore(_))
+                ),
                 "iter2: should have maxscore writer from fork"
             );
 
@@ -4379,8 +4391,10 @@ mod test {
             ))
             .await
             .expect("iter2: open reader");
-
-            let ms_reader = reader.maxscore_index_reader.as_ref().unwrap();
+            let Some(SparseIndexReader::MaxScore(ref ms_reader)) = reader.sparse_index_reader
+            else {
+                panic!("iter2: expected MaxScore reader");
+            };
 
             // Verify dim 0 count: deleted docs should be gone
             let count_dim0 = ms_reader.count_postings(&encode_u32(0)).await.unwrap();
@@ -4388,9 +4402,9 @@ mod test {
                 .values()
                 .filter(|pairs| pairs.iter().any(|(d, _)| *d == 0))
                 .count();
-            assert_eq!(
-                count_dim0, expected_count_dim0,
-                "iter2: count_postings(dim0) mismatch"
+            assert!(
+                count_dim0 >= expected_count_dim0,
+                "iter2: count_postings(dim0) mismatch: got {count_dim0}, expected >= {expected_count_dim0}"
             );
 
             // Verify large dim count
@@ -4402,9 +4416,9 @@ mod test {
                 .values()
                 .filter(|pairs| pairs.iter().any(|(d, _)| *d == LARGE_DIM))
                 .count();
-            assert_eq!(
-                count_large, expected_count_large,
-                "iter2: count_postings(large_dim) mismatch"
+            assert!(
+                count_large >= expected_count_large,
+                "iter2: count_postings(large_dim) mismatch: got {count_large}, expected >= {expected_count_large}"
             );
         }
 
@@ -4479,10 +4493,14 @@ mod test {
             .await
             .expect("final: open reader");
 
-            assert!(reader.maxscore_index_reader.is_some());
-            assert!(reader.sparse_index_reader.is_none());
-
-            let ms_reader = reader.maxscore_index_reader.as_ref().unwrap();
+            assert!(matches!(
+                reader.sparse_index_reader,
+                Some(SparseIndexReader::MaxScore(_))
+            ));
+            let Some(SparseIndexReader::MaxScore(ref ms_reader)) = reader.sparse_index_reader
+            else {
+                panic!("final: expected MaxScore reader");
+            };
 
             // 1. Verify all expected dimensions exist
             let dims = ms_reader.get_all_dimension_ids().await.unwrap();
@@ -4508,9 +4526,9 @@ mod test {
                     .values()
                     .filter(|pairs| pairs.iter().any(|(dd, _)| dd == d))
                     .count();
-                assert_eq!(
-                    count, expected,
-                    "final: count_postings(dim={d}) mismatch: got {count}, expected {expected}"
+                assert!(
+                    count >= expected,
+                    "final: count_postings(dim={d}) mismatch: got {count}, expected >= {expected}"
                 );
             }
 

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -26,13 +26,13 @@ use chroma_types::Cmek;
 use chroma_types::DatabaseUuid;
 use chroma_types::Schema;
 use chroma_types::SegmentType;
+use chroma_types::SparsePostingBlock;
 use chroma_types::BOOL_METADATA;
 use chroma_types::F32_METADATA;
 use chroma_types::FULL_TEXT_PLS;
 use chroma_types::SPARSE_MAX;
 use chroma_types::SPARSE_OFFSET_VALUE;
 use chroma_types::SPARSE_POSTING;
-use chroma_types::SparsePostingBlock;
 use chroma_types::STRING_METADATA;
 use chroma_types::U32_METADATA;
 use chroma_types::{
@@ -47,6 +47,11 @@ use thiserror::Error;
 use tracing::Instrument;
 use tracing::Span;
 
+/// Exactly one of `sparse_index_writer` (WAND) / `maxscore_index_writer`
+/// (MaxScore) is `Some`. For existing collections the choice is determined by
+/// which blockfile keys are present in the segment's file_path
+/// (`SPARSE_MAX` → WAND, `SPARSE_POSTING` → MaxScore). For fresh collections
+/// the schema's `algorithm` field decides.
 #[derive(Clone)]
 pub struct MetadataSegmentWriterShard<'me> {
     pub(crate) full_text_index_writer: Option<FullTextIndexWriter>,
@@ -570,10 +575,8 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             posting_file_path
         {
             // ── Fork path: MaxScore index ──────────────────────────
-            let (posting_prefix, posting_uuid) =
-                Segment::extract_prefix_and_id(posting_file_path).map_err(|_| {
-                    MetadataSegmentError::UuidParseError(posting_file_path.to_string())
-                })?;
+            let (posting_prefix, posting_uuid) = Segment::extract_prefix_and_id(posting_file_path)
+                .map_err(|_| MetadataSegmentError::UuidParseError(posting_file_path.to_string()))?;
             let posting_reader = blockfile_provider
                 .read::<u32, SparsePostingBlock>(BlockfileReaderOptions::new(
                     posting_uuid,
@@ -1413,23 +1416,21 @@ impl<'me> MetadataSegmentWriterShard<'me> {
             None => return Err(Box::new(MetadataSegmentError::NoWriter)),
         };
 
-        let (sparse_index_flusher, maxscore_index_flusher) = match (
-            self.sparse_index_writer,
-            self.maxscore_index_writer,
-        ) {
-            (Some(w), None) => match Box::pin(w.commit()).await {
-                Ok(flusher) => (Some(flusher), None),
-                Err(e) => return Err(Box::new(e)),
-            },
-            (None, Some(w)) => match w.commit().await {
-                Ok(flusher) => (None, Some(flusher)),
-                Err(e) => return Err(Box::new(e)),
-            },
-            (None, None) => return Err(Box::new(MetadataSegmentError::NoWriter)),
-            (Some(_), Some(_)) => {
-                unreachable!("both sparse_index_writer and maxscore_index_writer are set")
-            }
-        };
+        let (sparse_index_flusher, maxscore_index_flusher) =
+            match (self.sparse_index_writer, self.maxscore_index_writer) {
+                (Some(w), None) => match Box::pin(w.commit()).await {
+                    Ok(flusher) => (Some(flusher), None),
+                    Err(e) => return Err(Box::new(e)),
+                },
+                (None, Some(w)) => match w.commit().await {
+                    Ok(flusher) => (None, Some(flusher)),
+                    Err(e) => return Err(Box::new(e)),
+                },
+                (None, None) => return Err(Box::new(MetadataSegmentError::NoWriter)),
+                (Some(_), Some(_)) => {
+                    unreachable!("both sparse_index_writer and maxscore_index_writer are set")
+                }
+            };
 
         Ok(MetadataSegmentFlusherShard {
             id: self.id,
@@ -1595,6 +1596,9 @@ impl MetadataSegmentFlusherShard {
     }
 }
 
+/// Exactly one of `sparse_index_reader` (WAND) / `maxscore_index_reader`
+/// (MaxScore) is `Some`, determined by the blockfile keys present in the
+/// segment's file_path.
 pub struct MetadataSegmentReaderShard<'me> {
     pub full_text_index_reader: Option<FullTextIndexReader<'me>>,
     pub string_metadata_index_reader: Option<MetadataIndexReader<'me>>,
@@ -1660,13 +1664,12 @@ impl MetadataSegmentReaderShard<'_> {
             Self::load_index_reader(segment, SPARSE_OFFSET_VALUE, blockfile_provider)
                 .instrument(Span::current());
 
-        let sparse_posting_future =
-            Self::load_index_reader::<u32, SparsePostingBlock>(
-                segment,
-                SPARSE_POSTING,
-                blockfile_provider,
-            )
-            .instrument(Span::current());
+        let sparse_posting_future = Self::load_index_reader::<u32, SparsePostingBlock>(
+            segment,
+            SPARSE_POSTING,
+            blockfile_provider,
+        )
+        .instrument(Span::current());
 
         let (
             pls_reader,
@@ -4138,5 +4141,452 @@ mod test {
             1,
             "FTS search for 'dogs' should return 1 result when FTS is enabled"
         );
+    }
+
+    // ── MaxScore multi-commit consistency test ─────────────────────────
+
+    /// Build a deterministic sparse vector for a document.
+    /// Each doc gets dimensions based on (offset % num_dims) to spread across dims.
+    fn make_sparse_vector(offset: u32, num_dims: u32, base_weight: f32) -> Vec<(u32, f32)> {
+        let mut pairs = Vec::new();
+        // Each doc gets 3-5 dimensions, deterministically chosen
+        for d in 0..num_dims {
+            if (offset + d).is_multiple_of(3) || d == 0 {
+                let weight = base_weight + (offset as f32 * 0.01) + (d as f32 * 0.1);
+                pairs.push((d, weight));
+            }
+        }
+        pairs
+    }
+
+    #[tokio::test]
+    async fn maxscore_segment_multi_commit_consistency() {
+        let handle = std::thread::Builder::new()
+            .name("maxscore_multi_commit".to_string())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                let runtime = Runtime::new().unwrap();
+                runtime.block_on(async {
+                    Box::pin(maxscore_segment_multi_commit_impl()).await;
+                });
+            })
+            .expect("Failed to spawn thread");
+
+        handle.join().expect("Test thread panicked");
+    }
+
+    async fn maxscore_segment_multi_commit_impl() {
+        use chroma_index::sparse::types::encode_u32;
+        use chroma_types::{MetadataValue, SparseIndexAlgorithm, SparseVector, SPARSE_POSTING};
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let storage = Storage::Local(LocalStorage::new(tmp_dir.path().to_str().unwrap()));
+        let block_cache = new_cache_for_test();
+        let sparse_index_cache = new_cache_for_test();
+        let arrow_blockfile_provider = ArrowBlockfileProvider::new(
+            storage,
+            TEST_MAX_BLOCK_SIZE_BYTES,
+            block_cache,
+            sparse_index_cache,
+            BlockManagerConfig::default_num_concurrent_block_flushes(),
+            BlockManagerConfig::default_max_concurrent_block_loads(),
+        );
+        let blockfile_provider =
+            BlockfileProvider::ArrowBlockfileProvider(arrow_blockfile_provider);
+        let tenant = "test_tenant";
+        let database_id = DatabaseUuid::new();
+
+        // Schema with MaxScore enabled
+        let mut schema = Schema::new_default(KnnIndex::Hnsw);
+        if let Some(sv) = &mut schema.defaults.sparse_vector {
+            if let Some(idx) = &mut sv.sparse_vector_index {
+                idx.enabled = true;
+            }
+        }
+        schema.set_sparse_algorithm(SparseIndexAlgorithm::MaxScore);
+        assert!(schema.is_maxscore_enabled());
+
+        let mut metadata_segment = chroma_types::Segment {
+            id: SegmentUuid::from_str("00000000-0000-0000-0000-000000000002").expect("parse error"),
+            r#type: chroma_types::SegmentType::BlockfileMetadata,
+            scope: chroma_types::SegmentScope::METADATA,
+            collection: CollectionUuid::from_str("00000000-0000-0000-0000-000000000000")
+                .expect("parse error"),
+            metadata: None,
+            file_path: HashMap::new(),
+        };
+
+        const SPARSE_KEY: &str = "sparse_emb";
+        const NUM_DIMS: u32 = 8;
+        // Also include a large dimension ID to test base64 encoding edge cases
+        const LARGE_DIM: u32 = 30000;
+
+        // Track what should be in the index at each step
+        let mut expected_docs: HashMap<u32, Vec<(u32, f32)>> = HashMap::new();
+
+        // ════════════════════════════════════════════════════════════
+        // Iteration 1: Fresh write — 20 documents (offsets 0..20)
+        // ════════════════════════════════════════════════════════════
+        {
+            let shard =
+                SegmentShard::try_from((&metadata_segment, 0u32)).expect("valid shard index");
+            let writer = MetadataSegmentWriterShard::from_segment(
+                tenant,
+                &database_id,
+                &shard,
+                &blockfile_provider,
+                None,
+                Some(&schema),
+            )
+            .await
+            .expect("iter1: create writer");
+
+            assert!(
+                writer.maxscore_index_writer.is_some(),
+                "iter1: should have maxscore writer"
+            );
+            assert!(
+                writer.sparse_index_writer.is_none(),
+                "iter1: should NOT have wand writer"
+            );
+
+            for offset in 0u32..20 {
+                let mut pairs = make_sparse_vector(offset, NUM_DIMS, 1.0);
+                // Add large dim to a few docs
+                if offset % 5 == 0 {
+                    pairs.push((LARGE_DIM, 0.5 + offset as f32 * 0.01));
+                }
+                let sv = SparseVector::from_pairs(pairs.iter().copied());
+                writer
+                    .set_metadata(SPARSE_KEY, &MetadataValue::SparseVector(sv), offset)
+                    .await
+                    .expect("iter1: set_metadata");
+                expected_docs.insert(offset, pairs);
+            }
+
+            let flusher = Box::pin(writer.commit()).await.expect("iter1: commit");
+            let file_paths = Box::pin(flusher.flush()).await.expect("iter1: flush");
+
+            assert!(
+                file_paths.contains_key(SPARSE_POSTING),
+                "iter1: SPARSE_POSTING should be in file_paths"
+            );
+            assert!(
+                !file_paths.contains_key(SPARSE_MAX),
+                "iter1: SPARSE_MAX should NOT be in file_paths"
+            );
+            metadata_segment.file_path = file_paths;
+        }
+
+        // Verify iteration 1
+        {
+            let shard =
+                SegmentShard::try_from((&metadata_segment, 0u32)).expect("valid shard index");
+            let reader = Box::pin(MetadataSegmentReaderShard::from_segment(
+                &shard,
+                &blockfile_provider,
+            ))
+            .await
+            .expect("iter1: open reader");
+
+            assert!(
+                reader.maxscore_index_reader.is_some(),
+                "iter1: maxscore reader"
+            );
+            assert!(
+                reader.sparse_index_reader.is_none(),
+                "iter1: no wand reader"
+            );
+
+            let ms_reader = reader.maxscore_index_reader.as_ref().unwrap();
+            let dims = ms_reader.get_all_dimension_ids().await.unwrap();
+            assert!(!dims.is_empty(), "iter1: should have dimensions");
+            assert!(dims.contains(&0), "iter1: dim 0 should exist");
+            assert!(dims.contains(&LARGE_DIM), "iter1: large dim should exist");
+
+            // Verify count_postings for dim 0
+            let count_dim0 = ms_reader.count_postings(&encode_u32(0)).await.unwrap();
+            let expected_count_dim0 = expected_docs
+                .values()
+                .filter(|pairs| pairs.iter().any(|(d, _)| *d == 0))
+                .count();
+            assert_eq!(
+                count_dim0, expected_count_dim0,
+                "iter1: count_postings(dim0) mismatch"
+            );
+        }
+
+        // ════════════════════════════════════════════════════════════
+        // Iteration 2: Fork — add 15 docs (20..35), delete 5 (0..5)
+        // ════════════════════════════════════════════════════════════
+        {
+            let shard =
+                SegmentShard::try_from((&metadata_segment, 0u32)).expect("valid shard index");
+            let writer = MetadataSegmentWriterShard::from_segment(
+                tenant,
+                &database_id,
+                &shard,
+                &blockfile_provider,
+                None,
+                Some(&schema),
+            )
+            .await
+            .expect("iter2: create writer (fork)");
+
+            assert!(
+                writer.maxscore_index_writer.is_some(),
+                "iter2: should have maxscore writer from fork"
+            );
+
+            // Add new documents
+            for offset in 20u32..35 {
+                let mut pairs = make_sparse_vector(offset, NUM_DIMS, 2.0);
+                if offset % 5 == 0 {
+                    pairs.push((LARGE_DIM, 0.5 + offset as f32 * 0.01));
+                }
+                let sv = SparseVector::from_pairs(pairs.iter().copied());
+                writer
+                    .set_metadata(SPARSE_KEY, &MetadataValue::SparseVector(sv), offset)
+                    .await
+                    .expect("iter2: set_metadata");
+                expected_docs.insert(offset, pairs);
+            }
+
+            // Delete offsets 0..5
+            for offset in 0u32..5 {
+                let pairs = expected_docs.remove(&offset).unwrap();
+                let sv = SparseVector::from_pairs(pairs.iter().copied());
+                writer
+                    .delete_metadata(SPARSE_KEY, &MetadataValue::SparseVector(sv), offset)
+                    .await
+                    .expect("iter2: delete_metadata");
+            }
+
+            let flusher = Box::pin(writer.commit()).await.expect("iter2: commit");
+            let file_paths = Box::pin(flusher.flush()).await.expect("iter2: flush");
+
+            assert!(file_paths.contains_key(SPARSE_POSTING));
+            metadata_segment.file_path = file_paths;
+        }
+
+        // Verify iteration 2
+        {
+            let shard =
+                SegmentShard::try_from((&metadata_segment, 0u32)).expect("valid shard index");
+            let reader = Box::pin(MetadataSegmentReaderShard::from_segment(
+                &shard,
+                &blockfile_provider,
+            ))
+            .await
+            .expect("iter2: open reader");
+
+            let ms_reader = reader.maxscore_index_reader.as_ref().unwrap();
+
+            // Verify dim 0 count: deleted docs should be gone
+            let count_dim0 = ms_reader.count_postings(&encode_u32(0)).await.unwrap();
+            let expected_count_dim0 = expected_docs
+                .values()
+                .filter(|pairs| pairs.iter().any(|(d, _)| *d == 0))
+                .count();
+            assert_eq!(
+                count_dim0, expected_count_dim0,
+                "iter2: count_postings(dim0) mismatch"
+            );
+
+            // Verify large dim count
+            let count_large = ms_reader
+                .count_postings(&encode_u32(LARGE_DIM))
+                .await
+                .unwrap();
+            let expected_count_large = expected_docs
+                .values()
+                .filter(|pairs| pairs.iter().any(|(d, _)| *d == LARGE_DIM))
+                .count();
+            assert_eq!(
+                count_large, expected_count_large,
+                "iter2: count_postings(large_dim) mismatch"
+            );
+        }
+
+        // ════════════════════════════════════════════════════════════
+        // Iteration 3: Fork — add 10 docs (35..45), update 5 (10..15)
+        // ════════════════════════════════════════════════════════════
+        {
+            let shard =
+                SegmentShard::try_from((&metadata_segment, 0u32)).expect("valid shard index");
+            let writer = MetadataSegmentWriterShard::from_segment(
+                tenant,
+                &database_id,
+                &shard,
+                &blockfile_provider,
+                None,
+                Some(&schema),
+            )
+            .await
+            .expect("iter3: create writer (fork)");
+
+            // Add new documents
+            for offset in 35u32..45 {
+                let mut pairs = make_sparse_vector(offset, NUM_DIMS, 3.0);
+                if offset % 7 == 0 {
+                    pairs.push((LARGE_DIM, 0.9));
+                }
+                let sv = SparseVector::from_pairs(pairs.iter().copied());
+                writer
+                    .set_metadata(SPARSE_KEY, &MetadataValue::SparseVector(sv), offset)
+                    .await
+                    .expect("iter3: set_metadata new");
+                expected_docs.insert(offset, pairs);
+            }
+
+            // Update docs 10..15 with new weights: delete old, then set new
+            for offset in 10u32..15 {
+                // Delete old vector first
+                let old_pairs = expected_docs.get(&offset).unwrap().clone();
+                let old_sv = SparseVector::from_pairs(old_pairs.iter().copied());
+                writer
+                    .delete_metadata(SPARSE_KEY, &MetadataValue::SparseVector(old_sv), offset)
+                    .await
+                    .expect("iter3: delete_metadata for update");
+
+                // Set new vector
+                let new_pairs = make_sparse_vector(offset, NUM_DIMS, 5.0);
+                let sv = SparseVector::from_pairs(new_pairs.iter().copied());
+                writer
+                    .set_metadata(SPARSE_KEY, &MetadataValue::SparseVector(sv), offset)
+                    .await
+                    .expect("iter3: set_metadata update");
+                expected_docs.insert(offset, new_pairs);
+            }
+
+            let flusher = Box::pin(writer.commit()).await.expect("iter3: commit");
+            let file_paths = Box::pin(flusher.flush()).await.expect("iter3: flush");
+
+            assert!(file_paths.contains_key(SPARSE_POSTING));
+            metadata_segment.file_path = file_paths;
+        }
+
+        // ════════════════════════════════════════════════════════════
+        // Final verification: full consistency check
+        // ════════════════════════════════════════════════════════════
+        {
+            let shard =
+                SegmentShard::try_from((&metadata_segment, 0u32)).expect("valid shard index");
+            let reader = Box::pin(MetadataSegmentReaderShard::from_segment(
+                &shard,
+                &blockfile_provider,
+            ))
+            .await
+            .expect("final: open reader");
+
+            assert!(reader.maxscore_index_reader.is_some());
+            assert!(reader.sparse_index_reader.is_none());
+
+            let ms_reader = reader.maxscore_index_reader.as_ref().unwrap();
+
+            // 1. Verify all expected dimensions exist
+            let dims = ms_reader.get_all_dimension_ids().await.unwrap();
+            for d in 0..NUM_DIMS {
+                let has_docs = expected_docs
+                    .values()
+                    .any(|pairs| pairs.iter().any(|(dd, _)| *dd == d));
+                if has_docs {
+                    assert!(dims.contains(&d), "final: dim {d} should exist");
+                }
+            }
+
+            // 2. Verify count_postings matches expected for every dimension
+            let mut all_dims: std::collections::HashSet<u32> = std::collections::HashSet::new();
+            for pairs in expected_docs.values() {
+                for (d, _) in pairs {
+                    all_dims.insert(*d);
+                }
+            }
+            for d in &all_dims {
+                let count = ms_reader.count_postings(&encode_u32(*d)).await.unwrap();
+                let expected = expected_docs
+                    .values()
+                    .filter(|pairs| pairs.iter().any(|(dd, _)| dd == d))
+                    .count();
+                assert_eq!(
+                    count, expected,
+                    "final: count_postings(dim={d}) mismatch: got {count}, expected {expected}"
+                );
+            }
+
+            // 3. Verify deleted docs (0..5) are not in any dimension's postings
+            for deleted_offset in 0u32..5 {
+                assert!(
+                    !expected_docs.contains_key(&deleted_offset),
+                    "sanity: offset {deleted_offset} should be deleted from expected_docs"
+                );
+            }
+
+            // 4. Verify total document count
+            let total_expected = expected_docs.len();
+            // 20 initial - 5 deleted + 15 added + 10 added = 40
+            assert_eq!(total_expected, 40, "should have 40 docs total");
+
+            // 5. Query correctness: run a few queries and compare to brute force
+            let test_queries: Vec<Vec<(u32, f32)>> = vec![
+                // Query hitting multiple dims
+                vec![(0, 1.0), (1, 0.5), (3, 0.8)],
+                // Query with large dim
+                vec![(0, 1.0), (LARGE_DIM, 2.0)],
+                // Single dim query
+                vec![(2, 1.0)],
+                // All dims query
+                (0..NUM_DIMS).map(|d| (d, 1.0)).collect(),
+            ];
+
+            for (qi, query) in test_queries.iter().enumerate() {
+                let k = 5u32;
+                let results = ms_reader
+                    .query(
+                        query.iter().copied(),
+                        k,
+                        chroma_types::SignedRoaringBitmap::Exclude(RoaringBitmap::new()),
+                    )
+                    .await
+                    .unwrap_or_else(|e| panic!("final: query {qi} failed: {e:?}"));
+
+                // Brute force
+                let mut bf_scores: Vec<(u32, f32)> = expected_docs
+                    .iter()
+                    .map(|(off, pairs)| {
+                        let score: f32 = query
+                            .iter()
+                            .map(|(qd, qw)| {
+                                pairs
+                                    .iter()
+                                    .find(|(dd, _)| dd == qd)
+                                    .map(|(_, dv)| qw * dv)
+                                    .unwrap_or(0.0)
+                            })
+                            .sum();
+                        (*off, score)
+                    })
+                    .filter(|(_, s)| *s > 0.0)
+                    .collect();
+                bf_scores.sort_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
+                bf_scores.truncate(k as usize);
+
+                // Verify recall
+                let result_offsets: std::collections::HashSet<u32> =
+                    results.iter().map(|s| s.offset).collect();
+                let bf_offsets: std::collections::HashSet<u32> =
+                    bf_scores.iter().map(|(o, _)| *o).collect();
+
+                if !bf_offsets.is_empty() {
+                    let overlap = result_offsets.intersection(&bf_offsets).count();
+                    let recall = overlap as f64 / bf_offsets.len() as f64;
+                    assert!(
+                        recall >= 0.8,
+                        "final: query {qi} recall {recall:.2} < 0.8 \
+                         (results: {result_offsets:?}, expected: {bf_offsets:?})"
+                    );
+                }
+            }
+        }
     }
 }

--- a/rust/segment/src/blockfile_metadata.rs
+++ b/rust/segment/src/blockfile_metadata.rs
@@ -20,6 +20,7 @@ use chroma_index::sparse::maxscore::{
 };
 use chroma_index::sparse::reader::SparseReader;
 use chroma_index::sparse::types::DEFAULT_BLOCK_SIZE;
+use chroma_index::sparse::types::{encode_u32, Score};
 use chroma_index::sparse::writer::SparseFlusher;
 use chroma_index::sparse::writer::SparseWriter;
 use chroma_types::Cmek;
@@ -51,7 +52,12 @@ use tracing::Span;
 ///
 /// For existing collections the variant is determined by which blockfile
 /// keys are present in the segment's file_path (`SPARSE_MAX` → WAND,
-/// `SPARSE_POSTING` → MaxScore). For fresh collections the schema's
+/// `SPARSE_POSTING` → MaxScore), not the schema, because schema changes
+/// are metadata-only and do not rewrite on-disk data. This matters
+/// during migration: a collection's schema may be updated to MaxScore
+/// while the existing segments still contain WAND blockfiles — the read
+/// path must use the on-disk format until compaction rewrites them.
+/// For fresh collections (no existing file paths) the schema's
 /// `algorithm` field decides.
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -67,10 +73,128 @@ pub(crate) enum SparseIndexFlusher {
     MaxScore(MaxScoreFlusher),
 }
 
+impl<'me> SparseIndexWriter<'me> {
+    pub async fn set(&self, offset: u32, sparse_vector: impl IntoIterator<Item = (u32, f32)>) {
+        match self {
+            Self::Wand(w) => w.set(offset, sparse_vector).await,
+            Self::MaxScore(w) => w.set(offset, sparse_vector).await,
+        }
+    }
+
+    pub async fn delete(&self, offset: u32, sparse_indices: impl IntoIterator<Item = u32>) {
+        match self {
+            Self::Wand(w) => w.delete(offset, sparse_indices).await,
+            Self::MaxScore(w) => w.delete(offset, sparse_indices).await,
+        }
+    }
+
+    pub async fn commit(self) -> Result<SparseIndexFlusher, Box<dyn ChromaError>> {
+        match self {
+            Self::Wand(w) => Ok(SparseIndexFlusher::Wand(
+                Box::pin(w.commit()).await.map_err(ChromaError::boxed)?,
+            )),
+            Self::MaxScore(w) => Ok(SparseIndexFlusher::MaxScore(
+                Box::pin(w.commit()).await.map_err(ChromaError::boxed)?,
+            )),
+        }
+    }
+}
+
+impl SparseIndexFlusher {
+    /// Flush the sparse index, returning `(file_path_key, paths)` entries
+    /// that should be registered on the segment.
+    pub async fn flush(
+        self,
+        prefix_path: &str,
+    ) -> Result<Vec<(String, Vec<String>)>, Box<dyn ChromaError>> {
+        match self {
+            Self::Wand(f) => {
+                let max_id = f.max_id();
+                let offset_value_id = f.offset_value_id();
+                Box::pin(f.flush()).await.map_err(ChromaError::boxed)?;
+                Ok(vec![
+                    (
+                        SPARSE_MAX.to_string(),
+                        vec![ChromaSegmentFlusher::flush_key(prefix_path, &max_id)],
+                    ),
+                    (
+                        SPARSE_OFFSET_VALUE.to_string(),
+                        vec![ChromaSegmentFlusher::flush_key(
+                            prefix_path,
+                            &offset_value_id,
+                        )],
+                    ),
+                ])
+            }
+            Self::MaxScore(f) => {
+                let posting_id = f.id();
+                Box::pin(f.flush()).await.map_err(ChromaError::boxed)?;
+                Ok(vec![(
+                    SPARSE_POSTING.to_string(),
+                    vec![ChromaSegmentFlusher::flush_key(prefix_path, &posting_id)],
+                )])
+            }
+        }
+    }
+}
+
 /// The sparse vector index reader for a segment shard.
 pub enum SparseIndexReader<'me> {
     Wand(SparseReader<'me>),
     MaxScore(MaxScoreReader<'me>),
+}
+
+impl<'me> SparseIndexReader<'me> {
+    /// Compute document frequency for each dimension.
+    pub async fn dimension_counts(
+        &self,
+        dimensions: &[u32],
+    ) -> Result<HashMap<u32, u32>, Box<dyn ChromaError>> {
+        let mut counts = HashMap::new();
+        match self {
+            Self::Wand(r) => {
+                let encoded: Vec<(u32, String)> =
+                    dimensions.iter().map(|d| (*d, encode_u32(*d))).collect();
+                r.load_offset_values(encoded.iter().map(|(_, e)| e.as_str()))
+                    .await;
+                for (dim, enc) in &encoded {
+                    let nt = r
+                        .get_dimension_offset_rank(enc, u32::MAX)
+                        .await
+                        .map_err(ChromaError::boxed)?
+                        .saturating_sub(
+                            r.get_dimension_offset_rank(enc, 0)
+                                .await
+                                .map_err(ChromaError::boxed)?,
+                        );
+                    counts.insert(*dim, nt);
+                }
+            }
+            Self::MaxScore(r) => {
+                for dim in dimensions {
+                    let nt = r
+                        .count_postings(&encode_u32(*dim))
+                        .await
+                        .map_err(ChromaError::boxed)? as u32;
+                    counts.insert(*dim, nt);
+                }
+            }
+        }
+        Ok(counts)
+    }
+
+    /// Run a sparse KNN query, returning scored results.
+    pub async fn knn_query(
+        &'me self,
+        query: impl IntoIterator<Item = (u32, f32)>,
+        k: u32,
+        mask: chroma_types::SignedRoaringBitmap,
+    ) -> Result<Vec<Score>, Box<dyn ChromaError>> {
+        match self {
+            Self::Wand(r) => r.wand(query, k, mask).await.map_err(ChromaError::boxed),
+            Self::MaxScore(r) => r.query(query, k, mask).await.map_err(ChromaError::boxed),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -792,11 +916,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                 }
             }
             MetadataValue::SparseVector(offset_value) => match &self.sparse_index_writer {
-                Some(SparseIndexWriter::MaxScore(w)) => {
-                    w.set(offset_id, offset_value.iter()).await;
-                    Ok(())
-                }
-                Some(SparseIndexWriter::Wand(w)) => {
+                Some(w) => {
                     w.set(offset_id, offset_value.iter()).await;
                     Ok(())
                 }
@@ -929,12 +1049,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
                 }
             }
             MetadataValue::SparseVector(offset_value) => match &self.sparse_index_writer {
-                Some(SparseIndexWriter::MaxScore(w)) => {
-                    w.delete(offset_id, offset_value.indices.iter().cloned())
-                        .await;
-                    Ok(())
-                }
-                Some(SparseIndexWriter::Wand(w)) => {
+                Some(w) => {
                     w.delete(offset_id, offset_value.indices.iter().cloned())
                         .await;
                     Ok(())
@@ -1431,14 +1546,7 @@ impl<'me> MetadataSegmentWriterShard<'me> {
         };
 
         let sparse_index_flusher = match self.sparse_index_writer {
-            Some(SparseIndexWriter::Wand(w)) => match Box::pin(w.commit()).await {
-                Ok(flusher) => Some(SparseIndexFlusher::Wand(flusher)),
-                Err(e) => return Err(Box::new(e)),
-            },
-            Some(SparseIndexWriter::MaxScore(w)) => match Box::pin(w.commit()).await {
-                Ok(flusher) => Some(SparseIndexFlusher::MaxScore(flusher)),
-                Err(e) => return Err(Box::new(e)),
-            },
+            Some(w) => Some(w.commit().await?),
             None => return Err(Box::new(MetadataSegmentError::NoWriter)),
         };
 
@@ -1568,38 +1676,10 @@ impl MetadataSegmentFlusherShard {
             )],
         );
 
-        match self.sparse_index_flusher {
-            Some(SparseIndexFlusher::Wand(sparse_flusher)) => {
-                let max_id = sparse_flusher.max_id();
-                let offset_value_id = sparse_flusher.offset_value_id();
-                match Box::pin(sparse_flusher.flush()).await {
-                    Ok(_) => {}
-                    Err(e) => return Err(Box::new(e)),
-                }
-                flushed.insert(
-                    SPARSE_MAX.to_string(),
-                    vec![ChromaSegmentFlusher::flush_key(&prefix_path, &max_id)],
-                );
-                flushed.insert(
-                    SPARSE_OFFSET_VALUE.to_string(),
-                    vec![ChromaSegmentFlusher::flush_key(
-                        &prefix_path,
-                        &offset_value_id,
-                    )],
-                );
+        if let Some(sparse_flusher) = self.sparse_index_flusher {
+            for (key, paths) in sparse_flusher.flush(&prefix_path).await? {
+                flushed.insert(key, paths);
             }
-            Some(SparseIndexFlusher::MaxScore(maxscore_flusher)) => {
-                let posting_id = maxscore_flusher.id();
-                match Box::pin(maxscore_flusher.flush()).await {
-                    Ok(_) => {}
-                    Err(e) => return Err(Box::new(e)),
-                }
-                flushed.insert(
-                    SPARSE_POSTING.to_string(),
-                    vec![ChromaSegmentFlusher::flush_key(&prefix_path, &posting_id)],
-                );
-            }
-            None => {}
         }
 
         Ok(flushed)
@@ -1719,7 +1799,8 @@ impl MetadataSegmentReaderShard<'_> {
 
         let sparse_posting_reader = sparse_posting_reader?;
 
-        // MaxScore takes precedence over WAND if both file paths exist.
+        // Exactly one of SPARSE_POSTING (MaxScore) or SPARSE_MAX (WAND)
+        // is present per segment; check MaxScore first, then fall back to WAND.
         let sparse_index_reader = if let Some(posting_reader) = sparse_posting_reader {
             Some(SparseIndexReader::MaxScore(MaxScoreReader::new(
                 posting_reader,

--- a/rust/segment/src/test.rs
+++ b/rust/segment/src/test.rs
@@ -120,6 +120,7 @@ impl TestDistributedSegment {
             &metadata_segment_shard,
             &self.blockfile_provider,
             None,
+            None,
         )
         .await
         .expect("Should be able to initialize metadata writer.");

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -1652,6 +1652,7 @@ mod tests {
                 &metadata_segment_shard,
                 &blockfile_provider,
                 None,
+                None,
             )
             .await
             .expect("Error creating segment writer");
@@ -1832,6 +1833,7 @@ mod tests {
             &metadata_segment_shard,
             &blockfile_provider,
             None,
+            None,
         )
         .await
         .expect("Error creating segment writer");
@@ -1989,6 +1991,7 @@ mod tests {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -2161,6 +2164,7 @@ mod tests {
             &metadata_segment_shard,
             &blockfile_provider,
             None,
+            None,
         )
         .await
         .expect("Error creating segment writer");
@@ -2319,6 +2323,7 @@ mod tests {
                 &database_id,
                 &metadata_segment_shard,
                 &blockfile_provider,
+                None,
                 None,
             )
             .await
@@ -2510,6 +2515,7 @@ mod tests {
             &database_id,
             &metadata_segment_shard,
             &blockfile_provider,
+            None,
             None,
         )
         .await

--- a/rust/worker/src/execution/operators/filter.rs
+++ b/rust/worker/src/execution/operators/filter.rs
@@ -1417,6 +1417,7 @@ mod tests {
                 &metadata_segment_shard,
                 &blockfile_provider,
                 None,
+                None,
             )
             .await
             .expect("Error creating segment writer");
@@ -1562,6 +1563,7 @@ mod tests {
             &database_id,
             &metadata_segment_shard,
             &blockfile_provider,
+            None,
             None,
         )
         .await

--- a/rust/worker/src/execution/operators/idf.rs
+++ b/rust/worker/src/execution/operators/idf.rs
@@ -141,7 +141,10 @@ impl Operator<IdfInput, IdfOutput> for Idf {
         let logs =
             materialize_logs(&record_segment_reader, input.logs.clone(), None, &plan).await?;
 
-        if let Some(sparse_index_reader) = metadata_segment_reader.sparse_index_reader.as_ref() {
+        if let Some(chroma_segment::blockfile_metadata::SparseIndexReader::Wand(
+            sparse_index_reader,
+        )) = metadata_segment_reader.sparse_index_reader.as_ref()
+        {
             let encoded_dimensions = self
                 .query
                 .indices

--- a/rust/worker/src/execution/operators/sparse_index_knn.rs
+++ b/rust/worker/src/execution/operators/sparse_index_knn.rs
@@ -66,7 +66,9 @@ impl Operator<SparseIndexKnnInput, SparseIndexKnnOutput> for SparseIndexKnn {
         ))
         .await?;
 
-        let Some(sparse_reader) = metadata_segement_reader.sparse_index_reader else {
+        let Some(chroma_segment::blockfile_metadata::SparseIndexReader::Wand(sparse_reader)) =
+            metadata_segement_reader.sparse_index_reader
+        else {
             return Ok(SparseIndexKnnOutput {
                 records: Vec::new(),
             });

--- a/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/attached_function_orchestrator.rs
@@ -705,6 +705,7 @@ impl Handler<TaskResult<CollectionAndSegments, GetCollectionAndSegmentsError>>
                     &message.metadata_segment,
                     &self.output_context.blockfile_provider,
                     cmek.clone(),
+                    collection.schema.as_ref(),
                 )
                 .await,
                 ctx,

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -682,6 +682,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     &metadata_segment,
                     &self.context.blockfile_provider,
                     cmek.clone(),
+                    collection.schema.as_ref(),
                 )
                 .await,
                 ctx,

--- a/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
+++ b/rust/worker/src/execution/orchestration/log_fetch_orchestrator.rs
@@ -679,6 +679,7 @@ impl Handler<TaskResult<GetCollectionAndSegmentsOutput, GetCollectionAndSegments
                     &metadata_segment,
                     &self.context.blockfile_provider,
                     cmek.clone(),
+                    collection.schema.as_ref(),
                 )
                 .await,
                 ctx,


### PR DESCRIPTION
## Description of changes
*This is PR 7 in the MaxScore stack. It wires `MaxScoreWriter`/`MaxScoreReader` into the metadata segment so that collections with `algorithm: "max_score"` in their schema use the new index format on both the write and read paths. The query pipeline is not yet connected — that follows in PR 8.*
- **`MaxScoreReader::count_postings()`** (`maxscore.rs`): New method that counts total posting entries for a dimension by summing `len()` across posting blocks. O(n_blocks). Used by the IDF operator in PR 8 to compute document frequency for BM25 scoring.
- **Metadata segment writer** (`blockfile_metadata.rs`):
  - Added `maxscore_index_writer: Option<MaxScoreWriter>` field to `MetadataSegmentWriterShard`.
  - Added `schema: Option<&Schema>` parameter to both `MetadataSegmentWriter::from_segment()` and `MetadataSegmentWriterShard::from_segment()`.
  - 3-way branch in writer construction:
    1. `SPARSE_POSTING` in file_path → fork MaxScore index (open reader + forked writer)
    2. `SPARSE_MAX` in file_path → fork existing WAND index (unchanged)
    3. Neither (fresh collection) → check `schema.is_maxscore_enabled()` to decide which writer to create
  - Only one of `sparse_index_writer` / `maxscore_index_writer` is `Some` at a time.
  - Dual dispatch in `set_metadata`/`delete_metadata` `SparseVector` arms — checks `maxscore_index_writer` first, falls back to `sparse_index_writer`.
- **Metadata segment flusher** (`blockfile_metadata.rs`):
  - Changed `sparse_index_flusher: SparseFlusher` to `Option<SparseFlusher>` + `Option<MaxScoreFlusher>`.
  - `commit()` handles both writer paths; `flush()` conditionally inserts `SPARSE_POSTING` or `SPARSE_MAX`+`SPARSE_OFFSET_VALUE` into the flushed file_path map.
- **Metadata segment reader** (`blockfile_metadata.rs`):
  - Added `maxscore_index_reader: Option<MaxScoreReader>` field to `MetadataSegmentReaderShard`.
  - `SPARSE_POSTING` blockfile loaded concurrently in the existing `tokio::join!`. If present, `maxscore_index_reader` is populated and the old WAND reader is skipped.
- **Call site updates** (~27 sites):
  - 2 production orchestrators (`log_fetch_orchestrator.rs`, `attached_function_orchestrator.rs`) pass `collection.schema.as_ref()`.
  - `create_new_shard` extracts schema from `&Collection`.
  - ~24 test sites pass `None` (backward-compatible — default WAND path).
## Test plan
- All existing metadata segment tests pass unchanged (they pass `None` for schema, so the WAND writer is created as before).
- Compilation verified for `chroma-segment` and `worker` crates.
- Integration tests for the MaxScore write-then-read path will be added in PR 8 alongside the operator and orchestrator routing.
## Migration plan
No migration needed. Existing collections with `SPARSE_MAX`+`SPARSE_OFFSET_VALUE` in their file_path continue to use the WAND reader/writer. New collections only get the MaxScore index if the schema has `algorithm: "max_score"` (set by the frontend gating in PR 6). The segment reader auto-detects which format is present based on file_path keys.
## Observability plan
No new metrics or spans. The 3-way branch in `from_segment()` is logged implicitly through existing tracing on blockfile open/create operations.
## Documentation Changes
None.