### PR TITLE
[ENH] Add IndexAndAdaptiveWal to clients

### DIFF
--- a/chromadb/api/models/AsyncCollection.py
+++ b/chromadb/api/models/AsyncCollection.py
@@ -95,6 +95,8 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
                   All committed writes will be visible.
                 - ReadLevel.INDEX_ONLY: Read only from the compacted index, skipping the WAL.
                   Faster, but recent writes that haven't been compacted may not be visible.
+                - ReadLevel.INDEX_AND_BOUNDED_WAL: Read from the index and up to a
+                  server-configured number of WAL entries for bounded query latency.
 
         Returns:
             int: The total number of embeddings added to the database
@@ -349,6 +351,8 @@ class AsyncCollection(CollectionCommon["AsyncServerAPI"]):
                   All committed writes will be visible.
                 - ReadLevel.INDEX_ONLY: Read only from the compacted index, skipping the WAL.
                   Faster, but recent writes that haven't been compacted may not be visible.
+                - ReadLevel.INDEX_AND_BOUNDED_WAL: Read from the index and up to a
+                  server-configured number of WAL entries for bounded query latency.
 
         Returns:
             SearchResult: Column-major format response with:

--- a/chromadb/api/models/Collection.py
+++ b/chromadb/api/models/Collection.py
@@ -49,6 +49,8 @@ class Collection(CollectionCommon["ServerAPI"]):
                   All committed writes will be visible.
                 - ReadLevel.INDEX_ONLY: Read only from the compacted index, skipping the WAL.
                   Faster, but recent writes that haven't been compacted may not be visible.
+                - ReadLevel.INDEX_AND_BOUNDED_WAL: Read from the index and up to a
+                  server-configured number of WAL entries for bounded query latency.
         """
         return self._client._count(
             collection_id=self.id,
@@ -364,6 +366,8 @@ class Collection(CollectionCommon["ServerAPI"]):
                   All committed writes will be visible.
                 - ReadLevel.INDEX_ONLY: Read only from the compacted index, skipping the WAL.
                   Faster, but recent writes that haven't been compacted may not be visible.
+                - ReadLevel.INDEX_AND_BOUNDED_WAL: Read from the index and up to a
+                  server-configured number of WAL entries for bounded query latency.
 
         Returns:
             SearchResult: Column-major format response with:

--- a/chromadb/api/types.py
+++ b/chromadb/api/types.py
@@ -810,10 +810,15 @@ class ReadLevel(str, Enum):
             All committed writes will be visible.
         INDEX_ONLY: Read only from the compacted index, skipping the WAL.
             Faster, but recent writes that haven't been compacted may not be visible.
+        INDEX_AND_BOUNDED_WAL: Read from the index and up to a server-configured
+            number of WAL entries. Provides a consistent prefix of the WAL with
+            bounded query latency: recently committed writes beyond the limit
+            may not be visible.
     """
 
     INDEX_AND_WAL = "index_and_wal"
     INDEX_ONLY = "index_only"
+    INDEX_AND_BOUNDED_WAL = "index_and_bounded_wal"
 
 
 # TODO: make warnings prettier and add link to migration docs

