### PR TITLE
[ENH](system): name and size all worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7866,6 +7866,7 @@ dependencies = [
  "chroma-error",
  "chroma-segment",
  "chroma-storage",
+ "chroma-system",
  "chroma-tracing",
  "chroma-types",
  "chrono",

--- a/rust/frontend/src/bin/frontend_service.rs
+++ b/rust/frontend/src/bin/frontend_service.rs
@@ -1,7 +1,17 @@
 use chroma_frontend::frontend_service_entrypoint;
+use chroma_system::thread_stack_size_bytes;
 use std::sync::Arc;
 
-#[tokio::main]
-async fn main() {
-    frontend_service_entrypoint(Arc::new(()) as _, Arc::new(()) as _, true).await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-frontend")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(frontend_service_entrypoint(
+            Arc::new(()) as _,
+            Arc::new(()) as _,
+            true,
+        ));
 }

--- a/rust/garbage_collector/src/bin/garbage_collector_service.rs
+++ b/rust/garbage_collector/src/bin/garbage_collector_service.rs
@@ -1,3 +1,4 @@
+use chroma_system::thread_stack_size_bytes;
 use garbage_collector_library::garbage_collector_service_entrypoint;
 use tracing::{error, info};
 
@@ -8,15 +9,22 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    info!("Starting garbage collector service");
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-gc")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(async {
+            info!("Starting garbage collector service");
 
-    match garbage_collector_service_entrypoint().await {
-        Ok(_) => info!("Garbage collector service completed successfully"),
-        Err(e) => {
-            error!("Garbage collector service failed: {:?}", e);
-            panic!("Garbage collector service failed: {:?}", e);
-        }
-    }
+            match garbage_collector_service_entrypoint().await {
+                Ok(_) => info!("Garbage collector service completed successfully"),
+                Err(e) => {
+                    error!("Garbage collector service failed: {:?}", e);
+                    panic!("Garbage collector service failed: {:?}", e);
+                }
+            }
+        });
 }

--- a/rust/rust-sysdb/Cargo.toml
+++ b/rust/rust-sysdb/Cargo.toml
@@ -16,6 +16,7 @@ tonic-health = { workspace = true }
 chroma-config = { workspace = true }
 chroma-error = { workspace = true }
 chroma-storage = { workspace = true }
+chroma-system = { workspace = true }
 chroma-types = { workspace = true }
 chroma-tracing = { workspace = true, features = ["grpc"]}
 serde = { workspace = true }

--- a/rust/rust-sysdb/src/bin/sysdb_service.rs
+++ b/rust/rust-sysdb/src/bin/sysdb_service.rs
@@ -1,6 +1,14 @@
+use chroma_system::thread_stack_size_bytes;
 use rust_sysdb::sysdb_service_entrypoint;
 
-#[tokio::main]
-async fn main() {
-    Box::pin(sysdb_service_entrypoint()).await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-rust-sysdb")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(async {
+            Box::pin(sysdb_service_entrypoint()).await;
+        });
 }

--- a/rust/s3heap-service/src/bin/heap_tender_service.rs
+++ b/rust/s3heap-service/src/bin/heap_tender_service.rs
@@ -1,6 +1,10 @@
+use chroma_system::thread_stack_size_bytes;
+
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .thread_name("chroma-heap-tender")
+        .thread_stack_size(thread_stack_size_bytes())
         .build()
         .unwrap()
         .block_on(s3heap_service::entrypoint());

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -2,7 +2,7 @@ use super::operator::OperatorType;
 use super::{operator::TaskMessage, worker_thread::WorkerThread};
 use crate::execution::affinity::{io_core_for_task, pin_current_thread};
 use crate::execution::config::DispatcherConfig;
