### PR TITLE
[BUG] Return tx.Error from InsertOnConflictDoNothing on Create failure

### DIFF
--- a/go/pkg/sysdb/metastore/db/dao/collection.go
+++ b/go/pkg/sysdb/metastore/db/dao/collection.go
@@ -474,8 +474,8 @@ func (s *collectionDb) InsertOnConflictDoNothing(in *dbmodel.Collection) (didIns
 		DoNothing: true,
 	}).Create(&in)
 	if tx.Error != nil {
-		log.Error("InsertOnConflictDoNothing collection failed", zap.Error(err))
-		return false, err
+		log.Error("InsertOnConflictDoNothing collection failed", zap.Error(tx.Error))
+		return false, tx.Error
 	}
 	if tx.RowsAffected == 0 {
 		log.Debug("InsertOnConflictDoNothing collection already exists")


### PR DESCRIPTION
## Summary

Use `tx.Error` for logging and the return value when `Create` fails in `InsertOnConflictDoNothing`, so callers observe the real GORM error.

Fixes #6889