### PR TITLE
fix: scope AsyncFastAPI HTTP client pool to instance instead of class

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -70,10 +70,9 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     # Mixing asyncio and threading in this manner usually discouraged, but
     # this gives a better user experience with practically no downsides.
     # https://github.com/encode/httpx/issues/2058
-    _clients: Dict[int, httpx.AsyncClient] = {}
-
     def __init__(self, system: System):
         super().__init__(system)
+        self._clients: Dict[int, httpx.AsyncClient] = {}
 
         system.settings.require("chroma_server_host")
         system.settings.require("chroma_server_http_port")
@@ -617,7 +616,11 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
         tenant: str = DEFAULT_TENANT,
         database: str = DEFAULT_DATABASE,
     ) -> DeleteResult:
-        body: dict = {"where": where, "ids": ids, "where_document": where_document}
+        body: Dict[str, Any] = {
+            "where": where,
+            "ids": ids,
+            "where_document": where_document,
+        }
         if limit is not None:
             body["limit"] = limit
         resp = await self._make_request(

--- a/chromadb/test/test_async_fastapi_transport.py
+++ b/chromadb/test/test_async_fastapi_transport.py
@@ -1,0 +1,53 @@
+import asyncio
+from typing import Any, List, cast
+from unittest.mock import MagicMock, patch
+
+from chromadb.api.async_fastapi import AsyncFastAPI
+from chromadb.config import Settings, System
+
+
+class _FakeAsyncHTTPClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.headers = kwargs.get("headers", {})
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def test_async_fastapi_clients_are_instance_scoped() -> None:
+    settings = Settings(
+        chroma_api_impl="chromadb.api.async_fastapi.AsyncFastAPI",
+        chroma_server_host="localhost",
+        chroma_server_http_port=9000,
+    )
+    created_clients: List[_FakeAsyncHTTPClient] = []
+
+    def factory(*_: Any, **kwargs: Any) -> _FakeAsyncHTTPClient:
+        client = _FakeAsyncHTTPClient(**kwargs)
+        created_clients.append(client)
+        return client
+
+    async def run() -> None:
+        with patch.object(AsyncFastAPI, "require", return_value=MagicMock()):
+            with patch(
+                "chromadb.api.async_fastapi.httpx.AsyncClient", side_effect=factory
+            ):
+                api_one = AsyncFastAPI(System(settings))
+                api_two = AsyncFastAPI(System(settings))
+
+                client_one = cast(_FakeAsyncHTTPClient, api_one._get_client())
+                client_two = cast(_FakeAsyncHTTPClient, api_two._get_client())
+
+                assert client_one is not client_two
+                assert len(created_clients) == 2
+
+                await api_one._cleanup()
+                assert client_one.closed is True
+                assert client_two.closed is False
+                assert api_two._get_client() is client_two
+
+                await api_two._cleanup()
+                assert client_two.closed is True
+
+    asyncio.run(run())


### PR DESCRIPTION
Fixes #6869

## Problem

`AsyncFastAPI._clients` is declared as a **class variable**, so all instances share the same `Dict[int, httpx.AsyncClient]` pool. When multiple `AsyncFastAPI` instances are created (e.g. in tests or multi-tenant setups), they cross-contaminate each other's HTTP transports. Closing one instance's client can corrupt another instance's connection pool.

## Fix

Move `_clients` initialization from class-level to `__init__`, making it an instance variable:

```diff
-_clients: Dict[int, httpx.AsyncClient] = {}
-
 def __init__(self, system: System):
     super().__init__(system)
+    self._clients: Dict[int, httpx.AsyncClient] = {}
```

## Tests

53-line test verifying that two `AsyncFastAPI` instances maintain independent client pools and that cleanup of one does not affect the other.

_This fix was developed with AI assistance and reviewed by a human._