### PR TITLE
[BUG] Replace unsafe pickle.load() with SafeUnpickler (CWE-502)

### DIFF
--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -70,9 +70,17 @@ class PersistentData:
 
     @staticmethod
     def load_from_file(filename: str) -> "PersistentData":
-        """Load persistent data from a file"""
+        """Load persistent data from a file using SafeUnpickler to prevent arbitrary code execution (CWE-502)"""
+        class SafeUnpickler(pickle.Unpickler):
+            ALLOWED_CLASSES = {
+                ("chromadb.segment.impl.vector.local_persistent_hnsw", "PersistentData"),
+            }
+            def find_class(self, module, name):
+                if (module, name) not in self.ALLOWED_CLASSES:
+                    raise pickle.UnpicklingError(f"Forbidden: {module}.{name}")
+                return super().find_class(module, name)
         with open(filename, "rb") as f:
-            ret = cast(PersistentData, pickle.load(f))
+            ret = cast(PersistentData, SafeUnpickler(f).load())
             return ret
 
 

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -74,6 +74,13 @@ class PersistentData:
         class SafeUnpickler(pickle.Unpickler):
             ALLOWED_CLASSES = {
                 ("chromadb.segment.impl.vector.local_persistent_hnsw", "PersistentData"),
+                ("builtins", "dict"),
+                ("builtins", "list"),
+                ("builtins", "int"),
+                ("builtins", "str"),
+                ("builtins", "float"),
+                ("builtins", "bool"),
+                ("builtins", "bytes"),
             }
             def find_class(self, module, name):
                 if (module, name) not in self.ALLOWED_CLASSES:

--- a/chromadb/segment/impl/vector/local_persistent_hnsw.py
+++ b/chromadb/segment/impl/vector/local_persistent_hnsw.py
@@ -40,7 +40,23 @@ from chromadb.utils.read_write_lock import ReadRWLock, WriteRWLock
 
 logger = logging.getLogger(__name__)
 
+class SafeUnpickler(pickle.Unpickler):
+    """Restricts unpickling to allowed classes only, preventing arbitrary code execution (CWE-502)"""
+    ALLOWED_CLASSES = {
+        ("chromadb.segment.impl.vector.local_persistent_hnsw", "PersistentData"),
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "int"),
+        ("builtins", "str"),
+        ("builtins", "float"),
+        ("builtins", "bool"),
+        ("builtins", "bytes"),
+    }
 
+    def find_class(self, module, name):
+        if (module, name) not in self.ALLOWED_CLASSES:
+            raise pickle.UnpicklingError(f"Forbidden: {module}.{name}")
+        return super().find_class(module, name)
 class PersistentData:
     """Stores the data and metadata needed for a PersistentLocalHnswSegment"""
 
@@ -71,21 +87,6 @@ class PersistentData:
     @staticmethod
     def load_from_file(filename: str) -> "PersistentData":
         """Load persistent data from a file using SafeUnpickler to prevent arbitrary code execution (CWE-502)"""
-        class SafeUnpickler(pickle.Unpickler):
-            ALLOWED_CLASSES = {
-                ("chromadb.segment.impl.vector.local_persistent_hnsw", "PersistentData"),
-                ("builtins", "dict"),
-                ("builtins", "list"),
-                ("builtins", "int"),
-                ("builtins", "str"),
-                ("builtins", "float"),
-                ("builtins", "bool"),
-                ("builtins", "bytes"),
-            }
-            def find_class(self, module, name):
-                if (module, name) not in self.ALLOWED_CLASSES:
-                    raise pickle.UnpicklingError(f"Forbidden: {module}.{name}")
-                return super().find_class(module, name)
         with open(filename, "rb") as f:
             ret = cast(PersistentData, SafeUnpickler(f).load())
             return ret

--- a/chromadb/test/segment/test_safe_unpickler.py
+++ b/chromadb/test/segment/test_safe_unpickler.py
@@ -1,0 +1,84 @@
+import io
+import os
+import pickle
+import pytest
+
+from chromadb.segment.impl.vector.local_persistent_hnsw import (
+    PersistentData,
+    SafeUnpickler,
+)
+
+
+def test_safe_unpickler_blocks_exploit():
+    """Malicious pickle payload must be rejected (CWE-502)"""
+    class Exploit:
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    buf = io.BytesIO()
+    pickle.dump(Exploit(), buf)
+    buf.seek(0)
+
+    with pytest.raises(pickle.UnpicklingError):
+        SafeUnpickler(buf).load()
+
+
+def test_safe_unpickler_loads_valid_data():
+    """Valid PersistentData must load correctly in memory"""
+    data = PersistentData(
+        dimensionality=128,
+        total_elements_added=10,
+        id_to_label={"abc": 1},
+        label_to_id={1: "abc"},
+        id_to_seq_id={"abc": 1},
+    )
+
+    buf = io.BytesIO()
+    pickle.dump(data, buf)
+    buf.seek(0)
+
+    result = SafeUnpickler(buf).load()
+    assert result.dimensionality == 128
+    assert result.total_elements_added == 10
+    assert result.id_to_label == {"abc": 1}
+
+
+def test_load_from_file_backward_compatibility(tmp_path):
+    """Test loading a real persisted pickle file from disk - verifies backward compatibility
+    with existing serialized indices as requested in issue #6926"""
+    data = PersistentData(
+        dimensionality=128,
+        total_elements_added=10,
+        id_to_label={"abc": 1, "def": 2},
+        label_to_id={1: "abc", 2: "def"},
+        id_to_seq_id={"abc": 1, "def": 2},
+    )
+
+    # Save to a real file on disk exactly as ChromaDB would
+    filepath = tmp_path / "index_metadata.pickle"
+    with open(filepath, "wb") as f:
+        pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
+
+    # Load using the actual load_from_file method with SafeUnpickler
+    result = PersistentData.load_from_file(str(filepath))
+
+    assert result.dimensionality == 128
+    assert result.total_elements_added == 10
+    assert result.id_to_label == {"abc": 1, "def": 2}
+    assert result.label_to_id == {1: "abc", 2: "def"}
+    assert result.id_to_seq_id == {"abc": 1, "def": 2}
+
+
+def test_load_from_file_blocks_malicious_pickle(tmp_path):
+    """Malicious pickle file on disk must be rejected by load_from_file"""
+    class Exploit:
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    # Write malicious pickle to disk exactly as an attacker would
+    filepath = tmp_path / "index_metadata.pickle"
+    with open(filepath, "wb") as f:
+        pickle.dump(Exploit(), f)
+
+    with pytest.raises(pickle.UnpicklingError):
+        PersistentData.load_from_file(str(filepath))


### PR DESCRIPTION
Fixes #6926
Problem
PersistentData.load_from_file() used pickle.load() to deserialize index metadata, enabling arbitrary code execution via malicious pickle files (CWE-502).
Fix

Replaced pickle.load() with a SafeUnpickler that only allows PersistentData and required primitive types (dict, list, str, int, float, bool, bytes) to be deserialized
Moved SafeUnpickler to module level for cleaner code structure and testability
Confirmed SeqId = int, no numpy types in PersistentData — allowlist is complete

Testing
Added 4 regression tests in chromadb/test/segment/test_safe_unpickler.py:

test_safe_unpickler_blocks_exploit — verifies malicious payload is rejected
test_safe_unpickler_loads_valid_data — verifies valid data loads correctly in memory
test_load_from_file_backward_compatibility — verifies real persisted pickle file loads correctly from disk
test_load_from_file_blocks_malicious_pickle — verifies malicious pickle file on disk is rejected