### PR TITLE
fix(async): correct heartbeat path in AsyncFastAPI

### DIFF
--- a/chromadb/api/async_fastapi.py
+++ b/chromadb/api/async_fastapi.py
@@ -171,7 +171,7 @@ class AsyncFastAPI(BaseHTTPClient, AsyncServerAPI):
     @trace_method("AsyncFastAPI.heartbeat", OpenTelemetryGranularity.OPERATION)
     @override
     async def heartbeat(self) -> int:
-        response = await self._make_request("get", "")
+        response = await self._make_request("get", "/heartbeat")
         return int(response["nanosecond heartbeat"])
 
     @trace_method("AsyncFastAPI.create_database", OpenTelemetryGranularity.OPERATION)


### PR DESCRIPTION
## Summary

`AsyncFastAPI.heartbeat()` was calling `_make_request("get", "")` — an empty path — causing the method to hit the base API URL instead of `/heartbeat`.

The sync `FastAPI.heartbeat()` correctly uses `/heartbeat`. This made the async health-check method fail even when the server was fully healthy.

## Root Cause

```python
# Before (broken)
async def heartbeat(self) -> int:
    response = await self._make_request("get", "")  # hits base URL
    return int(response["nanosecond heartbeat"])

# After (fixed)
async def heartbeat(self) -> int:
    response = await self._make_request("get", "/heartbeat")
    return int(response["nanosecond heartbeat"])
```

## Changes

- `chromadb/api/async_fastapi.py`: change empty string path to `"/heartbeat"` to match the sync implementation

Closes #6870