### PR TITLE
[DOC] Add Superlinked embedding function integration

### DIFF
--- a/docs/mintlify/docs.json
+++ b/docs/mintlify/docs.json
@@ -223,7 +223,8 @@
               "integrations/embedding-models/cloudflare-workers-ai",
               "integrations/embedding-models/amazon-bedrock",
               "integrations/embedding-models/baseten",
-              "integrations/embedding-models/chroma-cloud-qwen"
+              "integrations/embedding-models/chroma-cloud-qwen",
+              "integrations/embedding-models/superlinked"
             ]
           },
           {
@@ -231,7 +232,8 @@
             "pages": [
               "integrations/embedding-models/chroma-bm25",
               "integrations/embedding-models/chroma-cloud-splade",
-              "integrations/embedding-models/hugging-face"
+              "integrations/embedding-models/hugging-face",
+              "integrations/embedding-models/superlinked"
             ]
           },
           {

--- a/docs/mintlify/integrations/embedding-models/superlinked.mdx
+++ b/docs/mintlify/integrations/embedding-models/superlinked.mdx
@@ -1,0 +1,128 @@
+---
+title: Superlinked
+---
+
+[Superlinked](https://superlinked.com) is a self-hosted inference engine (SIE) for embedding, reranking, and extraction. The `sie-chroma` package exposes SIE as a Chroma `EmbeddingFunction`, giving you access to 85+ dense and sparse text embedding models from a single endpoint. You need a running SIE instance; see the [Superlinked quickstart](https://superlinked.com/docs) for deployment options.
+
+<Tabs>
+<Tab title="Python" icon="python">
+
+Install the `sie-chroma` package:
+
+```bash
+pip install sie-chroma
+```
+
+Use `SIEEmbeddingFunction` for dense embeddings:
+
+```python
+import chromadb
+from sie_chroma import SIEEmbeddingFunction
+
+embedding_function = SIEEmbeddingFunction(
+    base_url="http://localhost:8080",
+    model="BAAI/bge-m3",
+)
+
+client = chromadb.Client()
+collection = client.create_collection(
+    name="documents",
+    embedding_function=embedding_function,
+)
+
+collection.add(
+    documents=[
+        "Machine learning is a subset of artificial intelligence.",
+        "Neural networks are inspired by biological neurons.",
+        "Deep learning uses multiple layers of neural networks.",
+    ],
+    ids=["doc1", "doc2", "doc3"],
+)
+
+results = collection.query(query_texts=["What is deep learning?"], n_results=2)
+```
+
+For hybrid search on Chroma Cloud, `SIESparseEmbeddingFunction` returns learned sparse vectors (SPLADE / BGE-M3) as `dict[int, float]`:
+
+```python
+from sie_chroma import SIESparseEmbeddingFunction
+
+sparse_ef = SIESparseEmbeddingFunction(
+    base_url="http://localhost:8080",
+    model="naver/splade-v3",
+)
+```
+
+</Tab>
+
+<Tab title="TypeScript" icon="js">
+
+```bash
+npm install @superlinked/sie-chroma
+```
+
+```typescript
+import { ChromaClient } from "chromadb";
+import { SIEEmbeddingFunction } from "@superlinked/sie-chroma";
+
+const embedder = new SIEEmbeddingFunction({
+  baseUrl: "http://localhost:8080",
+  model: "BAAI/bge-m3",
+});
+
+const client = new ChromaClient();
+const collection = await client.createCollection({
+  name: "documents",
+  embeddingFunction: embedder,
+});
+
+await collection.add({
+  ids: ["doc1", "doc2", "doc3"],
+  documents: [
+    "Machine learning is a subset of artificial intelligence.",
+    "Neural networks are inspired by biological neurons.",
+    "Deep learning uses multiple layers of neural networks.",
+  ],
+});
+
+const results = await collection.query({
+  queryTexts: ["What is deep learning?"],
+  nResults: 2,
+});
+```
+
+</Tab>
+</Tabs>
+
+## Multimodal
+
+Chroma's `EmbeddingFunction` protocol accepts text input only. For image embedding with SIE-supported multimodal models (CLIP, SigLIP, ColPali), use the SIE SDK directly to pre-compute embeddings and pass them to Chroma via `collection.add(embeddings=...)`:
+
+```python
+from sie_sdk import SIEClient
+from sie_sdk.types import Item
+import chromadb
+
+sie = SIEClient("http://localhost:8080")
+chroma = chromadb.Client()
+collection = chroma.create_collection("images")
+
+results = sie.encode(
+    "openai/clip-vit-large-patch14",
+    [Item(images=["img1.jpg"]), Item(images=["img2.jpg"])],
+    output_types=["dense"],
+)
+
+collection.add(
+    ids=["img1", "img2"],
+    embeddings=[r["dense"].tolist() for r in results],
+    metadatas=[{"path": "img1.jpg"}, {"path": "img2.jpg"}],
+)
+```
+
+## Links
+
+- [`sie-chroma` on PyPI](https://pypi.org/project/sie-chroma/)
+- [`@superlinked/sie-chroma` on npm](https://www.npmjs.com/package/@superlinked/sie-chroma)
+- [Superlinked on GitHub](https://github.com/superlinked/sie)
+- [Superlinked docs](https://superlinked.com/docs)


### PR DESCRIPTION
## Summary

Adds a docs page for [Superlinked](https://superlinked.com) (SIE), a self-hosted inference engine for embedding, reranking, and extraction. The `sie-chroma` package exposes SIE as a Chroma `EmbeddingFunction`, giving users access to 85+ dense and sparse embedding models — including multimodal ones (CLIP, SigLIP) — from a single endpoint.

## Files added

- `docs/mintlify/integrations/embedding-models/superlinked.mdx`

Page uses Mintlify `<Tabs>` components matching the Cohere / Jina / OpenAI / Ollama pages in the same directory.

## Highlights

- `SIEEmbeddingFunction` for dense embeddings (standard collections)
- `SIESparseEmbeddingFunction` returning `dict[int, float]` sparse vectors (SPLADE / BGE-M3) for Chroma Cloud hybrid search
- Python (`sie-chroma`) and TypeScript (`@superlinked/sie-chroma`) packages
- Multimodal support via CLIP / SigLIP

## Links

- Package (Python): https://pypi.org/project/sie-chroma/
- Package (npm): https://www.npmjs.com/package/@superlinked/sie-chroma
- Source: https://github.com/superlinked/sie
- Docs: https://superlinked.com/docs

Note: the page should likely also be added to `docs.json` navigation — happy to do that in a follow-up commit once reviewers confirm the intended position in the sidebar. Opened as draft for feedback.