### PR TITLE
[ENH]: add parallel embedding support to SentenceTransformerEmbeddingFunction

### DIFF
--- a/chromadb/test/ef/test_sentence_transformer_ef.py
+++ b/chromadb/test/ef/test_sentence_transformer_ef.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+import numpy as np
+
+
+@pytest.fixture(autouse=True)
+def clear_models_cache():
+    """Clear the class-level models cache before each test to ensure isolation."""
+    SentenceTransformerEmbeddingFunction.models = {}
+
+
+def test_initialization_no_pool():
+    """Verify that a pool is not started by default."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        ef = SentenceTransformerEmbeddingFunction(model_name="test_model")
+        mock_st.assert_called_once_with(model_name_or_path="test_model", device="cpu")
+        assert ef._pool is None
+
+
+def test_initialization_with_pool():
+    """Verify that a multi-process pool is started when devices are specified."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        mock_instance = mock_st.return_value
+        mock_instance.start_multi_process_pool.return_value = {"pool": "test_pool"}
+
+        ef = SentenceTransformerEmbeddingFunction(
+            model_name="test_model", multiprocess_devices=["cpu", "cpu"]
+        )
+
+        mock_instance.start_multi_process_pool.assert_called_once_with(
+            target_devices=["cpu", "cpu"]
+        )
+        assert ef._pool == {"pool": "test_pool"}
+
+
+def test_call_with_batch_size():
+    """Verify that batch_size is passed to encode when specified."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        mock_instance = mock_st.return_value
+        mock_instance.encode.return_value = [np.array([0.1, 0.2])]
+
+        ef = SentenceTransformerEmbeddingFunction(model_name="test_model", batch_size=10)
+        ef(["test doc"])
+
+        mock_instance.encode.assert_called_once()
+        args, kwargs = mock_instance.encode.call_args
+        assert kwargs["batch_size"] == 10
+
+
+def test_call_without_batch_size():
+    """Verify that batch_size is NOT passed to encode when it is None."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        mock_instance = mock_st.return_value
+        mock_instance.encode.return_value = [np.array([0.1, 0.2])]
+
+        ef = SentenceTransformerEmbeddingFunction(model_name="test_model")
+        ef(["test doc"])
+
+        mock_instance.encode.assert_called_once()
+        args, kwargs = mock_instance.encode.call_args
+        assert "batch_size" not in kwargs
+
+
+def test_call_with_pool():
+    """Verify that the pool is passed to encode when multi-processing is enabled."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        mock_instance = mock_st.return_value
+        mock_instance.start_multi_process_pool.return_value = {"pool": "test_pool"}
+        mock_instance.encode.return_value = [np.array([0.1, 0.2])]
+
+        ef = SentenceTransformerEmbeddingFunction(
+            model_name="test_model", multiprocess_devices=["cpu"]
+        )
+        ef(["test doc"])
+
+        args, kwargs = mock_instance.encode.call_args
+        assert kwargs["pool"] == {"pool": "test_pool"}
+
+
+def test_config_roundtrip():
+    """Verify that getting config and rebuilding from it preserves all new parameters."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        ef = SentenceTransformerEmbeddingFunction(
+            model_name="test_model",
+            batch_size=10,
+            multiprocess_devices=["cpu"],
+            normalize_embeddings=True,
+        )
+
+        config = ef.get_config()
+        assert config["batch_size"] == 10
+        assert config["multiprocess_devices"] == ["cpu"]
+
+        # Rebuild from config
+        new_ef = SentenceTransformerEmbeddingFunction.build_from_config(config)
+        assert new_ef.batch_size == 10
+        assert new_ef.multiprocess_devices == ["cpu"]
+        assert new_ef.normalize_embeddings is True
+
+
+def test_cleanup():
+    """Verify that deleting the instance stops the multi-process pool."""
+    with patch("sentence_transformers.SentenceTransformer") as mock_st:
+        mock_instance = mock_st.return_value
+        mock_instance.start_multi_process_pool.return_value = {"pool": "test_pool"}
+
+        ef = SentenceTransformerEmbeddingFunction(
+            model_name="test_model", multiprocess_devices=["cpu"]
+        )
+        pool = ef._pool
+        ef.__del__()
+
+        mock_instance.stop_multi_process_pool.assert_called_once_with(pool)

