### PR TITLE
[ENH]: Seal redistributes lower offset ids to prev active shard

### DIFF
--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -577,11 +577,13 @@ impl PartitionedMaterializeLogsResult {
         pivot_offset_id: u32,
         next_new_offset_id: Option<&AtomicU32>,
     ) -> Option<PartitionedMaterializeLogsResult> {
-        let mut new_partitioned = self.clone();
-        let active_shard = new_partitioned.shards.last_mut()?;
-        let new_active_shard = active_shard.split(pivot_offset_id, next_new_offset_id);
-        new_partitioned.shards.push(new_active_shard);
-        Some(new_partitioned)
+        let mut new = self.clone();
+        let new_shard = new
+            .shards
+            .last_mut()?
+            .split(pivot_offset_id, next_new_offset_id);
+        new.shards.push(new_shard);
+        Some(new)
     }
 
     pub fn get_active_record_delta(&self) -> i32 {

--- a/rust/segment/src/types.rs
+++ b/rust/segment/src/types.rs
@@ -572,10 +572,14 @@ impl PartitionedMaterializeLogsResult {
         self.shards.iter().any(|s| s.has_backfill())
     }
 
-    pub fn split(&self, pivot_offset_id: u32) -> Option<PartitionedMaterializeLogsResult> {
+    pub fn split(
+        &self,
+        pivot_offset_id: u32,
+        next_new_offset_id: Option<&AtomicU32>,
+    ) -> Option<PartitionedMaterializeLogsResult> {
         let mut new_partitioned = self.clone();
         let active_shard = new_partitioned.shards.last_mut()?;
-        let new_active_shard = active_shard.split(pivot_offset_id);
+        let new_active_shard = active_shard.split(pivot_offset_id, next_new_offset_id);
         new_partitioned.shards.push(new_active_shard);
         Some(new_partitioned)
     }
@@ -631,7 +635,11 @@ impl MaterializeLogsResult {
         }
     }
 
-    pub fn split(&mut self, pivot_offset_id: u32) -> MaterializeLogsResult {
+    pub fn split(
+        &mut self,
+        pivot_offset_id: u32,
+        next_new_offset_id: Option<&AtomicU32>,
+    ) -> MaterializeLogsResult {
         let mut other_mat_logs = self.clone();
         let mut old_visibility = vec![false; self.materialized.total_len()];
         let mut new_visibility = old_visibility.clone();
@@ -653,11 +661,27 @@ impl MaterializeLogsResult {
         self.materialized.set_visibility(old_visibility);
 
         other_mat_logs.materialized.set_visibility(new_visibility);
+
+        match next_new_offset_id {
+            Some(counter) => {
+                for record in other_mat_logs.iter() {
+                    let id = counter.fetch_add(1, Ordering::SeqCst);
+                    record.set_offset_id(id);
+                }
+            }
+            None => {
+                let mut new_offset_id = 1u32;
+                for record in other_mat_logs.iter() {
+                    record.set_offset_id(new_offset_id);
+                    new_offset_id += 1;
+                }
+            }
+        }
+
         other_mat_logs
     }
 }
 
-// IntoIterator is implemented for &'a MaterializeLogsResult rather than MaterializeLogsResult because the iterator needs to hand out values with a lifetime of 'a.
 impl<'log_data> IntoIterator for &'log_data MaterializeLogsResult {
     type Item = BorrowedMaterializedLogRecord<'log_data>;
     type IntoIter = MaterializeLogsResultIter<'log_data>;

--- a/rust/worker/src/execution/operators/seal_operator.rs
+++ b/rust/worker/src/execution/operators/seal_operator.rs
@@ -1,13 +1,19 @@
-use crate::execution::orchestration::compact::CreateNewShardError;
+use std::collections::BinaryHeap;
+use std::sync::atomic::AtomicU32;
+
 use async_trait::async_trait;
 use chroma_blockstore::provider::BlockfileProvider;
 use chroma_error::ChromaError;
 use chroma_segment::{
-    bloom_filter::BloomFilterManager, spann_provider::SpannProvider,
-    types::PartitionedMaterializeLogsResult,
+    bloom_filter::BloomFilterManager,
+    spann_provider::SpannProvider,
+    types::{MaterializeLogsResultIter, PartitionedMaterializeLogsResult},
 };
 use chroma_system::Operator;
+use chroma_types::MaterializedLogOperation;
 use thiserror::Error;
+
+use crate::execution::orchestration::compact::CreateNewShardError;
 
 #[derive(Error, Debug)]
 pub enum SealOperatorError {
@@ -27,6 +33,36 @@ impl ChromaError for SealOperatorError {
             }
             _ => chroma_error::ErrorCodes::Internal,
         }
+    }
+}
+
+struct PartitionCursor<'a> {
+    offset_id: u32,
+    partition_idx: usize,
+    iter: MaterializeLogsResultIter<'a>,
+}
+
+impl PartialEq for PartitionCursor<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.offset_id == other.offset_id && self.partition_idx == other.partition_idx
+    }
+}
+
+impl Eq for PartitionCursor<'_> {}
+
+impl PartialOrd for PartitionCursor<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PartitionCursor<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Reversed for min-heap: smallest offset_id has highest priority
+        other
+            .offset_id
+            .cmp(&self.offset_id)
+            .then_with(|| other.partition_idx.cmp(&self.partition_idx))
     }
 }
 