-use crate::utils::duration_ms;
+use crate::utils::{duration_ms, thread_stack_size_bytes};
 use crate::{
     Component, ComponentContext, ComponentHandle, ConsumeJoinHandleError, Handler,
     ReceiverForMessage, System,
@@ -194,6 +194,7 @@ impl Dispatcher {
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder.enable_all();
         builder.thread_name("chroma-io");
+        builder.thread_stack_size(thread_stack_size_bytes());
         if let Some(affinity_count) = config.io_affinity_num_cores {
             let total_cores = std::thread::available_parallelism()
                 .map(|n| n.get())

--- a/rust/system/src/system.rs
+++ b/rust/system/src/system.rs
@@ -5,6 +5,7 @@ use super::ComponentSender;
 use super::ConsumableJoinHandle;
 use super::Message;
 use super::{executor::ComponentExecutor, Component, ComponentHandle, Handler, StreamHandler};
+use crate::utils::thread_stack_size_bytes;
 use futures::Stream;
 use futures::StreamExt;
 use std::fmt::Debug;
@@ -67,9 +68,24 @@ impl System {
                 tracing::debug!("Spawning on dedicated thread");
                 // Spawn on a dedicated thread
                 let rt = Builder::new_current_thread().enable_all().build().unwrap();
-                let join_handle = std::thread::spawn(move || {
-                    rt.block_on(async move { executor.run(rx).await });
-                });
+                let thread_name = format!(
+                    "chroma-dedicated-{}",
+                    C::get_name().to_ascii_lowercase().replace(' ', "-")
+                );
+                let thread_stack_size = thread_stack_size_bytes();
+                let log_thread_name = thread_name.clone();
+                let join_handle = std::thread::Builder::new()
+                    .name(thread_name)
+                    .stack_size(thread_stack_size)
+                    .spawn(move || {
+                        tracing::debug!(
+                            thread_name = %log_thread_name,
+                            stack_size_bytes = thread_stack_size,
+                            "Running component on dedicated thread"
+                        );
+                        rt.block_on(async move { executor.run(rx).await });
+                    })
+                    .expect("dedicated component thread should spawn");
                 ComponentHandle::new(
                     cancel_token,
                     Some(ConsumableJoinHandle::from_thread_handle(join_handle)),

--- a/rust/system/src/utils/mod.rs
+++ b/rust/system/src/utils/mod.rs
@@ -12,3 +12,48 @@ use std::time::Duration;
 pub fn duration_ms(d: Duration) -> f64 {
     d.as_secs_f64() * 1000.0
 }
+
+const DEFAULT_THREAD_STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Returns the configured stack size for Rust worker threads.
+///
+/// `CHROMA_THREAD_STACK_SIZE_BYTES` takes precedence. If it is unset, `RUST_MIN_STACK`
+/// is used. Invalid values fall back to 16MiB.
+pub fn thread_stack_size_bytes() -> usize {
+    std::env::var("CHROMA_THREAD_STACK_SIZE_BYTES")
+        .ok()
+        .or_else(|| std::env::var("RUST_MIN_STACK").ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_THREAD_STACK_SIZE_BYTES)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::thread_stack_size_bytes;
+
+    #[test]
+    fn chroma_thread_stack_size_overrides_rust_min_stack() {
+        unsafe {
+            std::env::set_var("RUST_MIN_STACK", "8388608");
+            std::env::set_var("CHROMA_THREAD_STACK_SIZE_BYTES", "16777216");
+        }
+        assert_eq!(thread_stack_size_bytes(), 16 * 1024 * 1024);
+        unsafe {
+            std::env::remove_var("CHROMA_THREAD_STACK_SIZE_BYTES");
+            std::env::remove_var("RUST_MIN_STACK");
+        }
+    }
+
+    #[test]
+    fn falls_back_to_rust_min_stack() {
+        unsafe {
+            std::env::remove_var("CHROMA_THREAD_STACK_SIZE_BYTES");
+            std::env::set_var("RUST_MIN_STACK", "4194304");
+        }
+        assert_eq!(thread_stack_size_bytes(), 4 * 1024 * 1024);
+        unsafe {
+            std::env::remove_var("RUST_MIN_STACK");
+        }
+    }
+}

--- a/rust/worker/src/bin/compaction_client.rs
+++ b/rust/worker/src/bin/compaction_client.rs
@@ -1,4 +1,11 @@
-#[tokio::main]
-async fn main() {
-    worker::compaction_client_entrypoint().await;
+use chroma_system::thread_stack_size_bytes;
+
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-compaction-client")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(worker::compaction_client_entrypoint());
 }

--- a/rust/worker/src/bin/compaction_service.rs
+++ b/rust/worker/src/bin/compaction_service.rs
@@ -1,3 +1,4 @@
+use chroma_system::thread_stack_size_bytes;
 use worker::compaction_service_entrypoint;
 
 #[cfg(not(target_env = "msvc"))]
@@ -7,7 +8,12 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    compaction_service_entrypoint().await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-compaction")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(compaction_service_entrypoint());
 }

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -1,3 +1,4 @@
+use chroma_system::thread_stack_size_bytes;
 use worker::query_service_entrypoint;
 
 #[cfg(not(target_env = "msvc"))]
@@ -7,7 +8,12 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    query_service_entrypoint().await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("chroma-query")
+        .thread_stack_size(thread_stack_size_bytes())
+        .build()
+        .unwrap()
+        .block_on(query_service_entrypoint());
 }

--- a/rust/worker/src/execution/operators/commit_segment_writer.rs
+++ b/rust/worker/src/execution/operators/commit_segment_writer.rs
@@ -9,7 +9,7 @@ use tracing::Instrument;
 
 #[derive(Error, Debug)]
 pub enum CommitSegmentWriterOperatorError {
-    #[error("Finishing segment writer failed {0}")]
+    #[error("Finishing segment writer failed {0:?}")]
     FinishSegmentWriterFailed(#[from] Box<dyn ChromaError>),
 }
 

--- a/rust/worker/src/execution/operators/flush_segment_writer.rs
+++ b/rust/worker/src/execution/operators/flush_segment_writer.rs
@@ -11,7 +11,7 @@ use tracing::Instrument;
 
 #[derive(Error, Debug)]
 pub enum FlushSegmentWriterOperatorError {
-    #[error("Finishing segment writer failed {0}")]
+    #[error("Finishing segment writer failed {0:?}")]
     FinishSegmentWriterFailed(#[from] Box<dyn ChromaError>),
     #[error("Segment flusher is missing")]
     SegmentFlusherMissing,


### PR DESCRIPTION
## Description of changes

Replace #[tokio::main] with explicit runtime builders across all service
binaries to set descriptive thread names and configurable stack sizes.
This improves debuggability of thread dumps and prevents stack overflows
for deeply recursive workloads.

- Add thread_stack_size_bytes() to chroma-system, configurable via
  CHROMA_THREAD_STACK_SIZE_BYTES or RUST_MIN_STACK (default 16MiB)
- Name threads in all service binaries (frontend, gc, sysdb,
  heap_tender, compaction, query, compaction_client)
- Name and size dedicated component threads in System
- Set stack size on the IO dispatcher runtime
- Fix error formatting to use Debug ({0:?}) for Box<dyn ChromaError>

## Test plan

CI

## Migration plan

N/A

## Observability plan

Improved.

## Documentation Changes

N/A

Co-authored-by: AI