--- a/chromadb/test/utils/test_embedding_function_schemas.py
+++ b/chromadb/test/utils/test_embedding_function_schemas.py
@@ -366,6 +366,18 @@ class TestEmbeddingFunctionSchemas:
                 # If that fails, try with common minimal args
                 return ef_class(model_name="test-model")
 
+    def test_sentence_transformer_schema_explicit_nulls(self) -> None:
+        """Test that sentence_transformer schema explicitly allows null values for batch_size and multiprocess_devices"""
+        config = {
+            "model_name": "all-MiniLM-L6-v2",
+            "device": "cpu",
+            "normalize_embeddings": False,
+            "batch_size": None,
+            "multiprocess_devices": None,
+            "kwargs": {},
+        }
+        validate_config_schema(config, "sentence_transformer")
+
     @pytest.mark.parametrize("ef_name", get_embedding_function_names())
     def test_validate_config_with_schema(
         self,

--- a/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
+++ b/chromadb/utils/embedding_functions/sentence_transformer_embedding_function.py
@@ -1,5 +1,5 @@
 from chromadb.api.types import EmbeddingFunction, Space, Embeddings, Documents
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import numpy as np
 from chromadb.utils.embedding_functions.schemas import validate_config_schema
 
@@ -15,14 +15,26 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         model_name: str = "all-MiniLM-L6-v2",
         device: str = "cpu",
         normalize_embeddings: bool = False,
+        batch_size: Optional[int] = None,
+        multiprocess_devices: Optional[List[str]] = None,
         **kwargs: Any,
     ):
         """Initialize SentenceTransformerEmbeddingFunction.
 
         Args:
-            model_name (str, optional): Identifier of the SentenceTransformer model, defaults to "all-MiniLM-L6-v2"
-            device (str, optional): Device used for computation, defaults to "cpu"
-            normalize_embeddings (bool, optional): Whether to normalize returned vectors, defaults to False
+            model_name (str, optional): Identifier of the SentenceTransformer model,
+                defaults to "all-MiniLM-L6-v2"
+            device (str, optional): Device used for computation, defaults to "cpu".
+                Ignored when multiprocess_devices is set.
+            normalize_embeddings (bool, optional): Whether to normalize returned
+                vectors, defaults to False.
+            batch_size (int, optional): Number of documents to encode per batch.
+                Defaults to None (uses sentence-transformers default of 32).
+            multiprocess_devices (list[str], optional): If provided, encoding is
+                distributed across these devices using sentence-transformers'
+                built-in multi-process pool. Example: ["cuda:0", "cuda:1"] or
+                ["cpu", "cpu", "cpu", "cpu"]. When set, `device` is ignored.
+                Defaults to None (single-process).
             **kwargs: Additional arguments to pass to the SentenceTransformer model.
         """
         try:
@@ -35,6 +47,9 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         self.model_name = model_name
         self.device = device
         self.normalize_embeddings = normalize_embeddings
+        self.batch_size = batch_size
+        self.multiprocess_devices = multiprocess_devices
+
         for key, value in kwargs.items():
             if not isinstance(value, (str, int, float, bool, list, dict, tuple)):
                 raise ValueError(f"Keyword argument {key} is not a primitive type")
@@ -46,6 +61,22 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
             )
         self._model = self.models[model_name]
 
+        # Start a persistent multi-process pool if devices are specified.
+        # Kept alive for the lifetime of this instance to avoid paying
+        # process-spawn overhead on every __call__.
+        self._pool: Optional[Dict[str, Any]] = None
+        if self.multiprocess_devices is not None:
+            self._pool = self._model.start_multi_process_pool(
+                target_devices=self.multiprocess_devices
+            )
+
+    def __del__(self) -> None:
+        if self._pool is not None:
+            try:
+                self._model.stop_multi_process_pool(self._pool)
+            except Exception:
+                pass
+
     def __call__(self, input: Documents) -> Embeddings:
         """Generate embeddings for the given documents.
 
@@ -55,10 +86,17 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         Returns:
             Embeddings for the documents.
         """