@@ -136,9 +172,6 @@ impl Operator<SealInput, SealOutput> for SealOperator {
             });
         }
 
-        // TODO(tanujnay112): Change this to actually calculate a good pivot to move
-        let min_offset_to_move = 0;
-
         tracing::info!(
             "Active shard overflow detected: {} + {} > {} with {} excess records. Creating new active shard",
             active_shard_record_count,
@@ -157,8 +190,11 @@ impl Operator<SealInput, SealOutput> for SealOperator {
             )
             .await?;
 
-        let new_shard_outputs =
-            split_materialized_outputs(&input.materialized_outputs, min_offset_to_move)?;
+        // Use count-based split to move exactly the excess records to the new shard
+        let new_shard_outputs = split_materialized_outputs_by_count(
+            &input.materialized_outputs,
+            excess_record_count as usize,
+        )?;
 
         Ok(SealOutput {
             sealed_writers,
@@ -167,18 +203,112 @@ impl Operator<SealInput, SealOutput> for SealOperator {
     }
 }
 
+fn split_materialized_outputs_by_count(
+    outputs: &[PartitionedMaterializeLogsResult],
+    count_to_move: usize,
+) -> Result<Vec<PartitionedMaterializeLogsResult>, SealOperatorError> {
+    // MaterializeLogsResult::split moves AddNew records with offset_id >= pivot to the new
+    // shard. Since AddNew records are assigned monotonically increasing offset_ids, the HIGHEST
+    // offsets move and the lowest stay. To move exactly `count_to_move` records, we therefore
+    // need to identify the pivot as the offset_id of the first AddNew record that should move,
+    // i.e. skip the `count_to_stay` lowest-offset AddNew records, then pivot on the next.
+    //
+    // Algorithm:
+    // 1. Count total AddNew records across all partitions' active shards.
+    // 2. count_to_stay = total_add_new - count_to_move (clamped to 0).
+    // 3. Initialize PQ with first AddNew from each partition, pop `count_to_stay` records
+    //    (smallest offset_ids), and set pivot = next AddNew offset_id.
+
+    let total_add_new: usize = outputs
+        .iter()
+        .filter_map(|p| p.shards.last())
+        .map(|shard| {
+            shard
+                .iter()
+                .filter(|r| r.get_operation() == MaterializedLogOperation::AddNew)
+                .count()
+        })
+        .sum();
+
+    let count_to_stay = total_add_new.saturating_sub(count_to_move);
+
+    let mut pq = BinaryHeap::new();
+
+    for (partition_idx, partition) in outputs.iter().enumerate() {
+        if let Some(active_shard) = partition.shards.last() {
+            let mut iter = active_shard.iter();
+            if let Some(first_record) = next_add_new(&mut iter) {
+                pq.push(PartitionCursor {
+                    offset_id: first_record.get_offset_id(),
+                    partition_idx,
+                    iter,
+                });
+            }
+        }
+    }
+
+    if pq.is_empty() {
+        return Err(SealOperatorError::InvariantViolation(format!(
+            "No movable records in active shards, but count_to_move = {count_to_move}",
+        )));
+    }
+
+    if count_to_stay == 0 {
+        let pivot = pq.peek().map(|c| c.offset_id).unwrap_or(u32::MAX);
+        return split_materialized_outputs(outputs, pivot);
+    }
+
+    let mut records_processed = 0;
+
+    let pivot_offset_id = loop {
+        let Some(mut cursor) = pq.pop() else {
+            return Err(SealOperatorError::InvariantViolation(format!(
+                "Exhausted all records after {records_processed} but needed to keep {count_to_stay}",
+            )));
+        };
+
+        records_processed += 1;
+
+        if records_processed == count_to_stay {
+            let next_from_same = next_add_new(&mut cursor.iter).map(|r| r.get_offset_id());
+            let next_from_pq = pq.peek().map(|c| c.offset_id);
+            break next_from_same
+                .into_iter()
+                .chain(next_from_pq)
+                .min()
+                .unwrap_or(u32::MAX);
+        }
+
+        if let Some(next_record) = next_add_new(&mut cursor.iter) {
+            cursor.offset_id = next_record.get_offset_id();
+            pq.push(cursor);
+        }
+    };
+
+    split_materialized_outputs(outputs, pivot_offset_id)
+}
+
+fn next_add_new<'a>(
+    iter: &mut MaterializeLogsResultIter<'a>,
+) -> Option<chroma_segment::types::BorrowedMaterializedLogRecord<'a>> {
+    iter.find(|r| r.get_operation() == MaterializedLogOperation::AddNew)
+}
+
 fn split_materialized_outputs(
     outputs: &[PartitionedMaterializeLogsResult],
     pivot_offset_id: u32,
 ) -> Result<Vec<PartitionedMaterializeLogsResult>, SealOperatorError> {
     let mut new_shard_results = Vec::new();
+    let next_new_offset_id = AtomicU32::new(1);
 
     for output_partition in outputs {
-        let new_partition = output_partition.split(pivot_offset_id).ok_or_else(|| {
-            SealOperatorError::InvariantViolation(
-                "Failed to split partition: no shards found".to_string(),
-            )
-        })?;
+        let new_partition = output_partition
+            .split(pivot_offset_id, Some(&next_new_offset_id))
+            .ok_or_else(|| {
+                SealOperatorError::InvariantViolation(
+                    "Failed to split partition: no shards found".to_string(),
+                )
+            })?;
         new_shard_results.push(new_partition);
     }
 

--- a/rust/worker/src/execution/operators/seal_operator.rs
+++ b/rust/worker/src/execution/operators/seal_operator.rs
@@ -120,6 +120,13 @@ pub struct SealOutput {
     pub split_materialized_outputs: Vec<PartitionedMaterializeLogsResult>,
 }
 
+/// Implementation of the SealOperator.
+///
+/// IMPORTANT: This operator assumes it will create at most one new shard during the sealing
+/// process. It does not perform recursive splitting - if the active shard exceeds the configured
+/// shard size, it will only split once, moving overflow records into a single new shard.
+/// The new shard may itself exceed the shard size limit, but further splitting would require
+/// another compaction cycle.
 #[async_trait]
 impl Operator<SealInput, SealOutput> for SealOperator {
     type Error = SealOperatorError;
@@ -235,9 +242,15 @@ fn split_materialized_outputs_by_count(
     let mut pq = BinaryHeap::new();
 
     for (partition_idx, partition) in outputs.iter().enumerate() {
+        debug_assert!(
+            !partition.shards.is_empty(),
+            "Partition {} has no shards - this is an invariant violation",
+            partition_idx
+        );
+
         if let Some(active_shard) = partition.shards.last() {
             let mut iter = active_shard.iter();
-            if let Some(first_record) = next_add_new(&mut iter) {
+            if let Some(first_record) = advance_to_next_add_new(&mut iter) {
                 pq.push(PartitionCursor {
                     offset_id: first_record.get_offset_id(),
                     partition_idx,
@@ -269,17 +282,12 @@ fn split_materialized_outputs_by_count(
 
         records_processed += 1;
 
-        if records_processed == count_to_stay {
-            let next_from_same = next_add_new(&mut cursor.iter).map(|r| r.get_offset_id());
-            let next_from_pq = pq.peek().map(|c| c.offset_id);
-            break next_from_same
-                .into_iter()
-                .chain(next_from_pq)
-                .min()
-                .unwrap_or(u32::MAX);
+        if records_processed > count_to_stay {
+            // This cursor's offset_id is the pivot - it's the first record to be moved
+            break cursor.offset_id;
         }
 
-        if let Some(next_record) = next_add_new(&mut cursor.iter) {
+        if let Some(next_record) = advance_to_next_add_new(&mut cursor.iter) {
             cursor.offset_id = next_record.get_offset_id();
             pq.push(cursor);
         }
@@ -288,7 +296,7 @@ fn split_materialized_outputs_by_count(
     split_materialized_outputs(outputs, pivot_offset_id)
 }
 
-fn next_add_new<'a>(
+fn advance_to_next_add_new<'a>(
     iter: &mut MaterializeLogsResultIter<'a>,
 ) -> Option<chroma_segment::types::BorrowedMaterializedLogRecord<'a>> {
     iter.find(|r| r.get_operation() == MaterializedLogOperation::AddNew)

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1029,7 +1029,8 @@ pub async fn compact(
 #[cfg(test)]
 mod tests {
     use chroma_log::test::{
-        add_delete_net_zero_generator, upsert_generator, TEST_EMBEDDING_DIMENSION,
+        add_delete_generator, add_delete_net_zero_generator, upsert_generator,
+        TEST_EMBEDDING_DIMENSION,
     };
     use chroma_types::{DatabaseName, SegmentScope, SegmentType};
     use std::collections::{HashMap, HashSet};
@@ -1048,7 +1049,7 @@ mod tests {
     use chroma_index::{hnsw_provider::HnswIndexProvider, spann::types::GarbageCollectionContext};
     use chroma_log::{
         in_memory_log::{InMemoryLog, InternalLogRecord},
-        test::{add_delete_generator, LogGenerator},
+        test::LogGenerator,
         Log,
     };
     use chroma_segment::{
@@ -1061,7 +1062,7 @@ mod tests {
     use chroma_types::{
         operator::{Filter, Limit, Projection, ProjectionRecord},
         Collection, DocumentExpression, DocumentOperator, MetadataExpression, PrimitiveOperator,
-        Segment, SegmentShard, SegmentType, SegmentUuid, Where,
+        Segment, SegmentShard, SegmentUuid, Where,
     };
     use futures::TryStreamExt;
     use regex::Regex;
@@ -3673,12 +3674,11 @@ mod tests {
                 system.clone(),
                 collection_id,
                 database_name.clone(),
-                false,          // No rebuild
-                HashSet::new(), // No segment scopes
-                1,              // fetch_log_batch_size
-                10,             // fetch_log_concurrency
-                1000,           // max_compaction_size - reduced to below shard size
-                10,             // max_partition_size
+                None, // No rebuild
+                1,    // fetch_log_batch_size
+                10,   // fetch_log_concurrency
+                1000, // max_compaction_size - reduced to below shard size
+                10,   // max_partition_size
                 Log::InMemory(in_memory_log.clone()),
                 sysdb.clone(),
                 test_segments.blockfile_provider.clone(),

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1018,7 +1018,7 @@ mod tests {
     use chroma_log::test::{
         add_delete_net_zero_generator, upsert_generator, TEST_EMBEDDING_DIMENSION,
     };
-    use chroma_types::DatabaseName;
+    use chroma_types::{DatabaseName, SegmentType};
     use std::collections::{HashMap, HashSet};
 
     use chroma_blockstore::arrow::config::{BlockManagerConfig, TEST_MAX_BLOCK_SIZE_BYTES};
@@ -3555,6 +3555,209 @@ mod tests {
         )
         .await;
         assert_eq!(old_records, new_records);
+    }
+
+    #[tokio::test]
+    async fn test_seal_with_sharding() {
+        let config = RootConfig::default();
+        let system = System::default();
+        let registry = Registry::new();
+        let dispatcher = Dispatcher::try_from_config(&config.query_service.dispatcher, &registry)
+            .await
+            .expect("Should be able to initialize dispatcher");
+        let dispatcher_handle = system.start_component(dispatcher);
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+
+        // Create test segments with SPANN configuration (dimension 6 for add_delete_generator)
+        let mut test_segments = TestDistributedSegment::new_with_dimension(6).await;
+
+        // Configure collection for SPANN
+        test_segments.collection.config =
+            chroma_types::InternalCollectionConfiguration::default_spann();
+        test_segments.collection.schema = Some(
+            chroma_types::Schema::try_from(&test_segments.collection.config)
+                .expect("Should be able to create schema from config"),
+        );
+
+        // Change vector segment to SPANN type
+        test_segments.vector_segment.r#type = SegmentType::Spann;
+
+        let collection_id = test_segments.collection.collection_id;
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
+
+        // Create collection with SPANN configuration
+        sysdb
+            .create_collection(
+                test_segments.collection.tenant.clone(),
+                database_name.clone(),
+                collection_id,
+                test_segments.collection.name.clone(),
+                vec![
+                    test_segments.record_segment.clone(),
+                    test_segments.metadata_segment.clone(),
+                    test_segments.vector_segment.clone(),
+                ],
+                Some(test_segments.collection.config.clone()),
+                Some(test_segments.collection.schema.clone().unwrap()),
+                None,
+                Some(6),
+                false,
+            )
+            .await
+            .expect("Collection create should be successful");
+
+        let mut in_memory_log = InMemoryLog::new();
+        let mut log_offset = 0i64;
+
+        // Insert records in two batches and compact after each to create 2 shards
+        for batch_num in 0..2 {
+            let start = batch_num * 120;
+            let end = (batch_num + 1) * 120;
+            let batch_logs: Vec<_> = add_delete_generator.generate_vec(start..=end);
+
+            batch_logs.into_iter().for_each(|log| {
+                in_memory_log.add_log(
+                    collection_id,
+                    InternalLogRecord {
+                        collection_id,
+                        log_offset,
+                        log_ts: log_offset + 1,
+                        record: log,
+                    },
+                );
+                log_offset += 1;
+            });
+
+            // Compact after each batch to create one shard at a time
+            let compact_result = Box::pin(compact(
+                system.clone(),
+                collection_id,
+                database_name.clone(),
+                false,          // No rebuild
+                HashSet::new(), // No segment scopes
+                1,              // fetch_log_batch_size
+                10,             // fetch_log_concurrency
+                1000,           // max_compaction_size - reduced to below shard size
+                10,             // max_partition_size
+                Log::InMemory(in_memory_log.clone()),
+                sysdb.clone(),
+                test_segments.blockfile_provider.clone(),
+                test_segments.hnsw_provider.clone(),
+                test_segments.spann_provider.clone(),
+                dispatcher_handle.clone(),
+                false,
+                None,
+                None,
+                Some(150), // Shard size 50 to create 1 shard per batch
+                None,
+            ))
+            .await;
+            assert!(
+                compact_result.is_ok(),
+                "Compaction batch {} failed: {:?}",
+                batch_num,
+                compact_result.err()
+            );
+        }
+
+        let collection = sysdb
+            .get_collection_with_segments(None, collection_id)
+            .await
+            .expect("Should get collection with segments");
+
+        let mut shard_offset_ids: Vec<Vec<u32>> = Vec::new();
+        let mut max_shard_offset_ids: Vec<u32> = Vec::new();
+        for shard in collection
+            .record_segment
+            .get_shards()
+            .expect("Should get shards")
+        {
+            let shard_reader = Box::pin(RecordSegmentReaderShard::from_segment(
+                &shard,
+                &test_segments.blockfile_provider,
+                None,
+            ))
+            .await
+            .expect("Should create shard reader");
+            let offset_stream = shard_reader.get_offset_stream(..);
+            let offset_ids: Vec<u32> = offset_stream
+                .try_collect()
+                .await
+                .expect("Should collect offset ids");
+            shard_offset_ids.push(offset_ids);
+
+            let max_offset_id = shard_reader.get_max_offset_id();
+            max_shard_offset_ids.push(max_offset_id);
+        }
+
+        println!("offset ids: {:?}", shard_offset_ids);
+        println!("max offset ids: {:?}", max_shard_offset_ids);
+
+        assert_eq!(max_shard_offset_ids, vec![190, 10]);
+
+        // Two batches of 121 logs each under add_delete_generator = 242 log entries:
+        //   - 200 add ops (offsets not divisible by 6) producing ids id_1..id_200
+        //   - 42 delete ops (offsets divisible by 6) targeting id_0..id_40, of which 2 are
+        //     no-ops: id_0 is never added, and id_20 is deleted once per batch (offset 120
+        //     appears in both ranges).
+        // Net: 200 adds - 40 effective deletes = 160 live records.
+        // With shard_size = 150, seal must cap the first (existing) shard at exactly 150 and
+        // spill the remaining 10 into a new shard.
+        const SHARD_SIZE: usize = 150;
+        const EXPECTED_TOTAL_LIVE_RECORDS: usize = 160;
+        const EXPECTED_SPILLOVER: usize = EXPECTED_TOTAL_LIVE_RECORDS - SHARD_SIZE;
+
+        assert_eq!(
+            shard_offset_ids.len(),
+            2,
+            "Expected exactly 2 shards after seal; got {}",
+            shard_offset_ids.len()
+        );
+
+        assert_eq!(
+            shard_offset_ids[0].len(),
+            SHARD_SIZE,
+            "Active shard should be capped at shard_size = {SHARD_SIZE}; got {}",
+            shard_offset_ids[0].len()
+        );
+
+        assert_eq!(
+            shard_offset_ids[1].len(),
+            EXPECTED_SPILLOVER,
+            "New shard should contain the spillover of {EXPECTED_SPILLOVER} records; got {}",
+            shard_offset_ids[1].len()
+        );
+
+        let total_live: usize = shard_offset_ids.iter().map(|s| s.len()).sum();
+        assert_eq!(
+            total_live, EXPECTED_TOTAL_LIVE_RECORDS,
+            "Total live records across shards should be {EXPECTED_TOTAL_LIVE_RECORDS}; got {total_live}",
+        );
+
+        for (idx, offsets) in shard_offset_ids.iter().enumerate() {
+            assert!(
+                offsets.len() <= SHARD_SIZE,
+                "Shard {idx} exceeds shard_size cap: {} > {SHARD_SIZE}",
+                offsets.len()
+            );
+            assert!(
+                offsets.windows(2).all(|w| w[0] < w[1]),
+                "Shard {idx} offset ids are not strictly increasing"
+            );
+        }
+
+        // Every offset_id in the new (spillover) shard must be strictly greater than all
+        // offsets that stayed in the active shard in their ORIGINAL (pre-renumbering) space.
+        // Post-split, the new shard renumbers offsets starting from 1, so here we only
+        // assert the new shard's renumbered ids form a contiguous [1, EXPECTED_SPILLOVER]
+        // range as a sanity check.
+        assert_eq!(
+            shard_offset_ids[1],
+            (1u32..=EXPECTED_SPILLOVER as u32).collect::<Vec<_>>(),
+            "New shard should have contiguous renumbered offset ids starting from 1"
+        );
     }
 
     /// Test that rebuilding a collection also rebuilds its attached function's output collection.

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -1031,7 +1031,7 @@ mod tests {
     use chroma_log::test::{
         add_delete_net_zero_generator, upsert_generator, TEST_EMBEDDING_DIMENSION,
     };
-    use chroma_types::{DatabaseName, SegmentScope};
+    use chroma_types::{DatabaseName, SegmentScope, SegmentType};
     use std::collections::{HashMap, HashSet};
 
     use crate::{
@@ -3593,6 +3593,209 @@ mod tests {
         )
         .await;
         assert_eq!(old_records, new_records);
+    }
+
+    #[tokio::test]
+    async fn test_seal_with_sharding() {
+        let config = RootConfig::default();
+        let system = System::default();
+        let registry = Registry::new();
+        let dispatcher = Dispatcher::try_from_config(&config.query_service.dispatcher, &registry)
+            .await
+            .expect("Should be able to initialize dispatcher");
+        let dispatcher_handle = system.start_component(dispatcher);
+        let mut sysdb = SysDb::Test(TestSysDb::new());
+
+        // Create test segments with SPANN configuration (dimension 6 for add_delete_generator)
+        let mut test_segments = TestDistributedSegment::new_with_dimension(6).await;
+
+        // Configure collection for SPANN
+        test_segments.collection.config =
+            chroma_types::InternalCollectionConfiguration::default_spann();
+        test_segments.collection.schema = Some(
+            chroma_types::Schema::try_from(&test_segments.collection.config)
+                .expect("Should be able to create schema from config"),
+        );
+
+        // Change vector segment to SPANN type
+        test_segments.vector_segment.r#type = SegmentType::Spann;
+
+        let collection_id = test_segments.collection.collection_id;
+        let database_name =
+            chroma_types::DatabaseName::new(test_segments.collection.database.clone())
+                .expect("database name should be valid");
+
+        // Create collection with SPANN configuration
+        sysdb
+            .create_collection(
+                test_segments.collection.tenant.clone(),
+                database_name.clone(),
+                collection_id,
+                test_segments.collection.name.clone(),
+                vec![
+                    test_segments.record_segment.clone(),
+                    test_segments.metadata_segment.clone(),
+                    test_segments.vector_segment.clone(),
+                ],
+                Some(test_segments.collection.config.clone()),
+                Some(test_segments.collection.schema.clone().unwrap()),
+                None,
+                Some(6),
+                false,
+            )
+            .await
+            .expect("Collection create should be successful");
+
+        let mut in_memory_log = InMemoryLog::new();
+        let mut log_offset = 0i64;
+
+        // Insert records in two batches and compact after each to create 2 shards
+        for batch_num in 0..2 {
+            let start = batch_num * 120;
+            let end = (batch_num + 1) * 120;
+            let batch_logs: Vec<_> = add_delete_generator.generate_vec(start..=end);
+
+            batch_logs.into_iter().for_each(|log| {
+                in_memory_log.add_log(
+                    collection_id,
+                    InternalLogRecord {
+                        collection_id,
+                        log_offset,
+                        log_ts: log_offset + 1,
+                        record: log,
+                    },
+                );
+                log_offset += 1;
+            });
+
+            // Compact after each batch to create one shard at a time
+            let compact_result = Box::pin(compact(
+                system.clone(),
+                collection_id,
+                database_name.clone(),
+                false,          // No rebuild
+                HashSet::new(), // No segment scopes
+                1,              // fetch_log_batch_size
+                10,             // fetch_log_concurrency
+                1000,           // max_compaction_size - reduced to below shard size
+                10,             // max_partition_size
+                Log::InMemory(in_memory_log.clone()),
+                sysdb.clone(),
+                test_segments.blockfile_provider.clone(),
+                test_segments.hnsw_provider.clone(),
+                test_segments.spann_provider.clone(),
+                dispatcher_handle.clone(),
+                false,
+                None,
+                None,
+                Some(150), // Shard size 50 to create 1 shard per batch
+                None,
+            ))
+            .await;
+            assert!(
+                compact_result.is_ok(),
+                "Compaction batch {} failed: {:?}",
+                batch_num,
+                compact_result.err()
+            );
+        }
+
+        let collection = sysdb
+            .get_collection_with_segments(None, collection_id)
+            .await
+            .expect("Should get collection with segments");
+
+        let mut shard_offset_ids: Vec<Vec<u32>> = Vec::new();
+        let mut max_shard_offset_ids: Vec<u32> = Vec::new();
+        for shard in collection
+            .record_segment
+            .get_shards()
+            .expect("Should get shards")
+        {
+            let shard_reader = Box::pin(RecordSegmentReaderShard::from_segment(
+                &shard,
+                &test_segments.blockfile_provider,
+                None,
+            ))
+            .await
+            .expect("Should create shard reader");
+            let offset_stream = shard_reader.get_offset_stream(..);
+            let offset_ids: Vec<u32> = offset_stream
+                .try_collect()
+                .await
+                .expect("Should collect offset ids");
+            shard_offset_ids.push(offset_ids);
+
+            let max_offset_id = shard_reader.get_max_offset_id();
+            max_shard_offset_ids.push(max_offset_id);
+        }
+
+        println!("offset ids: {:?}", shard_offset_ids);
+        println!("max offset ids: {:?}", max_shard_offset_ids);
+
+        assert_eq!(max_shard_offset_ids, vec![190, 10]);
+
+        // Two batches of 121 logs each under add_delete_generator = 242 log entries:
+        //   - 200 add ops (offsets not divisible by 6) producing ids id_1..id_200
+        //   - 42 delete ops (offsets divisible by 6) targeting id_0..id_40, of which 2 are
+        //     no-ops: id_0 is never added, and id_20 is deleted once per batch (offset 120
+        //     appears in both ranges).
+        // Net: 200 adds - 40 effective deletes = 160 live records.
+        // With shard_size = 150, seal must cap the first (existing) shard at exactly 150 and
+        // spill the remaining 10 into a new shard.
+        const SHARD_SIZE: usize = 150;
+        const EXPECTED_TOTAL_LIVE_RECORDS: usize = 160;
+        const EXPECTED_SPILLOVER: usize = EXPECTED_TOTAL_LIVE_RECORDS - SHARD_SIZE;
+
+        assert_eq!(
+            shard_offset_ids.len(),
+            2,
+            "Expected exactly 2 shards after seal; got {}",
+            shard_offset_ids.len()
+        );
+
+        assert_eq!(
+            shard_offset_ids[0].len(),
+            SHARD_SIZE,
+            "Active shard should be capped at shard_size = {SHARD_SIZE}; got {}",
+            shard_offset_ids[0].len()
+        );
+
+        assert_eq!(
+            shard_offset_ids[1].len(),
+            EXPECTED_SPILLOVER,
+            "New shard should contain the spillover of {EXPECTED_SPILLOVER} records; got {}",
+            shard_offset_ids[1].len()
+        );
+
+        let total_live: usize = shard_offset_ids.iter().map(|s| s.len()).sum();
+        assert_eq!(
+            total_live, EXPECTED_TOTAL_LIVE_RECORDS,
+            "Total live records across shards should be {EXPECTED_TOTAL_LIVE_RECORDS}; got {total_live}",
+        );
+
+        for (idx, offsets) in shard_offset_ids.iter().enumerate() {
+            assert!(
+                offsets.len() <= SHARD_SIZE,
+                "Shard {idx} exceeds shard_size cap: {} > {SHARD_SIZE}",
+                offsets.len()
+            );
+            assert!(
+                offsets.windows(2).all(|w| w[0] < w[1]),
+                "Shard {idx} offset ids are not strictly increasing"
+            );
+        }
+
+        // Every offset_id in the new (spillover) shard must be strictly greater than all
+        // offsets that stayed in the active shard in their ORIGINAL (pre-renumbering) space.
+        // Post-split, the new shard renumbers offsets starting from 1, so here we only
+        // assert the new shard's renumbered ids form a contiguous [1, EXPECTED_SPILLOVER]
+        // range as a sanity check.
+        assert_eq!(
+            shard_offset_ids[1],
+            (1u32..=EXPECTED_SPILLOVER as u32).collect::<Vec<_>>(),
+            "New shard should have contiguous renumbered offset ids starting from 1"
+        );
     }
 
     /// Test that rebuilding a collection also rebuilds its attached function's output collection.


### PR DESCRIPTION
## Description of changes

This change adjusts seal operators splitting logic to redistribute new records across the remaining space in the previously active segment and the new active segment while resetting the offset ids of those in the new active segment.

This allows new shard to reclaim ids in the offset id space.

- Improvements & Bug fixes
    - ...
- New functionality
    - ...

## Test plan

A test has been added in compact.rs.

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the_ [_docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_