### PR TITLE
[BUG]: Remove extra io threadpool

### DIFF
--- a/rust/system/src/execution/affinity.rs
+++ b/rust/system/src/execution/affinity.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "linux")]
-pub(crate) fn pin_current_thread(core_id: usize) -> bool {
+pub fn pin_current_thread(core_id: usize) -> bool {
     if core_id >= libc::CPU_SETSIZE as usize {
         return false;
     }
@@ -15,7 +15,7 @@ pub(crate) fn pin_current_thread(core_id: usize) -> bool {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub(crate) fn pin_current_thread(_core_id: usize) -> bool {
+pub fn pin_current_thread(_core_id: usize) -> bool {
     false
 }
 
@@ -36,31 +36,12 @@ pub(crate) fn cpu_core_for_worker(
     }
 }
 
-/// Return the core to pin for an IO runtime thread.
-///
-/// IO threads cycle from the top: `total_cores - 1, total_cores - 2, ...`
-/// wrapping after `affinity_count` slots.
-/// If `affinity_count >= total_cores`, clamp to `total_cores`.
-pub(crate) fn io_core_for_task(
-    task_index: usize,
-    affinity_count: usize,
-    total_cores: usize,
-) -> Option<usize> {
-    if affinity_count == 0 || total_cores == 0 {
-        return None;
-    }
-    let effective = affinity_count.min(total_cores);
-    let offset = task_index % effective;
-    Some((total_cores - 1) - offset)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{cpu_core_for_worker, io_core_for_task};
+    use super::cpu_core_for_worker;
 
     #[test]
     fn cpu_affinity_wraps_within_count() {
-        // 4 affinity cores on a 4-core machine: cycle 0,1,2,3
         let cores: Vec<usize> = (0..10)
             .map(|worker_id| cpu_core_for_worker(worker_id, 4, 4).unwrap())
             .collect();
@@ -68,50 +49,20 @@ mod tests {
     }
 
     #[test]
-    fn io_affinity_descends_and_wraps() {
-        // 4 affinity cores on a 4-core machine: cycle 3,2,1,0
-        let cores: Vec<usize> = (0..10)
-            .map(|task_id| io_core_for_task(task_id, 4, 4).unwrap())
-            .collect();
-        assert_eq!(cores, vec![3, 2, 1, 0, 3, 2, 1, 0, 3, 2]);
-    }
-
-    #[test]
-    fn nine_cores_three_affinity() {
-        // 3 CPU affinity cores on a 9-core machine: cycle 0,1,2
-        let cores: Vec<usize> = (0..6)
-            .map(|worker_id| cpu_core_for_worker(worker_id, 3, 9).unwrap())
-            .collect();
-        assert_eq!(cores, vec![0, 1, 2, 0, 1, 2]);
-        // 3 IO affinity cores on a 9-core machine: cycle 8,7,6
-        let cores: Vec<usize> = (0..6)
-            .map(|task_id| io_core_for_task(task_id, 3, 9).unwrap())
-            .collect();
-        assert_eq!(cores, vec![8, 7, 6, 8, 7, 6]);
-    }
-
-    #[test]
-    fn affinity_count_exceeds_total_clamps() {
-        // 12 affinity cores on a 9-core machine: clamp to 9
+    fn cpu_affinity_count_exceeds_total_clamps() {
         let cores: Vec<usize> = (0..9)
             .map(|worker_id| cpu_core_for_worker(worker_id, 12, 9).unwrap())
             .collect();
         assert_eq!(cores, vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
-        let cores: Vec<usize> = (0..9)
-            .map(|task_id| io_core_for_task(task_id, 12, 9).unwrap())
-            .collect();
-        assert_eq!(cores, vec![8, 7, 6, 5, 4, 3, 2, 1, 0]);
     }
 
     #[test]
     fn zero_affinity_returns_none() {
         assert_eq!(cpu_core_for_worker(0, 0, 9), None);
-        assert_eq!(io_core_for_task(0, 0, 9), None);
     }
 
     #[test]
     fn zero_total_cores_returns_none() {
         assert_eq!(cpu_core_for_worker(0, 3, 0), None);
-        assert_eq!(io_core_for_task(0, 3, 0), None);
     }
 }

--- a/rust/system/src/execution/config.rs
+++ b/rust/system/src/execution/config.rs
@@ -18,26 +18,12 @@ pub struct DispatcherConfig {
     #[serde(default = "DispatcherConfig::default_active_io_tasks")]
     pub active_io_tasks: usize,
 
-    // NOTE(rescrv):  The next two fields are for cpu and I/O affinity.
-    //
-    // If cpu_affinity_num_cores + io_affinity_num_cores <= |CPUs| you'll get one OR I/O task per
-    // core.  If cpu_affinity_num_cores + io_affinity_num_cores > |CPUs| you'll get the excess
-    // threads scheduled in a way that balances I/O and CPU threads.
-    //
-    // Put another way:
-    // - CPU fills in from the left
-    // - I/O fills in from the right
-    // - If you reach the end, you go back to where you started.
-    /// Number of CPU cores used for worker-thread pinning.
-    /// Worker threads are pinned as 0, 1, 2, ... and wrap at this count.
-    /// If unset, CPU worker pinning is disabled.
+    /// Number of CPU cores reserved for dedicated CPU worker threads.
+    /// Workers pin to cores `[0 .. cpu_affinity_num_cores)`. The main and IO
+    /// tokio runtimes share the remaining cores `[cpu_affinity_num_cores .. N)`.
+    /// If unset, no pinning is applied.
     #[serde(default, alias = "cpu_affinity_max_core")]
     pub cpu_affinity_num_cores: Option<usize>,
-    /// Number of IO cores used for IO task pinning.
-    /// IO tasks are pinned as N-1, N-2, ... 0 and then wrap.
-    /// If unset, IO task pinning is disabled.
-    #[serde(default, alias = "io_affinity_start_core")]
-    pub io_affinity_num_cores: Option<usize>,
 }
 
 impl DispatcherConfig {
@@ -71,7 +57,6 @@ impl Default for DispatcherConfig {
             worker_queue_size: DispatcherConfig::default_worker_queue_size(),
             active_io_tasks: DispatcherConfig::default_active_io_tasks(),
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         }
     }
 }

--- a/rust/system/src/execution/dispatcher.rs
+++ b/rust/system/src/execution/dispatcher.rs
@@ -1,6 +1,5 @@
 use super::operator::OperatorType;
 use super::{operator::TaskMessage, worker_thread::WorkerThread};
-use crate::execution::affinity::{io_core_for_task, pin_current_thread};
 use crate::execution::config::DispatcherConfig;
 use crate::utils::duration_ms;
 use crate::{
@@ -17,7 +16,6 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
-use tokio::runtime::Runtime;
 use tracing::{trace_span, Instrument, Span};
 
 /// The dispatcher is responsible for distributing tasks to worker threads.
@@ -67,7 +65,6 @@ pub struct Dispatcher {
     task_queue: VecDeque<(TaskMessage, Span)>,
     waiters: Vec<TaskRequestMessage>,
     active_io_tasks: Arc<AtomicU64>,
-    io_runtime: Arc<Runtime>,
     worker_handles: Arc<Mutex<Vec<ComponentHandle<WorkerThread>>>>,
     metrics: DispatcherMetrics,
 }
@@ -173,42 +170,14 @@ pub struct DispatcherStats {
 impl Dispatcher {
     /// Create a new dispatcher from a configuration.
     pub fn new(config: DispatcherConfig) -> Self {
-        let io_runtime = Self::build_io_runtime(&config);
         Dispatcher {
             config: config.clone(),
             task_queue: VecDeque::new(),
             waiters: Vec::new(),
             active_io_tasks: Arc::new(AtomicU64::new(config.active_io_tasks as u64)),
-            io_runtime: Arc::new(io_runtime),
             worker_handles: Arc::new(Mutex::new(Vec::new())),
             metrics: DispatcherMetrics::new(),
         }
-    }
-
-    /// Build a dedicated tokio runtime for IO tasks.
-    ///
-    /// When `io_affinity_num_cores` is set, each runtime thread is pinned to a
-    /// core on startup via `on_thread_start`, filling from the right
-    /// (total - 1, total - 2, ...) and wrapping after `affinity_count` slots.
-    fn build_io_runtime(config: &DispatcherConfig) -> Runtime {
-        let mut builder = tokio::runtime::Builder::new_multi_thread();
-        builder.enable_all();
-        builder.thread_name("chroma-io");
-        if let Some(affinity_count) = config.io_affinity_num_cores {
-            let total_cores = std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(1);
-            let thread_index = Arc::new(AtomicU64::new(0));
-            builder.on_thread_start(move || {
-                let idx = thread_index.fetch_add(1, Ordering::Relaxed) as usize;
-                if let Some(core) = io_core_for_task(idx, affinity_count, total_cores) {
-                    if !pin_current_thread(core) {
-                        tracing::warn!(core_id = core, "failed to pin IO runtime thread");
-                    }
-                }
-            });
-        }
-        builder.build().expect("IO tokio runtime should build")
     }
 
     /// Spawn worker threads
@@ -306,7 +275,7 @@ impl Dispatcher {
                     .queue_latency_ms
                     .record(duration_ms(task_created_at.elapsed()), &task_kv);
                 self.record_depths();
-                self.io_runtime.spawn(async move {
+                tokio::spawn(async move {
                     task.run().instrument(child_span).await;
                     drop(counter);
                 });
@@ -751,7 +720,6 @@ mod tests {
             worker_queue_size: 1000,
             active_io_tasks: 1000,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         let counter = Arc::new(AtomicUsize::new(0));
@@ -787,7 +755,6 @@ mod tests {
             worker_queue_size: 1000,
             active_io_tasks: 1000,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         let counter = Arc::new(AtomicUsize::new(0));
@@ -823,7 +790,6 @@ mod tests {
             worker_queue_size: 1,
             active_io_tasks: 1,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let mut dispatcher_handle = system.start_component(dispatcher);
         let (result_receiver, result_rx) = OneshotMessageReceiver::new();
@@ -850,7 +816,6 @@ mod tests {
             worker_queue_size: 1,
             active_io_tasks: 1,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let mut dispatcher_handle = system.start_component(dispatcher);
 

--- a/rust/system/src/execution/mod.rs
+++ b/rust/system/src/execution/mod.rs
@@ -3,9 +3,11 @@ pub mod config;
 pub mod dispatcher;
 pub mod operator;
 pub mod orchestrator;
+pub mod runtime;
 pub mod worker_thread;
 
 pub use config::*;
 pub use dispatcher::*;
 pub use operator::*;
 pub use orchestrator::*;
+pub use runtime::*;

--- a/rust/system/src/execution/operator.rs
+++ b/rust/system/src/execution/operator.rs
@@ -504,7 +504,6 @@ mod tests {
             worker_queue_size: 1000,
             active_io_tasks: 1000,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 

--- a/rust/system/src/execution/orchestrator.rs
+++ b/rust/system/src/execution/orchestrator.rs
@@ -474,7 +474,6 @@ mod tests {
             worker_queue_size: 1,
             active_io_tasks: 10,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 

--- a/rust/system/src/execution/runtime.rs
+++ b/rust/system/src/execution/runtime.rs
@@ -1,0 +1,35 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+use crate::execution::affinity::pin_current_thread;
+use crate::execution::config::DispatcherConfig;
+
+/// Build the `chroma-main` tokio runtime pinned to the cores not reserved
+/// for dedicated CPU workers: `[cpu .. total_cores)`.
+pub fn build_tokio_main_runtime(config: &DispatcherConfig) -> std::io::Result<Runtime> {
+    let total_cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    let cpu = config.cpu_affinity_num_cores.unwrap_or(0).min(total_cores);
+    let io = total_cores - cpu;
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    builder.thread_name("chroma-main");
+
+    if io > 0 && cpu > 0 {
+        builder.worker_threads(io);
+        let thread_index = Arc::new(AtomicU64::new(0));
+        builder.on_thread_start(move || {
+            let idx = thread_index.fetch_add(1, Ordering::Relaxed) as usize;
+            let core = cpu + (idx % io);
+            if !pin_current_thread(core) {
+                tracing::warn!(core_id = core, "failed to pin main runtime thread");
+            }
+        });
+    }
+
+    builder.build()
+}

--- a/rust/worker/src/bin/compaction_service.rs
+++ b/rust/worker/src/bin/compaction_service.rs
@@ -1,4 +1,4 @@
-use worker::compaction_service_entrypoint;
+use worker::{compaction_service_entrypoint, load_root_config};
 
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -7,7 +7,10 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    compaction_service_entrypoint().await;
+fn main() {
+    let root_config = load_root_config();
+    let runtime =
+        chroma_system::build_tokio_main_runtime(&root_config.compaction_service.dispatcher)
+            .expect("failed to build chroma-main tokio runtime");
+    runtime.block_on(compaction_service_entrypoint());
 }

--- a/rust/worker/src/bin/query_service.rs
+++ b/rust/worker/src/bin/query_service.rs
@@ -1,4 +1,4 @@
-use worker::query_service_entrypoint;
+use worker::{load_root_config, query_service_entrypoint};
 
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -7,7 +7,9 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-#[tokio::main]
-async fn main() {
-    query_service_entrypoint().await;
+fn main() {
+    let root_config = load_root_config();
+    let runtime = chroma_system::build_tokio_main_runtime(&root_config.query_service.dispatcher)
+        .expect("failed to build chroma-main tokio runtime");
+    runtime.block_on(query_service_entrypoint());
 }

--- a/rust/worker/src/compactor/compaction_manager.rs
+++ b/rust/worker/src/compactor/compaction_manager.rs
@@ -1306,7 +1306,6 @@ mod tests {
             worker_queue_size: 100,
             active_io_tasks: 100,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         manager.set_dispatcher(dispatcher_handle);

--- a/rust/worker/src/execution/orchestration/compact.rs
+++ b/rust/worker/src/execution/orchestration/compact.rs
@@ -2809,7 +2809,6 @@ mod tests {
             worker_queue_size: 100,
             active_io_tasks: 100,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 
@@ -3040,7 +3039,6 @@ mod tests {
             worker_queue_size: 100,
             active_io_tasks: 100,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 
@@ -3370,7 +3368,6 @@ mod tests {
             worker_queue_size: 100,
             active_io_tasks: 100,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
 

--- a/rust/worker/src/lib.rs
+++ b/rust/worker/src/lib.rs
@@ -20,9 +20,8 @@ pub mod execution;
 
 const CONFIG_PATH_ENV_VAR: &str = "CONFIG_PATH";
 
-pub async fn query_service_entrypoint() {
-    // Check if the config path is set in the env var
-    let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
+pub fn load_root_config() -> config::RootConfig {
+    match std::env::var(CONFIG_PATH_ENV_VAR) {
         Ok(config_path) => {
             eprintln!("loading from {config_path}");
             config::RootConfig::load_from_path(&config_path)
@@ -31,7 +30,11 @@ pub async fn query_service_entrypoint() {
             eprintln!("loading from default path because {err}");
             config::RootConfig::load()
         }
-    };
+    }
+}
+
+pub async fn query_service_entrypoint() {
+    let config = load_root_config();
 
     let config = config.query_service;
     let registry = Registry::new();
@@ -81,17 +84,7 @@ pub async fn query_service_entrypoint() {
 }
 
 pub async fn compaction_service_entrypoint() {
-    // Check if the config path is set in the env var
-    let config = match std::env::var(CONFIG_PATH_ENV_VAR) {
-        Ok(config_path) => {
-            eprintln!("loading from {config_path}");
-            config::RootConfig::load_from_path(&config_path)
-        }
-        Err(err) => {
-            eprintln!("loading from default path because {err}");
-            config::RootConfig::load()
-        }
-    };
+    let config = load_root_config();
 
     let config = config.compaction_service;
     let registry = Registry::new();

--- a/rust/worker/src/server.rs
+++ b/rust/worker/src/server.rs
@@ -949,7 +949,6 @@ mod tests {
             worker_queue_size: 10,
             active_io_tasks: 10,
             cpu_affinity_num_cores: None,
-            io_affinity_num_cores: None,
         });
         let dispatcher_handle = system.start_component(dispatcher);
         server.set_dispatcher(dispatcher_handle);


### PR DESCRIPTION
This change removes the extra threadpool created in what was formerly known as `build_io_runtime`. It replaces the implicit tokio runtime created by [tokio::main] with an explicit one that takes in the dispatcher configs and pins its threads away from all the cpu affinity cores.

- Improvements & Bug fixes
  - ...
- New functionality
  - ...

## Test plan

_How are these changes tested?_

- [ ] Tests pass locally with `pytest` for python, `yarn test` for js, `cargo test` for rust

## Migration plan

_Are there any migrations, or any forwards/backwards compatibility changes needed in order to make sure this change deploys reliably?_

## Observability plan

_What is the plan to instrument and monitor this change?_

## Documentation Changes

_Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs section](https://github.com/chroma-core/chroma/tree/main/docs/docs.trychroma.com)?_
