### PR TITLE
[DOC] Update link in schema-basics.mdx for Search API

### DIFF
--- a/docs/mintlify/cloud/schema/schema-basics.mdx
+++ b/docs/mintlify/cloud/schema/schema-basics.mdx
@@ -44,7 +44,7 @@ Chroma uses two reserved key names:
 **`K.EMBEDDING`** (`#embedding`) stores dense vector embeddings with Vector Index enabled, sourcing from `K.DOCUMENT`. This enables semantic similarity search.
 
 <Callout>
-Use `K.DOCUMENT` and `K.EMBEDDING` in your code (they correspond to internal keys `#document` and `#embedding`). These special keys are automatically configured and cannot be manually modified. See the [Search API field reference](../search-api/search-basics#constructor-parameters) for more details.
+Use `K.DOCUMENT` and `K.EMBEDDING` in your code (they correspond to internal keys `#document` and `#embedding`). These special keys are automatically configured and cannot be manually modified. See the [Search API field reference](../search-api/pagination-selection#selectable-fields) for more details.
 </Callout>
 
 ### Example: Using Defaults

--- a/docs/mintlify/cloud/schema/schema-basics.mdx
+++ b/docs/mintlify/cloud/schema/schema-basics.mdx
@@ -44,7 +44,7 @@ Chroma uses two reserved key names:
 **`K.EMBEDDING`** (`#embedding`) stores dense vector embeddings with Vector Index enabled, sourcing from `K.DOCUMENT`. This enables semantic similarity search.
 
 <Callout>
-Use `K.DOCUMENT` and `K.EMBEDDING` in your code (they correspond to internal keys `#document` and `#embedding`). These special keys are automatically configured and cannot be manually modified. See the [Search API field reference](../search-api/pagination-selection#available-fields) for more details.
+Use `K.DOCUMENT` and `K.EMBEDDING` in your code (they correspond to internal keys `#document` and `#embedding`). These special keys are automatically configured and cannot be manually modified. See the [Search API field reference](../search-api/search-basics#constructor-parameters) for more details.
 </Callout>
 
 ### Example: Using Defaults


### PR DESCRIPTION
## Description of changes
Updates the Search API reference link in schema-basics.mdx to point to the correct and more relevant section.

### Changes
- Replaced outdated link:
`../search-api/pagination-selection#available-fields`
- Updated to:
`../search-api/pagination-selection#selectable-fields`

The previous link pointed to a less relevant section for understanding Search API fields. The updated link directs users to the correct section, improving clarity and navigation within the documentation.

Improves documentation accuracy and user experience. No functional changes.