--- a/chromadb/test/api/test_count_api.py
+++ b/chromadb/test/api/test_count_api.py
@@ -66,6 +66,26 @@ def test_count_with_read_level_index_only(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_count_with_read_level_index_and_bounded_wal(
+    client_factories: ClientFactories,
+) -> None:
+    """Test count with ReadLevel.INDEX_AND_BOUNDED_WAL returns a valid count."""
+    collection, _ = _create_test_collection(client_factories)
+
+    collection.add(
+        ids=["doc1", "doc2", "doc3"],
+        documents=["apple fruit", "banana fruit", "car vehicle"],
+        embeddings=[[0.1, 0.2, 0.3, 0.4], [0.2, 0.3, 0.4, 0.5], [0.9, 0.8, 0.7, 0.6]],
+    )
+
+    # Count with INDEX_AND_BOUNDED_WAL reads up to a server-configured number of WAL entries.
+    # Result depends on the configured limit and WAL size.
+    count = collection.count(read_level=ReadLevel.INDEX_AND_BOUNDED_WAL)
+    assert isinstance(count, int)
+    assert count >= 0
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
 def test_count_default_read_level(
     client_factories: ClientFactories,
 ) -> None:

--- a/chromadb/test/api/test_search_api.py
+++ b/chromadb/test/api/test_search_api.py
@@ -78,6 +78,27 @@ def test_search_with_read_level_index_only(
 
 
 @pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
+def test_search_with_read_level_index_and_bounded_wal(
+    client_factories: ClientFactories,
+) -> None:
+    """Test search with ReadLevel.INDEX_AND_BOUNDED_WAL returns results."""
+    collection, _ = _create_test_collection(client_factories)
+
+    collection.add(
+        ids=["doc1", "doc2", "doc3"],
+        documents=["apple fruit", "banana fruit", "car vehicle"],
+        embeddings=[[0.1, 0.2, 0.3, 0.4], [0.2, 0.3, 0.4, 0.5], [0.9, 0.8, 0.7, 0.6]],
+    )
+
+    # Search with INDEX_AND_BOUNDED_WAL reads up to a server-configured number of WAL entries
+    search = Search().rank(Knn(query=[0.1, 0.2, 0.3, 0.4], limit=10))
+    results = collection.search(search, read_level=ReadLevel.INDEX_AND_BOUNDED_WAL)
+
+    assert results["ids"] is not None
+    assert len(results["ids"]) == 1
+
+
+@pytest.mark.skipif(is_spann_disabled_mode, reason=skip_reason_spann_disabled)
 def test_search_default_read_level(
     client_factories: ClientFactories,
 ) -> None:
@@ -99,4 +120,3 @@ def test_search_default_read_level(
     assert results["ids"] is not None
     assert len(results["ids"]) == 1
     assert len(results["ids"][0]) > 0
-

--- a/clients/new-js/packages/chromadb/src/collection.ts
+++ b/clients/new-js/packages/chromadb/src/collection.ts
@@ -80,6 +80,7 @@ export interface Collection {
      * Controls whether to read from the write-ahead log.
      * - ReadLevel.INDEX_AND_WAL: Read from both index and WAL (default)
      * - ReadLevel.INDEX_ONLY: Read only from index, faster but recent writes may not be visible
+     * - ReadLevel.INDEX_AND_BOUNDED_WAL: Read up to a server-configured number of WAL entries
      */
     readLevel?: ReadLevel;
   }): Promise<number>;
@@ -231,6 +232,7 @@ export interface Collection {
        * Controls whether to read from the write-ahead log.
        * - ReadLevel.INDEX_AND_WAL: Read from both index and WAL (default)
        * - ReadLevel.INDEX_ONLY: Read only from index, faster but recent writes may not be visible
+       * - ReadLevel.INDEX_AND_BOUNDED_WAL: Read up to a server-configured number of WAL entries
        */
       readLevel?: ReadLevel;
     },

--- a/clients/new-js/packages/chromadb/src/types.ts
+++ b/clients/new-js/packages/chromadb/src/types.ts
@@ -18,10 +18,13 @@ export type UserIdentity = GetUserIdentityResponse;
  *   All committed writes will be visible. This is the default.
  * - INDEX_ONLY: Read only from the compacted index, skipping the WAL.
  *   Recent writes that haven't been compacted may not be visible, but queries are faster.
+ * - INDEX_AND_BOUNDED_WAL: Read from the index and up to a server-configured number of
+ *   WAL entries for bounded query latency.
  */
 export const ReadLevel = {
   INDEX_AND_WAL: "index_and_wal",
   INDEX_ONLY: "index_only",
+  INDEX_AND_BOUNDED_WAL: "index_and_bounded_wal",
 } as const;
 
 export type ReadLevel = (typeof ReadLevel)[keyof typeof ReadLevel];

--- a/clients/new-js/packages/chromadb/test/count.test.ts
+++ b/clients/new-js/packages/chromadb/test/count.test.ts
@@ -60,10 +60,19 @@ describe("count with readLevel", () => {
     expect(mockApiClient.get).toHaveBeenCalledTimes(1);
     expect(capturedQuery.read_level).toBe("index_and_wal");
 
+    // Test with INDEX_AND_BOUNDED_WAL
+    mockApiClient.get.mockClear();
+    const count3 = await collection.count({
+      readLevel: ReadLevel.INDEX_AND_BOUNDED_WAL,
+    });
+    expect(count3).toBe(42);
+    expect(mockApiClient.get).toHaveBeenCalledTimes(1);
+    expect(capturedQuery.read_level).toBe("index_and_bounded_wal");
+
     // Test without readLevel (should not send query)
     mockApiClient.get.mockClear();
-    const count3 = await collection.count();
-    expect(count3).toBe(42);
+    const count4 = await collection.count();
+    expect(count4).toBe(42);
     expect(mockApiClient.get).toHaveBeenCalledTimes(1);
     expect(capturedQuery).toBeUndefined();
   });

--- a/clients/new-js/packages/chromadb/test/search.expression.test.ts
+++ b/clients/new-js/packages/chromadb/test/search.expression.test.ts
@@ -644,6 +644,16 @@ describe("search expression DSL", () => {
     expect(mockApiClient.post).toHaveBeenCalledTimes(1);
     expect(capturedBody.read_level).toBe("index_and_wal");
 
+    // Test with INDEX_AND_BOUNDED_WAL
+    mockApiClient.post.mockClear();
+    await collection.search(
+      new Search().rank(Knn({ query: [0.1, 0.2], limit: 5 })),
+      { readLevel: ReadLevel.INDEX_AND_BOUNDED_WAL },
+    );
+
+    expect(mockApiClient.post).toHaveBeenCalledTimes(1);
+    expect(capturedBody.read_level).toBe("index_and_bounded_wal");
+
     // Test without readLevel (should be undefined)
     mockApiClient.post.mockClear();
     await collection.search(

--- a/docs/scripts/generate_ts_reference.ts
+++ b/docs/scripts/generate_ts_reference.ts
@@ -23,8 +23,8 @@ const TYPE_SIMPLIFICATIONS: Record<string, string> = {
   "number[][]": "Embeddings",
   "number[]": "Embedding",
   "Record<string, boolean | number | string | SparseVector | null>": "Metadata",
-  "(ReadLevel)[keyof ReadLevel]": '"index_and_wal" | "index_only"',
-  "(typeof ReadLevel)[keyof typeof ReadLevel]": '"index_and_wal" | "index_only"',
+  "(ReadLevel)[keyof ReadLevel]": '"index_and_wal" | "index_only" | "index_and_bounded_wal"',
+  "(typeof ReadLevel)[keyof typeof ReadLevel]": '"index_and_wal" | "index_only" | "index_and_bounded_wal"',
 };
 
 // =============================================================================

--- a/rust/chroma/src/collection.rs
+++ b/rust/chroma/src/collection.rs
@@ -178,6 +178,8 @@ impl ChromaCollection {
     ///     All committed writes will be visible.
     ///   - [`ReadLevel::IndexOnly`] - Read only from the compacted index, skipping the WAL.
     ///     Faster, but recent writes that haven't been compacted may not be visible.
+    ///   - [`ReadLevel::IndexAndBoundedWal`] - Read from the index and up to a server-configured
+    ///     number of WAL entries for bounded query latency.
     ///
     /// # Example
     ///
@@ -572,6 +574,8 @@ impl ChromaCollection {
     ///     All committed writes will be visible.
     ///   - [`ReadLevel::IndexOnly`] - Read only from the compacted index, skipping the WAL.
     ///     Faster, but recent writes that haven't been compacted may not be visible.
+    ///   - [`ReadLevel::IndexAndBoundedWal`] - Read from the index and up to a server-configured
+    ///     number of WAL entries for bounded query latency.
     ///
     /// # Example
     ///
@@ -1483,12 +1487,22 @@ mod tests {
             // IndexOnly may omit recent WAL writes; just ensure the call succeeds
             // and the response structure matches the requested payload.
             let index_only = collection
-                .search_with_options(vec![search], ReadLevel::IndexOnly)
+                .search_with_options(vec![search.clone()], ReadLevel::IndexOnly)
                 .await
                 .unwrap();
             assert_eq!(index_only.ids.len(), 1);
             assert!(index_only.documents[0].is_some());
             assert!(index_only.scores[0].is_some());
+
+            // IndexAndBoundedWal reads up to a server-configured number of WAL entries;
+            // just ensure the call succeeds and the response structure is valid.
+            let bounded = collection
+                .search_with_options(vec![search], ReadLevel::IndexAndBoundedWal)
+                .await
+                .unwrap();
+            assert_eq!(bounded.ids.len(), 1);
+            assert!(bounded.documents[0].is_some());
+            assert!(bounded.scores[0].is_some());
         })
         .await;
     }
@@ -1524,6 +1538,13 @@ mod tests {
             // INDEX_ONLY may omit recent WAL writes; just ensure the call succeeds
             let count = collection
                 .count_with_options(ReadLevel::IndexOnly)
+                .await
+                .unwrap();
+            assert!(count <= 3);
+
+            // INDEX_AND_BOUNDED_WAL reads up to a configured limit; just ensure the call succeeds
+            let count = collection
+                .count_with_options(ReadLevel::IndexAndBoundedWal)
                 .await
                 .unwrap();
             assert!(count <= 3);


### PR DESCRIPTION
## Description of changes
Add the `IndexAndBoundedWal` read level variant across all client layers so users can opt into bounded WAL reads. This level reads from the index plus up to a server-configured number of WAL entries, providing bounded query latency while still including recent writes within the limit.
- New functionality
  - Python: `ReadLevel.INDEX_AND_BOUNDED_WAL` enum variant with updated docstrings on `Collection.count()`, `Collection.search()`, and their async counterparts
  - JS: `ReadLevel.INDEX_AND_BOUNDED_WAL` const value with updated JSDoc on `count()` and `search()`
  - Rust SDK: Updated rustdoc on `count_with_options` and `search_with_options`, added `IndexAndBoundedWal` to integration tests
  - Docs: Updated TS reference type simplifications
## Test plan
- [x] Python: `test_count_with_read_level_index_and_bounded_wal` and `test_search_with_read_level_index_and_bounded_wal` acceptance tests
- [x] JS: `INDEX_AND_BOUNDED_WAL` passthrough assertions in `count.test.ts` and `search.expression.test.ts`
- [x] Rust SDK: `IndexAndBoundedWal` cases added to `test_k8s_integration_search_with_read_levels` and `test_k8s_integration_count_with_read_levels`