### PR TITLE
[ENH]: Make compaction client grpc timeout configurable

### DIFF
--- a/rust/worker/src/compactor/compaction_client.rs
+++ b/rust/worker/src/compactor/compaction_client.rs
@@ -4,8 +4,9 @@ use chroma_types::chroma_proto::{
 };
 use clap::{Parser, Subcommand};
 use std::io::Write;
+use std::time::Duration;
 use thiserror::Error;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
 use uuid::Uuid;
 
 /// Error for compaction client
@@ -26,6 +27,10 @@ pub struct CompactionClient {
     /// Url of the target compactor
     #[arg(short, long)]
     url: String,
+
+    #[arg(long, default_value_t = 60)]
+    request_timeout_secs: u64,
+
     /// Subcommand for compaction
     #[command(subcommand)]
     command: CompactionCommand,
@@ -60,7 +65,12 @@ pub enum CompactionCommand {
 
 impl CompactionClient {
     async fn grpc_client(&self) -> Result<CompactorClient<Channel>, CompactionClientError> {
-        Ok(CompactorClient::connect(self.url.clone()).await?)
+        let endpoint = Endpoint::from_shared(self.url.clone())?
+            .connect_timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(self.request_timeout_secs));
+
+        let channel = endpoint.connect().await?;
+        Ok(CompactorClient::new(channel))
     }
 
     pub async fn run(&self, w: &mut dyn Write) -> Result<(), CompactionClientError> {


### PR DESCRIPTION
## Description of changes

The default grpc timeout from the compaction client here is 30 seconds.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
