### PR TITLE
[BUG] Update HF EF base URL

### DIFF
--- a/chromadb/utils/embedding_functions/huggingface_embedding_function.py
+++ b/chromadb/utils/embedding_functions/huggingface_embedding_function.py
@@ -17,6 +17,7 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
         api_key: Optional[str] = None,
         model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
         api_key_env_var: str = "CHROMA_HUGGINGFACE_API_KEY",
+        base_url: str = "https://router.huggingface.co/",
     ):
         """
         Initialize the HuggingFaceEmbeddingFunction.
@@ -26,6 +27,8 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
                 Defaults to "CHROMA_HUGGINGFACE_API_KEY".
             model_name (str, optional): The name of the model to use for text embeddings.
                 Defaults to "sentence-transformers/all-MiniLM-L6-v2".
+            base_url (str, optional): The base URL for the HuggingFace inference router.
+                Defaults to "https://router.huggingface.co/".
         """
         try:
             import httpx
@@ -52,8 +55,12 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
             )
 
         self.model_name = model_name
+        self.base_url = base_url
 
-        self._api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{model_name}"
+        self._api_url = (
+            f"{self.base_url.rstrip('/')}/hf-inference/models/"
+            f"{model_name}/pipeline/feature-extraction"
+        )
         self._session = httpx.Client()
         self._session.headers.update({"Authorization": f"Bearer {self.api_key}"})
 
@@ -95,16 +102,25 @@ class HuggingFaceEmbeddingFunction(EmbeddingFunction[Documents]):
     def build_from_config(config: Dict[str, Any]) -> "EmbeddingFunction[Documents]":
         api_key_env_var = config.get("api_key_env_var")
         model_name = config.get("model_name")
+        base_url = config.get("base_url")
 
         if api_key_env_var is None or model_name is None:
             assert False, "This code should not be reached"
 
         return HuggingFaceEmbeddingFunction(
-            api_key_env_var=api_key_env_var, model_name=model_name
+            api_key_env_var=api_key_env_var,
+            model_name=model_name,
+            base_url=base_url
+            if base_url is not None
+            else "https://router.huggingface.co/",
         )
 
     def get_config(self) -> Dict[str, Any]:
-        return {"api_key_env_var": self.api_key_env_var, "model_name": self.model_name}
+        return {
+            "api_key_env_var": self.api_key_env_var,
+            "model_name": self.model_name,
+            "base_url": self.base_url,
+        }
 
     def validate_config_update(
         self, old_config: Dict[str, Any], new_config: Dict[str, Any]

--- a/schemas/embedding_functions/huggingface.json
+++ b/schemas/embedding_functions/huggingface.json
@@ -12,6 +12,10 @@
         "api_key_env_var": {
             "type": "string",
             "description": "Environment variable name that contains your API key for the HuggingFace API"
+        },
+        "base_url": {
+            "type": "string",
+            "description": "The base URL for the HuggingFace inference router"
         }
     },
     "required": [


### PR DESCRIPTION
* https://github.com/chroma-core/chroma/issues/6748
* updates the URL to the correct endpoint. This was tested locally using this code:
```
import chromadb

import chromadb.utils.embedding_functions as embedding_functions
huggingface_ef = embedding_functions.HuggingFaceEmbeddingFunction(
    api_key="...",
    model_name="sentence-transformers/all-MiniLM-L6-v2" # and embeddinggemma
)

client = chromadb.Client()
collection = client.create_collection("test", embedding_function=huggingface_ef)

collection.add(
    documents=["Hello, world!", "Hello, world!", "Hello, world!"],
    metadatas=[{"source": "test"}, {"source": "test"}, {"source": "test"}],
    ids=["1", "2", "3"],
)

results = collection.query(
    query_texts=["Hello, world!"],
    n_results=2,
)
print(results)
```
* add a base_url param so users can override in case this happens again in the future. this param is optional, so it should not break config backwards compatibility. existing EF configs have this config option unset, so it should use the default endpoint (the now correct one)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>