### PR TITLE
[ENH](spanner-migrations): Add interactive Spanner SQL shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8812,6 +8812,7 @@ dependencies = [
  "regex",
  "rust-embed",
  "serde",
+ "serde_json",
  "sha2",
  "thiserror 1.0.69",
  "tokio",

--- a/rust/spanner-migrations/Cargo.toml
+++ b/rust/spanner-migrations/Cargo.toml
@@ -16,6 +16,7 @@ chroma-config = { workspace = true }
 chroma-types = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { workspace = true }
 thiserror = "1.0"
 google-cloud-spanner = { workspace = true }
 google-cloud-googleapis = { workspace = true }

--- a/rust/spanner-migrations/src/bin/spanner-shell.rs
+++ b/rust/spanner-migrations/src/bin/spanner-shell.rs
@@ -1,6 +1,7 @@
 use std::io::{self, IsTerminal, Read, Write};
 
 use chroma_tracing::{init_global_filter_layer, init_otel_layer, init_stdout_layer, init_tracing};
+use chroma_types::Topology;
 use clap::{Parser, ValueEnum};
 use google_cloud_googleapis::spanner::admin::database::v1::UpdateDatabaseDdlRequest;
 use google_cloud_spanner::admin::client::Client as AdminClient;
@@ -14,6 +15,7 @@ use spanner_migrations::{
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum TargetDatabase {
     Sysdb,
+    #[value(alias = "log")]
     Logdb,
 }
 
@@ -24,6 +26,21 @@ impl TargetDatabase {
             Self::Logdb => "spanner_logdb",
         }
     }
+
+    fn shell_name(self) -> &'static str {
+        match self {
+            Self::Sysdb => "sysdb",
+            Self::Logdb => "log",
+        }
+    }
+
+    fn from_repl_arg(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "sysdb" | "spanner_sysdb" => Some(Self::Sysdb),
+            "log" | "logdb" | "spanner_logdb" => Some(Self::Logdb),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -31,6 +48,13 @@ enum SqlKind {
     Query,
     Dml,
     Ddl,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReplCommand {
+    Help,
+    Quit,
+    SwitchDatabase(TargetDatabase),
 }
 
 #[derive(Debug, Parser)]
@@ -56,12 +80,88 @@ struct Args {
     execute: Option<String>,
 }
 
-struct ShellContext {
+struct ShellConnection {
     client: Client,
     admin_client: AdminClient,
     database_path: String,
-    topology_name: String,
     admin_rpc_timeout_secs: u64,
+}
+
+struct ShellContext {
+    connection: ShellConnection,
+    topology: Topology<TopologySpannerConfig>,
+    topology_name: String,
+    target_database: TargetDatabase,
+}
+
+impl ShellContext {
+    async fn connect(
+        topology: &Topology<TopologySpannerConfig>,
+        target_database: TargetDatabase,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let connection = connect_target(topology, target_database).await?;
+        Ok(Self {
+            connection,
+            topology: topology.clone(),
+            topology_name: topology.name.to_string(),
+            target_database,
+        })
+    }
+
+    fn prompt_label(&self) -> &'static str {
+        self.target_database.shell_name()
+    }
+
+    async fn switch_database(
+        &mut self,
+        target_database: TargetDatabase,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if self.target_database == target_database {
+            println!(
+                "Already connected to {} via {} on {}.",
+                self.target_database.slug(),
+                self.topology_name,
+                self.connection.database_path
+            );
+            return Ok(());
+        }
+
+        let new_connection = connect_target(&self.topology, target_database).await?;
+        let old_connection = std::mem::replace(&mut self.connection, new_connection);
+        self.target_database = target_database;
+        old_connection.client.close().await;
+        println!(
+            "Switched to {} via {} on {}.",
+            self.target_database.slug(),
+            self.topology_name,
+            self.connection.database_path
+        );
+        Ok(())
+    }
+
+    async fn close(self) {
+        self.connection.client.close().await;
+    }
+}
+
+async fn connect_target(
+    topology: &Topology<TopologySpannerConfig>,
+    target_database: TargetDatabase,
+) -> Result<ShellConnection, Box<dyn std::error::Error>> {
+    let spanner_config = match target_database {
+        TargetDatabase::Sysdb => &topology.config.sysdb_spanner,
+        TargetDatabase::Logdb => &topology.config.logdb_spanner,
+    };
+
+    let connected = connect_spanner(spanner_config)
+        .await
+        .map_err(render_connection_error)?;
+    Ok(ShellConnection {
+        client: connected.client,
+        admin_client: connected.admin_client,
+        database_path: connected.database_path,
+        admin_rpc_timeout_secs: connected.admin_rpc_timeout_secs,
+    })
 }
 
 #[tokio::main]
@@ -75,25 +175,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_shell_tracing(&config);
 
     let topology = select_topology(&config.topologies, args.topology.as_deref())?;
-    let spanner_config = match args.database {
-        TargetDatabase::Sysdb => &topology.config.sysdb_spanner,
-        TargetDatabase::Logdb => &topology.config.logdb_spanner,
-    };
-
-    let connected = connect_spanner(spanner_config)
-        .await
-        .map_err(render_connection_error)?;
-    let mut shell = ShellContext {
-        client: connected.client,
-        admin_client: connected.admin_client,
-        database_path: connected.database_path,
-        topology_name: topology.name.to_string(),
-        admin_rpc_timeout_secs: connected.admin_rpc_timeout_secs,
-    };
+    let mut shell = ShellContext::connect(topology, args.database).await?;
 
     if let Some(sql) = args.execute {
         run_statement(&mut shell, &sql).await?;
-        shell.client.close().await;
+        shell.close().await;
         return Ok(());
     }
 
@@ -103,19 +189,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if !input.trim().is_empty() {
             run_statement(&mut shell, &input).await?;
         }
-        shell.client.close().await;
+        shell.close().await;
         return Ok(());
     }
 
     println!(
-        "Connected to {} via {} on {}. End statements with ';'. Type 'help' or 'quit'.",
-        args.database.slug(),
+        "Connected to {} via {} on {}. Use 'use sysdb' or 'use log'. End statements with ';'. Type 'help' or 'quit'.",
+        shell.target_database.slug(),
         shell.topology_name,
-        shell.database_path
+        shell.connection.database_path
     );
 
     repl(&mut shell).await?;
-    shell.client.close().await;
+    shell.close().await;
     Ok(())
 }
 
