### PR TITLE
Fix typos in comments/docs: seperately, accomodate, recieve, occured, compatiblity

### DIFF
--- a/chromadb/segment/impl/metadata/sqlite.py
+++ b/chromadb/segment/impl/metadata/sqlite.py
@@ -159,7 +159,7 @@ class SqliteMetadataSegment(MetadataReader):
         )
 
         # If there is a query that touches the metadata table, it uses
-        # where and where_document filters, we treat this case seperately
+        # where and where_document filters, we treat this case separately
         if where is not None or where_document is not None:
             metadata_q = (
                 self._db.querybuilder()

--- a/chromadb/segment/impl/vector/local_hnsw.py
+++ b/chromadb/segment/impl/vector/local_hnsw.py
@@ -221,7 +221,7 @@ class LocalHnswSegment(VectorReader):
 
     @trace_method("LocalHnswSegment._ensure_index", OpenTelemetryGranularity.ALL)
     def _ensure_index(self, n: int, dim: int) -> None:
-        """Create or resize the index as necessary to accomodate N new records"""
+        """Create or resize the index as necessary to accommodate N new records"""
         if not self._index:
             self._dimensionality = dim
             self._init_index(dim)

--- a/chromadb/test/client/test_multiple_clients_concurrency.py
+++ b/chromadb/test/client/test_multiple_clients_concurrency.py
@@ -21,7 +21,7 @@ def test_multiple_clients_concurrently(client_factories: ClientFactories) -> Non
 
     collections = [f"collection{i}" for i in range(COLLECTION_COUNT)]
 
-    # Create N clients, each on a seperate thread, each with their own database
+    # Create N clients, each on a separate thread, each with their own database
     def run_target(n: int) -> None:
         thread_client = client_factories.create_client(
             tenant=DEFAULT_TENANT,

--- a/clients/js/packages/chromadb-client/README.md
+++ b/clients/js/packages/chromadb-client/README.md
@@ -2,7 +2,7 @@
 
 Chroma is the open-source data infrastructure for AI. Chroma makes it easy to build LLM apps by making knowledge, facts, and skills pluggable for LLMs.
 
-**Note:** JS client version 3._ is only compatible with chromadb v1.0.6 and newer or Chroma Cloud. For prior version compatiblity, please use JS client version 2._.
+**Note:** JS client version 3._ is only compatible with chromadb v1.0.6 and newer or Chroma Cloud. For prior version compatibility, please use JS client version 2._.
 
 **This package provides embedding libraries as peer dependencies**, allowing you to manage your own versions of embedding libraries and keep your dependency tree lean by not bundling dependencies you don't use. For a thick client with bundled embedding functions, install `chromadb`.
 

--- a/rust/index/src/hnsw_provider.rs
+++ b/rust/index/src/hnsw_provider.rs
@@ -43,7 +43,7 @@ type CacheKey = CollectionUuid;
 // 1. get index version v1
 // 2. get index version v2 (> v1)
 // 3. get index version v1 (can happen due to an inflight query
-//    that started before compaction of v2 occured) -- this will
+//    that started before compaction of v2 occurred) -- this will
 //    evict v2 even though it is more recent and will be used again in future.
 // Once we have versioning propagated throughout the system we can make
 // this better. We can also do a deferred eviction for such entries when

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -615,7 +615,7 @@ mod tests {
     #[derive(Debug)]
     struct MockIoDispatchUser {
         pub dispatcher: ComponentHandle<Dispatcher>,
-        counter: Arc<AtomicUsize>, // We expect to recieve DISPATCH_COUNT messages
+        counter: Arc<AtomicUsize>, // We expect to receive DISPATCH_COUNT messages
         sent_tasks: Arc<Mutex<HashSet<Uuid>>>,
         received_tasks: Arc<Mutex<HashSet<Uuid>>>,
     }
@@ -683,7 +683,7 @@ mod tests {
     #[derive(Debug)]
     struct MockDispatchUser {
         pub dispatcher: ComponentHandle<Dispatcher>,
-        counter: Arc<AtomicUsize>, // We expect to recieve DISPATCH_COUNT messages
+        counter: Arc<AtomicUsize>, // We expect to receive DISPATCH_COUNT messages
         sent_tasks: Arc<Mutex<HashSet<Uuid>>>,
         received_tasks: Arc<Mutex<HashSet<Uuid>>>,
     }

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -1345,7 +1345,7 @@ impl WhereConversionError {
 /// unifying them together, and the structure of the unified AST should be identical to the one here.
 /// Currently both `where` and `where_document` clauses will be translated into `Where`, and if both are
 /// present we simply create a conjunction of both clauses as the actual filter. This is consistent with
-/// the semantics we used to have when the `where` and `where_document` clauses are treated seperately.
+/// the semantics we used to have when the `where` and `where_document` clauses are treated separately.
 // TODO: Remove this note once the `where` clause and `where_document` clause is unified in the API level.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]

--- a/rust/types/src/signed_rbm.rs
+++ b/rust/types/src/signed_rbm.rs
@@ -13,7 +13,7 @@ use roaring::RoaringBitmap;
 ///
 /// `{$and: [{<k0>: {$gt: <v0>}}, {<k1>: {$ne: <v1>}}]}`
 ///
-/// The naive way is to evaluate the `$gt` and `$ne` seperately and take the conjunction, but this requires
+/// The naive way is to evaluate the `$gt` and `$ne` separately and take the conjunction, but this requires
 /// us to know the full set of existing ids because it is needed to evaluate `$ne`.
 /// However, we can first evaluate `$gt` and then exclude the offset ids for records with metadata `k1=v1`.
 /// This behavior is captured in the `BitAnd::bitand` operator of `SignedRoaringBitmap`:

--- a/rust/worker/src/execution/operators/count_records.rs
+++ b/rust/worker/src/execution/operators/count_records.rs
@@ -99,7 +99,7 @@ impl Operator<CountRecordsInput, CountRecordsOutput> for CountRecordsOperator {
                 match *e {
                     RecordSegmentReaderShardCreationError::UninitializedSegment => {
                         tracing::info!("[CountQueryOrchestrator] Record segment is uninitialized; using {} records from log", input.log_records.len());
-                        // This means there no compaction has occured.
+                        // This means there no compaction has occurred.
                         // So we can just traverse the log records
                         // and count the number of records.
                         let mut seen_id_set = HashSet::new();


### PR DESCRIPTION
Comment/doc-only typo fixes across Python, Rust, and JS client README:

- `seperately` -> `separately` (4 files)
- `accomodate` -> `accommodate` (1 file)
- `recieve` -> `receive` (1 file, 2 occurrences)
- `occured` -> `occurred` (2 files)
- `compatiblity` -> `compatibility` (JS client README)

No behavior changes.