### PR TITLE
[CHORE] stabilize Tilt dev environment configs

### DIFF
--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 2
+    max_concurrent_jobs: 10
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -310,7 +310,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period: 60
+  collection_soft_delete_grace_period_seconds: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/chroma_mcmr.yaml
+++ b/rust/worker/chroma_mcmr.yaml
@@ -70,7 +70,7 @@ query_service:
             admission_rate_limit: 256 # 256MiB/s
             shards: 64
             eviction: lru
-        num_concurrent_block_flushes: 40
+        num_concurrent_block_flushes: 1
       sparse_index_manager_config:
         sparse_index_cache_config:
           lru:
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 50
+    max_concurrent_jobs: 2
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000
@@ -310,6 +310,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
+  collection_soft_delete_grace_period: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 50
+    max_concurrent_jobs: 2
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000
@@ -192,7 +192,7 @@ compaction_service:
           lru:
             name: "block_cache"
             capacity: 1000
-        num_concurrent_block_flushes: 40
+        num_concurrent_block_flushes: 1
       sparse_index_manager_config:
         sparse_index_cache_config:
           lru:
@@ -311,6 +311,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
+  collection_soft_delete_grace_period: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -175,7 +175,7 @@ compaction_service:
     active_io_tasks: 10000
   compactor:
     compaction_manager_queue_size: 1000
-    max_concurrent_jobs: 2
+    max_concurrent_jobs: 10
     compaction_interval_sec: 10
     min_compaction_size: 10
     max_compaction_size: 10000

--- a/rust/worker/chroma_mcmr2.yaml
+++ b/rust/worker/chroma_mcmr2.yaml
@@ -311,7 +311,7 @@ garbage_collector:
     - crate_name: "garbage_collector"
       filter_level: "debug"
   relative_cutoff_time_seconds: 60 # GC all versions created at time < now() - relative_cutoff_time_seconds (1 minute)
-  collection_soft_delete_grace_period: 60
+  collection_soft_delete_grace_period_seconds: 60
   max_collections_to_gc: 1000
   gc_interval_mins: 1
   enable_log_gc_for_tenant: ["default_tenant"]


### PR DESCRIPTION
## Description of changes

Reduce concurrency settings and add GC grace period in both
chroma_mcmr.yaml and chroma_mcmr2.yaml to improve stability:
- Lower num_concurrent_block_flushes from 40 to 1
- Lower max_concurrent_jobs from 50 to 2
- Add collection_soft_delete_grace_period of 60 seconds

## Test plan

CI

## Migration plan

N/A

## Observability plan

N/A

## Documentation Changes

N/A

Co-authored-by: AI
