### PR TITLE
[ENH] Validate path type in PersistentClient to produce a clear error

### DIFF
--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -214,6 +214,14 @@ def PersistentClient(
     Returns:
         ClientAPI: A configured client instance.
     """
+    if not isinstance(path, (str, Path)):
+        raise TypeError(
+            f"PersistentClient(path=...) expects a str or pathlib.Path, "
+            f"got {type(path).__name__}. "
+            f"Hint: if you passed a config dict, pass the path string explicitly, "
+            f"e.g. PersistentClient(path=config['chroma_dir'])."
+        )
+
     if settings is None:
         settings = Settings()
     settings.persist_directory = str(path)


### PR DESCRIPTION
## What

`PersistentClient(path=...)` currently accepts any value and coerces it via `str(path)`. When a caller accidentally passes something that isn't a path (e.g. a config dict), the call appears to succeed until ChromaDB tries to touch the filesystem, at which point it fails with:

```
chromadb.errors.InternalError: File name too long (os error 36)
```

…because `str({'some': 'dict'})` is a perfectly valid Python string, just a useless one as a filesystem path.

## Why

The type annotation already says `Union[str, Path]`, so enforcing it at the boundary costs nothing and prevents a frustrating downstream error. The current failure mode is especially confusing because the exception comes from the Rust bindings layer and doesn't mention the original `path` argument.

## Change

One `isinstance` check in `PersistentClient`:

```python
if not isinstance(path, (str, Path)):
    raise TypeError(
        f"PersistentClient(path=...) expects a str or pathlib.Path, "
        f"got {type(path).__name__}. ..."
    )
```

Clear error with a hint pointing at the most common cause (passing a dict).

## Tests

Happy to add a test if you'd like — easy one-liner asserting `TypeError` is raised for `PersistentClient(path={"foo": "bar"})`. Didn't include one by default since the rest of this function isn't unit-tested at that layer.

## How I hit this

Building an OpenMW (Morrowind game engine) mod that gives NPCs per-NPC ChromaDB memory. I passed my whole config dict to the wrapper by mistake, the "File name too long" error was not an obvious lead, and I only found the real cause by reading the source. Thought I'd shorten that path for the next person.