### PR TITLE
[BUG] Fail compaction job when Success response job_id mismatches awaiter

### DIFF
--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -389,8 +389,10 @@ impl CompactionManager {
                     CompactionResponse::Success { job_id, .. } => {
                         if job_id != &resp.job_id {
                             tracing::event!(Level::ERROR, name = "mismatched job ids in result", lhs =? *job_id, rhs =? resp.job_id);
+                            self.scheduler.fail_job(resp.job_id).await;
+                        } else {
+                            self.scheduler.succeed_job(resp.job_id);
                         }
-                        self.scheduler.succeed_job(resp.job_id);
                     }
                     CompactionResponse::RequireCompactionOffsetRepair {
                         job_id: collection_id,


### PR DESCRIPTION
## Summary

When `CompactionResponse::Success` carries a `job_id` that does not match the awaiter\u2019s `resp.job_id`, the scheduler now calls `fail_job` instead of incorrectly calling `succeed_job`.

## Context

Aligns the Success branch with the existing mismatch handling in `RequireCompactionOffsetRepair`.

Fixes #6887