@@ -151,12 +237,13 @@ async fn repl(shell: &mut ShellContext) -> Result<(), Box<dyn std::error::Error>
     let mut buffer = String::new();
 
     loop {
+        let prompt_label = shell.prompt_label();
         let prompt = if buffer.trim().is_empty() {
-            "spanner> "
+            format!("{prompt_label}> ")
         } else {
-            "       > "
+            format!("{:width$}> ", "", width = prompt_label.len())
         };
-        print!("{prompt}");
+        print!("{}", prompt);
         io::stdout().flush()?;
 
         let mut line = String::new();
@@ -172,14 +259,24 @@ async fn repl(shell: &mut ShellContext) -> Result<(), Box<dyn std::error::Error>
 
         let trimmed = line.trim();
         if buffer.trim().is_empty() {
-            match trimmed {
-                "" => continue,
-                "quit" | "exit" | "\\q" => break,
-                "help" => {
+            match parse_repl_command(trimmed) {
+                Ok(Some(ReplCommand::Quit)) => break,
+                Ok(Some(ReplCommand::Help)) => {
                     print_help();
                     continue;
                 }
-                _ => {}
+                Ok(Some(ReplCommand::SwitchDatabase(target_database))) => {
+                    if let Err(err) = shell.switch_database(target_database).await {
+                        eprintln!("error: {err}");
+                    }
+                    continue;
+                }
+                Ok(None) if trimmed.is_empty() => continue,
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("error: {err}");
+                    continue;
+                }
             }
         }
 
@@ -201,9 +298,51 @@ fn print_help() {
     println!("Commands:");
     println!("  help          Show this help.");
     println!("  quit | exit   Exit the shell.");
+    println!("  use <db>      Switch to 'sysdb' or 'log'.");
+    println!("  \\c <db>       Alias for 'use <db>'.");
     println!("Notes:");
     println!("  One statement at a time.");
     println!("  Multi-line statements are supported and execute when the last line ends with ';'.");
+}
+
+fn parse_repl_command(line: &str) -> Result<Option<ReplCommand>, String> {
+    let command = line.trim().trim_end_matches(';').trim();
+    if command.is_empty() {
+        return Ok(None);
+    }
+
+    match command {
+        "help" => return Ok(Some(ReplCommand::Help)),
+        "quit" | "exit" | "\\q" => return Ok(Some(ReplCommand::Quit)),
+        _ => {}
+    }
+
+    let mut parts = command.split_whitespace();
+    let Some(verb) = parts.next() else {
+        return Ok(None);
+    };
+    match verb.to_ascii_lowercase().as_str() {
+        "use" => parse_switch_command(parts),
+        _ if verb == "\\c" => parse_switch_command(parts),
+        _ => Ok(None),
+    }
+}
+
+fn parse_switch_command<'a>(
+    mut args: impl Iterator<Item = &'a str>,
+) -> Result<Option<ReplCommand>, String> {
+    const USAGE: &str = "Usage: use <sysdb|log> or \\c <sysdb|log>";
+
+    let Some(target) = args.next() else {
+        return Err(USAGE.to_string());
+    };
+    if args.next().is_some() {
+        return Err(USAGE.to_string());
+    }
+
+    let target_database = TargetDatabase::from_repl_arg(target)
+        .ok_or_else(|| format!("Unknown database '{}'. Use 'sysdb' or 'log'.", target))?;
+    Ok(Some(ReplCommand::SwitchDatabase(target_database)))
 }
 
 async fn run_statement(
@@ -216,13 +355,13 @@ async fn run_statement(
     }
 
     match classify_sql(&sql)? {
-        SqlKind::Query => execute_query(&mut shell.client, &sql).await?,
-        SqlKind::Dml => execute_dml(&mut shell.client, &sql).await?,
+        SqlKind::Query => execute_query(&mut shell.connection.client, &sql).await?,
+        SqlKind::Dml => execute_dml(&mut shell.connection.client, &sql).await?,
         SqlKind::Ddl => {
             execute_ddl(
-                &shell.admin_client,
-                &shell.database_path,
-                shell.admin_rpc_timeout_secs,
+                &shell.connection.admin_client,
+                &shell.connection.database_path,
+                shell.connection.admin_rpc_timeout_secs,
                 &sql,
             )
             .await?
@@ -361,7 +500,10 @@ fn render_connection_error(err: RunMigrationsError) -> Box<dyn std::error::Error
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_sql, strip_leading_comments, wrap_query_for_json, SqlKind};
+    use super::{
+        classify_sql, parse_repl_command, strip_leading_comments, wrap_query_for_json, ReplCommand,
+        SqlKind, TargetDatabase,
+    };
 
     #[test]
     fn strips_leading_comments_before_classifying() {
@@ -385,6 +527,34 @@ mod tests {
         assert_eq!(
             wrap_query_for_json("select * from collections"),
             "SELECT TO_JSON_STRING(TO_JSON((SELECT AS STRUCT row_data.*))) AS row_json FROM (select * from collections) AS row_data"
+        );
+    }
+
+    #[test]
+    fn parses_database_switch_commands() {
+        assert_eq!(
+            parse_repl_command("use sysdb").unwrap(),
+            Some(ReplCommand::SwitchDatabase(TargetDatabase::Sysdb))
+        );
+        assert_eq!(
+            parse_repl_command("use log;").unwrap(),
+            Some(ReplCommand::SwitchDatabase(TargetDatabase::Logdb))
+        );
+        assert_eq!(
+            parse_repl_command("\\c spanner_logdb").unwrap(),
+            Some(ReplCommand::SwitchDatabase(TargetDatabase::Logdb))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_switch_commands() {
+        assert_eq!(
+            parse_repl_command("use").unwrap_err(),
+            "Usage: use <sysdb|log> or \\c <sysdb|log>"
+        );
+        assert_eq!(
+            parse_repl_command("use other").unwrap_err(),
+            "Unknown database 'other'. Use 'sysdb' or 'log'."
         );
     }
 }

--- a/rust/spanner-migrations/src/bin/spanner-shell.rs
+++ b/rust/spanner-migrations/src/bin/spanner-shell.rs
@@ -1,0 +1,390 @@
+use std::io::{self, IsTerminal, Read, Write};
+
+use chroma_tracing::{init_global_filter_layer, init_otel_layer, init_stdout_layer, init_tracing};
+use clap::{Parser, ValueEnum};
+use google_cloud_googleapis::spanner::admin::database::v1::UpdateDatabaseDdlRequest;
+use google_cloud_spanner::admin::client::Client as AdminClient;
+use google_cloud_spanner::client::Client;
+use google_cloud_spanner::statement::Statement;
+use serde_json::Value;
+use spanner_migrations::{
+    connect_spanner, ddl_wait_retry_setting, RootConfig, RunMigrationsError, TopologySpannerConfig,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum TargetDatabase {
+    Sysdb,
+    Logdb,
+}
+
+impl TargetDatabase {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Sysdb => "spanner_sysdb",
+            Self::Logdb => "spanner_logdb",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SqlKind {
+    Query,
+    Dml,
+    Ddl,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    version,
+    about = "Interactive SQL shell for the configured Spanner target"
+)]
+struct Args {
+    /// Override CONFIG_PATH before loading migration config.
+    #[arg(long)]
+    config_path: Option<String>,
+
+    /// Which configured database to target.
+    #[arg(long, value_enum, default_value_t = TargetDatabase::Sysdb)]
+    database: TargetDatabase,
+
+    /// Topology to connect to. Defaults to the first configured topology.
+    #[arg(long)]
+    topology: Option<String>,
+
+    /// Execute one SQL statement and exit.
+    #[arg(long, short = 'e')]
+    execute: Option<String>,
+}
+
+struct ShellContext {
+    client: Client,
+    admin_client: AdminClient,
+    database_path: String,
+    topology_name: String,
+    admin_rpc_timeout_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    if let Some(config_path) = &args.config_path {
+        std::env::set_var("CONFIG_PATH", config_path);
+    }
+
+    let config = RootConfig::load()?;
+    init_shell_tracing(&config);
+
+    let topology = select_topology(&config.topologies, args.topology.as_deref())?;
+    let spanner_config = match args.database {
+        TargetDatabase::Sysdb => &topology.config.sysdb_spanner,
+        TargetDatabase::Logdb => &topology.config.logdb_spanner,
+    };
+
+    let connected = connect_spanner(spanner_config)
+        .await
+        .map_err(render_connection_error)?;
+    let mut shell = ShellContext {
+        client: connected.client,
+        admin_client: connected.admin_client,
+        database_path: connected.database_path,
+        topology_name: topology.name.to_string(),
+        admin_rpc_timeout_secs: connected.admin_rpc_timeout_secs,
+    };
+
+    if let Some(sql) = args.execute {
+        run_statement(&mut shell, &sql).await?;
+        shell.client.close().await;
+        return Ok(());
+    }
+
+    if !io::stdin().is_terminal() {
+        let mut input = String::new();
+        io::stdin().read_to_string(&mut input)?;
+        if !input.trim().is_empty() {
+            run_statement(&mut shell, &input).await?;
+        }
+        shell.client.close().await;
+        return Ok(());
+    }
+
+    println!(
+        "Connected to {} via {} on {}. End statements with ';'. Type 'help' or 'quit'.",
+        args.database.slug(),
+        shell.topology_name,
+        shell.database_path
+    );
+
+    repl(&mut shell).await?;
+    shell.client.close().await;
+    Ok(())
+}
+
+fn init_shell_tracing(config: &spanner_migrations::MigrationConfig) {
+    let tracing_layers = vec![
+        init_global_filter_layer(&config.otel_filters),
+        init_otel_layer(&config.service_name, &config.otel_endpoint),
+        init_stdout_layer(),
+    ];
+    init_tracing(tracing_layers);
+}
+
+fn select_topology<'a>(
+    topologies: &'a [chroma_types::Topology<TopologySpannerConfig>],
+    requested: Option<&str>,
+) -> Result<&'a chroma_types::Topology<TopologySpannerConfig>, Box<dyn std::error::Error>> {
+    if topologies.is_empty() {
+        return Err("No topologies defined in configuration".into());
+    }
+
+    if let Some(requested) = requested {
+        return topologies
+            .iter()
+            .find(|topology| topology.name.to_string() == requested)
+            .ok_or_else(|| format!("Topology '{}' not found in configuration", requested).into());
+    }
+
+    Ok(&topologies[0])
+}
+
+async fn repl(shell: &mut ShellContext) -> Result<(), Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let mut buffer = String::new();
+
+    loop {
+        let prompt = if buffer.trim().is_empty() {
+            "spanner> "
+        } else {
+            "       > "
+        };
+        print!("{prompt}");
+        io::stdout().flush()?;
+
+        let mut line = String::new();
+        let bytes_read = stdin.read_line(&mut line)?;
+        if bytes_read == 0 {
+            if !buffer.trim().is_empty() {
+                if let Err(err) = run_statement(shell, &buffer).await {
+                    eprintln!("error: {err}");
+                }
+            }
+            break;
+        }
+
+        let trimmed = line.trim();
+        if buffer.trim().is_empty() {
+            match trimmed {
+                "" => continue,
+                "quit" | "exit" | "\\q" => break,
+                "help" => {
+                    print_help();
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        buffer.push_str(&line);
+        if !trimmed.ends_with(';') {
+            continue;
+        }
+
+        if let Err(err) = run_statement(shell, &buffer).await {
+            eprintln!("error: {err}");
+        }
+        buffer.clear();
+    }
+
+    Ok(())
+}
+
+fn print_help() {
+    println!("Commands:");
+    println!("  help          Show this help.");
+    println!("  quit | exit   Exit the shell.");
+    println!("Notes:");
+    println!("  One statement at a time.");
+    println!("  Multi-line statements are supported and execute when the last line ends with ';'.");
+}
+
+async fn run_statement(
+    shell: &mut ShellContext,
+    raw_sql: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sql = normalize_sql(raw_sql, &shell.topology_name)?;
+    if sql.is_empty() {
+        return Ok(());
+    }
+
+    match classify_sql(&sql)? {
+        SqlKind::Query => execute_query(&mut shell.client, &sql).await?,
+        SqlKind::Dml => execute_dml(&mut shell.client, &sql).await?,
+        SqlKind::Ddl => {
+            execute_ddl(
+                &shell.admin_client,
+                &shell.database_path,
+                shell.admin_rpc_timeout_secs,
+                &sql,
+            )
+            .await?
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_sql(raw_sql: &str, topology_name: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let sql = raw_sql.trim();
+    if sql.is_empty() {
+        return Ok(String::new());
+    }
+
+    let sql = sql.trim_end_matches(';').trim().to_string();
+    if sql.contains("@topo_name") {
+        return Ok(sql.replace("@topo_name", &format!("'{}'", topology_name)));
+    }
+    Ok(sql)
+}
+
+fn classify_sql(sql: &str) -> Result<SqlKind, Box<dyn std::error::Error>> {
+    let leading = strip_leading_comments(sql).to_ascii_lowercase();
+    let keyword = leading
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| "SQL statement is empty".to_string())?;
+
+    match keyword {
+        "select" | "with" | "show" | "describe" | "explain" => Ok(SqlKind::Query),
+        "insert" | "update" | "delete" => Ok(SqlKind::Dml),
+        "create" | "alter" | "drop" | "truncate" => Ok(SqlKind::Ddl),
+        other => Err(format!("Unsupported statement type '{}'", other).into()),
+    }
+}
+
+fn strip_leading_comments(sql: &str) -> &str {
+    let mut rest = sql.trim_start();
+    loop {
+        if let Some(stripped) = rest.strip_prefix("--") {
+            if let Some((_, remaining)) = stripped.split_once('\n') {
+                rest = remaining.trim_start();
+                continue;
+            }
+            return "";
+        }
+
+        if let Some(stripped) = rest.strip_prefix("/*") {
+            if let Some((_, remaining)) = stripped.split_once("*/") {
+                rest = remaining.trim_start();
+                continue;
+            }
+            return "";
+        }
+
+        return rest;
+    }
+}
+
+async fn execute_query(client: &mut Client, sql: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let wrapped = wrap_query_for_json(sql);
+    let stmt = Statement::new(&wrapped);
+    let mut tx = client.single().await?;
+    let mut iter = tx.query(stmt).await?;
+    let mut row_count = 0usize;
+
+    while let Some(row) = iter.next().await? {
+        let row_json: String = row.column_by_name("row_json")?;
+        print_row_json(&row_json)?;
+        row_count += 1;
+    }
+
+    println!("{} row(s)", row_count);
+    Ok(())
+}
+
+fn wrap_query_for_json(sql: &str) -> String {
+    format!(
+        "SELECT TO_JSON_STRING(TO_JSON((SELECT AS STRUCT row_data.*))) AS row_json FROM ({sql}) AS row_data"
+    )
+}
+
+fn print_row_json(row_json: &str) -> Result<(), Box<dyn std::error::Error>> {
+    match serde_json::from_str::<Value>(row_json) {
+        Ok(value) => println!("{}", serde_json::to_string_pretty(&value)?),
+        Err(_) => println!("{row_json}"),
+    }
+    Ok(())
+}
+
+async fn execute_dml(client: &mut Client, sql: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let (_, rows_affected) = client
+        .read_write_transaction::<i64, google_cloud_spanner::client::Error, _>(|tx| {
+            let sql = sql.to_string();
+            Box::pin(async move {
+                let stmt = Statement::new(&sql);
+                let rows_affected = tx.update(stmt).await?;
+                Ok(rows_affected)
+            })
+        })
+        .await?;
+
+    println!("{} row(s) affected", rows_affected);
+    Ok(())
+}
+
+async fn execute_ddl(
+    admin_client: &AdminClient,
+    database_path: &str,
+    admin_rpc_timeout_secs: u64,
+    sql: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let request = UpdateDatabaseDdlRequest {
+        database: database_path.to_string(),
+        statements: vec![sql.to_string()],
+        operation_id: String::new(),
+        proto_descriptors: Vec::new(),
+        throughput_mode: false,
+    };
+
+    let mut operation = admin_client
+        .database()
+        .update_database_ddl(request, None)
+        .await?;
+    operation
+        .wait(Some(ddl_wait_retry_setting(admin_rpc_timeout_secs)))
+        .await?;
+    println!("DDL applied");
+    Ok(())
+}
+
+fn render_connection_error(err: RunMigrationsError) -> Box<dyn std::error::Error> {
+    err.to_string().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_sql, strip_leading_comments, wrap_query_for_json, SqlKind};
+
+    #[test]
+    fn strips_leading_comments_before_classifying() {
+        assert_eq!(
+            strip_leading_comments("-- hello\n/* world */\nSELECT 1"),
+            "SELECT 1"
+        );
+    }
+
+    #[test]
+    fn classifies_select_and_dml() {
+        assert!(matches!(classify_sql("SELECT 1").unwrap(), SqlKind::Query));
+        assert!(matches!(
+            classify_sql("/* leading */ INSERT INTO t (id) VALUES (1)").unwrap(),
+            SqlKind::Dml
+        ));
+    }
+
+    #[test]
+    fn wraps_queries_with_select_as_struct_json_conversion() {
+        assert_eq!(
+            wrap_query_for_json("select * from collections"),
+            "SELECT TO_JSON_STRING(TO_JSON((SELECT AS STRUCT row_data.*))) AS row_json FROM (select * from collections) AS row_data"
+        );
+    }
+}

--- a/rust/spanner-migrations/src/config.rs
+++ b/rust/spanner-migrations/src/config.rs
@@ -53,16 +53,116 @@ impl MigrationConfig {
     fn default_otel_endpoint() -> String {
         "http://otel-collector:4317".to_string()
     }
+
+    fn from_service_topologies(
+        sysdb_service: CompatSysDbServiceConfig,
+        log_service: CompatLogServiceConfig,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let log_topologies = log_service.regions_and_topologies.ok_or(
+            "log_service.regions_and_topologies is required when rust-sysdb-migration is absent",
+        )?;
+
+        let mut topologies =
+            Vec::with_capacity(sysdb_service.regions_and_topologies.topologies.len());
+        for sysdb_topology in sysdb_service.regions_and_topologies.topologies {
+            let logdb_topology = log_topologies
+                .topologies
+                .iter()
+                .find(|topology| topology.name == sysdb_topology.name)
+                .ok_or_else(|| {
+                    format!(
+                        "Topology '{}' exists in sysdb_service but not log_service",
+                        sysdb_topology.name
+                    )
+                })?;
+
+            if sysdb_topology.regions() != logdb_topology.regions() {
+                return Err(format!(
+                    "Topology '{}' has different regions in sysdb_service and log_service",
+                    sysdb_topology.name
+                )
+                .into());
+            }
+
+            topologies.push(Topology::new(
+                sysdb_topology.name.clone(),
+                sysdb_topology.regions().to_vec(),
+                TopologySpannerConfig {
+                    sysdb_spanner: sysdb_topology.config.spanner,
+                    logdb_spanner: logdb_topology.config.spanner.clone(),
+                },
+            ));
+        }
+
+        Ok(Self {
+            migration_mode: MigrationMode::default(),
+            service_name: Self::default_service_name(),
+            otel_endpoint: sysdb_service.otel_endpoint,
+            otel_filters: sysdb_service.otel_filters,
+            topologies,
+        })
+    }
 }
 
-/// Root config wrapper to extract rust-sysdb-migration section
+#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+struct IgnoredRegionConfig {}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+struct CompatTopologySpannerConfig {
+    spanner: SpannerConfig,
+}
+
+#[derive(Deserialize)]
+struct CompatSysDbServiceConfig {
+    #[serde(default = "MigrationConfig::default_otel_endpoint")]
+    otel_endpoint: String,
+    #[serde(default)]
+    otel_filters: Vec<OtelFilter>,
+    regions_and_topologies: chroma_types::MultiCloudMultiRegionConfiguration<
+        IgnoredRegionConfig,
+        CompatTopologySpannerConfig,
+    >,
+}
+
+#[derive(Deserialize)]
+struct CompatLogServiceConfig {
+    #[serde(default)]
+    regions_and_topologies: Option<
+        chroma_types::MultiCloudMultiRegionConfiguration<
+            IgnoredRegionConfig,
+            CompatTopologySpannerConfig,
+        >,
+    >,
+}
+
+/// Root config wrapper that can extract either the dedicated migration section
+/// or derive it from the standard sysdb/log service topology config.
 #[derive(Deserialize)]
 pub struct RootConfig {
     #[serde(rename = "rust-sysdb-migration")]
-    pub rust_sysdb_migration: MigrationConfig,
+    #[serde(default)]
+    pub rust_sysdb_migration: Option<MigrationConfig>,
+    #[serde(default)]
+    sysdb_service: Option<CompatSysDbServiceConfig>,
+    #[serde(default)]
+    log_service: Option<CompatLogServiceConfig>,
 }
 
 impl RootConfig {
+    fn into_migration_config(self) -> Result<MigrationConfig, Box<dyn std::error::Error>> {
+        if let Some(config) = self.rust_sysdb_migration {
+            return Ok(config);
+        }
+
+        let sysdb_service = self
+            .sysdb_service
+            .ok_or("Missing rust-sysdb-migration and sysdb_service sections in configuration")?;
+        let log_service = self
+            .log_service
+            .ok_or("Missing rust-sysdb-migration and log_service sections in configuration")?;
+        MigrationConfig::from_service_topologies(sysdb_service, log_service)
+    }
+
     pub fn load() -> Result<MigrationConfig, Box<dyn std::error::Error>> {
         let path =
             env::var(CONFIG_PATH_ENV_VAR).unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_string());
@@ -91,11 +191,125 @@ impl RootConfig {
             .merge(Env::prefixed("CHROMA_").map(|k| k.as_str().replace("__", ".").into()));
 
         let root: RootConfig = f.extract()?;
+        let config = root.into_migration_config()?;
         println!("Parsed RootConfig");
         println!(
-            "Found {} topologies in rust-sysdb-migration",
-            root.rust_sysdb_migration.topologies.len()
+            "Found {} topologies in migration configuration",
+            config.topologies.len()
         );
-        Ok(root.rust_sysdb_migration)
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chroma_config::spanner::{SpannerConfig, SpannerEmulatorConfig};
+    use chroma_types::{
+        MultiCloudMultiRegionConfiguration, ProviderRegion, RegionName, Topology, TopologyName,
+    };
+
+    fn emulator(database: &str) -> SpannerConfig {
+        let mut emulator = SpannerEmulatorConfig::default();
+        emulator.database = database.to_string();
+        SpannerConfig::Emulator(emulator)
+    }
+
+    fn region(name: &str) -> ProviderRegion<IgnoredRegionConfig> {
+        ProviderRegion::new(
+            RegionName::new(name).unwrap(),
+            "tilt",
+            name,
+            IgnoredRegionConfig::default(),
+        )
+    }
+
+    fn sysdb_service(topology_name: &str, database: &str) -> CompatSysDbServiceConfig {
+        CompatSysDbServiceConfig {
+            otel_endpoint: "http://otel.example:4317".to_string(),
+            otel_filters: vec![],
+            regions_and_topologies: MultiCloudMultiRegionConfiguration::new(
+                RegionName::new("tilt-config-1").unwrap(),
+                vec![region("tilt-config-1"), region("tilt-config-2")],
+                vec![Topology::new(
+                    TopologyName::new(topology_name).unwrap(),
+                    vec![
+                        RegionName::new("tilt-config-1").unwrap(),
+                        RegionName::new("tilt-config-2").unwrap(),
+                    ],
+                    CompatTopologySpannerConfig {
+                        spanner: emulator(database),
+                    },
+                )],
+            )
+            .unwrap(),
+        }
+    }
+
+    fn log_service(topology_name: &str, database: &str) -> CompatLogServiceConfig {
+        CompatLogServiceConfig {
+            regions_and_topologies: Some(
+                MultiCloudMultiRegionConfiguration::new(
+                    RegionName::new("tilt-config-1").unwrap(),
+                    vec![region("tilt-config-1"), region("tilt-config-2")],
+                    vec![Topology::new(
+                        TopologyName::new(topology_name).unwrap(),
+                        vec![
+                            RegionName::new("tilt-config-1").unwrap(),
+                            RegionName::new("tilt-config-2").unwrap(),
+                        ],
+                        CompatTopologySpannerConfig {
+                            spanner: emulator(database),
+                        },
+                    )],
+                )
+                .unwrap(),
+            ),
+        }
+    }
+
+    #[test]
+    fn derives_migration_config_from_service_topologies() {
+        let root = RootConfig {
+            rust_sysdb_migration: None,
+            sysdb_service: Some(sysdb_service("tilt-spanning", "local-sysdb-database")),
+            log_service: Some(log_service("tilt-spanning", "local-logdb-database")),
+        };
+
+        let config = root.into_migration_config().unwrap();
+
+        assert_eq!(config.service_name, "rust-sysdb-migration");
+        assert_eq!(config.otel_endpoint, "http://otel.example:4317");
+        assert_eq!(config.topologies.len(), 1);
+        assert_eq!(config.topologies[0].name.to_string(), "tilt-spanning");
+        assert_eq!(
+            config.topologies[0].config.sysdb_spanner.database_path(),
+            emulator("local-sysdb-database").database_path()
+        );
+        assert_eq!(
+            config.topologies[0].config.logdb_spanner.database_path(),
+            emulator("local-logdb-database").database_path()
+        );
+    }
+
+    #[test]
+    fn explicit_migration_section_takes_precedence() {
+        let root = RootConfig {
+            rust_sysdb_migration: Some(MigrationConfig {
+                migration_mode: MigrationMode::Apply,
+                service_name: "explicit".to_string(),
+                otel_endpoint: "http://explicit:4317".to_string(),
+                otel_filters: vec![],
+                topologies: vec![],
+            }),
+            sysdb_service: Some(sysdb_service("tilt-spanning", "local-sysdb-database")),
+            log_service: Some(log_service("tilt-spanning", "local-logdb-database")),
+        };
+
+        let config = root.into_migration_config().unwrap();
+
+        assert_eq!(config.service_name, "explicit");
+        assert!(matches!(config.migration_mode, MigrationMode::Apply));
+        assert!(config.topologies.is_empty());
     }
 }

--- a/rust/spanner-migrations/src/config.rs
+++ b/rust/spanner-migrations/src/config.rs
@@ -210,9 +210,10 @@ mod tests {
     };
 
     fn emulator(database: &str) -> SpannerConfig {
-        let mut emulator = SpannerEmulatorConfig::default();
-        emulator.database = database.to_string();
-        SpannerConfig::Emulator(emulator)
+        SpannerConfig::Emulator(SpannerEmulatorConfig {
+            database: database.to_string(),
+            ..SpannerEmulatorConfig::default()
+        })
     }
 
     fn region(name: &str) -> ProviderRegion<IgnoredRegionConfig> {

--- a/rust/spanner-migrations/src/lib.rs
+++ b/rust/spanner-migrations/src/lib.rs
@@ -10,13 +10,14 @@ mod runner;
 pub use config::MigrationConfig;
 pub use config::MigrationMode;
 pub use config::RootConfig;
+pub use config::SpannerConfig;
 pub use config::TopologySpannerConfig;
 pub use migrations::MigrationDir;
 pub use migrations::MIGRATION_DIRS;
 
 use std::time::Duration;
 
-use chroma_config::spanner::{SpannerChannelConfig, SpannerConfig, SpannerSessionPoolConfig};
+use chroma_config::spanner::{SpannerChannelConfig, SpannerSessionPoolConfig};
 use google_cloud_gax::conn::Environment;
 use google_cloud_gax::grpc::Code;
 use google_cloud_gax::retry::RetrySetting;
@@ -26,6 +27,14 @@ use google_cloud_spanner::client::{ChannelConfig, Client, ClientConfig};
 use google_cloud_spanner::session::SessionConfig;
 use runner::MigrationRunner;
 use thiserror::Error;
+
+/// An initialized Spanner client pair plus connection metadata.
+pub struct ConnectedSpanner {
+    pub client: Client,
+    pub admin_client: AdminClient,
+    pub database_path: String,
+    pub admin_rpc_timeout_secs: u64,
+}
 
 /// Converts a SpannerSessionPoolConfig to the library's SessionConfig.
 fn to_session_config(cfg: &SpannerSessionPoolConfig) -> SessionConfig {
@@ -158,6 +167,52 @@ pub async fn run_migrations(
 ) -> Result<(), RunMigrationsError> {
     validate_slug(slug)?;
 
+    let ConnectedSpanner {
+        client,
+        admin_client,
+        database_path,
+        admin_rpc_timeout_secs,
+    } = connect_spanner(spanner_config).await?;
+    let mut runner =
+        MigrationRunner::new(client, admin_client, database_path, admin_rpc_timeout_secs);
+    if let Some(topology) = topology_name {
+        runner = runner.with_topology(topology.to_string());
+    }
+
+    match mode {
+        MigrationMode::Apply => {
+            tracing::info!("Initializing migrations table...");
+            runner
+                .initialize_migrations_table()
+                .await
+                .map_err(|e| RunMigrationsError::InitializeMigrationsTableError(e.to_string()))?;
+
+            tracing::info!("Applying migrations...");
+            runner
+                .apply_all_migrations(slug)
+                .await
+                .map_err(|e| RunMigrationsError::ApplyMigrationsError(e.to_string()))?;
+
+            tracing::info!("Migrations applied successfully!");
+        }
+        MigrationMode::Validate => {
+            tracing::info!("Validating migrations...");
+            runner
+                .validate_all_migrations(slug)
+                .await
+                .map_err(|e| RunMigrationsError::ValidateMigrationsError(e.to_string()))?;
+
+            tracing::info!("All migrations are applied!");
+        }
+    }
+
+    Ok(())
+}
+
+/// Connects to Spanner using the shared migration configuration conventions.
+pub async fn connect_spanner(
+    spanner_config: &SpannerConfig,
+) -> Result<ConnectedSpanner, RunMigrationsError> {
     let session_config = to_session_config(spanner_config.session_pool());
     let (database_path, client_config, admin_client_config) = match spanner_config {
         SpannerConfig::Emulator(emulator) => {
@@ -221,41 +276,12 @@ pub async fn run_migrations(
         .await
         .map_err(|e| RunMigrationsError::CreateAdminClientError(e.to_string()))?;
 
-    let admin_rpc_timeout_secs = spanner_config.channel().admin_rpc_timeout_secs;
-    let mut runner =
-        MigrationRunner::new(client, admin_client, database_path, admin_rpc_timeout_secs);
-    if let Some(topology) = topology_name {
-        runner = runner.with_topology(topology.to_string());
-    }
-
-    match mode {
-        MigrationMode::Apply => {
-            tracing::info!("Initializing migrations table...");
-            runner
-                .initialize_migrations_table()
-                .await
-                .map_err(|e| RunMigrationsError::InitializeMigrationsTableError(e.to_string()))?;
-
-            tracing::info!("Applying migrations...");
-            runner
-                .apply_all_migrations(slug)
-                .await
-                .map_err(|e| RunMigrationsError::ApplyMigrationsError(e.to_string()))?;
-
-            tracing::info!("Migrations applied successfully!");
-        }
-        MigrationMode::Validate => {
-            tracing::info!("Validating migrations...");
-            runner
-                .validate_all_migrations(slug)
-                .await
-                .map_err(|e| RunMigrationsError::ValidateMigrationsError(e.to_string()))?;
-
-            tracing::info!("All migrations are applied!");
-        }
-    }
-
-    Ok(())
+    Ok(ConnectedSpanner {
+        client,
+        admin_client,
+        database_path,
+        admin_rpc_timeout_secs: spanner_config.channel().admin_rpc_timeout_secs,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes

Add spanner-shell binary that provides an interactive REPL and
one-shot execution mode for running SQL against configured Spanner
databases.  Supports query, DML, and DDL statements with JSON
pretty-printed output.

Extract connect_spanner() from run_migrations() into a reusable
public function returning ConnectedSpanner so the shell (and future
tools) can establish connections independently.

Extend RootConfig to derive migration config from the standard
sysdb_service/log_service topology sections when the dedicated
rust-sysdb-migration block is absent, allowing the shell to work
with existing service configs.

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