+        encode_kwargs: Dict[str, Any] = {
+            "convert_to_numpy": True,
+            "normalize_embeddings": self.normalize_embeddings,
+            "pool": self._pool,
+        }
+        if self.batch_size is not None:
+            encode_kwargs["batch_size"] = self.batch_size
+
         embeddings = self._model.encode(
             list(input),
-            convert_to_numpy=True,
-            normalize_embeddings=self.normalize_embeddings,
+            **encode_kwargs,
         )
 
         return [np.array(embedding, dtype=np.float32) for embedding in embeddings]
@@ -79,6 +117,8 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
         model_name = config.get("model_name")
         device = config.get("device")
         normalize_embeddings = config.get("normalize_embeddings")
+        batch_size = config.get("batch_size")
+        multiprocess_devices = config.get("multiprocess_devices", None)
         kwargs = config.get("kwargs", {})
 
         if model_name is None or device is None or normalize_embeddings is None:
@@ -88,6 +128,8 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
             model_name=model_name,
             device=device,
             normalize_embeddings=normalize_embeddings,
+            batch_size=batch_size,
+            multiprocess_devices=multiprocess_devices,
             **kwargs,
         )
 
@@ -96,6 +138,8 @@ class SentenceTransformerEmbeddingFunction(EmbeddingFunction[Documents]):
             "model_name": self.model_name,
             "device": self.device,
             "normalize_embeddings": self.normalize_embeddings,
+            "batch_size": self.batch_size,
+            "multiprocess_devices": self.multiprocess_devices,
             "kwargs": self.kwargs,
         }
 

--- a/schemas/embedding_functions/sentence_transformer.json
+++ b/schemas/embedding_functions/sentence_transformer.json
@@ -17,6 +17,15 @@
             "type": "boolean",
             "description": "Whether to normalize returned vectors"
         },
+        "batch_size": {
+            "type": ["integer", "null"],
+            "description": "Number of documents to encode per batch"
+        },
+        "multiprocess_devices": {
+            "type": ["array", "null"],
+            "items": { "type": "string" },
+            "description": "Devices for multi-process encoding"
+        },
         "kwargs": {
             "type": "object",
             "description": "Additional arguments to pass to the SentenceTransformer model",


### PR DESCRIPTION
## Description of changes

_Summarize the changes made by this PR._

This PR adds support for data-parallel embedding computation in the `SentenceTransformerEmbeddingFunction`. Fixes #6903 . This brings it to parity with other local embedding functions (like `FastEmbed`) and allows users to fully utilize multi-core CPUs and multi-GPU setups.

- Improvements & Bug fixes
  - N/A
- New functionality
  - **`batch_size` support**: Users can now specify a custom `batch_size` for local encoding. It defaults to `None`, which falls back to the `sentence-transformers` internal default (32).
  - **Multi-process pool support**: Introduced the `multiprocess_devices` parameter. When provided (e.g., `["cpu", "cpu"]` or `["cuda:0", "cuda:1"]`), a persistent multi-process pool is initialized and used for all embedding calls.
  - **Automatic Cleanup**: Implemented `__del__` to ensure the multi-process pool is properly stopped when the embedding function instance is garbage collected.
  - **Schema Integration**: Updated the `sentence_transformer` JSON schema to include the new parameters as nullable fields, ensuring configuration persistence and validation work correctly.

## Test plan

_How are these changes tested?_

- [x] Tests pass locally with `pytest` for python
    - Created `chromadb/test/ef/test_sentence_transformer_ef.py` with 7 new unit tests covering initialization, execution, resource cleanup, and configuration roundtrips.
    - Updated `chromadb/test/utils/test_embedding_function_schemas.py` to verify that the updated schema correctly validates the new fields (including `null` values).

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

No migrations are required. The changes are fully backwards compatible:
- Existing collections without `batch_size` or `multiprocess_devices` in their config will default to `None`, maintaining the previous behavior (single-process, library-default batch size).
- The JSON schema updates include `null` in the permitted types for the new fields to handle existing deployments.

## Observability plan

_What is the plan to instrument and monitor this change?_

Standard python logging is used. No additional observability instrumentation is required for this local compute change.

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section]?_
- For the [docs section], a small update to the Embedding Functions page would be beneficial to highlight the parallelization capabilities.
