### PR TITLE
[BUG] Log segment metadata value in convertSegmentMetadataToModel debug output

### DIFF
--- a/go/pkg/sysdb/coordinator/model_db_convert.go
+++ b/go/pkg/sysdb/coordinator/model_db_convert.go
@@ -177,7 +177,7 @@ func convertSegmentMetadataToModel(segmentMetadataList []*dbmodel.SegmentMetadat
 		if metadata.Empty() {
 			metadata = nil
 		}
-		log.Debug("segment metadata to model", zap.Any("segmentMetadata", nil))
+		log.Debug("segment metadata to model", zap.Any("segmentMetadata", metadata))
 		return metadata
 	}
 }


### PR DESCRIPTION
## What

Fixes the `log.Debug` call in `convertSegmentMetadataToModel` so it logs the resolved `metadata` instead of always logging `nil`.

## Why

The previous code passed `nil` to `zap.Any`, so debug output did not reflect the converted segment metadata.

Fixes #6885