### PR TITLE
[ENH]: Refactor offset_id to be a mutable AtomicU32 in record

### DIFF
--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -5,7 +5,7 @@ use chroma_types::{
     Operation, Schema, SegmentType, SegmentUuid, UpdateMetadata, UpdateMetadataValue,
 };
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{Instrument, Span};
@@ -144,7 +144,7 @@ pub struct MaterializedLogRecord {
     // in the record segment at which the record was found.
     // If not present in the segment then it is the offset id
     // at which it should be inserted.
-    offset_id: u32,
+    offset_id: AtomicU32,
     // Set only for the records that are being inserted for the first time
     // in the log since data_record will be None in such cases. For other
     // cases, just read from data record.
@@ -185,7 +185,7 @@ impl MaterializedLogRecord {
     fn from_segment_offset_id(offset_id: u32) -> Self {
         Self {
             offset_id_exists_in_segment: true,
-            offset_id,
+            offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: None,
             final_operation: MaterializedLogOperation::Initial,
             metadata_to_be_merged: None,
@@ -232,7 +232,7 @@ impl MaterializedLogRecord {
 
         Ok(Self {
             offset_id_exists_in_segment: false,
-            offset_id,
+            offset_id: AtomicU32::new(offset_id),
             user_id_at_log_index: Some(log_index),
             final_operation: MaterializedLogOperation::AddNew,
             metadata_to_be_merged: merged_metadata,
@@ -253,7 +253,15 @@ pub struct BorrowedMaterializedLogRecord<'log_data> {
 
 impl<'log_data> BorrowedMaterializedLogRecord<'log_data> {
     pub fn get_offset_id(&self) -> u32 {
-        self.materialized_log_record.offset_id
+        self.materialized_log_record
+            .offset_id
+            .load(Ordering::Relaxed)
+    }
+
+    pub fn set_offset_id(&self, id: u32) {
+        self.materialized_log_record
+            .offset_id
+            .store(id, Ordering::Relaxed);
     }
 
     pub fn get_operation(&self) -> MaterializedLogOperation {
@@ -294,7 +302,11 @@ impl<'log_data> BorrowedMaterializedLogRecord<'log_data> {
 
         match record_segment_reader {
             Some(reader) => Ok(reader
-                .get_user_id_for_offset_id(self.materialized_log_record.offset_id)
+                .get_user_id_for_offset_id(
+                    self.materialized_log_record
+                        .offset_id
+                        .load(Ordering::Relaxed),
+                )
                 .await?
                 .to_string()),
             None => Err(LogMaterializerError::RecordSegmentReaderShardRequired),
@@ -311,7 +323,11 @@ impl<'log_data> BorrowedMaterializedLogRecord<'log_data> {
             true => match record_segment_reader {
                 Some(reader) => {
                     reader
-                        .get_data_for_offset_id(self.materialized_log_record.offset_id)
+                        .get_data_for_offset_id(
+                            self.materialized_log_record
+                                .offset_id
+                                .load(Ordering::Relaxed),
+                        )
                         .await?
                 }
                 None => None,
@@ -336,7 +352,9 @@ pub struct HydratedMaterializedLogRecord<'log_data, 'segment_data> {
 
 impl<'log_data, 'segment_data: 'log_data> HydratedMaterializedLogRecord<'log_data, 'segment_data> {
     pub fn get_offset_id(&self) -> u32 {
-        self.materialized_log_record.offset_id
+        self.materialized_log_record
+            .offset_id
+            .load(Ordering::Relaxed)
     }
 
     pub fn get_operation(&self) -> MaterializedLogOperation {
@@ -625,7 +643,7 @@ impl MaterializeLogsResult {
 
         for (record, idx) in self.materialized.iter() {
             if record.final_operation == MaterializedLogOperation::AddNew
-                && record.offset_id >= pivot_offset_id
+                && record.offset_id.load(Ordering::Relaxed) >= pivot_offset_id
             {
                 old_visibility[idx] = false;
                 new_visibility[idx] = true;
@@ -789,7 +807,7 @@ pub async fn materialize_logs(
                                 // Overwrite.
                                 let mut materialized_record =
                                     match MaterializedLogRecord::from_log_record(
-                                        curr_val.offset_id,
+                                        curr_val.offset_id.load(Ordering::Relaxed),
                                         log_index,
                                         log_record,
                                     ) {
@@ -929,7 +947,7 @@ pub async fn materialize_logs(
                                         let curr_val = existing_id_to_materialized.remove(log_record.record.id.as_str()).unwrap();
                                         // Overwrite.
                                         let mut materialized_record =
-                                            match MaterializedLogRecord::from_log_record(curr_val.offset_id, log_index, log_record) {
+                                            match MaterializedLogRecord::from_log_record(curr_val.offset_id.load(Ordering::Relaxed), log_index, log_record) {
                                                 Ok(record) => record,
                                                 Err(e) => {
                                                     return Err(e);
@@ -1044,7 +1062,11 @@ pub async fn materialize_logs(
     for (_key, value) in new_id_to_materialized {
         res.push(value);
     }
-    res.sort_by(|x, y| x.offset_id.cmp(&y.offset_id));
+    res.sort_by(|x, y| {
+        x.offset_id
+            .load(Ordering::Relaxed)
+            .cmp(&y.offset_id.load(Ordering::Relaxed))
+    });
 
     tracing::info!(
         "Log count before materialization: {}, after materialization: {}. Total number of logs in chunk: {}",


### PR DESCRIPTION
## Description of changes

This is to allow the seal operator to eventually reset offset ids in new shards.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
