### PR TITLE
fix(async): from_system_async() now binds to the provided system

### DIFF
--- a/chromadb/api/async_client.py
+++ b/chromadb/api/async_client.py
@@ -103,6 +103,7 @@ class AsyncClient(SharedSystemClient, AsyncClientAPI):
         database: str = DEFAULT_DATABASE,
     ) -> "AsyncClient":
         """Create a client from an existing system. This is useful for testing and debugging."""
+        SharedSystemClient._populate_data_from_system(system)
         return await AsyncClient.create(tenant, database, system.settings)
 
     @classmethod


### PR DESCRIPTION
## Summary

`AsyncClient.from_system_async(system, ...)` was ignoring the `system` argument and creating a fresh client stack from `system.settings`. This violated the documented contract ("create a client from an existing system") and was inconsistent with the sync `Client.from_system()`.

## Root Cause

The sync `from_system()` calls `SharedSystemClient._populate_data_from_system(system)` before constructing the client, which caches the existing `System` object. Subsequent `create()` calls then find and reuse that cached system via its identifier.

The async version skipped this step, so `AsyncClient.create()` always spun up a brand new system, giving the client a different UUID than the one passed in.

```python
# Before (broken — ignores system)
async def from_system_async(cls, system, tenant=..., database=...) -> "AsyncClient":
    return await AsyncClient.create(tenant, database, system.settings)

# After (fixed — matches sync behaviour)
async def from_system_async(cls, system, tenant=..., database=...) -> "AsyncClient":
    SharedSystemClient._populate_data_from_system(system)
    return await AsyncClient.create(tenant, database, system.settings)
```

## Changes

- `chromadb/api/async_client.py`: add `SharedSystemClient._populate_data_from_system(system)` call before `AsyncClient.create()`, mirroring the sync `Client.from_system()` implementation

Closes #6871